### PR TITLE
Enhance Tools/Scripts/dump-class-layout to be able to dump classes in static libraries and other binaries as well.

### DIFF
--- a/Tools/Scripts/dump-class-layout
+++ b/Tools/Scripts/dump-class-layout
@@ -46,10 +46,32 @@ def webkit_build_dir():
     scriptpath = os.path.dirname(os.path.realpath(__file__))
     return subprocess.check_output([os.path.join(scriptpath, "webkit-build-directory"), "--top-level"]).decode().strip()
 
+def find_binary(build_dir, config, name):
+    if os.path.isfile(name):
+        return name
+
+    candidates = [
+        os.path.join(name + ".framework", name),  # Framework.
+        "lib" + name + ".a",                      # Static library, named as the build system names it.
+        name + ".a",
+        "lib" + name + ".dylib",
+        name + ".dylib",
+        name,                                     # Executable.
+    ]
+
+    configuration_dir = os.path.join(build_dir, config)
+    for candidate in candidates:
+        path = os.path.join(configuration_dir, candidate)
+        if os.path.isfile(path):
+            return path
+
+    print('error: found no framework, library or executable named "%s" in "%s"' % (name, configuration_dir))
+    sys.exit(1)
+
 def main(argv=None):
     parser = argparse.ArgumentParser(description='Dumps the in-memory layout of the given class or classes, showing padding holes.')
-    parser.add_argument('framework', metavar='framework',
-        help='name of the framework containing the class (e.g. "WebCore")')
+    parser.add_argument('binary', metavar='binary',
+        help='name of the framework, static library or executable containing the class (e.g. "WebCore", "JavaScriptCoreTools"), or a path to one')
     parser.add_argument('classname', metavar='classname', nargs='+',
         help='name of the class or struct to dump (may specify multiple classes)')
 
@@ -80,8 +102,7 @@ def main(argv=None):
     if args.target_path is not None:
         target_path = args.target_path
     else:
-        target_path = os.path.join(build_dir, args.config, args.framework + ".framework", args.framework);
-    
+        target_path = find_binary(build_dir, args.config, args.binary)
     lldb_instance = LLDBDebuggerInstance(target_path, args.arch)
 
     # Check if stdout is a TTY to determine if we should use colors

--- a/Tools/lldb/lldb_dump_class_layout.py
+++ b/Tools/lldb/lldb_dump_class_layout.py
@@ -386,19 +386,55 @@ class LLDBDebuggerInstance:
         if not self.target:
             print("Failed to make target for " + self.binary_path)
 
-        self.module = self.target.GetModuleAtIndex(0)
-        if not self.module:
-            print("Failed to get first module in " + self.binary_path)
+        self.archive_member_specs = self._archive_member_specs()
+        self.search_start_index = 0
+
+        self.module = None
+        if not self.archive_member_specs:
+            self.module = self.target.GetModuleAtIndex(0)
+            if not self.module:
+                print("Failed to get first module in " + self.binary_path)
 
     def __del__(self):
         if lldb:
             lldb.SBDebugger.Destroy(self.debugger)
 
-    def layout_for_classname(self, classname, skip_nested=False):
-        types = self.module.FindTypes(classname)
-        if types.GetSize():
-            # There can be more that one type with a given name, but for now just return the first one.
-            return ClassLayout(self.target, types.GetTypeAtIndex(0), skip_nested=skip_nested)
+    # A static library is an ar archive of object files, each of which carries its own debug
+    # info. lldb models each member as a separate module, so an archive needs its members
+    # enumerated and searched one at a time. Returns [] for a single Mach-O binary.
+    def _archive_member_specs(self):
+        specs = lldb.SBModuleSpecList.GetModuleSpecifications(str(self.binary_path))
+        members = [specs.GetSpecAtIndex(i) for i in range(specs.GetSize())]
+        members = [spec for spec in members if spec.GetObjectName()]
+        if not members:
+            return []
 
-        print('error: no type matches "%s" in "%s"' % (classname, self.module.file))
+        # A fat archive lists every member once per architecture; only search one of them.
+        architecture = self.architecture if self.architecture else members[0].GetTriple().split('-')[0]
+        return [spec for spec in members if spec.GetTriple().split('-')[0] == architecture]
+
+    def _modules_to_search(self):
+        if not self.archive_member_specs:
+            yield self.module
+            return
+
+        # Adding a member evicts the previously added one, since all members share the archive's
+        # path. Resume from the member that satisfied the previous lookup: consecutive lookups
+        # usually land in the same member, and scanning a large archive is slow.
+        count = len(self.archive_member_specs)
+        for i in range(count):
+            index = (self.search_start_index + i) % count
+            module = self.target.AddModule(self.archive_member_specs[index])
+            if module:
+                self.search_start_index = index
+                yield module
+
+    def layout_for_classname(self, classname, skip_nested=False):
+        for module in self._modules_to_search():
+            types = module.FindTypes(classname)
+            if types.GetSize():
+                # There can be more that one type with a given name, but for now just return the first one.
+                return ClassLayout(self.target, types.GetTypeAtIndex(0), skip_nested=skip_nested)
+
+        print('error: no type matches "%s" in "%s"' % (classname, self.binary_path))
         return None


### PR DESCRIPTION
#### 38ff8b34a54151a1cfafa359c6178b3b353f2bef
<pre>
Enhance Tools/Scripts/dump-class-layout to be able to dump classes in static libraries and other binaries as well.
<a href="https://bugs.webkit.org/show_bug.cgi?id=323262">https://bugs.webkit.org/show_bug.cgi?id=323262</a>
<a href="https://rdar.apple.com/186508769">rdar://186508769</a>

Reviewed by Yusuke Suzuki.

We used to be able to dump class layouts in WebKit frameworks:
% /usr/bin/python3 ./Tools/Scripts/dump-class-layout -b WebKitBuild -c Release JavaScriptCore CodeBlock

Now, we can also dump class layouts in static libraries as well e.g.
% /usr/bin/python3 ./Tools/Scripts/dump-class-layout -b WebKitBuild -c Release libJavaScriptCoreTools.a Corpse::Snapshot

Or more conveniently, we can do so by specifying the path to the binary file:
% /usr/bin/python3 ./Tools/Scripts/dump-class-layout WebKitBuild/Release/libJavaScriptCoreTools.a Corpse::Snapshot

./Tools/Scripts/dump-class-layout will now look for target binaries (of various formats) to dump from in this order:
1. name + &quot;.framework/&quot; + name
2. &quot;lib&quot; + name + &quot;.a&quot;
3. name + &quot;.a&quot;
4. &quot;lib&quot; + name + &quot;.dylib&quot;
5. name + &quot;.dylib&quot;,
6. name

First one found that is a valid file will be consulted for the class layout info to dump.

* Tools/Scripts/dump-class-layout:
(webkit_build_dir):
(find_binary):
(main.or):
(main):
* Tools/lldb/lldb_dump_class_layout.py:
(LLDBDebuggerInstance.__init__):
(LLDBDebuggerInstance):
(LLDBDebuggerInstance._archive_member_specs):
(LLDBDebuggerInstance._modules_to_search):
(LLDBDebuggerInstance.layout_for_classname):

Canonical link: <a href="https://commits.webkit.org/320394@main">https://commits.webkit.org/320394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7ff2e57d4477ecdde71dbab81d0fc6a89a60559

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184665 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/58582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52407 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194997 "Failed to checkout and rebase branch from PR 73098") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186527 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/59938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/194997 "Failed to checkout and rebase branch from PR 73098") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187620 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/59938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/194997 "Failed to checkout and rebase branch from PR 73098") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/59938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/194997 "Failed to checkout and rebase branch from PR 73098") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/59938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/44455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/6053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/58315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196943 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/58255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/164397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/153765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58957 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/153423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28053 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/47944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127765 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/57458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/19476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/56819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/56894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->