### PR TITLE
Fix testLibJSCTools's CorpseSnapshotTest and CorpseSymbolTest to run better for ASAN builds.

### DIFF
--- a/Source/JavaScriptCore/corpse/tests/CorpseSnapshotTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseSnapshotTest.cpp
@@ -53,6 +53,8 @@ void testSnapshot()
     }
 
     unsigned firstId = 0;
+    mach_port_t firstCorpsePort = MACH_PORT_NULL;
+    mach_port_t secondCorpsePort = MACH_PORT_NULL;
     {
         Snapshot snapshot(process);
         TEST_ASSERT(snapshot.isValid(), "a snapshot of this process is valid");
@@ -60,13 +62,19 @@ void testSnapshot()
         TEST_ASSERT(snapshot.process() == process.get(), "a snapshot keeps the process it came from");
         firstId = snapshot.id();
         TEST_ASSERT(firstId, "a snapshot has an identifier");
+        firstCorpsePort = snapshot.corpsePort();
 
         Snapshot second(process);
         TEST_ASSERT(second.isValid(), "a second snapshot of the same process is valid");
         TEST_ASSERT(second.id() > firstId, "identifiers increase");
         TEST_ASSERT(second.corpsePort() != snapshot.corpsePort(),
             "two snapshots hold two different corpses");
+        secondCorpsePort = second.corpsePort();
     }
+    TEST_ASSERT_EQ(machPortSendRightCount(firstCorpsePort), 0u,
+        "destroying a snapshot gives its corpse port back");
+    TEST_ASSERT_EQ(machPortSendRightCount(secondCorpsePort), 0u,
+        "and so does destroying the second");
     {
         // The two above are gone; their identifiers must not come back.
         Snapshot later(process);
@@ -91,23 +99,29 @@ void testSnapshot()
     }
 
     {
-        // A corpse and the threads read out of it are Mach ports. Taking many
-        // snapshots must not leave any of them behind.
-        static constexpr unsigned rounds = 100;
-        unsigned before = machPortNameCount();
-        for (unsigned round = 0; round < rounds; ++round) {
+        // A corpse and the thread rights read out of it are Mach ports. Taking a snapshot
+        // must not leave any of them behind.
+        unsigned namesBefore = machPortNameCount();
+        mach_port_t corpsePort = MACH_PORT_NULL;
+        {
             Snapshot snapshot(process);
-            if (!snapshot.isValid())
-                continue;
+            if (!snapshot.isValid()) {
+                TEST_ASSERT(false, "a snapshot of this process is valid");
+                return;
+            }
+            corpsePort = snapshot.corpsePort();
+            TEST_ASSERT(machPortSendRightCount(corpsePort), "a snapshot holds a right to its corpse");
+
+            unsigned namesBeforeThreads = machPortNameCount();
             snapshot.threads();
+            TEST_ASSERT_EQ(machPortNameCount(), namesBeforeThreads,
+                "reading the thread list gives back every thread right it took");
         }
-        unsigned after = machPortNameCount();
-        // A handful of names may come and go for reasons of their own; a leak of
-        // one port per round would be a hundred.
-        static constexpr unsigned allowedDrift = 8;
-        TEST_ASSERT(after <= before + allowedDrift, "taking and dropping snapshots leaks no Mach port");
-        if (after > before + allowedDrift)
-            dataLogLn("    port names before ", before, ", after ", after, ", over ", rounds, " snapshots");
+
+        TEST_ASSERT_EQ(machPortSendRightCount(corpsePort), static_cast<unsigned>(0),
+            "destroying a snapshot gives back the right to its corpse");
+        TEST_ASSERT_EQ(machPortNameCount(), namesBefore,
+            "and leaves no port name behind");
     }
 }
 

--- a/Source/JavaScriptCore/corpse/tests/CorpseSymbolTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseSymbolTest.cpp
@@ -78,15 +78,15 @@ void testSymbol()
     {
         // A function in the shared cache, where __LINKEDIT is shared between images
         // and the trie is reached by a different route.
-        void* expected = dlsym(RTLD_DEFAULT, "malloc");
-        TEST_ASSERT(expected, "malloc can be looked up locally");
-        Address found = snapshot.symbol("malloc");
+        void* expected = dlsym(RTLD_DEFAULT, "tolower");
+        TEST_ASSERT(expected, "tolower can be looked up locally");
+        Address found = snapshot.symbol("tolower");
         TEST_ASSERT(found, "a symbol exported by a shared cache image is found");
         // A function pointer arrives signed on arm64e; only the address it names is
         // being compared here.
         TEST_ASSERT_HEX_EQ(found.stripped().toMachVMAddress(),
             Address(expected).stripped().toMachVMAddress(),
-            "malloc resolves to the address this process uses for it");
+            "tolower resolves to the address this process uses for it");
     }
     {
         // A data symbol in the shared cache.


### PR DESCRIPTION
#### 951d88a0fe8bffd6a1d0e80c42a019a28c416720
<pre>
Fix testLibJSCTools&apos;s CorpseSnapshotTest and CorpseSymbolTest to run better for ASAN builds.
<a href="https://bugs.webkit.org/show_bug.cgi?id=323232">https://bugs.webkit.org/show_bug.cgi?id=323232</a>
<a href="https://rdar.apple.com/186484113">rdar://186484113</a>

Reviewed by Dan Hecht.

CorpseSymbolTest was previously looking up the symbol for `malloc`.  ASAN builds overrides `malloc`
with its own implementation, which causes the test to fail.  We now change CorpseSymbolTest to look
up `tolower` from the standard C library instead.

A test in CorpseSnapshotTest was doing 100 interactions of creating Snapshots and requesting their
threads list.  This was done to see if the operations leak any mach ports.  As a result, this test
was taking on the order of 1.1 seconds to run for a Release / Debug build, and ~9 seconds for an
ASAN build.

CorpseSnapshotTest is now fixed to run that test exactly once and confirm that there&apos;s no increase
in mach ports allocated.  CorpseSnapshotTest now takes 60-90 ms to run.

No new tests because this is a test fix.

* Source/JavaScriptCore/corpse/tests/CorpseSnapshotTest.cpp:
(JSCToolsTest::testSnapshot):
* Source/JavaScriptCore/corpse/tests/CorpseSymbolTest.cpp:
(JSCToolsTest::testSymbol):

Canonical link: <a href="https://commits.webkit.org/320353@main">https://commits.webkit.org/320353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ca20c1ebb244a5449c04fe4b4fffcf3096c39c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194907 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/29b10b0a-886b-4fbd-af61-06b884aab965) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59847 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58228 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6751a34b-1571-4333-8150-9f87c9636b77) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187529 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/47892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/124509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5779bdc1-4948-46b9-aa54-64cb9428a251) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46605 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/6477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13321 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/156987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/44385 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/5969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45850 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51157 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/196851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58167 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/196851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58871 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/196851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28023 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47872 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131159 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127648 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57373 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/19402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56735 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56983 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56807 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->