### PR TITLE
PrivateClickMeasurement path constants should be ASCIILiteral to avoid unsafeSpan

### DIFF
--- a/Source/WebCore/loader/PrivateClickMeasurement.cpp
+++ b/Source/WebCore/loader/PrivateClickMeasurement.cpp
@@ -37,9 +37,9 @@
 namespace WebCore {
 
 static constexpr auto privateClickMeasurementTriggerAttributionPath = "/.well-known/private-click-measurement/trigger-attribution/"_s;
-static const char privateClickMeasurementTokenSignaturePath[] = "/.well-known/private-click-measurement/sign-unlinkable-token/";
-static const char privateClickMeasurementTokenPublicKeyPath[] = "/.well-known/private-click-measurement/get-token-public-key/";
-static const char privateClickMeasurementReportAttributionPath[] = "/.well-known/private-click-measurement/report-attribution/";
+static constexpr auto privateClickMeasurementTokenSignaturePath = "/.well-known/private-click-measurement/sign-unlinkable-token/"_s;
+static constexpr auto privateClickMeasurementTokenPublicKeyPath = "/.well-known/private-click-measurement/get-token-public-key/"_s;
+static constexpr auto privateClickMeasurementReportAttributionPath = "/.well-known/private-click-measurement/report-attribution/"_s;
 static constexpr auto privateClickMeasurementToSKAdNetworkURLPrefix = "https://apps.apple.com/app/id"_s;
 const size_t privateClickMeasurementAttributionTriggerDataPathSegmentSize = 2;
 const size_t privateClickMeasurementPriorityPathSegmentSize = 2;
@@ -279,9 +279,9 @@ bool PrivateClickMeasurement::hasHigherPriorityThan(const PrivateClickMeasuremen
     return m_attributionTriggerData->priority > other.m_attributionTriggerData->priority;
 }
 
-static URL makeValidURL(const RegistrableDomain& domain, const char* path)
+static URL makeValidURL(const RegistrableDomain& domain, ASCIILiteral path)
 {
-    URL validURL { makeString("https://"_s, domain.string(), unsafeSpan(path)) };
+    URL validURL { makeString("https://"_s, domain.string(), path) };
     return validURL.isValid() ? validURL : URL { };
 }
 


### PR DESCRIPTION
#### a19c53e12f2d6e87fe835555a6e9cb0cbd77ced0
<pre>
PrivateClickMeasurement path constants should be ASCIILiteral to avoid unsafeSpan
<a href="https://bugs.webkit.org/show_bug.cgi?id=323243">https://bugs.webkit.org/show_bug.cgi?id=323243</a>
<a href="https://rdar.apple.com/186495899">rdar://186495899</a>

Reviewed by Chris Dumez.

The token-signature, token-public-key, and report-attribution path
constants were declared as `static const char[]`, while their siblings
(trigger-attribution and the SKAdNetwork prefix) already use ASCIILiteral
(_s). Passing the C-string constants to makeValidURL() forced it to take a
`const char*` and wrap the argument in unsafeSpan(), a runtime scan flagged
as an unsafe buffer access.

Declare the three constants as `constexpr auto ... = &quot;...&quot;_s` and change
makeValidURL() to take an ASCIILiteral, passing it straight to makeString().
This drops the unsafeSpan() call and the runtime length computation with no
behavior change.

* Source/WebCore/loader/PrivateClickMeasurement.cpp:
(WebCore::makeValidURL):

Canonical link: <a href="https://commits.webkit.org/320387@main">https://commits.webkit.org/320387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a51998dbf9507c325ed639a9649dfa40eba1253

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194953 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148849 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e2b6e38-3e09-4b13-b502-ab205405df1e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186431 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58223 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144262 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100123 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/68281e4b-179d-43af-9756-139a443c62f9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164840 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124545 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a40092e8-0df6-4331-ab5f-202290f1764d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46599 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44754 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44381 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5964 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51152 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49076 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196846 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58162 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153694 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41159 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58866 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/40997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153346 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47863 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131154 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127642 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57368 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19399 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56730 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56978 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56802 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->