### PR TITLE
SpeculationRules::parseSingleRule rebuilds its allowed-keys HashSet on every call

### DIFF
--- a/Source/WebCore/loader/SpeculationRules.cpp
+++ b/Source/WebCore/loader/SpeculationRules.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <wtf/HashSet.h>
 #include <wtf/JSONValues.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/URL.h>
 #include <wtf/URLHash.h>
 #include <wtf/Vector.h>
@@ -170,13 +171,13 @@ static std::optional<SpeculationRules::DocumentPredicate> parseDocumentPredicate
 // https://html.spec.whatwg.org/C#parse-a-speculation-rule
 static std::optional<SpeculationRules::Rule> parseSingleRule(const JSON::Object& input, const String& rulesetLevelTag, const URL& rulesetBaseURL, const URL& documentBaseURL)
 {
-    const HashSet<String> allowedKeys = {
+    static NeverDestroyed<HashSet<String>> allowedKeys = std::initializer_list<String> {
         "source"_s, "urls"_s, "where"_s, "requires"_s, "target_hint"_s,
         "referrer_policy"_s, "relative_to"_s, "eagerness"_s,
         "expects_no_vary_search"_s, "tag"_s
     };
     for (const auto& key : input.keys()) {
-        if (!allowedKeys.contains(key))
+        if (!allowedKeys->contains(key))
             return std::nullopt;
     }
 


### PR DESCRIPTION
#### d9136f7891344cfe1635fb97cda11d9163fef9cc
<pre>
SpeculationRules::parseSingleRule rebuilds its allowed-keys HashSet on every call
<a href="https://bugs.webkit.org/show_bug.cgi?id=323242">https://bugs.webkit.org/show_bug.cgi?id=323242</a>
<a href="https://rdar.apple.com/186495063">rdar://186495063</a>

Reviewed by Chris Dumez.

parseSingleRule() constructed a 10-element HashSet&lt;String&gt; of the allowed
rule keys as a function-local, so the set was allocated, hashed, and
destroyed once per rule parsed. The set is a read-only constant, so hoist
it to a NeverDestroyed static that is built once.

No change in behavior.

* Source/WebCore/loader/SpeculationRules.cpp:
(WebCore::parseSingleRule):

Canonical link: <a href="https://commits.webkit.org/320391@main">https://commits.webkit.org/320391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/185ef8b14b6999a254539731a68ade6de3e8ae01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194901 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148848 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c8ce2bf9-ba07-4f9d-a57a-1deea0ab1637) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144190 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100122 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/baac77a6-f207-4e15-b19f-b381fbcc0334) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187523 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164837 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124506 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c53e508c-c528-4ff9-bdda-517921b2e8aa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46597 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44753 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156979 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44378 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5963 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196845 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58161 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153692 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41161 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58865 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153344 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47864 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131153 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127641 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57367 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19396 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56729 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56977 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56801 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->