### PR TITLE
Fix cookie list splitting in the test HTTP/2 server.

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/NetworkConnection.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/NetworkConnection.mm
@@ -126,11 +126,17 @@ void Connection::receiveHTTPMessagingRequest(CompletionHandler<void(HTTPRequestD
                         });
                         if (RetainPtr fields = adoptNS(nw_http_request_copy_header_fields(request.get()))) {
                             nw_http_fields_enumerate(fields.get(), ^bool(const char* name, size_t nameLength, const char* value, size_t valueLength) {
+                                String fieldName = String::fromUTF8(std::span(name, nameLength));
                                 String fieldValue = String::fromUTF8(std::span(value, valueLength));
-                                auto addResult = blockPartial.headerFields.add(String::fromUTF8(std::span(name, nameLength)), fieldValue);
-                                // RFC 7230 3.2.2: repeated fields with the same name are combined by joining with a comma.
-                                if (!addResult.isNewEntry)
-                                    addResult.iterator->value = makeString(addResult.iterator->value, ", "_s, fieldValue);
+                                auto addResult = blockPartial.headerFields.add(fieldName, fieldValue);
+                                if (!addResult.isNewEntry) {
+                                    // RFC 7540 8.1.2.5: cookie crumbling splits a single Cookie header into multiple
+                                    // header fields on the wire, which must be rejoined with "; " to reconstruct the
+                                    // original Cookie header value. All other repeated fields are combined per RFC
+                                    // 7230 3.2.2 by joining with a comma.
+                                    ASCIILiteral separator = fieldName == "cookie"_s ? "; "_s : ", "_s;
+                                    addResult.iterator->value = makeString(addResult.iterator->value, separator, fieldValue);
+                                }
                                 return true;
                             });
                         }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP2Server.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP2Server.mm
@@ -131,6 +131,47 @@ TEST(HTTP2Server, MultipleRequestsOverOneConnection)
     EXPECT_WK_STREQ("true", [webView stringByEvaluatingJavaScript:@"performance.getEntriesByType('resource').every(entry => entry.nextHopProtocol === 'h2').toString()"]);
 }
 
+TEST(HTTP2Server, MultipleCookiesSetBeforeLoad)
+{
+    // RFC 7540 8.1.2.5 "cookie crumbling": a client may split one logical Cookie header into
+    // multiple header fields on the wire. These must be rejoined with "; ", not the "," used
+    // for other repeated header fields (RFC 7230 3.2.2), to reconstruct the Cookie header value.
+    RetainPtr<NSString> receivedCookieHeader;
+
+    HTTPServer server([&](Connection connection) {
+        connection.receiveHTTPMessagingRequest([&, connection](HTTPRequestData&& request) {
+            receivedCookieHeader = request.headerFields.get("cookie"_s).createNSString();
+            connection.sendHTTPMessagingResponse(HTTPResponse("hello"_s));
+        });
+    }, HTTPServer::Protocol::Http2);
+
+    RetainPtr<NSHTTPCookie> firstCookie = [NSHTTPCookie cookieWithProperties:@{
+        NSHTTPCookiePath: @"/",
+        NSHTTPCookieName: @"firstCookie",
+        NSHTTPCookieValue: @"firstValue",
+        NSHTTPCookieDomain: @"127.0.0.1",
+    }];
+    RetainPtr<NSHTTPCookie> secondCookie = [NSHTTPCookie cookieWithProperties:@{
+        NSHTTPCookiePath: @"/",
+        NSHTTPCookieName: @"secondCookie",
+        NSHTTPCookieValue: @"secondValue",
+        NSHTTPCookieDomain: @"127.0.0.1",
+    }];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    WKHTTPCookieStore *cookieStore = webView.get().configuration.websiteDataStore.httpCookieStore;
+    __block bool cookiesSet = false;
+    [cookieStore setCookie:firstCookie.get() completionHandler:^{
+        [cookieStore setCookie:secondCookie.get() completionHandler:^{
+            cookiesSet = true;
+        }];
+    }];
+    TestWebKitAPI::Util::run(&cookiesSet);
+
+    [webView synchronouslyLoadRequestIgnoringSSLErrors:server.request()];
+    EXPECT_WK_STREQ("firstCookie=firstValue; secondCookie=secondValue", receivedCookieHeader.get());
+}
+
 } // namespace TestWebKitAPI
 
 #endif // HAVE(NETWORK_FRAMEWORK_HTTP_MESSAGING)


### PR DESCRIPTION
#### 7b6b37f2db60eb7cedc45f099883b8e5b870f6b4
<pre>
Fix cookie list splitting in the test HTTP/2 server.
<a href="https://rdar.apple.com/186509924">rdar://186509924</a>

Reviewed by Alex Christensen.

Multiple cookies are separated with a semicolon and space rather than a comma, like other headers.
This discrepancy was noticed by substituting HTTP/2 and HTTP/3 into a set of existing API tests that currently use HTTP/1.1, and noticing that WKHTTPCookieStore.CookiesSetBeforeLoad failed on the new protocols, so I duplicated that test into the HTTP2Server.mm file.

* Tools/TestWebKitAPI/Helpers/cocoa/NetworkConnection.mm:
(TestWebKitAPI::Connection::receiveHTTPMessagingRequest const):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP2Server.mm:
(TestWebKitAPI::TEST(HTTP2Server, MultipleCookiesSetBeforeLoad)):

Canonical link: <a href="https://commits.webkit.org/320457@main">https://commits.webkit.org/320457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e74e27abef551b84c6b56ecd9c55d4849e4ae41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194950 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148887 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186481 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144261 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100152 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a8cc0397-1d32-4ec6-9898-9c4b33357591) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124544 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/302ce7e7-1a56-4c8f-b9b7-289efd5d8061) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46642 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44783 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157021 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44413 "Passed tests") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6007 "Hash 1e74e27a for PR 73102 does not build (failure)") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49108 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196896 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58209 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153724 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58911 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153380 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28084 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47902 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127695 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57412 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19435 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56773 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57021 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56848 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->