### PR TITLE
Remove extraneous get()'s from WebParentalControlsURLFilter.mm

### DIFF
--- a/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
+++ b/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
@@ -62,7 +62,7 @@ BEWebContentFilter* WebParentalControlsURLFilter::ensureWebContentFilter()
     if (!m_webContentFilter)
         lazyInitialize(m_webContentFilter, adoptNS([[BEWebContentFilter alloc] init]));
 
-    return m_webContentFilter.get();
+    return m_webContentFilter;
 }
 
 bool WebParentalControlsURLFilter::isEnabledImpl() const
@@ -97,7 +97,7 @@ void WebParentalControlsURLFilter::isURLAllowedImpl(WebCore::IsMainFrameLoad isM
         if (WebCore::DeprecatedGlobalSettings::webContentRestrictionsTransitiveTrustEnabled()) {
             BOOL isMainFrameForEvaluation = (isMainFrame == WebCore::IsMainFrameLoad::Yes);
             if ([filter respondsToSelector:@selector(evaluateURL:mainFrameURL:isMainFrame:completionHandler:)]) {
-                [filter evaluateURL:url.createNSURL().get() mainFrameURL:mainDocumentURL.createNSURL().get() isMainFrame:isMainFrameForEvaluation completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)](BOOL shouldBlock, NSData *replacementData) mutable {
+                [filter evaluateURL:url.createNSURL() mainFrameURL:mainDocumentURL.createNSURL() isMainFrame:isMainFrameForEvaluation completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)](BOOL shouldBlock, NSData *replacementData) mutable {
                     if (completionHandler)
                         completionHandler(!shouldBlock, replacementData);
                 }).get()];
@@ -106,7 +106,7 @@ void WebParentalControlsURLFilter::isURLAllowedImpl(WebCore::IsMainFrameLoad isM
         }
 #endif
 #endif
-        [filter evaluateURL:url.createNSURL().get() completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)](BOOL shouldBlock, NSData *replacementData) mutable {
+        [filter evaluateURL:url.createNSURL() completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)](BOOL shouldBlock, NSData *replacementData) mutable {
             // Make sure we don't crash even if [BEWebContentFilter evaluateURL:completionHandler:] calls its
             // completion handler more than once (which seems to happen in practice).
             if (completionHandler)
@@ -125,7 +125,7 @@ void WebParentalControlsURLFilter::allowURL(const URL& url, CompletionHandler<vo
             return;
         }
 
-        [protect(ensureWebContentFilter()) allowURL:url.createNSURL().get() completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)](BOOL didAllow, NSError *) mutable {
+        [protect(ensureWebContentFilter()) allowURL:url.createNSURL() completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)](BOOL didAllow, NSError *) mutable {
             RELEASE_LOG(Loading, "WebParentalControlsURLFilter::allowURL result %d.\n", didAllow);
             callOnMainRunLoop([didAllow, completionHandler = WTF::move(completionHandler)] mutable {
                 if (completionHandler)
@@ -189,7 +189,7 @@ void WebParentalControlsURLFilter::requestPermissionForURL(const URL& url, const
                         completionHandler(didAllow);
                 });
             });
-            [filter requestPermissionForURL:url.createNSURL().get() referrerURL:referrerURL.createNSURL().get() presentingView:presentingViewAsUIView completionHandler:permissionDecisionCompletionHandler.get()];
+            [filter requestPermissionForURL:url.createNSURL() referrerURL:referrerURL.createNSURL() presentingView:presentingViewAsUIView completionHandler:permissionDecisionCompletionHandler.get()];
             return;
         }
 #endif


### PR DESCRIPTION
#### 8c21d7727b4793b2d5e539bb815e3107055c892a
<pre>
Remove extraneous get()&apos;s from WebParentalControlsURLFilter.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=323266">https://bugs.webkit.org/show_bug.cgi?id=323266</a>
<a href="https://rdar.apple.com/186513989">rdar://186513989</a>

Reviewed by Sihui Liu and Per Arne Vollan.

These are no longer necessary.

No new tests needed.

* Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm:
(WebKit::WebParentalControlsURLFilter::ensureWebContentFilter):
(WebKit::WebParentalControlsURLFilter::isURLAllowedImpl):
(WebKit::WebParentalControlsURLFilter::allowURL):
(WebKit::WebParentalControlsURLFilter::requestPermissionForURL):

Canonical link: <a href="https://commits.webkit.org/320452@main">https://commits.webkit.org/320452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/612f626e5de73b4140dfbb1d2a512458a07b4032

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194958 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148894 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b343b215-6c7c-4ad4-8624-fd4d34048884) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58276 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144268 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100159 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/239c33fe-81a5-4623-bca2-e8cbf721bec3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187581 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47930 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164876 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124551 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9a608654-8c5d-401f-8f6c-92e1deab25bc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46645 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44790 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157024 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44420 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6014 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196906 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58216 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153733 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58918 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153389 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28081 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47908 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131207 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127702 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57419 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19442 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56780 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57028 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56855 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->