### PR TITLE
[Site Isolation] http/tests/misc/webtiming-cross-origin-and-back1.html is a timeout

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -286,7 +286,7 @@ void InjectedBundle::didReceiveMessageToPage(WKBundlePageRef page, WKStringRef m
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "WorkQueueProcessedCallback")) {
-        if (!topLoadingFrame() && m_testRunner && !m_testRunner->shouldWaitUntilDone())
+        if (m_testRunner && !m_testRunner->shouldWaitUntilDone() && InjectedBundle::page() && !InjectedBundle::page()->topLoadingFrame())
             InjectedBundle::page()->dump();
         return;
     }
@@ -396,7 +396,8 @@ void InjectedBundle::beginTesting(WKDictionaryRef settings, BegingTestingMode te
 
 void InjectedBundle::done()
 {
-    setTopLoadingFrame(0);
+    for (auto& page : m_pages)
+        page->setTopLoadingFrame(nullptr);
 
     m_accessibilityController->resetToConsistentState();
 

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -73,9 +73,6 @@ public:
 
     bool isTestRunning() { return !!testRunner(); }
 
-    WKBundleFrameRef topLoadingFrame() { return m_topLoadingFrame; }
-    void setTopLoadingFrame(WKBundleFrameRef frame) { m_topLoadingFrame = frame; }
-
     bool shouldDumpPixels() const { return m_dumpPixels; }
 
     enum class IsFinalTestOutput : bool { No, Yes };
@@ -187,8 +184,6 @@ private:
     RefPtr<GCController> m_gcController;
     RefPtr<EventSendingController> m_eventSendingController;
     RefPtr<TextInputController> m_textInputController;
-
-    WKBundleFrameRef m_topLoadingFrame { nullptr };
 
     bool m_dumpPixels { false };
     bool m_pixelResultIsPending { false };

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -275,6 +275,7 @@ void InjectedBundlePage::resetAfterTest()
     InjectedBundle::singleton().resetUserScriptInjectedCount();
 
     m_didCommitMainFrameLoad = false;
+    m_topLoadingFrame = nullptr;
 }
 
 // Loader Client Callbacks
@@ -386,8 +387,8 @@ void InjectedBundlePage::didStartProvisionalLoadForFrame(WKBundleFrameRef frame)
     if (testRunner->shouldDumpFrameLoadCallbacks())
         dumpLoadEvent(frame, "didStartProvisionalLoadForFrame"_s);
 
-    if (!injectedBundle.topLoadingFrame())
-        injectedBundle.setTopLoadingFrame(frame);
+    if (!m_topLoadingFrame)
+        setTopLoadingFrame(frame);
 
     if (testRunner->shouldStopProvisionalFrameLoads())
         dumpLoadEvent(frame, "stopping load in didStartProvisionalLoadForFrame callback"_s);
@@ -1092,10 +1093,13 @@ void InjectedBundlePage::frameDidChangeLocation(WKBundleFrameRef frame)
         return;
     }
 
-    if (frame != injectedBundle.topLoadingFrame())
+    if (frame != m_topLoadingFrame)
         return;
 
-    injectedBundle.setTopLoadingFrame(nullptr);
+    setTopLoadingFrame(nullptr);
+
+    if (injectedBundle.page() != this)
+        return;
 
     if (testRunner->shouldDisplayOnLoadFinish()) {
         if (auto page = InjectedBundle::singleton().page())
@@ -1126,7 +1130,7 @@ void InjectedBundlePage::frameDidChangeLocation(WKBundleFrameRef frame)
 
 void InjectedBundlePage::notifyDone()
 {
-    if (InjectedBundle::singleton().topLoadingFrame())
+    if (m_topLoadingFrame)
         return;
     forceImmediateCompletion();
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h
@@ -41,6 +41,9 @@ public:
 
     WKBundlePageRef page() const { return m_page; }
 
+    WKBundleFrameRef topLoadingFrame() { return m_topLoadingFrame; }
+    void setTopLoadingFrame(WKBundleFrameRef frame) { m_topLoadingFrame = frame; }
+
     void notifyDone();
     void forceImmediateCompletion();
     void dump();
@@ -122,6 +125,7 @@ private:
     void frameDidChangeLocation(WKBundleFrameRef);
 
     WKBundlePageRef m_page;
+    WKBundleFrameRef m_topLoadingFrame { nullptr };
     WKRetainPtr<WKBundleScriptWorldRef> m_world;
     bool m_didCommitMainFrameLoad { false };
 };


### PR DESCRIPTION
#### edd9fe9dbe988d809ee9819e78bc0f4c1668f0d2
<pre>
[Site Isolation] http/tests/misc/webtiming-cross-origin-and-back1.html is a timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=322870">https://bugs.webkit.org/show_bug.cgi?id=322870</a>
<a href="https://rdar.apple.com/186116994">rdar://186116994</a>

Reviewed by Alex Christensen.

Currently, m_topLoadingFrame is tracked per-process in the InjectedBundle which means it is
shared by all the WKBundlePages of InjectedBundle. Because it&apos;s per process, it can end
up tracking the wrong load of the various pages. In webtiming-cross-origin-and-back1.html&apos;s case,
it was an abandoned provisional load from a redirect. For tests with pop-ups, the pop-up can overwrite
the opener&apos;s m_topLoadingFrame. WebKit relies on m_topLoadingFrame to match the load&apos;s
frame to properly notify the test runner. If the loading frame does not match m_topLoadingFrame,
the test runner is never notified and the test times out.

The fix is to have each page track its own m_topLoadingFrame so that provisional loads for
pages in the shared process don&apos;t overwrite the primary page&apos;s (ie InjectedBundle::page())
m_topLoadingFrame. We additionally check that the page being loaded is the primary page. If not,
we don&apos;t notify the test runner and exit early.

http/tests/misc/webtiming-cross-origin-and-back1.html is the relevant test.

* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::didReceiveMessageToPage):
(WTR::InjectedBundle::done):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
(WTR::InjectedBundle::topLoadingFrame): Deleted.
(WTR::InjectedBundle::setTopLoadingFrame): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::InjectedBundlePage::resetAfterTest):
(WTR::InjectedBundlePage::didStartProvisionalLoadForFrame):
(WTR::InjectedBundlePage::frameDidChangeLocation):
(WTR::InjectedBundlePage::notifyDone):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.h:
(WTR::InjectedBundlePage::topLoadingFrame):
(WTR::InjectedBundlePage::setTopLoadingFrame):

Canonical link: <a href="https://commits.webkit.org/320484@main">https://commits.webkit.org/320484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da98800663a7187698ea9b7fdf32e11797a91058

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195147 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/557cb7ca-52b7-4925-97b8-e4d5c673bd66) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186675 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144418 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1ffd1de3-5796-4e69-ba07-898c5d23174b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48086 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165016 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124703 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74ac526a-145e-459b-bda7-a813f22aa139) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46810 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44918 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157182 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44574 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6203 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49263 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197096 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58403 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153895 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59107 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41186 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153552 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28092 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48069 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127956 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57605 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19592 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56963 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57214 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57040 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->