### PR TITLE
Replace references to a font's "specifiedSize" with "computedSize"

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -698,7 +698,6 @@
                 "style-extractor-custom": true,
                 "high-priority": true,
                 "skip-computed-style-initial": true,
-                "computed-style-getter": "specifiedFontSize",
                 "computed-style-storage-container": "opaque",
                 "computed-style-storage-path": ["m_inheritedData", "fontData", "fontCascade"],
                 "computed-style-type": "float",

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -11673,15 +11673,15 @@ const Style::ComputedStyle& Document::initialStyle() const
         m_cachedInitialStyle->setZoom(zoom);
 
         auto initialFontFamily = FontFamily { standardFamily, FontFamilyKind::Generic };
-        auto initialSpecifiedFontSize = Style::fontSizeForKeyword(CSSValueMedium, false, settingsValues(), inQuirksMode());
-        auto initialUsedFontSize = Style::usedFontSizeFromSpecifiedSize(initialSpecifiedFontSize, false, zoomForFontDescription, Style::MinimumFontSizeRule::AbsoluteAndRelative, settingsValues());
+        auto initialComputedFontSize = Style::fontSizeForKeyword(CSSValueMedium, false, settingsValues(), inQuirksMode());
+        auto initialUsedFontSize = Style::usedFontSizeFromComputedSize(initialComputedFontSize, false, zoomForFontDescription, Style::MinimumFontSizeRule::AbsoluteAndRelative, settingsValues());
         auto allowUserInstalledFonts = settings().shouldAllowUserInstalledFonts() ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No;
 
         FontCascadeDescription fontDescription;
         fontDescription.setSpecifiedLocale(contentLanguage());
         fontDescription.setOneFamily(WTF::move(initialFontFamily));
         fontDescription.setKeywordSizeFromIdentifier(CSSValueMedium);
-        fontDescription.setSpecifiedSize(initialSpecifiedFontSize);
+        fontDescription.setComputedSize(initialComputedFontSize);
         fontDescription.setUsedSize(initialUsedFontSize, zoomForFontDescription);
         fontDescription.setShouldAllowUserInstalledFonts(allowUserInstalledFonts);
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -235,7 +235,7 @@ void CanvasRenderingContext2D::setFontWithoutUpdatingStyle(const String& newFont
     else {
         static NeverDestroyed<AtomString> family = DefaultFontFamily;
         fontDescription.setOneFamily(family.get());
-        fontDescription.setSpecifiedSize(DefaultFontSize);
+        fontDescription.setComputedSize(DefaultFontSize);
         fontDescription.setUsedSize(DefaultFontSize);
     }
 

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
@@ -115,7 +115,7 @@ void OffscreenCanvasRenderingContext2D::setFont(const String& newFont)
     // relative to the default font.
     FontCascadeDescription fontDescription;
     fontDescription.setOneFamily(DefaultFontFamily);
-    fontDescription.setSpecifiedSize(DefaultFontSize);
+    fontDescription.setComputedSize(DefaultFontSize);
     fontDescription.setUsedSize(DefaultFontSize);
 
     if (auto fontCascade = Style::resolveForUnresolvedFont(*unresolvedFont, WTF::move(fontDescription), context)) {

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -224,7 +224,7 @@ void NonFastScrollableRegionOverlay::drawRect(PageOverlay& pageOverlay, Graphics
     
     FontCascadeDescription fontDescription;
     fontDescription.setOneFamily("Helvetica"_s);
-    fontDescription.setSpecifiedSize(12);
+    fontDescription.setComputedSize(12);
     fontDescription.setUsedSize(12);
     fontDescription.setWeight(FontSelectionValue(500));
     FontCascade font(WTF::move(fontDescription));
@@ -505,7 +505,7 @@ void InteractionRegionOverlay::drawSettings(GraphicsContext& context)
 
     FontCascadeDescription fontDescription;
     fontDescription.setOneFamily("Helvetica"_s);
-    fontDescription.setSpecifiedSize(12);
+    fontDescription.setComputedSize(12);
     fontDescription.setUsedSize(12);
     fontDescription.setWeight(FontSelectionValue(500));
     FontCascade font(WTF::move(fontDescription));
@@ -620,7 +620,7 @@ void InteractionRegionOverlay::drawRect(PageOverlay&, GraphicsContext& context, 
 #if ENABLE(INTERACTION_REGION_TEXT_CONTENT)
         FontCascadeDescription fontDescription;
         fontDescription.setOneFamily("Helvetica"_s);
-        fontDescription.setSpecifiedSize(10);
+        fontDescription.setComputedSize(10);
         fontDescription.setUsedSize(10);
         fontDescription.setWeight(FontSelectionValue(500));
         FontCascade font(WTF::move(fontDescription));

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.cpp
@@ -178,7 +178,7 @@ TextStream& operator<<(TextStream& ts, const FontCascadeDescription& fontCascade
         first = false;
     }
 
-    ts << ", specified size "_s << fontCascadeDescription.specifiedSize();
+    ts << ", specified size "_s << fontCascadeDescription.computedSize();
     ts << ", used size "_s << fontCascadeDescription.usedSize();
     ts << ", is absolute size "_s << fontCascadeDescription.isAbsoluteSize();
     if (fontCascadeDescription.kerning() != Kerning::Auto)

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -79,7 +79,7 @@ public:
     unsigned effectiveFamilyCount() const;
     FontFamilySpecification effectiveFamilyAt(unsigned) const;
 
-    float specifiedSize() const { return m_specifiedSize; }
+    float computedSize() const { return m_computedSize; }
     bool isAbsoluteSize() const { return m_isAbsoluteSize; }
     FontSelectionValue lighterWeight() const { return lighterWeight(weight()); }
     FontSelectionValue bolderWeight() const { return bolderWeight(weight()); }
@@ -113,7 +113,7 @@ public:
     void setFamilies(const Vector<FontFamily>& families) { m_families = RefCountedFixedVector<FontFamily>::createFromVector(families); }
     void setFamilies(RefCountedFixedVector<FontFamily>& families) { m_families = families; }
     void setFamilies(Ref<RefCountedFixedVector<FontFamily>>&& families) { m_families = WTF::move(families); }
-    void setSpecifiedSize(float s) { m_specifiedSize = clampToFloat(s); }
+    void setComputedSize(float s) { m_computedSize = clampToFloat(s); }
     void setIsAbsoluteSize(bool s) { m_isAbsoluteSize = s; }
     void setKerning(Kerning kerning) { m_kerning = static_cast<unsigned>(kerning); }
     void setKeywordSize(unsigned size)
@@ -137,7 +137,7 @@ public:
     bool equalForTextAutoSizing(const FontCascadeDescription& other) const
     {
         return familiesEqualForTextAutoSizing(other)
-            && m_specifiedSize == other.m_specifiedSize
+            && m_computedSize == other.m_computedSize
             && variantSettings() == other.variantSettings()
             && m_isAbsoluteSize == other.m_isAbsoluteSize;
     }
@@ -148,8 +148,8 @@ public:
 private:
     Ref<RefCountedFixedVector<FontFamily>> m_families;
 
-    // Specified CSS value. Independent of rendering issues such as integer rounding, minimum font sizes, and zooming.
-    float m_specifiedSize { 0 };
+    // Computed CSS value. Independent of rendering issues such as integer rounding, minimum font sizes, and zooming. Used for "em" and "rem" units and CSS inheritance.
+    float m_computedSize { 0 };
     // Whether or not CSS specified an explicit size (logical sizes like "medium" don't count).
     unsigned m_isAbsoluteSize : 1;
     unsigned m_kerning : 2; // Kerning
@@ -166,7 +166,7 @@ inline bool FontCascadeDescription::operator==(const FontCascadeDescription& oth
 {
     return static_cast<const FontDescription&>(*this) == static_cast<const FontDescription&>(other)
         && arePointingToEqualData(m_families, other.m_families)
-        && m_specifiedSize == other.m_specifiedSize
+        && m_computedSize == other.m_computedSize
         && m_isAbsoluteSize == other.m_isAbsoluteSize
         && m_kerning == other.m_kerning
         && m_keywordSize == other.m_keywordSize

--- a/Source/WebCore/platform/graphics/ca/FrameProcessIndicators.cpp
+++ b/Source/WebCore/platform/graphics/ca/FrameProcessIndicators.cpp
@@ -116,7 +116,7 @@ FontCascade FrameProcessIndicators::makeFont()
 {
     FontCascadeDescription fontDescription;
     fontDescription.setOneFamily("Helvetica"_s);
-    fontDescription.setSpecifiedSize(fontSize);
+    fontDescription.setComputedSize(fontSize);
     fontDescription.setUsedSize(fontSize);
 
     FontCascade font(WTF::move(fontDescription));

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.mm
@@ -87,7 +87,7 @@ void PlatformCALayer::drawRepaintIndicator(GraphicsContext& graphicsContext, Pla
 
     FontCascadeDescription fontDescription;
     fontDescription.setOneFamily("Helvetica"_s);
-    fontDescription.setSpecifiedSize(fontSize);
+    fontDescription.setComputedSize(fontSize);
     fontDescription.setUsedSize(fontSize);
 
     FontCascade cascade(WTF::move(fontDescription));

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -49,7 +49,7 @@ FontCascade::FontCascade(const FontPlatformData& fontData, FontSmoothingMode fon
     m_fontDescription.setFontSmoothing(fontSmoothingMode);
     RetainPtr ctFont = fontData.ctFont();
 
-    m_fontDescription.setSpecifiedSize(CTFontGetSize(ctFont.get()));
+    m_fontDescription.setComputedSize(CTFontGetSize(ctFont.get()));
     m_fontDescription.setUsedSize(CTFontGetSize(ctFont.get()));
     m_fontDescription.setIsItalic(CTFontGetSymbolicTraits(ctFont.get()) & kCTFontTraitItalic);
     m_fontDescription.setWeight((CTFontGetSymbolicTraits(ctFont.get()) & kCTFontTraitBold) ? boldWeightValue() : normalWeightValue());

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -104,7 +104,7 @@ const FontCascade& MockRealtimeVideoSource::DrawingState::timeFont()
         return *m_timeFont;
 
     auto& description = fontDescription();
-    description.setSpecifiedSize(m_baseFontSize);
+    description.setComputedSize(m_baseFontSize);
     description.setUsedSize(m_baseFontSize);
     m_timeFont = { FontCascadeDescription { description } };
     m_timeFont->update(nullptr);
@@ -118,7 +118,7 @@ const FontCascade& MockRealtimeVideoSource::DrawingState::bipBopFont()
         return *m_bipBopFont;
 
     auto& description = fontDescription();
-    description.setSpecifiedSize(m_bipBopFontSize);
+    description.setComputedSize(m_bipBopFontSize);
     description.setUsedSize(m_bipBopFontSize);
     m_bipBopFont = { FontCascadeDescription { description } };
     m_bipBopFont->update(nullptr);
@@ -132,7 +132,7 @@ const FontCascade& MockRealtimeVideoSource::DrawingState::statsFont()
         return *m_statsFont;
 
     auto& description = fontDescription();
-    description.setSpecifiedSize(m_statsFontSize);
+    description.setComputedSize(m_statsFontSize);
     description.setUsedSize(m_statsFontSize);
     m_statsFont = { FontCascadeDescription { description } };
     m_statsFont->update(nullptr);

--- a/Source/WebCore/platform/win/cairo/DragImageWinCairo.cpp
+++ b/Source/WebCore/platform/win/cairo/DragImageWinCairo.cpp
@@ -242,7 +242,7 @@ static FontCascade dragLabelFont(int size, bool bold)
     FontCascadeDescription description;
     description.setWeight(bold ? boldWeightValue() : normalWeightValue());
     description.setOneFamily(metrics.lfSmCaptionFont.lfFaceName);
-    description.setSpecifiedSize((float)size);
+    description.setComputedSize((float)size);
     description.setUsedSize((float)size);
     result = FontCascade(WTF::move(description));
     result.update();

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4604,16 +4604,16 @@ static bool NODELETE isNonBlocksOrNonFixedHeightListItems(const RenderObject& re
 
 // For now, we auto size single lines of text the same as multiple lines.
 // We've been experimenting with low values for single lines of text.
-static inline float oneLineTextMultiplier(RenderObject& renderer, float specifiedSize)
+static inline float oneLineTextMultiplier(RenderObject& renderer, float size)
 {
     const float coefficient = renderer.settings().oneLineTextMultiplierCoefficient();
-    return std::max((1.0f / log10f(specifiedSize) * coefficient), 1.0f);
+    return std::max((1.0f / log10f(size) * coefficient), 1.0f);
 }
 
-static inline float textMultiplier(RenderObject& renderer, float specifiedSize)
+static inline float textMultiplier(RenderObject& renderer, float size)
 {
     const float coefficient = renderer.settings().multiLineTextMultiplierCoefficient();
-    return std::max((1.0f / log10f(specifiedSize) * coefficient), 1.0f);
+    return std::max((1.0f / log10f(size) * coefficient), 1.0f);
 }
 
 void RenderBlockFlow::adjustFontSizes(float size, float visibleWidth)
@@ -4672,8 +4672,8 @@ void RenderBlockFlow::adjustFontSizes(float size, float visibleWidth)
         auto& text = downcast<RenderText>(*descendant);
         auto& oldStyle = text.style();
         auto& fontDescription = oldStyle.fontDescription();
-        float specifiedSize = fontDescription.specifiedSize();
-        float scaledSize = roundf(specifiedSize * scale);
+        float computedSize = fontDescription.computedSize();
+        float scaledSize = roundf(computedSize * scale);
         if (scaledSize > 0 && scaledSize < minFontSize) {
             // Record the width of the block and the line count the first time we resize text and use it from then on for text resizing.
             // This makes text resizing consistent even if the block's width or line count changes (which can be caused by text resizing itself 5159915).
@@ -4682,10 +4682,10 @@ void RenderBlockFlow::adjustFontSizes(float size, float visibleWidth)
             if (m_widthForTextAutosizing == -1)
                 m_widthForTextAutosizing = actualWidth;
 
-            float lineTextMultiplier = lineCount == ONE_LINE ? oneLineTextMultiplier(text, specifiedSize) : textMultiplier(text, specifiedSize);
-            float candidateNewSize = roundf(std::min(minFontSize, specifiedSize * lineTextMultiplier));
+            float lineTextMultiplier = lineCount == ONE_LINE ? oneLineTextMultiplier(text, computedSize) : textMultiplier(text, computedSize);
+            float candidateNewSize = roundf(std::min(minFontSize, computedSize * lineTextMultiplier));
 
-            if (candidateNewSize > specifiedSize && candidateNewSize != fontDescription.usedSize() && text.textNode() && oldStyle.textSizeAdjust().isAuto())
+            if (candidateNewSize > computedSize && candidateNewSize != fontDescription.usedSize() && text.textNode() && oldStyle.textSizeAdjust().isAuto())
                 protect(document())->textAutoSizing().addTextNode(*protect(text.textNode()), candidateNewSize);
         }
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4467,7 +4467,7 @@ static RefPtr<Pattern> patternForDescription(PatternDescription description, Flo
 
         FontCascadeDescription fontDescription;
         fontDescription.setOneFamily("Helvetica"_s);
-        fontDescription.setSpecifiedSize(10);
+        fontDescription.setComputedSize(10);
         fontDescription.setUsedSize(10);
         fontDescription.setWeight(FontSelectionValue(500));
         FontCascade font(WTF::move(fontDescription));

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -109,7 +109,7 @@ static unsigned computeFontHash(const FontCascade& font)
     // FIXME: Would be better to hash the family name rather than hashing a hash of the family name. Also, should this use FontCascadeDescription::familyNameHash?
     return computeHash(
         ASCIICaseInsensitiveHash::hash(font.fontDescription().firstFamily().name),
-        font.fontDescription().specifiedSize()
+        font.fontDescription().computedSize()
     );
 }
 
@@ -223,13 +223,13 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
         if (renderer.style().fontDescription().usedSize() == averageSize)
             continue;
 
-        float specifiedSize = renderer.style().fontDescription().specifiedSize();
+        float computedSize = renderer.style().fontDescription().computedSize();
         float maxScaleIncrease = renderer.settings().maxTextAutosizingScaleIncrease();
-        float scaleChange = averageSize / specifiedSize;
+        float scaleChange = averageSize / computedSize;
         if (scaleChange > maxScaleIncrease && firstPass) {
             firstPass = false;
-            averageSize = std::round(specifiedSize * maxScaleIncrease);
-            scaleChange = averageSize / specifiedSize;
+            averageSize = std::round(computedSize * maxScaleIncrease);
+            scaleChange = averageSize / computedSize;
         }
 
         LOG(TextAutosizing, "  adjust node size %p firstPass=%d averageSize=%f scaleChange=%f", node.ptr(), firstPass, averageSize, scaleChange);
@@ -264,7 +264,7 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
                 return Style::evaluate<LayoutUnit>(length, Style::ZoomFactor::none()).toInt();
             },
             [&](const Style::LineHeight::Number& number) {
-                return LayoutUnit { number.value * LayoutUnit { fontDescription.specifiedSize() } }.toInt();
+                return LayoutUnit { number.value * LayoutUnit { fontDescription.computedSize() } }.toInt();
             }
         );
 
@@ -297,7 +297,7 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
             if (!firstLetterStyle)
                 continue;
             auto fontDescription = firstLetterStyle->fontDescription();
-            fontDescription.setUsedSize(averageSize * fontDescription.specifiedSize() / parentStyle.fontDescription().specifiedSize());
+            fontDescription.setUsedSize(averageSize * fontDescription.computedSize() / parentStyle.fontDescription().computedSize());
             firstLetterStyle->setFontDescription(FontCascadeDescription { fontDescription });
         }
 
@@ -325,7 +325,7 @@ void TextAutoSizingValue::reset()
 
         // Reset the font size back to the original specified size
         auto fontDescription = renderer->style().fontDescription();
-        float originalSize = fontDescription.specifiedSize();
+        float originalSize = fontDescription.computedSize();
         if (fontDescription.usedSize() != originalSize) {
             fontDescription.setUsedSize(originalSize);
             auto style = cloneRenderStyleWithState(renderer->style());

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1225,7 +1225,7 @@ static void setFontFromControlSize(Style::ComputedStyle& style, NSControlSize co
     NSFont* font = [NSFont systemFontOfSize:[NSFont systemFontSizeForControlSize:controlSize]];
     fontDescription.setOneFamily("-apple-system"_s);
     fontDescription.setUsedSize([font pointSize] * style.usedZoom(), style.usedZoom());
-    fontDescription.setSpecifiedSize([font pointSize]);
+    fontDescription.setComputedSize([font pointSize]);
 
     // Reset line height
     style.setLineHeight(Style::ComputedStyle::initialLineHeight());
@@ -1638,7 +1638,7 @@ std::optional<FontCascadeDescription> RenderThemeMac::controlFont(StyleAppearanc
         NSFont* nsFont = [NSFont systemFontOfSize:[NSFont systemFontSizeForControlSize:controlSizeForFont(font)]];
         fontDescription.setOneFamily("-apple-system"_s);
         fontDescription.setUsedSize([nsFont pointSize] * zoomFactor, zoomFactor);
-        fontDescription.setSpecifiedSize([nsFont pointSize]);
+        fontDescription.setComputedSize([nsFont pointSize]);
         return fontDescription;
     }
     default:

--- a/Source/WebCore/rendering/style/AutosizeStatus.cpp
+++ b/Source/WebCore/rendering/style/AutosizeStatus.cpp
@@ -43,7 +43,7 @@ auto AutosizeStatus::compute(const Style::ComputedStyle& style) -> AutosizeStatu
 
         const float maximumDifferenceBetweenFixedLineHeightAndFontSize = 5;
         auto& lineHeight = style.specifiedLineHeight();
-        if (auto fixedLineHeight = lineHeight.tryFixed(); fixedLineHeight && fixedLineHeight->resolveZoom(style.usedZoomForLength()) - style.specifiedFontSize() > maximumDifferenceBetweenFixedLineHeightAndFontSize)
+        if (auto fixedLineHeight = lineHeight.tryFixed(); fixedLineHeight && fixedLineHeight->resolveZoom(style.usedZoomForLength()) - style.fontSize() > maximumDifferenceBetweenFixedLineHeightAndFontSize)
             return false;
 
         if (style.whiteSpaceCollapse() == WhiteSpaceCollapse::Collapse && style.textWrapMode() == TextWrapMode::NoWrap)
@@ -78,8 +78,8 @@ auto AutosizeStatus::isIdempotentTextAutosizingCandidate(const Style::ComputedSt
     if (fields.contains(AutosizeStatus::Fields::AvoidSubtree))
         return false;
 
-    constexpr auto smallMinimumDifferenceThresholdBetweenLineHeightAndSpecifiedFontSizeForBoostingText = 5.0f;
-    constexpr auto largeMinimumDifferenceThresholdBetweenLineHeightAndSpecifiedFontSizeForBoostingText = 25.0f;
+    constexpr auto smallMinimumDifferenceThresholdBetweenLineHeightAndComputedFontSizeForBoostingText = 5.0f;
+    constexpr auto largeMinimumDifferenceThresholdBetweenLineHeightAndComputedFontSizeForBoostingText = 25.0f;
 
     if (fields.contains(AutosizeStatus::Fields::FixedHeight)) {
         if (fields.contains(AutosizeStatus::Fields::FixedWidth)) {
@@ -88,9 +88,9 @@ auto AutosizeStatus::isIdempotentTextAutosizingCandidate(const Style::ComputedSt
                     return false;
                 if (auto fixedHeight = style.height().tryFixed(); fixedHeight && style.specifiedLineHeight().isFixed()) {
                     if (auto fixedSpecifiedLineHeight = style.specifiedLineHeight().tryFixed()) {
-                        auto specifiedSize = style.specifiedFontSize();
+                        auto size = style.fontSize();
                         auto zoomFactor = style.usedZoomForLength();
-                        if (fixedHeight->resolveZoom(zoomFactor) == specifiedSize && fixedSpecifiedLineHeight->resolveZoom(zoomFactor) == specifiedSize)
+                        if (fixedHeight->resolveZoom(zoomFactor) == size && fixedSpecifiedLineHeight->resolveZoom(zoomFactor) == size)
                             return false;
                     }
                 }
@@ -99,10 +99,10 @@ auto AutosizeStatus::isIdempotentTextAutosizingCandidate(const Style::ComputedSt
             if (fields.contains(AutosizeStatus::Fields::Floating)) {
                 if (auto fixedHeight = style.height().tryFixed(); style.specifiedLineHeight().isFixed() && fixedHeight) {
                     if (auto fixedSpecifiedLineHeight = style.specifiedLineHeight().tryFixed()) {
-                        auto specifiedSize = style.specifiedFontSize();
+                        auto size = style.fontSize();
                         auto zoomFactor = style.usedZoomForLength();
-                        if (fixedSpecifiedLineHeight->resolveZoom(Style::ZoomFactor { 1.0f }) - specifiedSize > smallMinimumDifferenceThresholdBetweenLineHeightAndSpecifiedFontSizeForBoostingText
-                            && fixedHeight->resolveZoom(zoomFactor) - specifiedSize > smallMinimumDifferenceThresholdBetweenLineHeightAndSpecifiedFontSizeForBoostingText)
+                        if (fixedSpecifiedLineHeight->resolveZoom(Style::ZoomFactor { 1.0f }) - size > smallMinimumDifferenceThresholdBetweenLineHeightAndComputedFontSizeForBoostingText
+                            && fixedHeight->resolveZoom(zoomFactor) - size > smallMinimumDifferenceThresholdBetweenLineHeightAndComputedFontSizeForBoostingText)
                             return true;
                     }
                 }
@@ -131,7 +131,7 @@ auto AutosizeStatus::isIdempotentTextAutosizingCandidate(const Style::ComputedSt
             return true;
         if (fields.contains(AutosizeStatus::Fields::FixedWidth))
             return true;
-        if (auto fixedSpecifiedLineHeight = style.specifiedLineHeight().tryFixed(); fixedSpecifiedLineHeight && fixedSpecifiedLineHeight->resolveZoom(style.usedZoomForLength()) - style.specifiedFontSize() > largeMinimumDifferenceThresholdBetweenLineHeightAndSpecifiedFontSizeForBoostingText)
+        if (auto fixedSpecifiedLineHeight = style.specifiedLineHeight().tryFixed(); fixedSpecifiedLineHeight && fixedSpecifiedLineHeight->resolveZoom(style.usedZoomForLength()) - style.fontSize() > largeMinimumDifferenceThresholdBetweenLineHeightAndComputedFontSizeForBoostingText)
             return true;
         return false;
     }
@@ -165,7 +165,7 @@ bool AutosizeStatus::probablyContainsASmallFixedNumberOfLines(const Style::Compu
     if (heightOrMaxHeight <= 0)
         return false;
 
-    float approximateLineHeight = lineHeightAsNumber ? lineHeightAsNumber->value * style.specifiedFontSize() : lineHeightAsLength->resolveZoom(zoomFactor);
+    float approximateLineHeight = lineHeightAsNumber ? lineHeightAsNumber->value * style.fontSize() : lineHeightAsLength->resolveZoom(zoomFactor);
     if (approximateLineHeight <= 0)
         return false;
 
@@ -180,10 +180,10 @@ bool AutosizeStatus::probablyContainsASmallFixedNumberOfLines(const Style::Compu
         && approximateNumberOfLines - std::floor(approximateNumberOfLines) <= thresholdForConsideringAnApproximateNumberOfLinesToBeCloseToAnInteger;
 }
 
-float AutosizeStatus::idempotentTextSize(float specifiedSize, float pageScale)
+float AutosizeStatus::idempotentTextSize(float size, float pageScale)
 {
     if (pageScale >= 1)
-        return specifiedSize;
+        return size;
 
     // This describes a piecewise curve when the page scale is 2/3.
     static constexpr std::array points = {
@@ -202,21 +202,21 @@ float AutosizeStatus::idempotentTextSize(float specifiedSize, float pageScale)
         return point;
     };
 
-    if (specifiedSize <= 0)
+    if (size <= 0)
         return 0;
 
     float result = scalePoint(points.back()).y();
     for (size_t i = 1; i < points.size(); ++i) {
-        if (points[i].x() < specifiedSize)
+        if (points[i].x() < size)
             continue;
         auto leftPoint = scalePoint(points[i - 1]);
         auto rightPoint = scalePoint(points[i]);
-        float fraction = (specifiedSize - leftPoint.x()) / (rightPoint.x() - leftPoint.x());
+        float fraction = (size - leftPoint.x()) / (rightPoint.x() - leftPoint.x());
         result = leftPoint.y() + fraction * (rightPoint.y() - leftPoint.y());
         break;
     }
 
-    return std::max(std::round(result), specifiedSize);
+    return std::max(std::round(result), size);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/AutosizeStatus.h
+++ b/Source/WebCore/rendering/style/AutosizeStatus.h
@@ -50,7 +50,7 @@ public:
     constexpr bool contains(Fields) const;
 
     bool isIdempotentTextAutosizingCandidate(const Style::ComputedStyle&);
-    static float idempotentTextSize(float specifiedSize, float pageScale);
+    static float idempotentTextSize(float size, float pageScale);
     static bool probablyContainsASmallFixedNumberOfLines(const Style::ComputedStyle&);
 
     constexpr bool operator==(const AutosizeStatus&) const = default;

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -269,7 +269,7 @@ bool RenderSVGInlineText::computeNewScaledFontForStyle(const RenderObject& rende
     auto fontDescription = style.fontDescription();
 
     // FIXME: We need to better handle the case when we compute very small fonts below (below 1pt).
-    fontDescription.setUsedSize(Style::usedFontSizeFromSpecifiedSizeForSVGInlineText(fontDescription.specifiedSize(), fontDescription.isAbsoluteSize(), scalingFactor, protect(renderer.document())));
+    fontDescription.setUsedSize(Style::usedFontSizeFromComputedSizeForSVGInlineText(fontDescription.computedSize(), fontDescription.isAbsoluteSize(), scalingFactor, protect(renderer.document())));
 
     // SVG controls its own glyph orientation, so don't allow writing-mode
     // to affect it.

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -74,7 +74,7 @@ static std::optional<Style::ComputedStyle> styleForFirstLetter(const RenderEleme
         auto newFontDescription = firstLetterStyle.fontDescription();
         float capRatio = firstLetterStyle.metricsOfPrimaryFont().capHeight().value() / firstLetterStyle.usedFontSize();
         float startingFontSize = ((firstLetterStyle.initialLetter().height() - 1) * lineHeight + paragraph->style().metricsOfPrimaryFont().intCapHeight()) / capRatio;
-        newFontDescription.setSpecifiedSize(startingFontSize);
+        newFontDescription.setComputedSize(startingFontSize);
         newFontDescription.setUsedSize(startingFontSize);
         firstLetterStyle.setFontDescription(WTF::move(newFontDescription));
 
@@ -82,7 +82,7 @@ static std::optional<Style::ComputedStyle> styleForFirstLetter(const RenderEleme
         int actualCapHeight = firstLetterStyle.metricsOfPrimaryFont().intCapHeight();
         while (actualCapHeight > desiredCapHeight) {
             auto newFontDescription = firstLetterStyle.fontDescription();
-            newFontDescription.setSpecifiedSize(newFontDescription.specifiedSize() - 1);
+            newFontDescription.setComputedSize(newFontDescription.computedSize() - 1);
             newFontDescription.setUsedSize(newFontDescription.usedSize() - 1);
             firstLetterStyle.setFontDescription(WTF::move(newFontDescription));
             actualCapHeight = firstLetterStyle.metricsOfPrimaryFont().intCapHeight();

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1003,7 +1003,7 @@ void Adjuster::adjustSVGElementStyle(Style::ComputedStyle& style, const SVGEleme
         // children inherit the correct (unzoomed) computed size. The SVG root transform handles
         // the zoom scaling, consistent with other SVG content.
         auto fontDescription = style.fontDescription();
-        auto usedFontSize = usedFontSizeFromSpecifiedSize(fontDescription.specifiedSize(), fontDescription.isAbsoluteSize(), /*useSVGZoomRules=*/true, style, protect(svgElement.document()));
+        auto usedFontSize = usedFontSizeFromComputedSize(fontDescription.computedSize(), fontDescription.isAbsoluteSize(), /*useSVGZoomRules=*/true, style, protect(svgElement.document()));
         fontDescription.setUsedSize(usedFontSize.size, usedFontSize.zoomFactor);
         style.setFontDescription(WTF::move(fontDescription));
     }
@@ -1399,20 +1399,20 @@ auto Adjuster::adjustmentForTextAutosizing(const Style::ComputedStyle& style, co
 
     auto& fontDescription = style.fontDescription();
     auto initialUsedFontSize = fontDescription.usedSize();
-    auto specifiedFontSize = fontDescription.specifiedSize();
+    auto computedFontSize = fontDescription.computedSize();
 
     bool isCandidate = newStatus.isIdempotentTextAutosizingCandidate(style);
-    if (!isCandidate && WTF::areEssentiallyEqual(initialUsedFontSize, specifiedFontSize))
+    if (!isCandidate && WTF::areEssentiallyEqual(initialUsedFontSize, computedFontSize))
         return adjustmentForTextAutosizing;
 
-    auto adjustedFontSize = AutosizeStatus::idempotentTextSize(fontDescription.specifiedSize(), initialScale);
+    auto adjustedFontSize = AutosizeStatus::idempotentTextSize(fontDescription.computedSize(), initialScale);
     if (isCandidate && WTF::areEssentiallyEqual(initialUsedFontSize, adjustedFontSize))
         return adjustmentForTextAutosizing;
 
     if (!hasTextChild(element))
         return adjustmentForTextAutosizing;
 
-    adjustmentForTextAutosizing.newFontSize = isCandidate ? adjustedFontSize : specifiedFontSize;
+    adjustmentForTextAutosizing.newFontSize = isCandidate ? adjustedFontSize : computedFontSize;
 
     // FIXME: We should restore computed line height to its original value in the case where the element is not
     // an idempotent text autosizing candidate; otherwise, if an element that is a text autosizing candidate contains

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -320,9 +320,9 @@ inline void BuilderCustom::applyInitialLineHeight(BuilderState& builderState)
     builderState.style().setSpecifiedLineHeight(ComputedStyle::initialSpecifiedLineHeight());
 }
 
-static inline float computeBaseSpecifiedFontSize(const Document& document, const ComputedStyle& style)
+static inline float computeBaseComputedFontSize(const Document& document, const ComputedStyle& style)
 {
-    float result = style.specifiedFontSize();
+    float result = style.fontSize();
     auto* frame = document.frame();
     if (frame && style.textZoom() != TextZoom::Reset)
         result *= frame->textZoomFactor();
@@ -337,10 +337,10 @@ static inline float computeLineHeightMultiplierDueToFontSize(const Document& doc
     if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value); primitiveValue && primitiveValue->isLength()) {
         auto minimumFontSize = document.settings().minimumFontSize();
         if (minimumFontSize > 0) {
-            auto specifiedFontSize = computeBaseSpecifiedFontSize(document, style);
+            auto computedFontSize = computeBaseComputedFontSize(document, style);
             // Small font sizes cause a preposterously large (near infinity) line-height. Add a fuzz-factor of 1px which opts out of
             // boosted line-height.
-            if (specifiedFontSize < minimumFontSize && specifiedFontSize >= 1) {
+            if (computedFontSize < minimumFontSize && computedFontSize >= 1) {
                 // FIXME: There are two settings which are relevant here: minimum font size, and minimum logical font size (as
                 // well as things like the zoom property, text zoom on the page, and text autosizing). The minimum logical font
                 // size is nonzero by default, and already incorporated into the computed font size, so if we just use the ratio
@@ -351,7 +351,7 @@ static inline float computeLineHeightMultiplierDueToFontSize(const Document& doc
 
                 // This calculation matches the line-height computed size calculation in
                 // TextAutoSizing::Value::adjustTextNodeSizes().
-                auto scaleChange = minimumFontSize / specifiedFontSize;
+                auto scaleChange = minimumFontSize / computedFontSize;
                 return scaleChange;
             }
         }
@@ -469,7 +469,7 @@ inline void BuilderCustom::applyInitialFontSize(BuilderState& builderState)
 inline void BuilderCustom::applyInheritFontSize(BuilderState& builderState)
 {
     const auto& parentFontDescription = builderState.parentStyle().fontDescription();
-    float size = parentFontDescription.specifiedSize();
+    float size = parentFontDescription.computedSize();
 
     if (size < 0)
         return;
@@ -579,7 +579,7 @@ inline void BuilderCustom::applyValueFontSize(BuilderState& builderState, CSSVal
     auto& fontDescription = builderState.fontDescription();
     builderState.setFontDescriptionKeywordSizeFromIdentifier(CSSValueInvalid);
 
-    float parentSize = builderState.parentStyle().fontDescription().specifiedSize();
+    float parentSize = builderState.parentStyle().fontDescription().computedSize();
     bool parentIsAbsoluteSize = builderState.parentStyle().fontDescription().isAbsoluteSize();
 
     float size = 0;

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -209,14 +209,14 @@ void BuilderState::updateFontForTextSizeAdjust()
         return;
 
     auto newFontDescription = m_style.fontDescription();
-    auto baseSize = newFontDescription.specifiedSize();
+    auto baseSize = newFontDescription.computedSize();
     if (!m_style.textSizeAdjust().isNone())
         baseSize *= m_style.textSizeAdjust().multiplier();
 
     float zoomFactor = m_style.usedZoom();
     if (auto* frame = document().frame(); frame && m_style.textZoom() != TextZoom::Reset)
         zoomFactor *= frame->textZoomFactor();
-    newFontDescription.setSpecifiedSize(baseSize);
+    newFontDescription.setComputedSize(baseSize);
     newFontDescription.setUsedSize(baseSize * zoomFactor, zoomFactor);
 
     m_style.setFontDescriptionWithoutUpdate(WTF::move(newFontDescription));
@@ -241,7 +241,7 @@ void BuilderState::updateFontForZoomChange()
         return;
 #endif
 
-    setFontDescriptionFontSize(m_style.fontDescription().specifiedSize());
+    setFontDescriptionFontSize(m_style.fontDescription().computedSize());
 }
 
 void BuilderState::updateFontForGenericFamilyChange()
@@ -266,7 +266,7 @@ void BuilderState::updateFontForGenericFamilyChange()
         auto fixedSize =  document().settings().defaultFixedFontSize();
         auto defaultSize =  document().settings().defaultFontSize();
         float fixedScaleFactor = (fixedSize && defaultSize) ? static_cast<float>(fixedSize) / defaultSize : 1;
-        return parentFont.useFixedDefaultSize() ? childFont.specifiedSize() / fixedScaleFactor : childFont.specifiedSize() * fixedScaleFactor;
+        return parentFont.useFixedDefaultSize() ? childFont.computedSize() / fixedScaleFactor : childFont.computedSize() * fixedScaleFactor;
     }();
 
     auto newFontDescription = childFont;
@@ -296,8 +296,8 @@ void BuilderState::updateFontForSizeChange()
 
 void BuilderState::setFontSize(FontCascadeDescription& fontDescription, float size)
 {
-    fontDescription.setSpecifiedSize(size);
-    auto usedFontSize = Style::usedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), useSVGZoomRules(), style(), document());
+    fontDescription.setComputedSize(size);
+    auto usedFontSize = Style::usedFontSizeFromComputedSize(size, fontDescription.isAbsoluteSize(), useSVGZoomRules(), style(), document());
     fontDescription.setUsedSize(usedFontSize.size, usedFontSize.zoomFactor);
 }
 

--- a/Source/WebCore/style/StyleBuilderStateInlines.h
+++ b/Source/WebCore/style/StyleBuilderStateInlines.h
@@ -72,12 +72,12 @@ inline void BuilderState::setFontDescriptionIsAbsoluteSize(bool isAbsoluteSize)
 
 inline void BuilderState::setFontDescriptionFontSize(float fontSize)
 {
-    if (m_style.fontDescription().specifiedSize() != fontSize) {
+    if (m_style.fontDescription().computedSize() != fontSize) {
         m_fontDirty = true;
-        m_style.mutableFontDescriptionWithoutUpdate().setSpecifiedSize(fontSize);
+        m_style.mutableFontDescriptionWithoutUpdate().setComputedSize(fontSize);
     }
 
-    SUPPRESS_UNCOUNTED_ARG auto usedFontSize = Style::usedFontSizeFromSpecifiedSize(fontSize, m_style.fontDescription().isAbsoluteSize(), useSVGZoomRules(), style(), document());
+    SUPPRESS_UNCOUNTED_ARG auto usedFontSize = Style::usedFontSizeFromComputedSize(fontSize, m_style.fontDescription().isAbsoluteSize(), useSVGZoomRules(), style(), document());
     if (m_style.fontDescription().usedSize() != usedFontSize.size || m_style.fontDescription().usedZoomFactor() != usedFontSize.zoomFactor) {
         m_fontDirty = true;
         m_style.mutableFontDescriptionWithoutUpdate().setUsedSize(usedFontSize.size, usedFontSize.zoomFactor);

--- a/Source/WebCore/style/StyleFontSizeFunctions.cpp
+++ b/Source/WebCore/style/StyleFontSizeFunctions.cpp
@@ -42,13 +42,13 @@ namespace WebCore {
 
 namespace Style {
 
-float usedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, float zoomFactor, MinimumFontSizeRule minimumSizeRule, const SettingsValues& settings)
+float usedFontSizeFromComputedSize(float computedSize, bool isAbsoluteSize, float zoomFactor, MinimumFontSizeRule minimumSizeRule, const SettingsValues& settings)
 {
     // Text with a 0px font size should not be visible and therefore needs to be
     // exempt from minimum font size rules. Acid3 relies on this for pixel-perfect
     // rendering. This is also compatible with other browsers that have minimum
     // font size settings (e.g. Firefox).
-    if (std::abs(specifiedSize) < std::numeric_limits<float>::epsilon())
+    if (std::abs(computedSize) < std::numeric_limits<float>::epsilon())
         return 0.0f;
 
     // We support two types of minimum font size. The first is a hard override that applies to
@@ -62,11 +62,11 @@ float usedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, fl
     // since sites will mis-render otherwise (e.g., http://www.gamespot.com with a 9px minimum).
 
     if (minimumSizeRule == MinimumFontSizeRule::None)
-        return specifiedSize;
+        return computedSize;
 
     int minSize = settings.minimumFontSize;
     int minLogicalSize = settings.minimumLogicalFontSize;
-    float zoomedSize = specifiedSize * zoomFactor;
+    float zoomedSize = computedSize * zoomFactor;
 
     // Apply the hard minimum first. We only apply the hard minimum if after zooming we're still too small.
     zoomedSize = std::max(zoomedSize, static_cast<float>(minSize));
@@ -75,7 +75,7 @@ float usedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, fl
     // after zooming. The font size must either be relative to the user default or the original size
     // must have been acceptable. In other words, we only apply the smart minimum whenever we're positive
     // doing so won't disrupt the layout.
-    if (minimumSizeRule == MinimumFontSizeRule::AbsoluteAndRelative && (specifiedSize >= minLogicalSize || !isAbsoluteSize)) {
+    if (minimumSizeRule == MinimumFontSizeRule::AbsoluteAndRelative && (computedSize >= minLogicalSize || !isAbsoluteSize)) {
         // The smart minimum is a logical (pre-zoom) readability floor, not a device-space floor. When
         // zooming the page out, scale it by the zoom factor so small text still shrinks proportionally
         // with the page (as other engines do) instead of being pinned to a minLogicalSize device floor
@@ -90,7 +90,7 @@ float usedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, fl
     return std::min(maximumAllowedFontSize, zoomedSize);
 }
 
-UsedFontSize usedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, bool useSVGZoomRules, const ComputedStyle& style, const Document& document)
+UsedFontSize usedFontSizeFromComputedSize(float computedSize, bool isAbsoluteSize, bool useSVGZoomRules, const ComputedStyle& style, const Document& document)
 {
     float zoomFactor = 1.0f;
     if (!useSVGZoomRules) {
@@ -99,12 +99,12 @@ UsedFontSize usedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteS
         if (frame && style.textZoom() != TextZoom::Reset)
             zoomFactor *= frame->textZoomFactor();
     }
-    return { usedFontSizeFromSpecifiedSize(specifiedSize, isAbsoluteSize, zoomFactor, useSVGZoomRules ? MinimumFontSizeRule::None : MinimumFontSizeRule::AbsoluteAndRelative, document.settingsValues()), zoomFactor };
+    return { usedFontSizeFromComputedSize(computedSize, isAbsoluteSize, zoomFactor, useSVGZoomRules ? MinimumFontSizeRule::None : MinimumFontSizeRule::AbsoluteAndRelative, document.settingsValues()), zoomFactor };
 }
 
-float usedFontSizeFromSpecifiedSizeForSVGInlineText(float specifiedSize, bool isAbsoluteSize, float zoomFactor, const Document& document)
+float usedFontSizeFromComputedSizeForSVGInlineText(float computedSize, bool isAbsoluteSize, float zoomFactor, const Document& document)
 {
-    return usedFontSizeFromSpecifiedSize(specifiedSize, isAbsoluteSize, zoomFactor, MinimumFontSizeRule::Absolute, document.settingsValues());
+    return usedFontSizeFromComputedSize(computedSize, isAbsoluteSize, zoomFactor, MinimumFontSizeRule::Absolute, document.settingsValues());
 }
 
 constexpr int fontSizeTableMax = 16;

--- a/Source/WebCore/style/StyleFontSizeFunctions.h
+++ b/Source/WebCore/style/StyleFontSizeFunctions.h
@@ -43,9 +43,9 @@ struct UsedFontSize {
     float zoomFactor { 1.0f };
 };
 
-float usedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, float zoomFactor, MinimumFontSizeRule, const SettingsValues&);
-UsedFontSize usedFontSizeFromSpecifiedSize(float specifiedSize, bool isAbsoluteSize, bool useSVGZoomRules, const ComputedStyle&, const Document&);
-float usedFontSizeFromSpecifiedSizeForSVGInlineText(float specifiedSize, bool isAbsoluteSize, float zoomFactor, const Document&);
+float usedFontSizeFromComputedSize(float computedSize, bool isAbsoluteSize, float zoomFactor, MinimumFontSizeRule, const SettingsValues&);
+UsedFontSize usedFontSizeFromComputedSize(float computedSize, bool isAbsoluteSize, bool useSVGZoomRules, const ComputedStyle&, const Document&);
+float usedFontSizeFromComputedSizeForSVGInlineText(float computedSize, bool isAbsoluteSize, float zoomFactor, const Document&);
 float NODELETE adjustedFontSize(float size, const WebCore::FontSizeAdjust&, const FontMetrics&);
 
 // Given a CSS keyword id in the range (CSSValueXxSmall to CSSValueXxxLarge), this function will return

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -293,7 +293,7 @@ public:
 
     bool equals(const Style::ComputedStyle& a, const Style::ComputedStyle& b) const final
     {
-        return a.specifiedFontSize() == b.specifiedFontSize();
+        return a.fontSize() == b.fontSize();
     }
 };
 

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -93,9 +93,9 @@ Style::ComputedStyle resolveForDocument(const Document& document)
 
         fontDescription.setKeywordSizeFromIdentifier(CSSValueMedium);
         int size = fontSizeForKeyword(CSSValueMedium, false, document);
-        fontDescription.setSpecifiedSize(size);
+        fontDescription.setComputedSize(size);
         bool useSVGZoomRules = document.isSVGDocument();
-        auto usedFontSize = usedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), useSVGZoomRules, documentStyle, document);
+        auto usedFontSize = usedFontSizeFromComputedSize(size, fontDescription.isAbsoluteSize(), useSVGZoomRules, documentStyle, document);
         fontDescription.setUsedSize(usedFontSize.size, usedFontSize.zoomFactor);
 
         auto [fontOrientation, glyphOrientation] = documentStyle.fontAndGlyphOrientation();

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -356,7 +356,7 @@ std::optional<FontCascade> resolveForUnresolvedFont(const CSSPropertyParserHelpe
     ASSERT(protectedContext->cssFontSelector());
 
     // Map the font property longhands into the style.
-    float parentSize = fontDescription.specifiedSize();
+    float parentSize = fontDescription.computedSize();
 
     auto useFixedDefaultSize = [](const FontCascadeDescription& fontDescription) {
         return fontDescription.familyCount() == 1
@@ -376,8 +376,8 @@ std::optional<FontCascade> resolveForUnresolvedFont(const CSSPropertyParserHelpe
     if (useFixedDefaultSize(fontDescription) != oldFamilyUsedFixedDefaultSize) {
         if (auto sizeIdentifier = fontDescription.keywordSizeAsIdentifier()) {
             auto size = Style::fontSizeForKeyword(sizeIdentifier, !oldFamilyUsedFixedDefaultSize, protectedContext->settingsValues());
-            fontDescription.setSpecifiedSize(size);
-            fontDescription.setUsedSize(usedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), 1.0, MinimumFontSizeRule::None, protectedContext->settingsValues()));
+            fontDescription.setComputedSize(size);
+            fontDescription.setUsedSize(usedFontSizeFromComputedSize(size, fontDescription.isAbsoluteSize(), 1.0, MinimumFontSizeRule::None, protectedContext->settingsValues()));
         }
     }
 
@@ -394,7 +394,7 @@ std::optional<FontCascade> resolveForUnresolvedFont(const CSSPropertyParserHelpe
     auto resolvedSize = fontSizeFromUnresolvedFontSize(unresolvedFont.size, parentSize, fontDescription, protectedContext);
     fontDescription.setKeywordSizeFromIdentifier(resolvedSize.keyword);
     if (resolvedSize.size > 0) {
-        fontDescription.setSpecifiedSize(resolvedSize.size);
+        fontDescription.setComputedSize(resolvedSize.size);
         fontDescription.setUsedSize(resolvedSize.size);
     }
 

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -674,8 +674,8 @@ std::unique_ptr<Style::ComputedStyle> Resolver::defaultStyleForElement(const Ele
     fontDescription.setKeywordSizeFromIdentifier(CSSValueMedium);
 
     auto size = fontSizeForKeyword(CSSValueMedium, false, protect(document()));
-    fontDescription.setSpecifiedSize(size);
-    auto usedFontSize = usedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), is<SVGElement>(element), *style, protect(document()));
+    fontDescription.setComputedSize(size);
+    auto usedFontSize = usedFontSizeFromComputedSize(size, fontDescription.isAbsoluteSize(), is<SVGElement>(element), *style, protect(document()));
     fontDescription.setUsedSize(usedFontSize.size, usedFontSize.zoomFactor);
 
     fontDescription.setShouldAllowUserInstalledFonts(settings().shouldAllowUserInstalledFonts() ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No);

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
@@ -131,9 +131,9 @@ inline TextOrientation ComputedStyleProperties::computedTextOrientation() const
 
 // FIXME: Support font properties.
 
-float ComputedStyleProperties::specifiedFontSize() const
+float ComputedStyleProperties::fontSize() const
 {
-    return fontDescription().specifiedSize();
+    return fontDescription().computedSize();
 }
 
 inline FontFamilies ComputedStyleProperties::fontFamily() const

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
@@ -127,9 +127,6 @@ inline void ComputedStyleProperties::setTextAutospace(TextAutospace value)
 
 inline void ComputedStyleProperties::setFontSize(float size)
 {
-    // size must be specifiedSize if Text Autosizing is enabled, but computedSize if text
-    // zoom is enabled (if neither is enabled it's irrelevant as they're probably the same).
-
     ASSERT(std::isfinite(size));
     if (!std::isfinite(size) || size < 0)
         size = 0;
@@ -137,7 +134,7 @@ inline void ComputedStyleProperties::setFontSize(float size)
         size = std::min(maximumAllowedFontSize, size);
 
     auto description = fontDescription();
-    description.setSpecifiedSize(size);
+    description.setComputedSize(size);
     description.setUsedSize(size, description.usedZoomFactor());
     setFontDescription(WTF::move(description));
 

--- a/Source/WebCore/style/values/inline/StyleLineHeight.cpp
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.cpp
@@ -173,7 +173,7 @@ auto Evaluation<LineHeight, float>::operator()(
             return evaluate<LayoutUnit>(length, zoom).toFloat();
         },
         [&](const LineHeight::Number& number) {
-            return LayoutUnit { number.value * LayoutUnit { context.computedFontSize } }.toFloat();
+            return LayoutUnit { number.value * LayoutUnit { context.fontSize } }.toFloat();
         }
     );
 }

--- a/Source/WebCore/style/values/inline/StyleLineHeight.h
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.h
@@ -101,7 +101,7 @@ template<> struct Blending<LineHeight> {
 // MARK: - Evaluation
 
 struct LineHeightEvaluationContext {
-    float computedFontSize;
+    float fontSize;
     float lineSpacing;
 };
 

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -66,7 +66,7 @@ static double unzoomFontMetric(double metric, const FontDescription& fontDescrip
 static double resolveEm(const FontCascade& fontCascadeForUnit)
 {
     auto& fontDescription = fontCascadeForUnit.fontDescription();
-    return fontDescription.specifiedSize();
+    return fontDescription.computedSize();
 }
 
 // Resolve the "ex" and "rex" units.
@@ -79,7 +79,7 @@ static double resolveEx(const FontCascade& fontCascadeForUnit)
     if (fontMetrics.xHeight())
         return unzoomFontMetric(fontMetrics.xHeight().value(), fontDescription);
 
-    return fontDescription.specifiedSize() / 2.0;
+    return fontDescription.computedSize() / 2.0;
 }
 
 // Resolve the "cap" and "rcap" units.
@@ -126,7 +126,7 @@ static double resolveLh(const ComputedStyle* style, const FontCascade& fallbackF
         return evaluate<float>(
             style->specifiedLineHeight(),
             LineHeightEvaluationContext {
-                fontDescription.specifiedSize(),
+                fontDescription.computedSize(),
                 static_cast<float>(unzoomFontMetric(fontCascade.metricsOfPrimaryFont().lineSpacing(), fontDescription)),
             },
             ZoomFactor::none()
@@ -707,7 +707,7 @@ bool equalForLengthResolution(const ComputedStyle& styleA, const ComputedStyle& 
 
     if (styleA.fontDescription().usedSize() != styleB.fontDescription().usedSize())
         return false;
-    if (styleA.fontDescription().specifiedSize() != styleB.fontDescription().specifiedSize())
+    if (styleA.fontDescription().computedSize() != styleB.fontDescription().computedSize())
         return false;
     if (styleA.metricsOfPrimaryFont().xHeight() != styleB.metricsOfPrimaryFont().xHeight())
         return false;
@@ -727,7 +727,7 @@ bool equalForLengthResolution(const ComputedStyle& styleA, const ComputedStyle& 
 
 double emToPxDouble(double value, const ComputedStyle& style)
 {
-    return value * style.fontCascade().fontDescription().specifiedSize();
+    return value * style.fontCascade().fontDescription().computedSize();
 }
 
 double emToPxDoubleZoomed(double value, const ComputedStyle& style)


### PR DESCRIPTION
#### 294be00ae9b1bac3bea4e5dec163c24cf36973e6
<pre>
Replace references to a font&apos;s &quot;specifiedSize&quot; with &quot;computedSize&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=323224">https://bugs.webkit.org/show_bug.cgi?id=323224</a>

Reviewed by Antti Koivisto.

Part 2 of <a href="https://bugs.webkit.org/show_bug.cgi?id=319263">https://bugs.webkit.org/show_bug.cgi?id=319263</a>

FontDescription and Style::ComputedStyleBase reference a font&apos;s &quot;specified size&quot;,
but the value they currently associate with that is actually the CSS concept of a
computed style size than a specified one.

Rather than using the &quot;computed&quot; prefix on Style::ComputedStyleBase, which would
be redundant, the bare name &quot;fontSize&quot; is used instead.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp:
* Source/WebCore/page/DebugPageOverlays.cpp:
* Source/WebCore/platform/graphics/FontCascadeDescription.cpp:
* Source/WebCore/platform/graphics/FontCascadeDescription.h:
* Source/WebCore/platform/graphics/ca/FrameProcessIndicators.cpp:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.mm:
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
* Source/WebCore/platform/win/cairo/DragImageWinCairo.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
* Source/WebCore/rendering/TextAutoSizing.cpp:
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
* Source/WebCore/rendering/style/AutosizeStatus.cpp:
* Source/WebCore/rendering/style/AutosizeStatus.h:
* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
* Source/WebCore/style/StyleAdjuster.cpp:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleBuilderState.cpp:
* Source/WebCore/style/StyleBuilderStateInlines.h:
* Source/WebCore/style/StyleFontSizeFunctions.cpp:
* Source/WebCore/style/StyleFontSizeFunctions.h:
* Source/WebCore/style/StyleInterpolationWrappers.h:
* Source/WebCore/style/StyleResolveForDocument.cpp:
* Source/WebCore/style/StyleResolveForFont.cpp:
* Source/WebCore/style/StyleResolver.cpp:
* Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h:
* Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h:
* Source/WebCore/style/values/inline/StyleLineHeight.cpp:
* Source/WebCore/style/values/inline/StyleLineHeight.h:
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:

Canonical link: <a href="https://commits.webkit.org/320431@main">https://commits.webkit.org/320431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6012183af08cbf2da2cc62fb46cb1feadba80b6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194829 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148787 "Hash 6012183a for PR 73063 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186363 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144054 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/148787 "Hash 6012183a for PR 73063 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124470 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46554 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44715 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156938 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44337 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5901 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49024 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196773 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58095 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153630 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41184 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58800 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153289 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47817 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131092 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127553 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57303 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19351 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56667 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56912 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56736 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->