### PR TITLE
[JSC] Add Karatsuba multiplication to `JSBigInt`

### DIFF
--- a/JSTests/microbenchmarks/bigint-mul-large-unequal.js
+++ b/JSTests/microbenchmarks/bigint-mul-large-unequal.js
@@ -1,0 +1,32 @@
+function test(xs, ys, count) {
+    let acc = 0n;
+    for (let i = 0; i < count; i++) {
+        const j = i & 7;
+        acc ^= xs[j] * ys[j];
+    }
+    return acc;
+}
+noInline(test);
+
+const LARGE_DIGITS = 1024;
+const SMALL_DIGITS = 96;
+
+const xs = [];
+const ys = [];
+let mix = 0x9e3779b97f4a7c15n;
+function next(digits) {
+    let value = 0n;
+    for (let digit = 0; digit < digits; digit++) {
+        mix = (mix * 6364136223846793005n + 1442695040888963407n) & 0xffffffffffffffffn;
+        value |= mix << BigInt(64 * digit);
+    }
+    return value | (1n << BigInt(64 * digits - 1));
+}
+for (let i = 0; i < 8; i++) {
+    xs.push(next(LARGE_DIGITS));
+    ys.push(next(SMALL_DIGITS));
+}
+
+let result = 0n;
+for (let i = 0; i < 10; i++)
+    result = test(xs, ys, 1000);

--- a/JSTests/microbenchmarks/bigint-mul-large.js
+++ b/JSTests/microbenchmarks/bigint-mul-large.js
@@ -1,0 +1,31 @@
+function test(xs, ys, count) {
+    let acc = 0n;
+    for (let i = 0; i < count; i++) {
+        const j = i & 7;
+        acc ^= xs[j] * ys[j];
+    }
+    return acc;
+}
+noInline(test);
+
+const DIGITS = 256;
+
+const xs = [];
+const ys = [];
+let mix = 0x9e3779b97f4a7c15n;
+function next() {
+    let value = 0n;
+    for (let digit = 0; digit < DIGITS; digit++) {
+        mix = (mix * 6364136223846793005n + 1442695040888963407n) & 0xffffffffffffffffn;
+        value |= mix << BigInt(64 * digit);
+    }
+    return value | (1n << BigInt(64 * DIGITS - 1));
+}
+for (let i = 0; i < 8; i++) {
+    xs.push(next());
+    ys.push(next());
+}
+
+let result = 0n;
+for (let i = 0; i < 10; i++)
+    result = test(xs, ys, 1000);

--- a/JSTests/stress/bigint-multiply-karatsuba.js
+++ b/JSTests/stress/bigint-multiply-karatsuba.js
@@ -1,0 +1,73 @@
+//@ slow!
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+function refMul(a, b) {
+    let result = 0n;
+    let shift = 0n;
+    while (b > 0n) {
+        const chunk = b & 0xffffn;
+        if (chunk)
+            result += (a * chunk) << shift;
+        b >>= 16n;
+        shift += 16n;
+    }
+    return result;
+}
+
+function makeOperand(digits, width, seed) {
+    let mix = BigInt.asUintN(width, 0x9e3779b97f4a7c15n * BigInt(seed + 1));
+    const mask = (1n << BigInt(width)) - 1n;
+    let value = 0n;
+    for (let i = 0; i < digits; i++) {
+        mix = BigInt.asUintN(width, mix * 6364136223846793005n + 1442695040888963407n);
+        value |= (mix & mask) << BigInt(width * i);
+    }
+    return value | (1n << BigInt(width * digits - 1));
+}
+
+function makeSparseOperand(digits, width, seed) {
+    let value = 1n << BigInt(width * digits - 1);
+    for (let i = 0; i < digits; i++) {
+        if ((i * 7 + seed) % 5 === 0)
+            value |= ((1n << BigInt(width)) - 1n) << BigInt(width * i);
+    }
+    return value;
+}
+
+function check(x, y) {
+    const expected = refMul(x, y);
+    shouldBe(x * y, expected);
+    shouldBe(y * x, expected);
+    shouldBe((-x) * y, -expected);
+    shouldBe((-x) * (-y), expected);
+}
+
+for (const width of [32, 64]) {
+    for (const size of [33, 34, 35, 36, 37, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 64, 67, 68, 69, 70, 72, 79, 80, 81, 87, 88, 89, 96, 97, 100, 104, 136, 137, 144, 200, 255, 256, 257, 300, 512, 513]) {
+        const x = makeOperand(size, width, size);
+        check(x, makeOperand(size, width, size * 3 + 1));
+        shouldBe(x * x, refMul(x, x));
+    }
+
+    for (const [larger, smaller] of [[35, 34], [40, 34], [40, 39], [41, 40], [44, 43], [45, 44], [68, 34], [69, 34], [80, 40], [81, 40], [88, 44], [89, 44], [100, 34], [1000, 34], [1000, 39], [1000, 43], [70, 35], [97, 36], [104, 97], [200, 97], [300, 128], [1000, 40], [1000, 41], [1000, 44], [1000, 45], [1000, 100], [1000, 257], [2100, 70]]) {
+        check(makeOperand(larger, width, larger + smaller), makeOperand(smaller, width, larger * smaller));
+    }
+
+    for (const size of [34, 36, 40, 41, 44, 45, 68, 80, 88, 97, 104, 256, 257]) {
+        const ones = (1n << BigInt(width * size)) - 1n;
+        check(ones, ones);
+        check(ones, ones - (1n << BigInt(width * (size - 1))));
+        check(ones << BigInt(width * size), ones);
+        check(1n << BigInt(width * size), (1n << BigInt(width * size)) + 1n);
+    }
+
+    for (const size of [36, 40, 44, 70, 80, 88, 104, 136, 257]) {
+        const sparse = makeSparseOperand(size, width, size);
+        check(sparse, makeSparseOperand(size, width, size + 1));
+        check(sparse, makeOperand(size, width, size * 2));
+        check(makeOperand(size * 3, width, size), sparse);
+    }
+}

--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -1191,6 +1191,180 @@ ALWAYS_INLINE void JSBigInt::multiplySpecialLowFixed(std::span<const Digit, XSiz
     }
 }
 
+// Karatsuba multiplication, ported from V8 [1], which is in turn based on Go's math/big [2].
+//
+// [1]: https://source.chromium.org/chromium/chromium/src/+/main:v8/src/bigint/mul-karatsuba.cc
+// [2]: https://go.dev/src/math/big/nat.go
+static constexpr size_t karatsubaThreshold = 44;
+
+static size_t karatsubaRoundUpLength(size_t length)
+{
+    if (length <= 36)
+        return roundUpToMultipleOf<2>(length);
+    unsigned shift = std::bit_width(length) - 5;
+    if ((length >> shift) >= 0x18)
+        shift++;
+    size_t additive = (static_cast<size_t>(1) << shift) - 1;
+    if (shift >= 2 && (length & additive) < (static_cast<size_t>(1) << (shift - 2)))
+        return length;
+    return ((length + additive) >> shift) << shift;
+}
+
+static size_t karatsubaLength(size_t n)
+{
+    n = karatsubaRoundUpLength(n);
+    unsigned i = 0;
+    while (n > karatsubaThreshold) {
+        n >>= 1;
+        i++;
+    }
+    return n << i;
+}
+
+template<typename DigitType>
+static std::span<DigitType> clampedSubspan(std::span<DigitType> x, size_t offset, size_t length)
+{
+    if (offset >= x.size())
+        return { };
+    return x.subspan(offset, std::min(length, x.size() - offset));
+}
+
+JSBigInt::Digit JSBigInt::inplaceAddAndPropagate(std::span<Digit> z, std::span<const Digit> x)
+{
+    x = normalize(x);
+    Digit carry = inplaceAdd(z, x);
+    for (size_t i = x.size(); i < z.size() && carry; i++) {
+        Digit newCarry = 0;
+        z[i] = digitAdd(z[i], carry, newCarry);
+        carry = newCarry;
+    }
+    return carry;
+}
+
+JSBigInt::Digit JSBigInt::inplaceSubAndPropagate(std::span<Digit> z, std::span<const Digit> x)
+{
+    x = normalize(x);
+    Digit borrow = inplaceSub(z, x);
+    for (size_t i = x.size(); i < z.size() && borrow; i++) {
+        Digit newBorrow = 0;
+        z[i] = digitSub(z[i], borrow, newBorrow);
+        borrow = newBorrow;
+    }
+    return borrow;
+}
+
+void JSBigInt::karatsubaAbsoluteDifference(std::span<Digit> result, std::span<const Digit> x, std::span<const Digit> y, bool& negative)
+{
+    x = normalize(x);
+    y = normalize(y);
+    if (compareDigits(x, y) == ComparisonResult::LessThan) {
+        negative = !negative;
+        std::swap(x, y);
+    }
+    auto difference = subSchoolbook(x, y, result);
+    zeroSpan(result.subspan(difference.size()));
+}
+
+void JSBigInt::multiplyZeroPadded(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result)
+{
+    auto product = multiplyDigits(x, y, result);
+    zeroSpan(result.subspan(product.size()));
+}
+
+void JSBigInt::karatsubaMain(std::span<Digit> z, std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> scratch, size_t n)
+{
+    if (n < karatsubaThreshold) {
+        multiplyZeroPadded(x, y, z.first(2 * n));
+        return;
+    }
+    ASSERT(scratch.size() >= 4 * n);
+    ASSERT(!(n & 1));
+    size_t n2 = n >> 1;
+    auto x0 = clampedSubspan(x, 0, n2);
+    auto x1 = clampedSubspan(x, n2, n2);
+    auto y0 = clampedSubspan(y, 0, n2);
+    auto y1 = clampedSubspan(y, n2, n2);
+    auto scratchForRecursion = scratch.subspan(2 * n, 2 * n);
+
+    auto p0 = scratch.first(n);
+    karatsubaMain(p0, x0, y0, scratchForRecursion, n2);
+    memcpySpan(z.first(n), p0);
+
+    auto p2 = scratch.subspan(n, n);
+    karatsubaMain(p2, x1, y1, scratchForRecursion, n2);
+    auto z2 = clampedSubspan(z, n, n);
+    memcpySpan(z2, p2.first(z2.size()));
+    ASSERT(normalize(p2).size() <= z2.size());
+
+    Digit overflow = inplaceAddAndPropagate(z.subspan(n2), p0);
+    overflow += inplaceAddAndPropagate(z.subspan(n2), p2);
+
+    auto xDifference = scratch.first(n2);
+    auto yDifference = scratch.subspan(n2, n2);
+    bool negative = false;
+    karatsubaAbsoluteDifference(xDifference, x1, x0, negative);
+    karatsubaAbsoluteDifference(yDifference, y0, y1, negative);
+    auto p1 = scratch.subspan(n, n);
+    karatsubaMain(p1, xDifference, yDifference, scratchForRecursion, n2);
+    if (negative)
+        overflow -= inplaceSubAndPropagate(z.subspan(n2), p1);
+    else
+        overflow += inplaceAddAndPropagate(z.subspan(n2), p1);
+    ASSERT_UNUSED(overflow, !overflow);
+}
+
+void JSBigInt::karatsubaChunk(std::span<Digit> z, std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> scratch)
+{
+    x = normalize(x);
+    y = normalize(y);
+    if (x.size() < y.size())
+        std::swap(x, y);
+    if (y.size() < karatsubaThreshold) {
+        multiplyZeroPadded(x, y, z);
+        return;
+    }
+    karatsubaStart(z, x, y, scratch, karatsubaLength(y.size()));
+}
+
+void JSBigInt::karatsubaStart(std::span<Digit> z, std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> scratch, size_t k)
+{
+    karatsubaMain(z, x, y, scratch, k);
+    if (z.size() > 2 * k)
+        zeroSpan(z.subspan(2 * k));
+    if (k >= x.size())
+        return;
+
+    Vector<Digit> chunkProduct(2 * k);
+    auto product = chunkProduct.mutableSpan();
+    auto x0 = x.first(k);
+    auto y0 = clampedSubspan(y, 0, k);
+    auto y1 = clampedSubspan(y, k, y.size());
+    if (!y1.empty()) {
+        karatsubaChunk(product, x0, y1, scratch);
+        inplaceAddAndPropagate(z.subspan(k), product);
+    }
+    for (size_t i = k; i < x.size(); i += k) {
+        auto xi = clampedSubspan(x, i, k);
+        karatsubaChunk(product, xi, y0, scratch);
+        inplaceAddAndPropagate(z.subspan(i), product);
+        if (!y1.empty()) {
+            karatsubaChunk(product, xi, y1, scratch);
+            inplaceAddAndPropagate(z.subspan(i + k), product);
+        }
+    }
+}
+
+std::span<JSBigInt::Digit> JSBigInt::multiplyKaratsuba(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result)
+{
+    ASSERT(x.size() >= y.size());
+    RELEASE_ASSERT(result.size() >= x.size() + y.size());
+    size_t k = karatsubaLength(y.size());
+    Vector<Digit> scratch(4 * k);
+    auto z = result.first(x.size() + y.size());
+    karatsubaStart(z, x, y, scratch.mutableSpan(), k);
+    return z;
+}
+
 ALWAYS_INLINE std::span<JSBigInt::Digit> JSBigInt::multiplyDigitsInto(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result)
 {
     ASSERT(!y.empty());
@@ -1225,6 +1399,8 @@ ALWAYS_INLINE std::span<JSBigInt::Digit> JSBigInt::multiplyDigitsInto(std::span<
     }
     if (y.size() == 1)
         return multiplySingle(x, y[0], result);
+    if (y.size() >= karatsubaThreshold)
+        return multiplyKaratsuba(x, y, result);
     if (shouldUseComba(x.size(), y.size()))
         return multiplyComba(x, y, result);
     return multiplySchoolbook(x, y, result);

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -543,6 +543,12 @@ private:
     template<size_t N>
     static std::span<Digit, N * 2> squareCombaFixed(std::span<const Digit, N> x, std::span<Digit, N * 2> result);
     static std::span<Digit> multiplyDigitsInto(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result);
+    static void multiplyZeroPadded(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result);
+    static std::span<Digit> multiplyKaratsuba(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result);
+    static void karatsubaStart(std::span<Digit> z, std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> scratch, size_t k);
+    static void karatsubaChunk(std::span<Digit> z, std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> scratch);
+    static void karatsubaMain(std::span<Digit> z, std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> scratch, size_t n);
+    static void karatsubaAbsoluteDifference(std::span<Digit> result, std::span<const Digit> x, std::span<const Digit> y, bool& negative);
 
     static std::span<Digit> NODELETE divideSingle(std::span<Digit> q, Digit& remainder, std::span<const Digit>, Digit);
     static std::tuple<std::span<Digit>, std::span<Digit>> divideSchoolbook(std::span<Digit> q, std::span<Digit> r, std::span<const Digit>, std::span<const Digit>);
@@ -598,6 +604,8 @@ private:
 
     static Digit NODELETE inplaceAdd(std::span<Digit> z, std::span<const Digit> x);
     static Digit NODELETE inplaceSub(std::span<Digit> z, std::span<const Digit> x);
+    static Digit NODELETE inplaceAddAndPropagate(std::span<Digit> z, std::span<const Digit> x);
+    static Digit NODELETE inplaceSubAndPropagate(std::span<Digit> z, std::span<const Digit> x);
 
     static constexpr unsigned maxCachedModDivisorSize = 32; // 2048-bit divisors on 64-bit
     static constexpr unsigned maxFixedCachedModDivisorSize = 4;


### PR DESCRIPTION
#### cbd15fc88bdeffb4618a464681e03ef1f25bc5b6
<pre>
[JSC] Add Karatsuba multiplication to `JSBigInt`
<a href="https://bugs.webkit.org/show_bug.cgi?id=323244">https://bugs.webkit.org/show_bug.cgi?id=323244</a>

Reviewed by Yusuke Suzuki.

JSBigInt multiplies with O(n^2) schoolbook / Comba loops only, so the time per
product grows quadratically with the operand size: 1000 x 1000 digits takes
336 us and 4000 x 4000 takes 5.3 ms. Add Karatsuba multiplication for products
whose smaller operand has at least 44 digits, which brings the growth to
O(n^1.58). This is a port of V8&apos;s implementation [1], itself based on Go&apos;s
math/big [2].

The threshold is 44 rather than V8&apos;s 34 because JSC&apos;s Comba base case is faster
than V8&apos;s schoolbook: balanced shapes win from 40 digits, but for a long x the
length rounding pads an odd smaller operand by a digit, and at 41 or 43 digits
that padding costs the 2-3% Karatsuba would gain. At 44 no measured shape
regresses. Sizes below the threshold keep the existing paths, and allocation,
sign and normalization in multiplyImpl are unchanged.

Time per product (us, 64-bit digits, Apple M4, best of 3 x 7 rounds):

digits          Before      After

40 x 40          0.647      0.652
43 x 43          0.738      0.738
44 x 44          0.762      0.714
64 x 64          1.658      1.406
100 x 100        3.987      2.872
256 x 256       23.901     13.113
1000 x 1000    335.548    122.562
4000 x 4000   5337.000   1110.688
1000 x 43       16.089     16.447
1000 x 45       16.870     16.677
10000 x 45     163.054    164.321
10000 x 100    352.316    276.342

                                   Baseline                  Patched

bigint-mul-large              249.7296+-0.6119     ^    140.1950+-0.4092        ^ definitely 1.7813x faster
bigint-mul-large-unequal      371.3519+-0.7129     ^    299.9962+-0.7217        ^ definitely 1.2379x faster

[1]: <a href="https://source.chromium.org/chromium/chromium/src/+/main">https://source.chromium.org/chromium/chromium/src/+/main</a>:v8/src/bigint/mul-karatsuba.cc
[2]: <a href="https://go.dev/src/math/big/nat.go">https://go.dev/src/math/big/nat.go</a>

Tests: JSTests/microbenchmarks/bigint-mul-large-unequal.js
       JSTests/microbenchmarks/bigint-mul-large.js
       JSTests/stress/bigint-multiply-karatsuba.js

* JSTests/microbenchmarks/bigint-mul-large-unequal.js: Added.
(test):
(next):
* JSTests/microbenchmarks/bigint-mul-large.js: Added.
(test):
(next):
* JSTests/stress/bigint-multiply-karatsuba.js: Added.
(shouldBe):
(refMul):
(makeOperand):
(makeSparseOperand):
(check):
* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::karatsubaRoundUpLength):
(JSC::karatsubaLength):
(JSC::clampedSubspan):
(JSC::JSBigInt::inplaceAddAndPropagate):
(JSC::JSBigInt::inplaceSubAndPropagate):
(JSC::JSBigInt::karatsubaAbsoluteDifference):
(JSC::JSBigInt::multiplyZeroPadded):
(JSC::JSBigInt::karatsubaMain):
(JSC::JSBigInt::karatsubaChunk):
(JSC::JSBigInt::karatsubaStart):
(JSC::JSBigInt::multiplyKaratsuba):
(JSC::JSBigInt::multiplyDigitsInto):
* Source/JavaScriptCore/runtime/JSBigInt.h:

Canonical link: <a href="https://commits.webkit.org/320495@main">https://commits.webkit.org/320495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f680ae6e8c6746bad246f9f402b82042cbc8ff74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195244 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144494 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48168 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165089 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124786 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46893 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/6724 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13589 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157259 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44657 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6297 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46175 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197193 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58497 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153973 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41230 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59203 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41260 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153632 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48149 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131491 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128091 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57699 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19675 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57058 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57135 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->