### PR TITLE
[Swift in WebKit] Address some Swift compiler diagnostic warnings

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h
@@ -121,12 +121,14 @@ typedef NS_ENUM(NSInteger, WKTextExtractionEditableType) {
 };
 
 @interface WKTextExtractionLink : NSObject
+- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithURL:(NSURL *)url range:(NSRange)range;
 @property (nonatomic, readonly) NSURL *url;
 @property (nonatomic, readonly) NSRange range;
 @end
 
 @interface WKTextExtractionEditable : NSObject
+- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithLabel:(NSString *)label placeholder:(NSString *)placeholder isSecure:(BOOL)isSecure isFocused:(BOOL)isFocused;
 @property (nonatomic, readonly) NSString *label;
 @property (nonatomic, readonly) NSString *placeholder;
@@ -144,34 +146,40 @@ typedef NS_ENUM(NSInteger, WKTextExtractionEditableType) {
 @end
 
 @interface WKTextExtractionContainerItem : WKTextExtractionItem
+- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithContainer:(WKTextExtractionContainer)container rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children eventListeners:(WKTextExtractionEventListenerTypes)eventListeners ariaAttributes:(NSDictionary<NSString *, NSString *> *)ariaAttributes accessibilityRole:(NSString *)accessibilityRole nodeIdentifier:(nullable NSString *)nodeIdentifier;
 @property (nonatomic, readonly) WKTextExtractionContainer container;
 @end
 
 @interface WKTextExtractionFormItem : WKTextExtractionItem
+- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithAutocomplete:(NSString *)autocomplete name:(NSString *)name rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children eventListeners:(WKTextExtractionEventListenerTypes)eventListeners ariaAttributes:(NSDictionary<NSString *, NSString *> *)ariaAttributes accessibilityRole:(NSString *)accessibilityRole nodeIdentifier:(nullable NSString *)nodeIdentifier;
 @property (nonatomic, readonly) NSString *autocomplete;
 @property (nonatomic, readonly) NSString *name;
 @end
 
 @interface WKTextExtractionLinkItem : WKTextExtractionItem
+- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithTarget:(NSString *)target url:(nullable NSURL *)url rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children eventListeners:(WKTextExtractionEventListenerTypes)eventListeners ariaAttributes:(NSDictionary<NSString *, NSString *> *)ariaAttributes accessibilityRole:(NSString *)accessibilityRole nodeIdentifier:(nullable NSString *)nodeIdentifier;
 @property (nonatomic, readonly) NSString *target;
 @property (nonatomic, readonly, nullable) NSURL *url;
 @end
 
 @interface WKTextExtractionIFrameItem : WKTextExtractionItem
+- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithOrigin:(NSString *)origin rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children eventListeners:(WKTextExtractionEventListenerTypes)eventListeners ariaAttributes:(NSDictionary<NSString *, NSString *> *)ariaAttributes accessibilityRole:(NSString *)accessibilityRole nodeIdentifier:(nullable NSString *)nodeIdentifier;
 @property (nonatomic, readonly) NSString *origin;
 @end
 
 @interface WKTextExtractionContentEditableItem : WKTextExtractionItem
+- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithContentEditableType:(WKTextExtractionEditableType)contentEditableType isFocused:(BOOL)isFocused rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children eventListeners:(WKTextExtractionEventListenerTypes)eventListeners ariaAttributes:(NSDictionary<NSString *, NSString *> *)ariaAttributes accessibilityRole:(NSString *)accessibilityRole nodeIdentifier:(nullable NSString *)nodeIdentifier;
 @property (nonatomic, readonly) WKTextExtractionEditableType contentEditableType;
 @property (nonatomic, readonly, getter=isFocused) BOOL focused;
 @end
 
 @interface WKTextExtractionTextFormControlItem : WKTextExtractionItem
+- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithEditable:(WKTextExtractionEditable *)editable controlType:(NSString *)controlType autocomplete:(NSString *)autocomplete isReadonly:(BOOL)isReadonly isDisabled:(BOOL)isDisabled isChecked:(BOOL)isChecked rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children eventListeners:(WKTextExtractionEventListenerTypes)eventListeners ariaAttributes:(NSDictionary<NSString *, NSString *> *)ariaAttributes accessibilityRole:(NSString *)accessibilityRole nodeIdentifier:(nullable NSString *)nodeIdentifier;
 @property (nonatomic, readonly) NSString *label;
 @property (nonatomic, readonly) NSString *placeholder;
@@ -185,6 +193,7 @@ typedef NS_ENUM(NSInteger, WKTextExtractionEditableType) {
 @end
 
 @interface WKTextExtractionTextItem : WKTextExtractionItem
+- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithContent:(NSString *)content selectedRange:(NSRange)selectedRange links:(NSArray<WKTextExtractionLink *> *)links editable:(WKTextExtractionEditable * _Nullable)editable rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children eventListeners:(WKTextExtractionEventListenerTypes)eventListeners ariaAttributes:(NSDictionary<NSString *, NSString *> *)ariaAttributes accessibilityRole:(NSString *)accessibilityRole nodeIdentifier:(nullable NSString *)nodeIdentifier;
 @property (nonatomic, readonly) NSArray<WKTextExtractionLink *> *links;
 @property (nonatomic, readonly, nullable) WKTextExtractionEditable *editable;
@@ -193,17 +202,20 @@ typedef NS_ENUM(NSInteger, WKTextExtractionEditableType) {
 @end
 
 @interface WKTextExtractionScrollableItem : WKTextExtractionItem
+- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithContentSize:(CGSize)contentSize rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children eventListeners:(WKTextExtractionEventListenerTypes)eventListeners ariaAttributes:(NSDictionary<NSString *, NSString *> *)ariaAttributes accessibilityRole:(NSString *)accessibilityRole nodeIdentifier:(nullable NSString *)nodeIdentifier;
 @property (nonatomic, readonly) CGSize contentSize;
 @end
 
 @interface WKTextExtractionSelectItem : WKTextExtractionItem
+- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithSelectedValues:(NSArray<NSString *> *)selectedValues supportsMultiple:(BOOL)supportsMultiple rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children eventListeners:(WKTextExtractionEventListenerTypes)eventListeners ariaAttributes:(NSDictionary<NSString *, NSString *> *)ariaAttributes accessibilityRole:(NSString *)accessibilityRole nodeIdentifier:(nullable NSString *)nodeIdentifier;
 @property (nonatomic, readonly) NSArray<NSString *> *selectedValues;
 @property (nonatomic, readonly) BOOL supportsMultiple;
 @end
 
 @interface WKTextExtractionImageItem : WKTextExtractionItem
+- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithName:(NSString *)name altText:(NSString *)altText rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children eventListeners:(WKTextExtractionEventListenerTypes)eventListeners ariaAttributes:(NSDictionary<NSString *, NSString *> *)ariaAttributes accessibilityRole:(NSString *)accessibilityRole nodeIdentifier:(nullable NSString *)nodeIdentifier;
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) NSString *altText;

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
@@ -29,9 +29,9 @@ import WebKit_Private
 @_spiOnly public import UIIntelligenceSupport
 
 #if WTF_PLATFORM_IOS_FAMILY
-@_spi(UIIntelligenceSupport) public import UIKit
+@_spi(UIIntelligenceSupport) import UIKit
 #else
-@_spi(UIIntelligenceSupport) public import AppKit
+@_spi(UIIntelligenceSupport) import AppKit
 #endif
 
 private func createEditable(for editable: WKTextExtractionEditable?) -> IntelligenceElement.Text.Editable? {

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -183,7 +183,11 @@ final class WebBackForwardList {
         backForwardLog("(Back/Forward) WebBackForwardList \(ObjectIdentifier(self)) had its page closed with current size \(entries.count)")
 
         // We should have always started out with an m_page and we should never close the page twice
+        #if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
+        let pageAvailable = Bool(fromCxx: page)
+        #else
         let pageAvailable = page.__convertToBool()
+        #endif
         assert(pageAvailable)
         if pageAvailable {
             for item in entries {
@@ -348,11 +352,17 @@ final class WebBackForwardList {
     func currentItem() -> WebKit.WebBackForwardListItem? {
         assertValidIndex()
 
+        #if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
+        guard Bool(fromCxx: page) else {
+            return nil
+        }
+        #else
         guard page.__convertToBool() else {
             return nil
         }
+        #endif
 
-        guard let currentIndex = currentIndex else {
+        guard let currentIndex else {
             return nil
         }
 
@@ -363,11 +373,17 @@ final class WebBackForwardList {
     func backItem() -> WebKit.WebBackForwardListItem? {
         assertValidIndex()
 
+        #if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
+        guard Bool(fromCxx: page) else {
+            return nil
+        }
+        #else
         guard page.__convertToBool() else {
             return nil
         }
+        #endif
 
-        guard let currentIndex = currentIndex else {
+        guard let currentIndex else {
             return nil
         }
 
@@ -385,11 +401,17 @@ final class WebBackForwardList {
     func forwardItem() -> WebKit.WebBackForwardListItem? {
         assertValidIndex()
 
+        #if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
+        guard Bool(fromCxx: page) else {
+            return nil
+        }
+        #else
         guard page.__convertToBool() else {
             return nil
         }
+        #endif
 
-        guard let currentIndex = currentIndex else {
+        guard let currentIndex else {
             return nil
         }
 
@@ -400,6 +422,7 @@ final class WebBackForwardList {
         guard currentIndex < entries.count - 1 else {
             return nil
         }
+
         return entries[currentIndex + 1]
     }
 
@@ -407,11 +430,17 @@ final class WebBackForwardList {
     func itemAtDeltaFromCurrentIndex(delta: Int, allowSkipping: Bool = true) -> WebKit.WebBackForwardListItem? {
         assertValidIndex()
 
+        #if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
+        guard Bool(fromCxx: page) else {
+            return nil
+        }
+        #else
         guard page.__convertToBool() else {
             return nil
         }
+        #endif
 
-        guard let currentIndex = currentIndex else {
+        guard let currentIndex else {
             return nil
         }
 
@@ -445,9 +474,15 @@ final class WebBackForwardList {
     }
 
     func itemAtIndexWithoutSkipping(index: Int) -> (item: WebKit.WebBackForwardListItem?, index: Int) {
+        #if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
+        guard Bool(fromCxx: page) else {
+            return (nil, index)
+        }
+        #else
         guard page.__convertToBool() else {
             return (nil, index)
         }
+        #endif
 
         if index < 0 || index >= entries.count {
             return (nil, index)
@@ -459,11 +494,17 @@ final class WebBackForwardList {
     private func rawBackListEntryCount() -> Int {
         assertValidIndex()
 
+        #if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
+        guard Bool(fromCxx: page) else {
+            return 0
+        }
+        #else
         guard page.__convertToBool() else {
             return 0
         }
+        #endif
 
-        guard let currentIndex = currentIndex else {
+        guard let currentIndex else {
             return 0
         }
 
@@ -473,9 +514,15 @@ final class WebBackForwardList {
     private func rawForwardListEntryCount() -> Int {
         assertValidIndex()
 
+        #if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
+        guard Bool(fromCxx: page) else {
+            return 0
+        }
+        #else
         guard page.__convertToBool() else {
             return 0
         }
+        #endif
 
         guard let currentIndex = currentIndex else {
             return 0
@@ -484,19 +531,14 @@ final class WebBackForwardList {
         return entries.count - (currentIndex + 1)
     }
 
-    private enum MakeAPIArray {
-        case no
-        case yes
-    }
-
     @used
     func backListCountForAPI() -> Int {
-        backListWithLimitInternal(limit: UInt(rawBackListEntryCount()), makeAPIArray: .no).count
+        backListWithLimitInternal(limit: UInt(rawBackListEntryCount()), makeAPIArray: false).count
     }
 
     @used
     func forwardListCountForAPI() -> Int {
-        forwardListWithLimitInternal(limit: UInt(rawForwardListEntryCount()), makeAPIArray: .no).count
+        forwardListWithLimitInternal(limit: UInt(rawForwardListEntryCount()), makeAPIArray: false).count
     }
 
     private func rawCounts() -> WebKit.WebBackForwardListCounts {
@@ -505,10 +547,10 @@ final class WebBackForwardList {
 
     private static func makeListPairResult(
         items: [WebKit.WebBackForwardListItem],
-        makeAPIArray: MakeAPIArray
+        makeAPIArray: Bool
     ) -> (count: Int, array: API.RefAPIArray?) {
         let count = items.count
-        guard makeAPIArray == .yes else {
+        guard makeAPIArray else {
             return (count: count, array: nil)
         }
         let array = count > 0 ? API.Array.create(list: items.map { WebKit.toAPIObject($0) }) : API.Array.create()
@@ -518,21 +560,27 @@ final class WebBackForwardList {
     @used
     func backListAsAPIArrayWithLimit(limit: UInt) -> API.RefAPIArray {
         // swift-format-ignore: NeverForceUnwrap
-        backListWithLimitInternal(limit: limit, makeAPIArray: .yes).array!
+        backListWithLimitInternal(limit: limit, makeAPIArray: true).array!
     }
 
     @used
     func forwardListAsAPIArrayWithLimit(limit: UInt) -> API.RefAPIArray {
         // swift-format-ignore: NeverForceUnwrap
-        forwardListWithLimitInternal(limit: limit, makeAPIArray: .yes).array!
+        forwardListWithLimitInternal(limit: limit, makeAPIArray: true).array!
     }
 
-    private func backListWithLimitInternal(limit: UInt, makeAPIArray: MakeAPIArray) -> (count: Int, array: API.RefAPIArray?) {
+    private func backListWithLimitInternal(limit: UInt, makeAPIArray: Bool) -> (count: Int, array: API.RefAPIArray?) {
         assertValidIndex()
 
+        #if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
+        guard Bool(fromCxx: page) else {
+            return WebBackForwardList.makeListPairResult(items: [], makeAPIArray: makeAPIArray)
+        }
+        #else
         guard page.__convertToBool() else {
             return WebBackForwardList.makeListPairResult(items: [], makeAPIArray: makeAPIArray)
         }
+        #endif
 
         guard let unwrappedCurrentIndex = currentIndex else {
             return WebBackForwardList.makeListPairResult(items: [], makeAPIArray: makeAPIArray)
@@ -571,12 +619,18 @@ final class WebBackForwardList {
         return WebBackForwardList.makeListPairResult(items: backItems, makeAPIArray: makeAPIArray)
     }
 
-    private func forwardListWithLimitInternal(limit: UInt, makeAPIArray: MakeAPIArray) -> (count: Int, array: API.RefAPIArray?) {
+    private func forwardListWithLimitInternal(limit: UInt, makeAPIArray: Bool) -> (count: Int, array: API.RefAPIArray?) {
         assertValidIndex()
 
+        #if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
+        guard Bool(fromCxx: page) else {
+            return WebBackForwardList.makeListPairResult(items: [], makeAPIArray: makeAPIArray)
+        }
+        #else
         guard page.__convertToBool() else {
             return WebBackForwardList.makeListPairResult(items: [], makeAPIArray: makeAPIArray)
         }
+        #endif
 
         guard let unwrappedCurrentIndex = currentIndex else {
             return WebBackForwardList.makeListPairResult(items: [], makeAPIArray: makeAPIArray)
@@ -674,8 +728,8 @@ final class WebBackForwardList {
     func backForwardListState(filter: WebBackForwardListItemFilter) -> WebKit.BackForwardListState {
         assertValidIndex()
 
-        var backForwardListState = WebKit.BackForwardListState.init()
-        if let currentIndex = currentIndex {
+        var backForwardListState = WebKit.BackForwardListState()
+        if let currentIndex {
             setOptionalUInt32Value(&backForwardListState.currentIndex, UInt32(currentIndex))
         }
 
@@ -867,7 +921,7 @@ final class WebBackForwardList {
 
     @used
     func goBackItemSkippingItemsWithoutUserGesture() -> WebKit.RefPtrWebBackForwardListItem {
-        guard let currentIndex = currentIndex else {
+        guard let currentIndex else {
             return WebKit.RefPtrWebBackForwardListItem()
         }
         if currentIndex == 0 {
@@ -880,7 +934,7 @@ final class WebBackForwardList {
 
     @used
     func goForwardItemSkippingItemsWithoutUserGesture() -> WebKit.RefPtrWebBackForwardListItem {
-        guard let currentIndex = currentIndex else {
+        guard let currentIndex else {
             return WebKit.RefPtrWebBackForwardListItem()
         }
         if currentIndex >= entries.count {
@@ -1023,17 +1077,24 @@ final class WebBackForwardList {
     ) {
         let process = WebKit.WebProcessProxy.fromConnection(connection)
 
-        // __convertToBool necessary due to rdar://137879510
+        #if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
+        let hasItemID = Bool(fromCxx: navigatedFrameState.ptr().itemID)
+        let hasFrameItemID = Bool(fromCxx: navigatedFrameState.ptr().frameItemID)
+        #else
+        let hasItemID = navigatedFrameState.ptr().itemID.__convertToBool()
+        let hasFrameItemID = navigatedFrameState.ptr().frameItemID.__convertToBool()
+        #endif
+
         if messageCheck(
             process: process,
-            !navigatedFrameState.ptr().itemID.__convertToBool()
-                || contentsMatch(navigatedFrameState.ptr().itemID.pointee.processIdentifier(), process.ptr().coreProcessIdentifier())
+            !hasItemID || contentsMatch(navigatedFrameState.ptr().itemID.pointee.processIdentifier(), process.ptr().coreProcessIdentifier())
         ) {
             return
         }
+
         if messageCheck(
             process: process,
-            !navigatedFrameState.ptr().frameItemID.__convertToBool()
+            !hasFrameItemID
                 || contentsMatch(navigatedFrameState.ptr().frameItemID.pointee.processIdentifier(), process.ptr().coreProcessIdentifier())
         ) {
             return
@@ -1059,6 +1120,7 @@ final class WebBackForwardList {
         } else {
             pagesMatch = framePage == nil && listPage == nil
         }
+
         if messageCheck(process: process, pagesMatch) {
             return
         }
@@ -1152,10 +1214,18 @@ final class WebBackForwardList {
             }
         }
 
-        // __convertToBool necessary due to rdar://137879510
-        if !frameState.ptr().itemID.__convertToBool() || !frameState.ptr().frameItemID.__convertToBool() {
+        #if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
+        let hasItemID = Bool(fromCxx: frameState.ptr().itemID)
+        let hasFrameItemID = Bool(fromCxx: frameState.ptr().frameItemID)
+        #else
+        let hasItemID = frameState.ptr().itemID.__convertToBool()
+        let hasFrameItemID = frameState.ptr().frameItemID.__convertToBool()
+        #endif
+
+        guard hasItemID && hasFrameItemID else {
             return
         }
+
         let itemID = frameState.ptr().itemID.pointee
         let frameItemID = frameState.ptr().frameItemID.pointee
         guard let frameItem = WebKit.WebBackForwardListFrameItem.itemForID(itemID, frameItemID) else {
@@ -1167,6 +1237,7 @@ final class WebBackForwardList {
         guard let webPageProxy = page.get() else {
             return
         }
+
         // We can't use == here due to rdar://162357139
         if messageCheck(
             process: process,

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.h
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.h
@@ -38,6 +38,8 @@ NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 NS_SWIFT_UI_ACTOR
 @interface WKTextSelectionController : NSObject
 
+- (instancetype)init NS_UNAVAILABLE;
+
 - (instancetype)initWithView:(WKWebView *)view;
 
 - (void)addTextSelectionManager;

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestPDFDocument.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestPDFDocument.h
@@ -51,6 +51,8 @@ NS_SWIFT_UI_ACTOR
 
 @property (nonatomic, readonly, nullable) NSURL *linkURL;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 - (instancetype)initWithPDFAnnotation:(PDFAnnotation *)annotation;
 
 @end
@@ -65,6 +67,8 @@ NS_SWIFT_UI_ACTOR
 @property (nonatomic, readonly) NSString *text;
 
 @property (nonatomic, readonly) NSInteger characterCount;
+
+- (instancetype)init NS_UNAVAILABLE;
 
 - (instancetype)initWithPDFPage:(PDFPage *)page;
 
@@ -82,6 +86,8 @@ NS_SWIFT_UI_ACTOR
 @property (nonatomic, readonly) NSInteger pageCount;
 
 - (nullable TestPDFPage *)pageAtIndex:(NSInteger)index;
+
+- (instancetype)init NS_UNAVAILABLE;
 
 - (instancetype)initFromData:(NSData *)data;
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift
@@ -143,7 +143,9 @@ struct WebPageTests {
 
             // The 2-QWAC is fetched after the navigation commits, so waiting for the navigation to finish
             // is not enough; this waits for the property to be observed changing.
-            _ = try await #require(changes.first { @Sendable in $0 })
+            for try await change in changes where change {
+                break
+            }
 
             let qualifiedServerTrust = try #require(page.qualifiedServerTrust)
             let serverTrust = try #require(page.serverTrust)


### PR DESCRIPTION
#### 99d900fc04e1dcdff781731e938f56ee64458308
<pre>
[Swift in WebKit] Address some Swift compiler diagnostic warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=323233">https://bugs.webkit.org/show_bug.cgi?id=323233</a>
<a href="https://rdar.apple.com/186484704">rdar://186484704</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift

* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtractionInternal.h:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift:
* Source/WebKit/UIProcess/WebBackForwardList.swift:
(Direction.pageClosed):
(Direction.currentItem):
(Direction.backItem):
(Direction.forwardItem):
(Direction.itemAtDeltaFromCurrentIndex(_:allowSkipping:)):
(Direction.itemAtIndexWithoutSkipping(_:index:)):
(Direction.rawBackListEntryCount):
(Direction.rawForwardListEntryCount):
(MakeAPIArray.backListWithLimitInternal(_:makeAPIArray:array:)):
(MakeAPIArray.forwardListWithLimitInternal(_:makeAPIArray:array:)):
(MakeAPIArray.backForwardListState(_:)):
(MakeAPIArray.backForwardUpdateItem(_:frameState:)):
(Direction.backListCountForAPI):
(Direction.forwardListCountForAPI):
(Direction.backListAsAPIArrayWithLimit(_:)):
(Direction.forwardListAsAPIArrayWithLimit(_:)):
(Direction.backListWithLimitInternal(_:makeAPIArray:array:)):
(Direction.forwardListWithLimitInternal(_:makeAPIArray:array:)):
(Direction.backForwardListState(_:)):
(Direction.goBackItemSkippingItemsWithoutUserGesture):
(Direction.goForwardItemSkippingItemsWithoutUserGesture):
(Direction.backForwardUpdateItem(_:frameState:)):
(MakeAPIArray.backListCountForAPI): Deleted.
(MakeAPIArray.forwardListCountForAPI): Deleted.
(MakeAPIArray.rawCounts): Deleted.
(MakeAPIArray.backListAsAPIArrayWithLimit(_:)): Deleted.
(MakeAPIArray.forwardListAsAPIArrayWithLimit(_:)): Deleted.
(MakeAPIArray.removeAllItems): Deleted.
(MakeAPIArray.clear): Deleted.
(MakeAPIArray.restoreFromState(_:)): Deleted.
(MakeAPIArray.setItemsAsRestoredFromSession): Deleted.
(MakeAPIArray.setItemsAsRestoredFromSessionIf(_:)): Deleted.
(MakeAPIArray.didRemoveItem(_:)): Deleted.
(MakeAPIArray.goBackItemSkippingItemsWithoutUserGesture): Deleted.
(MakeAPIArray.goForwardItemSkippingItemsWithoutUserGesture): Deleted.
(MakeAPIArray.loggingString): Deleted.
(MakeAPIArray.addChildItem(_:frameState:)): Deleted.
(MakeAPIArray.setBackForwardItemIdentifier(_:itemID:)): Deleted.
(MakeAPIArray.completeFrameStateForNavigation(_:)): Deleted.
(MakeAPIArray.messageCheckItemURLs(_:process:)): Deleted.
(MakeAPIArray.setHandlingProvisionalMessage(_:)): Deleted.
(MakeAPIArray.backForwardAddItem(_:navigatedFrameState:)): Deleted.
(MakeAPIArray.backForwardClearChildren(_:frameItemID:)): Deleted.
(MakeAPIArray.updateFrameIdentifier(_:newFrameID:)): Deleted.
(MakeAPIArray.backForwardGoToItem(_:)): Deleted.
(MakeAPIArray.backForwardGoToItemShared(_:)): Deleted.
(MakeAPIArray.frameStates): Deleted.
* Source/WebKit/UIProcess/mac/WKTextSelectionController.h:
* Tools/TestWebKitAPI/Helpers/cocoa/TestPDFDocument.h:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageTests.swift:
(WebPageTests.qualifiedServerTrust):

Canonical link: <a href="https://commits.webkit.org/320700@main">https://commits.webkit.org/320700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/722fc32b33ffea2843585a4929cc56c0b3332be2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185585 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195902 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150319 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7c6da9a-e30c-4156-939a-24591803809a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145026 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100549 "Exiting early after 60 failures. 60 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48709 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125321 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f6aec54-1051-4ae0-b422-c2aa592da688) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47435 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45489 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157799 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45174 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6957 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197857 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59157 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154559 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41404 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59865 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41779 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154209 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48676 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132215 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129115 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58336 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20196 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57713 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57953 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57778 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->