### PR TITLE
[Win] Make Swift-enabled built products runnable on test workers

### DIFF
--- a/Tools/CISupport/built-product-archive
+++ b/Tools/CISupport/built-product-archive
@@ -26,7 +26,9 @@
 
 from __future__ import print_function
 import errno
+import filecmp
 import fnmatch
+import json
 import optparse
 import os
 import shutil
@@ -138,6 +140,46 @@ def removeDirectoryIfExists(thinDirectory, platform):
 
 def copyBuildFiles(source, destination, patterns):
     shutil.copytree(source, destination, ignore=shutil.ignore_patterns(*patterns))
+
+
+def swiftRuntimeIsRequired(buildDirectory):
+    with open(os.path.join(buildDirectory, 'cmakeconfig.h')) as configuration:
+        enabledDefinitions = set(line.strip() for line in configuration)
+    return any(
+        '#define {} 1'.format(feature) in enabledDefinitions
+        for feature in ('ENABLE_BACK_FORWARD_LIST_SWIFT', 'ENABLE_SWIFT_DEMO_URI_SCHEME')
+    )
+
+
+def copySwiftRuntimeLibraries(destination):
+    swiftCompiler = shutil.which('swiftc')
+    if not swiftCompiler:
+        raise RuntimeError('Could not find swiftc while archiving the Windows build')
+
+    targetInfo = json.loads(subprocess.check_output([swiftCompiler, '-print-target-info'], text=True))
+    runtimeBinDirectory = next((
+        path for path in targetInfo['paths']['runtimeLibraryPaths']
+        if os.path.isfile(os.path.join(path, 'swiftCore.dll'))
+    ), None)
+    if not runtimeBinDirectory:
+        raise RuntimeError('Could not find the Swift runtime bin directory')
+    runtimeLibraries = [
+        os.path.join(runtimeBinDirectory, filename)
+        for filename in sorted(os.listdir(runtimeBinDirectory))
+        if filename.lower().endswith('.dll')
+    ]
+    if not runtimeLibraries:
+        raise RuntimeError('Could not find Swift runtime libraries in {}'.format(runtimeBinDirectory))
+
+    print('Copying Swift runtime libraries from: {}'.format(runtimeBinDirectory))
+    for runtimeLibrary in runtimeLibraries:
+        destinationLibrary = os.path.join(destination, os.path.basename(runtimeLibrary))
+        if os.path.exists(destinationLibrary):
+            if not filecmp.cmp(runtimeLibrary, destinationLibrary, shallow=False):
+                raise RuntimeError('Swift runtime library conflicts with existing file: {}'.format(destinationLibrary))
+            print('Swift runtime library already present: {}'.format(destinationLibrary))
+            continue
+        shutil.copy2(runtimeLibrary, destinationLibrary)
 
 
 def createZipFromList(listToZip, configuration, excludePatterns=None):
@@ -281,6 +323,8 @@ def archiveBuiltProduct(configuration, platform, fullPlatform, minify=False):
 
         removeDirectoryIfExists(thinDirectory, platform)
         copyBuildFiles(binDirectory, thinBinDirectory, ['*.ilk'])
+        if swiftRuntimeIsRequired(_configurationBuildDirectory):
+            copySwiftRuntimeLibraries(thinBinDirectory)
 
         if createZip(thinDirectory, configuration):
             return 1

--- a/Tools/CISupport/built_product_archive_unittest.py
+++ b/Tools/CISupport/built_product_archive_unittest.py
@@ -1,0 +1,180 @@
+# Copyright (C) 2026 John James Jacoby. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+SCRIPT_PATH = os.path.join(os.path.dirname(__file__), 'built-product-archive')
+SPEC = importlib.util.spec_from_file_location(
+    'built_product_archive',
+    SCRIPT_PATH,
+    loader=importlib.machinery.SourceFileLoader('built_product_archive', SCRIPT_PATH),
+)
+built_product_archive = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(built_product_archive)
+
+
+class SwiftRuntimeIsRequiredTest(unittest.TestCase):
+    def test_detects_enabled_swift_features(self):
+        configurations = (
+            ('#define ENABLE_BACK_FORWARD_LIST_SWIFT 1\n#define ENABLE_SWIFT_DEMO_URI_SCHEME 0\n', True),
+            ('#define ENABLE_BACK_FORWARD_LIST_SWIFT 0\n#define ENABLE_SWIFT_DEMO_URI_SCHEME 1\n', True),
+            ('#define ENABLE_BACK_FORWARD_LIST_SWIFT 0\n#define ENABLE_SWIFT_DEMO_URI_SCHEME 0\n', False),
+        )
+        for contents, expected in configurations:
+            with self.subTest(contents=contents), tempfile.TemporaryDirectory() as directory:
+                with open(os.path.join(directory, 'cmakeconfig.h'), 'w') as file:
+                    file.write(contents)
+                self.assertEqual(built_product_archive.swiftRuntimeIsRequired(directory), expected)
+
+
+class CopySwiftRuntimeLibrariesTest(unittest.TestCase):
+    def test_copies_only_dlls_from_runtime_bin_directory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            compilerBinDirectory = os.path.join(directory, 'toolchain', 'usr', 'bin')
+            runtimeBinDirectory = os.path.join(directory, 'usr', 'bin')
+            destination = os.path.join(directory, 'archive')
+            os.makedirs(compilerBinDirectory)
+            os.makedirs(runtimeBinDirectory)
+            os.makedirs(destination)
+
+            with open(os.path.join(compilerBinDirectory, 'sourcekitdInProc.dll'), 'w') as file:
+                file.write('sourcekitdInProc.dll')
+            for filename in ('swiftCore.dll', 'FoundationEssentials.DLL', 'README.txt'):
+                with open(os.path.join(runtimeBinDirectory, filename), 'w') as file:
+                    file.write(filename)
+
+            targetInfo = json.dumps({
+                'paths': {'runtimeLibraryPaths': [compilerBinDirectory, runtimeBinDirectory]},
+            })
+            with patch.object(built_product_archive.shutil, 'which', return_value='swiftc'), patch.object(
+                built_product_archive.subprocess, 'check_output', return_value=targetInfo
+            ):
+                built_product_archive.copySwiftRuntimeLibraries(destination)
+
+            self.assertEqual(sorted(os.listdir(destination)), ['FoundationEssentials.DLL', 'swiftCore.dll'])
+
+    def test_accepts_identical_existing_library(self):
+        with tempfile.TemporaryDirectory() as directory:
+            runtimeBinDirectory = os.path.join(directory, 'runtime')
+            destination = os.path.join(directory, 'archive')
+            os.makedirs(runtimeBinDirectory)
+            os.makedirs(destination)
+            for parent in (runtimeBinDirectory, destination):
+                with open(os.path.join(parent, 'swiftCore.dll'), 'w') as file:
+                    file.write('swiftCore.dll')
+
+            targetInfo = json.dumps({'paths': {'runtimeLibraryPaths': [runtimeBinDirectory]}})
+            with patch.object(built_product_archive.shutil, 'which', return_value='swiftc'), patch.object(
+                built_product_archive.subprocess, 'check_output', return_value=targetInfo
+            ):
+                built_product_archive.copySwiftRuntimeLibraries(destination)
+
+            self.assertEqual(os.listdir(destination), ['swiftCore.dll'])
+
+    def test_rejects_conflicting_existing_library(self):
+        with tempfile.TemporaryDirectory() as directory:
+            runtimeBinDirectory = os.path.join(directory, 'runtime')
+            destination = os.path.join(directory, 'archive')
+            os.makedirs(runtimeBinDirectory)
+            os.makedirs(destination)
+            with open(os.path.join(runtimeBinDirectory, 'swiftCore.dll'), 'w') as file:
+                file.write('runtime')
+            with open(os.path.join(destination, 'swiftCore.dll'), 'w') as file:
+                file.write('existing')
+
+            targetInfo = json.dumps({'paths': {'runtimeLibraryPaths': [runtimeBinDirectory]}})
+            with patch.object(built_product_archive.shutil, 'which', return_value='swiftc'), patch.object(
+                built_product_archive.subprocess, 'check_output', return_value=targetInfo
+            ):
+                with self.assertRaisesRegex(RuntimeError, 'conflicts with existing file'):
+                    built_product_archive.copySwiftRuntimeLibraries(destination)
+
+    def test_fails_when_swiftc_is_unavailable(self):
+        with tempfile.TemporaryDirectory() as destination, patch.object(
+            built_product_archive.shutil, 'which', return_value=None
+        ):
+            with self.assertRaisesRegex(RuntimeError, 'Could not find swiftc'):
+                built_product_archive.copySwiftRuntimeLibraries(destination)
+
+    def test_fails_when_runtime_bin_directory_is_unavailable(self):
+        with tempfile.TemporaryDirectory() as directory:
+            runtimeBinDirectory = os.path.join(directory, 'usr', 'bin')
+            destination = os.path.join(directory, 'archive')
+            os.makedirs(runtimeBinDirectory)
+            os.makedirs(destination)
+
+            targetInfo = json.dumps({'paths': {'runtimeLibraryPaths': [runtimeBinDirectory]}})
+            with patch.object(built_product_archive.shutil, 'which', return_value='swiftc'), patch.object(
+                built_product_archive.subprocess, 'check_output', return_value=targetInfo
+            ):
+                with self.assertRaisesRegex(RuntimeError, 'Could not find the Swift runtime bin directory'):
+                    built_product_archive.copySwiftRuntimeLibraries(destination)
+
+
+class ArchiveBuiltProductTest(unittest.TestCase):
+    def test_windows_archive_includes_swift_runtime_libraries(self):
+        oldConfigurationBuildDirectory = built_product_archive._configurationBuildDirectory
+        built_product_archive._configurationBuildDirectory = os.path.join('WebKitBuild', 'Release')
+        try:
+            with patch.object(built_product_archive, 'removeDirectoryIfExists'), patch.object(
+                built_product_archive, 'copyBuildFiles'
+            ), patch.object(built_product_archive, 'swiftRuntimeIsRequired', return_value=True), patch.object(
+                built_product_archive, 'copySwiftRuntimeLibraries'
+            ) as copyRuntime, patch.object(
+                built_product_archive, 'createZip', return_value=0
+            ), patch.object(built_product_archive.shutil, 'rmtree'):
+                result = built_product_archive.archiveBuiltProduct('Release', 'win', 'win')
+        finally:
+            built_product_archive._configurationBuildDirectory = oldConfigurationBuildDirectory
+
+        self.assertIsNone(result)
+        copyRuntime.assert_called_once_with(os.path.join('WebKitBuild', 'Release', 'thin', 'bin'))
+
+    def test_windows_archive_without_swift_does_not_copy_runtime_libraries(self):
+        oldConfigurationBuildDirectory = built_product_archive._configurationBuildDirectory
+        built_product_archive._configurationBuildDirectory = os.path.join('WebKitBuild', 'Release')
+        try:
+            with patch.object(built_product_archive, 'removeDirectoryIfExists'), patch.object(
+                built_product_archive, 'copyBuildFiles'
+            ), patch.object(built_product_archive, 'swiftRuntimeIsRequired', return_value=False), patch.object(
+                built_product_archive, 'copySwiftRuntimeLibraries'
+            ) as copyRuntime, patch.object(
+                built_product_archive, 'createZip', return_value=0
+            ), patch.object(built_product_archive.shutil, 'rmtree'):
+                result = built_product_archive.archiveBuiltProduct('Release', 'win', 'win')
+        finally:
+            built_product_archive._configurationBuildDirectory = oldConfigurationBuildDirectory
+
+        self.assertIsNone(result)
+        copyRuntime.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#### df07d6a5cfd4df7f1efb169ef823af73dbb10da0
<pre>
[Win] Make Swift-enabled built products runnable on test workers

<a href="https://bugs.webkit.org/show_bug.cgi?id=323228">https://bugs.webkit.org/show_bug.cgi?id=323228</a>

Reviewed by Adrian Taylor.

Swift support makes WebKit2.dll depend on libraries from the Windows Swift runtime. The build worker has those libraries installed, but the built product archive sent to the test worker does not contain them, so WebKitTestRunner cannot start.

Use swiftc -print-target-info to locate the runtime and copy its DLLs into the Windows archive.

Add tests for runtime discovery, filtering, failures, and archive integration.

Canonical link: <a href="https://commits.webkit.org/320860@main">https://commits.webkit.org/320860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9651a08296803f366a487c5e1f1f3a741ef0fe04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196160 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150526 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145235 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100689 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165797 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125540 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47650 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45671 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158010 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45378 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7231 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198134 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59420 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154794 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41517 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60128 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154438 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48887 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129470 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58590 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20402 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57969 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58203 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58033 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->