### PR TITLE
[list-marker] Rename RenderListMarker to RenderListOutsideMarker

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -342,7 +342,7 @@ rendering/RenderLayerScrollableArea.cpp
 rendering/RenderLayoutState.cpp
 rendering/RenderListBox.cpp
 rendering/RenderListItem.cpp
-rendering/RenderListMarker.cpp
+rendering/RenderListOutsideMarker.cpp
 rendering/RenderMenuList.cpp
 rendering/RenderMultiColumnFlow.cpp
 rendering/RenderMultiColumnSet.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -76,7 +76,7 @@ rendering/RenderLayerScrollableArea.cpp
 rendering/RenderLayoutState.cpp
 rendering/RenderListBox.cpp
 rendering/RenderListItem.cpp
-rendering/RenderListMarker.cpp
+rendering/RenderListOutsideMarker.cpp
 rendering/RenderMultiColumnFlow.cpp
 rendering/RenderMultiColumnSet.cpp
 rendering/RenderObject.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3094,7 +3094,7 @@ rendering/RenderLineBoxList.cpp @header:RenderStyleGetters @cost:5
 rendering/RenderLineBreak.cpp @header:RenderStyleGetters @cost:6
 rendering/RenderListBox.cpp @header:RenderStyleGetters @cost:8
 rendering/RenderListItem.cpp @header:RenderStyleGetters @cost:7
-rendering/RenderListMarker.cpp @header:RenderStyleGetters @cost:8
+rendering/RenderListOutsideMarker.cpp @header:RenderStyleGetters @cost:8
 rendering/RenderMarquee.cpp @header:RenderStyleGetters @cost:5
 rendering/RenderMedia.cpp @header:RenderStyleGetters @cost:6
 rendering/RenderMenuList.cpp @header:RenderStyleGetters @cost:8

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -4717,7 +4717,7 @@
 		A8EA79F60A1916DF00A8EF5F /* HTMLLIElement.h in Headers */ = {isa = PBXBuildFile; fileRef = A8EA79EA0A1916DF00A8EF5F /* HTMLLIElement.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A8EA79F70A1916DF00A8EF5F /* HTMLDListElement.h in Headers */ = {isa = PBXBuildFile; fileRef = A8EA79EB0A1916DF00A8EF5F /* HTMLDListElement.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A8EA79FA0A1916DF00A8EF5F /* HTMLDirectoryElement.h in Headers */ = {isa = PBXBuildFile; fileRef = A8EA79EE0A1916DF00A8EF5F /* HTMLDirectoryElement.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		A8EA7A500A191A5200A8EF5F /* RenderListMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = A8EA7A4A0A191A5200A8EF5F /* RenderListMarker.h */; };
+		A8EA7A500A191A5200A8EF5F /* RenderListOutsideMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = A8EA7A4A0A191A5200A8EF5F /* RenderListOutsideMarker.h */; };
 		A8EA7A520A191A5200A8EF5F /* RenderListItem.h in Headers */ = {isa = PBXBuildFile; fileRef = A8EA7A4C0A191A5200A8EF5F /* RenderListItem.h */; };
 		A8EA7CAB0A192B9C00A8EF5F /* HTMLMarqueeElement.h in Headers */ = {isa = PBXBuildFile; fileRef = A8EA7C9D0A192B9C00A8EF5F /* HTMLMarqueeElement.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A8EA7CAF0A192B9C00A8EF5F /* HTMLHRElement.h in Headers */ = {isa = PBXBuildFile; fileRef = A8EA7CA10A192B9C00A8EF5F /* HTMLHRElement.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -18254,8 +18254,8 @@
 		A8EA79EF0A1916DF00A8EF5F /* HTMLOListElement.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = HTMLOListElement.cpp; sourceTree = "<group>"; };
 		A8EA79F00A1916DF00A8EF5F /* HTMLLIElement.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = HTMLLIElement.cpp; sourceTree = "<group>"; };
 		A8EA7A480A191A5200A8EF5F /* RenderListItem.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = RenderListItem.cpp; sourceTree = "<group>"; };
-		A8EA7A4A0A191A5200A8EF5F /* RenderListMarker.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = RenderListMarker.h; sourceTree = "<group>"; };
-		A8EA7A4B0A191A5200A8EF5F /* RenderListMarker.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = RenderListMarker.cpp; sourceTree = "<group>"; };
+		A8EA7A4A0A191A5200A8EF5F /* RenderListOutsideMarker.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = RenderListOutsideMarker.h; sourceTree = "<group>"; };
+		A8EA7A4B0A191A5200A8EF5F /* RenderListOutsideMarker.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = RenderListOutsideMarker.cpp; sourceTree = "<group>"; };
 		A8EA7A4C0A191A5200A8EF5F /* RenderListItem.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = RenderListItem.h; sourceTree = "<group>"; };
 		A8EA7C9D0A192B9C00A8EF5F /* HTMLMarqueeElement.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = HTMLMarqueeElement.h; sourceTree = "<group>"; };
 		A8EA7C9E0A192B9C00A8EF5F /* HTMLMarqueeElement.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = HTMLMarqueeElement.cpp; sourceTree = "<group>"; };
@@ -42602,8 +42602,8 @@
 				ABB5419D0ACDDFE4002820EB /* RenderListBox.h */,
 				A8EA7A480A191A5200A8EF5F /* RenderListItem.cpp */,
 				A8EA7A4C0A191A5200A8EF5F /* RenderListItem.h */,
-				A8EA7A4B0A191A5200A8EF5F /* RenderListMarker.cpp */,
-				A8EA7A4A0A191A5200A8EF5F /* RenderListMarker.h */,
+				A8EA7A4B0A191A5200A8EF5F /* RenderListOutsideMarker.cpp */,
+				A8EA7A4A0A191A5200A8EF5F /* RenderListOutsideMarker.h */,
 				0F56028E0E4B76580065B038 /* RenderMarquee.cpp */,
 				0F56028D0E4B76580065B038 /* RenderMarquee.h */,
 				E4C279560CF9741900E97B98 /* RenderMedia.cpp */,
@@ -48453,7 +48453,7 @@
 				BCEA4864097D93020094C9E4 /* RenderLineBreak.h in Headers */,
 				ABB5419F0ACDDFE4002820EB /* RenderListBox.h in Headers */,
 				A8EA7A520A191A5200A8EF5F /* RenderListItem.h in Headers */,
-				A8EA7A500A191A5200A8EF5F /* RenderListMarker.h in Headers */,
+				A8EA7A500A191A5200A8EF5F /* RenderListOutsideMarker.h in Headers */,
 				0F56028F0E4B76580065B038 /* RenderMarquee.h in Headers */,
 				439046D812DA25E800AF80A2 /* RenderMathMLBlock.h in Headers */,
 				9331BAD929F033FA00137ED2 /* RenderMathMLBlockInlines.h in Headers */,

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -118,7 +118,7 @@
 #include "RenderLayer.h"
 #include "RenderLineBreak.h"
 #include "RenderListBox.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderMathMLOperator.h"
 #include "RenderMeter.h"
 #include "RenderObjectInlines.h"
@@ -1911,7 +1911,7 @@ void AXObjectCache::setDirtyStitchGroups(const RenderBlock& renderBlock)
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 void AXObjectCache::onTextRunsChanged(const RenderObject& renderer)
 {
-    if (is<RenderInline>(renderer) || is<RenderListMarker>(renderer)) {
+    if (is<RenderInline>(renderer) || is<RenderListOutsideMarker>(renderer)) {
         // Fast-path exit for common renderers that will never produce text runs.
         return;
     }

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -667,7 +667,7 @@ String AXTextMarkerRange::toString(IncludeListMarkerText includeListMarkerText, 
         // non-zero length means textual node, zero length means replaced node (AKA "attachments" in AX)
         if (it.text().length()) {
             // If this is in a list item, we need to add the text for the list marker
-            // because a RenderListMarker does not have a Node equivalent and thus does not appear
+            // because a RenderListOutsideMarker does not have a Node equivalent and thus does not appear
             // when iterating text.
             // Don't add list marker text for new line character.
             if (it.text().length() != 1 || !isASCIIWhitespace(it.text()[0]))

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -113,7 +113,7 @@
 #include "RenderImage.h"
 #include "RenderListBox.h"
 #include "RenderListItem.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderTableCell.h"
 #include "RenderView.h"
 #include "RuleFeature.h"
@@ -919,7 +919,7 @@ bool AccessibilityNodeObject::canHaveChildren() const
     if (node() && !renderer() && WebCore::elementName(node()) == ElementName::HTML_noscript)
         return false;
 
-    if (CheckedPtr listMarker = dynamicDowncast<RenderListMarker>(renderer()))
+    if (CheckedPtr listMarker = dynamicDowncast<RenderListOutsideMarker>(renderer()))
         return listMarker->hasContentProperty();
 
     // If this is an AccessibilityRenderObject, then it's okay if this object
@@ -4183,8 +4183,8 @@ Vector<AXStitchGroup> AccessibilityNodeObject::stitchGroups() const
                 continue;
             }
 
-            if (CheckedPtr renderListMarker = dynamicDowncast<RenderListMarker>(box->renderer())) {
-                if (RefPtr object = cache->getOrCreate(const_cast<RenderListMarker&>(*renderListMarker)))
+            if (CheckedPtr renderListMarker = dynamicDowncast<RenderListOutsideMarker>(box->renderer())) {
+                if (RefPtr object = cache->getOrCreate(const_cast<RenderListOutsideMarker&>(*renderListMarker)))
                     appendToCurrentGroup(object->objectID());
                 continue;
             }
@@ -4312,7 +4312,7 @@ String AccessibilityNodeObject::stringValue() const
                 if (!runStartNode)
                     runStartNode = memberNode;
                 runEndNode = memberNode;
-            } else if (CheckedPtr renderListMarker = dynamicDowncast<RenderListMarker>(object->renderer())) {
+            } else if (CheckedPtr renderListMarker = dynamicDowncast<RenderListOutsideMarker>(object->renderer())) {
                 // List markers have no DOM node. Flush any pending text run, then append marker text.
                 flushRun();
                 builder.append(renderListMarker->textContent());

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -106,7 +106,7 @@
 #include "RenderLayer.h"
 #include "RenderLayerInlines.h"
 #include "RenderListItem.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderObjectInlines.h"
 #include "RenderText.h"
 #include "RenderTextControl.h"

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -117,7 +117,7 @@
 #include "RenderLineBreak.h"
 #include "RenderListBox.h"
 #include "RenderListItem.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderMathMLBlock.h"
 #include "RenderObjectInlines.h"
 #include "RenderSVGInlineText.h"
@@ -325,7 +325,7 @@ AccessibilityObject* AccessibilityRenderObject::parentObject() const
 #endif // !USE(ATSPI)
 
     // Expose markers that are not direct children of a list item too.
-    if (m_renderer->isRenderListMarker()) {
+    if (m_renderer->isRenderListOutsideMarker()) {
         for (CheckedRef listItemAncestor : ancestorsOfType<RenderListItem>(*m_renderer)) {
             RefPtr parent = dynamicDowncast<AccessibilityRenderObject>(axObjectCache()->getOrCreate(listItemAncestor));
             if (parent && parent->markerRenderer() == m_renderer)
@@ -438,7 +438,7 @@ String AccessibilityRenderObject::textUnderElement(TextUnderElementMode mode) co
         return { };
     }
 
-    if (auto* listMarker = dynamicDowncast<RenderListMarker>(*m_renderer)) {
+    if (auto* listMarker = dynamicDowncast<RenderListOutsideMarker>(*m_renderer)) {
         // A `content` marker has no text of its own; the child walk below reads the renderers holding it.
         if (!listMarker->hasContentProperty()) {
             if (mode.includeListMarkers == IncludeListMarkerText::Yes)
@@ -591,11 +591,11 @@ String AccessibilityRenderObject::stringValue() const
         return textUnderElement();
 #endif
 
-    if (CheckedPtr renderListMarker = dynamicDowncast<RenderListMarker>(m_renderer.get())) {
+    if (CheckedPtr renderListMarker = dynamicDowncast<RenderListOutsideMarker>(m_renderer.get())) {
 #if USE(ATSPI)
         return renderListMarker->textContent();
 #else
-        return renderListMarker->textContent(RenderListMarker::IncludeSuffix::No);
+        return renderListMarker->textContent(RenderListOutsideMarker::IncludeSuffix::No);
 #endif
     }
 
@@ -678,7 +678,7 @@ LayoutRect AccessibilityRenderObject::boundingBoxRect() const
                         if (axID == objectID())
                             break;
                         if (RefPtr object = cache->objectForID(axID)) {
-                            if (CheckedPtr renderListMarker = dynamicDowncast<RenderListMarker>(object->renderer())) {
+                            if (CheckedPtr renderListMarker = dynamicDowncast<RenderListOutsideMarker>(object->renderer())) {
                                 if (!object->isAXHidden())
                                     renderListMarker->absoluteFocusRingQuads(quads);
                             }
@@ -1333,7 +1333,7 @@ bool AccessibilityRenderObject::computeIsIgnored() const
         // Otherwise fall through; use presence of help text, title, or description to decide.
     }
 
-    if (m_renderer->isRenderListMarker()) {
+    if (m_renderer->isRenderListOutsideMarker()) {
         RefPtr parent = parentObjectUnignored();
         return parent && !parent->isListItem();
     }
@@ -1568,9 +1568,9 @@ AXTextRuns AccessibilityRenderObject::textRuns()
 
     for (CheckedPtr ancestor = renderText->parent(); ancestor && !ancestor->element(); ancestor = ancestor->parent()) {
         // A marker that needs renderers for its content (a synthesized glyph, bidi text, or a `content`
-        // value) puts them in an anonymous inline-block inside the RenderListMarker, and that anonymous
+        // value) puts them in an anonymous inline-block inside the RenderListOutsideMarker, and that anonymous
         // style carries no pseudo type for the ::marker case above to catch. We do so here instead.
-        if (ancestor->isRenderListMarker())
+        if (ancestor->isRenderListOutsideMarker())
             return { };
     }
 
@@ -1754,7 +1754,7 @@ AXTextRunLineID AccessibilityRenderObject::listMarkerLineID() const
 
 String AccessibilityRenderObject::listMarkerText() const
 {
-    CheckedPtr marker = dynamicDowncast<RenderListMarker>(renderer());
+    CheckedPtr marker = dynamicDowncast<RenderListOutsideMarker>(renderer());
     return marker ? marker->textContent() : String();
 }
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -2487,7 +2487,7 @@ AccessibilityRole AccessibilityRenderObject::determineAccessibilityRole()
             return AccessibilityRole::ListItem;
     }
 
-    if (m_renderer->isRenderListMarker())
+    if (m_renderer->isRenderListOutsideMarker())
         return AccessibilityRole::ListMarker;
     if (m_renderer->isBR())
         return AccessibilityRole::LineBreak;
@@ -2983,7 +2983,7 @@ void AccessibilityRenderObject::addChildren()
     auto addChildIfNeeded = [this](AccessibilityObject& object) {
 #if USE(ATSPI)
         // FIXME: Consider removing this ATSPI-only branch with https://bugs.webkit.org/show_bug.cgi?id=282117.
-        if (object.renderer() && object.renderer()->isRenderListMarker())
+        if (object.renderer() && object.renderer()->isRenderListOutsideMarker())
             return;
 #endif
         addChild(object);

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -32,7 +32,7 @@
 #include "PlatformScreen.h"
 #include "RenderLayer.h"
 #include "RenderListItem.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderObjectInlines.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
@@ -832,7 +832,7 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
     if (!utf16Offset)
         return { WTF::move(defaultAttributes), -1, -1 };
 
-    if (is<RenderListMarker>(*m_coreObject->renderer()))
+    if (is<RenderListOutsideMarker>(*m_coreObject->renderer()))
         return { WTF::move(defaultAttributes), 0, static_cast<int>(m_coreObject->stringValue().length()) };
 
     if (!m_coreObject->node())

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -57,7 +57,7 @@
 #include "RenderLineBreak.h"
 #include "RenderListBox.h"
 #include "RenderListItem.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderMathMLBlock.h"
 #include "RenderMenuList.h"
 #include "RenderModel.h"
@@ -123,7 +123,7 @@ void BoxGeometryUpdater::clear()
     m_nestedListMarkerOffsets.clear();
 }
 
-void BoxGeometryUpdater::setListMarkerOffsetForMarkerOutside(const RenderListMarker& listMarker)
+void BoxGeometryUpdater::setListMarkerOffsetForMarkerOutside(const RenderListOutsideMarker& listMarker)
 {
     CheckedRef layoutBox = *listMarker.layoutBox();
     ASSERT(layoutBox->isListMarkerBox());
@@ -525,7 +525,7 @@ static std::optional<LayoutUnit> baselineForBox(const RenderBox& renderBox)
         return { };
     }
 
-    if (CheckedPtr listMarker = dynamicDowncast<RenderListMarker>(renderBox)) {
+    if (CheckedPtr listMarker = dynamicDowncast<RenderListOutsideMarker>(renderBox)) {
         if (CheckedPtr listItem = listMarker->listItem(); listItem && !listMarker->isImage())
             return fontMetricsBasedBaseline(*listMarker);
         return { };
@@ -567,7 +567,7 @@ static inline void setIntegrationBaseline(const RenderBox& renderBox)
         return;
 
     auto hasNonSyntheticBaseline = [&] {
-        if (auto* renderListMarker = dynamicDowncast<RenderListMarker>(renderBox))
+        if (auto* renderListMarker = dynamicDowncast<RenderListOutsideMarker>(renderBox))
             return !renderListMarker->isImage();
 
         if (is<RenderReplaced>(renderBox) && renderBox.style().display() == Style::DisplayType::InlineFlow)
@@ -797,7 +797,7 @@ void BoxGeometryUpdater::updateBoxGeometryAfterIntegrationLayout(const Layout::E
         // FIXME: These should eventually be all absorbed by LFC layout.
         setIntegrationBaseline(*renderBox);
 
-        if (CheckedPtr renderListMarker = dynamicDowncast<RenderListMarker>(*renderBox)) {
+        if (CheckedPtr renderListMarker = dynamicDowncast<RenderListOutsideMarker>(*renderBox)) {
             CheckedRef style = layoutBox.parent().style();
             boxGeometry.setHorizontalMargin(horizontalLogicalMargin(*renderListMarker, { }, style->writingMode()));
             setListMarkerOffsetForMarkerOutside(*renderListMarker);
@@ -840,7 +840,7 @@ void BoxGeometryUpdater::updateBoxGeometry(const RenderElement& renderer, std::o
 
     if (auto* renderBox = dynamicDowncast<RenderBox>(renderer)) {
         updateLayoutBoxDimensions(*renderBox, availableWidth, intrinsicWidthMode);
-        if (auto* renderListMarker = dynamicDowncast<RenderListMarker>(renderer))
+        if (auto* renderListMarker = dynamicDowncast<RenderListOutsideMarker>(renderer))
             setListMarkerOffsetForMarkerOutside(*renderListMarker);
         return;
     }

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h
@@ -39,7 +39,7 @@ class RenderLineBreak;
 class RenderInline;
 class RenderTable;
 class RenderListItem;
-class RenderListMarker;
+class RenderListOutsideMarker;
 
 namespace LayoutIntegration {
 
@@ -63,7 +63,7 @@ private:
     void updateLayoutBoxDimensions(const RenderBox&, std::optional<LayoutUnit> availableWidth, std::optional<Layout::IntrinsicWidthMode> = std::nullopt);
     void updateLineBreakBoxDimensions(const RenderLineBreak&);
     void updateInlineBoxDimensions(const RenderInline&, std::optional<LayoutUnit> availableWidth, std::optional<Layout::IntrinsicWidthMode> = std::nullopt);
-    void setListMarkerOffsetForMarkerOutside(const RenderListMarker&);
+    void setListMarkerOffsetForMarkerOutside(const RenderListOutsideMarker&);
 
     Layout::BoxGeometry::HorizontalEdges horizontalLogicalMargin(const RenderBoxModelObject&, std::optional<LayoutUnit> availableWidth, WritingMode);
     Layout::BoxGeometry::VerticalEdges verticalLogicalMargin(const RenderBoxModelObject&, std::optional<LayoutUnit> availableWidth, WritingMode);

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -43,7 +43,7 @@
 #include "RenderImage.h"
 #include "RenderLineBreak.h"
 #include "RenderListItem.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderMenuList.h"
 #include "RenderObjectInlines.h"
 #include "RenderSVGInline.h"
@@ -79,7 +79,7 @@ static Layout::Box::IsAnonymous NODELETE isAnonymous(const RenderObject& rendere
 static Layout::Box::ElementAttributes elementAttributes(const RenderElement& renderer)
 {
     auto nodeType = [&] {
-        if (is<RenderListMarker>(renderer))
+        if (is<RenderListOutsideMarker>(renderer))
             return Layout::Box::NodeType::ListMarker;
         if (is<RenderReplaced>(renderer))
             return is<RenderImage>(renderer) ? Layout::Box::NodeType::Image : Layout::Box::NodeType::ReplacedElement;
@@ -230,7 +230,7 @@ void BoxTreeUpdater::adjustStyleIfNeeded(const RenderElement& renderer, Style::C
         adjustStyle(*firstLineStyle);
 }
 
-static EnumSet<Layout::ElementBox::ListMarkerAttribute> calculateListMarkerAttribute(const RenderListMarker& listMarkerRenderer)
+static EnumSet<Layout::ElementBox::ListMarkerAttribute> calculateListMarkerAttribute(const RenderListOutsideMarker& listMarkerRenderer)
 {
     auto listMarkerAttributes = EnumSet<Layout::ElementBox::ListMarkerAttribute> { };
     if (listMarkerRenderer.isImage())
@@ -308,7 +308,7 @@ UniqueRef<Layout::Box> BoxTreeUpdater::createLayoutBox(RenderObject& renderer)
     auto style = Style::ComputedStyle::clone(renderElement.style());
     adjustStyleIfNeeded(renderElement, style, firstLineStyle.get());
 
-    if (CheckedPtr listMarkerRenderer = dynamicDowncast<RenderListMarker>(renderElement))
+    if (CheckedPtr listMarkerRenderer = dynamicDowncast<RenderListOutsideMarker>(renderElement))
         return makeUniqueRef<Layout::ElementBox>(elementAttributes(renderElement), calculateListMarkerAttribute(*listMarkerRenderer), WTF::move(style), WTF::move(firstLineStyle));
 
     return makeUniqueRef<Layout::ElementBox>(elementAttributes(renderElement), WTF::move(style), WTF::move(firstLineStyle));
@@ -411,7 +411,7 @@ void BoxTreeUpdater::updateStyle(const RenderObject& renderer)
     auto newStyle = Style::ComputedStyle::clone(downcast<RenderElement>(renderer).style());
     adjustStyleIfNeeded(downcast<RenderElement>(renderer), newStyle, firstLineNewStyle.get());
     layoutBox->updateStyle(WTF::move(newStyle), WTF::move(firstLineNewStyle));
-    if (auto* listMarkerRenderer = dynamicDowncast<RenderListMarker>(renderer)) {
+    if (auto* listMarkerRenderer = dynamicDowncast<RenderListOutsideMarker>(renderer)) {
         if (auto* elementBox = dynamicDowncast<Layout::ElementBox>(*layoutBox))
             elementBox->setListMarkerAttributes(calculateListMarkerAttribute(*listMarkerRenderer));
     }

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -33,7 +33,7 @@
 #include "RenderImage.h"
 #include "RenderInline.h"
 #include "RenderLineBreak.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderObjectInlines.h"
 #include "RenderSVGBlock.h"
 #include "RenderSVGForeignObject.h"
@@ -58,7 +58,7 @@ bool canUseForIntrinsicWidthComputation(const RenderBlockFlow& blockContainer)
         if (!renderer->isInFlow())
             return false;
 
-        auto isFullySupportedInFlowRenderer = isAnyOf<RenderText, RenderLineBreak, RenderInline, RenderListMarker>(renderer);
+        auto isFullySupportedInFlowRenderer = isAnyOf<RenderText, RenderLineBreak, RenderInline, RenderListOutsideMarker>(renderer);
         if (isFullySupportedInFlowRenderer)
             continue;
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp
@@ -144,15 +144,15 @@ LeafBoxIterator closestBoxForHorizontalPosition(const LineBox& lineBox, float ho
     if (firstBox == lastBox && (!editableOnly || isEditable(firstBox)))
         return firstBox;
 
-    if (firstBox && horizontalPosition <= firstBox->logicalLeft() && !firstBox->renderer().isRenderListMarker() && (!editableOnly || isEditable(firstBox)))
+    if (firstBox && horizontalPosition <= firstBox->logicalLeft() && !firstBox->renderer().isRenderListOutsideMarker() && (!editableOnly || isEditable(firstBox)))
         return firstBox;
 
-    if (lastBox && horizontalPosition >= lastBox->logicalRight() && !lastBox->renderer().isRenderListMarker() && (!editableOnly || isEditable(lastBox)))
+    if (lastBox && horizontalPosition >= lastBox->logicalRight() && !lastBox->renderer().isRenderListOutsideMarker() && (!editableOnly || isEditable(lastBox)))
         return lastBox;
 
     auto closestBox = lastBox;
     for (auto box = firstBox; box; box = box.traverseLogicalRightwardOnLineIgnoringLineBreak()) {
-        if (!box->renderer().isRenderListMarker() && (!editableOnly || isEditable(box))) {
+        if (!box->renderer().isRenderListOutsideMarker() && (!editableOnly || isEditable(box))) {
             if (horizontalPosition < box->logicalRight())
                 return box;
             closestBox = box;

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -63,7 +63,7 @@
 #include "RenderLayoutState.h"
 #include "RenderLineBreak.h"
 #include "RenderListItem.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderObjectInlines.h"
 #include "RenderView.h"
 #include "SVGTextFragment.h"

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -50,7 +50,7 @@ class RenderBlockFlow;
 class RenderBox;
 class RenderBoxModelObject;
 class RenderInline;
-class RenderListMarker;
+class RenderListOutsideMarker;
 struct PaintInfo;
 
 namespace Layout {
@@ -176,7 +176,7 @@ private:
 
     bool NODELETE isContentConsideredStale() const;
 
-    using ExcludedMarkerList = Vector<CheckedPtr<RenderListMarker>>;
+    using ExcludedMarkerList = Vector<CheckedPtr<RenderListOutsideMarker>>;
     ExcludedMarkerList excludedMarkersForFirstFormattedLine(Layout::InlineLayoutState&);
     void setExcludedMarkerPositions(const ExcludedMarkerList&);
 

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -1190,7 +1190,7 @@ Document* LocalFrameViewLayoutContext::document() const
     return frame().document();
 }
 
-ListItemExcludedMarkerScope::ListItemExcludedMarkerScope(LocalFrameViewLayoutContext& layoutContext, RenderListMarker& excludedMarker)
+ListItemExcludedMarkerScope::ListItemExcludedMarkerScope(LocalFrameViewLayoutContext& layoutContext, RenderListOutsideMarker& excludedMarker)
     : m_layoutContext(layoutContext)
 {
     // Nested list items lay out inside their ancestor's layout, so this is a stack: an ancestor stays in it while

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -48,7 +48,7 @@ class RenderBlock;
 class RenderBlockFlow;
 class RenderBox;
 class RenderLayoutState;
-class RenderListMarker;
+class RenderListOutsideMarker;
 class RenderView;
 namespace Layout {
 class LayoutState;
@@ -198,7 +198,7 @@ public:
 
     bool repaintsBlocked() const { return m_repaintsBlocked; }
 
-    using ExcludedMarkerList = Vector<SingleThreadWeakPtr<RenderListMarker>>;
+    using ExcludedMarkerList = Vector<SingleThreadWeakPtr<RenderListOutsideMarker>>;
     const ExcludedMarkerList& excludedMarkers() const LIFETIME_BOUND { return m_excludedMarkers; }
 
 private:
@@ -358,7 +358,7 @@ private:
 
 class ListItemExcludedMarkerScope {
 public:
-    ListItemExcludedMarkerScope(LocalFrameViewLayoutContext&, RenderListMarker&);
+    ListItemExcludedMarkerScope(LocalFrameViewLayoutContext&, RenderListOutsideMarker&);
     ~ListItemExcludedMarkerScope();
 
 private:

--- a/Source/WebCore/rendering/LegacyInlineIterator.h
+++ b/Source/WebCore/rendering/LegacyInlineIterator.h
@@ -26,7 +26,7 @@
 #include "RenderBlockFlow.h"
 #include "RenderChildIterator.h"
 #include "RenderInline.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderText.h"
 #include "TrailingObjects.h"
 #include "UnicodeBidi.h"
@@ -362,7 +362,7 @@ ALWAYS_INLINE UCharDirection LegacyInlineIterator::direction() const
         return surrogateTextDirection(codeUnit);
     }
 
-    if (auto* listMarkerRenderer = dynamicDowncast<RenderListMarker>(*m_renderer))
+    if (auto* listMarkerRenderer = dynamicDowncast<RenderListOutsideMarker>(*m_renderer))
         return listMarkerRenderer->writingMode().isBidiLTR() ? U_LEFT_TO_RIGHT : U_RIGHT_TO_LEFT;
 
     return U_OTHER_NEUTRAL;

--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -401,7 +401,7 @@ void OutlinePainter::collectFocusRingRectsForInline(const RenderInline& renderer
     renderer.collectLineBoxRects(rects, additionalOffset);
 
     for (CheckedRef child : childrenOfType<RenderBoxModelObject>(renderer)) {
-        if (child->isRenderListMarker())
+        if (child->isRenderListOutsideMarker())
             continue;
         FloatPoint pos(additionalOffset);
         // FIXME: This doesn't work correctly with transforms.

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -73,7 +73,7 @@
 #include "RenderLayer.h"
 #include "RenderLayerScrollableArea.h"
 #include "RenderLayoutState.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderMenuList.h"
 #include "RenderObjectInlines.h"
 #include "RenderTableCell.h"

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -5453,7 +5453,7 @@ std::pair<LayoutUnit, LayoutUnit> RenderBlockFlow::computeInlineIntrinsicLogical
         }
 
         // Ignore spaces after a list marker.
-        if (child->isRenderListMarker())
+        if (child->isRenderListOutsideMarker())
             stripFrontSpaces = true;
 
         isPrevChildInlineFlow = !child->isRenderText() && child->isRenderInline();

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -84,7 +84,7 @@
 #include "RenderLayerScrollableArea.h"
 #include "RenderLayoutState.h"
 #include "RenderListItem.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderMathMLBlock.h"
 #include "RenderMultiColumnFlow.h"
 #include "RenderObjectInlines.h"
@@ -5087,7 +5087,7 @@ LayoutUnit RenderBox::lineHeight() const
     auto shouldUseLineHeightFromStyle = [&] {
         if (is<RenderBlock>(*this))
             return true;
-        if (CheckedPtr listMarkerRenderer = dynamicDowncast<RenderListMarker>(*this))
+        if (CheckedPtr listMarkerRenderer = dynamicDowncast<RenderListOutsideMarker>(*this))
             return !listMarkerRenderer->isImage();
         return false;
     };

--- a/Source/WebCore/rendering/RenderElementInlines.h
+++ b/Source/WebCore/rendering/RenderElementInlines.h
@@ -65,7 +65,7 @@ inline bool RenderElement::isAnonymousBlock() const
 #if ENABLE(MATHML)
         && !isRenderMathMLBlock()
 #endif
-        && !isRenderListMarker()
+        && !isRenderListOutsideMarker()
         && !isRenderFragmentedFlow()
         && !isRenderMultiColumnSet()
         && !isRenderView()

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -48,7 +48,7 @@
 #include "RenderLayer.h"
 #include "RenderLayoutState.h"
 #include "RenderLineBreak.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderObjectInlines.h"
 #include "RenderTable.h"
 #include "RenderTheme.h"

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -458,7 +458,7 @@ void RenderListItem::styleDidChange(Style::Difference diff, const Style::Compute
     }
 }
 
-RenderListMarker* RenderListItem::excludedMarker() const
+RenderListOutsideMarker* RenderListItem::excludedMarker() const
 {
     auto* marker = markerBox();
     if (marker && marker->parent() == this && marker->isExcludedMarker())
@@ -512,9 +512,9 @@ void RenderListItem::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintO
     RenderBlockFlow::paintObject(paintInfo, paintOffset);
 }
 
-RenderListMarker* RenderListItem::markerBox() const
+RenderListOutsideMarker* RenderListItem::markerBox() const
 {
-    return dynamicDowncast<RenderListMarker>(m_marker.get());
+    return dynamicDowncast<RenderListOutsideMarker>(m_marker.get());
 }
 
 String RenderListItem::markerText(ListMarkerIncludeSuffix includeSuffix) const
@@ -574,7 +574,7 @@ bool RenderListItem::isInReversedOrderedList() const
     return list && list->isReversed();
 }
 
-void RenderListItem::placeExcludedMarker(RenderListMarker& marker)
+void RenderListItem::placeExcludedMarker(RenderListOutsideMarker& marker)
 {
     auto excludedPosition = marker.excludedPosition();
     CheckedPtr firstFormattedLineRoot = excludedPosition ? excludedPosition->firstFormattedLineRoot.get() : nullptr;
@@ -668,9 +668,9 @@ RenderListItem::FirstFormattedLineCandidate RenderListItem::firstFormattedLineRo
     return { { }, fallbackParent, stoppedAtTableRubyOrReplaced };
 }
 
-Vector<CheckedPtr<RenderListMarker>> RenderListItem::excludedMarkersForContainer(const RenderBlockFlow& inlineRoot, const Vector<SingleThreadWeakPtr<RenderListMarker>>& allExcludedMarkers)
+Vector<CheckedPtr<RenderListOutsideMarker>> RenderListItem::excludedMarkersForContainer(const RenderBlockFlow& inlineRoot, const Vector<SingleThreadWeakPtr<RenderListOutsideMarker>>& allExcludedMarkers)
 {
-    auto markersForContainer = Vector<CheckedPtr<RenderListMarker>> { };
+    auto markersForContainer = Vector<CheckedPtr<RenderListOutsideMarker>> { };
     for (auto& marker : allExcludedMarkers) {
         ASSERT(marker->isExcludedMarker());
         CheckedPtr listItem = marker->listItem();

--- a/Source/WebCore/rendering/RenderListItem.h
+++ b/Source/WebCore/rendering/RenderListItem.h
@@ -23,7 +23,7 @@
 #pragma once
 
 #include "RenderBlockFlow.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 
 namespace WebCore {
 
@@ -51,7 +51,7 @@ public:
 
     RenderBoxModelObject* markerRenderer() const { return m_marker.get(); }
     void setMarkerRenderer(RenderBoxModelObject& marker) { m_marker = marker; }
-    RenderListMarker* markerBox() const;
+    RenderListOutsideMarker* markerBox() const;
 
     // Fills in what the marker shows, in whichever shape it was built.
     void updateMarkerContent();
@@ -65,7 +65,7 @@ public:
         bool stoppedAtTableRubyOrReplaced { false };
     };
     static FirstFormattedLineCandidate firstFormattedLineRootFor(RenderBlock& blockContainer, const RenderBoxModelObject& marker);
-    static Vector<CheckedPtr<RenderListMarker>> excludedMarkersForContainer(const RenderBlockFlow& lineContainer, const Vector<SingleThreadWeakPtr<RenderListMarker>>&);
+    static Vector<CheckedPtr<RenderListOutsideMarker>> excludedMarkersForContainer(const RenderBlockFlow& lineContainer, const Vector<SingleThreadWeakPtr<RenderListOutsideMarker>>&);
 
 private:
     ASCIILiteral renderName() const final { return "RenderListItem"_s; }
@@ -76,8 +76,8 @@ private:
     void layoutBlock(RelayoutChildren, LayoutUnit pageLogicalHeight = 0_lu) final;
     void layoutExcludedChildren(RelayoutChildren) final;
 
-    void placeExcludedMarker(RenderListMarker&);
-    RenderListMarker* excludedMarker() const;
+    void placeExcludedMarker(RenderListOutsideMarker&);
+    RenderListOutsideMarker* excludedMarker() const;
 
     void styleDidChange(Style::Difference, const Style::ComputedStyle* oldStyle) final;
 

--- a/Source/WebCore/rendering/RenderListOutsideMarker.cpp
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.cpp
@@ -23,7 +23,7 @@
  */
 
 #include "config.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 
 #include "BaselineAlignment.h"
 #include "CSSCounterStyleDescriptors.h"
@@ -64,21 +64,21 @@
 
 namespace WebCore {
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderListMarker);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderListOutsideMarker);
 
-RenderListMarker::RenderListMarker(RenderListItem& listItem, Style::ComputedStyle&& style)
-    : RenderBox(Type::ListMarker, listItem.document(), WTF::move(style))
+RenderListOutsideMarker::RenderListOutsideMarker(RenderListItem& listItem, Style::ComputedStyle&& style)
+    : RenderBox(Type::ListOutsideMarker, listItem.document(), WTF::move(style))
     , m_listItem(listItem)
 {
     setInline(true);
     setBlockLevelReplacedOrAtomicInline(true); // pretend to be replaced
-    ASSERT(isRenderListMarker());
+    ASSERT(isRenderListOutsideMarker());
 }
 
 // Do not add any code in below destructor. Add it to willBeDestroyed() instead.
-RenderListMarker::~RenderListMarker() = default;
+RenderListOutsideMarker::~RenderListOutsideMarker() = default;
 
-void RenderListMarker::willBeDestroyed()
+void RenderListOutsideMarker::willBeDestroyed()
 {
     if (m_image)
         protect(m_image)->removeClient(*this);
@@ -90,19 +90,18 @@ static Style::Difference NODELETE adjustedStyleDifference(Style::Difference diff
     if (diff >= Style::DifferenceResult::Layout)
         return diff;
     // FIXME: Preferably we do this at Style::ComputedStyle::changeRequiresLayout but checking against pseudo(::marker) is not sufficient.
-    auto needsLayout =
-           oldStyle.listStylePosition() != newStyle.listStylePosition()
+    auto needsLayout = oldStyle.listStylePosition() != newStyle.listStylePosition()
         || oldStyle.listStyleType() != newStyle.listStyleType()
         || oldStyle.display().isInlineType() != newStyle.display().isInlineType();
     return needsLayout ? Style::DifferenceResult::Layout : diff;
 }
 
-void RenderListMarker::styleWillChange(Style::Difference diff, const Style::ComputedStyle& newStyle)
+void RenderListOutsideMarker::styleWillChange(Style::Difference diff, const Style::ComputedStyle& newStyle)
 {
     RenderBox::styleWillChange(adjustedStyleDifference(diff, style(), newStyle), newStyle);
 }
 
-void RenderListMarker::styleDidChange(Style::Difference diff, const Style::ComputedStyle* oldStyle)
+void RenderListOutsideMarker::styleDidChange(Style::Difference diff, const Style::ComputedStyle* oldStyle)
 {
     if (oldStyle)
         diff = adjustedStyleDifference(diff, *oldStyle, style());
@@ -119,14 +118,14 @@ void RenderListMarker::styleDidChange(Style::Difference diff, const Style::Compu
     }
 }
 
-bool RenderListMarker::isImage() const
+bool RenderListOutsideMarker::isImage() const
 {
     // `content` supersedes list-style-image (css-lists-3 §3.3), so a marker with generated content
     // is never treated as an image marker (affects inline margins, baseline, and layout attributes).
     return m_image && !protect(m_image)->errorOccurred() && !hasContentProperty();
 }
 
-bool RenderListMarker::hasContentProperty() const
+bool RenderListOutsideMarker::hasContentProperty() const
 {
     return document().settings().cssMarkerContentEnabled() && style().content().isData();
 }
@@ -173,7 +172,7 @@ static bool counterStyleChainHasStrongDirectionalitySymbols(const CSSRegisteredC
     }
 }
 
-bool RenderListMarker::textNeedsBidiResolution() const
+bool RenderListOutsideMarker::textNeedsBidiResolution() const
 {
     if (hasContentProperty() || isImage() || synthesizesGlyph() || style().listStyleType().isNone())
         return false;
@@ -191,19 +190,19 @@ bool RenderListMarker::textNeedsBidiResolution() const
     return counterStyleChainHasStrongDirectionalitySymbols(*counterStyle);
 }
 
-bool RenderListMarker::needsContentContainer() const
+bool RenderListOutsideMarker::needsContentContainer() const
 {
     return hasContentProperty() || textNeedsBidiResolution() || synthesizesGlyph();
 }
 
-RenderBlockFlow* RenderListMarker::contentContainer() const
+RenderBlockFlow* RenderListOutsideMarker::contentContainer() const
 {
     // When the marker has generated content, its sole child is the anonymous
     // inline-block box holding that content (created by RenderTreeBuilder::List).
     return dynamicDowncast<RenderBlockFlow>(firstChild());
 }
 
-LayoutRect RenderListMarker::localSelectionRect()
+LayoutRect RenderListOutsideMarker::localSelectionRect()
 {
     return LayoutRect(LayoutPoint(), borderBoxSize());
 }
@@ -223,7 +222,7 @@ static auto textRunForContent(ListMarkerTextContent textContent, const Style::Co
     return { WTF::move(textRun), WTF::move(textForRun) };
 }
 
-void RenderListMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
+void RenderListOutsideMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 {
     if (style().usedVisibility() != Visibility::Visible)
         return;
@@ -308,7 +307,7 @@ void RenderListMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
     }
 
     if (writingMode().isHorizontal()) {
-        // This is required because RenderListMarker hand-draws the text, instead of running inline
+        // This is required because RenderListOutsideMarker hand-draws the text, instead of running inline
         // layout and paint on its (RenderText) subtree (LayoutUnit vs. float precision)
         // FIXME: The vertical path mispositions the marker line box separately (it ignores fallback-font
         // metrics), so this is limited to horizontal writing modes for now. See webkit.org/b/319618.
@@ -321,7 +320,7 @@ void RenderListMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffse
     context.drawText(style().fontCascade(), textRunForContent(m_textContent, style()), textOrigin);
 }
 
-RenderBox* RenderListMarker::parentBox(RenderBox& box)
+RenderBox* RenderListOutsideMarker::parentBox(RenderBox& box)
 {
     ASSERT(m_listItem);
     CheckedPtr multiColumnFlow = dynamicDowncast<RenderMultiColumnFlow>(m_listItem->enclosingFragmentedFlow());
@@ -331,7 +330,7 @@ RenderBox* RenderListMarker::parentBox(RenderBox& box)
     return placeholder ? placeholder->parentBox() : box.parentBox();
 };
 
-void RenderListMarker::layout()
+void RenderListOutsideMarker::layout()
 {
     StackStats::LayoutCheckPoint layoutCheckPoint;
     ASSERT(needsLayout());
@@ -369,7 +368,7 @@ void RenderListMarker::layout()
     clearNeedsLayout();
 }
 
-void RenderListMarker::layoutContentContainer(RenderBlockFlow& container)
+void RenderListOutsideMarker::layoutContentContainer(RenderBlockFlow& container)
 {
     // The marker participates in its list item's line as a single atomic inline. Lay its
     // generated-content subtree out at its max-content (shrink-to-fit) width, like an
@@ -409,7 +408,7 @@ void RenderListMarker::layoutContentContainer(RenderBlockFlow& container)
     addVisualOverflow(contentVisualOverflow);
 }
 
-void RenderListMarker::imageChanged(WrappedImagePtr o, const IntRect* rect)
+void RenderListOutsideMarker::imageChanged(WrappedImagePtr o, const IntRect* rect)
 {
     if (parent()) {
         RefPtr image = m_image;
@@ -431,7 +430,7 @@ void RenderListMarker::imageChanged(WrappedImagePtr o, const IntRect* rect)
     RenderBox::imageChanged(o, rect);
 }
 
-void RenderListMarker::updateInlineMarginsAndContent()
+void RenderListOutsideMarker::updateInlineMarginsAndContent()
 {
     // FIXME: It's messy to use the preferredLogicalWidths dirty bit for this optimization, also unclear if this is premature optimization.
     if (hasInvalidContentLogicalWidths())
@@ -439,7 +438,7 @@ void RenderListMarker::updateInlineMarginsAndContent()
     updateInlineMargins();
 }
 
-void RenderListMarker::updateContent()
+void RenderListOutsideMarker::updateContent()
 {
     if (hasContentProperty()) {
         // css-lists-3 §3.3: `content` (not normal) supersedes list-style-image/type. The generated
@@ -469,7 +468,7 @@ void RenderListMarker::updateContent()
         updateContentContainerText();
 }
 
-void RenderListMarker::updateContentContainerText()
+void RenderListOutsideMarker::updateContentContainerText()
 {
     CheckedPtr container = contentContainer();
     if (!container) {
@@ -491,7 +490,7 @@ void RenderListMarker::updateContentContainerText()
     textRenderer->setText(m_textContent.textWithSuffix);
 }
 
-void RenderListMarker::computeIntrinsicLogicalWidthContributions()
+void RenderListOutsideMarker::computeIntrinsicLogicalWidthContributions()
 {
     ASSERT(hasInvalidContentLogicalWidths());
     updateContent();
@@ -532,7 +531,7 @@ void RenderListMarker::computeIntrinsicLogicalWidthContributions()
     updateInlineMargins();
 }
 
-void RenderListMarker::updateInlineMargins()
+void RenderListOutsideMarker::updateInlineMargins()
 {
     constexpr int markerPadding = listMarkerImagePadding;
     const FontMetrics& fontMetrics = style().metricsOfPrimaryFont();
@@ -571,24 +570,24 @@ void setListMarkerInlineMargins(Style::ComputedStyle& markerStyle, WritingMode l
     markerStyle.setMarginBottom(startIsTop ? endEdge : startEdge);
 }
 
-bool RenderListMarker::isDisclosureMarker() const
+bool RenderListOutsideMarker::isDisclosureMarker() const
 {
     return listMarkerIsDisclosure(style(), protect(document()));
 }
 
-RenderListItem* RenderListMarker::listItem() const
+RenderListItem* RenderListOutsideMarker::listItem() const
 {
     return m_listItem.get();
 }
 
-void RenderListMarker::setExcludedPosition(ExcludedPosition excludedPosition)
+void RenderListOutsideMarker::setExcludedPosition(ExcludedPosition excludedPosition)
 {
     ASSERT(excludedPosition.firstFormattedLineRoot);
 
     m_excludedPosition = excludedPosition;
 }
 
-void RenderListMarker::invalidateExcludedMarkerContainer()
+void RenderListOutsideMarker::invalidateExcludedMarkerContainer()
 {
     ASSERT(m_excludedPosition);
 
@@ -603,12 +602,12 @@ void RenderListMarker::invalidateExcludedMarkerContainer()
     m_excludedPosition = { };
 }
 
-Node* RenderListMarker::nodeForHitTest() const
+Node* RenderListOutsideMarker::nodeForHitTest() const
 {
     return m_listItem ? m_listItem->element() : nullptr;
 }
 
-FloatRect RenderListMarker::relativeMarkerRect()
+FloatRect RenderListOutsideMarker::relativeMarkerRect()
 {
     if (isImage())
         return { 0.f, 0.f, protect(m_image)->imageSize(this, style().usedZoom()).width(), protect(m_image)->imageSize(this, style().usedZoom()).height() };
@@ -627,7 +626,7 @@ FloatRect RenderListMarker::relativeMarkerRect()
     return relativeRect;
 }
 
-LayoutRect RenderListMarker::selectionRectForRepaint(const RenderLayerModelObject*, bool)
+LayoutRect RenderListOutsideMarker::selectionRectForRepaint(const RenderLayerModelObject*, bool)
 {
     ASSERT(!needsLayout());
     return { };
@@ -641,7 +640,7 @@ static RefPtr<CSSRegisteredCounterStyle> counterStyleFor(const Style::ComputedSt
     return document.counterStyleRegistry().resolvedCounterStyle(*counterStyle);
 }
 
-RefPtr<CSSRegisteredCounterStyle> RenderListMarker::counterStyle() const
+RefPtr<CSSRegisteredCounterStyle> RenderListOutsideMarker::counterStyle() const
 {
     return counterStyleFor(style(), protect(document()));
 }
@@ -697,7 +696,7 @@ ListMarkerTextContent listMarkerTextContent(const Style::ComputedStyle& markerSt
     return textContent;
 }
 
-bool RenderListMarker::synthesizesGlyph() const
+bool RenderListOutsideMarker::synthesizesGlyph() const
 {
     // `content` supersedes list-style-type, so a content marker never draws in place of a glyph, and a list-style-image marker draws the image instead.
     if (hasContentProperty() || isImage())
@@ -706,7 +705,7 @@ bool RenderListMarker::synthesizesGlyph() const
     return listType.isCircle() || listType.isDisc() || listType.isSquare();
 }
 
-std::pair<float, float> RenderListMarker::layoutBoundForTextContent(String text) const
+std::pair<float, float> RenderListOutsideMarker::layoutBoundForTextContent(String text) const
 {
     // FIXME: This should be part of InlineBoxBuilder (webkit.org/b/294342)
     // This is essentially what we do in LineBoxBuilder::enclosingAscentDescentWithFallbackFonts.

--- a/Source/WebCore/rendering/RenderListOutsideMarker.h
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.h
@@ -48,13 +48,13 @@ struct ListMarkerTextContent {
 };
 
 // Used to render the list item's marker.
-// The RenderListMarker always has to be a child of a RenderListItem.
-class RenderListMarker final : public RenderBox {
-    WTF_MAKE_TZONE_ALLOCATED(RenderListMarker);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderListMarker);
+// The RenderListOutsideMarker always has to be a child of a RenderListItem.
+class RenderListOutsideMarker final : public RenderBox {
+    WTF_MAKE_TZONE_ALLOCATED(RenderListOutsideMarker);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderListOutsideMarker);
 public:
-    RenderListMarker(RenderListItem&, Style::ComputedStyle&&);
-    virtual ~RenderListMarker();
+    RenderListOutsideMarker(RenderListItem&, Style::ComputedStyle&&);
+    virtual ~RenderListOutsideMarker();
 
     using IncludeSuffix = ListMarkerIncludeSuffix;
     String textContent(IncludeSuffix includeSuffix = IncludeSuffix::Yes) const
@@ -155,4 +155,4 @@ void setListMarkerInlineMargins(Style::ComputedStyle& markerStyle, WritingMode l
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderListMarker, isRenderListMarker())
+SPECIALIZE_TYPE_TRAITS_RENDER_OBJECT(RenderListOutsideMarker, isRenderListOutsideMarker())

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -69,7 +69,7 @@
 #include "RenderLayerCompositor.h"
 #include "RenderLayerScrollableArea.h"
 #include "RenderLineBreak.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderMultiColumnFlow.h"
 #include "RenderMultiColumnSet.h"
 #include "RenderMultiColumnSpannerPlaceholder.h"
@@ -3151,7 +3151,7 @@ bool RenderObject::isExcludedMarker() const
 {
     // An excluded list marker is the direct child of its list item, never wrapped in an anonymous block, and no part of in-flow layout.
     // Only markers whose first formatted line lives in a descendant block qualify (see childrenInline)
-    auto* marker = dynamicDowncast<RenderListMarker>(*this);
+    auto* marker = dynamicDowncast<RenderListOutsideMarker>(*this);
     if (!marker)
         return false;
     if (!document().settings().listMarkerPositionedPostLayoutEnabled())

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -145,7 +145,7 @@ public:
         LineBreak,
         ListBox,
         ListItem,
-        ListMarker,
+        ListOutsideMarker,
         Media,
         MenuList,
         Meter,
@@ -452,7 +452,7 @@ public:
     virtual bool isImage() const { return false; }
     bool isRenderListBox() const { return type() == Type::ListBox; }
     bool isRenderListItem() const { return type() == Type::ListItem; }
-    bool isRenderListMarker() const { return type() == Type::ListMarker; }
+    bool isRenderListOutsideMarker() const { return type() == Type::ListOutsideMarker; }
     bool isRenderMedia() const { return isRenderReplaced() && m_typeSpecificFlags.replacedFlags().contains(ReplacedFlag::IsMedia); }
     bool isRenderMenuList() const { return type() == Type::MenuList; }
     bool isRenderMeter() const { return type() == Type::Meter; }

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1810,7 +1810,7 @@ void RenderText::setRenderedText(const String& newText)
         break;
 #if !PLATFORM(IOS_FAMILY)
     // We use the same characters here as for list markers.
-    // See the listMarkerText function in RenderListMarker.cpp.
+    // See the listMarkerText function in RenderListOutsideMarker.cpp.
     case TextSecurity::Circle:
         secureText(whiteBullet);
         break;

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -65,7 +65,7 @@
 #include "RenderLayerScrollableArea.h"
 #include "RenderLineBreak.h"
 #include "RenderListItem.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderObjectInlines.h"
 #include "RenderQuote.h"
 #include "RenderSVGContainer.h"
@@ -364,8 +364,8 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
     if (auto* cell = dynamicDowncast<RenderTableCell>(o))
         ts << " [r="_s << cell->rowIndex() << " c="_s << cell->col() << " rs="_s << cell->rowSpan() << " cs="_s << cell->colSpan() << ']';
 
-    if (auto* listMarker = dynamicDowncast<RenderListMarker>(o)) {
-        auto text = listMarker->textContent(RenderListMarker::IncludeSuffix::No);
+    if (auto* listMarker = dynamicDowncast<RenderListOutsideMarker>(o)) {
+        auto text = listMarker->textContent(RenderListOutsideMarker::IncludeSuffix::No);
         if (!text.isEmpty()) {
             if (text.length() != 1)
                 text = quoteAndEscapeNonPrintables(text);
@@ -549,7 +549,7 @@ void write(TextStream& ts, const RenderObject& renderer, OptionSet<RenderAsTextF
         return;
     }
 
-    if (CheckedPtr listMarker = dynamicDowncast<RenderListMarker>(renderer); listMarker && listMarker->synthesizesGlyph())
+    if (CheckedPtr listMarker = dynamicDowncast<RenderListOutsideMarker>(renderer); listMarker && listMarker->synthesizesGlyph())
         return;
 
     for (auto& child : childrenOfType<RenderObject>(downcast<RenderElement>(renderer))) {
@@ -921,7 +921,7 @@ String markerTextForListItem(Element* element)
     auto* renderer = dynamicDowncast<RenderListItem>(element->renderer());
     if (!renderer)
         return String();
-    return renderer->markerText(RenderListMarker::IncludeSuffix::No);
+    return renderer->markerText(RenderListOutsideMarker::IncludeSuffix::No);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -35,7 +35,7 @@
 #include "Logging.h"
 #include "RenderBlock.h"
 #include "RenderElementInlines.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderObjectInlines.h"
 #include "RenderText.h"
 #include "RenderTextFragment.h"
@@ -246,7 +246,7 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
             parentRenderer = parentRenderer->parent();
 
         // If we have a list we should resize ListMarkers separately.
-        if (auto* listMarkerRenderer = dynamicDowncast<RenderListMarker>(*parentRenderer->firstChild())) {
+        if (auto* listMarkerRenderer = dynamicDowncast<RenderListOutsideMarker>(*parentRenderer->firstChild())) {
             auto style = cloneRenderStyleWithState(listMarkerRenderer->style());
             style.setFontDescription(FontCascadeDescription { fontDescription });
             listMarkerRenderer->setStyle(WTF::move(style));

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -35,7 +35,7 @@
 #include "RenderInline.h"
 #include "RenderLayer.h"
 #include "RenderLineBreak.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderSVGInlineText.h"
 #include "RenderTextInlines.h"
 #include "TrailingObjects.h"
@@ -673,7 +673,7 @@ inline void BreakingContext::commitAndUpdateLineBreakIfNeeded()
     if (!m_current.renderer()->isFloatingOrOutOfFlowPositioned()) {
         m_lastObject = m_current.renderer();
         if (m_lastObject->isBlockLevelReplacedOrAtomicInline() && m_autoWrap && (!m_lastObject->isImage() || m_allowImagesToBreak)) {
-            if (!is<RenderListMarker>(*m_lastObject)) {
+            if (!is<RenderListOutsideMarker>(*m_lastObject)) {
                 if (m_nextObject)
                     commitLineBreakAtCurrentWidth(*m_nextObject);
                 else

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 class RenderGrid;
 class RenderListItem;
-class RenderListMarker;
+class RenderListOutsideMarker;
 class RenderTreeUpdater;
 
 class RenderTreeBuilder {

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
@@ -91,7 +91,7 @@ struct ParentAndBeforeChild {
 
 static bool isExcludedMarker(const RenderBlock& parent, const RenderObject& child)
 {
-    CheckedPtr marker = dynamicDowncast<RenderListMarker>(child);
+    CheckedPtr marker = dynamicDowncast<RenderListOutsideMarker>(child);
     if (!marker || !marker->document().settings().listMarkerPositionedPostLayoutEnabled())
         return false;
     CheckedPtr listItem = dynamicDowncast<RenderListItem>(parent);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -29,7 +29,7 @@
 #include "RenderBlockFlow.h"
 #include "RenderChildIterator.h"
 #include "RenderImage.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderMenuList.h"
 #include "RenderMultiColumnFlow.h"
 #include "RenderObjectStyle.h"
@@ -50,7 +50,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderTreeBuilder::List);
 static RenderObject* firstNonMarkerChild(RenderBlock& parent)
 {
     RenderObject* child = parent.firstChild();
-    while (is<RenderListMarker>(child))
+    while (is<RenderListOutsideMarker>(child))
         child = child->nextSibling();
     return child;
 }
@@ -77,7 +77,7 @@ struct MarkerParentSearchResult {
     bool shouldCollapseAnonymousBlockParent { false };
 };
 
-static MarkerParentSearchResult parentCandidateForMarker(RenderListItem& listItemRenderer, const RenderListMarker& marker)
+static MarkerParentSearchResult parentCandidateForMarker(RenderListItem& listItemRenderer, const RenderListOutsideMarker& marker)
 {
     if (listItemRenderer.document().settings().listMarkerPositionedPostLayoutEnabled() && !markerNeedsOwnLine(listItemRenderer)) {
         // The outside marker is always the list item's first child and it takes no part in in-flow layout.
@@ -211,7 +211,7 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
         return;
     }
 
-    RenderPtr<RenderListMarker> newMarkerRenderer = WebCore::createRenderer<RenderListMarker>(listItemRenderer, WTF::move(newStyle));
+    RenderPtr<RenderListOutsideMarker> newMarkerRenderer = WebCore::createRenderer<RenderListOutsideMarker>(listItemRenderer, WTF::move(newStyle));
     newMarkerRenderer->initializeStyle();
     m_builder.addListItemNeedingMarkerUpdate(listItemRenderer);
     listItemRenderer.setMarkerRenderer(*newMarkerRenderer);
@@ -271,14 +271,14 @@ void RenderTreeBuilder::List::buildInlineMarker(RenderListItem& listItemRenderer
     m_builder.attach(marker.get(), WTF::move(textRenderer));
 }
 
-void RenderTreeBuilder::List::buildMarkerContentRenderers(RenderListMarker& marker)
+void RenderTreeBuilder::List::buildMarkerContentRenderers(RenderListOutsideMarker& marker)
 {
     ASSERT(marker.needsContentContainer());
     ASSERT(!marker.contentContainer());
 
     // css-lists-3 §3.3 generates the marker contents "exactly as for ::before": an anonymous
     // inline-block box holding the content list (strings, images, counters, quotes). The marker
-    // (RenderListMarker) lays this box out and paints it as a single atomic inline.
+    // (RenderListOutsideMarker) lays this box out and paints it as a single atomic inline.
     auto containerStyle = Style::ComputedStyle::createAnonymousStyleWithDisplay(marker.style(), Style::DisplayType::InlineFlowRoot);
     auto newContainer = WebCore::createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, marker.document(), WTF::move(containerStyle));
     newContainer->initializeStyle();
@@ -288,7 +288,7 @@ void RenderTreeBuilder::List::buildMarkerContentRenderers(RenderListMarker& mark
     if (!marker.hasContentProperty()) {
         // list-style-type text that needs renderers of its own, so inline layout can bidi-resolve it.
         // The text itself is only known once counter values resolve, so start empty and let
-        // RenderListMarker::updateContent() fill it in at layout time.
+        // RenderListOutsideMarker::updateContent() fill it in at layout time.
         auto textRenderer = WebCore::createRenderer<RenderText>(RenderObject::Type::Text, marker.document(), emptyString());
         m_builder.attach(container.get(), WTF::move(textRenderer));
         return;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-class RenderListMarker;
+class RenderListOutsideMarker;
 
 class RenderTreeBuilder::List {
     WTF_MAKE_TZONE_ALLOCATED(List);
@@ -43,7 +43,7 @@ public:
 private:
     // Builds the anonymous inline-block subtree holding the ::marker's generated content
     // (css-lists-3 §3.3). The caller tears down any prior content first.
-    void buildMarkerContentRenderers(RenderListMarker&);
+    void buildMarkerContentRenderers(RenderListOutsideMarker&);
     void buildInlineMarker(RenderListItem&, Style::ComputedStyle&&);
 
     RenderTreeBuilder& m_builder;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
@@ -28,7 +28,7 @@
 #include "RenderChildIterator.h"
 #include "RenderElementInlines.h"
 #include "RenderInline.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderMultiColumnFlow.h"
 #include "RenderMultiColumnSet.h"
 #include "RenderMultiColumnSpannerPlaceholder.h"
@@ -308,8 +308,8 @@ void RenderTreeBuilder::MultiColumn::createFragmentedFlow(RenderBlockFlow& flow)
 
     // An excluded marker takes no part in multi-column layout, and the list item positions it against its first
     // formatted line afterwards, which it can only do while the marker is still its own child.
-    CheckedPtr<RenderListMarker> excludedMarker;
-    for (auto& marker : childrenOfType<RenderListMarker>(flow)) {
+    CheckedPtr<RenderListOutsideMarker> excludedMarker;
+    for (auto& marker : childrenOfType<RenderListOutsideMarker>(flow)) {
         if (marker.isExcludedMarker()) {
             excludedMarker = &marker;
             break;

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -44,7 +44,7 @@
 #include "RenderElement.h"
 #include "RenderElementInlines.h"
 #include "RenderListItem.h"
-#include "RenderListMarker.h"
+#include "RenderListOutsideMarker.h"
 #include "RenderView.h"
 #include "StyleAnimations.h"
 #include "StyleableInlines.h"


### PR DESCRIPTION
#### 10ace68e7cd8d81ef2da87b682e4df3ca7e67637
<pre>
[list-marker] Rename RenderListMarker to RenderListOutsideMarker
<a href="https://bugs.webkit.org/show_bug.cgi?id=323226">https://bugs.webkit.org/show_bug.cgi?id=323226</a>
<a href="https://rdar.apple.com/problem/186472147">rdar://problem/186472147</a>

Reviewed by Antti Koivisto.

An inside marker is built as an anonymous inline box now, so this renderer is only ever created for
list-style-position: outside: the marker the list item excludes from its content and positions itself. Name it for
what it is.

renderName() keeps returning &quot;RenderListMarker&quot; so that no expected results move; the name in the render tree dumps
is what the marker is called in CSS terms, not the class name.

No change in behavior.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onTextRunsChanged):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarkerRange::toString const):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::canHaveChildren const):
(WebCore::AccessibilityNodeObject::stitchGroups const):
(WebCore::AccessibilityNodeObject::stringValue const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::parentObject const):
(WebCore::AccessibilityRenderObject::textUnderElement const):
(WebCore::AccessibilityRenderObject::stringValue const):
(WebCore::AccessibilityRenderObject::boundingBoxRect const):
(WebCore::AccessibilityRenderObject::computeIsIgnored const):
(WebCore::AccessibilityRenderObject::listMarkerText const):
(WebCore::AccessibilityRenderObject::determineAccessibilityRole):
(WebCore::AccessibilityRenderObject::addChildren):
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::textAttributes const):
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::BoxGeometryUpdater::setListMarkerOffsetForMarkerOutside):
(WebCore::LayoutIntegration::baselineForBox):
(WebCore::LayoutIntegration::setIntegrationBaseline):
(WebCore::LayoutIntegration::BoxGeometryUpdater::updateBoxGeometryAfterIntegrationLayout):
(WebCore::LayoutIntegration::BoxGeometryUpdater::updateBoxGeometry):
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h:
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::elementAttributes):
(WebCore::LayoutIntegration::calculateListMarkerAttribute):
(WebCore::LayoutIntegration::BoxTreeUpdater::createLayoutBox):
(WebCore::LayoutIntegration::BoxTreeUpdater::updateStyle):
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::canUseForIntrinsicWidthComputation):
* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.cpp:
(WebCore::InlineIterator::closestBoxForHorizontalPosition):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::ListItemExcludedMarkerScope::ListItemExcludedMarkerScope):
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/rendering/LegacyInlineIterator.h:
(WebCore::LegacyInlineIterator::direction const):
* Source/WebCore/rendering/OutlinePainter.cpp:
(WebCore::OutlinePainter::collectFocusRingRectsForInline):
* Source/WebCore/rendering/RenderBlock.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::computeInlineIntrinsicLogicalWidths const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::lineHeight const):
* Source/WebCore/rendering/RenderElementInlines.h:
(WebCore::RenderElement::isAnonymousBlock const):
* Source/WebCore/rendering/RenderInline.cpp:
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::excludedMarker const):
(WebCore::RenderListItem::markerBox const):
(WebCore::RenderListItem::placeExcludedMarker):
(WebCore::RenderListItem::excludedMarkersForContainer):
* Source/WebCore/rendering/RenderListItem.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::isExcludedMarker const):
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::isRenderListOutsideMarker const):
(WebCore::RenderObject::isRenderListMarker const): Deleted.
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::setRenderedText):
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::RenderTreeAsText::writeRenderObject):
(WebCore::write):
(WebCore::markerTextForListItem):
* Source/WebCore/rendering/TextAutoSizing.cpp:
(WebCore::TextAutoSizingValue::adjustTextNodeSizes):
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::BreakingContext::commitAndUpdateLineBreakIfNeeded):
* Source/WebCore/rendering/updating/RenderTreeBuilder.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp:
(WebCore::isExcludedMarker):
* Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp:
(WebCore::firstNonMarkerChild):
(WebCore::parentCandidateForMarker):
(WebCore::RenderTreeBuilder::List::updateItemMarker):
(WebCore::RenderTreeBuilder::List::buildMarkerContentRenderers):
* Source/WebCore/rendering/updating/RenderTreeBuilderList.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp:
(WebCore::RenderTreeBuilder::MultiColumn::createFragmentedFlow):
* Source/WebCore/style/Styleable.cpp:
* Source/WebCore/rendering/RenderListOutsideMarker.cpp: Renamed from Source/WebCore/rendering/RenderListMarker.cpp.
(WebCore::RenderListOutsideMarker::RenderListOutsideMarker):
(WebCore::RenderListOutsideMarker::willBeDestroyed):
(WebCore::adjustedStyleDifference):
(WebCore::RenderListOutsideMarker::styleWillChange):
(WebCore::RenderListOutsideMarker::styleDidChange):
(WebCore::RenderListOutsideMarker::isImage const):
(WebCore::RenderListOutsideMarker::hasContentProperty const):
(WebCore::RenderListOutsideMarker::textNeedsBidiResolution const):
(WebCore::RenderListOutsideMarker::needsContentContainer const):
(WebCore::RenderListOutsideMarker::contentContainer const):
(WebCore::RenderListOutsideMarker::localSelectionRect):
(WebCore::RenderListOutsideMarker::paint):
(WebCore::RenderListOutsideMarker::parentBox):
(WebCore::RenderListOutsideMarker::layout):
(WebCore::RenderListOutsideMarker::layoutContentContainer):
(WebCore::RenderListOutsideMarker::imageChanged):
(WebCore::RenderListOutsideMarker::updateInlineMarginsAndContent):
(WebCore::RenderListOutsideMarker::updateContent):
(WebCore::RenderListOutsideMarker::updateContentContainerText):
(WebCore::RenderListOutsideMarker::computeIntrinsicLogicalWidthContributions):
(WebCore::RenderListOutsideMarker::updateInlineMargins):
(WebCore::RenderListOutsideMarker::isDisclosureMarker const):
(WebCore::RenderListOutsideMarker::listItem const):
(WebCore::RenderListOutsideMarker::setExcludedPosition):
(WebCore::RenderListOutsideMarker::invalidateExcludedMarkerContainer):
(WebCore::RenderListOutsideMarker::nodeForHitTest const):
(WebCore::RenderListOutsideMarker::relativeMarkerRect):
(WebCore::RenderListOutsideMarker::selectionRectForRepaint):
(WebCore::RenderListOutsideMarker::counterStyle const):
(WebCore::RenderListOutsideMarker::synthesizesGlyph const):
(WebCore::RenderListOutsideMarker::layoutBoundForTextContent const):
* Source/WebCore/rendering/RenderListOutsideMarker.h: Renamed from Source/WebCore/rendering/RenderListMarker.h.

Canonical link: <a href="https://commits.webkit.org/320509@main">https://commits.webkit.org/320509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/756c3e1ce8375e56384fa2e54a63f258a2b6b1af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195294 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c92fa39-a153-464c-8014-8b2fb995d4be) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186821 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58606 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144544 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a1b8cc25-09b8-4f7b-81cd-58822a2def79) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124832 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dc52a551-f2a7-450d-bce3-8106fccae837) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46938 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157307 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44704 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6346 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197242 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58547 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154019 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41245 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59255 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153676 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48189 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131547 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128175 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57749 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19720 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57108 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57357 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57185 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->