### PR TITLE
AX: http/wpt/site-isolation/accessibility/two-iframes-shared-process.sub.html is flaky

### DIFF
--- a/LayoutTests/http/wpt/site-isolation/accessibility/two-iframes-shared-process.sub.html
+++ b/LayoutTests/http/wpt/site-isolation/accessibility/two-iframes-shared-process.sub.html
@@ -58,6 +58,12 @@ function countWebAreas(element) {
 var allowedRoles = ["AXWebArea", "AXButton", "AXHeading"];
 function dumpFilteredAccessibilityTree(element, indent) {
     var role = element.role;
+    if (role === null) {
+        for (var i = 0; i < indent; i++)
+            output += "    ";
+        output += "<element with null role, childrenCount=" + element.childrenCount + ">\n";
+        return;
+    }
     var matched = allowedRoles.some(r => role.endsWith(r));
     if (matched) {
         for (var i = 0; i < indent; i++)

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -140,8 +140,7 @@ http/tests/site-isolation/accessibility/client/simple-iframe.html [ Pass ]
 # Shared-process site isolation accessibility tests using the accessibility client API:
 # Skip by default, enable tests that are stable.
 http/wpt/site-isolation/accessibility [ Skip ]
-# Passes on the first run and fails or times out on subsequent
-webkit.org/b/322236 http/wpt/site-isolation/accessibility/two-iframes-shared-process.sub.html [ Pass Failure Timeout ]
+http/wpt/site-isolation/accessibility/two-iframes-shared-process.sub.html [ Pass ]
 
 # Skip glib-only combobox accessibility tests.
 accessibility/combobox/gtk [ Skip ]


### PR DESCRIPTION
#### 4310df9751500279df8894813ff087bb593a71fe
<pre>
AX: http/wpt/site-isolation/accessibility/two-iframes-shared-process.sub.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=323250">https://bugs.webkit.org/show_bug.cgi?id=323250</a>
<a href="https://rdar.apple.com/186501509">rdar://186501509</a>

Reviewed by Tyler Wilcock.

This test was failing due to <a href="https://bugs.webkit.org/show_bug.cgi?id=323182">https://bugs.webkit.org/show_bug.cgi?id=323182</a>
(AX: isolated tree can serve old page&apos;s content after navigation). With that fixed,
we can now make it reliable, so we can cover shared-process site isolation accessibility.

* LayoutTests/http/wpt/site-isolation/accessibility/two-iframes-shared-process.sub.html:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/320439@main">https://commits.webkit.org/320439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/771bdf76fd54abd0949b2fd6330b5906d1764bb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52326 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194917 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148860 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58237 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144236 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100132 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47901 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124519 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46614 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44763 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156996 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44392 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5975 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49085 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196862 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58176 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164334 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153702 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41189 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58880 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41008 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153353 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47877 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127663 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57381 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19413 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56743 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56992 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56816 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->