### PR TITLE
[Site Isolation] Concurrent navigations to the same site should share the same process

### DIFF
--- a/LayoutTests/http/tests/site-isolation/concurrent-same-site-navigations-use-same-process-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/concurrent-same-site-navigations-use-same-process-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Concurrent navigations to the same site use the same process
+

--- a/LayoutTests/http/tests/site-isolation/concurrent-same-site-navigations-use-same-process.html
+++ b/LayoutTests/http/tests/site-isolation/concurrent-same-site-navigations-use-same-process.html
@@ -1,0 +1,44 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+promise_test(async (t) => {
+    assert_true(!!window.internals, "This test requires internals API");
+
+    const crossSiteURL = "http://localhost:8000/site-isolation/resources/report-process-id.html";
+
+    const pids = [];
+    const gotBothPIDs = new Promise((resolve, reject) => {
+        const timeout = t.step_timeout(() => reject(new Error("Timed out waiting for both popups to report a process ID")), 8000);
+        const onMessage = (event) => {
+            if (event.data && event.data.type === "processId") {
+                pids.push(event.data.pid);
+                if (pids.length === 2) {
+                    clearTimeout(timeout);
+                    window.removeEventListener("message", onMessage);
+                    resolve();
+                }
+            }
+        };
+        window.addEventListener("message", onMessage);
+    });
+
+    const firstPopup = window.open();
+    const secondPopup = window.open();
+    t.add_cleanup(() => { firstPopup.close(); secondPopup.close(); });
+    firstPopup.location = crossSiteURL;
+    secondPopup.location = crossSiteURL;
+
+    await gotBothPIDs;
+
+    assert_equals(pids[0], pids[1], "Concurrent navigations to the same site should share one process");
+    assert_not_equals(pids[0], internals.processIdentifier, "The cross-site popups should not be in the opener's process");
+}, "Concurrent navigations to the same site use the same process");
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2229,7 +2229,7 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
                     prepareProcessForNavigation(WTF::move(process), page, suspendedPage.get(),
                         "Using target back/forward item's process and suspended page"_s, isolatedProcessType,
                         site, mainFrameSite, navigation, lockdownMode, enhancedSecurity, loadedWebArchive,
-                        WTF::move(dataStore), WTF::move(completionHandler));
+                        WTF::move(dataStore), browsingContextGroup, sourceProcess, WTF::move(completionHandler));
                     return;
                 }
             }
@@ -2239,7 +2239,7 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
                     prepareProcessForNavigation(process.releaseNonNull(), page, nullptr,
                         "Using target back/forward item's process (in-process BFCache)"_s, isolatedProcessType,
                         site, mainFrameSite, navigation, lockdownMode, enhancedSecurity, loadedWebArchive,
-                        WTF::move(dataStore), WTF::move(completionHandler));
+                        WTF::move(dataStore), browsingContextGroup, sourceProcess, WTF::move(completionHandler));
                     return;
                 }
             }
@@ -2290,21 +2290,31 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
         return completionHandler(WTF::move(process), suspendedPage.get(), reason);
 
     ASSERT(process->state() != AuxiliaryProcessProxy::State::Terminated);
-    prepareProcessForNavigation(WTF::move(process), page, suspendedPage.get(), reason, isolatedProcessType, site, mainFrameSite, navigation, lockdownMode, enhancedSecurity, loadedWebArchive, WTF::move(dataStore), WTF::move(completionHandler));
+    prepareProcessForNavigation(WTF::move(process), page, suspendedPage.get(), reason, isolatedProcessType, site, mainFrameSite, navigation, lockdownMode, enhancedSecurity, loadedWebArchive, WTF::move(dataStore), browsingContextGroup, sourceProcess, WTF::move(completionHandler));
 }
 
 void WebProcessPool::prepareProcessForNavigation(Ref<WebProcessProxy>&& process, WebPageProxy& page, SuspendedPageProxy* suspendedPage, ASCIILiteral reason, WebProcessProxy::IsolatedProcessType isolatedProcessType, const Site& site, const Site& mainFrameSite,
-    const API::Navigation& navigation, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, LoadedWebArchive loadedWebArchive, Ref<WebsiteDataStore>&& dataStore, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&& completionHandler, unsigned previousAttemptsCount)
+    const API::Navigation& navigation, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, LoadedWebArchive loadedWebArchive, Ref<WebsiteDataStore>&& dataStore, BrowsingContextGroup& browsingContextGroup, WebProcessProxy& sourceProcess, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&& completionHandler, unsigned previousAttemptsCount)
 {
     static constexpr unsigned maximumNumberOfAttempts = 3;
     auto preventProcessShutdownScope = process->shutdownPreventingScope();
-    auto callCompletionHandler = [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler), page = protect(page), navigation = protect(navigation), process, preventProcessShutdownScope = WTF::move(preventProcessShutdownScope), reason, dataStore, lockdownMode, enhancedSecurity, loadedWebArchive, previousAttemptsCount, isolatedProcessType, site, mainFrameSite](SuspendedPageProxy* suspendedPage) mutable {
+
+    RefPtr<FrameProcess> reservedFrameProcess;
+    if (protect(page.preferences())->siteIsolationEnabled() && !site.isEmpty() && !suspendedPage && process.ptr() != &sourceProcess && !browsingContextGroup.processForSite(site)) {
+        // BrowsingContextGroup's process map holds the FrameProcess weakly, so this strong reference is captured in the completion handler lambda below.
+        reservedFrameProcess = browsingContextGroup.ensureProcessForSite(site, mainFrameSite, process, protect(page.preferences()), loadedWebArchive, BrowsingContextGroupUpdate::None);
+        browsingContextGroup.addFrameProcessAndInjectPageContextIf(*reservedFrameProcess, [navigatingPage = Ref { page }](WebPageProxy& otherPage) {
+            return navigatingPage.ptr() != &otherPage;
+        });
+    }
+
+    auto callCompletionHandler = [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler), page = protect(page), navigation = protect(navigation), process, preventProcessShutdownScope = WTF::move(preventProcessShutdownScope), reason, dataStore, lockdownMode, enhancedSecurity, loadedWebArchive, previousAttemptsCount, isolatedProcessType, site, mainFrameSite, browsingContextGroup = Ref { browsingContextGroup }, sourceProcess = Ref { sourceProcess }, reservedFrameProcess = WTF::move(reservedFrameProcess)](SuspendedPageProxy* suspendedPage) mutable {
         // Since the IPC is asynchronous, make sure the destination process and suspended page are still valid.
         if (process->state() == AuxiliaryProcessProxy::State::Terminated && previousAttemptsCount < maximumNumberOfAttempts) {
             // The destination process crashed during the IPC to the network process, use a new process.
             ASSERT(isolatedProcessType != WebProcessProxy::IsolatedProcessType::Shared);
             Ref fallbackProcess = processForSite(dataStore, isolatedProcessType, site, mainFrameSite, lockdownMode, enhancedSecurity, page->configuration(), WebCore::ProcessSwapDisposition::None);
-            prepareProcessForNavigation(WTF::move(fallbackProcess), page, nullptr, reason, isolatedProcessType, site, mainFrameSite, navigation, lockdownMode, enhancedSecurity, loadedWebArchive, WTF::move(dataStore), WTF::move(completionHandler), previousAttemptsCount + 1);
+            prepareProcessForNavigation(WTF::move(fallbackProcess), page, nullptr, reason, isolatedProcessType, site, mainFrameSite, navigation, lockdownMode, enhancedSecurity, loadedWebArchive, WTF::move(dataStore), browsingContextGroup, sourceProcess, WTF::move(completionHandler), previousAttemptsCount + 1);
             return;
         }
         if (suspendedPage) {

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -642,7 +642,7 @@ private:
     void platformInvalidateContext();
 
     std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> processForNavigationInternal(WebPageProxy&, WebFrameProxy&, const API::Navigation&, const URL& sourceURL, WebProcessProxy::IsolatedProcessType, const WebCore::Site& mainFrameSite, ProcessSwapRequestedByClient, WebProcessProxy::LockdownMode, EnhancedSecurity, const FrameInfoData&, Ref<WebsiteDataStore>&&);
-    void prepareProcessForNavigation(Ref<WebProcessProxy>&&, WebPageProxy&, SuspendedPageProxy*, ASCIILiteral reason, WebProcessProxy::IsolatedProcessType, const WebCore::Site&, const WebCore::Site& mainFrameSite, const API::Navigation&, WebProcessProxy::LockdownMode, EnhancedSecurity, LoadedWebArchive, Ref<WebsiteDataStore>&&, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&&, unsigned previousAttemptsCount = 0);
+    void prepareProcessForNavigation(Ref<WebProcessProxy>&&, WebPageProxy&, SuspendedPageProxy*, ASCIILiteral reason, WebProcessProxy::IsolatedProcessType, const WebCore::Site&, const WebCore::Site& mainFrameSite, const API::Navigation&, WebProcessProxy::LockdownMode, EnhancedSecurity, LoadedWebArchive, Ref<WebsiteDataStore>&&, BrowsingContextGroup&, WebProcessProxy& sourceProcess, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&&, unsigned previousAttemptsCount = 0);
 
     RefPtr<WebProcessProxy> tryTakePrewarmedProcess(WebsiteDataStore&, WebProcessProxy::LockdownMode, EnhancedSecurity, const API::PageConfiguration&);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -1184,6 +1184,67 @@ TEST(SiteIsolation, OpenWithNoopener)
     EXPECT_NE([openerView _webProcessIdentifier], [openedView _webProcessIdentifier]);
 }
 
+TEST(SiteIsolation, ConcurrentPopupNavigationsToSameSiteShareProcessWhenOneFails)
+{
+    HTTPServer server({
+        { "/example"_s, { "hi"_s } },
+        { "/webkit-failing"_s, { HTTPResponse::Behavior::TerminateConnectionAfterReceivingRequest } },
+        { "/webkit-first"_s, { "hi"_s } },
+        { "/webkit-second"_s, { "hi"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto configuration = server.httpsProxyConfiguration();
+    enableSiteIsolation(configuration);
+
+    __block Vector<RetainPtr<TestWKWebView>> openedViews;
+    __block Vector<RetainPtr<TestNavigationDelegate>> openedDelegates;
+    __block unsigned failedPopups { 0 };
+    __block unsigned finishedPopups { 0 };
+    RetainPtr openerUIDelegate = adoptNS([TestUIDelegate new]);
+    openerUIDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *action, WKWindowFeatures *windowFeatures) {
+        enableSiteIsolation(configuration);
+        RetainPtr openedDelegate = adoptNS([TestNavigationDelegate new]);
+        [openedDelegate allowAnyTLSCertificate];
+        openedDelegate.get().didFailProvisionalNavigation = ^(WKWebView *, WKNavigation *, NSError *) {
+            failedPopups++;
+        };
+        openedDelegate.get().didFinishNavigation = ^(WKWebView *, WKNavigation *) {
+            finishedPopups++;
+        };
+        RetainPtr opened = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+        opened.get().navigationDelegate = openedDelegate.get();
+        openedDelegates.append(WTF::move(openedDelegate));
+        openedViews.append(WTF::move(opened));
+        return openedViews.last().get();
+    };
+
+    RetainPtr openerDelegate = adoptNS([TestNavigationDelegate new]);
+    [openerDelegate allowAnyTLSCertificate];
+    RetainPtr opener = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    opener.get().navigationDelegate = openerDelegate.get();
+    opener.get().UIDelegate = openerUIDelegate.get();
+    opener.get().configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+    [opener loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [openerDelegate waitForDidFinishNavigation];
+
+    [opener evaluateJavaScript:@"w1 = window.open(); w2 = window.open(); w3 = window.open();"
+        "w1.location = 'https://webkit.org/webkit-failing';"
+        "w2.location = 'https://webkit.org/webkit-first';"
+        "w3.location = 'https://webkit.org/webkit-second';" completionHandler:nil];
+    while (openedViews.size() < 3 || !failedPopups || finishedPopups < 2)
+        Util::spinRunLoop();
+
+    pid_t webKitPid = [openedViews[1] _webProcessIdentifier];
+    EXPECT_NE(webKitPid, 0);
+    EXPECT_EQ(webKitPid, [openedViews[2] _webProcessIdentifier]);
+    EXPECT_NE(webKitPid, [opener _webProcessIdentifier]);
+
+    for (auto& view : openedViews)
+        [view _close];
+    while (processStillRunning(webKitPid))
+        Util::spinRunLoop();
+}
+
 TEST(SiteIsolation, PreferencesUpdatesToAllProcesses)
 {
     HTTPServer server({


### PR DESCRIPTION
#### 7b5f5df9aba3f2e84f450068496c3ec50fd89d23
<pre>
[Site Isolation] Concurrent navigations to the same site should share the same process
<a href="https://bugs.webkit.org/show_bug.cgi?id=321029">https://bugs.webkit.org/show_bug.cgi?id=321029</a>
<a href="https://rdar.apple.com/184063194">rdar://184063194</a>

Reviewed by Sihui Liu.

With site isolation enabled, there is a race where two concurrent navigations to
the same site can create two different web processes. It is expected that
navigations to the same site should be in the same process.

Both navigations reach WebProcessPool::processForNavigation and notice that
BrowsingContextGroup::m_processMap doesn&apos;t have an existing process entry for
their site. So, they both create a new web process for themselves, creating two
processes for the same site.

The entry isn&apos;t added until ProvisionalPageProxy::initializeWebPage runs, and
for a main frame navigation that is on the far side of the
addAllowedFirstPartyForCookies IPC in prepareProcessForNavigation. Any
navigation that reaches prepareProcessForNavigation during that gap
sees an empty process map for the same site.

In this patch, I reserve a process before that hop, in
prepareProcessForNavigation. This also keeps the reservation up to date
since prepareProcessForNavigation is called multiple times to retry
process selection if the chosen process dies during the
`addAllowedFirstPartyForCookies` IPC.
To perform the reservation I call BrowsingContextGroup::ensureProcessForSite there,
then register the site and inject page context for the group&apos;s other pages,
exactly as initializeWebPage does.

m_processMap only holds the FrameProcess weakly, so something has to keep it
alive in the meantime. I capture a strong reference in the completion handler
used for the retry attempts, so the reservation lasts exactly until that
handler has run. By then continueNavigationInNewProcess has created the
ProvisionalPageProxy that owns the FrameProcess, or the navigation was abandoned
and nobody needs it. I don&apos;t store it in API::Navigation, because a navigation
outlives the frames using its process. That was the leak 319916@main fixed by
deleting the equivalent reference for the shared process.

This patch only handles main frame navigations. Subframe navigations return
from processForNavigation synchronously and create the ProvisionalFrameProxy
that registers the site in the same task, so two of them can never both find
the site unregistered.

Tests: http/tests/site-isolation/concurrent-same-site-navigations-use-same-process.html
       TestWebKitAPI.SiteIsolation.ConcurrentPopupNavigationsToSameSiteShareProcessWhenOneFails

* LayoutTests/http/tests/site-isolation/concurrent-same-site-navigations-use-same-process-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/concurrent-same-site-navigations-use-same-process.html: Added.
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation):
(WebKit::WebProcessPool::prepareProcessForNavigation):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, ConcurrentPopupNavigationsToSameSiteShareProcessWhenOneFails)):

Canonical link: <a href="https://commits.webkit.org/320471@main">https://commits.webkit.org/320471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b0606b7cae69e5d643a73e94943a84339362c89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195155 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5db0ad7d-5c64-4ac7-9501-77cd1b3a8543) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144427 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0978f4ee-4ce5-4445-a467-9cb58fa93b4b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48093 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165025 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124712 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/11e24cc9-601d-4da6-864d-cf3934052e63) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46817 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157189 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44583 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6211 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197104 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58410 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164522 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153902 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41214 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59115 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41195 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153559 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48072 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131404 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127964 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57612 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19601 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56971 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57222 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57048 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->