### PR TITLE
webRequest events not firing with tabs.create

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1737,7 +1737,8 @@ bool WebExtensionContext::hasPermissionToSendWebRequestEvent(WebExtensionTab* ta
     if (!hasPermission(WebExtensionPermission::webRequest(), tab))
         return false;
 
-    if (!tab->extensionHasPermission())
+    bool isMainFrameNavigation = loadInfo.type == ResourceLoadInfo::Type::Document && !loadInfo.parentFrameID;
+    if (!isMainFrameNavigation && !tab->extensionHasPermission())
         return false;
 
     if (resourceURL.isValid() && !hasPermission(resourceURL, tab))

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h
@@ -91,6 +91,7 @@
 
 @property (nonatomic, weak) TestWebExtensionWindow *window;
 @property (nonatomic, strong) WKWebView *webView;
+@property (nonatomic, copy) NSURL *overrideURL;
 
 - (void)changeWebViewIfNeededForURL:(NSURL *)url forExtensionContext:(WKWebExtensionContext *)context;
 

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm
@@ -558,6 +558,11 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     return _webView;
 }
 
+- (NSURL *)urlForWebExtensionContext:(WKWebExtensionContext *)context
+{
+    return _overrideURL ?: _webView.URL;
+}
+
 - (BOOL)isReaderModeActiveForWebExtensionContext:(WKWebExtensionContext *)context
 {
     return _showingReaderMode;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIWebRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIWebRequest.mm
@@ -942,6 +942,134 @@ TEST(WKWebExtensionAPIWebRequest, WebRequestFiresForDeclarativeNetRequestBlocked
     [manager run];
 }
 
+TEST(WKWebExtensionAPIWebRequest, WebRequestFiresForTabsCreate)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<html><body>hi</body></html>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"const expectedEvents = ['onBeforeRequest', 'onBeforeSendHeaders', 'onSendHeaders', 'onHeadersReceived', 'onResponseStarted', 'onCompleted']",
+        @"const firedEvents = []",
+        @"const filter = { urls: [ '<all_urls>' ] }",
+
+        @"function recordEvent(name, details) {",
+        @"  if (details?.type !== 'main_frame')",
+        @"    return",
+        @"  if (!details?.url?.includes('http://localhost'))",
+        @"    return",
+
+        @"  firedEvents.push(name)",
+
+        @"  if (name !== 'onCompleted')",
+        @"    return",
+
+        @"  browser.test.assertEq(JSON.stringify(firedEvents), JSON.stringify(expectedEvents), 'all main_frame webRequest events should fire in order')",
+        @"  browser.test.notifyPass()",
+        @"}",
+
+        @"browser.webRequest.onBeforeRequest.addListener((details) => recordEvent('onBeforeRequest', details), filter)",
+        @"browser.webRequest.onBeforeSendHeaders.addListener((details) => recordEvent('onBeforeSendHeaders', details), filter)",
+        @"browser.webRequest.onSendHeaders.addListener((details) => recordEvent('onSendHeaders', details), filter)",
+        @"browser.webRequest.onHeadersReceived.addListener((details) => recordEvent('onHeadersReceived', details), filter)",
+        @"browser.webRequest.onResponseStarted.addListener((details) => recordEvent('onResponseStarted', details), filter)",
+        @"browser.webRequest.onCompleted.addListener((details) => recordEvent('onCompleted', details), filter)",
+        @"browser.webRequest.onErrorOccurred.addListener((details) => { if (details?.type === 'main_frame') browser.test.notifyFail('unexpected onErrorOccurred') }, filter)",
+
+        [NSString stringWithFormat:@"browser.tabs.create({ url: '%@' })", urlRequest.URL.absoluteString]
+    ]);
+
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    auto *tabDocumentURLWithoutAccess = [NSURL URLWithString:@"https://webkit.org/"];
+
+    __weak TestWebExtensionManager *weakManager = manager.get();
+    manager.get().internalDelegate.openNewTab = ^(WKWebExtensionTabConfiguration *configuration, WKWebExtensionContext *context, void (^completionHandler)(id<WKWebExtensionTab>, NSError *)) {
+        auto *newTab = [weakManager.defaultWindow openNewTabAtIndex:configuration.index];
+        newTab.overrideURL = tabDocumentURLWithoutAccess;
+
+        if (configuration.url) {
+            [newTab changeWebViewIfNeededForURL:configuration.url forExtensionContext:context];
+            [newTab.webView loadRequest:[NSURLRequest requestWithURL:configuration.url]];
+        }
+
+        completionHandler(newTab, nil);
+    };
+
+    [manager run];
+}
+
+#if PLATFORM(MAC)
+TEST(WKWebExtensionAPIWebRequest, WebRequestFiresForWindowsCreate)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<html><body>hi</body></html>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"const expectedEvents = ['onBeforeRequest', 'onBeforeSendHeaders', 'onSendHeaders', 'onHeadersReceived', 'onResponseStarted', 'onCompleted']",
+        @"const firedEvents = []",
+        @"const filter = { urls: [ '<all_urls>' ] }",
+
+        @"function recordEvent(name, details) {",
+        @"  if (details?.type !== 'main_frame')",
+        @"    return",
+        @"  if (!details?.url?.includes('http://localhost'))",
+        @"    return",
+
+        @"  firedEvents.push(name)",
+
+        @"  if (name !== 'onCompleted')",
+        @"    return",
+
+        @"  browser.test.assertEq(JSON.stringify(firedEvents), JSON.stringify(expectedEvents), 'all main_frame webRequest events should fire in order')",
+        @"  browser.test.notifyPass()",
+        @"}",
+
+        @"browser.webRequest.onBeforeRequest.addListener((details) => recordEvent('onBeforeRequest', details), filter)",
+        @"browser.webRequest.onBeforeSendHeaders.addListener((details) => recordEvent('onBeforeSendHeaders', details), filter)",
+        @"browser.webRequest.onSendHeaders.addListener((details) => recordEvent('onSendHeaders', details), filter)",
+        @"browser.webRequest.onHeadersReceived.addListener((details) => recordEvent('onHeadersReceived', details), filter)",
+        @"browser.webRequest.onResponseStarted.addListener((details) => recordEvent('onResponseStarted', details), filter)",
+        @"browser.webRequest.onCompleted.addListener((details) => recordEvent('onCompleted', details), filter)",
+        @"browser.webRequest.onErrorOccurred.addListener((details) => { if (details?.type === 'main_frame') browser.test.notifyFail('unexpected onErrorOccurred') }, filter)",
+
+        [NSString stringWithFormat:@"browser.windows.create({ url: '%@' })", urlRequest.URL.absoluteString]
+    ]);
+
+    auto manager = Util::loadExtension(webRequestManifest, @{ @"background.js": backgroundScript });
+
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:WKWebExtensionPermissionWebRequest];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    auto *tabDocumentURLWithoutAccess = [NSURL URLWithString:@"https://webkit.org/"];
+
+    __weak TestWebExtensionManager *weakManager = manager.get();
+    manager.get().internalDelegate.openNewWindow = ^(WKWebExtensionWindowConfiguration *configuration, WKWebExtensionContext *context, void (^completionHandler)(id<WKWebExtensionWindow>, NSError *)) {
+        auto *newWindow = [weakManager openNewWindowUsingPrivateBrowsing:configuration.shouldBePrivate];
+        auto *newTab = newWindow.tabs.firstObject;
+        newTab.overrideURL = tabDocumentURLWithoutAccess;
+
+        NSURL *url = configuration.tabURLs.firstObject;
+        if (url) {
+            [newTab changeWebViewIfNeededForURL:url forExtensionContext:context];
+            [newTab.webView loadRequest:[NSURLRequest requestWithURL:url]];
+        }
+
+        completionHandler(newWindow, nil);
+    };
+
+    [manager run];
+}
+#endif
+
 TEST(WKWebExtensionAPIWebRequest, RedirectOccurredEvent)
 {
     TestWebKitAPI::HTTPServer server({


### PR DESCRIPTION
#### 7acdcf23cf0c0b6631a83a3a32911122766fe9a4
<pre>
webRequest events not firing with tabs.create
<a href="https://bugs.webkit.org/show_bug.cgi?id=315367">https://bugs.webkit.org/show_bug.cgi?id=315367</a>
<a href="https://rdar.apple.com/177727052">rdar://177727052</a>

Reviewed by Timothy Hatcher and Kiara Rose.

This patch makes a Safari Web Extension&apos;s webRequest events fire for the initial main-frame
navigation of a tab or window created with browser.tabs.create or browser.windows.create.

hasPermissionToSendWebRequestEvent required the extension to have host access to the tab&apos;s
committed document URL. A newly created tab whose main-frame navigation has not committed yet
has no committed URL, so the check failed and every webRequest event for the initial load was
dropped. Reloading or navigating from the address bar worked because the tab already had a
committed URL by then.

The committed document is only the relevant page for subresource and subframe loads. For a
top-level navigation the request is the document itself, and it is already covered by the
per-request host permission checks, so this patch skips the committed-document check for
main-frame navigations.

The test harness reports a tab&apos;s URL as its web view&apos;s URL, which during a navigation is the
provisional destination rather than the empty committed URL a new tab has, so it could not
reproduce this on its own. TestWebExtensionTab gains an overrideURL so a test can report a
document URL the extension cannot access.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIWebRequest.mm
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::hasPermissionToSendWebRequestEvent):
* Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionTab urlForWebExtensionContext:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIWebRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, WebRequestFiresForTabsCreate)):
(TestWebKitAPI::TEST(WKWebExtensionAPIWebRequest, WebRequestFiresForWindowsCreate)):

Canonical link: <a href="https://commits.webkit.org/320430@main">https://commits.webkit.org/320430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c976a2da0073158f8456a2f194370e30d8a14bab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194934 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148876 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186465 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144254 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100146 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187558 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124537 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46624 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44774 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44407 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/5992 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49097 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196880 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58194 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153720 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58897 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41023 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153373 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28073 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47893 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131186 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127681 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57398 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19427 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56760 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57009 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56834 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->