### PR TITLE
[list-marker] unicode-bidi and direction on ::marker have no effect on an inside marker

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5561,16 +5561,11 @@ imported/w3c/web-platform-tests/css/css-lists/li-list-item-counter-005.html [ Im
 imported/w3c/web-platform-tests/css/css-lists/marker-counter.html [ ImageOnlyFailure ]
 
 # list-style
-imported/w3c/web-platform-tests/css/css-lists/list-style-type-decimal-vertical-lr.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-lists/list-style-type-decimal-vertical-rl.html [ ImageOnlyFailure ]
 
 # list-style bidi support
 webkit.org/b/202849 imported/w3c/web-platform-tests/css/css-lists/list-style-type-string-005b.html [ ImageOnlyFailure ]
 webkit.org/b/249918 imported/w3c/web-platform-tests/css/css-lists/list-marker-symbol-bidi.html [ ImageOnlyFailure ]
 
-imported/w3c/web-platform-tests/css/css-lists/content-property/marker-text-matches-lower-greek.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-lists/content-property/marker-text-matches-lower-latin.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-lists/content-property/marker-text-matches-square.html [ ImageOnlyFailure ]
 
 # -- CSS multicol -- #
 webkit.org/b/214458 imported/w3c/web-platform-tests/css/css-multicol/multicol-fill-balance-003.html [ ImageOnlyFailure ]
@@ -5746,11 +5741,9 @@ webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/first-letter-
 webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/first-line-opacity-001.html [ ImageOnlyFailure ]
 webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/grammar-error-001.html [ ImageOnlyFailure ]
 webkit.org/b/204163 imported/w3c/web-platform-tests/css/css-pseudo/marker-content-010.html [ ImageOnlyFailure ]
-webkit.org/b/204163 imported/w3c/web-platform-tests/css/css-pseudo/marker-content-012.html [ ImageOnlyFailure ]
 webkit.org/b/204163 imported/w3c/web-platform-tests/css/css-pseudo/marker-content-017.html [ ImageOnlyFailure ]
 webkit.org/b/204163 imported/w3c/web-platform-tests/css/css-pseudo/marker-content-018.html [ ImageOnlyFailure ]
 webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/marker-list-style-position.html [ ImageOnlyFailure ]
-webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/marker-unicode-bidi-normal.html [ ImageOnlyFailure ]
 webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/spelling-error-001.html [ ImageOnlyFailure ]
 
 webkit.org/b/214462 imported/w3c/web-platform-tests/css/css-scoping/host-context-specificity-001.html [ ImageOnlyFailure ]
@@ -6091,13 +6084,10 @@ webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/grammar-spell
 webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-001.html [ ImageOnlyFailure ]
 webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-002.html [ ImageOnlyFailure ]
 webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/marker-content-024.html [ ImageOnlyFailure ]
-webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/marker-hyphens.html [ ImageOnlyFailure ]
 webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/marker-letter-spacing.html [ ImageOnlyFailure ]
 webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/marker-line-break.html [ ImageOnlyFailure ]
 webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/marker-overflow-wrap.html [ ImageOnlyFailure ]
 webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/marker-text-decoration-skip-ink.html [ ImageOnlyFailure ]
-webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/marker-text-emphasis.html [ ImageOnlyFailure ]
-webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/marker-text-shadow.html [ ImageOnlyFailure ]
 webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/marker-text-transform-uppercase.html [ ImageOnlyFailure ]
 webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/marker-word-break.html [ ImageOnlyFailure ]
 webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/selection-contenteditable-011.html [ ImageOnlyFailure ]

--- a/LayoutTests/css1/classification/list_style_position-expected.txt
+++ b/LayoutTests/css1/classification/list_style_position-expected.txt
@@ -21,7 +21,9 @@ layer at (0,0) size 800x600
             text run at (0,18) width 158: "space beneath the bullet."
       RenderBlock {UL} at (0,162) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderListMarker at (-1,0) size 7x18: bullet
+          RenderInline (generated) at (-1,0) size 7x18
+            RenderText at (-1,0) size 7x18
+              text run at (-1,0) width 7: "\x{2022}"
           RenderText {#text} at (0,0) size 719x36
             text run at (14,0) width 705: "The text in this item should not behave as expected; that is, it should line up with the bullet on the left margin,"
             text run at (0,18) width 268: "leaving no blank space beneath the bullet."
@@ -45,7 +47,9 @@ layer at (0,0) size 800x600
                     text run at (0,18) width 197: "blank space beneath the bullet."
               RenderBlock {UL} at (4,56) size 762x36
                 RenderListItem {LI} at (40,0) size 722x36
-                  RenderListMarker at (-1,0) size 7x18: bullet
+                  RenderInline (generated) at (-1,0) size 7x18
+                    RenderText at (-1,0) size 7x18
+                      text run at (-1,0) width 7: "\x{2022}"
                   RenderText {#text} at (0,0) size 719x36
                     text run at (14,0) width 705: "The text in this item should not behave as expected; that is, it should line up with the bullet on the left margin,"
                     text run at (0,18) width 268: "leaving no blank space beneath the bullet."

--- a/LayoutTests/css2.1/t1205-c565-list-pos-00-b-expected.txt
+++ b/LayoutTests/css2.1/t1205-c565-list-pos-00-b-expected.txt
@@ -16,7 +16,9 @@ layer at (0,0) size 800x96
             text run at (12,0) width 31: " Test"
       RenderBlock {OL} at (80,53) size 160x19 [color=#000080] [bgcolor=#000080]
         RenderListItem {LI} at (0,0) size 160x18
-          RenderListMarker at (0,0) size 16x18: "1"
+          RenderInline (generated) at (0,0) size 16x18
+            RenderText at (0,0) size 16x18
+              text run at (0,0) width 16: "1. "
           RenderInline {SPAN} at (16,0) size 27x18 [color=#FFFFFF]
             RenderText {#text} at (16,0) size 27x18
               text run at (16,0) width 27: "Test"

--- a/LayoutTests/css2.1/t1205-c566-list-stl-00-e-ag-expected.txt
+++ b/LayoutTests/css2.1/t1205-c566-list-stl-00-e-ag-expected.txt
@@ -8,7 +8,9 @@ layer at (0,0) size 800x116
           text run at (0,0) width 194: "There should be no red below."
       RenderBlock {UL} at (75,34) size 96x51 [color=#00FF00] [bgcolor=#FF0000] [border: (3px solid #000000)]
         RenderListItem {LI} at (3,3) size 90x45
-          RenderListMarker at (0,0) size 45x15: "A"
+          RenderInline (generated) at (0,0) size 45x15
+            RenderText at (0,0) size 45x15
+              text run at (0,0) width 45: "A. "
           RenderText {#text} at (0,0) size 90x45
             text run at (45,0) width 45: "x x"
             text run at (0,15) width 75: "xx xx"

--- a/LayoutTests/fast/css/001-expected.txt
+++ b/LayoutTests/fast/css/001-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {UL} at (0,0) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderListMarker at (-1,0) size 7x18: bullet
+          RenderInline (generated) at (-1,0) size 7x18
+            RenderText at (-1,0) size 7x18
+              text run at (-1,0) width 7: "\x{2022}"
           RenderText {#text} at (14,0) size 272x18
             text run at (14,0) width 272: "This list item should have an inside bullet."
           RenderBR {BR} at (285,0) size 1x18

--- a/LayoutTests/fast/html/details-add-child-1-expected.txt
+++ b/LayoutTests/fast/html/details-add-child-1-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x38
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 60x19
             text run at (16,1) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x19

--- a/LayoutTests/fast/html/details-add-child-2-expected.txt
+++ b/LayoutTests/fast/html/details-add-child-2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x38
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 60x19
             text run at (16,1) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x19

--- a/LayoutTests/fast/html/details-add-details-child-1-expected.txt
+++ b/LayoutTests/fast/html/details-add-details-child-1-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x38
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 60x19
             text run at (16,1) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x19

--- a/LayoutTests/fast/html/details-add-details-child-2-expected.txt
+++ b/LayoutTests/fast/html/details-add-details-child-2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x38
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 60x19
             text run at (16,1) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x19

--- a/LayoutTests/fast/html/details-add-summary-10-expected.txt
+++ b/LayoutTests/fast/html/details-add-summary-10-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x38
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 39x19
             text run at (16,1) width 39: "new 1"
         RenderBlock {SLOT} at (0,19) size 784x19

--- a/LayoutTests/fast/html/details-add-summary-6-expected.txt
+++ b/LayoutTests/fast/html/details-add-summary-6-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 39x19
             text run at (16,1) width 39: "new 1"
         RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/fast/html/details-add-summary-7-expected.txt
+++ b/LayoutTests/fast/html/details-add-summary-7-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x38
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 39x19
             text run at (16,1) width 39: "new 1"
         RenderBlock {SLOT} at (0,19) size 784x19

--- a/LayoutTests/fast/html/details-add-summary-8-expected.txt
+++ b/LayoutTests/fast/html/details-add-summary-8-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x38
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 39x19
             text run at (16,1) width 39: "new 2"
         RenderBlock {SLOT} at (0,19) size 784x19

--- a/LayoutTests/fast/html/details-add-summary-9-expected.txt
+++ b/LayoutTests/fast/html/details-add-summary-9-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x38
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 60x19
             text run at (16,1) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x19

--- a/LayoutTests/fast/html/details-add-summary-child-1-expected.txt
+++ b/LayoutTests/fast/html/details-add-summary-child-1-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 64x19
             text run at (16,1) width 64: "summary "
           RenderInline {B} at (79,1) size 145x19

--- a/LayoutTests/fast/html/details-add-summary-child-2-expected.txt
+++ b/LayoutTests/fast/html/details-add-summary-child-2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 64x19
             text run at (16,1) width 64: "summary "
           RenderInline {SPAN} at (79,1) size 145x19

--- a/LayoutTests/fast/html/details-nested-1-expected.txt
+++ b/LayoutTests/fast/html/details-nested-1-expected.txt
@@ -6,12 +6,16 @@ layer at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 784x139 [border: (8px solid #555599)]
         RenderListItem {SUMMARY} at (8,8) size 768x105 [border: (8px solid #9999CC)]
           RenderBlock (anonymous) at (8,8) size 752x20
-            RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+            RenderInline (generated) at (0,-1) size 17x20
+              RenderText at (0,-1) size 17x20
+                text run at (0,0) width 17: "\x{25BC} "
             RenderText {#text} at (16,1) size 60x19
               text run at (16,1) width 60: "summary"
           RenderBlock {DETAILS} at (8,27) size 752x70 [border: (8px solid #995555)]
             RenderListItem {SUMMARY} at (8,8) size 736x36 [border: (8px solid #CC9999)]
-              RenderListMarker at (8,7) size 17x19: "\x{25BC}"
+              RenderInline (generated) at (8,7) size 17x20
+                RenderText at (8,7) size 17x20
+                  text run at (8,7) width 17: "\x{25BC} "
               RenderText {#text} at (24,9) size 287x19
                 text run at (24,9) width 287: "nested summary (summary-deails-summary)"
             RenderBlock {SLOT} at (8,43) size 736x19

--- a/LayoutTests/fast/html/details-nested-2-expected.txt
+++ b/LayoutTests/fast/html/details-nested-2-expected.txt
@@ -5,13 +5,17 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x139 [border: (8px solid #555599)]
         RenderListItem {SUMMARY} at (8,8) size 768x36 [border: (8px solid #9999CC)]
-          RenderListMarker at (8,7) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (8,7) size 17x20
+            RenderText at (8,7) size 17x20
+              text run at (8,7) width 17: "\x{25BC} "
           RenderText {#text} at (24,9) size 60x19
             text run at (24,9) width 60: "summary"
         RenderBlock {SLOT} at (8,43) size 768x88
           RenderBlock {DETAILS} at (0,0) size 768x70 [border: (8px solid #995555)]
             RenderListItem {SUMMARY} at (8,8) size 752x36 [border: (8px solid #CC9999)]
-              RenderListMarker at (8,7) size 17x19: "\x{25BC}"
+              RenderInline (generated) at (8,7) size 17x20
+                RenderText at (8,7) size 17x20
+                  text run at (8,7) width 17: "\x{25BC} "
               RenderText {#text} at (24,9) size 269x19
                 text run at (24,9) width 269: "nested summary (details-deails-summary)"
             RenderBlock {SLOT} at (8,43) size 752x19

--- a/LayoutTests/fast/html/details-no-summary2-expected.txt
+++ b/LayoutTests/fast/html/details-no-summary2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 46x19
             text run at (16,1) width 46: "Details"
         RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/fast/html/details-open6-expected.txt
+++ b/LayoutTests/fast/html/details-open6-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 60x19
             text run at (16,1) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/fast/html/details-remove-child-1-expected.txt
+++ b/LayoutTests/fast/html/details-remove-child-1-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x38
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 60x19
             text run at (16,1) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x19

--- a/LayoutTests/fast/html/details-remove-child-2-expected.txt
+++ b/LayoutTests/fast/html/details-remove-child-2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x38
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 60x19
             text run at (16,1) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x19

--- a/LayoutTests/fast/html/details-remove-summary-4-expected.txt
+++ b/LayoutTests/fast/html/details-remove-summary-4-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 46x19
             text run at (16,1) width 46: "Details"
         RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/fast/html/details-remove-summary-5-expected.txt
+++ b/LayoutTests/fast/html/details-remove-summary-5-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 72x19
             text run at (16,1) width 72: "summary 2"
         RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/fast/html/details-remove-summary-6-expected.txt
+++ b/LayoutTests/fast/html/details-remove-summary-6-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 72x19
             text run at (16,1) width 72: "summary 1"
         RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/fast/html/details-remove-summary-child-1-expected.txt
+++ b/LayoutTests/fast/html/details-remove-summary-child-1-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 64x19
             text run at (16,1) width 64: "summary "
           RenderText {#text} at (79,1) size 190x19

--- a/LayoutTests/fast/html/details-remove-summary-child-2-expected.txt
+++ b/LayoutTests/fast/html/details-remove-summary-child-2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 64x19
             text run at (16,1) width 64: "summary "
           RenderInline {SPAN} at (79,1) size 185x19

--- a/LayoutTests/fast/lists/004-expected.txt
+++ b/LayoutTests/fast/lists/004-expected.txt
@@ -8,7 +8,9 @@ layer at (0,0) size 800x600
           RenderTableRow {TR} at (0,0) size 50x20
             RenderTableCell {TD} at (0,0) size 16x20 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderListItem {LI} at (1,1) size 14x18
-                RenderListMarker at (-1,0) size 7x18: bullet
+                RenderInline (generated) at (-1,0) size 7x18
+                  RenderText at (-1,0) size 7x18
+                    text run at (-1,0) width 7: "\x{2022}"
                 RenderImage {IMG} at (14,14) size 0x0
             RenderTableCell {TD} at (16,0) size 34x20 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 32x18

--- a/LayoutTests/fast/lists/inline-before-content-after-list-marker-expected.txt
+++ b/LayoutTests/fast/lists/inline-before-content-after-list-marker-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x56
     RenderBody {BODY} at (8,8) size 784x40 [color=#008000]
       RenderListItem {LI} at (0,0) size 784x40
         RenderBlock (anonymous) at (0,0) size 784x40
-          RenderListMarker at (-1,0) size 13x40: bullet
+          RenderInline (generated) at (-1,0) size 13x40
+            RenderText at (-1,0) size 13x40
+              text run at (-1,0) width 13: "\x{2022}"
           RenderInline (generated) at (32,0) size 80x40
             RenderText at (32,0) size 80x40
               text run at (32,0) width 80: "PA"

--- a/LayoutTests/fast/repaint/list-marker-expected.txt
+++ b/LayoutTests/fast/repaint/list-marker-expected.txt
@@ -26,7 +26,9 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,86) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
           RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-1,0) size 7x18: bullet
+            RenderInline (generated) at (-1,0) size 7x18
+              RenderText at (-1,0) size 7x18
+                text run at (-1,0) width 7: "\x{2022}"
             RenderText {#text} at (14,0) size 21x18
               text run at (14,0) width 21: "bar"
           RenderBlock {DIV} at (10,28) size 724x0
@@ -40,7 +42,9 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,154) size 784x18
         RenderListItem {LI} at (0,0) size 744x18
           RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (738,0) size 7x18: bullet
+            RenderInline (generated) at (738,0) size 7x18
+              RenderText at (738,0) size 7x18
+                text run at (738,0) width 7 RTL: "\x{2022}"
             RenderText {#text} at (709,0) size 21x18
               text run at (709,0) width 21: "bar"
           RenderBlock {DIV} at (10,28) size 724x0

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/text-selection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/text-selection-expected.txt
@@ -6,6 +6,6 @@ PASS Selection ending in ::before
 PASS Selection contained in ::before
 PASS Selection ending in ::marker
 PASS Selection contained in ::marker
-FAIL Selection ending in ::before-marker assert_equals: toString expected "hello" but got "o"
-FAIL Selection contained in ::before-marker assert_equals: toString expected "" but got "llo"
+PASS Selection ending in ::before-marker
+PASS Selection contained in ::before-marker
 

--- a/LayoutTests/platform/glib/css1/classification/list_style-expected.txt
+++ b/LayoutTests/platform/glib/css1/classification/list_style-expected.txt
@@ -14,7 +14,9 @@ layer at (0,0) size 800x600
           text run at (496,15) width 0: " "
       RenderBlock {UL} at (0,95) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderListMarker at (0,0) size 20x18: "A"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "A. "
           RenderText {#text} at (0,0) size 730x36
             text run at (20,0) width 710: "The text in this item should not behave as expected; that is, it should line up with the capital-A on the left margin,"
             text run at (0,18) width 286: "leaving no blank space beneath the capital-A."
@@ -39,7 +41,9 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (12,26) size 770x113 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
               RenderBlock {UL} at (4,4) size 762x36
                 RenderListItem {LI} at (40,0) size 722x36
-                  RenderListMarker at (0,0) size 20x18: "A"
+                  RenderInline (generated) at (0,0) size 20x18
+                    RenderText at (0,0) size 20x18
+                      text run at (0,0) width 20: "A. "
                   RenderText {#text} at (0,0) size 679x36
                     text run at (20,0) width 659: "The text in this item should not behave as expected; that is, it should line up with the capital-A on the left"
                     text run at (0,18) width 338: "margin, leaving no blank space beneath the capital-A."

--- a/LayoutTests/platform/glib/css1/classification/list_style_position-expected.txt
+++ b/LayoutTests/platform/glib/css1/classification/list_style_position-expected.txt
@@ -21,7 +21,9 @@ layer at (0,0) size 800x600
             text run at (0,18) width 154: "space beneath the bullet."
       RenderBlock {UL} at (0,162) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderListMarker at (-1,0) size 7x18: bullet
+          RenderInline (generated) at (-1,0) size 7x18
+            RenderText at (-1,0) size 7x18
+              text run at (-1,0) width 7: "\x{2022}"
           RenderText {#text} at (0,0) size 702x36
             text run at (14,0) width 688: "The text in this item should not behave as expected; that is, it should line up with the bullet on the left margin,"
             text run at (0,18) width 263: "leaving no blank space beneath the bullet."
@@ -45,7 +47,9 @@ layer at (0,0) size 800x600
                     text run at (0,18) width 193: "blank space beneath the bullet."
               RenderBlock {UL} at (4,56) size 762x36
                 RenderListItem {LI} at (40,0) size 722x36
-                  RenderListMarker at (-1,0) size 7x18: bullet
+                  RenderInline (generated) at (-1,0) size 7x18
+                    RenderText at (-1,0) size 7x18
+                      text run at (-1,0) width 7: "\x{2022}"
                   RenderText {#text} at (0,0) size 702x36
                     text run at (14,0) width 688: "The text in this item should not behave as expected; that is, it should line up with the bullet on the left margin,"
                     text run at (0,18) width 263: "leaving no blank space beneath the bullet."

--- a/LayoutTests/platform/glib/css2.1/t1205-c561-list-displ-00-b-expected.txt
+++ b/LayoutTests/platform/glib/css2.1/t1205-c561-list-displ-00-b-expected.txt
@@ -7,7 +7,9 @@ layer at (0,0) size 800x202
         RenderText {#text} at (0,0) size 756x18
           text run at (0,0) width 756: "There should be eight numbered lines below, all identical except for the numbering, which should match the description."
       RenderListItem {DIV} at (0,34) size 784x18 [color=#000080]
-        RenderListMarker at (0,0) size 16x18: "1"
+        RenderInline (generated) at (0,0) size 16x18
+          RenderText at (0,0) size 16x18
+            text run at (0,0) width 16: "1. "
         RenderText {#text} at (16,0) size 151x18
           text run at (16,0) width 151: "This should be line one."
       RenderBlock {DIV} at (0,52) size 784x18 [color=#000080]

--- a/LayoutTests/platform/glib/css2.1/t1205-c565-list-pos-00-b-expected.txt
+++ b/LayoutTests/platform/glib/css2.1/t1205-c565-list-pos-00-b-expected.txt
@@ -16,7 +16,9 @@ layer at (0,0) size 800x96
             text run at (12,0) width 30: " Test"
       RenderBlock {OL} at (80,53) size 160x19 [color=#000080] [bgcolor=#000080]
         RenderListItem {LI} at (0,0) size 160x18
-          RenderListMarker at (0,0) size 16x18: "1"
+          RenderInline (generated) at (0,0) size 16x18
+            RenderText at (0,0) size 16x18
+              text run at (0,0) width 16: "1. "
           RenderInline {SPAN} at (16,0) size 26x18 [color=#FFFFFF]
             RenderText {#text} at (16,0) size 26x18
               text run at (16,0) width 26: "Test"

--- a/LayoutTests/platform/glib/css2.1/t1205-c566-list-stl-00-e-ag-expected.txt
+++ b/LayoutTests/platform/glib/css2.1/t1205-c566-list-stl-00-e-ag-expected.txt
@@ -8,7 +8,9 @@ layer at (0,0) size 800x116
           text run at (0,0) width 192: "There should be no red below."
       RenderBlock {UL} at (75,34) size 96x51 [color=#00FF00] [bgcolor=#FF0000] [border: (3px solid #000000)]
         RenderListItem {LI} at (3,3) size 90x45
-          RenderListMarker at (0,0) size 45x15: "A"
+          RenderInline (generated) at (0,0) size 45x15
+            RenderText at (0,0) size 45x15
+              text run at (0,0) width 45: "A. "
           RenderText {#text} at (0,0) size 90x45
             text run at (45,0) width 45: "x x"
             text run at (0,15) width 75: "xx xx"

--- a/LayoutTests/platform/glib/fast/css-generated-content/details-summary-before-after-expected.txt
+++ b/LayoutTests/platform/glib/fast/css-generated-content/details-summary-before-after-expected.txt
@@ -10,7 +10,9 @@ layer at (0,0) size 800x130
               text run at (0,0) width 40: "before"
         RenderListItem {SUMMARY} at (1,19) size 782x58 [border: (1px solid #000000)]
           RenderBlock (anonymous) at (1,1) size 780x18
-            RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+            RenderInline (generated) at (0,0) size 20x18
+              RenderText at (0,0) size 20x18
+                text run at (0,0) width 20: "\x{25BC} "
             RenderInline (generated) at (20,0) size 40x18
               RenderText at (20,0) size 40x18
                 text run at (20,0) width 40: "before"

--- a/LayoutTests/platform/glib/fast/css/001-expected.txt
+++ b/LayoutTests/platform/glib/fast/css/001-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
       RenderBlock {UL} at (0,0) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderListMarker at (-1,0) size 7x18: bullet
+          RenderInline (generated) at (-1,0) size 7x18
+            RenderText at (-1,0) size 7x18
+              text run at (-1,0) width 7: "\x{2022}"
           RenderText {#text} at (14,0) size 264x18
             text run at (14,0) width 264: "This list item should have an inside bullet."
           RenderBR {BR} at (278,0) size 0x18

--- a/LayoutTests/platform/glib/fast/html/details-add-child-1-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-add-child-1-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x36
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 58x18
             text run at (20,0) width 58: "summary"
         RenderBlock {SLOT} at (0,18) size 784x18

--- a/LayoutTests/platform/glib/fast/html/details-add-child-2-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-add-child-2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x36
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 58x18
             text run at (20,0) width 58: "summary"
         RenderBlock {SLOT} at (0,18) size 784x18

--- a/LayoutTests/platform/glib/fast/html/details-add-details-child-1-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-add-details-child-1-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x36
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 58x18
             text run at (20,0) width 58: "summary"
         RenderBlock {SLOT} at (0,18) size 784x18

--- a/LayoutTests/platform/glib/fast/html/details-add-details-child-2-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-add-details-child-2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x36
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 58x18
             text run at (20,0) width 58: "summary"
         RenderBlock {SLOT} at (0,18) size 784x18

--- a/LayoutTests/platform/glib/fast/html/details-add-summary-1-and-click-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-add-summary-1-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x18
         RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 39x18
             text run at (20,0) width 39: "new 1"
         RenderBlock {SLOT} at (0,18) size 800x0

--- a/LayoutTests/platform/glib/fast/html/details-add-summary-10-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-add-summary-10-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x36
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 39x18
             text run at (20,0) width 39: "new 1"
         RenderBlock {SLOT} at (0,18) size 784x18

--- a/LayoutTests/platform/glib/fast/html/details-add-summary-2-and-click-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-add-summary-2-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x36
         RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 39x18
             text run at (20,0) width 39: "new 1"
         RenderBlock {SLOT} at (0,18) size 800x18

--- a/LayoutTests/platform/glib/fast/html/details-add-summary-3-and-click-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-add-summary-3-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x36
         RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 39x18
             text run at (20,0) width 39: "new 2"
         RenderBlock {SLOT} at (0,18) size 800x18

--- a/LayoutTests/platform/glib/fast/html/details-add-summary-4-and-click-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-add-summary-4-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x36
         RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 58x18
             text run at (20,0) width 58: "summary"
         RenderBlock {SLOT} at (0,18) size 800x18

--- a/LayoutTests/platform/glib/fast/html/details-add-summary-5-and-click-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-add-summary-5-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x36
         RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 39x18
             text run at (20,0) width 39: "new 1"
         RenderBlock {SLOT} at (0,18) size 800x18

--- a/LayoutTests/platform/glib/fast/html/details-add-summary-6-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-add-summary-6-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x18
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 39x18
             text run at (20,0) width 39: "new 1"
         RenderBlock {SLOT} at (0,18) size 784x0

--- a/LayoutTests/platform/glib/fast/html/details-add-summary-7-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-add-summary-7-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x36
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 39x18
             text run at (20,0) width 39: "new 1"
         RenderBlock {SLOT} at (0,18) size 784x18

--- a/LayoutTests/platform/glib/fast/html/details-add-summary-8-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-add-summary-8-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x36
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 39x18
             text run at (20,0) width 39: "new 2"
         RenderBlock {SLOT} at (0,18) size 784x18

--- a/LayoutTests/platform/glib/fast/html/details-add-summary-9-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-add-summary-9-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x36
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 58x18
             text run at (20,0) width 58: "summary"
         RenderBlock {SLOT} at (0,18) size 784x18

--- a/LayoutTests/platform/glib/fast/html/details-add-summary-child-1-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-add-summary-child-1-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x18
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 62x18
             text run at (20,0) width 62: "summary "
           RenderInline {B} at (82,0) size 142x18

--- a/LayoutTests/platform/glib/fast/html/details-add-summary-child-2-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-add-summary-child-2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x18
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 62x18
             text run at (20,0) width 62: "summary "
           RenderInline {SPAN} at (82,0) size 142x18

--- a/LayoutTests/platform/glib/fast/html/details-marker-style-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-marker-style-expected.txt
@@ -1,29 +1,37 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x322
-  RenderBlock {HTML} at (0,0) size 800x322
-    RenderBody {BODY} at (8,8) size 784x306
-      RenderBlock {DIV} at (0,0) size 784x28
-        RenderBlock {DETAILS} at (0,0) size 784x28
-          RenderListItem {SUMMARY} at (0,0) size 784x28
-            RenderListMarker at (0,1) size 25x26: "\x{25B6}"
-            RenderText {#text} at (25,1) size 94x26
+layer at (0,0) size 800x323
+  RenderBlock {HTML} at (0,0) size 800x323
+    RenderBody {BODY} at (8,8) size 784x307
+      RenderBlock {DIV} at (0,0) size 784x29
+        RenderBlock {DETAILS} at (0,0) size 784x29
+          RenderListItem {SUMMARY} at (0,0) size 784x29
+            RenderInline (generated) at (0,0) size 25x28
+              RenderText at (0,0) size 25x28
+                text run at (0,0) width 25: "\x{25B6} "
+            RenderText {#text} at (25,1) size 94x27
               text run at (25,1) width 94: "Summary"
-      RenderBlock {DIV} at (0,28) size 27x125
-        RenderBlock {DETAILS} at (0,0) size 27x125
-          RenderListItem {SUMMARY} at (0,0) size 27x125
-            RenderListMarker at (0,0) size 27x31: "\x{25BC}"
-            RenderText {#text} at (0,31) size 27x94
-              text run at (0,31) width 95: "Summary"
-      RenderBlock {DIV} at (0,153) size 784x28
-        RenderBlock {DETAILS} at (0,0) size 784x28
-          RenderListItem {SUMMARY} at (0,0) size 784x28
-            RenderListMarker at (0,1) size 25x26: "\x{25B6}"
-            RenderText {#text} at (25,1) size 94x26
+      RenderBlock {DIV} at (0,28) size 28x126
+        RenderBlock {DETAILS} at (0,0) size 28x125
+          RenderListItem {SUMMARY} at (0,0) size 28x125
+            RenderInline (generated) at (0,0) size 28x31
+              RenderText at (0,0) size 28x31
+                text run at (0,0) width 32: "\x{25BC} "
+            RenderText {#text} at (1,31) size 27x94
+              text run at (1,31) width 95: "Summary"
+      RenderBlock {DIV} at (0,153) size 784x29
+        RenderBlock {DETAILS} at (0,0) size 784x29
+          RenderListItem {SUMMARY} at (0,0) size 784x29
+            RenderInline (generated) at (0,0) size 25x28
+              RenderText at (0,0) size 25x28
+                text run at (0,0) width 25: "\x{25B6} "
+            RenderText {#text} at (25,1) size 94x27
               text run at (25,1) width 94: "Summary"
-      RenderBlock {DIV} at (0,181) size 27x125
-        RenderBlock {DETAILS} at (0,0) size 27x125
-          RenderListItem {SUMMARY} at (0,0) size 27x125
-            RenderListMarker at (0,0) size 27x31: "\x{25BC}"
-            RenderText {#text} at (0,31) size 27x94
-              text run at (0,31) width 95: "Summary"
+      RenderBlock {DIV} at (0,182) size 28x125
+        RenderBlock {DETAILS} at (0,0) size 28x125
+          RenderListItem {SUMMARY} at (0,0) size 28x125
+            RenderInline (generated) at (0,0) size 28x31
+              RenderText at (0,0) size 28x31
+                text run at (0,0) width 32: "\x{25BC} "
+            RenderText {#text} at (1,31) size 27x94
+              text run at (1,31) width 95: "Summary"

--- a/LayoutTests/platform/glib/fast/html/details-marker-style-mixed-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-marker-style-mixed-expected.txt
@@ -1,29 +1,37 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x322
-  RenderBlock {HTML} at (0,0) size 800x322
-    RenderBody {BODY} at (8,8) size 784x306
-      RenderBlock {DIV} at (0,0) size 784x28
-        RenderBlock {DETAILS} at (0,0) size 784x28
-          RenderListItem {SUMMARY} at (0,0) size 784x28
-            RenderListMarker at (0,1) size 25x26: "\x{25B6}"
-            RenderText {#text} at (25,1) size 94x26
+layer at (0,0) size 800x323
+  RenderBlock {HTML} at (0,0) size 800x323
+    RenderBody {BODY} at (8,8) size 784x307
+      RenderBlock {DIV} at (0,0) size 784x29
+        RenderBlock {DETAILS} at (0,0) size 784x29
+          RenderListItem {SUMMARY} at (0,0) size 784x29
+            RenderInline (generated) at (0,0) size 25x28
+              RenderText at (0,0) size 25x28
+                text run at (0,0) width 25: "\x{25B6} "
+            RenderText {#text} at (25,1) size 94x27
               text run at (25,1) width 94: "Summary"
-      RenderBlock {DIV} at (0,28) size 27x125
-        RenderBlock {DETAILS} at (0,0) size 27x125
-          RenderListItem {SUMMARY} at (0,0) size 27x125
-            RenderListMarker at (0,0) size 27x31: "\x{25BC}"
-            RenderText {#text} at (0,31) size 27x94
-              text run at (0,31) width 95: "Summary"
-      RenderBlock {DIV} at (0,153) size 784x28
-        RenderBlock {DETAILS} at (0,0) size 784x28
-          RenderListItem {SUMMARY} at (0,0) size 784x28
-            RenderListMarker at (0,1) size 25x26: "\x{25B6}"
-            RenderText {#text} at (25,1) size 94x26
+      RenderBlock {DIV} at (0,28) size 28x126
+        RenderBlock {DETAILS} at (0,0) size 28x125
+          RenderListItem {SUMMARY} at (0,0) size 28x125
+            RenderInline (generated) at (0,0) size 28x31
+              RenderText at (0,0) size 28x31
+                text run at (0,0) width 32: "\x{25BC} "
+            RenderText {#text} at (1,31) size 26x94
+              text run at (1,31) width 94: "Summary"
+      RenderBlock {DIV} at (0,153) size 784x29
+        RenderBlock {DETAILS} at (0,0) size 784x29
+          RenderListItem {SUMMARY} at (0,0) size 784x29
+            RenderInline (generated) at (0,0) size 25x28
+              RenderText at (0,0) size 25x28
+                text run at (0,0) width 25: "\x{25B6} "
+            RenderText {#text} at (25,1) size 94x27
               text run at (25,1) width 94: "Summary"
-      RenderBlock {DIV} at (0,181) size 27x125
-        RenderBlock {DETAILS} at (0,0) size 27x125
-          RenderListItem {SUMMARY} at (0,0) size 27x125
-            RenderListMarker at (0,0) size 27x31: "\x{25BC}"
-            RenderText {#text} at (0,31) size 27x94
-              text run at (0,31) width 95: "Summary"
+      RenderBlock {DIV} at (0,182) size 28x125
+        RenderBlock {DETAILS} at (0,0) size 28x125
+          RenderListItem {SUMMARY} at (0,0) size 28x125
+            RenderInline (generated) at (0,0) size 28x31
+              RenderText at (0,0) size 28x31
+                text run at (0,0) width 32: "\x{25BC} "
+            RenderText {#text} at (1,31) size 26x94
+              text run at (1,31) width 94: "Summary"

--- a/LayoutTests/platform/glib/fast/html/details-nested-1-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-nested-1-expected.txt
@@ -6,12 +6,16 @@ layer at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 784x136 [border: (8px solid #555599)]
         RenderListItem {SUMMARY} at (8,8) size 768x102 [border: (8px solid #9999CC)]
           RenderBlock (anonymous) at (8,8) size 752x18
-            RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+            RenderInline (generated) at (0,0) size 20x18
+              RenderText at (0,0) size 20x18
+                text run at (0,0) width 20: "\x{25BC} "
             RenderText {#text} at (20,0) size 58x18
               text run at (20,0) width 58: "summary"
           RenderBlock {DETAILS} at (8,26) size 752x68 [border: (8px solid #995555)]
             RenderListItem {SUMMARY} at (8,8) size 736x34 [border: (8px solid #CC9999)]
-              RenderListMarker at (8,8) size 20x18: "\x{25BC}"
+              RenderInline (generated) at (8,8) size 20x18
+                RenderText at (8,8) size 20x18
+                  text run at (8,8) width 20: "\x{25BC} "
               RenderText {#text} at (28,8) size 278x18
                 text run at (28,8) width 278: "nested summary (summary-deails-summary)"
             RenderBlock {SLOT} at (8,42) size 736x18

--- a/LayoutTests/platform/glib/fast/html/details-nested-2-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-nested-2-expected.txt
@@ -5,13 +5,17 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x136 [border: (8px solid #555599)]
         RenderListItem {SUMMARY} at (8,8) size 768x34 [border: (8px solid #9999CC)]
-          RenderListMarker at (8,8) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (8,8) size 20x18
+            RenderText at (8,8) size 20x18
+              text run at (8,8) width 20: "\x{25BC} "
           RenderText {#text} at (28,8) size 58x18
             text run at (28,8) width 58: "summary"
         RenderBlock {SLOT} at (8,42) size 768x86
           RenderBlock {DETAILS} at (0,0) size 768x68 [border: (8px solid #995555)]
             RenderListItem {SUMMARY} at (8,8) size 752x34 [border: (8px solid #CC9999)]
-              RenderListMarker at (8,8) size 20x18: "\x{25BC}"
+              RenderInline (generated) at (8,8) size 20x18
+                RenderText at (8,8) size 20x18
+                  text run at (8,8) width 20: "\x{25BC} "
               RenderText {#text} at (28,8) size 260x18
                 text run at (28,8) width 260: "nested summary (details-deails-summary)"
             RenderBlock {SLOT} at (8,42) size 752x18

--- a/LayoutTests/platform/glib/fast/html/details-no-summary2-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-no-summary2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x18
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 44x18
             text run at (20,0) width 44: "Details"
         RenderBlock {SLOT} at (0,18) size 784x0

--- a/LayoutTests/platform/glib/fast/html/details-open6-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-open6-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x18
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 58x18
             text run at (20,0) width 58: "summary"
         RenderBlock {SLOT} at (0,18) size 784x0

--- a/LayoutTests/platform/glib/fast/html/details-remove-child-1-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-remove-child-1-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x36
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 58x18
             text run at (20,0) width 58: "summary"
         RenderBlock {SLOT} at (0,18) size 784x18

--- a/LayoutTests/platform/glib/fast/html/details-remove-child-2-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-remove-child-2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x36
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 58x18
             text run at (20,0) width 58: "summary"
         RenderBlock {SLOT} at (0,18) size 784x18

--- a/LayoutTests/platform/glib/fast/html/details-remove-summary-1-and-click-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-remove-summary-1-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x18
         RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 44x18
             text run at (20,0) width 44: "Details"
         RenderBlock {SLOT} at (0,18) size 800x0

--- a/LayoutTests/platform/glib/fast/html/details-remove-summary-2-and-click-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-remove-summary-2-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x18
         RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 70x18
             text run at (20,0) width 70: "summary 2"
         RenderBlock {SLOT} at (0,18) size 800x0

--- a/LayoutTests/platform/glib/fast/html/details-remove-summary-3-and-click-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-remove-summary-3-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x18
         RenderListItem {SUMMARY} at (0,0) size 800x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 70x18
             text run at (20,0) width 70: "summary 1"
         RenderBlock {SLOT} at (0,18) size 800x0

--- a/LayoutTests/platform/glib/fast/html/details-remove-summary-4-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-remove-summary-4-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x18
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 44x18
             text run at (20,0) width 44: "Details"
         RenderBlock {SLOT} at (0,18) size 784x0

--- a/LayoutTests/platform/glib/fast/html/details-remove-summary-5-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-remove-summary-5-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x18
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 70x18
             text run at (20,0) width 70: "summary 2"
         RenderBlock {SLOT} at (0,18) size 784x0

--- a/LayoutTests/platform/glib/fast/html/details-remove-summary-6-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-remove-summary-6-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x18
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 70x18
             text run at (20,0) width 70: "summary 1"
         RenderBlock {SLOT} at (0,18) size 784x0

--- a/LayoutTests/platform/glib/fast/html/details-remove-summary-child-1-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-remove-summary-child-1-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x18
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 62x18
             text run at (20,0) width 62: "summary "
           RenderText {#text} at (82,0) size 186x18

--- a/LayoutTests/platform/glib/fast/html/details-remove-summary-child-2-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-remove-summary-child-2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x18
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 62x18
             text run at (20,0) width 62: "summary "
           RenderInline {SPAN} at (82,0) size 181x18

--- a/LayoutTests/platform/glib/fast/html/details-writing-mode-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-writing-mode-expected.txt
@@ -40,12 +40,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+                    RenderInline (generated) at (0,1) size 16x17
+                      RenderText at (0,1) size 16x17
+                        text run at (0,1) width 16: "\x{25B6} "
                     RenderText {#text} at (16,1) size 58x17
                       text run at (16,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+                    RenderInline (generated) at (0,0) size 20x18
+                      RenderText at (0,0) size 20x18
+                        text run at (0,0) width 20: "\x{25BC} "
                     RenderText {#text} at (20,0) size 58x18
                       text run at (20,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -53,12 +57,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+                    RenderInline (generated) at (0,1) size 16x17
+                      RenderText at (0,1) size 16x17
+                        text run at (0,1) width 16: "\x{25B6} "
                     RenderText {#text} at (16,1) size 58x17
                       text run at (16,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 20x18: "\x{25B2}"
+                    RenderInline (generated) at (0,0) size 20x18
+                      RenderText at (0,0) size 20x18
+                        text run at (0,0) width 20: "\x{25B2} "
                     RenderText {#text} at (20,0) size 58x18
                       text run at (20,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -66,12 +74,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x20: "\x{25BC}"
+                    RenderInline (generated) at (0,0) size 18x20
+                      RenderText at (0,0) size 18x20
+                        text run at (0,0) width 21: "\x{25BC} "
                     RenderText {#text} at (0,20) size 18x58
                       text run at (0,20) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (1,0) size 17x16: "\x{25B6}"
+                    RenderInline (generated) at (1,0) size 17x16
+                      RenderText at (1,0) size 17x16
+                        text run at (1,0) width 16: "\x{25B6} "
                     RenderText {#text} at (1,16) size 17x58
                       text run at (1,16) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -79,12 +91,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x20: "\x{25BC}"
+                    RenderInline (generated) at (0,0) size 18x20
+                      RenderText at (0,0) size 18x20
+                        text run at (0,0) width 21: "\x{25BC} "
                     RenderText {#text} at (0,20) size 18x58
                       text run at (0,20) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (1,0) size 17x16: "\x{25C0}"
+                    RenderInline (generated) at (1,0) size 17x16
+                      RenderText at (1,0) size 17x16
+                        text run at (1,0) width 16: "\x{25C0} "
                     RenderText {#text} at (1,16) size 17x58
                       text run at (1,16) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -96,20 +112,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (104,1) size 16x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,-1) size 16x19
-                        RenderText at (0,1) size 16x17
-                          text run at (0,1) width 4 RTL: " "
-                          text run at (4,1) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (104,1) size 16x17
+                      RenderText at (104,1) size 16x17
+                        text run at (104,1) width 4 RTL: " "
+                        text run at (108,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (46,1) size 58x17
                       text run at (46,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x18
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderInline (generated) at (100,0) size 20x18
+                      RenderText at (100,0) size 20x18
+                        text run at (100,0) width 4 RTL: " "
+                        text run at (104,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (42,0) size 58x18
                       text run at (42,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -117,20 +131,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (104,1) size 16x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,10) size 16x19
-                        RenderText at (0,1) size 16x17
-                          text run at (0,1) width 4 RTL: " "
-                          text run at (4,1) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (104,1) size 16x17
+                      RenderText at (104,1) size 16x17
+                        text run at (104,1) width 4 RTL: " "
+                        text run at (108,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (46,1) size 58x17
                       text run at (46,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderInline (generated) at (100,0) size 20x18
+                      RenderText at (100,0) size 20x18
+                        text run at (100,0) width 4 RTL: " "
+                        text run at (104,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (42,0) size 58x18
                       text run at (42,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -138,20 +150,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (10,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderInline (generated) at (0,100) size 18x20
+                      RenderText at (0,100) size 18x20
+                        text run at (0,100) width 5 RTL: " "
+                        text run at (0,104) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,42) size 18x58
                       text run at (0,42) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (1,104) size 17x16: "\x{25B6}"
-                      RenderBlock (generated) at (10,0) size 19x16
-                        RenderText at (1,0) size 17x16
-                          text run at (1,0) width 4 RTL: " "
-                          text run at (1,4) width 12 RTL: "\x{25B6}"
+                    RenderInline (generated) at (1,104) size 17x16
+                      RenderText at (1,104) size 17x16
+                        text run at (1,104) width 4 RTL: " "
+                        text run at (1,108) width 12 RTL: "\x{25B6}"
                     RenderText {#text} at (1,46) size 17x58
                       text run at (1,46) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -159,20 +169,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderInline (generated) at (0,100) size 18x20
+                      RenderText at (0,100) size 18x20
+                        text run at (0,100) width 5 RTL: " "
+                        text run at (0,104) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,42) size 18x58
                       text run at (0,42) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (1,104) size 17x16: "\x{25C0}"
-                      RenderBlock (generated) at (-1,0) size 19x16
-                        RenderText at (1,0) size 17x16
-                          text run at (1,0) width 4 RTL: " "
-                          text run at (1,4) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (1,104) size 17x16
+                      RenderText at (1,104) size 17x16
+                        text run at (1,104) width 4 RTL: " "
+                        text run at (1,108) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (1,46) size 17x58
                       text run at (1,46) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -215,12 +223,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+                    RenderInline (generated) at (0,1) size 16x17
+                      RenderText at (0,1) size 16x17
+                        text run at (0,1) width 16: "\x{25B6} "
                     RenderText {#text} at (16,1) size 58x17
                       text run at (16,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+                    RenderInline (generated) at (0,0) size 20x18
+                      RenderText at (0,0) size 20x18
+                        text run at (0,0) width 20: "\x{25BC} "
                     RenderText {#text} at (20,0) size 58x18
                       text run at (20,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -228,12 +240,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+                    RenderInline (generated) at (0,1) size 16x17
+                      RenderText at (0,1) size 16x17
+                        text run at (0,1) width 16: "\x{25B6} "
                     RenderText {#text} at (16,1) size 58x17
                       text run at (16,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 20x18: "\x{25B2}"
+                    RenderInline (generated) at (0,0) size 20x18
+                      RenderText at (0,0) size 20x18
+                        text run at (0,0) width 20: "\x{25B2} "
                     RenderText {#text} at (20,0) size 58x18
                       text run at (20,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -241,12 +257,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x20: "\x{25BC}"
+                    RenderInline (generated) at (0,0) size 18x20
+                      RenderText at (0,0) size 18x20
+                        text run at (0,0) width 21: "\x{25BC} "
                     RenderText {#text} at (0,20) size 18x58
                       text run at (0,20) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (1,0) size 17x16: "\x{25B6}"
+                    RenderInline (generated) at (1,0) size 17x16
+                      RenderText at (1,0) size 17x16
+                        text run at (1,0) width 16: "\x{25B6} "
                     RenderText {#text} at (1,16) size 17x58
                       text run at (1,16) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -254,12 +274,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x20: "\x{25BC}"
+                    RenderInline (generated) at (0,0) size 18x20
+                      RenderText at (0,0) size 18x20
+                        text run at (0,0) width 21: "\x{25BC} "
                     RenderText {#text} at (0,20) size 18x58
                       text run at (0,20) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (1,0) size 17x16: "\x{25C0}"
+                    RenderInline (generated) at (1,0) size 17x16
+                      RenderText at (1,0) size 17x16
+                        text run at (1,0) width 16: "\x{25C0} "
                     RenderText {#text} at (1,16) size 17x58
                       text run at (1,16) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -271,20 +295,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (58,1) size 16x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,-1) size 16x19
-                        RenderText at (0,1) size 16x17
-                          text run at (0,1) width 4 RTL: " "
-                          text run at (4,1) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (58,1) size 16x17
+                      RenderText at (58,1) size 16x17
+                        text run at (58,1) width 4 RTL: " "
+                        text run at (62,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (0,1) size 58x17
                       text run at (0,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (58,0) size 20x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x18
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderInline (generated) at (58,0) size 20x18
+                      RenderText at (58,0) size 20x18
+                        text run at (58,0) width 4 RTL: " "
+                        text run at (62,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (0,0) size 58x18
                       text run at (0,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -292,20 +314,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (58,1) size 16x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,10) size 16x19
-                        RenderText at (0,1) size 16x17
-                          text run at (0,1) width 4 RTL: " "
-                          text run at (4,1) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (58,1) size 16x17
+                      RenderText at (58,1) size 16x17
+                        text run at (58,1) width 4 RTL: " "
+                        text run at (62,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (0,1) size 58x17
                       text run at (0,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (58,0) size 20x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderInline (generated) at (58,0) size 20x18
+                      RenderText at (58,0) size 20x18
+                        text run at (58,0) width 4 RTL: " "
+                        text run at (62,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 58x18
                       text run at (0,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -313,20 +333,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,58) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (10,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderInline (generated) at (0,58) size 18x20
+                      RenderText at (0,58) size 18x20
+                        text run at (0,58) width 5 RTL: " "
+                        text run at (0,62) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x58
                       text run at (0,0) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (1,58) size 17x16: "\x{25B6}"
-                      RenderBlock (generated) at (10,0) size 19x16
-                        RenderText at (1,0) size 17x16
-                          text run at (1,0) width 4 RTL: " "
-                          text run at (1,4) width 12 RTL: "\x{25B6}"
+                    RenderInline (generated) at (1,58) size 17x16
+                      RenderText at (1,58) size 17x16
+                        text run at (1,58) width 4 RTL: " "
+                        text run at (1,62) width 12 RTL: "\x{25B6}"
                     RenderText {#text} at (1,0) size 17x58
                       text run at (1,0) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -334,20 +352,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,58) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderInline (generated) at (0,58) size 18x20
+                      RenderText at (0,58) size 18x20
+                        text run at (0,58) width 5 RTL: " "
+                        text run at (0,62) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x58
                       text run at (0,0) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (1,58) size 17x16: "\x{25C0}"
-                      RenderBlock (generated) at (-1,0) size 19x16
-                        RenderText at (1,0) size 17x16
-                          text run at (1,0) width 4 RTL: " "
-                          text run at (1,4) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (1,58) size 17x16
+                      RenderText at (1,58) size 17x16
+                        text run at (1,58) width 4 RTL: " "
+                        text run at (1,62) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (1,0) size 17x58
                       text run at (1,0) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -390,12 +406,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (23,1) size 16x17: "\x{25B6}"
+                    RenderInline (generated) at (23,1) size 16x17
+                      RenderText at (23,1) size 16x17
+                        text run at (23,1) width 16: "\x{25B6} "
                     RenderText {#text} at (39,1) size 58x17
                       text run at (39,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (21,0) size 20x18: "\x{25BC}"
+                    RenderInline (generated) at (21,0) size 20x18
+                      RenderText at (21,0) size 20x18
+                        text run at (21,0) width 20: "\x{25BC} "
                     RenderText {#text} at (41,0) size 58x18
                       text run at (41,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -403,12 +423,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (23,1) size 16x17: "\x{25B6}"
+                    RenderInline (generated) at (23,1) size 16x17
+                      RenderText at (23,1) size 16x17
+                        text run at (23,1) width 16: "\x{25B6} "
                     RenderText {#text} at (39,1) size 58x17
                       text run at (39,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (21,0) size 20x18: "\x{25B2}"
+                    RenderInline (generated) at (21,0) size 20x18
+                      RenderText at (21,0) size 20x18
+                        text run at (21,0) width 20: "\x{25B2} "
                     RenderText {#text} at (41,0) size 58x18
                       text run at (41,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -416,12 +440,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,21) size 18x20: "\x{25BC}"
+                    RenderInline (generated) at (0,21) size 18x20
+                      RenderText at (0,21) size 18x20
+                        text run at (0,21) width 21: "\x{25BC} "
                     RenderText {#text} at (0,41) size 18x58
                       text run at (0,41) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (1,23) size 17x16: "\x{25B6}"
+                    RenderInline (generated) at (1,23) size 17x16
+                      RenderText at (1,23) size 17x16
+                        text run at (1,23) width 16: "\x{25B6} "
                     RenderText {#text} at (1,39) size 17x58
                       text run at (1,39) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -429,12 +457,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,21) size 18x20: "\x{25BC}"
+                    RenderInline (generated) at (0,21) size 18x20
+                      RenderText at (0,21) size 18x20
+                        text run at (0,21) width 21: "\x{25BC} "
                     RenderText {#text} at (0,41) size 18x58
                       text run at (0,41) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (1,23) size 17x16: "\x{25C0}"
+                    RenderInline (generated) at (1,23) size 17x16
+                      RenderText at (1,23) size 17x16
+                        text run at (1,23) width 16: "\x{25C0} "
                     RenderText {#text} at (1,39) size 17x58
                       text run at (1,39) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -446,20 +478,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (81,1) size 16x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,-1) size 16x19
-                        RenderText at (0,1) size 16x17
-                          text run at (0,1) width 4 RTL: " "
-                          text run at (4,1) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (81,1) size 16x17
+                      RenderText at (81,1) size 16x17
+                        text run at (81,1) width 4 RTL: " "
+                        text run at (85,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (23,1) size 58x17
                       text run at (23,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (79,0) size 20x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x18
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderInline (generated) at (79,0) size 20x18
+                      RenderText at (79,0) size 20x18
+                        text run at (79,0) width 4 RTL: " "
+                        text run at (83,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (21,0) size 58x18
                       text run at (21,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -467,20 +497,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (81,1) size 16x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,10) size 16x19
-                        RenderText at (0,1) size 16x17
-                          text run at (0,1) width 4 RTL: " "
-                          text run at (4,1) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (81,1) size 16x17
+                      RenderText at (81,1) size 16x17
+                        text run at (81,1) width 4 RTL: " "
+                        text run at (85,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (23,1) size 58x17
                       text run at (23,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (79,0) size 20x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderInline (generated) at (79,0) size 20x18
+                      RenderText at (79,0) size 20x18
+                        text run at (79,0) width 4 RTL: " "
+                        text run at (83,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (21,0) size 58x18
                       text run at (21,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -488,20 +516,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,79) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (10,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderInline (generated) at (0,79) size 18x20
+                      RenderText at (0,79) size 18x20
+                        text run at (0,79) width 5 RTL: " "
+                        text run at (0,83) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,21) size 18x58
                       text run at (0,21) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (1,81) size 17x16: "\x{25B6}"
-                      RenderBlock (generated) at (10,0) size 19x16
-                        RenderText at (1,0) size 17x16
-                          text run at (1,0) width 4 RTL: " "
-                          text run at (1,4) width 12 RTL: "\x{25B6}"
+                    RenderInline (generated) at (1,81) size 17x16
+                      RenderText at (1,81) size 17x16
+                        text run at (1,81) width 4 RTL: " "
+                        text run at (1,85) width 12 RTL: "\x{25B6}"
                     RenderText {#text} at (1,23) size 17x58
                       text run at (1,23) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -509,20 +535,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,79) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderInline (generated) at (0,79) size 18x20
+                      RenderText at (0,79) size 18x20
+                        text run at (0,79) width 5 RTL: " "
+                        text run at (0,83) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,21) size 18x58
                       text run at (0,21) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (1,81) size 17x16: "\x{25C0}"
-                      RenderBlock (generated) at (-1,0) size 19x16
-                        RenderText at (1,0) size 17x16
-                          text run at (1,0) width 4 RTL: " "
-                          text run at (1,4) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (1,81) size 17x16
+                      RenderText at (1,81) size 17x16
+                        text run at (1,81) width 4 RTL: " "
+                        text run at (1,85) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (1,23) size 17x58
                       text run at (1,23) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -565,12 +589,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (46,1) size 16x17: "\x{25B6}"
+                    RenderInline (generated) at (46,1) size 16x17
+                      RenderText at (46,1) size 16x17
+                        text run at (46,1) width 16: "\x{25B6} "
                     RenderText {#text} at (62,1) size 58x17
                       text run at (62,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (42,0) size 20x18: "\x{25BC}"
+                    RenderInline (generated) at (42,0) size 20x18
+                      RenderText at (42,0) size 20x18
+                        text run at (42,0) width 20: "\x{25BC} "
                     RenderText {#text} at (62,0) size 58x18
                       text run at (62,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -578,12 +606,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (46,1) size 16x17: "\x{25B6}"
+                    RenderInline (generated) at (46,1) size 16x17
+                      RenderText at (46,1) size 16x17
+                        text run at (46,1) width 16: "\x{25B6} "
                     RenderText {#text} at (62,1) size 58x17
                       text run at (62,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (42,0) size 20x18: "\x{25B2}"
+                    RenderInline (generated) at (42,0) size 20x18
+                      RenderText at (42,0) size 20x18
+                        text run at (42,0) width 20: "\x{25B2} "
                     RenderText {#text} at (62,0) size 58x18
                       text run at (62,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -591,12 +623,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,42) size 18x20: "\x{25BC}"
+                    RenderInline (generated) at (0,42) size 18x20
+                      RenderText at (0,42) size 18x20
+                        text run at (0,42) width 21: "\x{25BC} "
                     RenderText {#text} at (0,62) size 18x58
                       text run at (0,62) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (1,46) size 17x16: "\x{25B6}"
+                    RenderInline (generated) at (1,46) size 17x16
+                      RenderText at (1,46) size 17x16
+                        text run at (1,46) width 16: "\x{25B6} "
                     RenderText {#text} at (1,62) size 17x58
                       text run at (1,62) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -604,12 +640,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,42) size 18x20: "\x{25BC}"
+                    RenderInline (generated) at (0,42) size 18x20
+                      RenderText at (0,42) size 18x20
+                        text run at (0,42) width 21: "\x{25BC} "
                     RenderText {#text} at (0,62) size 18x58
                       text run at (0,62) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (1,46) size 17x16: "\x{25C0}"
+                    RenderInline (generated) at (1,46) size 17x16
+                      RenderText at (1,46) size 17x16
+                        text run at (1,46) width 16: "\x{25C0} "
                     RenderText {#text} at (1,62) size 17x58
                       text run at (1,62) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -621,20 +661,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (104,1) size 16x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,-1) size 16x19
-                        RenderText at (0,1) size 16x17
-                          text run at (0,1) width 4 RTL: " "
-                          text run at (4,1) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (104,1) size 16x17
+                      RenderText at (104,1) size 16x17
+                        text run at (104,1) width 4 RTL: " "
+                        text run at (108,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (46,1) size 58x17
                       text run at (46,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x18
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderInline (generated) at (100,0) size 20x18
+                      RenderText at (100,0) size 20x18
+                        text run at (100,0) width 4 RTL: " "
+                        text run at (104,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (42,0) size 58x18
                       text run at (42,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -642,20 +680,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (104,1) size 16x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,10) size 16x19
-                        RenderText at (0,1) size 16x17
-                          text run at (0,1) width 4 RTL: " "
-                          text run at (4,1) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (104,1) size 16x17
+                      RenderText at (104,1) size 16x17
+                        text run at (104,1) width 4 RTL: " "
+                        text run at (108,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (46,1) size 58x17
                       text run at (46,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderInline (generated) at (100,0) size 20x18
+                      RenderText at (100,0) size 20x18
+                        text run at (100,0) width 4 RTL: " "
+                        text run at (104,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (42,0) size 58x18
                       text run at (42,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -663,20 +699,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (10,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderInline (generated) at (0,100) size 18x20
+                      RenderText at (0,100) size 18x20
+                        text run at (0,100) width 5 RTL: " "
+                        text run at (0,104) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,42) size 18x58
                       text run at (0,42) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (1,104) size 17x16: "\x{25B6}"
-                      RenderBlock (generated) at (10,0) size 19x16
-                        RenderText at (1,0) size 17x16
-                          text run at (1,0) width 4 RTL: " "
-                          text run at (1,4) width 12 RTL: "\x{25B6}"
+                    RenderInline (generated) at (1,104) size 17x16
+                      RenderText at (1,104) size 17x16
+                        text run at (1,104) width 4 RTL: " "
+                        text run at (1,108) width 12 RTL: "\x{25B6}"
                     RenderText {#text} at (1,46) size 17x58
                       text run at (1,46) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -684,20 +718,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderInline (generated) at (0,100) size 18x20
+                      RenderText at (0,100) size 18x20
+                        text run at (0,100) width 5 RTL: " "
+                        text run at (0,104) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,42) size 18x58
                       text run at (0,42) width 59: "summary"
                 RenderBlock {DETAILS} at (18,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (1,104) size 17x16: "\x{25C0}"
-                      RenderBlock (generated) at (-1,0) size 19x16
-                        RenderText at (1,0) size 17x16
-                          text run at (1,0) width 4 RTL: " "
-                          text run at (1,4) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (1,104) size 17x16
+                      RenderText at (1,104) size 17x16
+                        text run at (1,104) width 4 RTL: " "
+                        text run at (1,108) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (1,46) size 17x58
                       text run at (1,46) width 58: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120

--- a/LayoutTests/platform/glib/fast/html/details-writing-mode-mixed-expected.txt
+++ b/LayoutTests/platform/glib/fast/html/details-writing-mode-mixed-expected.txt
@@ -40,12 +40,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+                    RenderInline (generated) at (0,1) size 16x17
+                      RenderText at (0,1) size 16x17
+                        text run at (0,1) width 16: "\x{25B6} "
                     RenderText {#text} at (16,1) size 58x17
                       text run at (16,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+                    RenderInline (generated) at (0,0) size 20x18
+                      RenderText at (0,0) size 20x18
+                        text run at (0,0) width 20: "\x{25BC} "
                     RenderText {#text} at (20,0) size 58x18
                       text run at (20,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -53,12 +57,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+                    RenderInline (generated) at (0,1) size 16x17
+                      RenderText at (0,1) size 16x17
+                        text run at (0,1) width 16: "\x{25B6} "
                     RenderText {#text} at (16,1) size 58x17
                       text run at (16,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 20x18: "\x{25B2}"
+                    RenderInline (generated) at (0,0) size 20x18
+                      RenderText at (0,0) size 20x18
+                        text run at (0,0) width 20: "\x{25B2} "
                     RenderText {#text} at (20,0) size 58x18
                       text run at (20,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -66,28 +74,36 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x20: "\x{25BC}"
+                    RenderInline (generated) at (0,0) size 18x20
+                      RenderText at (0,0) size 18x20
+                        text run at (0,0) width 21: "\x{25BC} "
                     RenderText {#text} at (0,20) size 18x58
                       text run at (0,20) width 59: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x16: "\x{25B6}"
-                    RenderText {#text} at (0,16) size 18x58
-                      text run at (0,16) width 59: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (18,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (1,0) size 17x16
+                      RenderText at (1,0) size 17x16
+                        text run at (1,0) width 16: "\x{25B6} "
+                    RenderText {#text} at (1,16) size 17x58
+                      text run at (1,16) width 58: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (483,98) size 125x124 [border: (1px solid #000000)] [r=3 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x20: "\x{25BC}"
+                    RenderInline (generated) at (0,0) size 18x20
+                      RenderText at (0,0) size 18x20
+                        text run at (0,0) width 21: "\x{25BC} "
                     RenderText {#text} at (0,20) size 18x58
                       text run at (0,20) width 59: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x16: "\x{25C0}"
-                    RenderText {#text} at (0,16) size 18x58
-                      text run at (0,16) width 59: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (18,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (1,0) size 17x16
+                      RenderText at (1,0) size 17x16
+                        text run at (1,0) width 16: "\x{25C0} "
+                    RenderText {#text} at (1,16) size 17x58
+                      text run at (1,16) width 58: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
           RenderTableRow {TR} at (0,224) size 610x124
             RenderTableCell {TH} at (75,271) size 29x30 [border: (1px inset #000000)] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (6,53) size 16x18
@@ -96,20 +112,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (104,1) size 16x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,-1) size 16x19
-                        RenderText at (0,1) size 16x17
-                          text run at (0,1) width 4 RTL: " "
-                          text run at (4,1) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (104,1) size 16x17
+                      RenderText at (104,1) size 16x17
+                        text run at (104,1) width 4 RTL: " "
+                        text run at (108,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (46,1) size 58x17
                       text run at (46,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x18
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderInline (generated) at (100,0) size 20x18
+                      RenderText at (100,0) size 20x18
+                        text run at (100,0) width 4 RTL: " "
+                        text run at (104,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (42,0) size 58x18
                       text run at (42,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -117,20 +131,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (104,1) size 16x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,10) size 16x19
-                        RenderText at (0,1) size 16x17
-                          text run at (0,1) width 4 RTL: " "
-                          text run at (4,1) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (104,1) size 16x17
+                      RenderText at (104,1) size 16x17
+                        text run at (104,1) width 4 RTL: " "
+                        text run at (108,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (46,1) size 58x17
                       text run at (46,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderInline (generated) at (100,0) size 20x18
+                      RenderText at (100,0) size 20x18
+                        text run at (100,0) width 4 RTL: " "
+                        text run at (104,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (42,0) size 58x18
                       text run at (42,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -138,44 +150,40 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderInline (generated) at (0,100) size 18x20
+                      RenderText at (0,100) size 18x20
+                        text run at (0,100) width 5 RTL: " "
+                        text run at (0,104) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,42) size 18x58
                       text run at (0,42) width 59: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,104) size 18x16: "\x{25B6}"
-                      RenderBlock (generated) at (-1,0) size 19x16
-                        RenderText at (1,0) size 17x16
-                          text run at (1,0) width 4 RTL: " "
-                          text run at (1,4) width 12 RTL: "\x{25B6}"
-                    RenderText {#text} at (0,46) size 18x58
-                      text run at (0,46) width 59: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (18,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (1,104) size 17x16
+                      RenderText at (1,104) size 17x16
+                        text run at (1,104) width 4 RTL: " "
+                        text run at (1,108) width 12 RTL: "\x{25B6}"
+                    RenderText {#text} at (1,46) size 17x58
+                      text run at (1,46) width 58: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (483,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderInline (generated) at (0,100) size 18x20
+                      RenderText at (0,100) size 18x20
+                        text run at (0,100) width 5 RTL: " "
+                        text run at (0,104) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,42) size 18x58
                       text run at (0,42) width 59: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,104) size 18x16: "\x{25C0}"
-                      RenderBlock (generated) at (-1,0) size 19x16
-                        RenderText at (1,0) size 17x16
-                          text run at (1,0) width 4 RTL: " "
-                          text run at (1,4) width 12 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,46) size 18x58
-                      text run at (0,46) width 59: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (18,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (1,104) size 17x16
+                      RenderText at (1,104) size 17x16
+                        text run at (1,104) width 4 RTL: " "
+                        text run at (1,108) width 12 RTL: "\x{25C0}"
+                    RenderText {#text} at (1,46) size 17x58
+                      text run at (1,46) width 58: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
       RenderBlock (anonymous) at (0,352) size 769x18
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,370) size 612x352 [border: (1px outset #000000)]
@@ -215,12 +223,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+                    RenderInline (generated) at (0,1) size 16x17
+                      RenderText at (0,1) size 16x17
+                        text run at (0,1) width 16: "\x{25B6} "
                     RenderText {#text} at (16,1) size 58x17
                       text run at (16,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+                    RenderInline (generated) at (0,0) size 20x18
+                      RenderText at (0,0) size 20x18
+                        text run at (0,0) width 20: "\x{25BC} "
                     RenderText {#text} at (20,0) size 58x18
                       text run at (20,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -228,12 +240,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+                    RenderInline (generated) at (0,1) size 16x17
+                      RenderText at (0,1) size 16x17
+                        text run at (0,1) width 16: "\x{25B6} "
                     RenderText {#text} at (16,1) size 58x17
                       text run at (16,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (0,0) size 20x18: "\x{25B2}"
+                    RenderInline (generated) at (0,0) size 20x18
+                      RenderText at (0,0) size 20x18
+                        text run at (0,0) width 20: "\x{25B2} "
                     RenderText {#text} at (20,0) size 58x18
                       text run at (20,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -241,28 +257,36 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x20: "\x{25BC}"
+                    RenderInline (generated) at (0,0) size 18x20
+                      RenderText at (0,0) size 18x20
+                        text run at (0,0) width 21: "\x{25BC} "
                     RenderText {#text} at (0,20) size 18x58
                       text run at (0,20) width 59: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x16: "\x{25B6}"
-                    RenderText {#text} at (0,16) size 18x58
-                      text run at (0,16) width 59: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (18,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (1,0) size 17x16
+                      RenderText at (1,0) size 17x16
+                        text run at (1,0) width 16: "\x{25B6} "
+                    RenderText {#text} at (1,16) size 17x58
+                      text run at (1,16) width 58: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (483,98) size 125x124 [border: (1px solid #000000)] [r=3 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x20: "\x{25BC}"
+                    RenderInline (generated) at (0,0) size 18x20
+                      RenderText at (0,0) size 18x20
+                        text run at (0,0) width 21: "\x{25BC} "
                     RenderText {#text} at (0,20) size 18x58
                       text run at (0,20) width 59: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x16: "\x{25C0}"
-                    RenderText {#text} at (0,16) size 18x58
-                      text run at (0,16) width 59: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (18,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (1,0) size 17x16
+                      RenderText at (1,0) size 17x16
+                        text run at (1,0) width 16: "\x{25C0} "
+                    RenderText {#text} at (1,16) size 17x58
+                      text run at (1,16) width 58: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
           RenderTableRow {TR} at (0,224) size 610x124
             RenderTableCell {TH} at (75,271) size 29x30 [border: (1px inset #000000)] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (6,53) size 16x18
@@ -271,20 +295,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (58,1) size 16x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,-1) size 16x19
-                        RenderText at (0,1) size 16x17
-                          text run at (0,1) width 4 RTL: " "
-                          text run at (4,1) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (58,1) size 16x17
+                      RenderText at (58,1) size 16x17
+                        text run at (58,1) width 4 RTL: " "
+                        text run at (62,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (0,1) size 58x17
                       text run at (0,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (58,0) size 20x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x18
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderInline (generated) at (58,0) size 20x18
+                      RenderText at (58,0) size 20x18
+                        text run at (58,0) width 4 RTL: " "
+                        text run at (62,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (0,0) size 58x18
                       text run at (0,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -292,20 +314,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (58,1) size 16x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,10) size 16x19
-                        RenderText at (0,1) size 16x17
-                          text run at (0,1) width 4 RTL: " "
-                          text run at (4,1) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (58,1) size 16x17
+                      RenderText at (58,1) size 16x17
+                        text run at (58,1) width 4 RTL: " "
+                        text run at (62,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (0,1) size 58x17
                       text run at (0,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (58,0) size 20x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderInline (generated) at (58,0) size 20x18
+                      RenderText at (58,0) size 20x18
+                        text run at (58,0) width 4 RTL: " "
+                        text run at (62,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 58x18
                       text run at (0,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -313,44 +333,40 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,58) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderInline (generated) at (0,58) size 18x20
+                      RenderText at (0,58) size 18x20
+                        text run at (0,58) width 5 RTL: " "
+                        text run at (0,62) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x58
                       text run at (0,0) width 59: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,58) size 18x16: "\x{25B6}"
-                      RenderBlock (generated) at (-1,0) size 19x16
-                        RenderText at (1,0) size 17x16
-                          text run at (1,0) width 4 RTL: " "
-                          text run at (1,4) width 12 RTL: "\x{25B6}"
-                    RenderText {#text} at (0,0) size 18x58
-                      text run at (0,0) width 59: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (18,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (1,58) size 17x16
+                      RenderText at (1,58) size 17x16
+                        text run at (1,58) width 4 RTL: " "
+                        text run at (1,62) width 12 RTL: "\x{25B6}"
+                    RenderText {#text} at (1,0) size 17x58
+                      text run at (1,0) width 58: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (483,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,58) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderInline (generated) at (0,58) size 18x20
+                      RenderText at (0,58) size 18x20
+                        text run at (0,58) width 5 RTL: " "
+                        text run at (0,62) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x58
                       text run at (0,0) width 59: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,58) size 18x16: "\x{25C0}"
-                      RenderBlock (generated) at (-1,0) size 19x16
-                        RenderText at (1,0) size 17x16
-                          text run at (1,0) width 4 RTL: " "
-                          text run at (1,4) width 12 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,0) size 18x58
-                      text run at (0,0) width 59: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (18,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (1,58) size 17x16
+                      RenderText at (1,58) size 17x16
+                        text run at (1,58) width 4 RTL: " "
+                        text run at (1,62) width 12 RTL: "\x{25C0}"
+                    RenderText {#text} at (1,0) size 17x58
+                      text run at (1,0) width 58: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
       RenderBlock (anonymous) at (0,722) size 769x18
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,740) size 612x352 [border: (1px outset #000000)]
@@ -390,12 +406,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (23,1) size 16x17: "\x{25B6}"
+                    RenderInline (generated) at (23,1) size 16x17
+                      RenderText at (23,1) size 16x17
+                        text run at (23,1) width 16: "\x{25B6} "
                     RenderText {#text} at (39,1) size 58x17
                       text run at (39,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (21,0) size 20x18: "\x{25BC}"
+                    RenderInline (generated) at (21,0) size 20x18
+                      RenderText at (21,0) size 20x18
+                        text run at (21,0) width 20: "\x{25BC} "
                     RenderText {#text} at (41,0) size 58x18
                       text run at (41,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -403,12 +423,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (23,1) size 16x17: "\x{25B6}"
+                    RenderInline (generated) at (23,1) size 16x17
+                      RenderText at (23,1) size 16x17
+                        text run at (23,1) width 16: "\x{25B6} "
                     RenderText {#text} at (39,1) size 58x17
                       text run at (39,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (21,0) size 20x18: "\x{25B2}"
+                    RenderInline (generated) at (21,0) size 20x18
+                      RenderText at (21,0) size 20x18
+                        text run at (21,0) width 20: "\x{25B2} "
                     RenderText {#text} at (41,0) size 58x18
                       text run at (41,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -416,28 +440,36 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,21) size 18x20: "\x{25BC}"
+                    RenderInline (generated) at (0,21) size 18x20
+                      RenderText at (0,21) size 18x20
+                        text run at (0,21) width 21: "\x{25BC} "
                     RenderText {#text} at (0,41) size 18x58
                       text run at (0,41) width 59: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,23) size 18x16: "\x{25B6}"
-                    RenderText {#text} at (0,39) size 18x58
-                      text run at (0,39) width 59: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (18,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (1,23) size 17x16
+                      RenderText at (1,23) size 17x16
+                        text run at (1,23) width 16: "\x{25B6} "
+                    RenderText {#text} at (1,39) size 17x58
+                      text run at (1,39) width 58: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (483,98) size 125x124 [border: (1px solid #000000)] [r=3 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,21) size 18x20: "\x{25BC}"
+                    RenderInline (generated) at (0,21) size 18x20
+                      RenderText at (0,21) size 18x20
+                        text run at (0,21) width 21: "\x{25BC} "
                     RenderText {#text} at (0,41) size 18x58
                       text run at (0,41) width 59: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,23) size 18x16: "\x{25C0}"
-                    RenderText {#text} at (0,39) size 18x58
-                      text run at (0,39) width 59: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (18,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (1,23) size 17x16
+                      RenderText at (1,23) size 17x16
+                        text run at (1,23) width 16: "\x{25C0} "
+                    RenderText {#text} at (1,39) size 17x58
+                      text run at (1,39) width 58: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
           RenderTableRow {TR} at (0,224) size 610x124
             RenderTableCell {TH} at (75,271) size 29x30 [border: (1px inset #000000)] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (6,53) size 16x18
@@ -446,20 +478,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (81,1) size 16x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,-1) size 16x19
-                        RenderText at (0,1) size 16x17
-                          text run at (0,1) width 4 RTL: " "
-                          text run at (4,1) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (81,1) size 16x17
+                      RenderText at (81,1) size 16x17
+                        text run at (81,1) width 4 RTL: " "
+                        text run at (85,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (23,1) size 58x17
                       text run at (23,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (79,0) size 20x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x18
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderInline (generated) at (79,0) size 20x18
+                      RenderText at (79,0) size 20x18
+                        text run at (79,0) width 4 RTL: " "
+                        text run at (83,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (21,0) size 58x18
                       text run at (21,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -467,20 +497,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (81,1) size 16x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,10) size 16x19
-                        RenderText at (0,1) size 16x17
-                          text run at (0,1) width 4 RTL: " "
-                          text run at (4,1) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (81,1) size 16x17
+                      RenderText at (81,1) size 16x17
+                        text run at (81,1) width 4 RTL: " "
+                        text run at (85,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (23,1) size 58x17
                       text run at (23,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (79,0) size 20x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderInline (generated) at (79,0) size 20x18
+                      RenderText at (79,0) size 20x18
+                        text run at (79,0) width 4 RTL: " "
+                        text run at (83,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (21,0) size 58x18
                       text run at (21,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -488,44 +516,40 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,79) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderInline (generated) at (0,79) size 18x20
+                      RenderText at (0,79) size 18x20
+                        text run at (0,79) width 5 RTL: " "
+                        text run at (0,83) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,21) size 18x58
                       text run at (0,21) width 59: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x16: "\x{25B6}"
-                      RenderBlock (generated) at (-1,0) size 19x16
-                        RenderText at (1,0) size 17x16
-                          text run at (1,0) width 4 RTL: " "
-                          text run at (1,4) width 12 RTL: "\x{25B6}"
-                    RenderText {#text} at (0,23) size 18x58
-                      text run at (0,23) width 59: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (18,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (1,81) size 17x16
+                      RenderText at (1,81) size 17x16
+                        text run at (1,81) width 4 RTL: " "
+                        text run at (1,85) width 12 RTL: "\x{25B6}"
+                    RenderText {#text} at (1,23) size 17x58
+                      text run at (1,23) width 58: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (483,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,79) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderInline (generated) at (0,79) size 18x20
+                      RenderText at (0,79) size 18x20
+                        text run at (0,79) width 5 RTL: " "
+                        text run at (0,83) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,21) size 18x58
                       text run at (0,21) width 59: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x16: "\x{25C0}"
-                      RenderBlock (generated) at (-1,0) size 19x16
-                        RenderText at (1,0) size 17x16
-                          text run at (1,0) width 4 RTL: " "
-                          text run at (1,4) width 12 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,23) size 18x58
-                      text run at (0,23) width 59: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (18,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (1,81) size 17x16
+                      RenderText at (1,81) size 17x16
+                        text run at (1,81) width 4 RTL: " "
+                        text run at (1,85) width 12 RTL: "\x{25C0}"
+                    RenderText {#text} at (1,23) size 17x58
+                      text run at (1,23) width 58: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
       RenderBlock (anonymous) at (0,1092) size 769x18
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,1110) size 612x352 [border: (1px outset #000000)]
@@ -565,12 +589,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (46,1) size 16x17: "\x{25B6}"
+                    RenderInline (generated) at (46,1) size 16x17
+                      RenderText at (46,1) size 16x17
+                        text run at (46,1) width 16: "\x{25B6} "
                     RenderText {#text} at (62,1) size 58x17
                       text run at (62,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (42,0) size 20x18: "\x{25BC}"
+                    RenderInline (generated) at (42,0) size 20x18
+                      RenderText at (42,0) size 20x18
+                        text run at (42,0) width 20: "\x{25BC} "
                     RenderText {#text} at (62,0) size 58x18
                       text run at (62,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -578,12 +606,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (46,1) size 16x17: "\x{25B6}"
+                    RenderInline (generated) at (46,1) size 16x17
+                      RenderText at (46,1) size 16x17
+                        text run at (46,1) width 16: "\x{25B6} "
                     RenderText {#text} at (62,1) size 58x17
                       text run at (62,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (42,0) size 20x18: "\x{25B2}"
+                    RenderInline (generated) at (42,0) size 20x18
+                      RenderText at (42,0) size 20x18
+                        text run at (42,0) width 20: "\x{25B2} "
                     RenderText {#text} at (62,0) size 58x18
                       text run at (62,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -591,28 +623,36 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,42) size 18x20: "\x{25BC}"
+                    RenderInline (generated) at (0,42) size 18x20
+                      RenderText at (0,42) size 18x20
+                        text run at (0,42) width 21: "\x{25BC} "
                     RenderText {#text} at (0,62) size 18x58
                       text run at (0,62) width 59: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,46) size 18x16: "\x{25B6}"
-                    RenderText {#text} at (0,62) size 18x58
-                      text run at (0,62) width 59: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (18,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (1,46) size 17x16
+                      RenderText at (1,46) size 17x16
+                        text run at (1,46) width 16: "\x{25B6} "
+                    RenderText {#text} at (1,62) size 17x58
+                      text run at (1,62) width 58: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (483,98) size 125x124 [border: (1px solid #000000)] [r=3 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,42) size 18x20: "\x{25BC}"
+                    RenderInline (generated) at (0,42) size 18x20
+                      RenderText at (0,42) size 18x20
+                        text run at (0,42) width 21: "\x{25BC} "
                     RenderText {#text} at (0,62) size 18x58
                       text run at (0,62) width 59: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,46) size 18x16: "\x{25C0}"
-                    RenderText {#text} at (0,62) size 18x58
-                      text run at (0,62) width 59: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (18,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (1,46) size 17x16
+                      RenderText at (1,46) size 17x16
+                        text run at (1,46) width 16: "\x{25C0} "
+                    RenderText {#text} at (1,62) size 17x58
+                      text run at (1,62) width 58: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
           RenderTableRow {TR} at (0,224) size 610x124
             RenderTableCell {TH} at (75,271) size 29x30 [border: (1px inset #000000)] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (6,53) size 16x18
@@ -621,20 +661,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (104,1) size 16x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,-1) size 16x19
-                        RenderText at (0,1) size 16x17
-                          text run at (0,1) width 4 RTL: " "
-                          text run at (4,1) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (104,1) size 16x17
+                      RenderText at (104,1) size 16x17
+                        text run at (104,1) width 4 RTL: " "
+                        text run at (108,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (46,1) size 58x17
                       text run at (46,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25BC}"
-                      RenderBlock (generated) at (0,-1) size 20x19
-                        RenderText at (0,0) size 20x18
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25BC}"
+                    RenderInline (generated) at (100,0) size 20x18
+                      RenderText at (100,0) size 20x18
+                        text run at (100,0) width 4 RTL: " "
+                        text run at (104,0) width 16 RTL: "\x{25BC}"
                     RenderText {#text} at (42,0) size 58x18
                       text run at (42,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -642,20 +680,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (104,1) size 16x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,10) size 16x19
-                        RenderText at (0,1) size 16x17
-                          text run at (0,1) width 4 RTL: " "
-                          text run at (4,1) width 12 RTL: "\x{25C0}"
+                    RenderInline (generated) at (104,1) size 16x17
+                      RenderText at (104,1) size 16x17
+                        text run at (104,1) width 4 RTL: " "
+                        text run at (108,1) width 12 RTL: "\x{25C0}"
                     RenderText {#text} at (46,1) size 58x17
                       text run at (46,1) width 58: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x18
                   RenderListItem {SUMMARY} at (0,0) size 120x18
-                    RenderListMarker at (100,0) size 20x18: "\x{25B2}"
-                      RenderBlock (generated) at (0,10) size 20x19
-                        RenderText at (0,0) size 20x18
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (4,0) width 16 RTL: "\x{25B2}"
+                    RenderInline (generated) at (100,0) size 20x18
+                      RenderText at (100,0) size 20x18
+                        text run at (100,0) width 4 RTL: " "
+                        text run at (104,0) width 16 RTL: "\x{25B2}"
                     RenderText {#text} at (42,0) size 58x18
                       text run at (42,0) width 58: "summary"
                   RenderBlock {SLOT} at (0,18) size 120x0
@@ -663,41 +699,37 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderInline (generated) at (0,100) size 18x20
+                      RenderText at (0,100) size 18x20
+                        text run at (0,100) width 5 RTL: " "
+                        text run at (0,104) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,42) size 18x58
                       text run at (0,42) width 59: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,104) size 18x16: "\x{25B6}"
-                      RenderBlock (generated) at (-1,0) size 19x16
-                        RenderText at (1,0) size 17x16
-                          text run at (1,0) width 4 RTL: " "
-                          text run at (1,4) width 12 RTL: "\x{25B6}"
-                    RenderText {#text} at (0,46) size 18x58
-                      text run at (0,46) width 59: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (18,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (1,104) size 17x16
+                      RenderText at (1,104) size 17x16
+                        text run at (1,104) width 4 RTL: " "
+                        text run at (1,108) width 12 RTL: "\x{25B6}"
+                    RenderText {#text} at (1,46) size 17x58
+                      text run at (1,46) width 58: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (483,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,100) size 18x20: "\x{25B2}"
-                      RenderBlock (generated) at (-1,0) size 19x20
-                        RenderText at (0,0) size 18x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 17 RTL: "\x{25B2}"
+                    RenderInline (generated) at (0,100) size 18x20
+                      RenderText at (0,100) size 18x20
+                        text run at (0,100) width 5 RTL: " "
+                        text run at (0,104) width 17 RTL: "\x{25B2}"
                     RenderText {#text} at (0,42) size 18x58
                       text run at (0,42) width 59: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,104) size 18x16: "\x{25C0}"
-                      RenderBlock (generated) at (-1,0) size 19x16
-                        RenderText at (1,0) size 17x16
-                          text run at (1,0) width 4 RTL: " "
-                          text run at (1,4) width 12 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,46) size 18x58
-                      text run at (0,46) width 59: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (18,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (1,104) size 17x16
+                      RenderText at (1,104) size 17x16
+                        text run at (1,104) width 4 RTL: " "
+                        text run at (1,108) width 12 RTL: "\x{25C0}"
+                    RenderText {#text} at (1,46) size 17x58
+                      text run at (1,46) width 58: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120

--- a/LayoutTests/platform/glib/fast/lists/004-expected.txt
+++ b/LayoutTests/platform/glib/fast/lists/004-expected.txt
@@ -8,7 +8,9 @@ layer at (0,0) size 800x600
           RenderTableRow {TR} at (0,0) size 49x20
             RenderTableCell {TD} at (0,0) size 16x20 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderListItem {LI} at (1,1) size 14x18
-                RenderListMarker at (-1,0) size 7x18: bullet
+                RenderInline (generated) at (-1,0) size 7x18
+                  RenderText at (-1,0) size 7x18
+                    text run at (-1,0) width 7: "\x{2022}"
                 RenderImage {IMG} at (14,14) size 0x0
             RenderTableCell {TD} at (16,0) size 33x20 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
               RenderText {#text} at (1,1) size 31x18

--- a/LayoutTests/platform/glib/fast/lists/008-expected.txt
+++ b/LayoutTests/platform/glib/fast/lists/008-expected.txt
@@ -33,30 +33,42 @@ layer at (0,0) size 785x1808
             text run at (70,10) width 67: "Third item"
       RenderBlock {UL} at (0,300) size 189x134 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (41,1) size 147x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (9,10) size 7x18: bullet
+          RenderInline (generated) at (9,10) size 7x18
+            RenderText at (9,10) size 7x18
+              text run at (9,10) width 7: "\x{2022}"
           RenderText {#text} at (24,10) size 59x18
             text run at (24,10) width 59: "First item"
         RenderListItem {LI} at (41,39) size 147x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (9,10) size 7x18: bullet
+          RenderInline (generated) at (9,10) size 7x18
+            RenderText at (9,10) size 7x18
+              text run at (9,10) width 7: "\x{2022}"
           RenderText {#text} at (10,10) size 120x36
             text run at (24,10) width 106: "Second and very"
             text run at (10,28) width 91: "very long item"
         RenderListItem {LI} at (41,95) size 147x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (9,10) size 7x18: bullet
+          RenderInline (generated) at (9,10) size 7x18
+            RenderText at (9,10) size 7x18
+              text run at (9,10) width 7: "\x{2022}"
           RenderText {#text} at (24,10) size 66x18
             text run at (24,10) width 66: "Third item"
       RenderBlock {UL} at (0,450) size 189x134 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 147x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (130,10) size 8x18: bullet
+          RenderInline (generated) at (130,10) size 8x18
+            RenderText at (130,10) size 8x18
+              text run at (130,10) width 8 RTL: "\x{2022}"
           RenderText {#text} at (63,10) size 60x18
             text run at (63,10) width 60: "First item"
         RenderListItem {LI} at (1,39) size 147x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (130,10) size 8x18: bullet
+          RenderInline (generated) at (130,10) size 8x18
+            RenderText at (130,10) size 8x18
+              text run at (130,10) width 8 RTL: "\x{2022}"
           RenderText {#text} at (16,10) size 121x36
             text run at (16,10) width 107: "Second and very"
             text run at (45,28) width 92: "very long item"
         RenderListItem {LI} at (1,95) size 147x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (130,10) size 8x18: bullet
+          RenderInline (generated) at (130,10) size 8x18
+            RenderText at (130,10) size 8x18
+              text run at (130,10) width 8 RTL: "\x{2022}"
           RenderText {#text} at (56,10) size 67x18
             text run at (56,10) width 67: "Third item"
       RenderBlock {UL} at (0,600) size 189x134 [border: (1px solid #0000FF)]
@@ -89,30 +101,36 @@ layer at (0,0) size 785x1808
             text run at (70,10) width 67: "Third item"
       RenderBlock {UL} at (0,900) size 189x134 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (41,1) size 147x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,14) size 10x11
+          RenderInline (generated) at (10,10) size 17x18
+            RenderImage at (10,14) size 10x11
           RenderText {#text} at (27,10) size 59x18
             text run at (27,10) width 59: "First item"
         RenderListItem {LI} at (41,39) size 147x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,14) size 10x11
+          RenderInline (generated) at (10,10) size 17x18
+            RenderImage at (10,14) size 10x11
           RenderText {#text} at (10,10) size 123x36
             text run at (27,10) width 106: "Second and very"
             text run at (10,28) width 91: "very long item"
         RenderListItem {LI} at (41,95) size 147x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,14) size 10x11
+          RenderInline (generated) at (10,10) size 17x18
+            RenderImage at (10,14) size 10x11
           RenderText {#text} at (27,10) size 66x18
             text run at (27,10) width 66: "Third item"
       RenderBlock {UL} at (0,1050) size 189x134 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 147x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (126,14) size 11x11
+          RenderInline (generated) at (119,10) size 18x18
+            RenderImage at (126,14) size 11x11
           RenderText {#text} at (60,10) size 60x18
             text run at (60,10) width 60: "First item"
         RenderListItem {LI} at (1,39) size 147x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (126,14) size 11x11
+          RenderInline (generated) at (119,10) size 18x18
+            RenderImage at (126,14) size 11x11
           RenderText {#text} at (13,10) size 124x36
             text run at (13,10) width 107: "Second and very"
             text run at (45,28) width 92: "very long item"
         RenderListItem {LI} at (1,95) size 147x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (126,14) size 11x11
+          RenderInline (generated) at (119,10) size 18x18
+            RenderImage at (126,14) size 11x11
           RenderText {#text} at (53,10) size 67x18
             text run at (53,10) width 67: "Third item"
       RenderBlock {OL} at (0,1200) size 189x134 [border: (1px solid #0000FF)]
@@ -160,44 +178,47 @@ layer at (0,0) size 785x1808
             text run at (70,10) width 67: "Third item"
       RenderBlock {OL} at (0,1500) size 189x134 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (41,1) size 147x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 16x18: "1"
+          RenderInline (generated) at (10,10) size 16x18
+            RenderText at (10,10) size 16x18
+              text run at (10,10) width 16: "1. "
           RenderText {#text} at (26,10) size 59x18
             text run at (26,10) width 59: "First item"
         RenderListItem {LI} at (41,39) size 147x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 16x18: "2"
+          RenderInline (generated) at (10,10) size 16x18
+            RenderText at (10,10) size 16x18
+              text run at (10,10) width 16: "2. "
           RenderText {#text} at (10,10) size 122x36
             text run at (26,10) width 106: "Second and very"
             text run at (10,28) width 91: "very long item"
         RenderListItem {LI} at (41,95) size 147x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 16x18: "3"
+          RenderInline (generated) at (10,10) size 16x18
+            RenderText at (10,10) size 16x18
+              text run at (10,10) width 16: "3. "
           RenderText {#text} at (26,10) size 66x18
             text run at (26,10) width 66: "Third item"
       RenderBlock {OL} at (0,1650) size 189x134 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 147x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (120,10) size 17x18: "1"
-            RenderBlock (generated) at (0,-1) size 16x19
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "1"
+          RenderInline (generated) at (120,10) size 17x18
+            RenderText at (120,10) size 17x18
+              text run at (120,10) width 5 RTL: " "
+              text run at (124,10) width 5 RTL: "."
+              text run at (128,10) width 9: "1"
           RenderText {#text} at (61,10) size 60x18
             text run at (61,10) width 60: "First item"
         RenderListItem {LI} at (1,39) size 147x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (120,10) size 17x18: "2"
-            RenderBlock (generated) at (0,-1) size 16x19
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "2"
+          RenderInline (generated) at (120,10) size 17x18
+            RenderText at (120,10) size 17x18
+              text run at (120,10) width 5 RTL: " "
+              text run at (124,10) width 5 RTL: "."
+              text run at (128,10) width 9: "2"
           RenderText {#text} at (14,10) size 123x36
             text run at (14,10) width 107: "Second and very"
             text run at (45,28) width 92: "very long item"
         RenderListItem {LI} at (1,95) size 147x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (120,10) size 17x18: "3"
-            RenderBlock (generated) at (0,-1) size 16x19
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "3"
+          RenderInline (generated) at (120,10) size 17x18
+            RenderText at (120,10) size 17x18
+              text run at (120,10) width 5 RTL: " "
+              text run at (124,10) width 5 RTL: "."
+              text run at (128,10) width 9: "3"
           RenderText {#text} at (54,10) size 67x18
             text run at (54,10) width 67: "Third item"

--- a/LayoutTests/platform/glib/fast/lists/008-vertical-expected.txt
+++ b/LayoutTests/platform/glib/fast/lists/008-vertical-expected.txt
@@ -33,30 +33,42 @@ layer at (0,0) size 1808x585
             text run at (10,70) width 67: "Third item"
       RenderBlock {UL} at (300,0) size 134x189 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (1,41) size 38x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,9) size 18x7: bullet
+          RenderInline (generated) at (10,9) size 18x7
+            RenderText at (10,9) size 18x7
+              text run at (10,9) width 8: "\x{2022}"
           RenderText {#text} at (10,24) size 18x59
             text run at (10,24) width 60: "First item"
         RenderListItem {LI} at (39,41) size 56x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,9) size 18x7: bullet
+          RenderInline (generated) at (10,9) size 18x7
+            RenderText at (10,9) size 18x7
+              text run at (10,9) width 8: "\x{2022}"
           RenderText {#text} at (10,10) size 36x120
             text run at (10,24) width 107: "Second and very"
             text run at (28,10) width 92: "very long item"
         RenderListItem {LI} at (95,41) size 38x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,9) size 18x7: bullet
+          RenderInline (generated) at (10,9) size 18x7
+            RenderText at (10,9) size 18x7
+              text run at (10,9) width 8: "\x{2022}"
           RenderText {#text} at (10,24) size 18x66
             text run at (10,24) width 67: "Third item"
       RenderBlock {UL} at (450,0) size 134x189 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,130) size 18x8: bullet
+          RenderInline (generated) at (10,130) size 18x8
+            RenderText at (10,130) size 18x8
+              text run at (10,130) width 8 RTL: "\x{2022}"
           RenderText {#text} at (10,63) size 18x60
             text run at (10,63) width 60: "First item"
         RenderListItem {LI} at (39,1) size 56x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,130) size 18x8: bullet
+          RenderInline (generated) at (10,130) size 18x8
+            RenderText at (10,130) size 18x8
+              text run at (10,130) width 8 RTL: "\x{2022}"
           RenderText {#text} at (10,16) size 36x121
             text run at (10,16) width 107: "Second and very"
             text run at (28,45) width 92: "very long item"
         RenderListItem {LI} at (95,1) size 38x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,130) size 18x8: bullet
+          RenderInline (generated) at (10,130) size 18x8
+            RenderText at (10,130) size 18x8
+              text run at (10,130) width 8 RTL: "\x{2022}"
           RenderText {#text} at (10,56) size 18x67
             text run at (10,56) width 67: "Third item"
       RenderBlock {UL} at (600,0) size 134x189 [border: (1px solid #0000FF)]
@@ -89,30 +101,36 @@ layer at (0,0) size 1808x585
             text run at (10,70) width 67: "Third item"
       RenderBlock {UL} at (900,0) size 134x189 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (1,41) size 38x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,10) size 10x10
+          RenderInline (generated) at (10,10) size 18x17
+            RenderImage at (14,10) size 10x10
           RenderText {#text} at (10,27) size 18x59
             text run at (10,27) width 60: "First item"
         RenderListItem {LI} at (39,41) size 56x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,10) size 10x10
+          RenderInline (generated) at (10,10) size 18x17
+            RenderImage at (14,10) size 10x10
           RenderText {#text} at (10,10) size 36x123
             text run at (10,27) width 107: "Second and very"
             text run at (28,10) width 92: "very long item"
         RenderListItem {LI} at (95,41) size 38x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,10) size 10x10
+          RenderInline (generated) at (10,10) size 18x17
+            RenderImage at (14,10) size 10x10
           RenderText {#text} at (10,27) size 18x66
             text run at (10,27) width 67: "Third item"
       RenderBlock {UL} at (1050,0) size 134x189 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,126) size 10x11
+          RenderInline (generated) at (10,119) size 18x18
+            RenderImage at (14,126) size 10x11
           RenderText {#text} at (10,60) size 18x60
             text run at (10,60) width 60: "First item"
         RenderListItem {LI} at (39,1) size 56x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,126) size 10x11
+          RenderInline (generated) at (10,119) size 18x18
+            RenderImage at (14,126) size 10x11
           RenderText {#text} at (10,13) size 36x124
             text run at (10,13) width 107: "Second and very"
             text run at (28,45) width 92: "very long item"
         RenderListItem {LI} at (95,1) size 38x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,126) size 10x11
+          RenderInline (generated) at (10,119) size 18x18
+            RenderImage at (14,126) size 10x11
           RenderText {#text} at (10,53) size 18x67
             text run at (10,53) width 67: "Third item"
       RenderBlock {OL} at (1200,0) size 134x189 [border: (1px solid #0000FF)]
@@ -160,44 +178,47 @@ layer at (0,0) size 1808x585
             text run at (10,70) width 67: "Third item"
       RenderBlock {OL} at (1500,0) size 134x189 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (1,41) size 38x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 18x16: "1"
+          RenderInline (generated) at (10,10) size 18x16
+            RenderText at (10,10) size 18x16
+              text run at (10,10) width 17: "1. "
           RenderText {#text} at (10,26) size 18x59
             text run at (10,26) width 60: "First item"
         RenderListItem {LI} at (39,41) size 56x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 18x16: "2"
+          RenderInline (generated) at (10,10) size 18x16
+            RenderText at (10,10) size 18x16
+              text run at (10,10) width 17: "2. "
           RenderText {#text} at (10,10) size 36x122
             text run at (10,26) width 107: "Second and very"
             text run at (28,10) width 92: "very long item"
         RenderListItem {LI} at (95,41) size 38x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 18x16: "3"
+          RenderInline (generated) at (10,10) size 18x16
+            RenderText at (10,10) size 18x16
+              text run at (10,10) width 17: "3. "
           RenderText {#text} at (10,26) size 18x66
             text run at (10,26) width 67: "Third item"
       RenderBlock {OL} at (1650,0) size 134x189 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,120) size 18x17: "1"
-            RenderBlock (generated) at (-1,0) size 19x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 5 RTL: " "
-                text run at (0,4) width 5 RTL: "."
-                text run at (0,8) width 9: "1"
+          RenderInline (generated) at (10,120) size 18x17
+            RenderText at (10,120) size 18x17
+              text run at (10,120) width 5 RTL: " "
+              text run at (10,124) width 5 RTL: "."
+              text run at (10,128) width 9: "1"
           RenderText {#text} at (10,61) size 18x60
             text run at (10,61) width 60: "First item"
         RenderListItem {LI} at (39,1) size 56x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,120) size 18x17: "2"
-            RenderBlock (generated) at (-1,0) size 19x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 5 RTL: " "
-                text run at (0,4) width 5 RTL: "."
-                text run at (0,8) width 9: "2"
+          RenderInline (generated) at (10,120) size 18x17
+            RenderText at (10,120) size 18x17
+              text run at (10,120) width 5 RTL: " "
+              text run at (10,124) width 5 RTL: "."
+              text run at (10,128) width 9: "2"
           RenderText {#text} at (10,14) size 36x123
             text run at (10,14) width 107: "Second and very"
             text run at (28,45) width 92: "very long item"
         RenderListItem {LI} at (95,1) size 38x147 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,120) size 18x17: "3"
-            RenderBlock (generated) at (-1,0) size 19x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 5 RTL: " "
-                text run at (0,4) width 5 RTL: "."
-                text run at (0,8) width 9: "3"
+          RenderInline (generated) at (10,120) size 18x17
+            RenderText at (10,120) size 18x17
+              text run at (10,120) width 5 RTL: " "
+              text run at (10,124) width 5 RTL: "."
+              text run at (10,128) width 9: "3"
           RenderText {#text} at (10,54) size 18x67
             text run at (10,54) width 67: "Third item"

--- a/LayoutTests/platform/glib/fast/lists/009-expected.txt
+++ b/LayoutTests/platform/glib/fast/lists/009-expected.txt
@@ -11,6 +11,7 @@ layer at (0,0) size 800x600
           RenderBlock {DD} at (0,18) size 784x18
             RenderBlock {UL} at (0,0) size 784x18
               RenderListItem {LI} at (0,0) size 784x18
-                RenderListMarker at (0,5) size 12x10
+                RenderInline (generated) at (0,0) size 19x18
+                  RenderImage at (0,5) size 12x10
                 RenderText {#text} at (19,0) size 111x18
                   text run at (19,0) width 111: "LI text is here too"

--- a/LayoutTests/platform/glib/fast/lists/009-vertical-expected.txt
+++ b/LayoutTests/platform/glib/fast/lists/009-vertical-expected.txt
@@ -11,6 +11,7 @@ layer at (0,0) size 800x600
           RenderBlock {DD} at (18,0) size 18x584
             RenderBlock {UL} at (0,0) size 18x584
               RenderListItem {LI} at (0,0) size 18x584
-                RenderListMarker at (2,0) size 13x9
+                RenderInline (generated) at (0,0) size 18x16
+                  RenderImage at (2,0) size 13x9
                 RenderText {#text} at (0,16) size 18x111
                   text run at (0,16) width 112: "LI text is here too"

--- a/LayoutTests/platform/glib/fast/lists/li-br-expected.txt
+++ b/LayoutTests/platform/glib/fast/lists/li-br-expected.txt
@@ -10,6 +10,8 @@ layer at (0,0) size 800x585
             text run at (0,0) width 1470: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       RenderBlock {OL} at (0,34) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderListMarker at (0,0) size 16x18: "1"
+          RenderInline (generated) at (0,0) size 16x18
+            RenderText at (0,0) size 16x18
+              text run at (0,0) width 16: "1. "
           RenderText {#text} at (0,18) size 1470x18
             text run at (0,18) width 1470: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/LayoutTests/platform/glib/fast/lists/markers-in-selection-expected.txt
+++ b/LayoutTests/platform/glib/fast/lists/markers-in-selection-expected.txt
@@ -28,7 +28,9 @@ layer at (0,0) size 800x600
             text run at (0,0) width 157: "Item with outside marker"
       RenderBlock {UL} at (0,120) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-1,0) size 7x18: bullet
+          RenderInline (generated) at (-1,0) size 7x18
+            RenderText at (-1,0) size 7x18
+              text run at (-1,0) width 7: "\x{2022}"
           RenderText {#text} at (14,0) size 149x18
             text run at (14,0) width 149: "Item with inside marker"
       RenderBlock {UL} at (0,154) size 784x18
@@ -38,7 +40,8 @@ layer at (0,0) size 800x600
             text run at (0,0) width 199: "Item with outside image marker"
       RenderBlock {UL} at (0,188) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (0,4) size 10x11
+          RenderInline (generated) at (0,0) size 17x18
+            RenderImage at (0,4) size 10x11
           RenderText {#text} at (17,0) size 191x18
             text run at (17,0) width 191: "Item with inside image marker"
       RenderBlock {OL} at (0,222) size 784x36
@@ -52,11 +55,15 @@ layer at (0,0) size 800x600
             text run at (0,0) width 101: "and another one"
       RenderBlock {OL} at (0,274) size 784x36
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (0,0) size 16x18: "1"
+          RenderInline (generated) at (0,0) size 16x18
+            RenderText at (0,0) size 16x18
+              text run at (0,0) width 16: "1. "
           RenderText {#text} at (16,0) size 149x18
             text run at (16,0) width 149: "Item with inside ordinal"
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (0,0) size 16x18: "2"
+          RenderInline (generated) at (0,0) size 16x18
+            RenderText at (0,0) size 16x18
+              text run at (0,0) width 16: "2. "
           RenderText {#text} at (16,0) size 101x18
             text run at (16,0) width 101: "and another one"
       RenderBlock (anonymous) at (0,336) size 784x0

--- a/LayoutTests/platform/glib/fast/repaint/list-marker-expected.txt
+++ b/LayoutTests/platform/glib/fast/repaint/list-marker-expected.txt
@@ -26,7 +26,9 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,86) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
           RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-1,0) size 7x18: bullet
+            RenderInline (generated) at (-1,0) size 7x18
+              RenderText at (-1,0) size 7x18
+                text run at (-1,0) width 7: "\x{2022}"
             RenderText {#text} at (14,0) size 20x18
               text run at (14,0) width 20: "bar"
           RenderBlock {DIV} at (10,28) size 724x0
@@ -40,7 +42,9 @@ layer at (0,0) size 800x600
       RenderBlock {UL} at (0,154) size 784x18
         RenderListItem {LI} at (0,0) size 744x18
           RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (738,0) size 7x18: bullet
+            RenderInline (generated) at (738,0) size 7x18
+              RenderText at (738,0) size 7x18
+                text run at (738,0) width 7 RTL: "\x{2022}"
             RenderText {#text} at (710,0) size 20x18
               text run at (710,0) width 20: "bar"
           RenderBlock {DIV} at (10,28) size 724x0

--- a/LayoutTests/platform/gtk/fast/html/details-add-summary-1-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-add-summary-1-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 39x17
             text run at (16,1) width 39: "new 1"

--- a/LayoutTests/platform/gtk/fast/html/details-add-summary-10-and-click-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-add-summary-10-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 39x17
             text run at (16,1) width 39: "new 1"
 caret: position 0 of child 0 {#text} of child 1 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/gtk/fast/html/details-add-summary-2-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-add-summary-2-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 39x17
             text run at (16,1) width 39: "new 1"

--- a/LayoutTests/platform/gtk/fast/html/details-add-summary-3-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-add-summary-3-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 39x17
             text run at (16,1) width 39: "new 2"

--- a/LayoutTests/platform/gtk/fast/html/details-add-summary-4-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-add-summary-4-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 58x17
             text run at (16,1) width 58: "summary"

--- a/LayoutTests/platform/gtk/fast/html/details-add-summary-5-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-add-summary-5-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 39x17
             text run at (16,1) width 39: "new 1"

--- a/LayoutTests/platform/gtk/fast/html/details-add-summary-6-and-click-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-add-summary-6-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 39x17
             text run at (16,1) width 39: "new 1"
 caret: position 0 of child 0 {#text} of child 0 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/gtk/fast/html/details-add-summary-7-and-click-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-add-summary-7-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 39x17
             text run at (16,1) width 39: "new 1"
 caret: position 0 of child 0 {#text} of child 0 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/gtk/fast/html/details-add-summary-8-and-click-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-add-summary-8-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 39x17
             text run at (16,1) width 39: "new 2"
 caret: position 0 of child 0 {#text} of child 0 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/gtk/fast/html/details-add-summary-9-and-click-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-add-summary-9-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 58x17
             text run at (16,1) width 58: "summary"
 caret: position 0 of child 0 {#text} of child 1 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/gtk/fast/html/details-no-summary1-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-no-summary1-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 44x17
             text run at (16,1) width 44: "Details"

--- a/LayoutTests/platform/gtk/fast/html/details-no-summary3-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-no-summary3-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 44x17
             text run at (16,1) width 44: "Details"

--- a/LayoutTests/platform/gtk/fast/html/details-no-summary4-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-no-summary4-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x42
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 44x18
             text run at (20,0) width 44: "Details"
         RenderBlock {SLOT} at (0,18) size 784x24

--- a/LayoutTests/platform/gtk/fast/html/details-open-javascript-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-open-javascript-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x42
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 48x18
             text run at (20,0) width 48: "details1"
         RenderBlock {SLOT} at (0,18) size 784x24
@@ -13,7 +15,9 @@ layer at (0,0) size 800x600
           RenderText {#text} at (0,0) size 0x0
       RenderBlock {DETAILS} at (0,42) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 48x17
             text run at (16,1) width 48: "details2"
 layer at (11,29) size 186x18

--- a/LayoutTests/platform/gtk/fast/html/details-open1-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-open1-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 58x17
             text run at (16,1) width 58: "summary"

--- a/LayoutTests/platform/gtk/fast/html/details-open2-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-open2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x42
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 58x18
             text run at (20,0) width 58: "summary"
         RenderBlock {SLOT} at (0,18) size 784x24

--- a/LayoutTests/platform/gtk/fast/html/details-open3-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-open3-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 58x17
             text run at (16,1) width 58: "summary"

--- a/LayoutTests/platform/gtk/fast/html/details-open4-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-open4-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x42
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 58x18
             text run at (20,0) width 58: "summary"
         RenderBlock {SLOT} at (0,18) size 784x24

--- a/LayoutTests/platform/gtk/fast/html/details-open5-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-open5-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 58x17
             text run at (16,1) width 58: "summary"

--- a/LayoutTests/platform/gtk/fast/html/details-position-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-position-expected.txt
@@ -8,16 +8,22 @@ layer at (0,0) size 800x585
       RenderBlock {DETAILS} at (0,19) size 784x0
 layer at (50,150) size 48x19
   RenderListItem {SUMMARY} at (50,150) size 48x19
-    RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+    RenderInline (generated) at (0,1) size 16x17
+      RenderText at (0,1) size 16x17
+        text run at (0,1) width 16: "\x{25B6} "
     RenderText {#text} at (16,1) size 32x17
       text run at (16,1) width 32: "fixed"
 layer at (158,158) size 784x19
   RenderListItem {SUMMARY} at (0,0) size 784x19
-    RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+    RenderInline (generated) at (0,1) size 16x17
+      RenderText at (0,1) size 16x17
+        text run at (0,1) width 16: "\x{25B6} "
     RenderText {#text} at (16,1) size 46x17
       text run at (16,1) width 46: "relative"
 layer at (250,150) size 68x19
   RenderListItem {SUMMARY} at (250,150) size 68x19
-    RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+    RenderInline (generated) at (0,1) size 16x17
+      RenderText at (0,1) size 16x17
+        text run at (0,1) width 16: "\x{25B6} "
     RenderText {#text} at (16,1) size 52x17
       text run at (16,1) width 52: "absolute"

--- a/LayoutTests/platform/gtk/fast/html/details-remove-summary-1-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-remove-summary-1-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 44x17
             text run at (16,1) width 44: "Details"

--- a/LayoutTests/platform/gtk/fast/html/details-remove-summary-2-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-remove-summary-2-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 70x17
             text run at (16,1) width 70: "summary 2"

--- a/LayoutTests/platform/gtk/fast/html/details-remove-summary-3-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-remove-summary-3-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 70x17
             text run at (16,1) width 70: "summary 1"

--- a/LayoutTests/platform/gtk/fast/html/details-remove-summary-4-and-click-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-remove-summary-4-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 44x17
             text run at (16,1) width 44: "Details"
 caret: position 0 of child 0 {#text} of child 0 {SUMMARY} of child 0 {SLOT} of {#document-fragment} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/gtk/fast/html/details-remove-summary-5-and-click-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-remove-summary-5-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 70x17
             text run at (16,1) width 70: "summary 2"
 caret: position 0 of child 0 {#text} of child 2 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/gtk/fast/html/details-remove-summary-6-and-click-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-remove-summary-6-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,1) size 16x17: "\x{25B6}"
+          RenderInline (generated) at (0,1) size 16x17
+            RenderText at (0,1) size 16x17
+              text run at (0,1) width 16: "\x{25B6} "
           RenderText {#text} at (16,1) size 70x17
             text run at (16,1) width 70: "summary 1"
 caret: position 0 of child 0 {#text} of child 1 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/gtk/fast/html/details-replace-summary-child-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-replace-summary-child-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderBlock {SPAN} at (20,3) size 64x16
             RenderText {#text} at (0,0) size 64x15
               text run at (0,0) width 64: "Details1"

--- a/LayoutTests/platform/gtk/fast/html/details-replace-text-expected.txt
+++ b/LayoutTests/platform/gtk/fast/html/details-replace-text-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x37
         RenderListItem {SUMMARY} at (0,0) size 784x18
-          RenderListMarker at (0,0) size 20x18: "\x{25BC}"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "\x{25BC} "
           RenderText {#text} at (20,0) size 61x18
             text run at (20,0) width 61: "Summary"
         RenderBlock {SLOT} at (0,18) size 784x19

--- a/LayoutTests/platform/gtk/tables/mozilla/bugs/bug30692-expected.txt
+++ b/LayoutTests/platform/gtk/tables/mozilla/bugs/bug30692-expected.txt
@@ -8,12 +8,16 @@ layer at (0,0) size 800x600
           text run at (0,0) width 488: "BUG: Inside a cell, \"height:x%\" is ignored. It looks like 'auto' is used instead."
         RenderBR {BR} at (488,0) size 0x18
       RenderListItem {LI} at (0,18) size 784x18
-        RenderListMarker at (-1,0) size 7x18: bullet
+        RenderInline (generated) at (-1,0) size 7x18
+          RenderText at (-1,0) size 7x18
+            text run at (-1,0) width 7: "\x{2022}"
         RenderText {#text} at (14,0) size 260x18
           text run at (14,0) width 260: "Absolute units work correctly (eg. 50px)."
       RenderListItem {LI} at (0,36) size 784x490
         RenderBlock (anonymous) at (0,0) size 784x18
-          RenderListMarker at (-1,0) size 7x18: bullet
+          RenderInline (generated) at (-1,0) size 7x18
+            RenderText at (-1,0) size 7x18
+              text run at (-1,0) width 7: "\x{2022}"
           RenderText {#text} at (14,0) size 180x18
             text run at (14,0) width 180: "\"width:x%\" works correctly."
         RenderTable {TABLE} at (0,36) size 784x100

--- a/LayoutTests/platform/ios/css1/classification/list_style-expected.txt
+++ b/LayoutTests/platform/ios/css1/classification/list_style-expected.txt
@@ -14,7 +14,9 @@ layer at (0,0) size 800x600
           text run at (483,15) width 1: " "
       RenderBlock {UL} at (0,95) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderListMarker at (0,0) size 20x18: "A"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "A. "
           RenderText {#text} at (0,0) size 694x36
             text run at (19,0) width 675: "The text in this item should not behave as expected; that is, it should line up with the capital-A on the left"
             text run at (0,18) width 345: "margin, leaving no blank space beneath the capital-A."
@@ -39,7 +41,9 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (12,26) size 770x113 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
               RenderBlock {UL} at (4,4) size 762x36
                 RenderListItem {LI} at (40,0) size 722x36
-                  RenderListMarker at (0,0) size 20x18: "A"
+                  RenderInline (generated) at (0,0) size 20x18
+                    RenderText at (0,0) size 20x18
+                      text run at (0,0) width 20: "A. "
                   RenderText {#text} at (0,0) size 694x36
                     text run at (19,0) width 675: "The text in this item should not behave as expected; that is, it should line up with the capital-A on the left"
                     text run at (0,18) width 345: "margin, leaving no blank space beneath the capital-A."

--- a/LayoutTests/platform/ios/css2.1/t1205-c561-list-displ-00-b-expected.txt
+++ b/LayoutTests/platform/ios/css2.1/t1205-c561-list-displ-00-b-expected.txt
@@ -7,7 +7,9 @@ layer at (0,0) size 800x202
         RenderText {#text} at (0,0) size 772x18
           text run at (0,0) width 772: "There should be eight numbered lines below, all identical except for the numbering, which should match the description."
       RenderListItem {DIV} at (0,34) size 784x18 [color=#000080]
-        RenderListMarker at (0,0) size 16x18: "1"
+        RenderInline (generated) at (0,0) size 16x18
+          RenderText at (0,0) size 16x18
+            text run at (0,0) width 16: "1. "
         RenderText {#text} at (16,0) size 154x18
           text run at (16,0) width 154: "This should be line one."
       RenderBlock {DIV} at (0,52) size 784x18 [color=#000080]

--- a/LayoutTests/platform/ios/fast/html/details-add-child-1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-child-1-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x37
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 60x19
             text run at (16,0) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x18

--- a/LayoutTests/platform/ios/fast/html/details-add-child-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-child-2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x37
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 60x19
             text run at (16,0) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x18

--- a/LayoutTests/platform/ios/fast/html/details-add-details-child-1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-details-child-1-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x37
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 60x19
             text run at (16,0) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x18

--- a/LayoutTests/platform/ios/fast/html/details-add-details-child-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-details-child-2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x37
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 60x19
             text run at (16,0) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x18

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-1-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-1-and-click-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 40x19
             text run at (16,0) width 40: "new 1"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-1-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 40x19
             text run at (16,0) width 40: "new 1"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-10-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-10-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x37
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 39x19
             text run at (16,0) width 39: "new 1"
         RenderBlock {SLOT} at (0,19) size 800x18

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-10-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-10-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x37
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 39x19
             text run at (16,0) width 39: "new 1"
         RenderBlock {SLOT} at (0,19) size 784x18

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-2-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-2-and-click-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 40x19
             text run at (16,0) width 40: "new 1"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-2-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 40x19
             text run at (16,0) width 40: "new 1"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-3-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-3-and-click-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 40x19
             text run at (16,0) width 40: "new 2"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-3-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-3-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 40x19
             text run at (16,0) width 40: "new 2"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-4-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-4-and-click-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 61x19
             text run at (16,0) width 61: "summary"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-4-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-4-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 61x19
             text run at (16,0) width 61: "summary"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-5-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-5-and-click-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 40x19
             text run at (16,0) width 40: "new 1"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-5-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-5-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 40x19
             text run at (16,0) width 40: "new 1"

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-6-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-6-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 39x19
             text run at (16,0) width 39: "new 1"
         RenderBlock {SLOT} at (0,19) size 800x0

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-6-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-6-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 39x19
             text run at (16,0) width 39: "new 1"
         RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-7-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-7-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x37
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 39x19
             text run at (16,0) width 39: "new 1"
         RenderBlock {SLOT} at (0,19) size 800x18

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-7-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-7-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x37
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 39x19
             text run at (16,0) width 39: "new 1"
         RenderBlock {SLOT} at (0,19) size 784x18

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-8-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-8-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x37
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 39x19
             text run at (16,0) width 39: "new 2"
         RenderBlock {SLOT} at (0,19) size 800x18

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-8-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-8-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x37
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 39x19
             text run at (16,0) width 39: "new 2"
         RenderBlock {SLOT} at (0,19) size 784x18

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-9-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-9-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x37
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 60x19
             text run at (16,0) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 800x18

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-9-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-9-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x37
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 60x19
             text run at (16,0) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x18

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-child-1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-child-1-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 64x19
             text run at (16,0) width 64: "summary "
           RenderInline {B} at (79,0) size 145x19

--- a/LayoutTests/platform/ios/fast/html/details-add-summary-child-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-add-summary-child-2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 64x19
             text run at (16,0) width 64: "summary "
           RenderInline {SPAN} at (79,0) size 145x19

--- a/LayoutTests/platform/ios/fast/html/details-marker-style-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-marker-style-expected.txt
@@ -6,24 +6,32 @@ layer at (0,0) size 800x308
       RenderBlock {DIV} at (0,0) size 784x29
         RenderBlock {DETAILS} at (0,0) size 784x29
           RenderListItem {SUMMARY} at (0,0) size 784x29
-            RenderListMarker at (0,0) size 25x30: "\x{25B6}"
+            RenderInline (generated) at (0,0) size 25x29
+              RenderText at (0,0) size 25x29
+                text run at (0,0) width 25: "\x{25B6} "
             RenderText {#text} at (24,1) size 94x28
               text run at (24,1) width 94: "Summary"
       RenderBlock {DIV} at (0,29) size 29x118
         RenderBlock {DETAILS} at (0,0) size 29x118
           RenderListItem {SUMMARY} at (0,0) size 29x118
-            RenderListMarker at (0,0) size 30x24: "\x{25BC}"
+            RenderInline (generated) at (0,0) size 29x24
+              RenderText at (0,0) size 29x24
+                text run at (0,0) width 24: "\x{25BC} "
             RenderText {#text} at (1,23) size 28x95
               text run at (1,23) width 94: "Summary"
       RenderBlock {DIV} at (0,146) size 784x30
         RenderBlock {DETAILS} at (0,0) size 784x29
           RenderListItem {SUMMARY} at (0,0) size 784x29
-            RenderListMarker at (0,0) size 25x30: "\x{25B6}"
+            RenderInline (generated) at (0,0) size 25x29
+              RenderText at (0,0) size 25x29
+                text run at (0,0) width 25: "\x{25B6} "
             RenderText {#text} at (24,1) size 94x28
               text run at (24,1) width 94: "Summary"
       RenderBlock {DIV} at (0,175) size 29x118
         RenderBlock {DETAILS} at (0,0) size 29x118
           RenderListItem {SUMMARY} at (0,0) size 29x118
-            RenderListMarker at (0,0) size 30x24: "\x{25BC}"
+            RenderInline (generated) at (0,0) size 29x24
+              RenderText at (0,0) size 29x24
+                text run at (0,0) width 24: "\x{25BC} "
             RenderText {#text} at (1,23) size 28x95
               text run at (1,23) width 94: "Summary"

--- a/LayoutTests/platform/ios/fast/html/details-marker-style-mixed-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-marker-style-mixed-expected.txt
@@ -6,24 +6,32 @@ layer at (0,0) size 800x308
       RenderBlock {DIV} at (0,0) size 784x29
         RenderBlock {DETAILS} at (0,0) size 784x29
           RenderListItem {SUMMARY} at (0,0) size 784x29
-            RenderListMarker at (0,0) size 25x30: "\x{25B6}"
+            RenderInline (generated) at (0,0) size 25x29
+              RenderText at (0,0) size 25x29
+                text run at (0,0) width 25: "\x{25B6} "
             RenderText {#text} at (24,1) size 94x28
               text run at (24,1) width 94: "Summary"
-      RenderBlock {DIV} at (0,29) size 27x118
-        RenderBlock {DETAILS} at (0,0) size 27x118
-          RenderListItem {SUMMARY} at (0,0) size 27x118
-            RenderListMarker at (0,0) size 30x24: "\x{25BC}"
-            RenderText {#text} at (0,23) size 27x95
-              text run at (0,23) width 94: "Summary"
+      RenderBlock {DIV} at (0,29) size 29x118
+        RenderBlock {DETAILS} at (0,0) size 29x118
+          RenderListItem {SUMMARY} at (0,0) size 29x118
+            RenderInline (generated) at (0,0) size 29x24
+              RenderText at (0,0) size 29x24
+                text run at (0,0) width 24: "\x{25BC} "
+            RenderText {#text} at (1,23) size 27x95
+              text run at (1,23) width 94: "Summary"
       RenderBlock {DIV} at (0,146) size 784x30
         RenderBlock {DETAILS} at (0,0) size 784x29
           RenderListItem {SUMMARY} at (0,0) size 784x29
-            RenderListMarker at (0,0) size 25x30: "\x{25B6}"
+            RenderInline (generated) at (0,0) size 25x29
+              RenderText at (0,0) size 25x29
+                text run at (0,0) width 25: "\x{25B6} "
             RenderText {#text} at (24,1) size 94x28
               text run at (24,1) width 94: "Summary"
-      RenderBlock {DIV} at (0,175) size 27x118
-        RenderBlock {DETAILS} at (0,0) size 27x118
-          RenderListItem {SUMMARY} at (0,0) size 27x118
-            RenderListMarker at (0,0) size 30x24: "\x{25BC}"
-            RenderText {#text} at (0,23) size 27x95
-              text run at (0,23) width 94: "Summary"
+      RenderBlock {DIV} at (0,175) size 29x118
+        RenderBlock {DETAILS} at (0,0) size 29x118
+          RenderListItem {SUMMARY} at (0,0) size 29x118
+            RenderInline (generated) at (0,0) size 29x24
+              RenderText at (0,0) size 29x24
+                text run at (0,0) width 24: "\x{25BC} "
+            RenderText {#text} at (1,23) size 27x95
+              text run at (1,23) width 94: "Summary"

--- a/LayoutTests/platform/ios/fast/html/details-nested-1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-nested-1-expected.txt
@@ -6,12 +6,16 @@ layer at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 784x138 [border: (8px solid #555599)]
         RenderListItem {SUMMARY} at (8,8) size 768x104 [border: (8px solid #9999CC)]
           RenderBlock (anonymous) at (8,8) size 752x19
-            RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+            RenderInline (generated) at (0,-1) size 17x21
+              RenderText at (0,-1) size 17x21
+                text run at (0,0) width 17: "\x{25BC} "
             RenderText {#text} at (16,0) size 60x19
               text run at (16,0) width 60: "summary"
           RenderBlock {DETAILS} at (8,27) size 752x69 [border: (8px solid #995555)]
             RenderListItem {SUMMARY} at (8,8) size 736x35 [border: (8px solid #CC9999)]
-              RenderListMarker at (8,7) size 17x20: "\x{25BC}"
+              RenderInline (generated) at (8,7) size 17x21
+                RenderText at (8,7) size 17x21
+                  text run at (8,7) width 17: "\x{25BC} "
               RenderText {#text} at (24,8) size 287x19
                 text run at (24,8) width 287: "nested summary (summary-deails-summary)"
             RenderBlock {SLOT} at (8,43) size 736x18

--- a/LayoutTests/platform/ios/fast/html/details-nested-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-nested-2-expected.txt
@@ -5,13 +5,17 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x138 [border: (8px solid #555599)]
         RenderListItem {SUMMARY} at (8,8) size 768x35 [border: (8px solid #9999CC)]
-          RenderListMarker at (8,7) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (8,7) size 17x21
+            RenderText at (8,7) size 17x21
+              text run at (8,7) width 17: "\x{25BC} "
           RenderText {#text} at (24,8) size 60x19
             text run at (24,8) width 60: "summary"
         RenderBlock {SLOT} at (8,43) size 768x87
           RenderBlock {DETAILS} at (0,0) size 768x69 [border: (8px solid #995555)]
             RenderListItem {SUMMARY} at (8,8) size 752x35 [border: (8px solid #CC9999)]
-              RenderListMarker at (8,7) size 17x20: "\x{25BC}"
+              RenderInline (generated) at (8,7) size 17x21
+                RenderText at (8,7) size 17x21
+                  text run at (8,7) width 17: "\x{25BC} "
               RenderText {#text} at (24,8) size 269x19
                 text run at (24,8) width 269: "nested summary (details-deails-summary)"
             RenderBlock {SLOT} at (8,43) size 752x18

--- a/LayoutTests/platform/ios/fast/html/details-no-summary1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-no-summary1-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 47x19
             text run at (16,0) width 47: "Details"

--- a/LayoutTests/platform/ios/fast/html/details-no-summary2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-no-summary2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 46x19
             text run at (16,0) width 46: "Details"
         RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/platform/ios/fast/html/details-no-summary3-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-no-summary3-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 47x19
             text run at (16,0) width 47: "Details"

--- a/LayoutTests/platform/ios/fast/html/details-open1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-open1-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 61x19
             text run at (16,0) width 61: "summary"

--- a/LayoutTests/platform/ios/fast/html/details-open3-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-open3-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 61x19
             text run at (16,0) width 61: "summary"

--- a/LayoutTests/platform/ios/fast/html/details-open5-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-open5-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 61x19
             text run at (16,0) width 61: "summary"

--- a/LayoutTests/platform/ios/fast/html/details-open6-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-open6-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 60x19
             text run at (16,0) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/platform/ios/fast/html/details-position-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-position-expected.txt
@@ -8,16 +8,22 @@ layer at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,19) size 784x0
 layer at (50,150) size 50x19
   RenderListItem {SUMMARY} at (50,150) size 50x19
-    RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+    RenderInline (generated) at (0,-1) size 17x21
+      RenderText at (0,-1) size 17x21
+        text run at (0,0) width 17: "\x{25B6} "
     RenderText {#text} at (16,0) size 34x19
       text run at (16,0) width 34: "fixed"
 layer at (158,158) size 784x19
   RenderListItem {SUMMARY} at (0,0) size 784x19
-    RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+    RenderInline (generated) at (0,-1) size 17x21
+      RenderText at (0,-1) size 17x21
+        text run at (0,0) width 17: "\x{25B6} "
     RenderText {#text} at (16,0) size 49x19
       text run at (16,0) width 49: "relative"
 layer at (250,150) size 70x19
   RenderListItem {SUMMARY} at (250,150) size 71x19
-    RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+    RenderInline (generated) at (0,-1) size 17x21
+      RenderText at (0,-1) size 17x21
+        text run at (0,0) width 17: "\x{25B6} "
     RenderText {#text} at (16,0) size 55x19
       text run at (16,0) width 55: "absolute"

--- a/LayoutTests/platform/ios/fast/html/details-remove-child-1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-child-1-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x37
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 60x19
             text run at (16,0) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x18

--- a/LayoutTests/platform/ios/fast/html/details-remove-child-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-child-2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x37
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 60x19
             text run at (16,0) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x18

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-1-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-1-and-click-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 47x19
             text run at (16,0) width 47: "Details"

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-1-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 47x19
             text run at (16,0) width 47: "Details"

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-2-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-2-and-click-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 73x19
             text run at (16,0) width 73: "summary 2"

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-2-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 73x19
             text run at (16,0) width 73: "summary 2"

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-3-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-3-and-click-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 73x19
             text run at (16,0) width 73: "summary 1"

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-3-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-3-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,0) size 73x19
             text run at (16,0) width 73: "summary 1"

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-4-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-4-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 46x19
             text run at (16,0) width 46: "Details"
         RenderBlock {SLOT} at (0,19) size 800x0

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-4-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-4-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 46x19
             text run at (16,0) width 46: "Details"
         RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-5-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-5-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 72x19
             text run at (16,0) width 72: "summary 2"
         RenderBlock {SLOT} at (0,19) size 800x0

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-5-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-5-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 72x19
             text run at (16,0) width 72: "summary 2"
         RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-6-and-click-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-6-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x19
         RenderListItem {SUMMARY} at (0,0) size 800x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 72x19
             text run at (16,0) width 72: "summary 1"
         RenderBlock {SLOT} at (0,19) size 800x0

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-6-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-6-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 72x19
             text run at (16,0) width 72: "summary 1"
         RenderBlock {SLOT} at (0,19) size 784x0

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-child-1-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-child-1-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 64x19
             text run at (16,0) width 64: "summary "
           RenderText {#text} at (79,0) size 190x19

--- a/LayoutTests/platform/ios/fast/html/details-remove-summary-child-2-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-remove-summary-child-2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x19
         RenderListItem {SUMMARY} at (0,0) size 784x19
-          RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x21
+            RenderText at (0,-1) size 17x21
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,0) size 64x19
             text run at (16,0) width 64: "summary "
           RenderInline {SPAN} at (79,0) size 185x19

--- a/LayoutTests/platform/ios/fast/html/details-writing-mode-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-writing-mode-expected.txt
@@ -40,12 +40,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+                    RenderInline (generated) at (0,-1) size 17x21
+                      RenderText at (0,-1) size 17x21
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (16,0) size 61x19
                       text run at (16,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+                    RenderInline (generated) at (0,-1) size 17x21
+                      RenderText at (0,-1) size 17x21
+                        text run at (0,0) width 17: "\x{25BC} "
                     RenderText {#text} at (16,0) size 60x19
                       text run at (16,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -53,12 +57,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,0) size 17x20: "\x{25B6}"
+                    RenderInline (generated) at (0,-1) size 17x21
+                      RenderText at (0,-1) size 17x21
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (16,0) size 61x19
                       text run at (16,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,0) size 17x20: "\x{25B2}"
+                    RenderInline (generated) at (0,-1) size 17x21
+                      RenderText at (0,-1) size 17x21
+                        text run at (0,0) width 17: "\x{25B2} "
                     RenderText {#text} at (16,0) size 60x19
                       text run at (16,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -66,12 +74,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (0,0) size 20x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,0) size 21x17
+                      RenderText at (-1,0) size 21x17
+                        text run at (0,0) width 17: "\x{25BC} "
                     RenderText {#text} at (0,16) size 19x60
                       text run at (0,16) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (0,0) size 20x17: "\x{25B6}"
+                    RenderInline (generated) at (-1,0) size 21x17
+                      RenderText at (-1,0) size 21x17
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (0,16) size 19x61
                       text run at (0,16) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -79,12 +91,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (-1,0) size 20x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,0) size 21x17
+                      RenderText at (-1,0) size 21x17
+                        text run at (0,0) width 17: "\x{25BC} "
                     RenderText {#text} at (0,16) size 19x60
                       text run at (0,16) width 61: "summary"
                 RenderBlock {DETAILS} at (19,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (-1,0) size 20x17: "\x{25C0}"
+                    RenderInline (generated) at (-1,0) size 21x17
+                      RenderText at (-1,0) size 21x17
+                        text run at (0,0) width 17: "\x{25C0} "
                     RenderText {#text} at (0,16) size 19x61
                       text run at (0,16) width 61: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -96,20 +112,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (103,-1) size 17x20: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (103,-1) size 17x21
+                      RenderText at (103,-1) size 17x21
+                        text run at (103,0) width 5 RTL: " "
+                        text run at (107,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (43,0) size 61x19
                       text run at (43,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (103,-1) size 17x20: "\x{25BC}"
-                      RenderBlock (generated) at (0,0) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderInline (generated) at (103,-1) size 17x21
+                      RenderText at (103,-1) size 17x21
+                        text run at (103,0) width 6 RTL: " "
+                        text run at (108,0) width 12 RTL: "\x{25BC}"
                     RenderText {#text} at (44,0) size 60x19
                       text run at (44,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -117,20 +131,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (103,0) size 17x20: "\x{25C0}"
-                      RenderBlock (generated) at (0,11) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (103,-1) size 17x21
+                      RenderText at (103,-1) size 17x21
+                        text run at (103,0) width 5 RTL: " "
+                        text run at (107,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (43,0) size 61x19
                       text run at (43,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (103,0) size 17x20: "\x{25B2}"
-                      RenderBlock (generated) at (0,11) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderInline (generated) at (103,-1) size 17x21
+                      RenderText at (103,-1) size 17x21
+                        text run at (103,0) width 6 RTL: " "
+                        text run at (108,0) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (44,0) size 60x19
                       text run at (44,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -138,20 +150,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (0,103) size 20x17: "\x{25B2}"
-                      RenderBlock (generated) at (11,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,103) size 21x17
+                      RenderText at (-1,103) size 21x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,108) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,44) size 19x60
                       text run at (0,44) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (0,103) size 20x17: "\x{25B6}"
-                      RenderBlock (generated) at (11,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderInline (generated) at (-1,103) size 21x17
+                      RenderText at (-1,103) size 21x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,107) width 13 RTL: "\x{25B6}"
                     RenderText {#text} at (0,43) size 19x61
                       text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -159,20 +169,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (-1,103) size 20x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,103) size 21x17
+                      RenderText at (-1,103) size 21x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,108) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,44) size 19x60
                       text run at (0,44) width 61: "summary"
                 RenderBlock {DETAILS} at (19,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (-1,103) size 20x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (-1,103) size 21x17
+                      RenderText at (-1,103) size 21x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,107) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (0,43) size 19x61
                       text run at (0,43) width 61: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -215,12 +223,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+                    RenderInline (generated) at (0,-1) size 17x21
+                      RenderText at (0,-1) size 17x21
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (16,0) size 61x19
                       text run at (16,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+                    RenderInline (generated) at (0,-1) size 17x21
+                      RenderText at (0,-1) size 17x21
+                        text run at (0,0) width 17: "\x{25BC} "
                     RenderText {#text} at (16,0) size 60x19
                       text run at (16,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -228,12 +240,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,0) size 17x20: "\x{25B6}"
+                    RenderInline (generated) at (0,-1) size 17x21
+                      RenderText at (0,-1) size 17x21
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (16,0) size 61x19
                       text run at (16,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,0) size 17x20: "\x{25B2}"
+                    RenderInline (generated) at (0,-1) size 17x21
+                      RenderText at (0,-1) size 17x21
+                        text run at (0,0) width 17: "\x{25B2} "
                     RenderText {#text} at (16,0) size 60x19
                       text run at (16,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -241,12 +257,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (0,0) size 20x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,0) size 21x17
+                      RenderText at (-1,0) size 21x17
+                        text run at (0,0) width 17: "\x{25BC} "
                     RenderText {#text} at (0,16) size 19x60
                       text run at (0,16) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (0,0) size 20x17: "\x{25B6}"
+                    RenderInline (generated) at (-1,0) size 21x17
+                      RenderText at (-1,0) size 21x17
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (0,16) size 19x61
                       text run at (0,16) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -254,12 +274,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (-1,0) size 20x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,0) size 21x17
+                      RenderText at (-1,0) size 21x17
+                        text run at (0,0) width 17: "\x{25BC} "
                     RenderText {#text} at (0,16) size 19x60
                       text run at (0,16) width 61: "summary"
                 RenderBlock {DETAILS} at (19,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (-1,0) size 20x17: "\x{25C0}"
+                    RenderInline (generated) at (-1,0) size 21x17
+                      RenderText at (-1,0) size 21x17
+                        text run at (0,0) width 17: "\x{25C0} "
                     RenderText {#text} at (0,16) size 19x61
                       text run at (0,16) width 61: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -271,20 +295,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (59,-1) size 18x20: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (59,-1) size 18x21
+                      RenderText at (59,-1) size 18x21
+                        text run at (59,0) width 5 RTL: " "
+                        text run at (63,0) width 14 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 60x19
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (59,-1) size 17x20: "\x{25BC}"
-                      RenderBlock (generated) at (0,0) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderInline (generated) at (59,-1) size 17x21
+                      RenderText at (59,-1) size 17x21
+                        text run at (59,0) width 5 RTL: " "
+                        text run at (63,0) width 13 RTL: "\x{25BC}"
                     RenderText {#text} at (0,0) size 60x19
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -292,20 +314,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (59,0) size 18x20: "\x{25C0}"
-                      RenderBlock (generated) at (0,11) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (59,-1) size 18x21
+                      RenderText at (59,-1) size 18x21
+                        text run at (59,0) width 5 RTL: " "
+                        text run at (63,0) width 14 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 60x19
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (59,0) size 17x20: "\x{25B2}"
-                      RenderBlock (generated) at (0,11) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderInline (generated) at (59,-1) size 17x21
+                      RenderText at (59,-1) size 17x21
+                        text run at (59,0) width 5 RTL: " "
+                        text run at (63,0) width 13 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 60x19
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -313,20 +333,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (0,59) size 20x17: "\x{25B2}"
-                      RenderBlock (generated) at (11,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,59) size 21x17
+                      RenderText at (-1,59) size 21x17
+                        text run at (0,59) width 5 RTL: " "
+                        text run at (0,63) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 19x60
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (0,59) size 20x18: "\x{25B6}"
-                      RenderBlock (generated) at (11,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderInline (generated) at (-1,59) size 21x18
+                      RenderText at (-1,59) size 21x18
+                        text run at (0,59) width 5 RTL: " "
+                        text run at (0,63) width 13 RTL: "\x{25B6}"
                     RenderText {#text} at (0,0) size 19x60
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -334,20 +352,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (-1,59) size 20x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,59) size 21x17
+                      RenderText at (-1,59) size 21x17
+                        text run at (0,59) width 5 RTL: " "
+                        text run at (0,63) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 19x60
                       text run at (0,0) width 61: "summary"
                 RenderBlock {DETAILS} at (19,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (-1,59) size 20x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (-1,59) size 21x18
+                      RenderText at (-1,59) size 21x18
+                        text run at (0,59) width 5 RTL: " "
+                        text run at (0,63) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 19x60
                       text run at (0,0) width 61: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -390,12 +406,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (21,-1) size 18x20: "\x{25B6}"
+                    RenderInline (generated) at (21,-1) size 18x21
+                      RenderText at (21,-1) size 18x21
+                        text run at (21,0) width 18: "\x{25B6} "
                     RenderText {#text} at (38,0) size 61x19
                       text run at (38,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (22,-1) size 17x20: "\x{25BC}"
+                    RenderInline (generated) at (22,-1) size 17x21
+                      RenderText at (22,-1) size 17x21
+                        text run at (22,0) width 17: "\x{25BC} "
                     RenderText {#text} at (38,0) size 60x19
                       text run at (38,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -403,12 +423,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (21,0) size 18x20: "\x{25B6}"
+                    RenderInline (generated) at (21,-1) size 18x21
+                      RenderText at (21,-1) size 18x21
+                        text run at (21,0) width 18: "\x{25B6} "
                     RenderText {#text} at (38,0) size 61x19
                       text run at (38,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (22,0) size 17x20: "\x{25B2}"
+                    RenderInline (generated) at (22,-1) size 17x21
+                      RenderText at (22,-1) size 17x21
+                        text run at (22,0) width 17: "\x{25B2} "
                     RenderText {#text} at (38,0) size 60x19
                       text run at (38,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -416,12 +440,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (0,22) size 20x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,22) size 21x17
+                      RenderText at (-1,22) size 21x17
+                        text run at (0,22) width 17: "\x{25BC} "
                     RenderText {#text} at (0,38) size 19x60
                       text run at (0,38) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (0,21) size 20x18: "\x{25B6}"
+                    RenderInline (generated) at (-1,21) size 21x18
+                      RenderText at (-1,21) size 21x18
+                        text run at (0,21) width 17: "\x{25B6} "
                     RenderText {#text} at (0,38) size 19x61
                       text run at (0,38) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -429,12 +457,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (-1,22) size 20x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,22) size 21x17
+                      RenderText at (-1,22) size 21x17
+                        text run at (0,22) width 17: "\x{25BC} "
                     RenderText {#text} at (0,38) size 19x60
                       text run at (0,38) width 61: "summary"
                 RenderBlock {DETAILS} at (19,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (-1,21) size 20x18: "\x{25C0}"
+                    RenderInline (generated) at (-1,21) size 21x18
+                      RenderText at (-1,21) size 21x18
+                        text run at (0,21) width 17: "\x{25C0} "
                     RenderText {#text} at (0,38) size 19x61
                       text run at (0,38) width 61: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -446,20 +478,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (81,-1) size 18x20: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (81,-1) size 18x21
+                      RenderText at (81,-1) size 18x21
+                        text run at (81,0) width 5 RTL: " "
+                        text run at (85,0) width 14 RTL: "\x{25C0}"
                     RenderText {#text} at (21,0) size 61x19
                       text run at (21,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (81,-1) size 17x20: "\x{25BC}"
-                      RenderBlock (generated) at (0,0) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderInline (generated) at (81,-1) size 17x21
+                      RenderText at (81,-1) size 17x21
+                        text run at (81,0) width 5 RTL: " "
+                        text run at (85,0) width 13 RTL: "\x{25BC}"
                     RenderText {#text} at (22,0) size 60x19
                       text run at (22,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -467,20 +497,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (81,0) size 18x20: "\x{25C0}"
-                      RenderBlock (generated) at (0,11) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (81,-1) size 18x21
+                      RenderText at (81,-1) size 18x21
+                        text run at (81,0) width 5 RTL: " "
+                        text run at (85,0) width 14 RTL: "\x{25C0}"
                     RenderText {#text} at (21,0) size 61x19
                       text run at (21,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (81,0) size 17x20: "\x{25B2}"
-                      RenderBlock (generated) at (0,11) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderInline (generated) at (81,-1) size 17x21
+                      RenderText at (81,-1) size 17x21
+                        text run at (81,0) width 5 RTL: " "
+                        text run at (85,0) width 13 RTL: "\x{25B2}"
                     RenderText {#text} at (22,0) size 60x19
                       text run at (22,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -488,20 +516,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (0,81) size 20x17: "\x{25B2}"
-                      RenderBlock (generated) at (11,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,81) size 21x17
+                      RenderText at (-1,81) size 21x17
+                        text run at (0,81) width 5 RTL: " "
+                        text run at (0,85) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,22) size 19x60
                       text run at (0,22) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (0,81) size 20x18: "\x{25B6}"
-                      RenderBlock (generated) at (11,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderInline (generated) at (-1,81) size 21x18
+                      RenderText at (-1,81) size 21x18
+                        text run at (0,81) width 5 RTL: " "
+                        text run at (0,85) width 13 RTL: "\x{25B6}"
                     RenderText {#text} at (0,21) size 19x61
                       text run at (0,21) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -509,20 +535,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (-1,81) size 20x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,81) size 21x17
+                      RenderText at (-1,81) size 21x17
+                        text run at (0,81) width 5 RTL: " "
+                        text run at (0,85) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,22) size 19x60
                       text run at (0,22) width 61: "summary"
                 RenderBlock {DETAILS} at (19,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (-1,81) size 20x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (-1,81) size 21x18
+                      RenderText at (-1,81) size 21x18
+                        text run at (0,81) width 5 RTL: " "
+                        text run at (0,85) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (0,21) size 19x61
                       text run at (0,21) width 61: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -565,12 +589,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (43,-1) size 18x20: "\x{25B6}"
+                    RenderInline (generated) at (43,-1) size 18x21
+                      RenderText at (43,-1) size 18x21
+                        text run at (43,0) width 18: "\x{25B6} "
                     RenderText {#text} at (60,0) size 60x19
                       text run at (60,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (44,-1) size 17x20: "\x{25BC}"
+                    RenderInline (generated) at (44,-1) size 17x21
+                      RenderText at (44,-1) size 17x21
+                        text run at (44,0) width 17: "\x{25BC} "
                     RenderText {#text} at (60,0) size 60x19
                       text run at (60,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -578,12 +606,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (43,0) size 18x20: "\x{25B6}"
+                    RenderInline (generated) at (43,-1) size 18x21
+                      RenderText at (43,-1) size 18x21
+                        text run at (43,0) width 18: "\x{25B6} "
                     RenderText {#text} at (60,0) size 60x19
                       text run at (60,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (44,0) size 17x20: "\x{25B2}"
+                    RenderInline (generated) at (44,-1) size 17x21
+                      RenderText at (44,-1) size 17x21
+                        text run at (44,0) width 17: "\x{25B2} "
                     RenderText {#text} at (60,0) size 60x19
                       text run at (60,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -591,12 +623,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (0,44) size 20x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,44) size 21x17
+                      RenderText at (-1,44) size 21x17
+                        text run at (0,44) width 17: "\x{25BC} "
                     RenderText {#text} at (0,60) size 19x60
                       text run at (0,60) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (0,43) size 20x18: "\x{25B6}"
+                    RenderInline (generated) at (-1,43) size 21x18
+                      RenderText at (-1,43) size 21x18
+                        text run at (0,43) width 17: "\x{25B6} "
                     RenderText {#text} at (0,60) size 19x60
                       text run at (0,60) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -604,12 +640,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (-1,44) size 20x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,44) size 21x17
+                      RenderText at (-1,44) size 21x17
+                        text run at (0,44) width 17: "\x{25BC} "
                     RenderText {#text} at (0,60) size 19x60
                       text run at (0,60) width 61: "summary"
                 RenderBlock {DETAILS} at (19,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (-1,43) size 20x18: "\x{25C0}"
+                    RenderInline (generated) at (-1,43) size 21x18
+                      RenderText at (-1,43) size 21x18
+                        text run at (0,43) width 17: "\x{25C0} "
                     RenderText {#text} at (0,60) size 19x60
                       text run at (0,60) width 61: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -621,20 +661,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (103,-1) size 17x20: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (103,-1) size 17x21
+                      RenderText at (103,-1) size 17x21
+                        text run at (103,0) width 5 RTL: " "
+                        text run at (107,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (43,0) size 61x19
                       text run at (43,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (103,-1) size 17x20: "\x{25BC}"
-                      RenderBlock (generated) at (0,0) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderInline (generated) at (103,-1) size 17x21
+                      RenderText at (103,-1) size 17x21
+                        text run at (103,0) width 6 RTL: " "
+                        text run at (108,0) width 12 RTL: "\x{25BC}"
                     RenderText {#text} at (44,0) size 60x19
                       text run at (44,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -642,20 +680,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (103,0) size 17x20: "\x{25C0}"
-                      RenderBlock (generated) at (0,11) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (103,-1) size 17x21
+                      RenderText at (103,-1) size 17x21
+                        text run at (103,0) width 5 RTL: " "
+                        text run at (107,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (43,0) size 61x19
                       text run at (43,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (103,0) size 17x20: "\x{25B2}"
-                      RenderBlock (generated) at (0,11) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderInline (generated) at (103,-1) size 17x21
+                      RenderText at (103,-1) size 17x21
+                        text run at (103,0) width 6 RTL: " "
+                        text run at (108,0) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (44,0) size 60x19
                       text run at (44,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -663,20 +699,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (0,103) size 20x17: "\x{25B2}"
-                      RenderBlock (generated) at (11,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,103) size 21x17
+                      RenderText at (-1,103) size 21x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,108) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,44) size 19x60
                       text run at (0,44) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (0,103) size 20x17: "\x{25B6}"
-                      RenderBlock (generated) at (11,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderInline (generated) at (-1,103) size 21x17
+                      RenderText at (-1,103) size 21x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,107) width 13 RTL: "\x{25B6}"
                     RenderText {#text} at (0,43) size 19x61
                       text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -684,20 +718,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (-1,103) size 20x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,103) size 21x17
+                      RenderText at (-1,103) size 21x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,108) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,44) size 19x60
                       text run at (0,44) width 61: "summary"
                 RenderBlock {DETAILS} at (19,0) size 19x120
                   RenderListItem {SUMMARY} at (0,0) size 19x120
-                    RenderListMarker at (-1,103) size 20x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (-1,103) size 21x17
+                      RenderText at (-1,103) size 21x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,107) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (0,43) size 19x61
                       text run at (0,43) width 61: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120

--- a/LayoutTests/platform/ios/fast/html/details-writing-mode-mixed-expected.txt
+++ b/LayoutTests/platform/ios/fast/html/details-writing-mode-mixed-expected.txt
@@ -40,12 +40,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+                    RenderInline (generated) at (0,-1) size 17x21
+                      RenderText at (0,-1) size 17x21
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (16,0) size 61x19
                       text run at (16,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+                    RenderInline (generated) at (0,-1) size 17x21
+                      RenderText at (0,-1) size 17x21
+                        text run at (0,0) width 17: "\x{25BC} "
                     RenderText {#text} at (16,0) size 60x19
                       text run at (16,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -53,41 +57,53 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,0) size 17x20: "\x{25B6}"
+                    RenderInline (generated) at (0,-1) size 17x21
+                      RenderText at (0,-1) size 17x21
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (16,0) size 61x19
                       text run at (16,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,0) size 17x20: "\x{25B2}"
+                    RenderInline (generated) at (0,-1) size 17x21
+                      RenderText at (0,-1) size 17x21
+                        text run at (0,0) width 17: "\x{25B2} "
                     RenderText {#text} at (16,0) size 60x19
                       text run at (16,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (-2,0) size 20x17: "\x{25BC}"
-                    RenderText {#text} at (0,16) size 18x60
-                      text run at (0,16) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (-2,0) size 20x17: "\x{25B6}"
-                    RenderText {#text} at (0,16) size 18x61
-                      text run at (0,16) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,0) size 21x17
+                      RenderText at (-1,0) size 21x17
+                        text run at (0,0) width 17: "\x{25BC} "
+                    RenderText {#text} at (0,16) size 19x60
+                      text run at (0,16) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,0) size 21x17
+                      RenderText at (-1,0) size 21x17
+                        text run at (0,0) width 17: "\x{25B6} "
+                    RenderText {#text} at (0,16) size 19x61
+                      text run at (0,16) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,98) size 125x124 [border: (1px solid #000000)] [r=3 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 20x17: "\x{25BC}"
-                    RenderText {#text} at (0,16) size 18x60
-                      text run at (0,16) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 20x17: "\x{25C0}"
-                    RenderText {#text} at (0,16) size 18x61
-                      text run at (0,16) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,0) size 21x17
+                      RenderText at (-1,0) size 21x17
+                        text run at (0,0) width 17: "\x{25BC} "
+                    RenderText {#text} at (0,16) size 19x60
+                      text run at (0,16) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,0) size 21x17
+                      RenderText at (-1,0) size 21x17
+                        text run at (0,0) width 17: "\x{25C0} "
+                    RenderText {#text} at (0,16) size 19x61
+                      text run at (0,16) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
           RenderTableRow {TR} at (0,224) size 612x124
             RenderTableCell {TH} at (77,271) size 29x30 [border: (1px inset #000000)] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (6,53) size 17x18
@@ -96,20 +112,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (103,-1) size 17x20: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (103,-1) size 17x21
+                      RenderText at (103,-1) size 17x21
+                        text run at (103,0) width 5 RTL: " "
+                        text run at (107,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (43,0) size 61x19
                       text run at (43,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (103,-1) size 17x20: "\x{25BC}"
-                      RenderBlock (generated) at (0,0) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderInline (generated) at (103,-1) size 17x21
+                      RenderText at (103,-1) size 17x21
+                        text run at (103,0) width 6 RTL: " "
+                        text run at (108,0) width 12 RTL: "\x{25BC}"
                     RenderText {#text} at (44,0) size 60x19
                       text run at (44,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -117,65 +131,59 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (103,0) size 17x20: "\x{25C0}"
-                      RenderBlock (generated) at (0,11) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (103,-1) size 17x21
+                      RenderText at (103,-1) size 17x21
+                        text run at (103,0) width 5 RTL: " "
+                        text run at (107,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (43,0) size 61x19
                       text run at (43,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (103,0) size 17x20: "\x{25B2}"
-                      RenderBlock (generated) at (0,11) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderInline (generated) at (103,-1) size 17x21
+                      RenderText at (103,-1) size 17x21
+                        text run at (103,0) width 6 RTL: " "
+                        text run at (108,0) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (44,0) size 60x19
                       text run at (44,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (-2,103) size 20x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (-2,103) size 20x17: "\x{25B6}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25B6}"
-                    RenderText {#text} at (0,43) size 18x61
-                      text run at (0,43) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,103) size 21x17
+                      RenderText at (-1,103) size 21x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,108) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 19x60
+                      text run at (0,44) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,103) size 21x17
+                      RenderText at (-1,103) size 21x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,107) width 13 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,43) size 19x61
+                      text run at (0,43) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 20x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 20x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,43) size 18x61
-                      text run at (0,43) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,103) size 21x17
+                      RenderText at (-1,103) size 21x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,108) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 19x60
+                      text run at (0,44) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,103) size 21x17
+                      RenderText at (-1,103) size 21x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,107) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,43) size 19x61
+                      text run at (0,43) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
       RenderBlock (anonymous) at (0,352) size 784x18
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,370) size 614x352 [border: (1px outset #000000)]
@@ -215,12 +223,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,-1) size 17x20: "\x{25B6}"
+                    RenderInline (generated) at (0,-1) size 17x21
+                      RenderText at (0,-1) size 17x21
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (16,0) size 61x19
                       text run at (16,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,-1) size 17x20: "\x{25BC}"
+                    RenderInline (generated) at (0,-1) size 17x21
+                      RenderText at (0,-1) size 17x21
+                        text run at (0,0) width 17: "\x{25BC} "
                     RenderText {#text} at (16,0) size 60x19
                       text run at (16,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -228,41 +240,53 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,0) size 17x20: "\x{25B6}"
+                    RenderInline (generated) at (0,-1) size 17x21
+                      RenderText at (0,-1) size 17x21
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (16,0) size 61x19
                       text run at (16,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (0,0) size 17x20: "\x{25B2}"
+                    RenderInline (generated) at (0,-1) size 17x21
+                      RenderText at (0,-1) size 17x21
+                        text run at (0,0) width 17: "\x{25B2} "
                     RenderText {#text} at (16,0) size 60x19
                       text run at (16,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (-2,0) size 20x17: "\x{25BC}"
-                    RenderText {#text} at (0,16) size 18x60
-                      text run at (0,16) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (-2,0) size 20x17: "\x{25B6}"
-                    RenderText {#text} at (0,16) size 18x61
-                      text run at (0,16) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,0) size 21x17
+                      RenderText at (-1,0) size 21x17
+                        text run at (0,0) width 17: "\x{25BC} "
+                    RenderText {#text} at (0,16) size 19x60
+                      text run at (0,16) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,0) size 21x17
+                      RenderText at (-1,0) size 21x17
+                        text run at (0,0) width 17: "\x{25B6} "
+                    RenderText {#text} at (0,16) size 19x61
+                      text run at (0,16) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,98) size 125x124 [border: (1px solid #000000)] [r=3 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 20x17: "\x{25BC}"
-                    RenderText {#text} at (0,16) size 18x60
-                      text run at (0,16) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 20x17: "\x{25C0}"
-                    RenderText {#text} at (0,16) size 18x61
-                      text run at (0,16) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,0) size 21x17
+                      RenderText at (-1,0) size 21x17
+                        text run at (0,0) width 17: "\x{25BC} "
+                    RenderText {#text} at (0,16) size 19x60
+                      text run at (0,16) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,0) size 21x17
+                      RenderText at (-1,0) size 21x17
+                        text run at (0,0) width 17: "\x{25C0} "
+                    RenderText {#text} at (0,16) size 19x61
+                      text run at (0,16) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
           RenderTableRow {TR} at (0,224) size 612x124
             RenderTableCell {TH} at (77,271) size 29x30 [border: (1px inset #000000)] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (6,53) size 17x18
@@ -271,20 +295,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (59,-1) size 18x20: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (59,-1) size 18x21
+                      RenderText at (59,-1) size 18x21
+                        text run at (59,0) width 5 RTL: " "
+                        text run at (63,0) width 14 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 60x19
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (59,-1) size 17x20: "\x{25BC}"
-                      RenderBlock (generated) at (0,0) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderInline (generated) at (59,-1) size 17x21
+                      RenderText at (59,-1) size 17x21
+                        text run at (59,0) width 5 RTL: " "
+                        text run at (63,0) width 13 RTL: "\x{25BC}"
                     RenderText {#text} at (0,0) size 60x19
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -292,65 +314,59 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (59,0) size 18x20: "\x{25C0}"
-                      RenderBlock (generated) at (0,11) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (59,-1) size 18x21
+                      RenderText at (59,-1) size 18x21
+                        text run at (59,0) width 5 RTL: " "
+                        text run at (63,0) width 14 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 60x19
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (59,0) size 17x20: "\x{25B2}"
-                      RenderBlock (generated) at (0,11) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderInline (generated) at (59,-1) size 17x21
+                      RenderText at (59,-1) size 17x21
+                        text run at (59,0) width 5 RTL: " "
+                        text run at (63,0) width 13 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 60x19
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (-2,59) size 20x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,0) size 18x60
-                      text run at (0,0) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (-2,59) size 20x18: "\x{25B6}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25B6}"
-                    RenderText {#text} at (0,0) size 18x60
-                      text run at (0,0) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,59) size 21x17
+                      RenderText at (-1,59) size 21x17
+                        text run at (0,59) width 5 RTL: " "
+                        text run at (0,63) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,0) size 19x60
+                      text run at (0,0) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,59) size 21x18
+                      RenderText at (-1,59) size 21x18
+                        text run at (0,59) width 5 RTL: " "
+                        text run at (0,63) width 13 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,0) size 19x60
+                      text run at (0,0) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 20x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,0) size 18x60
-                      text run at (0,0) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 20x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,0) size 18x60
-                      text run at (0,0) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,59) size 21x17
+                      RenderText at (-1,59) size 21x17
+                        text run at (0,59) width 5 RTL: " "
+                        text run at (0,63) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,0) size 19x60
+                      text run at (0,0) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,59) size 21x18
+                      RenderText at (-1,59) size 21x18
+                        text run at (0,59) width 5 RTL: " "
+                        text run at (0,63) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,0) size 19x60
+                      text run at (0,0) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
       RenderBlock (anonymous) at (0,722) size 784x18
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,740) size 614x352 [border: (1px outset #000000)]
@@ -390,12 +406,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (21,-1) size 18x20: "\x{25B6}"
+                    RenderInline (generated) at (21,-1) size 18x21
+                      RenderText at (21,-1) size 18x21
+                        text run at (21,0) width 18: "\x{25B6} "
                     RenderText {#text} at (38,0) size 61x19
                       text run at (38,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (22,-1) size 17x20: "\x{25BC}"
+                    RenderInline (generated) at (22,-1) size 17x21
+                      RenderText at (22,-1) size 17x21
+                        text run at (22,0) width 17: "\x{25BC} "
                     RenderText {#text} at (38,0) size 60x19
                       text run at (38,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -403,41 +423,53 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (21,0) size 18x20: "\x{25B6}"
+                    RenderInline (generated) at (21,-1) size 18x21
+                      RenderText at (21,-1) size 18x21
+                        text run at (21,0) width 18: "\x{25B6} "
                     RenderText {#text} at (38,0) size 61x19
                       text run at (38,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (22,0) size 17x20: "\x{25B2}"
+                    RenderInline (generated) at (22,-1) size 17x21
+                      RenderText at (22,-1) size 17x21
+                        text run at (22,0) width 17: "\x{25B2} "
                     RenderText {#text} at (38,0) size 60x19
                       text run at (38,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (-2,22) size 20x17: "\x{25BC}"
-                    RenderText {#text} at (0,38) size 18x60
-                      text run at (0,38) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (-2,21) size 20x18: "\x{25B6}"
-                    RenderText {#text} at (0,38) size 18x61
-                      text run at (0,38) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,22) size 21x17
+                      RenderText at (-1,22) size 21x17
+                        text run at (0,22) width 17: "\x{25BC} "
+                    RenderText {#text} at (0,38) size 19x60
+                      text run at (0,38) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,21) size 21x18
+                      RenderText at (-1,21) size 21x18
+                        text run at (0,21) width 17: "\x{25B6} "
+                    RenderText {#text} at (0,38) size 19x61
+                      text run at (0,38) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,98) size 125x124 [border: (1px solid #000000)] [r=3 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,22) size 20x17: "\x{25BC}"
-                    RenderText {#text} at (0,38) size 18x60
-                      text run at (0,38) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,21) size 20x18: "\x{25C0}"
-                    RenderText {#text} at (0,38) size 18x61
-                      text run at (0,38) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,22) size 21x17
+                      RenderText at (-1,22) size 21x17
+                        text run at (0,22) width 17: "\x{25BC} "
+                    RenderText {#text} at (0,38) size 19x60
+                      text run at (0,38) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,21) size 21x18
+                      RenderText at (-1,21) size 21x18
+                        text run at (0,21) width 17: "\x{25C0} "
+                    RenderText {#text} at (0,38) size 19x61
+                      text run at (0,38) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
           RenderTableRow {TR} at (0,224) size 612x124
             RenderTableCell {TH} at (77,271) size 29x30 [border: (1px inset #000000)] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (6,53) size 17x18
@@ -446,20 +478,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (81,-1) size 18x20: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (81,-1) size 18x21
+                      RenderText at (81,-1) size 18x21
+                        text run at (81,0) width 5 RTL: " "
+                        text run at (85,0) width 14 RTL: "\x{25C0}"
                     RenderText {#text} at (21,0) size 61x19
                       text run at (21,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (81,-1) size 17x20: "\x{25BC}"
-                      RenderBlock (generated) at (0,0) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderInline (generated) at (81,-1) size 17x21
+                      RenderText at (81,-1) size 17x21
+                        text run at (81,0) width 5 RTL: " "
+                        text run at (85,0) width 13 RTL: "\x{25BC}"
                     RenderText {#text} at (22,0) size 60x19
                       text run at (22,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -467,65 +497,59 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (81,0) size 18x20: "\x{25C0}"
-                      RenderBlock (generated) at (0,11) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (81,-1) size 18x21
+                      RenderText at (81,-1) size 18x21
+                        text run at (81,0) width 5 RTL: " "
+                        text run at (85,0) width 14 RTL: "\x{25C0}"
                     RenderText {#text} at (21,0) size 61x19
                       text run at (21,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (81,0) size 17x20: "\x{25B2}"
-                      RenderBlock (generated) at (0,11) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderInline (generated) at (81,-1) size 17x21
+                      RenderText at (81,-1) size 17x21
+                        text run at (81,0) width 5 RTL: " "
+                        text run at (85,0) width 13 RTL: "\x{25B2}"
                     RenderText {#text} at (22,0) size 60x19
                       text run at (22,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (-2,81) size 20x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,22) size 18x60
-                      text run at (0,22) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (-2,81) size 20x18: "\x{25B6}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25B6}"
-                    RenderText {#text} at (0,21) size 18x61
-                      text run at (0,21) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,81) size 21x17
+                      RenderText at (-1,81) size 21x17
+                        text run at (0,81) width 5 RTL: " "
+                        text run at (0,85) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,22) size 19x60
+                      text run at (0,22) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,81) size 21x18
+                      RenderText at (-1,81) size 21x18
+                        text run at (0,81) width 5 RTL: " "
+                        text run at (0,85) width 13 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,21) size 19x61
+                      text run at (0,21) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 20x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,22) size 18x60
-                      text run at (0,22) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 20x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,21) size 18x61
-                      text run at (0,21) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,81) size 21x17
+                      RenderText at (-1,81) size 21x17
+                        text run at (0,81) width 5 RTL: " "
+                        text run at (0,85) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,22) size 19x60
+                      text run at (0,22) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,81) size 21x18
+                      RenderText at (-1,81) size 21x18
+                        text run at (0,81) width 5 RTL: " "
+                        text run at (0,85) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,21) size 19x61
+                      text run at (0,21) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
       RenderBlock (anonymous) at (0,1092) size 784x18
         RenderBR {BR} at (0,0) size 0x18
       RenderTable {TABLE} at (0,1110) size 614x352 [border: (1px outset #000000)]
@@ -565,12 +589,16 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (43,-1) size 18x20: "\x{25B6}"
+                    RenderInline (generated) at (43,-1) size 18x21
+                      RenderText at (43,-1) size 18x21
+                        text run at (43,0) width 18: "\x{25B6} "
                     RenderText {#text} at (60,0) size 60x19
                       text run at (60,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (44,-1) size 17x20: "\x{25BC}"
+                    RenderInline (generated) at (44,-1) size 17x21
+                      RenderText at (44,-1) size 17x21
+                        text run at (44,0) width 17: "\x{25BC} "
                     RenderText {#text} at (60,0) size 60x19
                       text run at (60,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -578,41 +606,53 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (43,0) size 18x20: "\x{25B6}"
+                    RenderInline (generated) at (43,-1) size 18x21
+                      RenderText at (43,-1) size 18x21
+                        text run at (43,0) width 18: "\x{25B6} "
                     RenderText {#text} at (60,0) size 60x19
                       text run at (60,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (44,0) size 17x20: "\x{25B2}"
+                    RenderInline (generated) at (44,-1) size 17x21
+                      RenderText at (44,-1) size 17x21
+                        text run at (44,0) width 17: "\x{25B2} "
                     RenderText {#text} at (60,0) size 60x19
                       text run at (60,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,98) size 125x124 [border: (1px solid #000000)] [r=3 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (-2,44) size 20x17: "\x{25BC}"
-                    RenderText {#text} at (0,60) size 18x60
-                      text run at (0,60) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (-2,43) size 20x18: "\x{25B6}"
-                    RenderText {#text} at (0,60) size 18x60
-                      text run at (0,60) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,44) size 21x17
+                      RenderText at (-1,44) size 21x17
+                        text run at (0,44) width 17: "\x{25BC} "
+                    RenderText {#text} at (0,60) size 19x60
+                      text run at (0,60) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,43) size 21x18
+                      RenderText at (-1,43) size 21x18
+                        text run at (0,43) width 17: "\x{25B6} "
+                    RenderText {#text} at (0,60) size 19x60
+                      text run at (0,60) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,98) size 125x124 [border: (1px solid #000000)] [r=3 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,44) size 20x17: "\x{25BC}"
-                    RenderText {#text} at (0,60) size 18x60
-                      text run at (0,60) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,43) size 20x18: "\x{25C0}"
-                    RenderText {#text} at (0,60) size 18x60
-                      text run at (0,60) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,44) size 21x17
+                      RenderText at (-1,44) size 21x17
+                        text run at (0,44) width 17: "\x{25BC} "
+                    RenderText {#text} at (0,60) size 19x60
+                      text run at (0,60) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,43) size 21x18
+                      RenderText at (-1,43) size 21x18
+                        text run at (0,43) width 17: "\x{25C0} "
+                    RenderText {#text} at (0,60) size 19x60
+                      text run at (0,60) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
           RenderTableRow {TR} at (0,224) size 612x124
             RenderTableCell {TH} at (77,271) size 29x30 [border: (1px inset #000000)] [r=4 c=1 rs=1 cs=1]
               RenderText {#text} at (6,53) size 17x18
@@ -621,20 +661,18 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (103,-1) size 17x20: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (103,-1) size 17x21
+                      RenderText at (103,-1) size 17x21
+                        text run at (103,0) width 5 RTL: " "
+                        text run at (107,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (43,0) size 61x19
                       text run at (43,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (103,-1) size 17x20: "\x{25BC}"
-                      RenderBlock (generated) at (0,0) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderInline (generated) at (103,-1) size 17x21
+                      RenderText at (103,-1) size 17x21
+                        text run at (103,0) width 6 RTL: " "
+                        text run at (108,0) width 12 RTL: "\x{25BC}"
                     RenderText {#text} at (44,0) size 60x19
                       text run at (44,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -642,62 +680,56 @@ layer at (0,0) size 800x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (103,0) size 17x20: "\x{25C0}"
-                      RenderBlock (generated) at (0,11) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (103,-1) size 17x21
+                      RenderText at (103,-1) size 17x21
+                        text run at (103,0) width 5 RTL: " "
+                        text run at (107,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (43,0) size 61x19
                       text run at (43,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x19
                   RenderListItem {SUMMARY} at (0,0) size 120x19
-                    RenderListMarker at (103,0) size 17x20: "\x{25B2}"
-                      RenderBlock (generated) at (0,11) size 17x20
-                        RenderText at (0,-1) size 17x21
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderInline (generated) at (103,-1) size 17x21
+                      RenderText at (103,-1) size 17x21
+                        text run at (103,0) width 6 RTL: " "
+                        text run at (108,0) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (44,0) size 60x19
                       text run at (44,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
             RenderTableCell {TD} at (359,224) size 125x124 [border: (1px solid #000000)] [r=4 c=4 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (-2,103) size 20x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (-2,103) size 20x17: "\x{25B6}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25B6}"
-                    RenderText {#text} at (0,43) size 18x61
-                      text run at (0,43) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,103) size 21x17
+                      RenderText at (-1,103) size 21x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,108) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 19x60
+                      text run at (0,44) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,103) size 21x17
+                      RenderText at (-1,103) size 21x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,107) width 13 RTL: "\x{25B6}"
+                    RenderText {#text} at (0,43) size 19x61
+                      text run at (0,43) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120
             RenderTableCell {TD} at (485,224) size 125x124 [border: (1px solid #000000)] [r=4 c=5 rs=1 cs=1]
               RenderBlock {DIV} at (2,2) size 120x120
-                RenderBlock {DETAILS} at (0,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 20x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
-                    RenderText {#text} at (0,44) size 18x60
-                      text run at (0,44) width 60: "summary"
-                RenderBlock {DETAILS} at (18,0) size 18x120
-                  RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 20x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 20x17
-                        RenderText at (-1,0) size 21x17
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25C0}"
-                    RenderText {#text} at (0,43) size 18x61
-                      text run at (0,43) width 60: "summary"
-                  RenderBlock {SLOT} at (18,0) size 0x120
+                RenderBlock {DETAILS} at (0,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,103) size 21x17
+                      RenderText at (-1,103) size 21x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,108) width 12 RTL: "\x{25B2}"
+                    RenderText {#text} at (0,44) size 19x60
+                      text run at (0,44) width 61: "summary"
+                RenderBlock {DETAILS} at (19,0) size 19x120
+                  RenderListItem {SUMMARY} at (0,0) size 19x120
+                    RenderInline (generated) at (-1,103) size 21x17
+                      RenderText at (-1,103) size 21x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,107) width 13 RTL: "\x{25C0}"
+                    RenderText {#text} at (0,43) size 19x61
+                      text run at (0,43) width 61: "summary"
+                  RenderBlock {SLOT} at (19,0) size 0x120

--- a/LayoutTests/platform/ios/fast/lists/008-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/008-expected.txt
@@ -33,30 +33,42 @@ layer at (0,0) size 800x1844
             text run at (65,10) width 69: "Third item"
       RenderBlock {UL} at (0,300) size 186x134 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (41,1) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (9,10) size 7x18: bullet
+          RenderInline (generated) at (9,10) size 7x18
+            RenderText at (9,10) size 7x18
+              text run at (9,10) width 7: "\x{2022}"
           RenderText {#text} at (24,10) size 62x18
             text run at (24,10) width 62: "First item"
         RenderListItem {LI} at (41,39) size 144x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (9,10) size 7x18: bullet
+          RenderInline (generated) at (9,10) size 7x18
+            RenderText at (9,10) size 7x18
+              text run at (9,10) width 7: "\x{2022}"
           RenderText {#text} at (10,10) size 121x36
             text run at (24,10) width 107: "Second and very"
             text run at (10,28) width 94: "very long item"
         RenderListItem {LI} at (41,95) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (9,10) size 7x18: bullet
+          RenderInline (generated) at (9,10) size 7x18
+            RenderText at (9,10) size 7x18
+              text run at (9,10) width 7: "\x{2022}"
           RenderText {#text} at (24,10) size 68x18
             text run at (24,10) width 68: "Third item"
       RenderBlock {UL} at (0,450) size 186x134 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (127,10) size 8x18: bullet
+          RenderInline (generated) at (127,10) size 8x18
+            RenderText at (127,10) size 8x18
+              text run at (127,10) width 8 RTL: "\x{2022}"
           RenderText {#text} at (57,10) size 63x18
             text run at (57,10) width 63: "First item"
         RenderListItem {LI} at (1,39) size 144x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (127,10) size 8x18: bullet
+          RenderInline (generated) at (127,10) size 8x18
+            RenderText at (127,10) size 8x18
+              text run at (127,10) width 8 RTL: "\x{2022}"
           RenderText {#text} at (12,10) size 122x36
             text run at (12,10) width 108: "Second and very"
             text run at (39,28) width 95: "very long item"
         RenderListItem {LI} at (1,95) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (127,10) size 8x18: bullet
+          RenderInline (generated) at (127,10) size 8x18
+            RenderText at (127,10) size 8x18
+              text run at (127,10) width 8 RTL: "\x{2022}"
           RenderText {#text} at (51,10) size 69x18
             text run at (51,10) width 69: "Third item"
       RenderBlock {UL} at (0,600) size 186x134 [border: (1px solid #0000FF)]
@@ -89,32 +101,38 @@ layer at (0,0) size 800x1844
             text run at (65,10) width 69: "Third item"
       RenderBlock {UL} at (0,900) size 186x152 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (41,1) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,14) size 10x11
+          RenderInline (generated) at (10,10) size 17x18
+            RenderImage at (10,14) size 10x11
           RenderText {#text} at (27,10) size 62x18
             text run at (27,10) width 62: "First item"
         RenderListItem {LI} at (41,39) size 144x74 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,14) size 10x11
+          RenderInline (generated) at (10,10) size 17x18
+            RenderImage at (10,14) size 10x11
           RenderText {#text} at (10,10) size 94x54
             text run at (27,10) width 75: "Second and"
             text run at (10,28) width 94: "very very long"
             text run at (10,46) width 29: "item"
         RenderListItem {LI} at (41,113) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,14) size 10x11
+          RenderInline (generated) at (10,10) size 17x18
+            RenderImage at (10,14) size 10x11
           RenderText {#text} at (27,10) size 68x18
             text run at (27,10) width 68: "Third item"
       RenderBlock {UL} at (0,1068) size 186x152 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (123,14) size 11x11
+          RenderInline (generated) at (116,10) size 18x18
+            RenderImage at (123,14) size 11x11
           RenderText {#text} at (54,10) size 63x18
             text run at (54,10) width 63: "First item"
         RenderListItem {LI} at (1,39) size 144x74 [border: (5px solid #FFA500)]
-          RenderListMarker at (123,14) size 11x11
+          RenderInline (generated) at (116,10) size 18x18
+            RenderImage at (123,14) size 11x11
           RenderText {#text} at (39,10) size 95x54
             text run at (41,10) width 76: "Second and"
             text run at (39,28) width 95: "very very long"
             text run at (104,46) width 30: "item"
         RenderListItem {LI} at (1,113) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (123,14) size 11x11
+          RenderInline (generated) at (116,10) size 18x18
+            RenderImage at (123,14) size 11x11
           RenderText {#text} at (48,10) size 69x18
             text run at (48,10) width 69: "Third item"
       RenderBlock {OL} at (0,1236) size 186x134 [border: (1px solid #0000FF)]
@@ -162,44 +180,47 @@ layer at (0,0) size 800x1844
             text run at (65,10) width 69: "Third item"
       RenderBlock {OL} at (0,1536) size 186x134 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (41,1) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 16x18: "1"
+          RenderInline (generated) at (10,10) size 16x18
+            RenderText at (10,10) size 16x18
+              text run at (10,10) width 16: "1. "
           RenderText {#text} at (26,10) size 62x18
             text run at (26,10) width 62: "First item"
         RenderListItem {LI} at (41,39) size 144x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 16x18: "2"
+          RenderInline (generated) at (10,10) size 16x18
+            RenderText at (10,10) size 16x18
+              text run at (10,10) width 16: "2. "
           RenderText {#text} at (10,10) size 123x36
             text run at (26,10) width 107: "Second and very"
             text run at (10,28) width 94: "very long item"
         RenderListItem {LI} at (41,95) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 16x18: "3"
+          RenderInline (generated) at (10,10) size 16x18
+            RenderText at (10,10) size 16x18
+              text run at (10,10) width 16: "3. "
           RenderText {#text} at (26,10) size 68x18
             text run at (26,10) width 68: "Third item"
       RenderBlock {OL} at (0,1686) size 186x134 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (117,10) size 17x18: "1"
-            RenderBlock (generated) at (0,-1) size 16x19
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "1"
+          RenderInline (generated) at (117,10) size 17x18
+            RenderText at (117,10) size 17x18
+              text run at (117,10) width 5 RTL: " "
+              text run at (121,10) width 5 RTL: "."
+              text run at (125,10) width 9: "1"
           RenderText {#text} at (55,10) size 63x18
             text run at (55,10) width 63: "First item"
         RenderListItem {LI} at (1,39) size 144x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (117,10) size 17x18: "2"
-            RenderBlock (generated) at (0,-1) size 16x19
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "2"
+          RenderInline (generated) at (117,10) size 17x18
+            RenderText at (117,10) size 17x18
+              text run at (117,10) width 5 RTL: " "
+              text run at (121,10) width 5 RTL: "."
+              text run at (125,10) width 9: "2"
           RenderText {#text} at (10,10) size 124x36
             text run at (10,10) width 108: "Second and very"
             text run at (39,28) width 95: "very long item"
         RenderListItem {LI} at (1,95) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (117,10) size 17x18: "3"
-            RenderBlock (generated) at (0,-1) size 16x19
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "3"
+          RenderInline (generated) at (117,10) size 17x18
+            RenderText at (117,10) size 17x18
+              text run at (117,10) width 5 RTL: " "
+              text run at (121,10) width 5 RTL: "."
+              text run at (125,10) width 9: "3"
           RenderText {#text} at (49,10) size 69x18
             text run at (49,10) width 69: "Third item"

--- a/LayoutTests/platform/ios/fast/lists/008-vertical-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/008-vertical-expected.txt
@@ -33,30 +33,42 @@ layer at (0,0) size 1844x600
             text run at (10,65) width 69: "Third item"
       RenderBlock {UL} at (300,0) size 134x186 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (1,41) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,9) size 18x7: bullet
+          RenderInline (generated) at (10,9) size 18x7
+            RenderText at (10,9) size 18x7
+              text run at (10,9) width 8: "\x{2022}"
           RenderText {#text} at (10,24) size 18x62
             text run at (10,24) width 62: "First item"
         RenderListItem {LI} at (39,41) size 56x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,9) size 18x7: bullet
+          RenderInline (generated) at (10,9) size 18x7
+            RenderText at (10,9) size 18x7
+              text run at (10,9) width 8: "\x{2022}"
           RenderText {#text} at (10,10) size 36x121
             text run at (10,24) width 107: "Second and very"
             text run at (28,10) width 94: "very long item"
         RenderListItem {LI} at (95,41) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,9) size 18x7: bullet
+          RenderInline (generated) at (10,9) size 18x7
+            RenderText at (10,9) size 18x7
+              text run at (10,9) width 8: "\x{2022}"
           RenderText {#text} at (10,24) size 18x68
             text run at (10,24) width 69: "Third item"
       RenderBlock {UL} at (450,0) size 134x186 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,127) size 18x8: bullet
+          RenderInline (generated) at (10,127) size 18x8
+            RenderText at (10,127) size 18x8
+              text run at (10,127) width 8 RTL: "\x{2022}"
           RenderText {#text} at (10,57) size 18x63
             text run at (10,57) width 62: "First item"
         RenderListItem {LI} at (39,1) size 56x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,127) size 18x8: bullet
+          RenderInline (generated) at (10,127) size 18x8
+            RenderText at (10,127) size 18x8
+              text run at (10,127) width 8 RTL: "\x{2022}"
           RenderText {#text} at (10,12) size 36x122
             text run at (10,12) width 107: "Second and very"
             text run at (28,39) width 94: "very long item"
         RenderListItem {LI} at (95,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,127) size 18x8: bullet
+          RenderInline (generated) at (10,127) size 18x8
+            RenderText at (10,127) size 18x8
+              text run at (10,127) width 8 RTL: "\x{2022}"
           RenderText {#text} at (10,51) size 18x69
             text run at (10,51) width 69: "Third item"
       RenderBlock {UL} at (600,0) size 134x186 [border: (1px solid #0000FF)]
@@ -89,32 +101,38 @@ layer at (0,0) size 1844x600
             text run at (10,65) width 69: "Third item"
       RenderBlock {UL} at (900,0) size 152x186 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (1,41) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,10) size 10x10
+          RenderInline (generated) at (10,10) size 18x17
+            RenderImage at (14,10) size 10x10
           RenderText {#text} at (10,27) size 18x62
             text run at (10,27) width 62: "First item"
         RenderListItem {LI} at (39,41) size 74x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,10) size 10x10
+          RenderInline (generated) at (10,10) size 18x17
+            RenderImage at (14,10) size 10x10
           RenderText {#text} at (10,10) size 54x94
             text run at (10,27) width 75: "Second and"
             text run at (28,10) width 94: "very very long"
             text run at (46,10) width 29: "item"
         RenderListItem {LI} at (113,41) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,10) size 10x10
+          RenderInline (generated) at (10,10) size 18x17
+            RenderImage at (14,10) size 10x10
           RenderText {#text} at (10,27) size 18x68
             text run at (10,27) width 69: "Third item"
       RenderBlock {UL} at (1068,0) size 152x186 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,123) size 10x11
+          RenderInline (generated) at (10,116) size 18x18
+            RenderImage at (14,123) size 10x11
           RenderText {#text} at (10,54) size 18x63
             text run at (10,54) width 62: "First item"
         RenderListItem {LI} at (39,1) size 74x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,123) size 10x11
+          RenderInline (generated) at (10,116) size 18x18
+            RenderImage at (14,123) size 10x11
           RenderText {#text} at (10,39) size 54x95
             text run at (10,41) width 75: "Second and"
             text run at (28,39) width 94: "very very long"
             text run at (46,104) width 29: "item"
         RenderListItem {LI} at (113,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,123) size 10x11
+          RenderInline (generated) at (10,116) size 18x18
+            RenderImage at (14,123) size 10x11
           RenderText {#text} at (10,48) size 18x69
             text run at (10,48) width 69: "Third item"
       RenderBlock {OL} at (1236,0) size 134x186 [border: (1px solid #0000FF)]
@@ -162,44 +180,47 @@ layer at (0,0) size 1844x600
             text run at (10,65) width 69: "Third item"
       RenderBlock {OL} at (1536,0) size 134x186 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (1,41) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 18x16: "1"
+          RenderInline (generated) at (10,10) size 18x16
+            RenderText at (10,10) size 18x16
+              text run at (10,10) width 17: "1. "
           RenderText {#text} at (10,26) size 18x62
             text run at (10,26) width 62: "First item"
         RenderListItem {LI} at (39,41) size 56x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 18x16: "2"
+          RenderInline (generated) at (10,10) size 18x16
+            RenderText at (10,10) size 18x16
+              text run at (10,10) width 17: "2. "
           RenderText {#text} at (10,10) size 36x123
             text run at (10,26) width 107: "Second and very"
             text run at (28,10) width 94: "very long item"
         RenderListItem {LI} at (95,41) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 18x16: "3"
+          RenderInline (generated) at (10,10) size 18x16
+            RenderText at (10,10) size 18x16
+              text run at (10,10) width 17: "3. "
           RenderText {#text} at (10,26) size 18x68
             text run at (10,26) width 69: "Third item"
       RenderBlock {OL} at (1686,0) size 134x186 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,117) size 18x17: "1"
-            RenderBlock (generated) at (-1,0) size 19x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 5 RTL: " "
-                text run at (0,4) width 5 RTL: "."
-                text run at (0,8) width 9: "1"
+          RenderInline (generated) at (10,117) size 18x17
+            RenderText at (10,117) size 18x17
+              text run at (10,117) width 5 RTL: " "
+              text run at (10,121) width 5 RTL: "."
+              text run at (10,125) width 9: "1"
           RenderText {#text} at (10,55) size 18x63
             text run at (10,55) width 62: "First item"
         RenderListItem {LI} at (39,1) size 56x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,117) size 18x17: "2"
-            RenderBlock (generated) at (-1,0) size 19x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 5 RTL: " "
-                text run at (0,4) width 5 RTL: "."
-                text run at (0,8) width 9: "2"
+          RenderInline (generated) at (10,117) size 18x17
+            RenderText at (10,117) size 18x17
+              text run at (10,117) width 5 RTL: " "
+              text run at (10,121) width 5 RTL: "."
+              text run at (10,125) width 9: "2"
           RenderText {#text} at (10,10) size 36x124
             text run at (10,10) width 107: "Second and very"
             text run at (28,39) width 94: "very long item"
         RenderListItem {LI} at (95,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,117) size 18x17: "3"
-            RenderBlock (generated) at (-1,0) size 19x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 5 RTL: " "
-                text run at (0,4) width 5 RTL: "."
-                text run at (0,8) width 9: "3"
+          RenderInline (generated) at (10,117) size 18x17
+            RenderText at (10,117) size 18x17
+              text run at (10,117) width 5 RTL: " "
+              text run at (10,121) width 5 RTL: "."
+              text run at (10,125) width 9: "3"
           RenderText {#text} at (10,49) size 18x69
             text run at (10,49) width 69: "Third item"

--- a/LayoutTests/platform/ios/fast/lists/009-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/009-expected.txt
@@ -11,6 +11,7 @@ layer at (0,0) size 800x600
           RenderBlock {DD} at (0,18) size 784x18
             RenderBlock {UL} at (0,0) size 784x18
               RenderListItem {LI} at (0,0) size 784x18
-                RenderListMarker at (0,5) size 12x10
+                RenderInline (generated) at (0,0) size 19x18
+                  RenderImage at (0,5) size 12x10
                 RenderText {#text} at (19,0) size 114x18
                   text run at (19,0) width 114: "LI text is here too"

--- a/LayoutTests/platform/ios/fast/lists/009-vertical-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/009-vertical-expected.txt
@@ -11,6 +11,7 @@ layer at (0,0) size 800x600
           RenderBlock {DD} at (18,0) size 18x584
             RenderBlock {UL} at (0,0) size 18x584
               RenderListItem {LI} at (0,0) size 18x584
-                RenderListMarker at (2,0) size 13x9
+                RenderInline (generated) at (0,0) size 18x16
+                  RenderImage at (2,0) size 13x9
                 RenderText {#text} at (0,16) size 18x114
                   text run at (0,16) width 114: "LI text is here too"

--- a/LayoutTests/platform/ios/fast/lists/li-br-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/li-br-expected.txt
@@ -10,6 +10,8 @@ layer at (0,0) size 800x600
             text run at (0,0) width 1492: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       RenderBlock {OL} at (0,34) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderListMarker at (0,0) size 16x18: "1"
+          RenderInline (generated) at (0,0) size 16x18
+            RenderText at (0,0) size 16x18
+              text run at (0,0) width 16: "1. "
           RenderText {#text} at (0,18) size 1492x18
             text run at (0,18) width 1492: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/LayoutTests/platform/ios/fast/lists/markers-in-selection-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/markers-in-selection-expected.txt
@@ -28,7 +28,9 @@ layer at (0,0) size 800x600
             text run at (0,0) width 162: "Item with outside marker"
       RenderBlock {UL} at (0,120) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-1,0) size 7x18: bullet
+          RenderInline (generated) at (-1,0) size 7x18
+            RenderText at (-1,0) size 7x18
+              text run at (-1,0) width 7: "\x{2022}"
           RenderText {#text} at (14,0) size 154x18
             text run at (14,0) width 154: "Item with inside marker"
       RenderBlock {UL} at (0,154) size 784x18
@@ -38,7 +40,8 @@ layer at (0,0) size 800x600
             text run at (0,0) width 205: "Item with outside image marker"
       RenderBlock {UL} at (0,188) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (0,4) size 10x11
+          RenderInline (generated) at (0,0) size 17x18
+            RenderImage at (0,4) size 10x11
           RenderText {#text} at (17,0) size 197x18
             text run at (17,0) width 197: "Item with inside image marker"
       RenderBlock {OL} at (0,222) size 784x36
@@ -52,11 +55,15 @@ layer at (0,0) size 800x600
             text run at (0,0) width 103: "and another one"
       RenderBlock {OL} at (0,274) size 784x36
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (0,0) size 16x18: "1"
+          RenderInline (generated) at (0,0) size 16x18
+            RenderText at (0,0) size 16x18
+              text run at (0,0) width 16: "1. "
           RenderText {#text} at (16,0) size 154x18
             text run at (16,0) width 154: "Item with inside ordinal"
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (0,0) size 16x18: "2"
+          RenderInline (generated) at (0,0) size 16x18
+            RenderText at (0,0) size 16x18
+              text run at (0,0) width 16: "2. "
           RenderText {#text} at (16,0) size 103x18
             text run at (16,0) width 103: "and another one"
       RenderBlock (anonymous) at (0,336) size 784x0

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug30692-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug30692-expected.txt
@@ -8,12 +8,16 @@ layer at (0,0) size 800x600
           text run at (0,0) width 497: "BUG: Inside a cell, \"height:x%\" is ignored. It looks like 'auto' is used instead."
         RenderBR {BR} at (496,0) size 1x18
       RenderListItem {LI} at (0,18) size 784x18
-        RenderListMarker at (-1,0) size 7x18: bullet
+        RenderInline (generated) at (-1,0) size 7x18
+          RenderText at (-1,0) size 7x18
+            text run at (-1,0) width 7: "\x{2022}"
         RenderText {#text} at (14,0) size 265x18
           text run at (14,0) width 265: "Absolute units work correctly (eg. 50px)."
       RenderListItem {LI} at (0,36) size 784x490
         RenderBlock (anonymous) at (0,0) size 784x18
-          RenderListMarker at (-1,0) size 7x18: bullet
+          RenderInline (generated) at (-1,0) size 7x18
+            RenderText at (-1,0) size 7x18
+              text run at (-1,0) width 7: "\x{2022}"
           RenderText {#text} at (14,0) size 183x18
             text run at (14,0) width 183: "\"width:x%\" works correctly."
         RenderTable {TABLE} at (0,36) size 784x100

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-no-summary4-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-no-summary4-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x39
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 46x19
             text run at (16,1) width 46: "Details"
         RenderBlock {SLOT} at (0,19) size 784x20

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-open-javascript-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-open-javascript-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x39
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 50x19
             text run at (16,1) width 50: "details1"
         RenderBlock {SLOT} at (0,19) size 784x20
@@ -13,7 +15,9 @@ layer at (0,0) size 800x600
           RenderText {#text} at (0,0) size 0x0
       RenderBlock {DETAILS} at (0,38) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 51x19
             text run at (16,1) width 51: "details2"
 layer at (11,30) size 142x13

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-open2-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-open2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x39
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 60x19
             text run at (16,1) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x20

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-open4-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-open4-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x39
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 60x19
             text run at (16,1) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x20

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-replace-summary-child-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-replace-summary-child-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderBlock {SPAN} at (16,3) size 63x16
             RenderText {#text} at (0,0) size 63x15
               text run at (0,0) width 63: "Details1"

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-replace-text-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/html/details-replace-text-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x38
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 63x19
             text run at (16,1) width 63: "Summary"
         RenderBlock {SLOT} at (0,19) size 784x19

--- a/LayoutTests/platform/mac-sequoia-wk2/tables/mozilla/bugs/bug30692-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/tables/mozilla/bugs/bug30692-expected.txt
@@ -8,12 +8,16 @@ layer at (0,0) size 800x600
           text run at (0,0) width 497: "BUG: Inside a cell, \"height:x%\" is ignored. It looks like 'auto' is used instead."
         RenderBR {BR} at (496,0) size 1x18
       RenderListItem {LI} at (0,18) size 784x18
-        RenderListMarker at (-1,0) size 7x18: bullet
+        RenderInline (generated) at (-1,0) size 7x18
+          RenderText at (-1,0) size 7x18
+            text run at (-1,0) width 7: "\x{2022}"
         RenderText {#text} at (14,0) size 265x18
           text run at (14,0) width 265: "Absolute units work correctly (eg. 50px)."
       RenderListItem {LI} at (0,36) size 784x490
         RenderBlock (anonymous) at (0,0) size 784x18
-          RenderListMarker at (-1,0) size 7x18: bullet
+          RenderInline (generated) at (-1,0) size 7x18
+            RenderText at (-1,0) size 7x18
+              text run at (-1,0) width 7: "\x{2022}"
           RenderText {#text} at (14,0) size 183x18
             text run at (14,0) width 183: "\"width:x%\" works correctly."
         RenderTable {TABLE} at (0,36) size 784x100

--- a/LayoutTests/platform/mac-wk2/fast/html/details-no-summary4-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/html/details-no-summary4-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x41
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 46x19
             text run at (16,1) width 46: "Details"
         RenderBlock {SLOT} at (0,19) size 784x22

--- a/LayoutTests/platform/mac-wk2/fast/html/details-open-javascript-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/html/details-open-javascript-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x41
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 50x19
             text run at (16,1) width 50: "details1"
         RenderBlock {SLOT} at (0,19) size 784x22
@@ -13,7 +15,9 @@ layer at (0,0) size 800x600
           RenderText {#text} at (0,0) size 0x0
       RenderBlock {DETAILS} at (0,40) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 51x19
             text run at (16,1) width 51: "details2"
 layer at (15,31) size 142x13

--- a/LayoutTests/platform/mac-wk2/fast/html/details-open2-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/html/details-open2-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x41
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 60x19
             text run at (16,1) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x22

--- a/LayoutTests/platform/mac-wk2/fast/html/details-open4-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/html/details-open4-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x41
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 60x19
             text run at (16,1) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 784x22

--- a/LayoutTests/platform/mac-wk2/fast/html/details-replace-summary-child-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/html/details-replace-summary-child-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderBlock {SPAN} at (16,3) size 63x16
             RenderText {#text} at (0,0) size 63x15
               text run at (0,0) width 63: "Details1"

--- a/LayoutTests/platform/mac-wk2/fast/html/details-replace-text-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/html/details-replace-text-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x38
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 63x19
             text run at (16,1) width 63: "Summary"
         RenderBlock {SLOT} at (0,19) size 784x19

--- a/LayoutTests/platform/mac-wk2/tables/mozilla/bugs/bug30692-expected.txt
+++ b/LayoutTests/platform/mac-wk2/tables/mozilla/bugs/bug30692-expected.txt
@@ -8,12 +8,16 @@ layer at (0,0) size 800x600
           text run at (0,0) width 497: "BUG: Inside a cell, \"height:x%\" is ignored. It looks like 'auto' is used instead."
         RenderBR {BR} at (496,0) size 1x18
       RenderListItem {LI} at (0,18) size 784x18
-        RenderListMarker at (-1,0) size 7x18: bullet
+        RenderInline (generated) at (-1,0) size 7x18
+          RenderText at (-1,0) size 7x18
+            text run at (-1,0) width 7: "\x{2022}"
         RenderText {#text} at (14,0) size 265x18
           text run at (14,0) width 265: "Absolute units work correctly (eg. 50px)."
       RenderListItem {LI} at (0,36) size 784x490
         RenderBlock (anonymous) at (0,0) size 784x18
-          RenderListMarker at (-1,0) size 7x18: bullet
+          RenderInline (generated) at (-1,0) size 7x18
+            RenderText at (-1,0) size 7x18
+              text run at (-1,0) width 7: "\x{2022}"
           RenderText {#text} at (14,0) size 183x18
             text run at (14,0) width 183: "\"width:x%\" works correctly."
         RenderTable {TABLE} at (0,36) size 784x100

--- a/LayoutTests/platform/mac/css1/classification/list_style-expected.txt
+++ b/LayoutTests/platform/mac/css1/classification/list_style-expected.txt
@@ -14,7 +14,9 @@ layer at (0,0) size 800x600
           text run at (483,15) width 1: " "
       RenderBlock {UL} at (0,95) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderListMarker at (0,0) size 20x18: "A"
+          RenderInline (generated) at (0,0) size 20x18
+            RenderText at (0,0) size 20x18
+              text run at (0,0) width 20: "A. "
           RenderText {#text} at (0,0) size 694x36
             text run at (19,0) width 675: "The text in this item should not behave as expected; that is, it should line up with the capital-A on the left"
             text run at (0,18) width 345: "margin, leaving no blank space beneath the capital-A."
@@ -39,7 +41,9 @@ layer at (0,0) size 800x600
             RenderTableCell {TD} at (12,26) size 770x113 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
               RenderBlock {UL} at (4,4) size 762x36
                 RenderListItem {LI} at (40,0) size 722x36
-                  RenderListMarker at (0,0) size 20x18: "A"
+                  RenderInline (generated) at (0,0) size 20x18
+                    RenderText at (0,0) size 20x18
+                      text run at (0,0) width 20: "A. "
                   RenderText {#text} at (0,0) size 694x36
                     text run at (19,0) width 675: "The text in this item should not behave as expected; that is, it should line up with the capital-A on the left"
                     text run at (0,18) width 345: "margin, leaving no blank space beneath the capital-A."

--- a/LayoutTests/platform/mac/css2.1/t1205-c561-list-displ-00-b-expected.txt
+++ b/LayoutTests/platform/mac/css2.1/t1205-c561-list-displ-00-b-expected.txt
@@ -7,7 +7,9 @@ layer at (0,0) size 800x202
         RenderText {#text} at (0,0) size 772x18
           text run at (0,0) width 772: "There should be eight numbered lines below, all identical except for the numbering, which should match the description."
       RenderListItem {DIV} at (0,34) size 784x18 [color=#000080]
-        RenderListMarker at (0,0) size 16x18: "1"
+        RenderInline (generated) at (0,0) size 16x18
+          RenderText at (0,0) size 16x18
+            text run at (0,0) width 16: "1. "
         RenderText {#text} at (16,0) size 154x18
           text run at (16,0) width 154: "This should be line one."
       RenderBlock {DIV} at (0,52) size 784x18 [color=#000080]

--- a/LayoutTests/platform/mac/fast/css-generated-content/details-summary-before-after-expected.txt
+++ b/LayoutTests/platform/mac/fast/css-generated-content/details-summary-before-after-expected.txt
@@ -10,7 +10,9 @@ layer at (0,0) size 800x131
               text run at (0,0) width 41: "before"
         RenderListItem {SUMMARY} at (1,19) size 782x60 [border: (1px solid #000000)]
           RenderBlock (anonymous) at (1,1) size 780x20
-            RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+            RenderInline (generated) at (0,-1) size 17x20
+              RenderText at (0,-1) size 17x20
+                text run at (0,0) width 17: "\x{25BC} "
             RenderInline (generated) at (16,1) size 42x19
               RenderText at (16,1) size 42x19
                 text run at (16,1) width 42: "before"

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-1-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-1-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 39x19
             text run at (16,1) width 39: "new 1"
         RenderBlock {SLOT} at (0,19) size 800x0

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-1-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-1-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 40x19
             text run at (16,1) width 40: "new 1"

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-10-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-10-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 40x19
             text run at (16,1) width 40: "new 1"
 caret: position 0 of child 0 {#text} of child 1 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-2-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-2-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x38
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 39x19
             text run at (16,1) width 39: "new 1"
         RenderBlock {SLOT} at (0,19) size 800x19

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-2-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-2-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 40x19
             text run at (16,1) width 40: "new 1"

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-3-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-3-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x38
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 39x19
             text run at (16,1) width 39: "new 2"
         RenderBlock {SLOT} at (0,19) size 800x19

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-3-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-3-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 40x19
             text run at (16,1) width 40: "new 2"

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-4-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-4-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x38
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 60x19
             text run at (16,1) width 60: "summary"
         RenderBlock {SLOT} at (0,19) size 800x19

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-4-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-4-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 61x19
             text run at (16,1) width 61: "summary"

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-5-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-5-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x38
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 39x19
             text run at (16,1) width 39: "new 1"
         RenderBlock {SLOT} at (0,19) size 800x19

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-5-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-5-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 40x19
             text run at (16,1) width 40: "new 1"

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-6-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-6-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 40x19
             text run at (16,1) width 40: "new 1"
 caret: position 0 of child 0 {#text} of child 0 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-7-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-7-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 40x19
             text run at (16,1) width 40: "new 1"
 caret: position 0 of child 0 {#text} of child 0 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-8-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-8-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 40x19
             text run at (16,1) width 40: "new 2"
 caret: position 0 of child 0 {#text} of child 0 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-add-summary-9-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-add-summary-9-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 61x19
             text run at (16,1) width 61: "summary"
 caret: position 0 of child 0 {#text} of child 1 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-marker-style-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-marker-style-expected.txt
@@ -6,24 +6,32 @@ layer at (0,0) size 800x308
       RenderBlock {DIV} at (0,0) size 784x30
         RenderBlock {DETAILS} at (0,0) size 784x30
           RenderListItem {SUMMARY} at (0,0) size 784x30
-            RenderListMarker at (0,-1) size 25x29: "\x{25B6}"
+            RenderInline (generated) at (0,-1) size 25x30
+              RenderText at (0,-1) size 25x30
+                text run at (0,0) width 25: "\x{25B6} "
             RenderText {#text} at (24,1) size 94x29
               text run at (24,1) width 94: "Summary"
       RenderBlock {DIV} at (0,29) size 30x118
         RenderBlock {DETAILS} at (0,0) size 30x118
           RenderListItem {SUMMARY} at (0,0) size 30x118
-            RenderListMarker at (-1,0) size 29x24: "\x{25BC}"
+            RenderInline (generated) at (-1,0) size 30x24
+              RenderText at (-1,0) size 30x24
+                text run at (0,0) width 24: "\x{25BC} "
             RenderText {#text} at (1,23) size 29x95
               text run at (1,23) width 94: "Summary"
       RenderBlock {DIV} at (0,146) size 784x30
         RenderBlock {DETAILS} at (0,0) size 784x30
           RenderListItem {SUMMARY} at (0,0) size 784x30
-            RenderListMarker at (0,-1) size 25x29: "\x{25B6}"
+            RenderInline (generated) at (0,-1) size 25x30
+              RenderText at (0,-1) size 25x30
+                text run at (0,0) width 25: "\x{25B6} "
             RenderText {#text} at (24,1) size 94x29
               text run at (24,1) width 94: "Summary"
       RenderBlock {DIV} at (0,175) size 30x118
         RenderBlock {DETAILS} at (0,0) size 30x118
           RenderListItem {SUMMARY} at (0,0) size 30x118
-            RenderListMarker at (-1,0) size 29x24: "\x{25BC}"
+            RenderInline (generated) at (-1,0) size 30x24
+              RenderText at (-1,0) size 30x24
+                text run at (0,0) width 24: "\x{25BC} "
             RenderText {#text} at (1,23) size 29x95
               text run at (1,23) width 94: "Summary"

--- a/LayoutTests/platform/mac/fast/html/details-marker-style-mixed-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-marker-style-mixed-expected.txt
@@ -6,24 +6,32 @@ layer at (0,0) size 800x308
       RenderBlock {DIV} at (0,0) size 784x30
         RenderBlock {DETAILS} at (0,0) size 784x30
           RenderListItem {SUMMARY} at (0,0) size 784x30
-            RenderListMarker at (0,-1) size 25x29: "\x{25B6}"
+            RenderInline (generated) at (0,-1) size 25x30
+              RenderText at (0,-1) size 25x30
+                text run at (0,0) width 25: "\x{25B6} "
             RenderText {#text} at (24,1) size 94x29
               text run at (24,1) width 94: "Summary"
       RenderBlock {DIV} at (0,29) size 28x118
         RenderBlock {DETAILS} at (0,0) size 28x118
           RenderListItem {SUMMARY} at (0,0) size 28x118
-            RenderListMarker at (0,0) size 28x24: "\x{25BC}"
+            RenderInline (generated) at (-1,0) size 30x24
+              RenderText at (-1,0) size 30x24
+                text run at (0,0) width 24: "\x{25BC} "
             RenderText {#text} at (0,23) size 28x95
               text run at (0,23) width 94: "Summary"
       RenderBlock {DIV} at (0,146) size 784x30
         RenderBlock {DETAILS} at (0,0) size 784x30
           RenderListItem {SUMMARY} at (0,0) size 784x30
-            RenderListMarker at (0,-1) size 25x29: "\x{25B6}"
+            RenderInline (generated) at (0,-1) size 25x30
+              RenderText at (0,-1) size 25x30
+                text run at (0,0) width 25: "\x{25B6} "
             RenderText {#text} at (24,1) size 94x29
               text run at (24,1) width 94: "Summary"
       RenderBlock {DIV} at (0,175) size 28x118
         RenderBlock {DETAILS} at (0,0) size 28x118
           RenderListItem {SUMMARY} at (0,0) size 28x118
-            RenderListMarker at (0,0) size 28x24: "\x{25BC}"
+            RenderInline (generated) at (-1,0) size 30x24
+              RenderText at (-1,0) size 30x24
+                text run at (0,0) width 24: "\x{25BC} "
             RenderText {#text} at (0,23) size 28x95
               text run at (0,23) width 94: "Summary"

--- a/LayoutTests/platform/mac/fast/html/details-no-summary1-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-no-summary1-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 47x19
             text run at (16,1) width 47: "Details"

--- a/LayoutTests/platform/mac/fast/html/details-no-summary3-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-no-summary3-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 47x19
             text run at (16,1) width 47: "Details"

--- a/LayoutTests/platform/mac/fast/html/details-open1-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-open1-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 61x19
             text run at (16,1) width 61: "summary"

--- a/LayoutTests/platform/mac/fast/html/details-open3-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-open3-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 61x19
             text run at (16,1) width 61: "summary"

--- a/LayoutTests/platform/mac/fast/html/details-open5-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-open5-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 61x19
             text run at (16,1) width 61: "summary"

--- a/LayoutTests/platform/mac/fast/html/details-position-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-position-expected.txt
@@ -8,16 +8,22 @@ layer at (0,0) size 800x585
       RenderBlock {DETAILS} at (0,19) size 784x0
 layer at (50,150) size 49x19
   RenderListItem {SUMMARY} at (50,150) size 49x20
-    RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+    RenderInline (generated) at (0,-1) size 17x20
+      RenderText at (0,-1) size 17x20
+        text run at (0,0) width 17: "\x{25B6} "
     RenderText {#text} at (16,1) size 33x19
       text run at (16,1) width 33: "fixed"
 layer at (158,158) size 784x19
   RenderListItem {SUMMARY} at (0,0) size 784x20
-    RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+    RenderInline (generated) at (0,-1) size 17x20
+      RenderText at (0,-1) size 17x20
+        text run at (0,0) width 17: "\x{25B6} "
     RenderText {#text} at (16,1) size 49x19
       text run at (16,1) width 49: "relative"
 layer at (250,150) size 70x19
   RenderListItem {SUMMARY} at (250,150) size 71x20
-    RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+    RenderInline (generated) at (0,-1) size 17x20
+      RenderText at (0,-1) size 17x20
+        text run at (0,0) width 17: "\x{25B6} "
     RenderText {#text} at (16,1) size 55x19
       text run at (16,1) width 55: "absolute"

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-1-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-1-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 46x19
             text run at (16,1) width 46: "Details"
         RenderBlock {SLOT} at (0,19) size 800x0

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-1-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-1-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 47x19
             text run at (16,1) width 47: "Details"

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-2-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-2-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 72x19
             text run at (16,1) width 72: "summary 2"
         RenderBlock {SLOT} at (0,19) size 800x0

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-2-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-2-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 73x19
             text run at (16,1) width 73: "summary 2"

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-3-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-3-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25BC} "
           RenderText {#text} at (16,1) size 72x19
             text run at (16,1) width 72: "summary 1"
         RenderBlock {SLOT} at (0,19) size 800x0

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-3-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-3-expected.txt
@@ -5,6 +5,8 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {DETAILS} at (0,0) size 784x20
         RenderListItem {SUMMARY} at (0,0) size 784x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 73x19
             text run at (16,1) width 73: "summary 1"

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-4-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-4-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 47x19
             text run at (16,1) width 47: "Details"
 caret: position 0 of child 0 {#text} of child 0 {SUMMARY} of child 0 {SLOT} of {#document-fragment} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-5-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-5-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 73x19
             text run at (16,1) width 73: "summary 2"
 caret: position 0 of child 0 {#text} of child 2 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-remove-summary-6-and-click-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-remove-summary-6-and-click-expected.txt
@@ -5,7 +5,9 @@ layer at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x600
       RenderBlock {DETAILS} at (0,0) size 800x20
         RenderListItem {SUMMARY} at (0,0) size 800x20
-          RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+          RenderInline (generated) at (0,-1) size 17x20
+            RenderText at (0,-1) size 17x20
+              text run at (0,0) width 17: "\x{25B6} "
           RenderText {#text} at (16,1) size 73x19
             text run at (16,1) width 73: "summary 1"
 caret: position 0 of child 0 {#text} of child 1 {SUMMARY} of child 1 {DETAILS} of body

--- a/LayoutTests/platform/mac/fast/html/details-writing-mode-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-writing-mode-expected.txt
@@ -40,12 +40,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+                    RenderInline (generated) at (0,-1) size 17x20
+                      RenderText at (0,-1) size 17x20
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (16,1) size 61x19
                       text run at (16,1) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+                    RenderInline (generated) at (0,-1) size 17x20
+                      RenderText at (0,-1) size 17x20
+                        text run at (0,0) width 17: "\x{25BC} "
                     RenderText {#text} at (16,1) size 60x19
                       text run at (16,1) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -53,12 +57,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+                    RenderInline (generated) at (0,-1) size 17x20
+                      RenderText at (0,0) size 17x20
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (16,0) size 61x18
                       text run at (16,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,1) size 17x19: "\x{25B2}"
+                    RenderInline (generated) at (0,-1) size 17x20
+                      RenderText at (0,0) size 17x20
+                        text run at (0,0) width 17: "\x{25B2} "
                     RenderText {#text} at (16,0) size 60x18
                       text run at (16,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -66,12 +74,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (1,0) size 19x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,0) size 20x17
+                      RenderText at (0,0) size 20x17
+                        text run at (0,0) width 17: "\x{25BC} "
                     RenderText {#text} at (0,16) size 18x60
                       text run at (0,16) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (1,0) size 19x17: "\x{25B6}"
+                    RenderInline (generated) at (-1,0) size 20x17
+                      RenderText at (0,0) size 20x17
+                        text run at (0,0) width 18: "\x{25B6} "
                     RenderText {#text} at (0,16) size 18x61
                       text run at (0,16) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -79,12 +91,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (-1,0) size 19x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,0) size 20x17
+                      RenderText at (-1,0) size 20x17
+                        text run at (0,0) width 16: "\x{25BC} "
                     RenderText {#text} at (1,16) size 19x60
                       text run at (1,16) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (-1,0) size 19x17: "\x{25C0}"
+                    RenderInline (generated) at (-1,0) size 20x17
+                      RenderText at (-1,0) size 20x17
+                        text run at (0,0) width 17: "\x{25C0} "
                     RenderText {#text} at (1,16) size 19x61
                       text run at (1,16) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -96,20 +112,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (103,-1) size 17x19: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (103,-1) size 17x20
+                      RenderText at (103,-1) size 17x20
+                        text run at (103,0) width 5 RTL: " "
+                        text run at (107,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (43,1) size 61x19
                       text run at (43,1) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (103,-1) size 17x19: "\x{25BC}"
-                      RenderBlock (generated) at (0,0) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderInline (generated) at (103,-1) size 17x20
+                      RenderText at (103,-1) size 17x20
+                        text run at (103,0) width 6 RTL: " "
+                        text run at (108,0) width 12 RTL: "\x{25BC}"
                     RenderText {#text} at (44,1) size 60x19
                       text run at (44,1) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -117,20 +131,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (103,1) size 17x19: "\x{25C0}"
-                      RenderBlock (generated) at (0,12) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (103,-1) size 17x20
+                      RenderText at (103,0) size 17x20
+                        text run at (103,0) width 5 RTL: " "
+                        text run at (107,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (43,0) size 61x18
                       text run at (43,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (103,1) size 17x19: "\x{25B2}"
-                      RenderBlock (generated) at (0,12) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderInline (generated) at (103,-1) size 17x20
+                      RenderText at (103,0) size 17x20
+                        text run at (103,0) width 6 RTL: " "
+                        text run at (108,0) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (44,0) size 60x18
                       text run at (44,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -138,20 +150,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (1,103) size 19x17: "\x{25B2}"
-                      RenderBlock (generated) at (12,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,103) size 20x17
+                      RenderText at (0,103) size 20x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,108) width 13 RTL: "\x{25B2}"
                     RenderText {#text} at (0,44) size 18x60
                       text run at (0,44) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (1,103) size 19x17: "\x{25B6}"
-                      RenderBlock (generated) at (12,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderInline (generated) at (-1,103) size 20x17
+                      RenderText at (0,103) size 20x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,107) width 14 RTL: "\x{25B6}"
                     RenderText {#text} at (0,43) size 18x61
                       text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -159,20 +169,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (-1,103) size 19x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,103) size 20x17
+                      RenderText at (-1,103) size 20x17
+                        text run at (0,103) width 4 RTL: " "
+                        text run at (0,108) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (1,44) size 19x60
                       text run at (1,44) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (-1,103) size 19x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (-1,103) size 20x17
+                      RenderText at (-1,103) size 20x17
+                        text run at (0,103) width 4 RTL: " "
+                        text run at (0,107) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (1,43) size 19x61
                       text run at (1,43) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -215,12 +223,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+                    RenderInline (generated) at (0,-1) size 17x20
+                      RenderText at (0,-1) size 17x20
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (16,1) size 61x19
                       text run at (16,1) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+                    RenderInline (generated) at (0,-1) size 17x20
+                      RenderText at (0,-1) size 17x20
+                        text run at (0,0) width 17: "\x{25BC} "
                     RenderText {#text} at (16,1) size 60x19
                       text run at (16,1) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -228,12 +240,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+                    RenderInline (generated) at (0,-1) size 17x20
+                      RenderText at (0,0) size 17x20
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (16,0) size 61x18
                       text run at (16,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,1) size 17x19: "\x{25B2}"
+                    RenderInline (generated) at (0,-1) size 17x20
+                      RenderText at (0,0) size 17x20
+                        text run at (0,0) width 17: "\x{25B2} "
                     RenderText {#text} at (16,0) size 60x18
                       text run at (16,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -241,12 +257,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (1,0) size 19x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,0) size 20x17
+                      RenderText at (0,0) size 20x17
+                        text run at (0,0) width 17: "\x{25BC} "
                     RenderText {#text} at (0,16) size 18x60
                       text run at (0,16) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (1,0) size 19x17: "\x{25B6}"
+                    RenderInline (generated) at (-1,0) size 20x17
+                      RenderText at (0,0) size 20x17
+                        text run at (0,0) width 18: "\x{25B6} "
                     RenderText {#text} at (0,16) size 18x61
                       text run at (0,16) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -254,12 +274,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (-1,0) size 19x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,0) size 20x17
+                      RenderText at (-1,0) size 20x17
+                        text run at (0,0) width 16: "\x{25BC} "
                     RenderText {#text} at (1,16) size 19x60
                       text run at (1,16) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (-1,0) size 19x17: "\x{25C0}"
+                    RenderInline (generated) at (-1,0) size 20x17
+                      RenderText at (-1,0) size 20x17
+                        text run at (0,0) width 17: "\x{25C0} "
                     RenderText {#text} at (1,16) size 19x61
                       text run at (1,16) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -271,20 +295,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (59,-1) size 18x19: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (59,-1) size 18x20
+                      RenderText at (59,-1) size 18x20
+                        text run at (59,0) width 5 RTL: " "
+                        text run at (63,0) width 14 RTL: "\x{25C0}"
                     RenderText {#text} at (0,1) size 60x19
                       text run at (0,1) width 60: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (59,-1) size 17x19: "\x{25BC}"
-                      RenderBlock (generated) at (0,0) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderInline (generated) at (59,-1) size 17x20
+                      RenderText at (59,-1) size 17x20
+                        text run at (59,0) width 5 RTL: " "
+                        text run at (63,0) width 13 RTL: "\x{25BC}"
                     RenderText {#text} at (0,1) size 60x19
                       text run at (0,1) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -292,20 +314,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (59,1) size 18x19: "\x{25C0}"
-                      RenderBlock (generated) at (0,12) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (59,-1) size 18x20
+                      RenderText at (59,0) size 18x20
+                        text run at (59,0) width 5 RTL: " "
+                        text run at (63,0) width 14 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (59,1) size 17x19: "\x{25B2}"
-                      RenderBlock (generated) at (0,12) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderInline (generated) at (59,-1) size 17x20
+                      RenderText at (59,0) size 17x20
+                        text run at (59,0) width 5 RTL: " "
+                        text run at (63,0) width 13 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -313,20 +333,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (1,59) size 19x17: "\x{25B2}"
-                      RenderBlock (generated) at (12,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,59) size 20x17
+                      RenderText at (0,59) size 20x17
+                        text run at (0,59) width 5 RTL: " "
+                        text run at (0,63) width 13 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (1,59) size 19x18: "\x{25B6}"
-                      RenderBlock (generated) at (12,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderInline (generated) at (-1,59) size 20x18
+                      RenderText at (0,59) size 20x18
+                        text run at (0,59) width 5 RTL: " "
+                        text run at (0,63) width 14 RTL: "\x{25B6}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -334,20 +352,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (-1,59) size 19x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,59) size 20x17
+                      RenderText at (-1,59) size 20x17
+                        text run at (0,59) width 4 RTL: " "
+                        text run at (0,63) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (1,0) size 19x60
                       text run at (1,0) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (-1,59) size 19x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (-1,59) size 20x18
+                      RenderText at (-1,59) size 20x18
+                        text run at (0,59) width 4 RTL: " "
+                        text run at (0,63) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (1,0) size 19x60
                       text run at (1,0) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -390,12 +406,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (21,-1) size 18x19: "\x{25B6}"
+                    RenderInline (generated) at (21,-1) size 18x20
+                      RenderText at (21,-1) size 18x20
+                        text run at (21,0) width 18: "\x{25B6} "
                     RenderText {#text} at (38,1) size 61x19
                       text run at (38,1) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (22,-1) size 17x19: "\x{25BC}"
+                    RenderInline (generated) at (22,-1) size 17x20
+                      RenderText at (22,-1) size 17x20
+                        text run at (22,0) width 17: "\x{25BC} "
                     RenderText {#text} at (38,1) size 60x19
                       text run at (38,1) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -403,12 +423,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (21,1) size 18x19: "\x{25B6}"
+                    RenderInline (generated) at (21,-1) size 18x20
+                      RenderText at (21,0) size 18x20
+                        text run at (21,0) width 18: "\x{25B6} "
                     RenderText {#text} at (38,0) size 61x18
                       text run at (38,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (22,1) size 17x19: "\x{25B2}"
+                    RenderInline (generated) at (22,-1) size 17x20
+                      RenderText at (22,0) size 17x20
+                        text run at (22,0) width 17: "\x{25B2} "
                     RenderText {#text} at (38,0) size 60x18
                       text run at (38,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -416,12 +440,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (1,22) size 19x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,22) size 20x17
+                      RenderText at (0,22) size 20x17
+                        text run at (0,22) width 17: "\x{25BC} "
                     RenderText {#text} at (0,38) size 18x60
                       text run at (0,38) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (1,21) size 19x18: "\x{25B6}"
+                    RenderInline (generated) at (-1,21) size 20x18
+                      RenderText at (0,21) size 20x18
+                        text run at (0,21) width 18: "\x{25B6} "
                     RenderText {#text} at (0,38) size 18x61
                       text run at (0,38) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -429,12 +457,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (-1,22) size 19x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,22) size 20x17
+                      RenderText at (-1,22) size 20x17
+                        text run at (0,22) width 16: "\x{25BC} "
                     RenderText {#text} at (1,38) size 19x60
                       text run at (1,38) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (-1,21) size 19x18: "\x{25C0}"
+                    RenderInline (generated) at (-1,21) size 20x18
+                      RenderText at (-1,21) size 20x18
+                        text run at (0,21) width 17: "\x{25C0} "
                     RenderText {#text} at (1,38) size 19x61
                       text run at (1,38) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -446,20 +478,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (81,-1) size 18x19: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (81,-1) size 18x20
+                      RenderText at (81,-1) size 18x20
+                        text run at (81,0) width 5 RTL: " "
+                        text run at (85,0) width 14 RTL: "\x{25C0}"
                     RenderText {#text} at (21,1) size 61x19
                       text run at (21,1) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (81,-1) size 17x19: "\x{25BC}"
-                      RenderBlock (generated) at (0,0) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderInline (generated) at (81,-1) size 17x20
+                      RenderText at (81,-1) size 17x20
+                        text run at (81,0) width 5 RTL: " "
+                        text run at (85,0) width 13 RTL: "\x{25BC}"
                     RenderText {#text} at (22,1) size 60x19
                       text run at (22,1) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -467,20 +497,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (81,1) size 18x19: "\x{25C0}"
-                      RenderBlock (generated) at (0,12) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (81,-1) size 18x20
+                      RenderText at (81,0) size 18x20
+                        text run at (81,0) width 5 RTL: " "
+                        text run at (85,0) width 14 RTL: "\x{25C0}"
                     RenderText {#text} at (21,0) size 61x18
                       text run at (21,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (81,1) size 17x19: "\x{25B2}"
-                      RenderBlock (generated) at (0,12) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderInline (generated) at (81,-1) size 17x20
+                      RenderText at (81,0) size 17x20
+                        text run at (81,0) width 5 RTL: " "
+                        text run at (85,0) width 13 RTL: "\x{25B2}"
                     RenderText {#text} at (22,0) size 60x18
                       text run at (22,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -488,20 +516,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (1,81) size 19x17: "\x{25B2}"
-                      RenderBlock (generated) at (12,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,81) size 20x17
+                      RenderText at (0,81) size 20x17
+                        text run at (0,81) width 5 RTL: " "
+                        text run at (0,85) width 13 RTL: "\x{25B2}"
                     RenderText {#text} at (0,22) size 18x60
                       text run at (0,22) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (1,81) size 19x18: "\x{25B6}"
-                      RenderBlock (generated) at (12,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderInline (generated) at (-1,81) size 20x18
+                      RenderText at (0,81) size 20x18
+                        text run at (0,81) width 5 RTL: " "
+                        text run at (0,85) width 14 RTL: "\x{25B6}"
                     RenderText {#text} at (0,21) size 18x61
                       text run at (0,21) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -509,20 +535,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (-1,81) size 19x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,81) size 20x17
+                      RenderText at (-1,81) size 20x17
+                        text run at (0,81) width 4 RTL: " "
+                        text run at (0,85) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (1,22) size 19x60
                       text run at (1,22) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (-1,81) size 19x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (-1,81) size 20x18
+                      RenderText at (-1,81) size 20x18
+                        text run at (0,81) width 4 RTL: " "
+                        text run at (0,85) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (1,21) size 19x61
                       text run at (1,21) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -565,12 +589,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (43,-1) size 18x19: "\x{25B6}"
+                    RenderInline (generated) at (43,-1) size 18x20
+                      RenderText at (43,-1) size 18x20
+                        text run at (43,0) width 18: "\x{25B6} "
                     RenderText {#text} at (60,1) size 60x19
                       text run at (60,1) width 60: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (44,-1) size 17x19: "\x{25BC}"
+                    RenderInline (generated) at (44,-1) size 17x20
+                      RenderText at (44,-1) size 17x20
+                        text run at (44,0) width 17: "\x{25BC} "
                     RenderText {#text} at (60,1) size 60x19
                       text run at (60,1) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -578,12 +606,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (43,1) size 18x19: "\x{25B6}"
+                    RenderInline (generated) at (43,-1) size 18x20
+                      RenderText at (43,0) size 18x20
+                        text run at (43,0) width 18: "\x{25B6} "
                     RenderText {#text} at (60,0) size 60x18
                       text run at (60,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (44,1) size 17x19: "\x{25B2}"
+                    RenderInline (generated) at (44,-1) size 17x20
+                      RenderText at (44,0) size 17x20
+                        text run at (44,0) width 17: "\x{25B2} "
                     RenderText {#text} at (60,0) size 60x18
                       text run at (60,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -591,12 +623,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (1,44) size 19x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,44) size 20x17
+                      RenderText at (0,44) size 20x17
+                        text run at (0,44) width 17: "\x{25BC} "
                     RenderText {#text} at (0,60) size 18x60
                       text run at (0,60) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (1,43) size 19x18: "\x{25B6}"
+                    RenderInline (generated) at (-1,43) size 20x18
+                      RenderText at (0,43) size 20x18
+                        text run at (0,43) width 18: "\x{25B6} "
                     RenderText {#text} at (0,60) size 18x60
                       text run at (0,60) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -604,12 +640,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (-1,44) size 19x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,44) size 20x17
+                      RenderText at (-1,44) size 20x17
+                        text run at (0,44) width 16: "\x{25BC} "
                     RenderText {#text} at (1,60) size 19x60
                       text run at (1,60) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (-1,43) size 19x18: "\x{25C0}"
+                    RenderInline (generated) at (-1,43) size 20x18
+                      RenderText at (-1,43) size 20x18
+                        text run at (0,43) width 17: "\x{25C0} "
                     RenderText {#text} at (1,60) size 19x60
                       text run at (1,60) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -621,20 +661,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (103,-1) size 17x19: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (103,-1) size 17x20
+                      RenderText at (103,-1) size 17x20
+                        text run at (103,0) width 5 RTL: " "
+                        text run at (107,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (43,1) size 61x19
                       text run at (43,1) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (103,-1) size 17x19: "\x{25BC}"
-                      RenderBlock (generated) at (0,0) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderInline (generated) at (103,-1) size 17x20
+                      RenderText at (103,-1) size 17x20
+                        text run at (103,0) width 6 RTL: " "
+                        text run at (108,0) width 12 RTL: "\x{25BC}"
                     RenderText {#text} at (44,1) size 60x19
                       text run at (44,1) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -642,20 +680,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (103,1) size 17x19: "\x{25C0}"
-                      RenderBlock (generated) at (0,12) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (103,-1) size 17x20
+                      RenderText at (103,0) size 17x20
+                        text run at (103,0) width 5 RTL: " "
+                        text run at (107,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (43,0) size 61x18
                       text run at (43,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (103,1) size 17x19: "\x{25B2}"
-                      RenderBlock (generated) at (0,12) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderInline (generated) at (103,-1) size 17x20
+                      RenderText at (103,0) size 17x20
+                        text run at (103,0) width 6 RTL: " "
+                        text run at (108,0) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (44,0) size 60x18
                       text run at (44,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -663,20 +699,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (1,103) size 19x17: "\x{25B2}"
-                      RenderBlock (generated) at (12,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,103) size 20x17
+                      RenderText at (0,103) size 20x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,108) width 13 RTL: "\x{25B2}"
                     RenderText {#text} at (0,44) size 18x60
                       text run at (0,44) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (1,103) size 19x17: "\x{25B6}"
-                      RenderBlock (generated) at (12,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderInline (generated) at (-1,103) size 20x17
+                      RenderText at (0,103) size 20x17
+                        text run at (0,103) width 5 RTL: " "
+                        text run at (0,107) width 14 RTL: "\x{25B6}"
                     RenderText {#text} at (0,43) size 18x61
                       text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120
@@ -684,20 +718,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (-1,103) size 19x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,103) size 20x17
+                      RenderText at (-1,103) size 20x17
+                        text run at (0,103) width 4 RTL: " "
+                        text run at (0,108) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (1,44) size 19x60
                       text run at (1,44) width 60: "summary"
                 RenderBlock {DETAILS} at (19,0) size 20x120
                   RenderListItem {SUMMARY} at (0,0) size 20x120
-                    RenderListMarker at (-1,103) size 19x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (-1,103) size 20x17
+                      RenderText at (-1,103) size 20x17
+                        text run at (0,103) width 4 RTL: " "
+                        text run at (0,107) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (1,43) size 19x61
                       text run at (1,43) width 60: "summary"
                   RenderBlock {SLOT} at (19,0) size 0x120

--- a/LayoutTests/platform/mac/fast/html/details-writing-mode-mixed-expected.txt
+++ b/LayoutTests/platform/mac/fast/html/details-writing-mode-mixed-expected.txt
@@ -40,12 +40,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+                    RenderInline (generated) at (0,-1) size 17x20
+                      RenderText at (0,-1) size 17x20
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (16,1) size 61x19
                       text run at (16,1) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+                    RenderInline (generated) at (0,-1) size 17x20
+                      RenderText at (0,-1) size 17x20
+                        text run at (0,0) width 17: "\x{25BC} "
                     RenderText {#text} at (16,1) size 60x19
                       text run at (16,1) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -53,12 +57,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+                    RenderInline (generated) at (0,-1) size 17x20
+                      RenderText at (0,0) size 17x20
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (16,0) size 61x18
                       text run at (16,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,1) size 17x19: "\x{25B2}"
+                    RenderInline (generated) at (0,-1) size 17x20
+                      RenderText at (0,0) size 17x20
+                        text run at (0,0) width 17: "\x{25B2} "
                     RenderText {#text} at (16,0) size 60x18
                       text run at (16,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -66,12 +74,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,0) size 20x17
+                      RenderText at (-1,0) size 20x17
+                        text run at (0,0) width 16: "\x{25BC} "
                     RenderText {#text} at (0,16) size 18x60
                       text run at (0,16) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25B6}"
+                    RenderInline (generated) at (-1,0) size 20x17
+                      RenderText at (-1,0) size 20x17
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (0,16) size 18x61
                       text run at (0,16) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -79,12 +91,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,0) size 20x17
+                      RenderText at (-1,0) size 20x17
+                        text run at (0,0) width 16: "\x{25BC} "
                     RenderText {#text} at (0,16) size 18x60
                       text run at (0,16) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25C0}"
+                    RenderInline (generated) at (-1,0) size 20x17
+                      RenderText at (-1,0) size 20x17
+                        text run at (0,0) width 17: "\x{25C0} "
                     RenderText {#text} at (0,16) size 18x61
                       text run at (0,16) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -96,20 +112,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (103,-1) size 17x19: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (103,-1) size 17x20
+                      RenderText at (103,-1) size 17x20
+                        text run at (103,0) width 5 RTL: " "
+                        text run at (107,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (43,1) size 61x19
                       text run at (43,1) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (103,-1) size 17x19: "\x{25BC}"
-                      RenderBlock (generated) at (0,0) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderInline (generated) at (103,-1) size 17x20
+                      RenderText at (103,-1) size 17x20
+                        text run at (103,0) width 6 RTL: " "
+                        text run at (108,0) width 12 RTL: "\x{25BC}"
                     RenderText {#text} at (44,1) size 60x19
                       text run at (44,1) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -117,20 +131,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (103,1) size 17x19: "\x{25C0}"
-                      RenderBlock (generated) at (0,12) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (103,-1) size 17x20
+                      RenderText at (103,0) size 17x20
+                        text run at (103,0) width 5 RTL: " "
+                        text run at (107,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (43,0) size 61x18
                       text run at (43,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (103,1) size 17x19: "\x{25B2}"
-                      RenderBlock (generated) at (0,12) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderInline (generated) at (103,-1) size 17x20
+                      RenderText at (103,0) size 17x20
+                        text run at (103,0) width 6 RTL: " "
+                        text run at (108,0) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (44,0) size 60x18
                       text run at (44,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -138,20 +150,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,103) size 20x17
+                      RenderText at (-1,103) size 20x17
+                        text run at (0,103) width 4 RTL: " "
+                        text run at (0,108) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,44) size 18x60
                       text run at (0,44) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B6}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderInline (generated) at (-1,103) size 20x17
+                      RenderText at (-1,103) size 20x17
+                        text run at (0,103) width 4 RTL: " "
+                        text run at (0,107) width 13 RTL: "\x{25B6}"
                     RenderText {#text} at (0,43) size 18x61
                       text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -159,20 +169,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,103) size 20x17
+                      RenderText at (-1,103) size 20x17
+                        text run at (0,103) width 4 RTL: " "
+                        text run at (0,108) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,44) size 18x60
                       text run at (0,44) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (-1,103) size 20x17
+                      RenderText at (-1,103) size 20x17
+                        text run at (0,103) width 4 RTL: " "
+                        text run at (0,107) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (0,43) size 18x61
                       text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -215,12 +223,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,-1) size 17x19: "\x{25B6}"
+                    RenderInline (generated) at (0,-1) size 17x20
+                      RenderText at (0,-1) size 17x20
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (16,1) size 61x19
                       text run at (16,1) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,-1) size 17x19: "\x{25BC}"
+                    RenderInline (generated) at (0,-1) size 17x20
+                      RenderText at (0,-1) size 17x20
+                        text run at (0,0) width 17: "\x{25BC} "
                     RenderText {#text} at (16,1) size 60x19
                       text run at (16,1) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -228,12 +240,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,1) size 17x19: "\x{25B6}"
+                    RenderInline (generated) at (0,-1) size 17x20
+                      RenderText at (0,0) size 17x20
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (16,0) size 61x18
                       text run at (16,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (0,1) size 17x19: "\x{25B2}"
+                    RenderInline (generated) at (0,-1) size 17x20
+                      RenderText at (0,0) size 17x20
+                        text run at (0,0) width 17: "\x{25B2} "
                     RenderText {#text} at (16,0) size 60x18
                       text run at (16,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -241,12 +257,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,0) size 20x17
+                      RenderText at (-1,0) size 20x17
+                        text run at (0,0) width 16: "\x{25BC} "
                     RenderText {#text} at (0,16) size 18x60
                       text run at (0,16) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25B6}"
+                    RenderInline (generated) at (-1,0) size 20x17
+                      RenderText at (-1,0) size 20x17
+                        text run at (0,0) width 17: "\x{25B6} "
                     RenderText {#text} at (0,16) size 18x61
                       text run at (0,16) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -254,12 +274,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,0) size 20x17
+                      RenderText at (-1,0) size 20x17
+                        text run at (0,0) width 16: "\x{25BC} "
                     RenderText {#text} at (0,16) size 18x60
                       text run at (0,16) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,0) size 18x17: "\x{25C0}"
+                    RenderInline (generated) at (-1,0) size 20x17
+                      RenderText at (-1,0) size 20x17
+                        text run at (0,0) width 17: "\x{25C0} "
                     RenderText {#text} at (0,16) size 18x61
                       text run at (0,16) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -271,20 +295,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (59,-1) size 18x19: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (59,-1) size 18x20
+                      RenderText at (59,-1) size 18x20
+                        text run at (59,0) width 5 RTL: " "
+                        text run at (63,0) width 14 RTL: "\x{25C0}"
                     RenderText {#text} at (0,1) size 60x19
                       text run at (0,1) width 60: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (59,-1) size 17x19: "\x{25BC}"
-                      RenderBlock (generated) at (0,0) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderInline (generated) at (59,-1) size 17x20
+                      RenderText at (59,-1) size 17x20
+                        text run at (59,0) width 5 RTL: " "
+                        text run at (63,0) width 13 RTL: "\x{25BC}"
                     RenderText {#text} at (0,1) size 60x19
                       text run at (0,1) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -292,20 +314,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (59,1) size 18x19: "\x{25C0}"
-                      RenderBlock (generated) at (0,12) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (59,-1) size 18x20
+                      RenderText at (59,0) size 18x20
+                        text run at (59,0) width 5 RTL: " "
+                        text run at (63,0) width 14 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (59,1) size 17x19: "\x{25B2}"
-                      RenderBlock (generated) at (0,12) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderInline (generated) at (59,-1) size 17x20
+                      RenderText at (59,0) size 17x20
+                        text run at (59,0) width 5 RTL: " "
+                        text run at (63,0) width 13 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 60x18
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -313,20 +333,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,59) size 20x17
+                      RenderText at (-1,59) size 20x17
+                        text run at (0,59) width 4 RTL: " "
+                        text run at (0,63) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x18: "\x{25B6}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderInline (generated) at (-1,59) size 20x18
+                      RenderText at (-1,59) size 20x18
+                        text run at (0,59) width 4 RTL: " "
+                        text run at (0,63) width 13 RTL: "\x{25B6}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -334,20 +352,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,59) size 20x17
+                      RenderText at (-1,59) size 20x17
+                        text run at (0,59) width 4 RTL: " "
+                        text run at (0,63) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,59) size 18x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (-1,59) size 20x18
+                      RenderText at (-1,59) size 20x18
+                        text run at (0,59) width 4 RTL: " "
+                        text run at (0,63) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (0,0) size 18x60
                       text run at (0,0) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -390,12 +406,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (21,-1) size 18x19: "\x{25B6}"
+                    RenderInline (generated) at (21,-1) size 18x20
+                      RenderText at (21,-1) size 18x20
+                        text run at (21,0) width 18: "\x{25B6} "
                     RenderText {#text} at (38,1) size 61x19
                       text run at (38,1) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (22,-1) size 17x19: "\x{25BC}"
+                    RenderInline (generated) at (22,-1) size 17x20
+                      RenderText at (22,-1) size 17x20
+                        text run at (22,0) width 17: "\x{25BC} "
                     RenderText {#text} at (38,1) size 60x19
                       text run at (38,1) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -403,12 +423,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (21,1) size 18x19: "\x{25B6}"
+                    RenderInline (generated) at (21,-1) size 18x20
+                      RenderText at (21,0) size 18x20
+                        text run at (21,0) width 18: "\x{25B6} "
                     RenderText {#text} at (38,0) size 61x18
                       text run at (38,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (22,1) size 17x19: "\x{25B2}"
+                    RenderInline (generated) at (22,-1) size 17x20
+                      RenderText at (22,0) size 17x20
+                        text run at (22,0) width 17: "\x{25B2} "
                     RenderText {#text} at (38,0) size 60x18
                       text run at (38,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -416,12 +440,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,22) size 18x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,22) size 20x17
+                      RenderText at (-1,22) size 20x17
+                        text run at (0,22) width 16: "\x{25BC} "
                     RenderText {#text} at (0,38) size 18x60
                       text run at (0,38) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,21) size 18x18: "\x{25B6}"
+                    RenderInline (generated) at (-1,21) size 20x18
+                      RenderText at (-1,21) size 20x18
+                        text run at (0,21) width 17: "\x{25B6} "
                     RenderText {#text} at (0,38) size 18x61
                       text run at (0,38) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -429,12 +457,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,22) size 18x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,22) size 20x17
+                      RenderText at (-1,22) size 20x17
+                        text run at (0,22) width 16: "\x{25BC} "
                     RenderText {#text} at (0,38) size 18x60
                       text run at (0,38) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,21) size 18x18: "\x{25C0}"
+                    RenderInline (generated) at (-1,21) size 20x18
+                      RenderText at (-1,21) size 20x18
+                        text run at (0,21) width 17: "\x{25C0} "
                     RenderText {#text} at (0,38) size 18x61
                       text run at (0,38) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -446,20 +478,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (81,-1) size 18x19: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (81,-1) size 18x20
+                      RenderText at (81,-1) size 18x20
+                        text run at (81,0) width 5 RTL: " "
+                        text run at (85,0) width 14 RTL: "\x{25C0}"
                     RenderText {#text} at (21,1) size 61x19
                       text run at (21,1) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (81,-1) size 17x19: "\x{25BC}"
-                      RenderBlock (generated) at (0,0) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderInline (generated) at (81,-1) size 17x20
+                      RenderText at (81,-1) size 17x20
+                        text run at (81,0) width 5 RTL: " "
+                        text run at (85,0) width 13 RTL: "\x{25BC}"
                     RenderText {#text} at (22,1) size 60x19
                       text run at (22,1) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -467,20 +497,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (81,1) size 18x19: "\x{25C0}"
-                      RenderBlock (generated) at (0,12) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (81,-1) size 18x20
+                      RenderText at (81,0) size 18x20
+                        text run at (81,0) width 5 RTL: " "
+                        text run at (85,0) width 14 RTL: "\x{25C0}"
                     RenderText {#text} at (21,0) size 61x18
                       text run at (21,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (81,1) size 17x19: "\x{25B2}"
-                      RenderBlock (generated) at (0,12) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderInline (generated) at (81,-1) size 17x20
+                      RenderText at (81,0) size 17x20
+                        text run at (81,0) width 5 RTL: " "
+                        text run at (85,0) width 13 RTL: "\x{25B2}"
                     RenderText {#text} at (22,0) size 60x18
                       text run at (22,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -488,20 +516,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,81) size 20x17
+                      RenderText at (-1,81) size 20x17
+                        text run at (0,81) width 4 RTL: " "
+                        text run at (0,85) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,22) size 18x60
                       text run at (0,22) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x18: "\x{25B6}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderInline (generated) at (-1,81) size 20x18
+                      RenderText at (-1,81) size 20x18
+                        text run at (0,81) width 4 RTL: " "
+                        text run at (0,85) width 13 RTL: "\x{25B6}"
                     RenderText {#text} at (0,21) size 18x61
                       text run at (0,21) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -509,20 +535,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,81) size 20x17
+                      RenderText at (-1,81) size 20x17
+                        text run at (0,81) width 4 RTL: " "
+                        text run at (0,85) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,22) size 18x60
                       text run at (0,22) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,81) size 18x18: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (-1,81) size 20x18
+                      RenderText at (-1,81) size 20x18
+                        text run at (0,81) width 4 RTL: " "
+                        text run at (0,85) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (0,21) size 18x61
                       text run at (0,21) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -565,12 +589,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (43,-1) size 18x19: "\x{25B6}"
+                    RenderInline (generated) at (43,-1) size 18x20
+                      RenderText at (43,-1) size 18x20
+                        text run at (43,0) width 18: "\x{25B6} "
                     RenderText {#text} at (60,1) size 60x19
                       text run at (60,1) width 60: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (44,-1) size 17x19: "\x{25BC}"
+                    RenderInline (generated) at (44,-1) size 17x20
+                      RenderText at (44,-1) size 17x20
+                        text run at (44,0) width 17: "\x{25BC} "
                     RenderText {#text} at (60,1) size 60x19
                       text run at (60,1) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -578,12 +606,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (43,1) size 18x19: "\x{25B6}"
+                    RenderInline (generated) at (43,-1) size 18x20
+                      RenderText at (43,0) size 18x20
+                        text run at (43,0) width 18: "\x{25B6} "
                     RenderText {#text} at (60,0) size 60x18
                       text run at (60,0) width 60: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (44,1) size 17x19: "\x{25B2}"
+                    RenderInline (generated) at (44,-1) size 17x20
+                      RenderText at (44,0) size 17x20
+                        text run at (44,0) width 17: "\x{25B2} "
                     RenderText {#text} at (60,0) size 60x18
                       text run at (60,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -591,12 +623,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,44) size 18x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,44) size 20x17
+                      RenderText at (-1,44) size 20x17
+                        text run at (0,44) width 16: "\x{25BC} "
                     RenderText {#text} at (0,60) size 18x60
                       text run at (0,60) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,43) size 18x18: "\x{25B6}"
+                    RenderInline (generated) at (-1,43) size 20x18
+                      RenderText at (-1,43) size 20x18
+                        text run at (0,43) width 17: "\x{25B6} "
                     RenderText {#text} at (0,60) size 18x60
                       text run at (0,60) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -604,12 +640,16 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,44) size 18x17: "\x{25BC}"
+                    RenderInline (generated) at (-1,44) size 20x17
+                      RenderText at (-1,44) size 20x17
+                        text run at (0,44) width 16: "\x{25BC} "
                     RenderText {#text} at (0,60) size 18x60
                       text run at (0,60) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,43) size 18x18: "\x{25C0}"
+                    RenderInline (generated) at (-1,43) size 20x18
+                      RenderText at (-1,43) size 20x18
+                        text run at (0,43) width 17: "\x{25C0} "
                     RenderText {#text} at (0,60) size 18x60
                       text run at (0,60) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -621,20 +661,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (103,-1) size 17x19: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (103,-1) size 17x20
+                      RenderText at (103,-1) size 17x20
+                        text run at (103,0) width 5 RTL: " "
+                        text run at (107,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (43,1) size 61x19
                       text run at (43,1) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (103,-1) size 17x19: "\x{25BC}"
-                      RenderBlock (generated) at (0,0) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25BC}"
+                    RenderInline (generated) at (103,-1) size 17x20
+                      RenderText at (103,-1) size 17x20
+                        text run at (103,0) width 6 RTL: " "
+                        text run at (108,0) width 12 RTL: "\x{25BC}"
                     RenderText {#text} at (44,1) size 60x19
                       text run at (44,1) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -642,20 +680,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (103,1) size 17x19: "\x{25C0}"
-                      RenderBlock (generated) at (0,12) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (103,-1) size 17x20
+                      RenderText at (103,0) size 17x20
+                        text run at (103,0) width 5 RTL: " "
+                        text run at (107,0) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (43,0) size 61x18
                       text run at (43,0) width 61: "summary"
                 RenderBlock {DETAILS} at (0,19) size 120x20
                   RenderListItem {SUMMARY} at (0,0) size 120x20
-                    RenderListMarker at (103,1) size 17x19: "\x{25B2}"
-                      RenderBlock (generated) at (0,12) size 17x19
-                        RenderText at (0,-1) size 17x20
-                          text run at (0,0) width 5 RTL: " "
-                          text run at (4,0) width 13 RTL: "\x{25B2}"
+                    RenderInline (generated) at (103,-1) size 17x20
+                      RenderText at (103,0) size 17x20
+                        text run at (103,0) width 6 RTL: " "
+                        text run at (108,0) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (44,0) size 60x18
                       text run at (44,0) width 60: "summary"
                   RenderBlock {SLOT} at (0,19) size 120x0
@@ -663,20 +699,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,103) size 20x17
+                      RenderText at (-1,103) size 20x17
+                        text run at (0,103) width 4 RTL: " "
+                        text run at (0,108) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,44) size 18x60
                       text run at (0,44) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B6}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25B6}"
+                    RenderInline (generated) at (-1,103) size 20x17
+                      RenderText at (-1,103) size 20x17
+                        text run at (0,103) width 4 RTL: " "
+                        text run at (0,107) width 13 RTL: "\x{25B6}"
                     RenderText {#text} at (0,43) size 18x61
                       text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120
@@ -684,20 +718,18 @@ layer at (0,0) size 785x1478
               RenderBlock {DIV} at (2,2) size 120x120
                 RenderBlock {DETAILS} at (0,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25B2}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 12 RTL: "\x{25B2}"
+                    RenderInline (generated) at (-1,103) size 20x17
+                      RenderText at (-1,103) size 20x17
+                        text run at (0,103) width 4 RTL: " "
+                        text run at (0,108) width 12 RTL: "\x{25B2}"
                     RenderText {#text} at (0,44) size 18x60
                       text run at (0,44) width 60: "summary"
                 RenderBlock {DETAILS} at (18,0) size 18x120
                   RenderListItem {SUMMARY} at (0,0) size 18x120
-                    RenderListMarker at (0,103) size 18x17: "\x{25C0}"
-                      RenderBlock (generated) at (0,0) size 19x17
-                        RenderText at (-1,0) size 20x17
-                          text run at (0,0) width 4 RTL: " "
-                          text run at (0,4) width 13 RTL: "\x{25C0}"
+                    RenderInline (generated) at (-1,103) size 20x17
+                      RenderText at (-1,103) size 20x17
+                        text run at (0,103) width 4 RTL: " "
+                        text run at (0,107) width 13 RTL: "\x{25C0}"
                     RenderText {#text} at (0,43) size 18x61
                       text run at (0,43) width 60: "summary"
                   RenderBlock {SLOT} at (18,0) size 0x120

--- a/LayoutTests/platform/mac/fast/lists/008-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/008-expected.txt
@@ -33,30 +33,42 @@ layer at (0,0) size 785x1844
             text run at (65,10) width 69: "Third item"
       RenderBlock {UL} at (0,300) size 186x134 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (41,1) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (9,10) size 7x18: bullet
+          RenderInline (generated) at (9,10) size 7x18
+            RenderText at (9,10) size 7x18
+              text run at (9,10) width 7: "\x{2022}"
           RenderText {#text} at (24,10) size 62x18
             text run at (24,10) width 62: "First item"
         RenderListItem {LI} at (41,39) size 144x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (9,10) size 7x18: bullet
+          RenderInline (generated) at (9,10) size 7x18
+            RenderText at (9,10) size 7x18
+              text run at (9,10) width 7: "\x{2022}"
           RenderText {#text} at (10,10) size 121x36
             text run at (24,10) width 107: "Second and very"
             text run at (10,28) width 94: "very long item"
         RenderListItem {LI} at (41,95) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (9,10) size 7x18: bullet
+          RenderInline (generated) at (9,10) size 7x18
+            RenderText at (9,10) size 7x18
+              text run at (9,10) width 7: "\x{2022}"
           RenderText {#text} at (24,10) size 68x18
             text run at (24,10) width 68: "Third item"
       RenderBlock {UL} at (0,450) size 186x134 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (127,10) size 8x18: bullet
+          RenderInline (generated) at (127,10) size 8x18
+            RenderText at (127,10) size 8x18
+              text run at (127,10) width 8 RTL: "\x{2022}"
           RenderText {#text} at (57,10) size 63x18
             text run at (57,10) width 63: "First item"
         RenderListItem {LI} at (1,39) size 144x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (127,10) size 8x18: bullet
+          RenderInline (generated) at (127,10) size 8x18
+            RenderText at (127,10) size 8x18
+              text run at (127,10) width 8 RTL: "\x{2022}"
           RenderText {#text} at (12,10) size 122x36
             text run at (12,10) width 108: "Second and very"
             text run at (40,28) width 94: "very long item"
         RenderListItem {LI} at (1,95) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (127,10) size 8x18: bullet
+          RenderInline (generated) at (127,10) size 8x18
+            RenderText at (127,10) size 8x18
+              text run at (127,10) width 8 RTL: "\x{2022}"
           RenderText {#text} at (51,10) size 69x18
             text run at (51,10) width 69: "Third item"
       RenderBlock {UL} at (0,600) size 186x134 [border: (1px solid #0000FF)]
@@ -89,32 +101,38 @@ layer at (0,0) size 785x1844
             text run at (65,10) width 69: "Third item"
       RenderBlock {UL} at (0,900) size 186x152 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (41,1) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,14) size 10x10
+          RenderInline (generated) at (10,10) size 17x18
+            RenderImage at (10,14) size 10x10
           RenderText {#text} at (27,10) size 62x18
             text run at (27,10) width 62: "First item"
         RenderListItem {LI} at (41,39) size 144x74 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,14) size 10x10
+          RenderInline (generated) at (10,10) size 17x18
+            RenderImage at (10,14) size 10x10
           RenderText {#text} at (10,10) size 94x54
             text run at (27,10) width 75: "Second and"
             text run at (10,28) width 94: "very very long"
             text run at (10,46) width 29: "item"
         RenderListItem {LI} at (41,113) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,14) size 10x10
+          RenderInline (generated) at (10,10) size 17x18
+            RenderImage at (10,14) size 10x10
           RenderText {#text} at (27,10) size 68x18
             text run at (27,10) width 68: "Third item"
       RenderBlock {UL} at (0,1068) size 186x152 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (123,14) size 11x10
+          RenderInline (generated) at (116,10) size 18x18
+            RenderImage at (123,14) size 11x10
           RenderText {#text} at (54,10) size 63x18
             text run at (54,10) width 63: "First item"
         RenderListItem {LI} at (1,39) size 144x74 [border: (5px solid #FFA500)]
-          RenderListMarker at (123,14) size 11x10
+          RenderInline (generated) at (116,10) size 18x18
+            RenderImage at (123,14) size 11x10
           RenderText {#text} at (40,10) size 94x54
             text run at (42,10) width 75: "Second and"
             text run at (40,28) width 94: "very very long"
             text run at (105,46) width 29: "item"
         RenderListItem {LI} at (1,113) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (123,14) size 11x10
+          RenderInline (generated) at (116,10) size 18x18
+            RenderImage at (123,14) size 11x10
           RenderText {#text} at (48,10) size 69x18
             text run at (48,10) width 69: "Third item"
       RenderBlock {OL} at (0,1236) size 186x134 [border: (1px solid #0000FF)]
@@ -162,44 +180,47 @@ layer at (0,0) size 785x1844
             text run at (65,10) width 69: "Third item"
       RenderBlock {OL} at (0,1536) size 186x134 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (41,1) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 16x18: "1"
+          RenderInline (generated) at (10,10) size 16x18
+            RenderText at (10,10) size 16x18
+              text run at (10,10) width 16: "1. "
           RenderText {#text} at (26,10) size 62x18
             text run at (26,10) width 62: "First item"
         RenderListItem {LI} at (41,39) size 144x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 16x18: "2"
+          RenderInline (generated) at (10,10) size 16x18
+            RenderText at (10,10) size 16x18
+              text run at (10,10) width 16: "2. "
           RenderText {#text} at (10,10) size 123x36
             text run at (26,10) width 107: "Second and very"
             text run at (10,28) width 94: "very long item"
         RenderListItem {LI} at (41,95) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 16x18: "3"
+          RenderInline (generated) at (10,10) size 16x18
+            RenderText at (10,10) size 16x18
+              text run at (10,10) width 16: "3. "
           RenderText {#text} at (26,10) size 68x18
             text run at (26,10) width 68: "Third item"
       RenderBlock {OL} at (0,1686) size 186x134 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (117,10) size 17x18: "1"
-            RenderBlock (generated) at (0,0) size 16x18
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "1"
+          RenderInline (generated) at (117,10) size 17x18
+            RenderText at (117,10) size 17x18
+              text run at (117,10) width 5 RTL: " "
+              text run at (121,10) width 5 RTL: "."
+              text run at (125,10) width 9: "1"
           RenderText {#text} at (55,10) size 63x18
             text run at (55,10) width 63: "First item"
         RenderListItem {LI} at (1,39) size 144x56 [border: (5px solid #FFA500)]
-          RenderListMarker at (117,10) size 17x18: "2"
-            RenderBlock (generated) at (0,0) size 16x18
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "2"
+          RenderInline (generated) at (117,10) size 17x18
+            RenderText at (117,10) size 17x18
+              text run at (117,10) width 5 RTL: " "
+              text run at (121,10) width 5 RTL: "."
+              text run at (125,10) width 9: "2"
           RenderText {#text} at (10,10) size 124x36
             text run at (10,10) width 108: "Second and very"
             text run at (40,28) width 94: "very long item"
         RenderListItem {LI} at (1,95) size 144x38 [border: (5px solid #FFA500)]
-          RenderListMarker at (117,10) size 17x18: "3"
-            RenderBlock (generated) at (0,0) size 16x18
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "3"
+          RenderInline (generated) at (117,10) size 17x18
+            RenderText at (117,10) size 17x18
+              text run at (117,10) width 5 RTL: " "
+              text run at (121,10) width 5 RTL: "."
+              text run at (125,10) width 9: "3"
           RenderText {#text} at (49,10) size 69x18
             text run at (49,10) width 69: "Third item"

--- a/LayoutTests/platform/mac/fast/lists/008-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/008-vertical-expected.txt
@@ -33,30 +33,42 @@ layer at (0,0) size 1844x585
             text run at (10,65) width 68: "Third item"
       RenderBlock {UL} at (300,0) size 134x186 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (1,41) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,9) size 18x7: bullet
+          RenderInline (generated) at (10,9) size 18x7
+            RenderText at (10,9) size 18x7
+              text run at (10,9) width 7: "\x{2022}"
           RenderText {#text} at (10,24) size 18x62
             text run at (10,24) width 62: "First item"
         RenderListItem {LI} at (39,41) size 56x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,9) size 18x7: bullet
+          RenderInline (generated) at (10,9) size 18x7
+            RenderText at (10,9) size 18x7
+              text run at (10,9) width 7: "\x{2022}"
           RenderText {#text} at (10,10) size 36x121
             text run at (10,24) width 107: "Second and very"
             text run at (28,10) width 94: "very long item"
         RenderListItem {LI} at (95,41) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,9) size 18x7: bullet
+          RenderInline (generated) at (10,9) size 18x7
+            RenderText at (10,9) size 18x7
+              text run at (10,9) width 7: "\x{2022}"
           RenderText {#text} at (10,24) size 18x68
             text run at (10,24) width 68: "Third item"
       RenderBlock {UL} at (450,0) size 134x186 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,127) size 18x8: bullet
+          RenderInline (generated) at (10,127) size 18x8
+            RenderText at (10,127) size 18x8
+              text run at (10,127) width 7 RTL: "\x{2022}"
           RenderText {#text} at (10,57) size 18x63
             text run at (10,57) width 62: "First item"
         RenderListItem {LI} at (39,1) size 56x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,127) size 18x8: bullet
+          RenderInline (generated) at (10,127) size 18x8
+            RenderText at (10,127) size 18x8
+              text run at (10,127) width 7 RTL: "\x{2022}"
           RenderText {#text} at (10,12) size 36x122
             text run at (10,12) width 107: "Second and very"
             text run at (28,40) width 94: "very long item"
         RenderListItem {LI} at (95,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,127) size 18x8: bullet
+          RenderInline (generated) at (10,127) size 18x8
+            RenderText at (10,127) size 18x8
+              text run at (10,127) width 7 RTL: "\x{2022}"
           RenderText {#text} at (10,51) size 18x69
             text run at (10,51) width 68: "Third item"
       RenderBlock {UL} at (600,0) size 134x186 [border: (1px solid #0000FF)]
@@ -89,32 +101,38 @@ layer at (0,0) size 1844x585
             text run at (10,65) width 68: "Third item"
       RenderBlock {UL} at (900,0) size 152x186 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (1,41) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,10) size 10x10
+          RenderInline (generated) at (10,10) size 18x17
+            RenderImage at (14,10) size 10x10
           RenderText {#text} at (10,27) size 18x62
             text run at (10,27) width 62: "First item"
         RenderListItem {LI} at (39,41) size 74x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,10) size 10x10
+          RenderInline (generated) at (10,10) size 18x17
+            RenderImage at (14,10) size 10x10
           RenderText {#text} at (10,10) size 54x94
             text run at (10,27) width 75: "Second and"
             text run at (28,10) width 94: "very very long"
             text run at (46,10) width 29: "item"
         RenderListItem {LI} at (113,41) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,10) size 10x10
+          RenderInline (generated) at (10,10) size 18x17
+            RenderImage at (14,10) size 10x10
           RenderText {#text} at (10,27) size 18x68
             text run at (10,27) width 68: "Third item"
       RenderBlock {UL} at (1068,0) size 152x186 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,123) size 10x11
+          RenderInline (generated) at (10,116) size 18x18
+            RenderImage at (14,123) size 10x11
           RenderText {#text} at (10,54) size 18x63
             text run at (10,54) width 62: "First item"
         RenderListItem {LI} at (39,1) size 74x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,123) size 10x11
+          RenderInline (generated) at (10,116) size 18x18
+            RenderImage at (14,123) size 10x11
           RenderText {#text} at (10,40) size 54x94
             text run at (10,42) width 75: "Second and"
             text run at (28,40) width 94: "very very long"
             text run at (46,105) width 29: "item"
         RenderListItem {LI} at (113,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (14,123) size 10x11
+          RenderInline (generated) at (10,116) size 18x18
+            RenderImage at (14,123) size 10x11
           RenderText {#text} at (10,48) size 18x69
             text run at (10,48) width 68: "Third item"
       RenderBlock {OL} at (1236,0) size 134x186 [border: (1px solid #0000FF)]
@@ -162,44 +180,47 @@ layer at (0,0) size 1844x585
             text run at (10,65) width 68: "Third item"
       RenderBlock {OL} at (1536,0) size 134x186 [border: (1px solid #0000FF)]
         RenderListItem {LI} at (1,41) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 18x16: "1"
+          RenderInline (generated) at (10,10) size 18x16
+            RenderText at (10,10) size 18x16
+              text run at (10,10) width 16: "1. "
           RenderText {#text} at (10,26) size 18x62
             text run at (10,26) width 62: "First item"
         RenderListItem {LI} at (39,41) size 56x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 18x16: "2"
+          RenderInline (generated) at (10,10) size 18x16
+            RenderText at (10,10) size 18x16
+              text run at (10,10) width 16: "2. "
           RenderText {#text} at (10,10) size 36x123
             text run at (10,26) width 107: "Second and very"
             text run at (28,10) width 94: "very long item"
         RenderListItem {LI} at (95,41) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,10) size 18x16: "3"
+          RenderInline (generated) at (10,10) size 18x16
+            RenderText at (10,10) size 18x16
+              text run at (10,10) width 16: "3. "
           RenderText {#text} at (10,26) size 18x68
             text run at (10,26) width 68: "Third item"
       RenderBlock {OL} at (1686,0) size 134x186 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,117) size 18x17: "1"
-            RenderBlock (generated) at (0,0) size 18x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 4 RTL: " "
-                text run at (0,4) width 4 RTL: "."
-                text run at (0,8) width 8: "1"
+          RenderInline (generated) at (10,117) size 18x17
+            RenderText at (10,117) size 18x17
+              text run at (10,117) width 4 RTL: " "
+              text run at (10,121) width 4 RTL: "."
+              text run at (10,125) width 8: "1"
           RenderText {#text} at (10,55) size 18x63
             text run at (10,55) width 62: "First item"
         RenderListItem {LI} at (39,1) size 56x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,117) size 18x17: "2"
-            RenderBlock (generated) at (0,0) size 18x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 4 RTL: " "
-                text run at (0,4) width 4 RTL: "."
-                text run at (0,8) width 8: "2"
+          RenderInline (generated) at (10,117) size 18x17
+            RenderText at (10,117) size 18x17
+              text run at (10,117) width 4 RTL: " "
+              text run at (10,121) width 4 RTL: "."
+              text run at (10,125) width 8: "2"
           RenderText {#text} at (10,10) size 36x124
             text run at (10,10) width 107: "Second and very"
             text run at (28,40) width 94: "very long item"
         RenderListItem {LI} at (95,1) size 38x144 [border: (5px solid #FFA500)]
-          RenderListMarker at (10,117) size 18x17: "3"
-            RenderBlock (generated) at (0,0) size 18x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 4 RTL: " "
-                text run at (0,4) width 4 RTL: "."
-                text run at (0,8) width 8: "3"
+          RenderInline (generated) at (10,117) size 18x17
+            RenderText at (10,117) size 18x17
+              text run at (10,117) width 4 RTL: " "
+              text run at (10,121) width 4 RTL: "."
+              text run at (10,125) width 8: "3"
           RenderText {#text} at (10,49) size 18x69
             text run at (10,49) width 68: "Third item"

--- a/LayoutTests/platform/mac/fast/lists/009-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/009-expected.txt
@@ -11,6 +11,7 @@ layer at (0,0) size 800x600
           RenderBlock {DD} at (0,18) size 784x18
             RenderBlock {UL} at (0,0) size 784x18
               RenderListItem {LI} at (0,0) size 784x18
-                RenderListMarker at (0,5) size 12x9
+                RenderInline (generated) at (0,0) size 19x18
+                  RenderImage at (0,5) size 12x9
                 RenderText {#text} at (19,0) size 114x18
                   text run at (19,0) width 114: "LI text is here too"

--- a/LayoutTests/platform/mac/fast/lists/009-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/009-vertical-expected.txt
@@ -11,6 +11,7 @@ layer at (0,0) size 800x600
           RenderBlock {DD} at (18,0) size 18x584
             RenderBlock {UL} at (0,0) size 18x584
               RenderListItem {LI} at (0,0) size 18x584
-                RenderListMarker at (2,0) size 12x9
+                RenderInline (generated) at (0,0) size 18x16
+                  RenderImage at (2,0) size 12x9
                 RenderText {#text} at (0,16) size 18x114
                   text run at (0,16) width 114: "LI text is here too"

--- a/LayoutTests/platform/mac/fast/lists/li-br-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/li-br-expected.txt
@@ -10,6 +10,8 @@ layer at (0,0) size 800x585
             text run at (0,0) width 1492: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       RenderBlock {OL} at (0,34) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderListMarker at (0,0) size 16x18: "1"
+          RenderInline (generated) at (0,0) size 16x18
+            RenderText at (0,0) size 16x18
+              text run at (0,0) width 16: "1. "
           RenderText {#text} at (0,18) size 1492x18
             text run at (0,18) width 1492: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/LayoutTests/platform/mac/fast/lists/markers-in-selection-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/markers-in-selection-expected.txt
@@ -28,7 +28,9 @@ layer at (0,0) size 800x600
             text run at (0,0) width 162: "Item with outside marker"
       RenderBlock {UL} at (0,120) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (-1,0) size 7x18: bullet
+          RenderInline (generated) at (-1,0) size 7x18
+            RenderText at (-1,0) size 7x18
+              text run at (-1,0) width 7: "\x{2022}"
           RenderText {#text} at (14,0) size 154x18
             text run at (14,0) width 154: "Item with inside marker"
       RenderBlock {UL} at (0,154) size 784x18
@@ -38,7 +40,8 @@ layer at (0,0) size 800x600
             text run at (0,0) width 205: "Item with outside image marker"
       RenderBlock {UL} at (0,188) size 784x18
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (0,4) size 10x10
+          RenderInline (generated) at (0,0) size 17x18
+            RenderImage at (0,4) size 10x10
           RenderText {#text} at (17,0) size 197x18
             text run at (17,0) width 197: "Item with inside image marker"
       RenderBlock {OL} at (0,222) size 784x36
@@ -52,11 +55,15 @@ layer at (0,0) size 800x600
             text run at (0,0) width 103: "and another one"
       RenderBlock {OL} at (0,274) size 784x36
         RenderListItem {LI} at (40,0) size 744x18
-          RenderListMarker at (0,0) size 16x18: "1"
+          RenderInline (generated) at (0,0) size 16x18
+            RenderText at (0,0) size 16x18
+              text run at (0,0) width 16: "1. "
           RenderText {#text} at (16,0) size 154x18
             text run at (16,0) width 154: "Item with inside ordinal"
         RenderListItem {LI} at (40,18) size 744x18
-          RenderListMarker at (0,0) size 16x18: "2"
+          RenderInline (generated) at (0,0) size 16x18
+            RenderText at (0,0) size 16x18
+              text run at (0,0) width 16: "2. "
           RenderText {#text} at (16,0) size 103x18
             text run at (16,0) width 103: "and another one"
       RenderBlock (anonymous) at (0,336) size 784x0

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -4178,7 +4178,12 @@ Vector<AXStitchGroup> AccessibilityNodeObject::stitchGroups() const
                 context.lastRenderer = box->renderer();
             });
 
-            if (CheckedPtr renderListMarker = dynamicDowncast<RenderListMarker>(box->renderer()); renderListMarker && !renderListMarker->isDisclosureMarker()) {
+            if (listMarkerIsDisclosure(dynamicDowncast<RenderElement>(box->renderer())) || listMarkerIsDisclosure(box->renderer().parent())) {
+                finalizeCurrentGroup();
+                continue;
+            }
+
+            if (CheckedPtr renderListMarker = dynamicDowncast<RenderListMarker>(box->renderer())) {
                 if (RefPtr object = cache->getOrCreate(const_cast<RenderListMarker&>(*renderListMarker)))
                     appendToCurrentGroup(object->objectID());
                 continue;

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -432,6 +432,12 @@ String AccessibilityRenderObject::textUnderElement(TextUnderElementMode mode) co
     if (CheckedPtr fileUpload = dynamicDowncast<RenderFileUploadControl>(*m_renderer))
         return fileUpload->buttonValue();
 
+    if (CheckedPtr markerInlineBox = m_renderer->parent(); is<RenderText>(*m_renderer) && markerInlineBox && markerInlineBox->style().isListMarkerStyle()) {
+        if (mode.includeListMarkers == IncludeListMarkerText::Yes)
+            return downcast<RenderText>(*m_renderer).text();
+        return { };
+    }
+
     if (auto* listMarker = dynamicDowncast<RenderListMarker>(*m_renderer)) {
         // A `content` marker has no text of its own; the child walk below reads the renderers holding it.
         if (!listMarker->hasContentProperty()) {

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -401,6 +401,12 @@ bool InlineFormattingUtils::isAtSoftWrapOpportunity(const InlineItem& previous, 
     if (&previous.layoutBox().parent() == &next.layoutBox().parent() && !mayWrapPrevious && !mayWrapNext)
         return false;
 
+    auto isMarkerContent = [](auto& inlineItem) {
+        return inlineItem.layoutBox().parent().style().isListMarkerStyle();
+    };
+    if (isMarkerContent(previous) && !isMarkerContent(next))
+        return TextUtil::isWrappingAllowed(nearestCommonAncestor(previous.layoutBox(), next.layoutBox(), formattingContext().root()).style());
+
     if (is<InlineTextItem>(previous) && is<InlineTextItem>(next)) {
         auto& previousInlineTextItem = uncheckedDowncast<InlineTextItem>(previous);
         auto& nextInlineTextItem = uncheckedDowncast<InlineTextItem>(next);
@@ -435,8 +441,8 @@ bool InlineFormattingUtils::isAtSoftWrapOpportunity(const InlineItem& previous, 
         return TextUtil::isWrappingAllowed(nearestCommonAncestor(previousInlineTextItem.layoutBox(), nextInlineTextItem.layoutBox(), formattingContext().root()).style());
     }
     if (previous.layoutBox().isListMarkerBox()) {
-        auto& listMarkerBox = downcast<ElementBox>(previous.layoutBox());
-        return !listMarkerBox.isListMarkerOutside();
+        // An outside marker is not on the line's content flow, so it offers nothing to break after.
+        return false;
     }
     if (next.layoutBox().isListMarkerBox()) {
         // FIXME: SHould this ever be the case?

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
@@ -356,6 +356,9 @@ void Line::appendText(const InlineTextItem& inlineTextItem, const Style::Compute
             return false;
         // This content is collapsible. Let's check if the last item is collapsed.
         for (auto& run : m_runs | std::views::reverse) {
+            // Nothing precedes the marker on the line, so this is the line's leading whitespace.
+            if (run.isListMarkerOrItsContent())
+                return true;
             if (run.isAtomicInlineBox())
                 return false;
             // https://drafts.csswg.org/css-text-3/#white-space-phase-1
@@ -363,7 +366,7 @@ void Line::appendText(const InlineTextItem& inlineTextItem, const Style::Compute
             // provided both spaces are within the same inline formatting context—is collapsed to have zero advance width.
             if (run.isText())
                 return run.hasCollapsibleTrailingWhitespace();
-            ASSERT(run.isListMarker() || run.isLineSpanningInlineBoxStart() || run.isInlineBoxStart() || run.isInlineBoxEnd() || run.isWordBreakOpportunity() || run.isOutOfFlow());
+            ASSERT(run.isLineSpanningInlineBoxStart() || run.isInlineBoxStart() || run.isInlineBoxEnd() || run.isWordBreakOpportunity() || run.isOutOfFlow());
         }
         // Leading whitespace.
         return true;
@@ -482,7 +485,7 @@ void Line::appendText(const InlineTextItem& inlineTextItem, const Style::Compute
 
 void Line::appendTextFast(const InlineTextItem& inlineTextItem, const Style::ComputedStyle& style, InlineLayoutUnit logicalWidth)
 {
-    auto lineHasContent = !m_runs.isEmpty();
+    auto lineHasContent = !m_runs.isEmpty() && !m_runs.last().isListMarkerOrItsContent();
     auto willCollapseCompletely = [&] {
         if (inlineTextItem.isEmpty())
             return true;
@@ -691,17 +694,21 @@ bool Line::restoreTrimmedTrailingWhitespace(InlineLayoutUnit trimmedTrailingWhit
     return false;
 }
 
+bool Line::Run::isListMarkerOrItsContent() const
+{
+    // A marker's contents inherit the ::marker style, so the marker and its text answer alike.
+    return isListMarker() || m_layoutBox->style().isListMarkerStyle();
+}
+
 bool Line::hasTrailingForcedLineBreak(const RunList& runs)
 {
     return !runs.isEmpty() && runs.last().isLineBreak();
 }
 
-bool Line::hasContentOrDecoration(IncludeInsideListMarker includeInsideListMarker) const
+bool Line::hasContentOrDecoration() const
 {
     if (m_runs.isEmpty())
         return false;
-    if (includeInsideListMarker == IncludeInsideListMarker::Yes && m_runs.first().isListMarkerInside())
-        return true;
     auto& formattingContext = this->formattingContext();
     for (auto& run : m_runs | std::views::reverse) {
         if (Line::Run::isContentfulOrHasDecoration(run, formattingContext) && !run.isListMarker())
@@ -794,7 +801,7 @@ inline static Line::Run::Type NODELETE toLineRunType(const InlineItem& inlineIte
         return Line::Run::Type::WordBreakOpportunity;
     case InlineItem::Type::AtomicInlineBox:
         if (inlineItem.layoutBox().isListMarkerBox())
-            return downcast<ElementBox>(inlineItem.layoutBox()).isListMarkerOutside() ? Line::Run::Type::ListMarkerOutside : Line::Run::Type::ListMarkerInside;
+            return Line::Run::Type::ListMarker;
         return Line::Run::Type::AtomicInlineBox;
     case InlineItem::Type::InlineBoxStart:
         return Line::Run::Type::InlineBoxStart;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.h
@@ -62,9 +62,8 @@ public:
 
     void setContentNeedsBidiReordering() { m_hasNonDefaultBidiLevelRun = true; }
 
-    enum class IncludeInsideListMarker : bool { No, Yes };
-    bool hasContent(IncludeInsideListMarker = IncludeInsideListMarker::No) const;
-    bool hasContentOrDecoration(IncludeInsideListMarker = IncludeInsideListMarker::No) const;
+    bool hasContent() const;
+    bool hasContentOrDecoration() const;
     bool hasRubyContent() const { return m_hasRubyContent; }
 
     InlineLayoutUnit contentLogicalWidth() const { return m_contentLogicalWidth; }
@@ -99,8 +98,7 @@ public:
             SoftLineBreak,
             WordBreakOpportunity,
             AtomicInlineBox,
-            ListMarkerInside,
-            ListMarkerOutside,
+            ListMarker,
             InlineBoxStart,
             InlineBoxEnd,
             LineSpanningInlineBoxStart,
@@ -112,9 +110,8 @@ public:
         bool isNonBreakingSpace() const { return m_type == Type::NonBreakingSpace; }
         bool isWordSeparator() const { return m_type == Type::WordSeparator; }
         bool isAtomicInlineBox() const { return m_type == Type::AtomicInlineBox; }
-        bool isListMarker() const { return isListMarkerInside() || isListMarkerOutside(); }
-        bool isListMarkerInside() const { return m_type == Type::ListMarkerInside; }
-        bool isListMarkerOutside() const { return m_type == Type::ListMarkerOutside; }
+        bool isListMarker() const { return m_type == Type::ListMarker; }
+        bool isListMarkerOrItsContent() const;
         bool isLineBreak() const { return isHardLineBreak() || isSoftLineBreak(); }
         bool isSoftLineBreak() const  { return m_type == Type::SoftLineBreak; }
         bool isHardLineBreak() const { return m_type == Type::HardLineBreak; }
@@ -339,12 +336,10 @@ private:
     Vector<InlineLayoutUnit> m_inlineBoxLogicalLeftStack;
 };
 
-inline bool Line::hasContent(IncludeInsideListMarker includeInsideListMarker) const
+inline bool Line::hasContent() const
 {
     if (m_runs.isEmpty())
         return false;
-    if (includeInsideListMarker == IncludeInsideListMarker::Yes && m_runs.first().isListMarkerInside())
-        return true;
     for (auto& run : m_runs | std::views::reverse) {
         if (run.isContentful() && !run.isListMarker())
             return true;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
@@ -525,7 +525,7 @@ void LineBoxBuilder::constructInlineLevelBoxes(LineBox& lineBox)
                 lineBox.parentInlineBox(run).setHasContent();
             }
 
-            if (run.isListMarkerOutside())
+            if (run.isListMarker())
                 m_outsideListMarkers.append(index);
 
             auto atomicInlineBox = InlineLevelBox::createAtomicInlineBox(listMarkerBox, style, logicalLeft, formattingContext.geometryForBox(listMarkerBox).borderBoxWidth());
@@ -877,7 +877,7 @@ void LineBoxBuilder::adjustOutsideListMarkersPosition(LineBox& lineBox)
     auto rootInlineBoxOffsetFromContentBoxOrIntrusiveFloat = lineBoxOffset + rootInlineBoxLogicalLeft;
     for (auto listMarkerBoxIndex : m_outsideListMarkers) {
         auto& listMarkerRun = lineLayoutResult().runs[listMarkerBoxIndex];
-        ASSERT(listMarkerRun.isListMarkerOutside());
+        ASSERT(listMarkerRun.isListMarker());
         auto& listMarkerBox = downcast<ElementBox>(listMarkerRun.layoutBox());
         auto& listMarkerInlineLevelBox = lineBox.inlineLevelBoxFor(listMarkerRun);
         // Move it to the logical left of the line box (from the logical left of the root inline box).

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -643,7 +643,7 @@ UniqueRef<LineContent> LineBuilder::placeInlineAndFloatContent(const InlineItemR
         auto handleTrailingContent = [&] {
             auto& quirks = formattingContext().quirks();
             auto lineHasOverflow = [&] {
-                return horizontalAvailableSpace < m_line.contentLogicalWidth() && m_line.hasContent(Line::IncludeInsideListMarker::Yes);
+                return horizontalAvailableSpace < m_line.contentLogicalWidth() && m_line.hasContent();
             };
             auto isLineBreakAfterWhitespace = [&] {
                 return rootStyle.lineBreak() == LineBreak::AfterWhiteSpace && intrinsicWidthMode() != IntrinsicWidthMode::Minimum && (!isLastInlineContent || lineHasOverflow());
@@ -1416,7 +1416,7 @@ void LineBuilder::handleBlockContent(const InlineItem& blockItem)
 {
     ASSERT(blockItem.isBlock());
     // Blocks are always the only content on the line.
-    ASSERT(!m_line.hasContent(Line::IncludeInsideListMarker::Yes));
+    ASSERT(!m_line.hasContent());
     if (isInIntrinsicWidthMode()) {
         CheckedRef blockBox = downcast<ElementBox>(blockItem.layoutBox());
         auto& boxGeometry = formattingContext().geometryForBox(blockBox.get());
@@ -1475,7 +1475,7 @@ LineBuilder::Result LineBuilder::handleInlineContent(const InlineItemRange& layo
         return availableWidth(m_line, availableTotalWidthForContent, intrinsicWidthMode());
     }();
 
-    auto lineHasContent = m_line.hasContent(Line::IncludeInsideListMarker::Yes);
+    auto lineHasContent = m_line.hasContent();
     auto verticalPositionHasFloatOrInlineContent = lineHasContent || isLineConstrainedByFloat() || !constraints.constrainedSideSet.isEmpty();
     auto lineBreakingResult = InlineContentBreaker::Result { InlineContentBreaker::Result::Action::Keep, InlineContentBreaker::IsEndOfLine::No, { }, { } };
 
@@ -1785,7 +1785,7 @@ LineBuilder::Result LineBuilder::processLineBreakingResult(LineCandidate& lineCa
         // We are keeping this content on the line but we need to check if we could have wrapped here
         // in order to be able to revert back to this position if needed.
         // Let's just ignore cases like collapsed leading whitespace for now.
-        if (lineCandidate.inlineContent.hasTrailingSoftWrapOpportunity() && m_line.hasContent(Line::IncludeInsideListMarker::Yes)) {
+        if (lineCandidate.inlineContent.hasTrailingSoftWrapOpportunity() && m_line.hasContent()) {
             auto& trailingRun = candidateRuns.last();
             auto& trailingInlineItem = trailingRun.inlineItem;
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
@@ -227,14 +227,9 @@ bool InlineQuirks::shouldCollapseLineBoxHeight(const Line::RunList& lineContent,
     if (!markerBox)
         return false;
 
-    if (!marker.isListMarkerOutside()) {
-        ASSERT(marker.isListMarkerInside());
-        return false;
-    }
-
     size_t emptyInlineBoxCount = 0;
     for (auto& run : lineContent) {
-        if (run.isListMarkerOutside())
+        if (run.isListMarker())
             continue;
         if (Line::Run::isContentfulOrHasDecoration(run, formattingContext()))
             return false;

--- a/Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.cpp
@@ -317,7 +317,7 @@ InlineLayoutUnit IntrinsicWidthHandler::computedIntrinsicWidthForConstraint(Intr
             if (lineLayoutResult.runs.isEmpty())
                 return contentWidth;
             auto& leadingRun = lineLayoutResult.runs.first();
-            if (leadingRun.isListMarkerOutside())
+            if (leadingRun.isListMarker())
                 contentWidth -= leadingRun.logicalRight();
             return contentWidth;
         }();

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -126,7 +126,7 @@ void BoxGeometryUpdater::clear()
 void BoxGeometryUpdater::setListMarkerOffsetForMarkerOutside(const RenderListMarker& listMarker)
 {
     CheckedRef layoutBox = *listMarker.layoutBox();
-    ASSERT(layoutBox->isListMarkerOutside());
+    ASSERT(layoutBox->isListMarkerBox());
     auto* ancestor = listMarker.containingBlock();
 
     auto offsetFromParentListItem = [&] {
@@ -800,8 +800,7 @@ void BoxGeometryUpdater::updateBoxGeometryAfterIntegrationLayout(const Layout::E
         if (CheckedPtr renderListMarker = dynamicDowncast<RenderListMarker>(*renderBox)) {
             CheckedRef style = layoutBox.parent().style();
             boxGeometry.setHorizontalMargin(horizontalLogicalMargin(*renderListMarker, { }, style->writingMode()));
-            if (!renderListMarker->isInside())
-                setListMarkerOffsetForMarkerOutside(*renderListMarker);
+            setListMarkerOffsetForMarkerOutside(*renderListMarker);
             const_cast<Layout::ElementBox&>(layoutBox).setListMarkerLayoutBounds(renderListMarker->layoutBounds());
         }
 
@@ -841,7 +840,7 @@ void BoxGeometryUpdater::updateBoxGeometry(const RenderElement& renderer, std::o
 
     if (auto* renderBox = dynamicDowncast<RenderBox>(renderer)) {
         updateLayoutBoxDimensions(*renderBox, availableWidth, intrinsicWidthMode);
-        if (auto* renderListMarker = dynamicDowncast<RenderListMarker>(renderer); renderListMarker && !renderListMarker->isInside())
+        if (auto* renderListMarker = dynamicDowncast<RenderListMarker>(renderer))
             setListMarkerOffsetForMarkerOutside(*renderListMarker);
         return;
     }

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -235,8 +235,6 @@ static EnumSet<Layout::ElementBox::ListMarkerAttribute> calculateListMarkerAttri
     auto listMarkerAttributes = EnumSet<Layout::ElementBox::ListMarkerAttribute> { };
     if (listMarkerRenderer.isImage())
         listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Image);
-    if (!listMarkerRenderer.isInside())
-        listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Outside);
     if (listMarkerRenderer.shouldCollapseAnonymousBlockParent())
         listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::ShouldCollapseAnonymousBlockParent);
 
@@ -245,8 +243,14 @@ static EnumSet<Layout::ElementBox::ListMarkerAttribute> calculateListMarkerAttri
 
 static bool markerTextSynthesizesGlyph(const RenderText& textRenderer)
 {
-    CheckedPtr marker = dynamicDowncast<RenderListMarker>(textRenderer.parent()->parent());
-    return marker && marker->synthesizesGlyph();
+    // The marker is this text's parent when it is an inline box, and its grandparent when a marker box holds the text in a content container of its own.
+    for (CheckedPtr marker = textRenderer.parent(); marker; marker = marker->parent()) {
+        if (marker->style().isListMarkerStyle())
+            return listMarkerSynthesizesGlyph(marker->style());
+        if (!marker->isAnonymous())
+            return false;
+    }
+    return false;
 }
 
 UniqueRef<Layout::Box> BoxTreeUpdater::createLayoutBox(RenderObject& renderer)

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.h
@@ -48,7 +48,6 @@ public:
 
     enum class ListMarkerAttribute : uint8_t {
         Image,
-        Outside,
         ShouldCollapseAnonymousBlockParent,
     };
     ElementBox(ElementAttributes&&, EnumSet<ListMarkerAttribute>, Style::ComputedStyle&&, std::unique_ptr<Style::ComputedStyle>&& firstLineStyle = nullptr);
@@ -101,7 +100,6 @@ public:
     void setListMarkerAttributes(EnumSet<ListMarkerAttribute> listMarkerAttributes) { m_replacedData->listMarkerAttributes = listMarkerAttributes; }
 
     bool isListMarkerImage() const { return m_replacedData && m_replacedData->listMarkerAttributes.contains(ListMarkerAttribute::Image); }
-    bool isListMarkerOutside() const { return m_replacedData && m_replacedData->listMarkerAttributes.contains(ListMarkerAttribute::Outside); }
     bool shouldCollapseAnonymousBlockParentForListMarker() const { return m_replacedData && m_replacedData->listMarkerAttributes.contains(ListMarkerAttribute::ShouldCollapseAnonymousBlockParent); }
 
     // FIXME: This is temporary until after list marker content is accessible by IFC (webkit.org/b/294342)

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2580,7 +2580,7 @@ std::pair<RenderObject*, RenderElement*> RenderBlock::firstLetterAndContainer(Re
         }
 
         RenderElement& current = downcast<RenderElement>(*firstLetter);
-        if (is<RenderListMarker>(current))
+        if (current.style().isListMarkerStyle())
             firstLetter = current.nextSibling();
         else if (current.isFloatingOrOutOfFlowPositioned()) {
             if (current.style().pseudoElementType() == PseudoElementType::FirstLetter) {

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2769,7 +2769,7 @@ FloatRect RenderElement::referenceBoxRect(CSSBoxType boxType) const
     // is removed this function should be moved to RenderLayerModelObject.
     // As this method is used by both SVG engines, we need to place it
     // here in RenderElement, as temporary solution.
-    if (element() && !is<SVGElement>(element()))
+    if (!is<SVGElement>(element()) && !is<RenderSVGViewportContainer>(*this))
         return { };
 
     auto alignReferenceBox = [&](FloatRect referenceBox) {

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -40,6 +40,7 @@
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderChildIterator.h"
 #include "RenderElementStyleInlines.h"
+#include "RenderImage.h"
 #include "RenderInline.h"
 #include "RenderMenuList.h"
 #include "RenderMultiColumnFlow.h"
@@ -183,6 +184,8 @@ Style::ComputedStyle RenderListItem::computeMarkerStyle() const
         markerStyle.setTextTransform({ });
         return markerStyle;
     }();
+
+    markerStyle.setPseudoElementIdentifier({ { PseudoElementType::Marker } });
 
     // A disclosure triangle is drawn from the system font rather than from the one the marker inherited, so that is the
     // font the marker has: it is what the glyph is measured with too, the way it is for every other marker.
@@ -390,17 +393,49 @@ void RenderListItem::updateValueNow() const
 void RenderListItem::updateValue()
 {
     m_value = std::nullopt;
-    if (m_marker) {
-        m_marker->setNeedsLayoutAndInvalidateContentLogicalWidths();
-        if (m_marker->excludedPosition())
-            m_marker->invalidateExcludedMarkerContainer();
+    if (CheckedPtr marker = markerBox()) {
+        marker->setNeedsLayoutAndInvalidateContentLogicalWidths();
+        if (marker->excludedPosition())
+            marker->invalidateExcludedMarkerContainer();
     }
 }
 
 void RenderListItem::updateMarkerContent()
 {
-    if (CheckedPtr marker = m_marker.get())
-        marker->updateInlineMarginsAndContent();
+    if (CheckedPtr markerBox = this->markerBox()) {
+        markerBox->updateInlineMarginsAndContent();
+        return;
+    }
+
+    CheckedPtr marker = dynamicDowncast<RenderInline>(m_marker.get());
+    // css-lists-3 §3.3: with a non-normal `content` the marker's contents are the author's, not ours to fill in.
+    if (!marker || marker->style().content().isData())
+        return;
+
+    if (CheckedPtr imageRenderer = dynamicDowncast<RenderImage>(marker->firstChild())) {
+        // The image is a renderer of its own; all the marker owes the line is the room after it, which the image keeps
+        // on its own end edge so that the inline formatting context puts it on the side the line runs towards.
+        setListMarkerInlineMargins(imageRenderer->mutableStyle(), writingMode(), { }, listMarkerImagePadding);
+        return;
+    }
+
+    CheckedPtr textRenderer = dynamicDowncast<RenderText>(marker->firstChild());
+    if (!textRenderer)
+        return;
+
+    auto textContent = listMarkerTextContent(marker->style(), *this);
+    if (!listMarkerSynthesizesGlyph(marker->style())) {
+        textRenderer->setText(textContent.textWithSuffix);
+        return;
+    }
+
+    // The glyph stands alone and the room after it is a margin rather than the suffix space, so that word-spacing and
+    // letter-spacing leave it be. TextBoxPainter draws it at a size the font metrics give it rather than at the counter
+    // style character's, so the room after it is measured from that same size (see Layout::TextUtil::width).
+    textRenderer->setText(textContent.textWithoutSuffix().toString());
+    auto& fontMetrics = marker->style().metricsOfPrimaryFont();
+    auto glyphWidth = LayoutUnit { (fontMetrics.intAscent() * 2 / 3 + 1) / 2 + 2 };
+    setListMarkerInlineMargins(marker->mutableStyle(), writingMode(), -1_lu, fontMetrics.intAscent() - glyphWidth + 1);
 }
 
 void RenderListItem::updateValueAndMarkerContent()
@@ -418,15 +453,16 @@ void RenderListItem::styleDidChange(Style::Difference diff, const Style::Compute
     if (diff == Style::DifferenceResult::Layout) {
         if (oldStyle && oldStyle->usedCounterDirectives().map.get("list-item"_s) != style().usedCounterDirectives().map.get("list-item"_s))
             usedCounterDirectivesChanged();
-        if (m_marker && m_marker->excludedPosition())
-            m_marker->invalidateExcludedMarkerContainer();
+        if (CheckedPtr marker = markerBox(); marker && marker->excludedPosition())
+            marker->invalidateExcludedMarkerContainer();
     }
 }
 
 RenderListMarker* RenderListItem::excludedMarker() const
 {
-    if (m_marker && m_marker->parent() == this && m_marker->isExcludedMarker())
-        return m_marker.get();
+    auto* marker = markerBox();
+    if (marker && marker->parent() == this && marker->isExcludedMarker())
+        return marker;
     return { };
 }
 
@@ -476,6 +512,11 @@ void RenderListItem::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintO
     RenderBlockFlow::paintObject(paintInfo, paintOffset);
 }
 
+RenderListMarker* RenderListItem::markerBox() const
+{
+    return dynamicDowncast<RenderListMarker>(m_marker.get());
+}
+
 String RenderListItem::markerText(ListMarkerIncludeSuffix includeSuffix) const
 {
     CheckedPtr marker = m_marker.get();
@@ -491,8 +532,8 @@ String RenderListItem::markerText(ListMarkerIncludeSuffix includeSuffix) const
 
 void RenderListItem::usedCounterDirectivesChanged()
 {
-    if (m_marker)
-        m_marker->setNeedsLayoutAndInvalidateContentLogicalWidths();
+    if (CheckedPtr marker = markerBox())
+        marker->setNeedsLayoutAndInvalidateContentLogicalWidths();
 
     updateValueAndMarkerContent();
     RefPtr list = enclosingList(*this);
@@ -570,7 +611,7 @@ void RenderListItem::placeExcludedMarker(RenderListMarker& marker)
     setLogicalLeftForChild(marker, logicalLeft);
 }
 
-RenderListItem::FirstFormattedLineCandidate RenderListItem::firstFormattedLineRootFor(RenderBlock& blockContainer, const RenderListMarker& marker)
+RenderListItem::FirstFormattedLineCandidate RenderListItem::firstFormattedLineRootFor(RenderBlock& blockContainer, const RenderBoxModelObject& marker)
 {
     RenderBlock* fallbackParent = { };
     bool stoppedAtTableRubyOrReplaced = false;

--- a/Source/WebCore/rendering/RenderListItem.h
+++ b/Source/WebCore/rendering/RenderListItem.h
@@ -49,9 +49,11 @@ public:
 
     Style::ComputedStyle computeMarkerStyle() const;
 
-    RenderListMarker* markerRenderer() const { return m_marker.get(); }
-    void setMarkerRenderer(RenderListMarker& marker) { m_marker = marker; }
+    RenderBoxModelObject* markerRenderer() const { return m_marker.get(); }
+    void setMarkerRenderer(RenderBoxModelObject& marker) { m_marker = marker; }
+    RenderListMarker* markerBox() const;
 
+    // Fills in what the marker shows, in whichever shape it was built.
     void updateMarkerContent();
 
     bool isInReversedOrderedList() const;
@@ -62,7 +64,7 @@ public:
         // FIXME: handle all block level children, not just replaced elements that got blockified.
         bool stoppedAtTableRubyOrReplaced { false };
     };
-    static FirstFormattedLineCandidate firstFormattedLineRootFor(RenderBlock& blockContainer, const RenderListMarker&);
+    static FirstFormattedLineCandidate firstFormattedLineRootFor(RenderBlock& blockContainer, const RenderBoxModelObject& marker);
     static Vector<CheckedPtr<RenderListMarker>> excludedMarkersForContainer(const RenderBlockFlow& lineContainer, const Vector<SingleThreadWeakPtr<RenderListMarker>>&);
 
 private:
@@ -84,7 +86,7 @@ private:
     void updateValueNow() const;
     void usedCounterDirectivesChanged();
 
-    SingleThreadWeakPtr<RenderListMarker> m_marker;
+    SingleThreadWeakPtr<RenderBoxModelObject> m_marker;
     mutable std::optional<int> m_value;
 };
 

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -537,16 +537,6 @@ void RenderListMarker::updateInlineMargins()
     constexpr int markerPadding = listMarkerImagePadding;
     const FontMetrics& fontMetrics = style().metricsOfPrimaryFont();
 
-    auto marginsForInsideMarker = [&]() -> std::pair<LayoutUnit, LayoutUnit> {
-        if (isImage())
-            return { 0, markerPadding };
-
-        if (synthesizesGlyph())
-            return { -1, fontMetrics.intAscent() - minContentLogicalWidthContribution() + 1 };
-
-        return { };
-    };
-
     auto marginsForOutsideMarker = [&]() -> std::pair<LayoutUnit, LayoutUnit> {
         if (isImage())
             return { -minContentLogicalWidthContribution() - markerPadding, markerPadding };
@@ -561,7 +551,7 @@ void RenderListMarker::updateInlineMargins()
         return { -minContentLogicalWidthContribution(), 0 };
     };
 
-    auto [marginStart, marginEnd] = isInside() ? marginsForInsideMarker() : marginsForOutsideMarker();
+    auto [marginStart, marginEnd] = marginsForOutsideMarker();
     setListMarkerInlineMargins(mutableStyle(), m_listItem->writingMode(), marginStart, marginEnd);
 }
 
@@ -579,11 +569,6 @@ void setListMarkerInlineMargins(Style::ComputedStyle& markerStyle, WritingMode l
     auto startIsTop = listItemWritingMode.isInlineTopToBottom();
     markerStyle.setMarginTop(startIsTop ? startEdge : endEdge);
     markerStyle.setMarginBottom(startIsTop ? endEdge : startEdge);
-}
-
-bool RenderListMarker::isInside() const
-{
-    return style().listStylePosition() == ListStylePosition::Inside;
 }
 
 bool RenderListMarker::isDisclosureMarker() const
@@ -668,6 +653,13 @@ bool listMarkerIsDisclosure(const Style::ComputedStyle& markerStyle, Document& d
         return false;
     auto system = counterStyle->system();
     return system == CSSCounterStyleDescriptors::System::DisclosureClosed || system == CSSCounterStyleDescriptors::System::DisclosureOpen;
+}
+
+bool listMarkerIsDisclosure(const RenderElement* renderer)
+{
+    if (!renderer || !renderer->style().isListMarkerStyle())
+        return false;
+    return listMarkerIsDisclosure(renderer->style(), protect(renderer->document()));
 }
 
 bool listMarkerSynthesizesGlyph(const Style::ComputedStyle& markerStyle)

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -62,7 +62,6 @@ public:
         return includeSuffix == IncludeSuffix::Yes ? m_textContent.textWithSuffix : m_textContent.textWithoutSuffix().toString();
     }
 
-    bool NODELETE isInside() const;
     bool isDisclosureMarker() const;
     bool synthesizesGlyph() const;
 
@@ -99,7 +98,6 @@ public:
         if (value) {
             ASSERT(parent());
             ASSERT(parent()->isAnonymousBlock());
-            ASSERT(!isInside());
         }
         m_shouldCollapseAnonymousBlockParent = value;
     }
@@ -152,6 +150,7 @@ constexpr int listMarkerImagePadding = 7;
 ListMarkerTextContent listMarkerTextContent(const Style::ComputedStyle& markerStyle, RenderListItem&);
 bool listMarkerSynthesizesGlyph(const Style::ComputedStyle& markerStyle);
 bool listMarkerIsDisclosure(const Style::ComputedStyle& markerStyle, Document&);
+bool listMarkerIsDisclosure(const RenderElement*);
 void setListMarkerInlineMargins(Style::ComputedStyle& markerStyle, WritingMode listItemWritingMode, LayoutUnit marginStart, LayoutUnit marginEnd);
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1893,7 +1893,8 @@ Node* RenderObject::nodeForHitTest() const
     auto* node = this->node();
     // If we hit the anonymous renderers inside generated content we should
     // actually hit the generated content so walk up to the PseudoElement.
-    if (!node && parent() && parent()->isBeforeOrAfterContent()) {
+    // A marker has no element of its own, so hitting its content is hitting the list item.
+    if (!node && parent() && (parent()->isBeforeOrAfterContent() || parent()->style().isListMarkerStyle())) {
         for (auto* renderer = parent(); renderer && !node; renderer = renderer->parent())
             node = renderer->element();
     }
@@ -3153,7 +3154,7 @@ bool RenderObject::isExcludedMarker() const
     auto* marker = dynamicDowncast<RenderListMarker>(*this);
     if (!marker)
         return false;
-    if (marker->isInside() || !document().settings().listMarkerPositionedPostLayoutEnabled())
+    if (!document().settings().listMarkerPositionedPostLayoutEnabled())
         return false;
     return parent() && !parent()->childrenInline();
 }

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -673,8 +673,7 @@ inline void BreakingContext::commitAndUpdateLineBreakIfNeeded()
     if (!m_current.renderer()->isFloatingOrOutOfFlowPositioned()) {
         m_lastObject = m_current.renderer();
         if (m_lastObject->isBlockLevelReplacedOrAtomicInline() && m_autoWrap && (!m_lastObject->isImage() || m_allowImagesToBreak)) {
-            auto* renderListMarker = dynamicDowncast<RenderListMarker>(*m_lastObject);
-            if (!renderListMarker || renderListMarker->isInside()) {
+            if (!is<RenderListMarker>(*m_lastObject)) {
                 if (m_nextObject)
                     commitLineBreakAtCurrentWidth(*m_nextObject);
                 else

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
@@ -92,7 +92,7 @@ struct ParentAndBeforeChild {
 static bool isExcludedMarker(const RenderBlock& parent, const RenderObject& child)
 {
     CheckedPtr marker = dynamicDowncast<RenderListMarker>(child);
-    if (!marker || marker->isInside() || !marker->document().settings().listMarkerPositionedPostLayoutEnabled())
+    if (!marker || !marker->document().settings().listMarkerPositionedPostLayoutEnabled())
         return false;
     CheckedPtr listItem = dynamicDowncast<RenderListItem>(parent);
     return listItem && !markerNeedsOwnLine(*listItem);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -28,6 +28,7 @@
 #include "LineInlineHeaders.h"
 #include "RenderBlockFlow.h"
 #include "RenderChildIterator.h"
+#include "RenderImage.h"
 #include "RenderListMarker.h"
 #include "RenderMenuList.h"
 #include "RenderMultiColumnFlow.h"
@@ -37,6 +38,7 @@
 #include "RenderTreeUpdaterGeneratedContent.h"
 #include "Settings.h"
 #include "StyleComputedStyle+GettersInlines.h"
+#include "StyleComputedStyle+SettersInlines.h"
 #include "StyleComputedStyle.h"
 #include "StyleContent.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -77,37 +79,36 @@ struct MarkerParentSearchResult {
 
 static MarkerParentSearchResult parentCandidateForMarker(RenderListItem& listItemRenderer, const RenderListMarker& marker)
 {
-    if (!marker.isInside() && listItemRenderer.document().settings().listMarkerPositionedPostLayoutEnabled() && !markerNeedsOwnLine(listItemRenderer)) {
+    if (listItemRenderer.document().settings().listMarkerPositionedPostLayoutEnabled() && !markerNeedsOwnLine(listItemRenderer)) {
         // The outside marker is always the list item's first child and it takes no part in in-flow layout.
         return { &listItemRenderer, false };
     }
 
-    if (marker.isInside()) {
-        // Past the marker itself, for a list-style-position change from outside to inside: the marker the list item
-        // was positioning is its own first child, so plain firstChild() would hand back the marker rather than the
-        // content this is meant to look at, and the marker would be pushed down into a descendant instead of taking
-        // a line at the start of the list item.
-        if (auto* firstChild = dynamicDowncast<RenderBlock>(firstNonMarkerChild(listItemRenderer))) {
-            if (!firstChild->isAnonymous())
-                return { &listItemRenderer, false };
-            // We may have created this anonymous block for the marker itself. Let's keep it in there.
-            if (firstChild->firstChild() == &marker && !marker.nextSibling())
-                return { firstChild, false };
-        }
-        auto result = RenderListItem::firstFormattedLineRootFor(listItemRenderer, marker);
-        return { result.parent, false };
-    }
     auto result = RenderListItem::firstFormattedLineRootFor(listItemRenderer, marker);
     return { result.parent ? result.parent : result.fallbackParent, result.stoppedAtTableRubyOrReplaced };
+}
+
+// An inside marker among the list item's own inline content is not a box of its own: it is an anonymous inline box
+// holding the marker's content renderers, so that they are inline content of the list item's formatting context and are
+// laid out, reordered and painted with the rest of the line.
+static void adjustStyleForInlineMarker(Style::ComputedStyle& markerStyle)
+{
+    markerStyle.setDisplay(Style::DisplayType::InlineFlow);
 }
 
 void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
 {
     auto& style = listItemRenderer.style();
 
-    if (listItemRenderer.element() && listItemRenderer.element()->hasTagName(HTMLNames::fieldsetTag)) {
-        if (auto* marker = listItemRenderer.markerRenderer())
+    auto destroyExistingMarker = [&] {
+        if (auto* marker = listItemRenderer.markerBox())
             m_builder.destroy(*marker);
+        else if (auto* inlineMarker = listItemRenderer.markerRenderer())
+            m_builder.destroyAndCleanUpAnonymousWrappers(*inlineMarker, { });
+    };
+
+    if (listItemRenderer.element() && listItemRenderer.element()->hasTagName(HTMLNames::fieldsetTag)) {
+        destroyExistingMarker();
         return;
     }
 
@@ -122,8 +123,7 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
     RefPtr styleImage = style.listStyleImage().tryStyleImage();
     auto hasListStyle = !style.listStyleType().isNone() || (styleImage && !styleImage->errorOccurred());
     if ((markerContentEnabled && newStyle.content().isNone()) || (!markerHasContent && !hasListStyle)) {
-        if (auto* marker = listItemRenderer.markerRenderer())
-            m_builder.destroy(*marker);
+        destroyExistingMarker();
         return;
     }
 
@@ -131,10 +131,23 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
     // excluded and attaches directly to the list item, while an inside one is ordinary inline content that needs an
     // anonymous block when the list item's other children are block level. Only attach() makes that call, and it is not
     // consulted when the marker's parent happens to be unchanged, so rebuild rather than patch the placement in place.
-    if (auto* markerRenderer = listItemRenderer.markerRenderer(); markerRenderer && markerRenderer->style().listStylePosition() != newStyle.listStylePosition())
+    auto shouldBuildInlineMarker = newStyle.listStylePosition() == ListStylePosition::Inside;
+
+    if (CheckedPtr inlineMarker = listItemRenderer.markerRenderer(); inlineMarker && !listItemRenderer.markerBox()) {
+        auto contentChanged = inlineMarker->style().content() != newStyle.content();
+        if (shouldBuildInlineMarker && !contentChanged) {
+            adjustStyleForInlineMarker(newStyle);
+            inlineMarker->setStyle(WTF::move(newStyle));
+            m_builder.addListItemNeedingMarkerUpdate(listItemRenderer);
+            return;
+        }
+        m_builder.destroyAndCleanUpAnonymousWrappers(*inlineMarker, { });
+    }
+
+    if (auto* markerRenderer = listItemRenderer.markerBox(); markerRenderer && markerRenderer->style().listStylePosition() != newStyle.listStylePosition())
         m_builder.destroyAndCleanUpAnonymousWrappers(*markerRenderer, { });
 
-    if (auto* markerRenderer = listItemRenderer.markerRenderer()) {
+    if (auto* markerRenderer = listItemRenderer.markerBox()) {
         // Whether the marker box holds inline content depends on `content` and on list-style-type
         // (only text markers with right-to-left content need it). The container also inherits
         // unicode-bidi, so rebuild on that too, to carry the new value into it.
@@ -193,12 +206,17 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
         return;
     }
 
+    if (shouldBuildInlineMarker) {
+        buildInlineMarker(listItemRenderer, WTF::move(newStyle));
+        return;
+    }
+
     RenderPtr<RenderListMarker> newMarkerRenderer = WebCore::createRenderer<RenderListMarker>(listItemRenderer, WTF::move(newStyle));
     newMarkerRenderer->initializeStyle();
     m_builder.addListItemNeedingMarkerUpdate(listItemRenderer);
     listItemRenderer.setMarkerRenderer(*newMarkerRenderer);
     auto searchResult = parentCandidateForMarker(listItemRenderer, *newMarkerRenderer);
-    auto shouldCollapseAnonymousBlockParent = !searchResult.parent && !newMarkerRenderer->isInside() && searchResult.shouldCollapseAnonymousBlockParent;
+    auto shouldCollapseAnonymousBlockParent = !searchResult.parent && searchResult.shouldCollapseAnonymousBlockParent;
     if (!searchResult.parent) {
         searchResult.parent = &listItemRenderer;
         if (auto* multiColumnFlow = listItemRenderer.multiColumnFlow())
@@ -207,10 +225,50 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
     m_builder.attach(*searchResult.parent, WTF::move(newMarkerRenderer), firstNonMarkerChild(*searchResult.parent));
     // For outside markers, if the search failed because a flex/grid container blockified a replaced
     // child (e.g., <img>), we should collapse the anonymous block's height so it doesn't inflate the list item.
-    listItemRenderer.markerRenderer()->setShouldCollapseAnonymousBlockParent(shouldCollapseAnonymousBlockParent);
+    listItemRenderer.markerBox()->setShouldCollapseAnonymousBlockParent(shouldCollapseAnonymousBlockParent);
 
-    if (listItemRenderer.markerRenderer()->needsContentContainer())
-        buildMarkerContentRenderers(*listItemRenderer.markerRenderer());
+    if (listItemRenderer.markerBox()->needsContentContainer())
+        buildMarkerContentRenderers(*listItemRenderer.markerBox());
+}
+
+static CheckedRef<RenderBlock> parentForInlineMarker(RenderListItem& listItemRenderer, const RenderInline& marker)
+{
+    if (CheckedPtr firstChild = dynamicDowncast<RenderBlock>(firstNonMarkerChild(listItemRenderer)); firstChild && !firstChild->isAnonymous())
+        return listItemRenderer;
+    auto firstFormattedLineRoot = RenderListItem::firstFormattedLineRootFor(listItemRenderer, marker);
+    if (firstFormattedLineRoot.parent)
+        return *firstFormattedLineRoot.parent;
+    return listItemRenderer;
+}
+
+void RenderTreeBuilder::List::buildInlineMarker(RenderListItem& listItemRenderer, Style::ComputedStyle&& markerStyle)
+{
+    adjustStyleForInlineMarker(markerStyle);
+    auto newMarker = WebCore::createRenderer<RenderInline>(RenderObject::Type::Inline, listItemRenderer.document(), WTF::move(markerStyle));
+    newMarker->initializeStyle();
+    CheckedRef marker = *newMarker;
+    CheckedRef markerParent = parentForInlineMarker(listItemRenderer, marker.get());
+    m_builder.attach(markerParent.get(), WTF::move(newMarker), firstNonMarkerChild(markerParent.get()));
+    listItemRenderer.setMarkerRenderer(marker.get());
+    // What the marker shows is only known once counter values resolve, so leave it to the builder to fill in when the
+    // tree is done changing, the same way the marker box's content is filled in.
+    m_builder.addListItemNeedingMarkerUpdate(listItemRenderer);
+
+    if (marker->style().content().isData()) {
+        RenderTreeUpdater::GeneratedContent::createContentRenderers(m_builder, marker.get(), marker->style(), PseudoElementType::Marker);
+        return;
+    }
+
+    // css-lists-3 §3.3: a list-style-image draws in place of the counter style's text, as an image of its own.
+    if (RefPtr styleImage = marker->style().listStyleImage().tryStyleImage(); styleImage && !styleImage->errorOccurred()) {
+        auto imageRenderer = WebCore::createRenderer<RenderImage>(RenderObject::Type::Image, listItemRenderer.document(), Style::ComputedStyle::createStyleInheritingFromPseudoStyle(marker->style()), styleImage.get());
+        imageRenderer->initializeStyle();
+        m_builder.attach(marker.get(), WTF::move(imageRenderer));
+        return;
+    }
+
+    auto textRenderer = WebCore::createRenderer<RenderText>(RenderObject::Type::Text, listItemRenderer.document(), emptyString());
+    m_builder.attach(marker.get(), WTF::move(textRenderer));
 }
 
 void RenderTreeBuilder::List::buildMarkerContentRenderers(RenderListMarker& marker)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.h
@@ -44,6 +44,7 @@ private:
     // Builds the anonymous inline-block subtree holding the ::marker's generated content
     // (css-lists-3 §3.3). The caller tears down any prior content first.
     void buildMarkerContentRenderers(RenderListMarker&);
+    void buildInlineMarker(RenderListItem&, Style::ComputedStyle&&);
 
     RenderTreeBuilder& m_builder;
 };

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -278,6 +278,11 @@ inline std::optional<PseudoElementType> ComputedStyleBase::pseudoElementType() c
     return m_nonInheritedFlags.pseudoElementType ? std::make_optional(static_cast<PseudoElementType>(m_nonInheritedFlags.pseudoElementType - 1)) : std::nullopt;
 }
 
+inline bool ComputedStyleBase::isListMarkerStyle() const
+{
+    return pseudoElementType() == PseudoElementType::Marker;
+}
+
 inline std::optional<PseudoElementType> pseudoElementType(const ComputedStyleBase& style)
 {
     return style.pseudoElementType();

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -595,6 +595,8 @@ public:
     // MARK: - Pseudo element/style
 
     inline std::optional<PseudoElementType> pseudoElementType() const;
+    // True for the ::marker style itself and for the styles its content renderers inherit from it.
+    inline bool isListMarkerStyle() const;
     const AtomString& pseudoElementNameArgument() const LIFETIME_BOUND;
 
     std::optional<PseudoElementIdentifier> NODELETE pseudoElementIdentifier() const;


### PR DESCRIPTION
#### 87c72505aec52b2072b1ead1caac9aaed6a02a49
<pre>
[list-marker] unicode-bidi and direction on ::marker have no effect on an inside marker
<a href="https://bugs.webkit.org/show_bug.cgi?id=323223">https://bugs.webkit.org/show_bug.cgi?id=323223</a>
<a href="https://rdar.apple.com/problem/186468752">rdar://problem/186468752</a>

Reviewed by Antti Koivisto.

An inside marker is inline content of its list item: css-lists-3 says it is &quot;inline content at the beginning of the
principal box&quot;, so the ::marker&apos;s own text properties are supposed to act on it the way they act on any other inline
content.
WebKit instead uses a RenderListMarker, an atomic inline level box where unicode-bidi, direction, hyphens, text-emphasis, text-shadow
do not apply properly.

Let&apos;s build the inside marker as an anonymous inline box (a RenderInline carrying the ::marker style)
holding the marker&apos;s own renderers: a RenderText for counter style text, a RenderImage for a list-style-image, or the generated content
renderers for &apos;content&apos; (RenderListMarker is left building only the outside markers it positions itself).

* LayoutTests/TestExpectations:
* LayoutTests/fast/css/001-expected.txt:
* LayoutTests/fast/html/details-add-child-1-expected.txt:
* LayoutTests/fast/html/details-add-child-2-expected.txt:
* LayoutTests/fast/html/details-add-details-child-1-expected.txt:
* LayoutTests/fast/html/details-add-details-child-2-expected.txt:
* LayoutTests/fast/html/details-add-summary-10-expected.txt:
* LayoutTests/fast/html/details-add-summary-6-expected.txt:
* LayoutTests/fast/html/details-add-summary-7-expected.txt:
* LayoutTests/fast/html/details-add-summary-8-expected.txt:
* LayoutTests/fast/html/details-add-summary-9-expected.txt:
* LayoutTests/fast/html/details-add-summary-child-1-expected.txt:
* LayoutTests/fast/html/details-add-summary-child-2-expected.txt:
* LayoutTests/fast/html/details-nested-1-expected.txt:
* LayoutTests/fast/html/details-nested-2-expected.txt:
* LayoutTests/fast/html/details-no-summary2-expected.txt:
* LayoutTests/fast/html/details-open6-expected.txt:
* LayoutTests/fast/html/details-remove-child-1-expected.txt:
* LayoutTests/fast/html/details-remove-child-2-expected.txt:
* LayoutTests/fast/html/details-remove-summary-4-expected.txt:
* LayoutTests/fast/html/details-remove-summary-5-expected.txt:
* LayoutTests/fast/html/details-remove-summary-6-expected.txt:
* LayoutTests/fast/html/details-remove-summary-child-1-expected.txt:
* LayoutTests/fast/html/details-remove-summary-child-2-expected.txt:
* LayoutTests/fast/lists/004-expected.txt:
* LayoutTests/fast/lists/inline-before-content-after-list-marker-expected.txt:
* LayoutTests/fast/repaint/list-marker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/text-selection-expected.txt:
* LayoutTests/platform/mac-wk2/fast/html/details-no-summary4-expected.txt:
* LayoutTests/platform/mac-wk2/fast/html/details-open-javascript-expected.txt:
* LayoutTests/platform/mac-wk2/fast/html/details-open2-expected.txt:
* LayoutTests/platform/mac-wk2/fast/html/details-open4-expected.txt:
* LayoutTests/platform/mac-wk2/fast/html/details-replace-summary-child-expected.txt:
* LayoutTests/platform/mac-wk2/fast/html/details-replace-text-expected.txt:
* LayoutTests/platform/mac/fast/css-generated-content/details-summary-before-after-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-1-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-1-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-10-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-2-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-2-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-3-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-3-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-4-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-4-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-5-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-5-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-6-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-7-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-8-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-add-summary-9-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-marker-style-expected.txt:
* LayoutTests/platform/mac/fast/html/details-marker-style-mixed-expected.txt:
* LayoutTests/platform/mac/fast/html/details-no-summary1-expected.txt:
* LayoutTests/platform/mac/fast/html/details-no-summary3-expected.txt:
* LayoutTests/platform/mac/fast/html/details-open1-expected.txt:
* LayoutTests/platform/mac/fast/html/details-open3-expected.txt:
* LayoutTests/platform/mac/fast/html/details-open5-expected.txt:
* LayoutTests/platform/mac/fast/html/details-position-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-1-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-1-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-2-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-2-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-3-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-3-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-4-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-5-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-remove-summary-6-and-click-expected.txt:
* LayoutTests/platform/mac/fast/html/details-writing-mode-expected.txt:
* LayoutTests/platform/mac/fast/html/details-writing-mode-mixed-expected.txt:
* LayoutTests/platform/mac/fast/lists/008-expected.txt:
* LayoutTests/platform/mac/fast/lists/008-vertical-expected.txt:
* LayoutTests/platform/mac/fast/lists/009-expected.txt:
* LayoutTests/platform/mac/fast/lists/009-vertical-expected.txt:
* LayoutTests/platform/mac/fast/lists/li-br-expected.txt:
* LayoutTests/platform/mac/fast/lists/markers-in-selection-expected.txt:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::stitchGroups const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textUnderElement const):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::InlineFormattingUtils::isAtSoftWrapOpportunity const):
* Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp:
(WebCore::Layout::Line::appendText):
(WebCore::Layout::Line::hasContentOrDecoration const):
(WebCore::Layout::Line::Run::isListMarkerOrItsContent const):
(WebCore::Layout::Line::appendTextFast):
(WebCore::Layout::toLineRunType):
* Source/WebCore/layout/formattingContexts/inline/InlineLine.h:
(WebCore::Layout::Line::hasContent const):
(WebCore::Layout::Line::Run::isListMarker const):
(WebCore::Layout::Line::Run::isListMarkerInside const): Deleted.
(WebCore::Layout::Line::Run::isListMarkerOutside const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp:
(WebCore::Layout::LineBoxBuilder::constructInlineLevelBoxes):
(WebCore::Layout::LineBoxBuilder::adjustOutsideListMarkersPosition):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::handleInlineContent):
(WebCore::Layout::LineBuilder::processLineBreakingResult):
(WebCore::Layout::LineBuilder::placeInlineAndFloatContent):
(WebCore::Layout::LineBuilder::handleBlockContent):
* Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp:
(WebCore::Layout::InlineQuirks::shouldCollapseLineBoxHeight const):
* Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.cpp:
(WebCore::Layout::IntrinsicWidthHandler::computedIntrinsicWidthForConstraint):
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::BoxGeometryUpdater::setListMarkerOffsetForMarkerOutside):
(WebCore::LayoutIntegration::BoxGeometryUpdater::updateBoxGeometry):
(WebCore::LayoutIntegration::BoxGeometryUpdater::updateBoxGeometryAfterIntegrationLayout):
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::calculateListMarkerAttribute):
(WebCore::LayoutIntegration::markerTextSynthesizesGlyph):
* Source/WebCore/layout/layouttree/LayoutElementBox.h:
(WebCore::Layout::ElementBox::isListMarkerImage const):
(WebCore::Layout::ElementBox::isListMarkerOutside const): Deleted.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::referenceBoxRect const):
* Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h:
(WebCore::Style::ComputedStyleBase::isListMarkerStyle const):
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::firstLetterAndContainer):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::computeMarkerStyle const):
(WebCore::RenderListItem::updateValue):
(WebCore::RenderListItem::updateMarkerContent):
(WebCore::RenderListItem::styleDidChange):
(WebCore::RenderListItem::excludedMarker const):
(WebCore::RenderListItem::markerBox const):
(WebCore::RenderListItem::usedCounterDirectivesChanged):
(WebCore::RenderListItem::firstFormattedLineRootFor):
* Source/WebCore/rendering/RenderListItem.h:
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::updateInlineMargins):
(WebCore::RenderListMarker::isInside const): Deleted.
(WebCore::listMarkerIsDisclosure):
* Source/WebCore/rendering/RenderListMarker.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::nodeForHitTest const):
(WebCore::RenderObject::isExcludedMarker const):
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::BreakingContext::commitAndUpdateLineBreakIfNeeded):
* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp:
(WebCore::isExcludedMarker):
* Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp:
(WebCore::adjustStyleForInlineMarker):
(WebCore::parentCandidateForMarker):
(WebCore::RenderTreeBuilder::List::updateItemMarker):
(WebCore::parentForInlineMarker):
(WebCore::RenderTreeBuilder::List::buildInlineMarker):
* Source/WebCore/rendering/updating/RenderTreeBuilderList.h:
* LayoutTests/css1/classification/list_style_position-expected.txt:
* LayoutTests/css2.1/t1205-c565-list-pos-00-b-expected.txt:
* LayoutTests/css2.1/t1205-c566-list-stl-00-e-ag-expected.txt:
* LayoutTests/platform/glib/css1/classification/list_style-expected.txt:
* LayoutTests/platform/glib/css1/classification/list_style_position-expected.txt:
* LayoutTests/platform/glib/css2.1/t1205-c561-list-displ-00-b-expected.txt:
* LayoutTests/platform/glib/css2.1/t1205-c565-list-pos-00-b-expected.txt:
* LayoutTests/platform/glib/css2.1/t1205-c566-list-stl-00-e-ag-expected.txt:
* LayoutTests/platform/glib/fast/css-generated-content/details-summary-before-after-expected.txt:
* LayoutTests/platform/glib/fast/css/001-expected.txt:
* LayoutTests/platform/glib/fast/html/details-add-child-1-expected.txt:
* LayoutTests/platform/glib/fast/html/details-add-child-2-expected.txt:
* LayoutTests/platform/glib/fast/html/details-add-details-child-1-expected.txt:
* LayoutTests/platform/glib/fast/html/details-add-details-child-2-expected.txt:
* LayoutTests/platform/glib/fast/html/details-add-summary-1-and-click-expected.txt:
* LayoutTests/platform/glib/fast/html/details-add-summary-10-expected.txt:
* LayoutTests/platform/glib/fast/html/details-add-summary-2-and-click-expected.txt:
* LayoutTests/platform/glib/fast/html/details-add-summary-3-and-click-expected.txt:
* LayoutTests/platform/glib/fast/html/details-add-summary-4-and-click-expected.txt:
* LayoutTests/platform/glib/fast/html/details-add-summary-5-and-click-expected.txt:
* LayoutTests/platform/glib/fast/html/details-add-summary-6-expected.txt:
* LayoutTests/platform/glib/fast/html/details-add-summary-7-expected.txt:
* LayoutTests/platform/glib/fast/html/details-add-summary-8-expected.txt:
* LayoutTests/platform/glib/fast/html/details-add-summary-9-expected.txt:
* LayoutTests/platform/glib/fast/html/details-add-summary-child-1-expected.txt:
* LayoutTests/platform/glib/fast/html/details-add-summary-child-2-expected.txt:
* LayoutTests/platform/glib/fast/html/details-marker-style-expected.txt:
* LayoutTests/platform/glib/fast/html/details-marker-style-mixed-expected.txt:
* LayoutTests/platform/glib/fast/html/details-nested-1-expected.txt:
* LayoutTests/platform/glib/fast/html/details-nested-2-expected.txt:
* LayoutTests/platform/glib/fast/html/details-no-summary2-expected.txt:
* LayoutTests/platform/glib/fast/html/details-open6-expected.txt:
* LayoutTests/platform/glib/fast/html/details-remove-child-1-expected.txt:
* LayoutTests/platform/glib/fast/html/details-remove-child-2-expected.txt:
* LayoutTests/platform/glib/fast/html/details-remove-summary-1-and-click-expected.txt:
* LayoutTests/platform/glib/fast/html/details-remove-summary-2-and-click-expected.txt:
* LayoutTests/platform/glib/fast/html/details-remove-summary-3-and-click-expected.txt:
* LayoutTests/platform/glib/fast/html/details-remove-summary-4-expected.txt:
* LayoutTests/platform/glib/fast/html/details-remove-summary-5-expected.txt:
* LayoutTests/platform/glib/fast/html/details-remove-summary-6-expected.txt:
* LayoutTests/platform/glib/fast/html/details-remove-summary-child-1-expected.txt:
* LayoutTests/platform/glib/fast/html/details-remove-summary-child-2-expected.txt:
* LayoutTests/platform/glib/fast/html/details-writing-mode-expected.txt:
* LayoutTests/platform/glib/fast/html/details-writing-mode-mixed-expected.txt:
* LayoutTests/platform/glib/fast/lists/004-expected.txt:
* LayoutTests/platform/glib/fast/lists/008-expected.txt:
* LayoutTests/platform/glib/fast/lists/008-vertical-expected.txt:
* LayoutTests/platform/glib/fast/lists/009-expected.txt:
* LayoutTests/platform/glib/fast/lists/009-vertical-expected.txt:
* LayoutTests/platform/glib/fast/lists/li-br-expected.txt:
* LayoutTests/platform/glib/fast/lists/markers-in-selection-expected.txt:
* LayoutTests/platform/glib/fast/repaint/list-marker-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-add-summary-1-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-add-summary-10-and-click-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-add-summary-2-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-add-summary-3-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-add-summary-4-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-add-summary-5-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-add-summary-6-and-click-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-add-summary-7-and-click-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-add-summary-8-and-click-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-add-summary-9-and-click-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-no-summary1-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-no-summary3-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-no-summary4-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-open-javascript-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-open1-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-open2-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-open3-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-open4-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-open5-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-position-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-remove-summary-1-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-remove-summary-2-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-remove-summary-3-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-remove-summary-4-and-click-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-remove-summary-5-and-click-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-remove-summary-6-and-click-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-replace-summary-child-expected.txt:
* LayoutTests/platform/gtk/fast/html/details-replace-text-expected.txt:
* LayoutTests/platform/gtk/tables/mozilla/bugs/bug30692-expected.txt:
* LayoutTests/platform/ios/css1/classification/list_style-expected.txt:
* LayoutTests/platform/ios/css2.1/t1205-c561-list-displ-00-b-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-child-1-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-child-2-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-details-child-1-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-details-child-2-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-1-and-click-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-1-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-10-and-click-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-10-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-2-and-click-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-2-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-3-and-click-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-3-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-4-and-click-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-4-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-5-and-click-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-5-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-6-and-click-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-6-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-7-and-click-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-7-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-8-and-click-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-8-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-9-and-click-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-9-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-child-1-expected.txt:
* LayoutTests/platform/ios/fast/html/details-add-summary-child-2-expected.txt:
* LayoutTests/platform/ios/fast/html/details-marker-style-expected.txt:
* LayoutTests/platform/ios/fast/html/details-marker-style-mixed-expected.txt:
* LayoutTests/platform/ios/fast/html/details-nested-1-expected.txt:
* LayoutTests/platform/ios/fast/html/details-nested-2-expected.txt:
* LayoutTests/platform/ios/fast/html/details-no-summary1-expected.txt:
* LayoutTests/platform/ios/fast/html/details-no-summary2-expected.txt:
* LayoutTests/platform/ios/fast/html/details-no-summary3-expected.txt:
* LayoutTests/platform/ios/fast/html/details-open1-expected.txt:
* LayoutTests/platform/ios/fast/html/details-open3-expected.txt:
* LayoutTests/platform/ios/fast/html/details-open5-expected.txt:
* LayoutTests/platform/ios/fast/html/details-open6-expected.txt:
* LayoutTests/platform/ios/fast/html/details-position-expected.txt:
* LayoutTests/platform/ios/fast/html/details-remove-child-1-expected.txt:
* LayoutTests/platform/ios/fast/html/details-remove-child-2-expected.txt:
* LayoutTests/platform/ios/fast/html/details-remove-summary-1-and-click-expected.txt:
* LayoutTests/platform/ios/fast/html/details-remove-summary-1-expected.txt:
* LayoutTests/platform/ios/fast/html/details-remove-summary-2-and-click-expected.txt:
* LayoutTests/platform/ios/fast/html/details-remove-summary-2-expected.txt:
* LayoutTests/platform/ios/fast/html/details-remove-summary-3-and-click-expected.txt:
* LayoutTests/platform/ios/fast/html/details-remove-summary-3-expected.txt:
* LayoutTests/platform/ios/fast/html/details-remove-summary-4-and-click-expected.txt:
* LayoutTests/platform/ios/fast/html/details-remove-summary-4-expected.txt:
* LayoutTests/platform/ios/fast/html/details-remove-summary-5-and-click-expected.txt:
* LayoutTests/platform/ios/fast/html/details-remove-summary-5-expected.txt:
* LayoutTests/platform/ios/fast/html/details-remove-summary-6-and-click-expected.txt:
* LayoutTests/platform/ios/fast/html/details-remove-summary-6-expected.txt:
* LayoutTests/platform/ios/fast/html/details-remove-summary-child-1-expected.txt:
* LayoutTests/platform/ios/fast/html/details-remove-summary-child-2-expected.txt:
* LayoutTests/platform/ios/fast/html/details-writing-mode-expected.txt:
* LayoutTests/platform/ios/fast/html/details-writing-mode-mixed-expected.txt:
* LayoutTests/platform/ios/fast/lists/008-expected.txt:
* LayoutTests/platform/ios/fast/lists/008-vertical-expected.txt:
* LayoutTests/platform/ios/fast/lists/009-expected.txt:
* LayoutTests/platform/ios/fast/lists/009-vertical-expected.txt:
* LayoutTests/platform/ios/fast/lists/li-br-expected.txt:
* LayoutTests/platform/ios/fast/lists/markers-in-selection-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug30692-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/html/details-no-summary4-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/html/details-open-javascript-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/html/details-open2-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/html/details-open4-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/html/details-replace-summary-child-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/html/details-replace-text-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/tables/mozilla/bugs/bug30692-expected.txt:
* LayoutTests/platform/mac-wk2/tables/mozilla/bugs/bug30692-expected.txt:
* LayoutTests/platform/mac/css1/classification/list_style-expected.txt:
* LayoutTests/platform/mac/css2.1/t1205-c561-list-displ-00-b-expected.txt:

Canonical link: <a href="https://commits.webkit.org/320504@main">https://commits.webkit.org/320504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d65a75fb14018cec35524cb974fd984e9557dff1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52632 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195219 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc88cc74-23e1-48dd-ae58-c08be7629825) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186746 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58531 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144477 "Found 29 new test failures: fast/html/details-add-summary-1.html fast/html/details-add-summary-10-and-click.html fast/html/details-add-summary-2.html fast/html/details-add-summary-3.html fast/html/details-add-summary-4.html fast/html/details-add-summary-5.html fast/html/details-add-summary-6-and-click.html fast/html/details-add-summary-7-and-click.html fast/html/details-add-summary-8-and-click.html fast/html/details-add-summary-9-and-click.html ... (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e20865c9-2834-4916-be39-e03e8ce51e44) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187839 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165075 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124768 "Found 2 new API test failures: TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/42949672974097MallocReadOnly, TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/4294967297444MallocReadOnly (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/890c2010-7b93-4ce5-adc5-c5fca72fc012) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46876 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44971 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44642 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6274 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51467 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197168 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58472 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153956 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41239 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59178 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41246 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153617 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48134 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131466 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128049 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57674 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19660 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57033 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57284 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57110 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->