### PR TITLE
[css-link-params] Add a tentative test for currentcolor as a parameter value

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2964,6 +2964,8 @@ imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/img-with-url-f
 imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/img-with-url-fragment-identifiers-2.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/img-with-url-function-1.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/img-with-url-function-2.html [ ImageOnlyFailure ]
+
+imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/link-parameters-currentcolor.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/animations/scripted/syncbase-after-removal.html [ Skip ]
 imported/w3c/web-platform-tests/svg/animations/media-fragment-override-animation.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/interact/use-instance-hover.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/link-parameters-currentcolor.tentative-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/link-parameters-currentcolor.tentative-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <circle cx="50" cy="50" r="48" fill="green" stroke-width="2"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/link-parameters-currentcolor.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/link-parameters-currentcolor.tentative.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Link Parameters - currentcolor as a parameter value resolves against the linking element</title>
+<link rel="author" title="Taher Ali" href="mailto:taher_ali@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-link-params/#link-param-prop">
+<link rel="match" href="circle-green-ref.html"/>
+<style>
+  img {
+    color: green;
+    link-parameters: param(--color, currentcolor);
+  }
+</style>
+
+<img src="circle-with-parameters.svg">


### PR DESCRIPTION
#### 3fc4ee5e22e7b0a9809c3f244c64d65855d22653
<pre>
[css-link-params] Add a tentative test for currentcolor as a parameter value
<a href="https://bugs.webkit.org/show_bug.cgi?id=323237">https://bugs.webkit.org/show_bug.cgi?id=323237</a>
<a href="https://rdar.apple.com/186489079">rdar://186489079</a>

Reviewed by Tim Nguyen.

param(--color, currentcolor) crosses into the SVG image as an unresolved token, so it
resolves against the image&apos;s own color rather than the linking element&apos;s.

We still need to figure out the interaction here: whether a parameter resolves at the
linking element or at use time inside the image.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/link-parameters-currentcolor.tentative-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/link-parameters-currentcolor.tentative.html: Added.

Canonical link: <a href="https://commits.webkit.org/320445@main">https://commits.webkit.org/320445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc659300fa529c9a6559824ae947e215c62d6ed5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58471 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194877 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148833 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/59ce7b69-1e32-4c15-92c5-981b6918bd68) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144078 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100109 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/59393289-30d3-451c-9bdc-b855ae856b95) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164826 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124494 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2c3051be-8b42-4e2a-9541-8589e073280c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46584 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44742 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156966 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44365 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5946 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196820 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58142 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153682 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41195 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58846 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153326 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47850 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127616 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57349 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19383 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56713 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56958 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56782 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->