### PR TITLE
`shape-outside` renders incorrectly when the float has margins

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-border-box-shape-margin-with-margin-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-border-box-shape-margin-with-margin-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float left, border-box with shape-margin, with margins reference</title>
+  <style>
+  .container {
+    width: 150px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: left;
+    /* Omit shape-outside: border-box; shape-margin: 25px; and shrink the inline end margin to what shape-margin adds. */
+    width: 50px;
+    height: 100px;
+    margin: 25px 25px 25px 50px;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-border-box-with-block-start-margin-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-border-box-with-block-start-margin-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float left, border-box, with a block start margin reference</title>
+  <style>
+  .container {
+    width: 150px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: left;
+    /* Omit shape-outside: border-box; and let the lines the shape does not cover push the float down instead. */
+    width: 100px;
+    height: 50px;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-border-box-with-margin-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-border-box-with-margin-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float left, border-box, with margins reference</title>
+  <style>
+  .container {
+    width: 100px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: left;
+    /* Omit shape-outside: border-box; */
+    width: 50px;
+    height: 100px;
+    margin: 0 0 0 25px;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-border-box-with-margin-right-float-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-border-box-with-margin-right-float-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float right, border-box, with margins reference</title>
+  <style>
+  .container {
+    width: 150px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: right;
+    /* Omit shape-outside: border-box; and the inline start margin the shape excludes. */
+    width: 50px;
+    height: 100px;
+    margin: 0 50px 0 0;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-content-box-with-margin-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-content-box-with-margin-ref.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float left, content-box, with margins reference</title>
+  <style>
+  .container {
+    width: 150px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: left;
+    /* Omit shape-outside: content-box; */
+    box-sizing: content-box;
+    width: 25px;
+    height: 100px;
+    padding: 0 0 0 25px;
+    border-style: solid;
+    border-color: lightgreen;
+    border-width: 0 0 0 25px;
+    margin: 0 0 0 25px;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-padding-box-with-margin-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-padding-box-with-margin-ref.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float left, padding-box, with margins reference</title>
+  <style>
+  .container {
+    width: 150px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: left;
+    /* Omit shape-outside: padding-box; */
+    box-sizing: content-box;
+    width: 25px;
+    height: 100px;
+    padding: 0 25px;
+    border-style: solid;
+    border-color: lightgreen;
+    border-width: 0 0 0 25px;
+    margin-left: 25px;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-shape-margin-with-margin-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-shape-margin-with-margin-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float left, border-box with shape-margin, with margins reference</title>
+  <style>
+  .container {
+    width: 150px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: left;
+    /* Omit shape-outside: border-box; shape-margin: 25px; and shrink the inline end margin to what shape-margin adds. */
+    width: 50px;
+    height: 100px;
+    margin: 25px 25px 25px 50px;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-shape-margin-with-margin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-shape-margin-with-margin.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float left, border-box with shape-margin, with margins</title>
+  <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#shapes-from-box-values">
+  <link rel="match" href="reference/shape-outside-border-box-shape-margin-with-margin-ref.html">
+  <meta name="assert" content="shape-margin expands the border-box shape after the float's margin has offset it.">
+  <style>
+  .container {
+    width: 150px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: left;
+    shape-outside: border-box;
+    shape-margin: 25px;
+    width: 50px;
+    height: 100px;
+    margin: 25px 50px;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-block-start-margin-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-block-start-margin-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float left, border-box, with a block start margin reference</title>
+  <style>
+  .container {
+    width: 150px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: left;
+    /* Omit shape-outside: border-box; and let the lines the shape does not cover push the float down instead. */
+    width: 100px;
+    height: 50px;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-block-start-margin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-block-start-margin.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float left, border-box, with a block start margin</title>
+  <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#shapes-from-box-values">
+  <link rel="match" href="reference/shape-outside-border-box-with-block-start-margin-ref.html">
+  <meta name="assert" content="The float's block start margin offsets the border-box shape, so lines next to that margin are not constrained by the float at all.">
+  <style>
+  .container {
+    width: 150px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: left;
+    shape-outside: border-box;
+    width: 100px;
+    height: 50px;
+    margin: 50px 0 0;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-margin-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-margin-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float left, border-box, with margins reference</title>
+  <style>
+  .container {
+    width: 100px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: left;
+    /* Omit shape-outside: border-box; */
+    width: 50px;
+    height: 100px;
+    margin: 0 0 0 25px;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-margin-right-float-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-margin-right-float-expected.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float right, border-box, with margins reference</title>
+  <style>
+  .container {
+    width: 150px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: right;
+    /* Omit shape-outside: border-box; and the inline start margin the shape excludes. */
+    width: 50px;
+    height: 100px;
+    margin: 0 50px 0 0;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-margin-right-float.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-margin-right-float.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float right, border-box, with margins</title>
+  <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#shapes-from-box-values">
+  <link rel="match" href="reference/shape-outside-border-box-with-margin-right-float-ref.html">
+  <meta name="assert" content="The float's inline start margin offsets the border-box shape of a right float, and its inline end margin is not part of the float area.">
+  <style>
+  .container {
+    width: 150px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: right;
+    shape-outside: border-box;
+    width: 50px;
+    height: 100px;
+    margin: 0 50px 0 25px;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-margin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-margin.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float left, border-box, with margins</title>
+  <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#shapes-from-box-values">
+  <link rel="match" href="reference/shape-outside-border-box-with-margin-ref.html">
+  <meta name="assert" content="The float's inline start margin offsets the border-box shape, and its inline end margin is not part of the float area.">
+  <style>
+  .container {
+    width: 100px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: left;
+    shape-outside: border-box;
+    width: 50px;
+    height: 100px;
+    margin: 0 25px;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-content-box-with-margin-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-content-box-with-margin-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float left, content-box, with margins reference</title>
+  <style>
+  .container {
+    width: 150px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: left;
+    /* Omit shape-outside: content-box; */
+    box-sizing: content-box;
+    width: 25px;
+    height: 100px;
+    padding: 0 0 0 25px;
+    border-style: solid;
+    border-color: lightgreen;
+    border-width: 0 0 0 25px;
+    margin: 0 0 0 25px;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-content-box-with-margin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-content-box-with-margin.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float left, content-box, with margins</title>
+  <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#shapes-from-box-values">
+  <link rel="match" href="reference/shape-outside-content-box-with-margin-ref.html">
+  <meta name="assert" content="The float's inline start margin offsets the content-box shape, and its inline end padding, border and margin are not part of the float area.">
+  <style>
+  .container {
+    width: 150px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: left;
+    shape-outside: content-box;
+    box-sizing: content-box;
+    width: 25px;
+    height: 100px;
+    padding: 0 25px;
+    border-style: solid;
+    border-color: lightgreen;
+    border-width: 0 25px;
+    margin: 0 25px;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-padding-box-with-margin-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-padding-box-with-margin-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float left, padding-box, with margins reference</title>
+  <style>
+  .container {
+    width: 150px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: left;
+    /* Omit shape-outside: padding-box; */
+    box-sizing: content-box;
+    width: 25px;
+    height: 100px;
+    padding: 0 25px;
+    border-style: solid;
+    border-color: lightgreen;
+    border-width: 0 0 0 25px;
+    margin-left: 25px;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-padding-box-with-margin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-padding-box-with-margin.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="utf-8">
+  <title>CSS Shape Test: float left, padding-box, with margins</title>
+  <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#shapes-from-box-values">
+  <link rel="match" href="reference/shape-outside-padding-box-with-margin-ref.html">
+  <meta name="assert" content="The float's inline start margin offsets the padding-box shape, and its inline end border is not part of the float area.">
+  <style>
+  .container {
+    width: 150px;
+    line-height: 0;
+  }
+
+  .shape {
+    float: left;
+    shape-outside: padding-box;
+    box-sizing: content-box;
+    width: 25px;
+    height: 100px;
+    padding: 0 25px;
+    border-style: solid;
+    border-color: lightgreen;
+    border-width: 0 25px;
+    margin-left: 25px;
+    background-color: orange;
+  }
+
+  .box {
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    background-color: blue;
+  }
+  </style>
+
+  <main class="container">
+    <div class="shape"></div>
+    <div><div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div></div>
+  </main>
+</html>

--- a/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp
@@ -143,20 +143,24 @@ static inline void populateIFCWithNewlyPlacedFloats(auto& blockRenderer, auto& p
 
         auto floatRect = floatingObject->frameRect();
 
+        auto borderBoxSize = floatingObject->renderer()->borderBoxSize();
+        auto marginOffset = floatingObject->marginOffset();
+        auto borderBoxTopLeft = floatRect.location() + marginOffset;
+
         auto boxGeometry = Layout::BoxGeometry { };
-        boxGeometry.setTopLeft(blockLogicalTopLeft + floatRect.location());
-        boxGeometry.setContentBoxWidth(floatRect.width());
-        boxGeometry.setContentBoxHeight(floatRect.height());
+        boxGeometry.setTopLeft(blockLogicalTopLeft + borderBoxTopLeft);
+        boxGeometry.setContentBoxWidth(borderBoxSize.width());
+        boxGeometry.setContentBoxHeight(borderBoxSize.height());
         boxGeometry.setBorder({ });
         boxGeometry.setPadding({ });
-        boxGeometry.setHorizontalMargin({ });
-        boxGeometry.setVerticalMargin({ });
+        boxGeometry.setHorizontalMargin({ marginOffset.width(), floatRect.width() - marginOffset.width() - borderBoxSize.width() });
+        boxGeometry.setVerticalMargin({ marginOffset.height(), floatRect.height() - marginOffset.height() - borderBoxSize.height() });
 
         auto shapeOutsideInfo = floatingObject->renderer()->shapeOutsideInfo();
         RefPtr shape = shapeOutsideInfo ? &shapeOutsideInfo->computedShape() : nullptr;
 
         auto usedPosition = Style::ComputedStyle::usedFloat(*floatingObject->renderer()) == UsedFloat::Left ? Layout::PlacedFloats::Item::Position::Start : Layout::PlacedFloats::Item::Position::End;
-        placedFloats.add({ usedPosition, boxGeometry, floatRect.location(), WTF::move(shape) });
+        placedFloats.add({ usedPosition, boxGeometry, borderBoxTopLeft, WTF::move(shape) });
     }
 }
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -891,18 +891,32 @@ void LineLayout::preparePlacedFloats()
             return LayoutRect { logicalLeft, logicalTop, logicalWidth, logicalHeight };
         }();
 
-        boxGeometry.setTopLeft(logicalRect.location());
-        boxGeometry.setContentBoxWidth(logicalRect.width());
-        boxGeometry.setContentBoxHeight(logicalRect.height());
+        auto logicalMargin = [&]() -> Layout::BoxGeometry::Edges {
+            auto borderBoxLogicalSize = floatingObject->renderer()->borderBoxSize();
+            if (!isHorizontalWritingMode)
+                borderBoxLogicalSize = borderBoxLogicalSize.transposedSize();
+            auto marginOffset = floatingObject->marginOffset();
+            auto marginBefore = isHorizontalWritingMode ? marginOffset.height() : marginOffset.width();
+            auto marginOnLogicalLeft = isHorizontalWritingMode ? marginOffset.width() : marginOffset.height();
+            auto marginOnLogicalRight = logicalRect.width() - marginOnLogicalLeft - borderBoxLogicalSize.width();
+            if (!placedFloatsIsLeftToRight)
+                std::swap(marginOnLogicalLeft, marginOnLogicalRight);
+            return { { marginOnLogicalLeft, marginOnLogicalRight }, { marginBefore, logicalRect.height() - marginBefore - borderBoxLogicalSize.height() } };
+        }();
+        auto borderBoxLogicalTopLeft = logicalRect.location() + LayoutSize { logicalMargin.horizontal.start, logicalMargin.vertical.before };
+
+        boxGeometry.setTopLeft(borderBoxLogicalTopLeft);
+        boxGeometry.setContentBoxWidth(logicalRect.width() - logicalMargin.width());
+        boxGeometry.setContentBoxHeight(logicalRect.height() - logicalMargin.height());
         boxGeometry.setBorder({ });
         boxGeometry.setPadding({ });
-        boxGeometry.setHorizontalMargin({ });
-        boxGeometry.setVerticalMargin({ });
+        boxGeometry.setHorizontalMargin(logicalMargin.horizontal);
+        boxGeometry.setVerticalMargin(logicalMargin.vertical);
 
         auto shapeOutsideInfo = floatingObject->renderer()->shapeOutsideInfo();
         RefPtr shape = shapeOutsideInfo ? &shapeOutsideInfo->computedShape() : nullptr;
 
-        placedFloats.add({ logicalPosition, boxGeometry, logicalRect.location(), WTF::move(shape) });
+        placedFloats.add({ logicalPosition, boxGeometry, borderBoxLogicalTopLeft, WTF::move(shape) });
     }
 }
 


### PR DESCRIPTION
#### aa065033bd3172ec763b8f31cd9b677af24b21fa
<pre>
`shape-outside` renders incorrectly when the float has margins
<a href="https://bugs.webkit.org/show_bug.cgi?id=323064">https://bugs.webkit.org/show_bug.cgi?id=323064</a>
<a href="https://rdar.apple.com/186327525">rdar://186327525</a>

Reviewed by Antti Koivisto.

IFC integration codepath builds that geometry out of FloatingObject::frameRect(), which is the margin box.
However shape&apos;s coordinates are relative to the float&apos;s border box.
Any margin on the float is dropped from the shape&apos;s position: the line is constrained as if the
shape sat at the float&apos;s margin box origin.

Tests: imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-margin.html
       imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-padding-box-with-margin.html
       imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-content-box-with-margin.html
       imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-shape-margin-with-margin.html
       imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-margin-right-float.html
       imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-block-start-margin.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-border-box-shape-margin-with-margin-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-border-box-with-block-start-margin-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-border-box-with-margin-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-border-box-with-margin-right-float-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-content-box-with-margin-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/reference/shape-outside-padding-box-with-margin-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-shape-margin-with-margin-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-shape-margin-with-margin.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-block-start-margin-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-block-start-margin.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-margin-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-margin-right-float-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-margin-right-float.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-border-box-with-margin.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-content-box-with-margin-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-content-box-with-margin.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-padding-box-with-margin-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-box/shape-outside-padding-box-with-margin.html: Added.
* Source/WebCore/layout/integration/LayoutIntegrationFormattingContextLayout.cpp:
(WebCore::LayoutIntegration::populateIFCWithNewlyPlacedFloats):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::preparePlacedFloats):

Canonical link: <a href="https://commits.webkit.org/320417@main">https://commits.webkit.org/320417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c35a52fc8e1a62a7fe3a531b13ceb091b0565c90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194959 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148895 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144269 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100160 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164875 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124552 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46644 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44792 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44419 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6015 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196904 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58217 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164361 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153732 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41172 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58919 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153388 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47911 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131208 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127703 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57420 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19441 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56781 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57029 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56856 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->