### PR TITLE
[JSC] Deleting a property of a dictionary prototype in place does not invalidate the megamorphic store cache

### DIFF
--- a/JSTests/stress/megamorphic-store-prototype-dictionary-delete.js
+++ b/JSTests/stress/megamorphic-store-prototype-dictionary-delete.js
@@ -1,0 +1,92 @@
+"use strict";
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+const shapeCount = 64;
+
+function makeShape(proto, i) {
+    const object = Object.create(proto);
+    for (let j = 0; j <= (i % 8); ++j)
+        object["k" + ((i * 5 + j * 3) % 13)] = j;
+    object["tag" + i] = i;
+    return object;
+}
+
+// Builds P1 -> P2 where P1 shadows P2's "x" with a writable data property, and
+// turns P1 into an uncacheable dictionary so that deleting P1.x later removes
+// the property in place without a Structure transition.
+function makeChain(P2) {
+    const P1 = Object.create(P2);
+    Object.defineProperty(P1, "x", { value: 0, writable: true, configurable: true, enumerable: true });
+    for (let i = 0; i < 5000; ++i)
+        P1["p" + i] = i;
+    for (let i = 0; i < testLoopCount; ++i)
+        makeShape(P1, i % shapeCount);
+    delete P1.p0;
+    return P1;
+}
+
+function put(object, value) {
+    object.x = value;
+}
+noInline(put);
+
+const unrelated = { unrelated: 1 };
+for (let i = 0; i < testLoopCount; ++i)
+    put(makeShape(unrelated, i % shapeCount), i);
+
+{
+    let setterCalls = 0;
+    const P2 = { set x(value) { setterCalls++; } };
+    const P1 = makeChain(P2);
+    for (let i = 0; i < testLoopCount; ++i) {
+        const object = makeShape(P1, i % shapeCount);
+        put(object, i);
+        shouldBe(Object.hasOwn(object, "x"), true);
+    }
+    shouldBe(setterCalls, 0);
+
+    delete P1.x;
+    for (let i = 0; i < shapeCount; ++i) {
+        const object = makeShape(P1, i);
+        put(object, i);
+        shouldBe(Object.hasOwn(object, "x"), false);
+    }
+    shouldBe(setterCalls, shapeCount);
+}
+
+{
+    const P2 = Object.defineProperty({}, "x", { value: 42, writable: false, configurable: true, enumerable: true });
+    const P1 = makeChain(P2);
+    for (let i = 0; i < testLoopCount; ++i) {
+        const object = makeShape(P1, i % shapeCount);
+        put(object, i);
+        shouldBe(object.x, i);
+    }
+
+    delete P1.x;
+    for (let i = 0; i < shapeCount; ++i) {
+        const object = makeShape(P1, i);
+        shouldThrow(() => put(object, i), "TypeError: Attempted to assign to readonly property.");
+        shouldBe(Object.hasOwn(object, "x"), false);
+        shouldBe(object.x, 42);
+    }
+}

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -2408,9 +2408,9 @@ bool JSObject::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, Proper
             ASSERT(!isValidOffset(structure->get(vm, propertyName, attributes)));
             if (offset != invalidOffset)
                 thisObject->locationForOffset(offset)->clear();
-            if (thisObject->mayBePrototype()) [[unlikely]]
-                vm.invalidateStructureChainIntegrity(VM::StructureChainIntegrityEvent::Remove);
         }
+        if (thisObject->mayBePrototype()) [[unlikely]]
+            vm.invalidateStructureChainIntegrity(VM::StructureChainIntegrityEvent::Remove);
     } else
         slot.setConfigurableMiss();
 


### PR DESCRIPTION
#### 41776a35d9581136117d35408f907e6bbc869632
<pre>
[JSC] Deleting a property of a dictionary prototype in place does not invalidate the megamorphic store cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=323254">https://bugs.webkit.org/show_bug.cgi?id=323254</a>

Reviewed by Yusuke Suzuki.

Deleting a property from an object whose Structure is an UncacheableDictionary
removes it in place, so the StructureID does not change. JSObject::deleteProperty
only bumped the megamorphic cache epoch on the transition path, so a store cache
entry that was recorded while a prototype shadowed a setter or a read-only
property stays valid after that shadowing property is deleted, and later stores
add an own property instead of calling the setter or throwing. Before 320236@main
such chains were never recorded in the store cache, which hid the missing bump.

Bump the epoch on both delete paths, matching the in-place add and attribute
change paths, which already invalidate without a transition.

Test: JSTests/stress/megamorphic-store-prototype-dictionary-delete.js

* JSTests/stress/megamorphic-store-prototype-dictionary-delete.js: Added.
(shouldBe):
(makeShape):
(makeChain):
(put):
(i.put.makeShape.const.P2.set x):
(i.put.makeShape):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::deleteProperty):

Canonical link: <a href="https://commits.webkit.org/320375@main">https://commits.webkit.org/320375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a21a622101513482c5d6e42545e56ee1ba6e686

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194924 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148867 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144244 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100138 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47916 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124527 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/46630 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/6492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13331 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44395 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5982 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45863 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49091 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196869 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58183 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/153707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41148 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58887 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153359 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47881 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131176 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127670 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57388 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/19416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56750 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/56999 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56823 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->