### PR TITLE
A page cannot opt out of the spatial video renderer (experimental)

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/media/spatial-video-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/spatial-video-support.js
@@ -107,6 +107,8 @@ class SpatialVideoSupport extends MediaControllerSupport
     _resolveProjection(media, host)
     {
         const declared = ProjectionAttributeValues[media.getAttribute("x-webkit-projection")?.trim().toLowerCase()];
+        if (declared === "none")
+            return null;
         if (declared)
             return { projection: declared, fovDegrees: null };
 
@@ -494,6 +496,7 @@ SpatialVideoSupport.CameraFOV = 80;
 SpatialVideoSupport.DragTolerance = 3;
 SpatialVideoSupport.DragSpeed = 0.005;
 const ProjectionAttributeValues = {
+    "none": "none",
     "equirectangular": "equirect360",
     "360": "equirect360",
     "halfequirectangular": "equirect180",


### PR DESCRIPTION
#### 32a2a7043e8be11c4559cee2d2b7b0fc3406f773
<pre>
A page cannot opt out of the spatial video renderer (experimental)
<a href="https://bugs.webkit.org/show_bug.cgi?id=323251">https://bugs.webkit.org/show_bug.cgi?id=323251</a>
<a href="https://rdar.apple.com/186502346">rdar://186502346</a>

Reviewed by Jer Noble.

Projected video renders whenever the container declares a projection kind, and x-webkit-projection
could only force the renderer on, so a page had no way to have the video presented as-is.

Resolve x-webkit-projection=&quot;none&quot; to no projection. All other values are unchanged, and the
existing webkitprojectionchanged event handles setting or removing it during playback.

* Source/WebCore/Modules/modern-media-controls/media/spatial-video-support.js:
(SpatialVideoSupport.prototype._resolveProjection):

Canonical link: <a href="https://commits.webkit.org/320442@main">https://commits.webkit.org/320442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3b7a1bfaa2a4ecadd55f71ab5efc944fdb4c8ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194918 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148861 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186446 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144238 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100133 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47900 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164851 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124521 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a572c86a-b65d-4e67-bf66-8951515de051) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46613 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44765 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156995 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44393 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5976 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196863 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58177 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153705 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41193 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58881 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153356 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47880 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131169 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127664 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57382 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19414 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56744 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56993 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56817 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->