### PR TITLE
Replace typedef with using in loader classes

### DIFF
--- a/Source/WebCore/loader/ResourceLoadStatistics.cpp
+++ b/Source/WebCore/loader/ResourceLoadStatistics.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 static Seconds timestampResolution { 5_s };
 
-typedef HashMap<RegistrableDomain, unsigned, RegistrableDomain::RegistrableDomainHash, HashTraits<RegistrableDomain>, HashTraits<unsigned>>::KeyValuePairType ResourceLoadStatisticsValue;
+using ResourceLoadStatisticsValue = HashMap<RegistrableDomain, unsigned, RegistrableDomain::RegistrableDomainHash, HashTraits<RegistrableDomain>, HashTraits<unsigned>>::KeyValuePairType;
 
 static void encodeHashSet(KeyedEncoder& encoder, const String& label,  const String& key, const HashSet<RegistrableDomain>& hashSet)
 {

--- a/Source/WebCore/loader/archive/ArchiveFactory.cpp
+++ b/Source/WebCore/loader/archive/ArchiveFactory.cpp
@@ -46,8 +46,8 @@
 
 namespace WebCore {
 
-typedef RefPtr<Archive> RawDataCreationFunction(const URL&, FragmentedSharedBuffer&);
-typedef HashMap<String, RawDataCreationFunction*, ASCIICaseInsensitiveHash> ArchiveMIMETypesMap;
+using RawDataCreationFunction = RefPtr<Archive>(const URL&, FragmentedSharedBuffer&);
+using ArchiveMIMETypesMap = HashMap<String, RawDataCreationFunction*, ASCIICaseInsensitiveHash>;
 
 // The create functions in the archive classes return RefPtr to concrete subclasses
 // of Archive. This adaptor makes the functions have a uniform return type.

--- a/Source/WebCore/loader/cache/MemoryCache.h
+++ b/Source/WebCore/loader/cache/MemoryCache.h
@@ -219,7 +219,7 @@ private:
     
     // A URL-based map of all resources that are in the cache (including the freshest version of objects that are currently being 
     // referenced by a Web page).
-    typedef HashMap<PAL::SessionID, std::unique_ptr<CachedResourceMap>> SessionCachedResourceMap;
+    using SessionCachedResourceMap = HashMap<PAL::SessionID, std::unique_ptr<CachedResourceMap>>;
     SessionCachedResourceMap m_sessionResources;
 
     Timer m_pruneTimer;

--- a/Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.h
+++ b/Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.h
@@ -28,7 +28,7 @@
 #include "ResourceRequest.h"
 #include <pal/SessionID.h>
 
-typedef const struct _CFCachedURLResponse* CFCachedURLResponseRef;
+using CFCachedURLResponseRef = const struct _CFCachedURLResponse*;
 
 namespace WebCore {
 


### PR DESCRIPTION
#### 307cb0cb11781086a04156750af05ea560b942fe
<pre>
Replace typedef with using in loader classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=323241">https://bugs.webkit.org/show_bug.cgi?id=323241</a>
<a href="https://rdar.apple.com/186492181">rdar://186492181</a>

Reviewed by Chris Dumez.

Modernize C-style typedef declarations to C++ alias declarations
(using) across a handful of loader files. No behavior change.

* Source/WebCore/loader/ResourceLoadStatistics.cpp:
* Source/WebCore/loader/archive/ArchiveFactory.cpp:
* Source/WebCore/loader/cache/MemoryCache.h:
* Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.h:

Canonical link: <a href="https://commits.webkit.org/320388@main">https://commits.webkit.org/320388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87692e919b97c50ff20a5ce571585ed4f6fb5c02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194889 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148842 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186423 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144129 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100118 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164834 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124500 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46595 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44749 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156977 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44375 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5956 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51145 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196844 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58154 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153689 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41160 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58858 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153341 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47860 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131147 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127634 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57360 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19393 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56723 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56970 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56794 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->