### PR TITLE
PrivateClickMeasurement token URL getters should return std::optional<URL> instead of const std::optional<const URL>

### DIFF
--- a/Source/WebCore/loader/AttributionTriggerData.cpp
+++ b/Source/WebCore/loader/AttributionTriggerData.cpp
@@ -30,12 +30,12 @@
 
 namespace WebCore::PCM {
 
-const std::optional<const URL> AttributionTriggerData::tokenPublicKeyURL() const
+std::optional<URL> AttributionTriggerData::tokenPublicKeyURL() const
 {
     return destinationSite ? PrivateClickMeasurement::tokenPublicKeyURL(*destinationSite) : URL();
 }
 
-const std::optional<const URL> AttributionTriggerData::tokenSignatureURL() const
+std::optional<URL> AttributionTriggerData::tokenSignatureURL() const
 {
     return destinationSite ? PrivateClickMeasurement::tokenSignatureURL(*destinationSite) : URL();
 }

--- a/Source/WebCore/loader/AttributionTriggerData.h
+++ b/Source/WebCore/loader/AttributionTriggerData.h
@@ -62,8 +62,8 @@ struct AttributionTriggerData {
         destinationUnlinkableToken->valueBase64URL = value;
     }
     void setDestinationSecretToken(const DestinationSecretToken& token) { destinationSecretToken = token; }
-    WEBCORE_EXPORT const std::optional<const URL> tokenPublicKeyURL() const;
-    WEBCORE_EXPORT const std::optional<const URL> tokenSignatureURL() const;
+    WEBCORE_EXPORT std::optional<URL> tokenPublicKeyURL() const;
+    WEBCORE_EXPORT std::optional<URL> tokenSignatureURL() const;
     WEBCORE_EXPORT Ref<JSON::Object> tokenSignatureJSON() const;
 
     uint8_t data { 0 };

--- a/Source/WebCore/loader/PrivateClickMeasurement.cpp
+++ b/Source/WebCore/loader/PrivateClickMeasurement.cpp
@@ -355,26 +355,26 @@ void PrivateClickMeasurement::setEphemeralSourceNonce(PCM::EphemeralNonce&& nonc
     m_ephemeralSourceNonce = WTF::move(nonce);
 }
 
-const std::optional<const URL> PrivateClickMeasurement::tokenPublicKeyURL(const RegistrableDomain& registrableDomain)
+std::optional<URL> PrivateClickMeasurement::tokenPublicKeyURL(const RegistrableDomain& registrableDomain)
 {
     if (registrableDomain.isEmpty())
         return std::nullopt;
     return makeValidURL(registrableDomain, privateClickMeasurementTokenPublicKeyPath);
 }
 
-const std::optional<const URL> PrivateClickMeasurement::tokenPublicKeyURL() const
+std::optional<URL> PrivateClickMeasurement::tokenPublicKeyURL() const
 {
     return tokenPublicKeyURL(m_sourceSite.registrableDomain);
 }
 
-const std::optional<const URL> PrivateClickMeasurement::tokenSignatureURL(const RegistrableDomain& registrableDomain)
+std::optional<URL> PrivateClickMeasurement::tokenSignatureURL(const RegistrableDomain& registrableDomain)
 {
     if (registrableDomain.isEmpty())
         return std::nullopt;
     return makeValidURL(registrableDomain, privateClickMeasurementTokenSignaturePath);
 }
 
-const std::optional<const URL> PrivateClickMeasurement::tokenSignatureURL() const
+std::optional<URL> PrivateClickMeasurement::tokenSignatureURL() const
 {
     if (!m_ephemeralSourceNonce || !m_ephemeralSourceNonce->isValid())
         return std::nullopt;

--- a/Source/WebCore/loader/PrivateClickMeasurement.h
+++ b/Source/WebCore/loader/PrivateClickMeasurement.h
@@ -97,10 +97,10 @@ public:
     void setEphemeral(PCM::AttributionEphemeral isEphemeral) { m_isEphemeral = isEphemeral; }
 
     // MARK: - Fraud Prevention
-    WEBCORE_EXPORT const std::optional<const URL> tokenPublicKeyURL() const;
-    WEBCORE_EXPORT static const std::optional<const URL> tokenPublicKeyURL(const RegistrableDomain&);
-    WEBCORE_EXPORT const std::optional<const URL> tokenSignatureURL() const;
-    WEBCORE_EXPORT static const std::optional<const URL> tokenSignatureURL(const RegistrableDomain&);
+    WEBCORE_EXPORT std::optional<URL> tokenPublicKeyURL() const;
+    WEBCORE_EXPORT static std::optional<URL> tokenPublicKeyURL(const RegistrableDomain&);
+    WEBCORE_EXPORT std::optional<URL> tokenSignatureURL() const;
+    WEBCORE_EXPORT static std::optional<URL> tokenSignatureURL(const RegistrableDomain&);
 
     WEBCORE_EXPORT Ref<JSON::Object> tokenSignatureJSON() const;
 


### PR DESCRIPTION
#### 5b7329cf1b86e72332e68c5069db0b953cfab522
<pre>
PrivateClickMeasurement token URL getters should return std::optional&lt;URL&gt; instead of const std::optional&lt;const URL&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=323252">https://bugs.webkit.org/show_bug.cgi?id=323252</a>
<a href="https://rdar.apple.com/186503027">rdar://186503027</a>

Reviewed by Chris Dumez.

tokenPublicKeyURL() and tokenSignatureURL() on PrivateClickMeasurement and
AttributionTriggerData returned `const std::optional&lt;const URL&gt;`, which
pessimizes copies in two compounding ways:

- The top-level `const` on the by-value return makes the returned prvalue
  const, so callers cannot move-construct from it and are forced to copy the
  URL (and its underlying String).
- The `const`-qualified element type (`optional&lt;const URL&gt;`) forces the
  `return makeValidURL(...)` inside these functions to copy rather than move
  the URL out of the `std::optional&lt;URL&gt;` that makeValidURL() returns, and
  makes the optional itself non-move-assignable.

Return plain `std::optional&lt;URL&gt;` instead. This is a move/RVO win with no
behavioral change; all existing call sites consume the result by value or
via `if (auto optURL = ...)` and are unaffected.

* Source/WebCore/loader/AttributionTriggerData.cpp:
(WebCore::PCM::AttributionTriggerData::tokenPublicKeyURL const):
(WebCore::PCM::AttributionTriggerData::tokenSignatureURL const):
* Source/WebCore/loader/AttributionTriggerData.h:
* Source/WebCore/loader/PrivateClickMeasurement.cpp:
(WebCore::PrivateClickMeasurement::tokenPublicKeyURL):
(WebCore::PrivateClickMeasurement::tokenPublicKeyURL const):
(WebCore::PrivateClickMeasurement::tokenSignatureURL):
(WebCore::PrivateClickMeasurement::tokenSignatureURL const):
* Source/WebCore/loader/PrivateClickMeasurement.h:

Canonical link: <a href="https://commits.webkit.org/320389@main">https://commits.webkit.org/320389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5496b085c6fb9a116c25427eb3e488c7180fa64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194919 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148862 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d6938a7-1bdd-48fa-bed4-2f8b811e61b8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144241 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100134 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ed5e048a-683b-46da-b509-ad5767e27655) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47902 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124524 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7626e5be-871c-416f-83ce-020c7576550c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46615 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44764 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/156997 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44394 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5977 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196864 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58178 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153708 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41158 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58882 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153360 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47878 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131170 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127665 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57383 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19415 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56745 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56994 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56818 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->