### PR TITLE
[css-values-5] attr() stops invalidating on attribute change after a view transition

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-invalidation-after-stylesheet-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-invalidation-after-stylesheet-change-expected.txt
@@ -1,0 +1,3 @@
+
+PASS attr() invalidates on attribute change after a style sheet is added
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-invalidation-after-stylesheet-change.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-invalidation-after-stylesheet-change.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>CSS Values and Units Test: attr() invalidation after a style sheet change</title>
+<meta name="assert" content="attr() keeps invalidating on attribute change after the style resolver is rebuilt by a style sheet change">
+<link rel="help" href="https://drafts.csswg.org/css-values/#attr-notation">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #target {
+    width: attr(data-foo type(<length>));
+  }
+</style>
+<div id="target" data-foo="10px"></div>
+<script>
+test(() => {
+  assert_equals(getComputedStyle(target).width, "10px");
+
+  target.setAttribute("data-foo", "20px");
+  assert_equals(getComputedStyle(target).width, "20px");
+
+  // Rebuilds the rule sets, which is where the attr() dependency used to live. The style has to
+  // reach the resolver before the next attribute change, otherwise the change is invalidated
+  // against the old rule sets and the dependency is still there.
+  const style = document.createElement("style");
+  style.textContent = "#unrelated { color: red }";
+  document.head.appendChild(style);
+  getComputedStyle(document.body).color;
+
+  target.setAttribute("data-foo", "30px");
+  assert_equals(getComputedStyle(target).width, "30px");
+
+  target.setAttribute("data-foo", "40px");
+  assert_equals(getComputedStyle(target).width, "40px");
+}, "attr() invalidates on attribute change after a style sheet is added");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-invalidation-after-view-transition-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-invalidation-after-view-transition-expected.txt
@@ -1,0 +1,3 @@
+
+PASS attr() invalidates on attribute change across repeated view transitions
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-invalidation-after-view-transition.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-invalidation-after-view-transition.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>CSS Values and Units Test: attr() invalidation after a view transition</title>
+<meta name="assert" content="attr() keeps invalidating on attribute change after a view transition has torn down its dynamically generated styles">
+<link rel="help" href="https://drafts.csswg.org/css-values/#attr-notation">
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/#dom-document-startviewtransition">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  /* No view-transition-name here on purpose. A participating element gets re-resolved by the
+     transition itself, which would hide a lost attr() dependency. Only the root participates. */
+  #target {
+    width: attr(data-foo type(<length>));
+    height: 10px;
+  }
+</style>
+<div id="target" data-foo="10px"></div>
+<script>
+promise_test(async () => {
+  assert_equals(getComputedStyle(target).width, "10px");
+
+  for (const width of ["20px", "30px", "40px"]) {
+    const transition = document.startViewTransition(() => {
+      target.setAttribute("data-foo", width);
+    });
+    await transition.finished;
+    assert_equals(getComputedStyle(target).width, width);
+  }
+}, "attr() invalidates on attribute change across repeated view transitions");
+</script>

--- a/Source/WebCore/style/AttributeChangeInvalidation.cpp
+++ b/Source/WebCore/style/AttributeChangeInvalidation.cpp
@@ -58,15 +58,18 @@ void AttributeChangeInvalidation::invalidateStyle(const QualifiedName& attribute
             mayAffectStyleInShadowTree = true;
         if (features.attributesAffectingHost.contains(attributeNameForLookups))
             shouldInvalidateCurrent = true;
-        else if (auto affectsShadowTree = features.substitutionAttributeNamesInRules.getOptional(attributeNameForLookups)) {
-            shouldInvalidateCurrent = true;
-            // Only invalidate the host's shadow subtree if a shadow-piercing rule (::part(),
-            // ::placeholder, etc.) actually uses attr() on this attribute and the element has
-            // a shadow tree to invalidate.
-            if (m_element->shadowRoot() && *affectsShadowTree == RuleFeatureSet::AffectsShadowTree::Yes)
-                mayAffectStyleInShadowTree = true;
-        }
     });
+
+    // attr() only reads attributes of the element being styled, so the dependency is registered on
+    // that element's scope and a single lookup covers it.
+    if (auto affectsShadowTree = Scope::forNode(m_element.get()).substitutionAttribute(attributeNameForLookups)) {
+        shouldInvalidateCurrent = true;
+        // Only invalidate the host's shadow subtree if a shadow-piercing rule (::part(),
+        // ::placeholder, etc.) actually uses attr() on this attribute and the element has
+        // a shadow tree to invalidate.
+        if (m_element->shadowRoot() && *affectsShadowTree == AttributeAffectsShadowTree::Yes)
+            mayAffectStyleInShadowTree = true;
+    }
 
     if (mayAffectStyleInShadowTree) {
         // FIXME: More fine-grained invalidation.

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -622,12 +622,6 @@ void RuleFeatureSet::add(const RuleFeatureSet& other)
     idsMatchingAncestorsInRules.addAll(other.idsMatchingAncestorsInRules);
     attributeLowercaseLocalNamesInRules.addAll(other.attributeLowercaseLocalNamesInRules);
     attributeLocalNamesInRules.addAll(other.attributeLocalNamesInRules);
-    for (auto& [name, affectsShadowTree] : other.substitutionAttributeNamesInRules) {
-        if (affectsShadowTree == AffectsShadowTree::Yes)
-            substitutionAttributeNamesInRules.set(name, AffectsShadowTree::Yes);
-        else
-            substitutionAttributeNamesInRules.add(name, AffectsShadowTree::No);
-    }
 
     auto addMap = [&](auto& map, auto& otherMap) {
         for (auto& keyValuePair : otherMap) {
@@ -660,17 +654,6 @@ void RuleFeatureSet::add(const RuleFeatureSet& other)
     usesHasPseudoClass = usesHasPseudoClass || other.usesHasPseudoClass;
 }
 
-void RuleFeatureSet::registerSubstitutionAttribute(const AtomString& attributeName, AffectsShadowTree affectsShadowTree)
-{
-    auto lowercaseName = attributeName.convertToASCIILowercase();
-    if (affectsShadowTree == AffectsShadowTree::Yes)
-        substitutionAttributeNamesInRules.set(lowercaseName, AffectsShadowTree::Yes);
-    else
-        substitutionAttributeNamesInRules.add(lowercaseName, AffectsShadowTree::No);
-    attributeLowercaseLocalNamesInRules.add(attributeName);
-    attributeLocalNamesInRules.add(attributeName);
-}
-
 void RuleFeatureSet::clear()
 {
     RELEASE_ASSERT(isMainThread());
@@ -679,7 +662,6 @@ void RuleFeatureSet::clear()
     idsMatchingAncestorsInRules.clear();
     attributeLowercaseLocalNamesInRules.clear();
     attributeLocalNamesInRules.clear();
-    substitutionAttributeNamesInRules.clear();
     idRules.clear();
     classRules.clear();
     hasPseudoClassRules.clear();

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -133,9 +133,6 @@ struct RuleFeatureSet {
     };
     void collectFeatures(CollectionContext&, const RuleData&, const Vector<Ref<const StyleRuleScope>>& scopeRules = { });
 
-    enum class AffectsShadowTree : bool { No, Yes };
-    void registerSubstitutionAttribute(const AtomString&, AffectsShadowTree = AffectsShadowTree::No);
-
     bool usesRelation(MatchElement::Relation relation) const { return usedRelations[std::to_underlying(relation)]; }
     void setUsesRelation(MatchElement::Relation relation) { usedRelations[std::to_underlying(relation)] = true; }
 
@@ -143,9 +140,6 @@ struct RuleFeatureSet {
     HashSet<AtomString> idsMatchingAncestorsInRules;
     HashSet<AtomString> attributeLowercaseLocalNamesInRules;
     HashSet<AtomString> attributeLocalNamesInRules;
-    // Maps the attribute name to whether at least one rule referencing it via attr() pierces a
-    // shadow boundary (e.g. ::part(), document author rules matching UA-shadow pseudos).
-    HashMap<AtomString, AffectsShadowTree> substitutionAttributeNamesInRules;
 
     HashMap<AtomString, std::unique_ptr<RuleFeatureVector>> idRules;
     HashMap<AtomString, std::unique_ptr<RuleFeatureVector>> classRules;

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -804,15 +804,18 @@ void Resolver::setGlobalStateAfterApplyingProperties(const BuilderState& builder
     // FIXME: This stuff should be somewhere else.
     auto* currentScope = builderState.element() ? &Scope::forNode(*builderState.element()) : nullptr;
     for (auto& entry : builderState.registeredSubstitutionAttributes()) {
-        ruleSets().mutableFeatures().registerSubstitutionAttribute(entry.name);
-        // For attr() applied to a pseudo-element, the originating element's scope may be
-        // different from this resolver's (e.g. ::placeholder styled in a UA shadow scope, with
-        // the originating <input> in the document scope). Register there too so attribute
-        // changes on the originating element trigger AttributeChangeInvalidation; mark the entry
-        // as shadow-tree-affecting on the originating scope so we only invalidate the host's
-        // shadow subtree when a shadow-piercing rule is the source of the dependency.
-        if (CheckedPtr targetScope = entry.targetScope.get(); targetScope && targetScope.get() != currentScope)
-            const_cast<Scope&>(*targetScope).resolver().ruleSets().mutableFeatures().registerSubstitutionAttribute(entry.name, RuleFeatureSet::AffectsShadowTree::Yes);
+        // Register on the scope of the element the attribute is read from, which is where
+        // AttributeChangeInvalidation looks when that attribute changes. For attr() applied to a
+        // pseudo-element that may differ from the scope being styled (e.g. ::placeholder styled in
+        // a UA shadow scope, with the originating <input> in the document scope); remember that so
+        // we only invalidate the host's shadow subtree when a shadow-piercing rule is the source of
+        // the dependency.
+        CheckedPtr targetScope = entry.targetScope.get();
+        auto* scope = targetScope ? targetScope.get() : currentScope;
+        if (!scope)
+            continue;
+        auto affectsShadowTree = scope != currentScope ? AttributeAffectsShadowTree::Yes : AttributeAffectsShadowTree::No;
+        scope->registerSubstitutionAttribute(entry.name, affectsShadowTree);
     }
     if (builderState.style().usesViewportUnits())
         document().setHasStyleWithViewportUnits();

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -175,6 +175,15 @@ void Scope::clearResolver()
     counterStyleRegistry().clearAuthorCounterStyles();
 }
 
+void Scope::registerSubstitutionAttribute(const AtomString& attributeName, AttributeAffectsShadowTree affectsShadowTree) const
+{
+    auto lowercaseName = attributeName.convertToASCIILowercase();
+    if (affectsShadowTree == AttributeAffectsShadowTree::Yes)
+        m_substitutionAttributes.set(lowercaseName, AttributeAffectsShadowTree::Yes);
+    else
+        m_substitutionAttributes.add(lowercaseName, AttributeAffectsShadowTree::No);
+}
+
 void Scope::releaseMemory()
 {
 #if ENABLE(CSS_SELECTOR_JIT)

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -74,6 +74,10 @@ class MatchResultCache;
 class Resolver;
 class RuleSet;
 
+// Whether a dependency on an attribute reaches past a shadow boundary, via a shadow-piercing
+// rule like ::part() or a document author rule matching a UA shadow pseudo-element.
+enum class AttributeAffectsShadowTree : bool { No, Yes };
+
 class Scope : public CanMakeWeakPtr<Scope>, public CanMakeCheckedPtr<Scope>, public Identified<ScopeIdentifier> {
     WTF_MAKE_TZONE_ALLOCATED(Scope);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Scope);
@@ -149,6 +153,12 @@ public:
     CustomPropertyRegistry& customPropertyRegistry() LIFETIME_BOUND { return m_customPropertyRegistry.get(); }
     const CSSCounterStyleRegistry& counterStyleRegistry() const LIFETIME_BOUND { return m_counterStyleRegistry.get(); }
     CSSCounterStyleRegistry& counterStyleRegistry() LIFETIME_BOUND { return m_counterStyleRegistry.get(); }
+
+    // Names of the attributes that attr() has been seen reading from elements in this scope. These
+    // are discovered by building style, so they are not derivable from the style sheets and have to
+    // survive both style sheet changes and the resolver being dropped.
+    void registerSubstitutionAttribute(const AtomString&, AttributeAffectsShadowTree) const;
+    std::optional<AttributeAffectsShadowTree> substitutionAttribute(const AtomString& lowercaseLocalName) const { return m_substitutionAttributes.getOptional(lowercaseLocalName); }
 
 protected:
     explicit Scope(Document&);
@@ -229,6 +239,8 @@ private:
 
     const UniqueRef<CustomPropertyRegistry> m_customPropertyRegistry;
     const UniqueRef<CSSCounterStyleRegistry> m_counterStyleRegistry;
+
+    mutable HashMap<AtomString, AttributeAffectsShadowTree> m_substitutionAttributes;
 };
 
 RefPtr<HTMLSlotElement> assignedSlotForScopeOrdinal(const Element&, ScopeOrdinal);

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -121,8 +121,6 @@ public:
 
     std::optional<DynamicMediaQueryEvaluationChanges> evaluateDynamicMediaQueryRules(const MQ::MediaQueryEvaluator&);
 
-    RuleFeatureSet& mutableFeatures() LIFETIME_BOUND;
-
     void setDynamicViewTransitionsStyle(RuleSet* ruleSet)
     {
         m_dynamicViewTransitionsStyle = ruleSet;
@@ -165,14 +163,6 @@ private:
 };
 
 inline const RuleFeatureSet& ScopeRuleSets::features() const
-{
-    if (m_defaultStyleVersionOnFeatureCollection < UserAgentStyle::defaultStyleVersion)
-        collectFeatures();
-    return m_features;
-}
-
-// FIXME: There should be just the const version.
-inline RuleFeatureSet& ScopeRuleSets::mutableFeatures()
 {
     if (m_defaultStyleVersionOnFeatureCollection < UserAgentStyle::defaultStyleVersion)
         collectFeatures();


### PR DESCRIPTION
#### aeb822d74e8b49ed54c57069f08e44afdb43b999
<pre>
[css-values-5] attr() stops invalidating on attribute change after a view transition
<a href="https://bugs.webkit.org/show_bug.cgi?id=323198">https://bugs.webkit.org/show_bug.cgi?id=323198</a>
<a href="https://rdar.apple.com/186467515">rdar://186467515</a>

Reviewed by Alan Baradlay.

View transition code likes to throw away the style resolver where (in RuleFeatureSet via
ScopeRuleSets) the attribute names mentioned in attr() functions were registered during style
building. We ended up forgetting the attributes and style invalidation stopped working correctly.

Style sheet mutations hit the same bug without throwing away the resolver, as collectFeatures()
rebuilds RuleFeatureSet from the style sheets.

Fix by moving the map to Style::Scope. This cleans up code in general as RuleFeatureSet no longer
needs to be mutable.

Tests: imported/w3c/web-platform-tests/css/css-values/attr-invalidation-after-stylesheet-change.html
       imported/w3c/web-platform-tests/css/css-values/attr-invalidation-after-view-transition.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-invalidation-after-stylesheet-change-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-invalidation-after-stylesheet-change.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-invalidation-after-view-transition-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-invalidation-after-view-transition.html: Added.
* Source/WebCore/style/AttributeChangeInvalidation.cpp:
(WebCore::Style::AttributeChangeInvalidation::invalidateStyle):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::add):
(WebCore::Style::RuleFeatureSet::clear):
(WebCore::Style::RuleFeatureSet::registerSubstitutionAttribute): Deleted.
* Source/WebCore/style/RuleFeature.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::setGlobalStateAfterApplyingProperties):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::registerSubstitutionAttribute):
* Source/WebCore/style/StyleScope.h:
(WebCore::Style::Scope::substitutionAttribute const):
* Source/WebCore/style/StyleScopeRuleSets.h:
(WebCore::Style::ScopeRuleSets::mutableFeatures): Deleted.

Canonical link: <a href="https://commits.webkit.org/320420@main">https://commits.webkit.org/320420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67933c233834adc0b5652a1041c2aaebb222451e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195012 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148945 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144310 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100210 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47979 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164917 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124593 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46695 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157072 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44467 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6068 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49158 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196959 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58270 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153779 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41174 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58972 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153436 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47956 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131260 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127780 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57473 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19488 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56834 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57082 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56909 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->