### PR TITLE
[GFC] A grid item's automatic minimum size is not clamped to a fixed max track sizing function.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/automatic-minimum-size-clamped-to-fixed-max-track-sizing-function-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/automatic-minimum-size-clamped-to-fixed-max-track-sizing-function-expected.txt
@@ -1,0 +1,15 @@
+
+PASS An item taller than its track does not grow the track past its fixed maximum
+PASS An item taller than its track does not grow the track past its fixed maximum when the grid container height is definite
+PASS An item shorter than its track's fixed maximum still lets the track grow to that maximum
+PASS An item taller than its track grows a track whose maximum is intrinsic
+PASS A specified minimum size is not clamped to the track's fixed maximum
+PASS A scroll container taller than its track does not grow the track past its fixed maximum
+PASS An item spanning several tracks does not grow any of them past their fixed maximums
+PASS An item with margins does not grow its track past its fixed maximum
+PASS An item taller than its track does not grow the track past a definite percentage maximum
+PASS An item taller than its track does not grow the track past a definite calc() maximum
+PASS An item taller than its track is sized to its grid area, not to its content
+PASS An item spanning several tracks is sized to its grid area, not to its content
+PASS An item with margins is sized to the stretch fit into its grid area
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/automatic-minimum-size-clamped-to-fixed-max-track-sizing-function.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/automatic-minimum-size-clamped-to-fixed-max-track-sizing-function.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<title>CSS Grid Layout Test: automatic minimum size clamped to a fixed max track sizing function</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#min-size-auto">
+<meta name="assert" content="A grid item that spans only tracks with a fixed max track sizing function has its automatic minimum size further clamped to the stretch fit into the grid area's maximum size, so an item larger than its track cannot grow that track past its maximum. A definite <length-percentage> maximum is fixed too. The clamp does not apply to a specified minimum size, to a track whose maximum is intrinsic, or to an item whose automatic minimum size is already zero.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<style>
+  .grid {
+    display: grid;
+    grid-template-columns: 50px;
+    grid-auto-rows: minmax(auto, 40px);
+  }
+
+  .definiteHeight {
+    height: 300px;
+  }
+
+  /* Taller than the track's maximum, so the item's automatic minimum size is what
+     would grow the track past that maximum if it were not clamped. */
+  .tallerThanMaximum {
+    height: 100px;
+  }
+
+  .shorterThanMaximum {
+    height: 20px;
+  }
+</style>
+
+<div class="grid" id="indefiniteHeight">
+  <div><div class="tallerThanMaximum"></div></div>
+</div>
+
+<div class="grid definiteHeight" id="definiteHeight">
+  <div><div class="tallerThanMaximum"></div></div>
+</div>
+
+<div class="grid definiteHeight" id="contentShorterThanMaximum">
+  <div><div class="shorterThanMaximum"></div></div>
+</div>
+
+<div class="grid" id="intrinsicMaximum" style="grid-auto-rows: minmax(auto, max-content)">
+  <div><div class="tallerThanMaximum"></div></div>
+</div>
+
+<div class="grid" id="specifiedMinimumSize">
+  <div style="min-height: 100px"><div class="tallerThanMaximum"></div></div>
+</div>
+
+<div class="grid" id="scrollableOverflow">
+  <div style="overflow: hidden"><div class="tallerThanMaximum"></div></div>
+</div>
+
+<div class="grid" id="spanningTwoTracks" style="row-gap: 10px">
+  <div style="grid-row: span 2"><div style="height: 200px"></div></div>
+</div>
+
+<div class="grid" id="itemWithMargins">
+  <div style="margin-top: 5px; margin-bottom: 5px"><div class="tallerThanMaximum"></div></div>
+</div>
+
+<div class="grid definiteHeight" id="percentageMaximum" style="grid-auto-rows: minmax(auto, 20%)">
+  <div><div class="tallerThanMaximum"></div></div>
+</div>
+
+<div class="grid definiteHeight" id="calculatedMaximum" style="grid-auto-rows: minmax(auto, calc(10% + 10px))">
+  <div><div class="tallerThanMaximum"></div></div>
+</div>
+
+<script>
+function usedRowSizes(gridContainer) {
+  return getComputedStyle(gridContainer).gridTemplateRows;
+}
+
+function usedItemHeight(gridContainer) {
+  return gridContainer.firstElementChild.getBoundingClientRect().height;
+}
+
+test(() => {
+  assert_equals(usedRowSizes(indefiniteHeight), "40px");
+}, "An item taller than its track does not grow the track past its fixed maximum");
+
+test(() => {
+  assert_equals(usedRowSizes(definiteHeight), "40px");
+}, "An item taller than its track does not grow the track past its fixed maximum when the grid container height is definite");
+
+test(() => {
+  assert_equals(usedRowSizes(contentShorterThanMaximum), "40px");
+}, "An item shorter than its track's fixed maximum still lets the track grow to that maximum");
+
+test(() => {
+  assert_equals(usedRowSizes(intrinsicMaximum), "100px");
+}, "An item taller than its track grows a track whose maximum is intrinsic");
+
+test(() => {
+  assert_equals(usedRowSizes(specifiedMinimumSize), "100px");
+}, "A specified minimum size is not clamped to the track's fixed maximum");
+
+test(() => {
+  assert_equals(usedRowSizes(scrollableOverflow), "40px");
+}, "A scroll container taller than its track does not grow the track past its fixed maximum");
+
+test(() => {
+  assert_equals(usedRowSizes(spanningTwoTracks), "40px 40px");
+}, "An item spanning several tracks does not grow any of them past their fixed maximums");
+
+test(() => {
+  assert_equals(usedRowSizes(itemWithMargins), "40px");
+}, "An item with margins does not grow its track past its fixed maximum");
+
+test(() => {
+  assert_equals(usedRowSizes(percentageMaximum), "60px");
+}, "An item taller than its track does not grow the track past a definite percentage maximum");
+
+test(() => {
+  assert_equals(usedRowSizes(calculatedMaximum), "40px");
+}, "An item taller than its track does not grow the track past a definite calc() maximum");
+
+test(() => {
+  assert_equals(usedItemHeight(indefiniteHeight), 40);
+}, "An item taller than its track is sized to its grid area, not to its content");
+
+test(() => {
+  assert_equals(usedItemHeight(spanningTwoTracks), 90);
+}, "An item spanning several tracks is sized to its grid area, not to its content");
+
+test(() => {
+  assert_equals(usedItemHeight(itemWithMargins), 30);
+}, "An item with margins is sized to the stretch fit into its grid area");
+</script>

--- a/Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.cpp
@@ -26,13 +26,48 @@
 #include "config.h"
 #include "GridItemSizingFunctions.h"
 
+#include "AxisConstraint.h"
 #include "GridLayoutUtils.h"
 #include "GridSizeTypes.h"
 #include "PlacedGridItem.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
+#include "TrackSizingFunctions.h"
 
 namespace WebCore {
 namespace Layout {
+
+// https://drafts.csswg.org/css-grid-2/#min-size-auto
+// The maximum size of the grid area an item is placed in, as represented by the sum of its grid
+// tracks' max track sizing functions plus any intervening fixed gutters. Absent unless every one of
+// those tracks has a fixed max track sizing function, since the automatic minimum size is only
+// clamped to the grid area in that case.
+static std::optional<LayoutUnit> gridAreaMaximumSize(size_t startLine, size_t endLine, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit gapSize,
+    const AxisConstraint& axisConstraint)
+{
+    LayoutUnit maximumSize;
+    for (auto trackIndex : std::views::iota(startLine, endLine)) {
+        auto& trackSizingFunction = trackSizingFunctions[trackIndex];
+        if (!trackSizingFunction.max.isLength())
+            return { };
+
+        auto& maximumBreadth = trackSizingFunction.max.length();
+        if (auto fixedMaximumBreadth = maximumBreadth.tryFixed()) {
+            maximumSize += Style::evaluate<LayoutUnit>(*fixedMaximumBreadth, trackSizingFunction.zoom);
+            continue;
+        }
+
+        if (!maximumBreadth.isPercentOrCalculated())
+            return { };
+        // When the constraint is indefinite, GridFormattingContext will transform any percent and
+        // calc functions into auto.
+        if (axisConstraint.scenario() != AxisConstraint::FreeSpaceScenario::Definite) {
+            ASSERT_NOT_REACHED();
+            return { };
+        }
+        maximumSize += Style::evaluate<LayoutUnit>(maximumBreadth, axisConstraint.availableSpace(), trackSizingFunction.zoom);
+    }
+    return maximumSize + GridLayoutUtils::totalGuttersSize(endLine - startLine, gapSize);
+}
 
 GridItemSizingFunctions GridItemSizingFunctions::inlineAxis(const IntegrationUtils& integrationUtils)
 {
@@ -48,7 +83,7 @@ GridItemSizingFunctions GridItemSizingFunctions::inlineAxis(const IntegrationUti
         // This mirrors GridLayoutUtils::inlineMinimumSize(), but is evaluated while track sizing is in
         // progress: the available space is not yet known, so it is absent for the automatic minimum size
         // and percentage/calc() minimum sizes resolve against a zero containing block size.
-        [&integrationUtils](const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit borderAndPadding, LayoutUnit) {
+        [&integrationUtils](const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit borderAndPadding, LayoutUnit, LayoutUnit gapSize, const AxisConstraint& axisConstraint) {
             auto& minimumSize = gridItem.inlineAxisSizes().minimumSize;
             return WTF::switchOn(minimumSize,
                 [&](const Style::MinimumSize::Fixed& fixed) {
@@ -61,7 +96,8 @@ GridItemSizingFunctions GridItemSizingFunctions::inlineAxis(const IntegrationUti
                     return BorderBoxSize { ContentBoxSize { Style::evaluate<LayoutUnit>(calculated, 0_lu, gridItem.usedZoom()) }, borderAndPadding }.value;
                 },
                 [&](const CSS::Keyword::Auto&) -> LayoutUnit {
-                    return GridLayoutUtils::automaticMinimumInlineSize(gridItem, borderAndPadding, trackSizingFunctions, { }, integrationUtils).value;
+                    auto gridAreaMaximumInlineSize = gridAreaMaximumSize(gridItem.columnStartLine(), gridItem.columnEndLine(), trackSizingFunctions, gapSize, axisConstraint);
+                    return GridLayoutUtils::automaticMinimumInlineSize(gridItem, borderAndPadding, trackSizingFunctions, { }, gridAreaMaximumInlineSize, integrationUtils).value;
                 },
                 [](const auto&) -> LayoutUnit {
                     ASSERT_NOT_IMPLEMENTED_YET();
@@ -83,7 +119,7 @@ GridItemSizingFunctions GridItemSizingFunctions::blockAxis(const GridFormattingC
         // This mirrors GridLayoutUtils::blockMinimumSize(), but is evaluated while track sizing is in
         // progress: the available space is not yet known, so it is absent for the automatic minimum size
         // and percentage/calc() minimum sizes resolve against a zero containing block size.
-        [&formattingContext](const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit borderAndPadding, LayoutUnit inlineAxisConstraint) {
+        [&formattingContext](const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit borderAndPadding, LayoutUnit inlineAxisConstraint, LayoutUnit gapSize, const AxisConstraint& axisConstraint) {
             auto& minimumSize = gridItem.blockAxisSizes().minimumSize;
             return WTF::switchOn(minimumSize,
                 [&](const Style::MinimumSize::Fixed& fixed) {
@@ -96,7 +132,8 @@ GridItemSizingFunctions GridItemSizingFunctions::blockAxis(const GridFormattingC
                     return BorderBoxSize { ContentBoxSize { Style::evaluate<LayoutUnit>(calculated, 0_lu, gridItem.usedZoom()) }, borderAndPadding }.value;
                 },
                 [&](const CSS::Keyword::Auto&) -> LayoutUnit {
-                    return GridLayoutUtils::automaticMinimumBlockSize(gridItem, borderAndPadding, trackSizingFunctions, { }, formattingContext, inlineAxisConstraint).value;
+                    auto gridAreaMaximumBlockSize = gridAreaMaximumSize(gridItem.rowStartLine(), gridItem.rowEndLine(), trackSizingFunctions, gapSize, axisConstraint);
+                    return GridLayoutUtils::automaticMinimumBlockSize(gridItem, borderAndPadding, trackSizingFunctions, { }, gridAreaMaximumBlockSize, formattingContext, inlineAxisConstraint).value;
                 },
                 [](const auto&) -> LayoutUnit {
                     ASSERT_NOT_IMPLEMENTED_YET();

--- a/Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.h
@@ -35,6 +35,7 @@ namespace Layout {
 class GridFormattingContext;
 class IntegrationUtils;
 class PlacedGridItem;
+struct AxisConstraint;
 
 // When resolving intrinsic track sizes, the track sizing algorithm queries each
 // grid item for a few different sizes: its min-content contribution, its
@@ -43,7 +44,7 @@ class PlacedGridItem;
 // callbacks — built with inlineAxis() for columns and blockAxis() for rows.
 struct GridItemSizingFunctions {
     GridItemSizingFunctions(Function<LayoutUnit(const PlacedGridItem&, LayoutUnit oppositeAxisConstraint)> minContentContributionFunction, Function<LayoutUnit(const PlacedGridItem&, LayoutUnit oppositeAxisConstraint)> maxContentContributionFunction,
-        Function<LayoutUnit(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit oppositeAxisConstraint)> usedMinimumSizeFunction)
+        Function<LayoutUnit(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit oppositeAxisConstraint, LayoutUnit gapSize, const AxisConstraint&)> usedMinimumSizeFunction)
             : minContentContribution(WTF::move(minContentContributionFunction))
             , maxContentContribution(WTF::move(maxContentContributionFunction))
             , usedMinimumSize(WTF::move(usedMinimumSizeFunction))
@@ -55,7 +56,7 @@ struct GridItemSizingFunctions {
 
     Function<LayoutUnit(const PlacedGridItem&, LayoutUnit oppositeAxisConstraint)> minContentContribution;
     Function<LayoutUnit(const PlacedGridItem&, LayoutUnit oppositeAxisConstraint)> maxContentContribution;
-    Function<LayoutUnit(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit oppositeAxisConstraint)> usedMinimumSize;
+    Function<LayoutUnit(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit oppositeAxisConstraint, LayoutUnit gapSize, const AxisConstraint&)> usedMinimumSize;
 };
 
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -382,7 +382,7 @@ LayoutUnit inlinePreferredSize(const PlacedGridItem& placedGridItem, LayoutUnit 
 
 // https://drafts.csswg.org/css-grid-1/#min-size-auto
 BorderBoxSize automaticMinimumInlineSize(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding, const TrackSizingFunctionsList& trackSizingFunctions,
-    std::optional<LayoutUnit> gridAreaInlineSize, const IntegrationUtils& integrationUtils)
+    std::optional<LayoutUnit> gridAreaInlineSize, std::optional<LayoutUnit> gridAreaMaximumInlineSize, const IntegrationUtils& integrationUtils)
 {
     auto& inlineAxisSizes = gridItem.inlineAxisSizes();
     ASSERT(inlineAxisSizes.minimumSize.isAuto());
@@ -407,11 +407,24 @@ BorderBoxSize automaticMinimumInlineSize(const PlacedGridItem& gridItem, LayoutU
     if (gridItemColumnSpanCount > 1 && spansFlexMaxTrackSizingFunction({ gridItemColumnStartLine, gridItemColumnEndLine }, trackSizingFunctions))
         return BorderBoxSize::zeroSized();
 
+    // However, if in a given dimension the grid item spans only grid tracks that have a fixed max
+    // track sizing function, then its specified size suggestion and content size suggestion in that
+    // dimension (and its input from this dimension to the transferred size suggestion in the
+    // opposite dimension) are further clamped to less than or equal to the stretch fit into the grid
+    // area’s maximum size in that dimension, as represented by the sum of those grid tracks’ max
+    // track sizing functions plus any intervening fixed gutters.
+    auto clampedToGridAreaMaximumSize = [&](BorderBoxSize sizeSuggestion) {
+        if (!gridAreaMaximumInlineSize)
+            return sizeSuggestion;
+        auto usedMargins = usedMarginsForAxis(gridItem, inlineAxisSizes);
+        return std::min(sizeSuggestion, stretchFitSize(borderAndPadding, *gridAreaMaximumInlineSize, usedMargins));
+    };
+
     // The content-based minimum size for a grid item in a given dimension is its
     auto contentBasedMinimumSize = [&] {
         // specified size suggestion if it exists
         if (auto specifiedSizeSuggestion = inlineSpecifiedSizeSuggestion(gridItem, borderAndPadding, gridAreaInlineSize))
-            return *specifiedSizeSuggestion;
+            return clampedToGridAreaMaximumSize(*specifiedSizeSuggestion);
 
         // otherwise its transferred size suggestion if that exists and the element is replaced
         if (gridItem.isReplacedElement()) {
@@ -419,22 +432,23 @@ BorderBoxSize automaticMinimumInlineSize(const PlacedGridItem& gridItem, LayoutU
                 return BorderBoxSize { ContentBoxSize { *transferredSizeSuggestion }, borderAndPadding };
         }
         // else its content size suggestion
-        return inlineContentSizeSuggestion(gridItem, borderAndPadding, gridAreaInlineSize.value_or(0_lu), integrationUtils);
+        return clampedToGridAreaMaximumSize(inlineContentSizeSuggestion(gridItem, borderAndPadding, gridAreaInlineSize.value_or(0_lu), integrationUtils));
     };
+
+    auto sizeSuggestion = contentBasedMinimumSize();
 
     // In all cases, the size suggestion is additionally clamped by the maximum size in
     // the affected axis, if it’s definite
     auto& maximumSize = inlineAxisSizes.maximumSize;
-    if (auto fixedMaximumSize = maximumSize.tryFixed()) {
-        auto maximumBorderBoxSize = BorderBoxSize { ContentBoxSize { Style::evaluate<LayoutUnit>(*fixedMaximumSize, gridItem.usedZoom()) }, borderAndPadding };
-        return std::min(contentBasedMinimumSize(), maximumBorderBoxSize);
-    }
-    return contentBasedMinimumSize();
+    if (auto fixedMaximumSize = maximumSize.tryFixed())
+        sizeSuggestion = std::min(sizeSuggestion, BorderBoxSize { ContentBoxSize { Style::evaluate<LayoutUnit>(*fixedMaximumSize, gridItem.usedZoom()) }, borderAndPadding });
+
+    return sizeSuggestion;
 }
 
 // https://drafts.csswg.org/css-grid-1/#min-size-auto
 BorderBoxSize automaticMinimumBlockSize(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding, const TrackSizingFunctionsList& trackSizingFunctions,
-    std::optional<LayoutUnit> gridAreaBlockSize, const GridFormattingContext& formattingContext, LayoutUnit inlineAxisConstraint)
+    std::optional<LayoutUnit> gridAreaBlockSize, std::optional<LayoutUnit> gridAreaMaximumBlockSize, const GridFormattingContext& formattingContext, LayoutUnit inlineAxisConstraint)
 {
     auto& blockAxisSizes = gridItem.blockAxisSizes();
     ASSERT(blockAxisSizes.minimumSize.isAuto());
@@ -459,11 +473,24 @@ BorderBoxSize automaticMinimumBlockSize(const PlacedGridItem& gridItem, LayoutUn
     if (gridItemRowSpanCount > 1 && spansFlexMaxTrackSizingFunction({ gridItemRowStartLine, gridItemRowEndLine }, trackSizingFunctions))
         return BorderBoxSize::zeroSized();
 
+    // However, if in a given dimension the grid item spans only grid tracks that have a fixed max
+    // track sizing function, then its specified size suggestion and content size suggestion in that
+    // dimension (and its input from this dimension to the transferred size suggestion in the
+    // opposite dimension) are further clamped to less than or equal to the stretch fit into the grid
+    // area’s maximum size in that dimension, as represented by the sum of those grid tracks’ max
+    // track sizing functions plus any intervening fixed gutters.
+    auto clampedToGridAreaMaximumSize = [&](BorderBoxSize sizeSuggestion) {
+        if (!gridAreaMaximumBlockSize)
+            return sizeSuggestion;
+        auto usedMargins = usedMarginsForAxis(gridItem, blockAxisSizes);
+        return std::min(sizeSuggestion, stretchFitSize(borderAndPadding, *gridAreaMaximumBlockSize, usedMargins));
+    };
+
     // The content-based minimum size for a grid item in a given dimension is its
     auto contentBasedMinimumSize = [&] {
         // specified size suggestion if it exists
         if (auto specifiedSizeSuggestion = blockSpecifiedSizeSuggestion(gridItem, borderAndPadding, gridAreaBlockSize))
-            return *specifiedSizeSuggestion;
+            return clampedToGridAreaMaximumSize(*specifiedSizeSuggestion);
 
         // otherwise its transferred size suggestion if that exists and the element is replaced
         if (gridItem.isReplacedElement()) {
@@ -471,17 +498,18 @@ BorderBoxSize automaticMinimumBlockSize(const PlacedGridItem& gridItem, LayoutUn
                 return *transferredSizeSuggestion;
         }
         // else its content size suggestion
-        return blockContentSizeSuggestion(gridItem, inlineAxisConstraint, formattingContext);
+        return clampedToGridAreaMaximumSize(blockContentSizeSuggestion(gridItem, inlineAxisConstraint, formattingContext));
     };
+
+    auto sizeSuggestion = contentBasedMinimumSize();
 
     // In all cases, the size suggestion is additionally clamped by the maximum size in
     // the affected axis, if it’s definite
     auto& maximumSize = blockAxisSizes.maximumSize;
-    if (auto fixedMaximumSize = maximumSize.tryFixed()) {
-        auto maximumBorderBoxSize = BorderBoxSize { ContentBoxSize { Style::evaluate<LayoutUnit>(*fixedMaximumSize, gridItem.usedZoom()) }, borderAndPadding };
-        return std::min(contentBasedMinimumSize(), maximumBorderBoxSize);
-    }
-    return contentBasedMinimumSize();
+    if (auto fixedMaximumSize = maximumSize.tryFixed())
+        sizeSuggestion = std::min(sizeSuggestion, BorderBoxSize { ContentBoxSize { Style::evaluate<LayoutUnit>(*fixedMaximumSize, gridItem.usedZoom()) }, borderAndPadding });
+
+    return sizeSuggestion;
 }
 
 LayoutUnit blockPreferredSize(const PlacedGridItem& placedGridItem, LayoutUnit borderAndPadding, LayoutUnit rowsSize, const GridFormattingContext& formattingContext, LayoutUnit inlineAxisConstraint, const UsedMargins& usedMargins)
@@ -552,7 +580,9 @@ LayoutUnit inlineMinimumSize(const PlacedGridItem& gridItem, const TrackSizingFu
             return BorderBoxSize { ContentBoxSize { Style::evaluate<LayoutUnit>(calculated, columnsSize, gridItem.usedZoom()) }, borderAndPadding }.value;
         },
         [&](const CSS::Keyword::Auto&) -> LayoutUnit {
-            return automaticMinimumInlineSize(gridItem, borderAndPadding, trackSizingFunctions, columnsSize, integrationUtils).value;
+            // The grid area is resolved by now, so it is what the automatic minimum size is clamped
+            // to, rather than the sum of the max track sizing functions used during track sizing.
+            return automaticMinimumInlineSize(gridItem, borderAndPadding, trackSizingFunctions, columnsSize, columnsSize, integrationUtils).value;
         },
         [](const auto&) -> LayoutUnit {
             ASSERT_NOT_IMPLEMENTED_YET();
@@ -575,7 +605,9 @@ LayoutUnit blockMinimumSize(const PlacedGridItem& gridItem, const TrackSizingFun
             return BorderBoxSize { ContentBoxSize { Style::evaluate<LayoutUnit>(calculated, rowsSize, gridItem.usedZoom()) }, borderAndPadding }.value;
         },
         [&](const CSS::Keyword::Auto&) -> LayoutUnit {
-            return automaticMinimumBlockSize(gridItem, borderAndPadding, trackSizingFunctions, rowsSize, formattingContext, inlineAxisConstraint).value;
+            // The grid area is resolved by now, so it is what the automatic minimum size is clamped
+            // to, rather than the sum of the max track sizing functions used during track sizing.
+            return automaticMinimumBlockSize(gridItem, borderAndPadding, trackSizingFunctions, rowsSize, rowsSize, formattingContext, inlineAxisConstraint).value;
         },
         [](const auto&) -> LayoutUnit {
             ASSERT_NOT_IMPLEMENTED_YET();

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -65,9 +65,11 @@ LayoutUnit blockMinimumSize(const PlacedGridItem&, const TrackSizingFunctionsLis
 
 // The automatic (auto) minimum size. The containing block size is absent while track sizing is in
 // progress, in which case percentage-based specified size suggestions cannot resolve and there is
-// no specified size suggestion; it is present once the available space is known.
-BorderBoxSize automaticMinimumInlineSize(const PlacedGridItem&, LayoutUnit borderAndPadding, const TrackSizingFunctionsList&, std::optional<LayoutUnit> gridAreaInlineSize, const IntegrationUtils&);
-BorderBoxSize automaticMinimumBlockSize(const PlacedGridItem&, LayoutUnit borderAndPadding, const TrackSizingFunctionsList&, std::optional<LayoutUnit> gridAreaBlockSize, const GridFormattingContext&, LayoutUnit inlineAxisConstraint);
+// no specified size suggestion; it is present once the available space is known. The grid area's
+// maximum size is absent when the item does not span only fixed-maximum tracks, or when the caller
+// does not clamp to it.
+BorderBoxSize automaticMinimumInlineSize(const PlacedGridItem&, LayoutUnit borderAndPadding, const TrackSizingFunctionsList&, std::optional<LayoutUnit> gridAreaInlineSize, std::optional<LayoutUnit> gridAreaMaximumInlineSize, const IntegrationUtils&);
+BorderBoxSize automaticMinimumBlockSize(const PlacedGridItem&, LayoutUnit borderAndPadding, const TrackSizingFunctionsList&, std::optional<LayoutUnit> gridAreaBlockSize, std::optional<LayoutUnit> gridAreaMaximumBlockSize, const GridFormattingContext&, LayoutUnit inlineAxisConstraint);
 LayoutUnit inlineMaximumSize(const PlacedGridItem&, LayoutUnit borderAndPadding);
 LayoutUnit blockMaximumSize(const PlacedGridItem&, LayoutUnit borderAndPadding);
 LayoutUnit inlineUsedSize(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit columnsSize, const IntegrationUtils&, const UsedMargins&);

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -299,20 +299,22 @@ static Vector<LayoutUnit> maxContentContributions(const TrackSizingItemList& tra
 // item's used minimum size as its preferred size; else the item's minimum contribution is its
 // min-content contribution.
 static LayoutUnit minimumContribution(const TrackSizingItemList& trackSizingItems, size_t gridItemIndex,
-    const GridItemSizingFunctions& gridItemSizingFunctions, const TrackSizingFunctionsList& trackSizingFunctions)
+    const GridItemSizingFunctions& gridItemSizingFunctions, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit gapSize,
+    const AxisConstraint& axisConstraint)
 {
     auto& trackSizingItem = trackSizingItems[gridItemIndex];
     auto& preferredSize = trackSizingItem.computedSizes.preferredSize;
     if (GridLayoutUtils::preferredSizeBehavesAsAuto(preferredSize) || GridLayoutUtils::sizeDependsOnContainingBlockSize(preferredSize))
-        return gridItemSizingFunctions.usedMinimumSize(trackSizingItem.gridItem, trackSizingFunctions, trackSizingItem.borderAndPadding, trackSizingItem.oppositeAxisConstraint);
+        return gridItemSizingFunctions.usedMinimumSize(trackSizingItem.gridItem, trackSizingFunctions, trackSizingItem.borderAndPadding, trackSizingItem.oppositeAxisConstraint, gapSize, axisConstraint);
     return gridItemSizingFunctions.minContentContribution(trackSizingItem.gridItem, trackSizingItem.oppositeAxisConstraint);
 }
 
 static Vector<LayoutUnit> minimumContributions(const TrackSizingItemList& trackSizingItems,
-    const GridItemIndexes& gridItemIndexes, const GridItemSizingFunctions& gridItemSizingFunctions, const TrackSizingFunctionsList& trackSizingFunctions)
+    const GridItemIndexes& gridItemIndexes, const GridItemSizingFunctions& gridItemSizingFunctions, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit gapSize,
+    const AxisConstraint& axisConstraint)
 {
     return gridItemIndexes.map([&](size_t gridItemIndex) {
-        return minimumContribution(trackSizingItems, gridItemIndex, gridItemSizingFunctions, trackSizingFunctions);
+        return minimumContribution(trackSizingItems, gridItemIndex, gridItemSizingFunctions, trackSizingFunctions, gapSize, axisConstraint);
     });
 }
 
@@ -398,14 +400,14 @@ static void sizeTracksToFitNonSpanningItems(const ResolveIntrinsicTrackSizesCont
                     });
 
                     // and ultimately floored by its minimum contribution.
-                    auto itemMinimumContributions = minimumContributions(trackSizingItems, singleSpanningItemsIndexes, gridItemSizingFunctions, resolveIntrinsicTrackSizesContext.trackSizingFunctionsList);
+                    auto itemMinimumContributions = minimumContributions(trackSizingItems, singleSpanningItemsIndexes, gridItemSizingFunctions, resolveIntrinsicTrackSizesContext.trackSizingFunctionsList, resolveIntrinsicTrackSizesContext.gapSize, resolveIntrinsicTrackSizesContext.axisConstraint);
 
                     auto limitedContributions = limitedContentContributions(minContentSizeContributions, fixedMaxTrackSizingFunctionSums, itemMinimumContributions);
                     return std::max({ }, std::ranges::max(limitedContributions));
                 }
                 // Otherwise, set the track’s base size to the maximum of its items’ minimum
                 // contributions, floored at zero.
-                auto contributions = minimumContributions(trackSizingItems, singleSpanningItemsIndexes, gridItemSizingFunctions, resolveIntrinsicTrackSizesContext.trackSizingFunctionsList);
+                auto contributions = minimumContributions(trackSizingItems, singleSpanningItemsIndexes, gridItemSizingFunctions, resolveIntrinsicTrackSizesContext.trackSizingFunctionsList, resolveIntrinsicTrackSizesContext.gapSize, resolveIntrinsicTrackSizesContext.axisConstraint);
                 return std::max({ }, std::ranges::max(contributions));
             },
             // A <length-percentage> min track sizing function was already resolved to an absolute
@@ -742,7 +744,7 @@ static void resolveIntrinsicTrackSizesWithSpanningItems(const ResolveIntrinsicTr
     auto& trackSizingFunctions = resolveIntrinsicTrackSizesContext.trackSizingFunctionsList;
     auto gapSize = resolveIntrinsicTrackSizesContext.gapSize;
 
-    auto minimumContributionsList = minimumContributions(trackSizingItems, spanningItems, gridItemSizingFunctions, trackSizingFunctions);
+    auto minimumContributionsList = minimumContributions(trackSizingItems, spanningItems, gridItemSizingFunctions, trackSizingFunctions, gapSize, resolveIntrinsicTrackSizesContext.axisConstraint);
     Vector<std::optional<LayoutUnit>> fixedMaxTrackSizingFunctionSums;
     if (isSizedUnderMinOrMaxContentConstraint(resolveIntrinsicTrackSizesContext.axisConstraint)) {
         fixedMaxTrackSizingFunctionSums = spanningItems.map([&](size_t gridItemIndex) {


### PR DESCRIPTION
#### 3974cac991a427729b1011d17d9f803d9f567d29
<pre>
[GFC] A grid item&apos;s automatic minimum size is not clamped to a fixed max track sizing function.
<a href="https://bugs.webkit.org/show_bug.cgi?id=323369">https://bugs.webkit.org/show_bug.cgi?id=323369</a>
<a href="https://rdar.apple.com/problem/186606479">rdar://problem/186606479</a>

Reviewed by Alan Baradlay.

<a href="https://drafts.csswg.org/css-grid-1/#min-size-auto">https://drafts.csswg.org/css-grid-1/#min-size-auto</a> says that if a grid item spans only grid tracks
that have a fixed max track sizing function, then its specified size suggestion and content size
suggestion are further clamped to less than or equal to the stretch fit into the grid area&apos;s
maximum size in that dimension, as represented by the sum of those grid tracks&apos; max track sizing
functions plus any intervening fixed gutters.

GFC never applied that clause. automaticMinimumInlineSize() and automaticMinimumBlockSize() only
clamped the size suggestion by the item&apos;s own maximum size, so an item whose content is taller or
wider than its grid area kept a content-based minimum size larger than the maximum the author gave
the tracks it spans.

The automatic minimum size is queried in two places, and the two know the grid area differently.

While track sizing is in progress the grid area does not exist yet, so gridAreaMaximumSize()
approximates it by the sum of the spanned tracks&apos; max track sizing functions plus the gutters
between them. This is the size described in the blub from the portion of
the spec mentioned earlier.

Once the tracks are sized the grid area is resolved, so inlineMinimumSize() and blockMinimumSize()
clamp against the grid area itself. Without this the row is capped correctly but the item inside it
is still laid out at its content size and overflows its own grid area.

Test: imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/automatic-minimum-size-clamped-to-fixed-max-track-sizing-function.html
Canonical link: <a href="https://commits.webkit.org/320750@main">https://commits.webkit.org/320750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/988188d960585ed254b1d279959d761ec6a01b6b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185034 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195368 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/149960 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32d57d97-2e70-4465-a34c-da26f049b90c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144597 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100319 "Exiting early after 60 failures. 60 tests run. 61 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/499de92a-6eae-49a0-b917-d295fa4ccc21) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165190 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124884 "Found 1 new API test failure: TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/42949672974097MallocReadOnly (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/70b4e165-6a96-45c9-8c22-2b14a0b8defc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47000 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45079 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157370 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44760 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6420 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51615 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197316 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58620 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154086 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41438 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59330 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153742 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48246 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131620 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128261 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57819 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19779 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57181 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57430 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57256 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->