### PR TITLE
webgpu.github.io/webgpu-samples/?sample=videoUploading does not play Lake with videoSource = videoElement

### DIFF
--- a/LayoutTests/fast/webgpu/external-texture-from-webm-video-element-expected.txt
+++ b/LayoutTests/fast/webgpu/external-texture-from-webm-video-element-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: PASS: the video element's frame was sampled through the external texture
+This test passes if it prints PASS: a video element whose media player runs in the web process must still deliver its frame to an imported external texture.

--- a/LayoutTests/fast/webgpu/external-texture-from-webm-video-element.html
+++ b/LayoutTests/fast/webgpu/external-texture-from-webm-video-element.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner) { testRunner.dumpAsText(); testRunner.waitUntilDone(); }
+
+// Verifies that importExternalTexture({ source: <video> }) samples the video's frame when the
+// video's media player is not hosted in the GPU process.
+//
+// WebM (and MSE) playback never registers a remote media engine, so its MediaPlayer decodes in the
+// web process -- but it still mints a MediaPlayerIdentifier. GPUExternalTextureDescriptor used to
+// read a non-null identifier as "the GPU process can fetch the current frame itself", so the frame
+// was never written into shared memory, the GPU process could not resolve the identifier, and the
+// external texture was silently bound to a black placeholder texture with no JS-visible error.
+//
+// The source video is a BT.601 video-range SMPTE-style chart of eight vertical color bars. Sampling
+// the external texture must reproduce those bars; the buggy path produces black everywhere.
+
+const video = "../../media/content/test-vp9-601-videorange.webm";
+
+// The render target is one row of 64 texels across the whole width of the video, so texel
+// 8 * bar + 3 lands in the middle of color bar `bar`. Bars 1 and 6 are crossed by an ellipse which
+// swaps their colors, so only the six bars which are constant over the full height are checked.
+const width = 64, height = 8;
+const sampledRow = 1; // v = 1.5 / 8, above the gradient strip at the bottom of the chart.
+const expectedBars = [
+    { bar: 0, name: "black" },
+    { bar: 2, name: "magenta" },
+    { bar: 3, name: "blue" },
+    { bar: 4, name: "yellow" },
+    { bar: 5, name: "green" },
+    { bar: 7, name: "white" },
+];
+
+const shader = `
+struct VertexOut {
+    @builtin(position) position: vec4f,
+    @location(0) uv: vec2f,
+}
+
+@vertex fn vertexMain(@builtin(vertex_index) index: u32) -> VertexOut {
+    // One oversized triangle covering the viewport, with uv (0,0) at its top left corner.
+    var positions = array<vec2f, 3>(vec2f(-1, -1), vec2f(3, -1), vec2f(-1, 3));
+    var uvs = array<vec2f, 3>(vec2f(0, 1), vec2f(2, 1), vec2f(0, -1));
+    return VertexOut(vec4f(positions[index], 0, 1), uvs[index]);
+}
+
+@group(0) @binding(0) var videoSampler: sampler;
+@group(0) @binding(1) var videoTexture: texture_external;
+
+@fragment fn fragmentMain(@location(0) uv: vec2f) -> @location(0) vec4f {
+    return textureSampleBaseClampToEdge(videoTexture, videoSampler, uv);
+}
+`;
+
+// Classify a pixel into a color name using generous thresholds, so that the exact YUV to RGB
+// conversion does not matter. The buggy (placeholder texture) path is black everywhere.
+function classify(r, g, b) {
+    const hi = 200, lo = 60;
+    const bit = v => v >= hi ? 1 : (v <= lo ? 0 : -1);
+    const bits = [bit(r), bit(g), bit(b)];
+    if (bits.includes(-1))
+        return `unclassified(${r},${g},${b})`;
+    return ["black", "blue", "green", "cyan", "red", "magenta", "yellow", "white"][bits[0] * 4 + bits[1] * 2 + bits[2]];
+}
+
+function playUntilFirstFrame(element, src) {
+    return new Promise(async (resolve, reject) => {
+        element.onerror = () => reject(`could not load ${src}`);
+        const gotFrame = new Promise(resolve => element.requestVideoFrameCallback(resolve));
+        element.src = src;
+        await new Promise(resolve => element.onloadedmetadata = resolve);
+        await element.play();
+        await gotFrame;
+        resolve();
+    });
+}
+
+onload = async () => {
+    try {
+        const adapter = await navigator.gpu?.requestAdapter();
+        const device = await adapter?.requestDevice();
+        if (!device) {
+            console.log("FAIL: No WebGPU device available");
+            if (window.testRunner) testRunner.notifyDone();
+            return;
+        }
+
+        const module = device.createShaderModule({ code: shader });
+        const pipeline = device.createRenderPipeline({
+            layout: "auto",
+            vertex: { module },
+            fragment: { module, targets: [{ format: "rgba8unorm" }] },
+        });
+        const sampler = device.createSampler({ magFilter: "nearest", minFilter: "nearest" });
+        const texture = device.createTexture({
+            size: [width, height],
+            format: "rgba8unorm",
+            usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+        });
+
+        // copyTextureToBuffer requires bytesPerRow to be a multiple of 256, which 64 rgba8unorm
+        // texels are exactly.
+        const bytesPerRow = width * 4;
+        const readbackBuffer = device.createBuffer({
+            size: bytesPerRow * height,
+            usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+        });
+
+        const element = document.querySelector("video");
+        await playUntilFirstFrame(element, video);
+
+        // A GPUExternalTexture expires at the end of the task it was imported in, so import, encode
+        // and submit without yielding.
+        const externalTexture = device.importExternalTexture({ source: element });
+        const bindGroup = device.createBindGroup({
+            layout: pipeline.getBindGroupLayout(0),
+            entries: [
+                { binding: 0, resource: sampler },
+                { binding: 1, resource: externalTexture },
+            ],
+        });
+
+        const encoder = device.createCommandEncoder();
+        const pass = encoder.beginRenderPass({
+            colorAttachments: [{
+                view: texture.createView(),
+                clearValue: [0, 0, 0, 1],
+                loadOp: "clear",
+                storeOp: "store",
+            }],
+        });
+        pass.setPipeline(pipeline);
+        pass.setBindGroup(0, bindGroup);
+        pass.draw(3);
+        pass.end();
+        encoder.copyTextureToBuffer(
+            { texture },
+            { buffer: readbackBuffer, bytesPerRow, rowsPerImage: height },
+            [width, height]
+        );
+        device.queue.submit([encoder.finish()]);
+
+        await readbackBuffer.mapAsync(GPUMapMode.READ);
+        const bytes = new Uint8Array(readbackBuffer.getMappedRange());
+
+        let allPass = true;
+        for (const e of expectedBars) {
+            const o = sampledRow * bytesPerRow + (8 * e.bar + 3) * 4;
+            const got = classify(bytes[o], bytes[o + 1], bytes[o + 2]);
+            if (got !== e.name) {
+                allPass = false;
+                console.log(`FAIL: color bar ${e.bar} expected ${e.name} but got ${got} — no video frame reached the external texture`);
+            }
+        }
+
+        readbackBuffer.unmap();
+
+        if (allPass)
+            console.log("PASS: the video element's frame was sampled through the external texture");
+
+    } catch (e) {
+        console.log("FAIL: " + e);
+    }
+
+    if (window.testRunner) testRunner.notifyDone();
+};
+</script>
+<video muted></video>
+This test passes if it prints PASS: a video element whose media player runs in the web process must still deliver its frame to an imported external texture.

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/gpu_external_texture_expiration-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/gpu_external_texture_expiration-expected.txt
@@ -7,9 +7,5 @@ PASS :import_and_use_in_different_task:sourceType="VideoElement"
 PASS :import_and_use_in_different_task:sourceType="VideoFrame"
 PASS :use_import_to_refresh:
 PASS :webcodec_video_frame_close_expire_immediately:
-FAIL :import_from_different_video_frame: assert_unreached:
-  - EXCEPTION: Error
-    assert@http://127.0.0.1:8000/webgpu/common/util/util.js:37:20
-    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/gpu_external_texture_expiration.spec.js:296:11
- Reached unreachable code
+PASS :import_from_different_video_frame:
 

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -506,7 +506,6 @@ ExceptionOr<Ref<GPUExternalTexture>> GPUDevice::importExternalTexture(GPUExterna
 
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
     if (RefPtr externalTexture = externalTextureForDescriptor(externalTextureDescriptor)) {
-        externalTexture->undestroy();
 #if ENABLE(WEB_CODECS)
         Ref videoElementRef = std::get<Ref<HTMLVideoElement>>(externalTextureDescriptor.source);
 #else
@@ -515,8 +514,9 @@ ExceptionOr<Ref<GPUExternalTexture>> GPUDevice::importExternalTexture(GPUExterna
         if (auto exception = checkVideoElementOriginTaint(videoElementRef))
             return WTF::move(*exception);
 
-        m_videoElementToExternalTextureMap.remove(videoElementRef);
         if (auto optionalMediaIdentifier = externalTextureDescriptor.mediaIdentifier()) {
+            externalTexture->undestroy();
+            m_videoElementToExternalTextureMap.remove(videoElementRef);
             m_backing->updateExternalTexture(externalTexture->backing(), *optionalMediaIdentifier);
             return externalTexture.releaseNonNull();
         }

--- a/Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h
@@ -53,11 +53,15 @@ struct GPUExternalTextureDescriptor : public GPUObjectDescriptorBase {
 #if ENABLE(WEB_CODECS)
         return WTF::switchOn(videoSource,
             [&](const Ref<HTMLVideoElement>& videoElement) -> WebGPU::VideoSourceIdentifier {
-                if (auto playerIdentifier = videoElement->playerIdentifier())
-                    return playerIdentifier;
+                RefPtr player = videoElement->player();
+                // Player needs to run in the GPU process to use the accelerated path
+                if (player && player->isHostedInGPUProcess()) {
+                    if (auto playerIdentifier = videoElement->playerIdentifier())
+                        return playerIdentifier;
+                }
                 RefPtr<WebCore::VideoFrame> result;
-                if (videoElement->player())
-                    result = protect(videoElement->player())->videoFrameForCurrentTime();
+                if (player)
+                    result = player->videoFrameForCurrentTime();
                 return result;
             },
             [&](const Ref<WebCodecsVideoFrame>& videoFrame) -> WebGPU::VideoSourceIdentifier {
@@ -74,6 +78,9 @@ struct GPUExternalTextureDescriptor : public GPUObjectDescriptorBase {
 #if ENABLE(WEB_CODECS)
         return WTF::switchOn(source,
             [&](const Ref<HTMLVideoElement>& videoElement) -> std::optional<WebCore::MediaPlayerIdentifier> {
+                RefPtr player = videoElement->player();
+                if (!player || !player->isHostedInGPUProcess())
+                    return std::nullopt;
                 return videoElement->playerIdentifier();
             },
             [&](const Ref<WebCodecsVideoFrame>&) -> std::optional<WebCore::MediaPlayerIdentifier> {

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -2041,6 +2041,11 @@ std::optional<MediaPlayerIdentifier> MediaPlayer::identifier() const
     return protect(m_private)->identifier();
 }
 
+bool MediaPlayer::isHostedInGPUProcess() const
+{
+    return protect(m_private)->mediaPlayerType() == MediaPlayerType::Remote;
+}
+
 std::optional<VideoFrameMetadata> MediaPlayer::videoFrameMetadata()
 {
     return protect(m_private)->videoFrameMetadata();

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -774,6 +774,7 @@ public:
     void audioOutputDeviceChanged();
 
     std::optional<MediaPlayerIdentifier> identifier() const;
+    bool isHostedInGPUProcess() const;
     bool hasMediaEngine() const;
 
     std::optional<VideoFrameMetadata> videoFrameMetadata();


### PR DESCRIPTION
#### b3d7d6cdd798bcc0900041524247ee71706e6d05
<pre>
webgpu.github.io/webgpu-samples/?sample=videoUploading does not play Lake with videoSource = videoElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=323225">https://bugs.webkit.org/show_bug.cgi?id=323225</a>
<a href="https://rdar.apple.com/186470526">rdar://186470526</a>

Reviewed by Dan Glastonbury.

In order to import video using the accelerated CVMetalTextureCache path,
we must ensure the video is already in the GPU process.

Test: fast/webgpu/external-texture-from-webm-video-element.html

* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
(WebCore::GPUDevice::importExternalTexture):
* Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h:
(WebCore::GPUExternalTextureDescriptor::mediaIdentifierForSource):
(WebCore::GPUExternalTextureDescriptor::mediaIdentifier const):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::isHostedInGPUProcess const):
* Source/WebCore/platform/graphics/MediaPlayer.h:

* LayoutTests/fast/webgpu/external-texture-from-webm-video-element-expected.txt: Added.
* LayoutTests/fast/webgpu/external-texture-from-webm-video-element.html: Added.

Canonical link: <a href="https://commits.webkit.org/320427@main">https://commits.webkit.org/320427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d145759623fb82eb9fe2e414d3ee56275fb5f13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195072 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/149001 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b49f408d-89e4-4a47-98a8-896c07e4fc7b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144361 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100243 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0742fd80-49e1-46c9-9d48-036331751ea1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48026 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164965 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124643 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/54184525-f4e9-4441-9be3-0c260f6f3ad3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46748 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157122 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44518 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6127 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51321 "Found 1 new failure in css/ShorthandSerializer.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197020 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164457 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153830 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41179 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59030 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153488 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48006 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131319 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127866 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57530 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19536 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56890 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57141 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56966 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->