### PR TITLE
[Text Extraction] Some checkboxes on google.com are invisible to Safari MCP

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -301,6 +301,7 @@ struct TraversalContext {
     Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>> enclosingBlocks;
     HashMap<Ref<Node>, unsigned> enclosingBlockNumberMap;
     HashSet<Ref<Node>> additionalContainersToCollect;
+    HashSet<Ref<Node>> visualProxiesToSkip;
     unsigned inAdditionalContainerToCollectCount { 0 };
     unsigned depth { 0 };
     Vector<bool, 1> hasOverflowItemsStack;
@@ -457,7 +458,7 @@ static inline void merge(Item& destinationItem, Item&& sourceItem)
     }
 }
 
-static inline FloatRect rootViewBounds(Node& node)
+static inline FloatRect rootViewBounds(const Node& node)
 {
     RefPtr view = node.document().view();
     if (!view) [[unlikely]]
@@ -527,6 +528,80 @@ static inline std::optional<FloatRect> visibleAssociatedLabelBounds(HTMLElement&
     }
 
     return std::nullopt;
+}
+
+static bool hasVisuallyDistinctStyling(const Style::ComputedStyle&);
+
+static inline bool paintsVisibleContent(const RenderObject& renderer)
+{
+    CheckedRef style = renderer.style();
+    if (style->usedVisibility() != Visibility::Visible)
+        return false;
+
+    if (style->opacity() < minOpacityToConsiderVisible)
+        return false;
+
+    if (CheckedPtr text = dynamicDowncast<RenderText>(renderer))
+        return text->hasRenderedText();
+
+    return renderer.isRenderReplaced() || hasVisuallyDistinctStyling(protect(style));
+}
+
+static inline RefPtr<Node> visualProxyForTransparentControl(const HTMLInputElement& input)
+{
+    if (!input.isCheckbox() && !input.isRadioButton())
+        return { };
+
+    CheckedPtr inputRenderer = input.renderer();
+    if (!inputRenderer)
+        return { };
+
+    static constexpr auto minTransparentControlLength = 8;
+    static constexpr auto maxTransparentControlLength = 96;
+    auto inputBounds = rootViewBounds(input);
+    if (inputBounds.width() < minTransparentControlLength || inputBounds.height() < minTransparentControlLength)
+        return { };
+
+    if (inputBounds.width() > maxTransparentControlLength || inputBounds.height() > maxTransparentControlLength)
+        return { };
+
+    static constexpr auto maxAncestorHopsToFindVisualProxy = 3;
+    static constexpr auto maxProxyContainerAreaRatio = 4;
+    static constexpr auto minProxyOverlapRatio = 0.5;
+    auto inputArea = inputBounds.area();
+    RefPtr ancestor = input.parentElement();
+    for (unsigned hop = 0; ancestor && hop < maxAncestorHopsToFindVisualProxy; ++hop, ancestor = ancestor->parentElement()) {
+        CheckedPtr ancestorRenderer = ancestor->renderer();
+        if (!ancestorRenderer)
+            break;
+
+        if (rootViewBounds(*ancestor).area() > maxProxyContainerAreaRatio * inputArea)
+            break;
+
+        for (CheckedRef descendant : descendantsOfType<RenderObject>(*ancestorRenderer)) {
+            if (descendant.ptr() == inputRenderer.get() || descendant->isDescendantOf(inputRenderer.get()))
+                continue;
+
+            if (!paintsVisibleContent(descendant))
+                continue;
+
+            RefPtr proxyNode = descendant->node();
+            if (!proxyNode)
+                continue;
+
+            auto proxyBounds = rootViewBounds(*proxyNode);
+            auto proxyArea = proxyBounds.area();
+            if (proxyArea <= 0)
+                continue;
+
+            if (intersection(proxyBounds, inputBounds).area() < minProxyOverlapRatio * proxyArea)
+                continue;
+
+            return proxyNode;
+        }
+    }
+
+    return { };
 }
 
 template<typename T>
@@ -603,8 +678,17 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
         return { SkipExtraction::SelfAndSubtree };
 
     if (context.skipNearlyTransparentContent && renderer->style().opacity() < minOpacityToConsiderVisible) {
-        if (RefPtr input = dynamicDowncast<HTMLInputElement>(node); !input || !visibleAssociatedLabelBounds(*input))
+        RefPtr input = dynamicDowncast<HTMLInputElement>(node);
+        if (!input)
             return { SkipExtraction::SelfAndSubtree };
+
+        if (!visibleAssociatedLabelBounds(*input)) {
+            RefPtr proxy = visualProxyForTransparentControl(*input);
+            if (!proxy)
+                return { SkipExtraction::SelfAndSubtree };
+
+            context.visualProxiesToSkip.add(proxy.releaseNonNull());
+        }
     }
 
     if (renderer->style().usedVisibility() == Visibility::Hidden)
@@ -1075,7 +1159,7 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
     if (context.depth >= maxExtractionRecursionDepth)
         return;
 
-    if (context.nodesToSkip.contains(node))
+    if (context.nodesToSkip.contains(node) || context.visualProxiesToSkip.contains(node))
         return;
 
     ++context.depth;
@@ -1728,6 +1812,7 @@ Result extractItem(Request&& request, LocalFrame& frame)
             .enclosingBlocks = { },
             .enclosingBlockNumberMap = { },
             .additionalContainersToCollect = WTF::move(additionalContainersToCollect),
+            .visualProxiesToSkip = { },
             .inAdditionalContainerToCollectCount = 0,
             .depth = 0,
             .hasOverflowItemsStack = { false },

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -1347,6 +1347,46 @@ TEST(TextExtractionTests, SkipNearlyTransparentContentByDefault)
     EXPECT_FALSE([defaultText containsString:@"unlabeled transparent field"]);
 }
 
+TEST(TextExtractionTests, ExtractTransparentCheckboxOverVisualProxy)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+    [webView synchronouslyLoadHTMLString:@R"HTML(
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <style>
+        .control { position: relative; width: 40px; height: 40px; }
+        .control input { position: absolute; inset: 0; width: 40px; height: 40px; margin: 0; opacity: 0; }
+        .box { position: absolute; left: 11px; top: 11px; width: 18px; height: 18px; border: 2px solid #5f6368; border-radius: 2px; }
+        </style>
+        </head>
+        <body>
+            <div class="control">
+                <input type="checkbox" aria-label="Select photos" checked>
+                <div class="box"><svg aria-hidden="true" viewBox="0 0 24 24" width="14" height="14"><path d="M1 12 8 19 22 4"></path></svg></div>
+            </div>
+            <input type="checkbox" aria-label="Genuinely invisible" style="opacity: 0">
+        </body>
+        </html>
+    )HTML"];
+
+    RetainPtr defaultText = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setFilterOptions:_WKTextExtractionFilterNone];
+        return configuration.autorelease();
+    }()];
+
+    EXPECT_TRUE([defaultText containsString:@"Select photos"]);
+    EXPECT_TRUE([defaultText containsString:@"checkbox"]);
+    EXPECT_TRUE([defaultText containsString:@"checked"]);
+    EXPECT_FALSE([defaultText containsString:@"Genuinely invisible"]);
+    EXPECT_FALSE([defaultText containsString:@"image"]);
+}
+
 TEST(TextExtractionTests, MinimalHTMLOutput)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{


### PR DESCRIPTION
#### 4cc311091515165d384c55e063c66346d17fb4a6
<pre>
[Text Extraction] Some checkboxes on google.com are invisible to Safari MCP
<a href="https://bugs.webkit.org/show_bug.cgi?id=323270">https://bugs.webkit.org/show_bug.cgi?id=323270</a>
<a href="https://rdar.apple.com/186510338">rdar://186510338</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

On some google.com subdomains, checkboxes and radio buttons are implemented in such a way where:

-   The actual `input` elements are hidden (`opacity: 0;`).
-   What (visually) looks like the checkbox or radio button is actually a plain SVG icon, hidden
    from the accessibility tree.

As a result, these elements are effectively hidden from the agent because the accessible elements
are fully transparent, and the non-accessible elements are filtered out as noise.

To fix this, augment the extraction heuristic to detect when transparent form controls are overlaid
over or under with sibling elements of the same size (similar to how we detect transparent controls
with visible labels in the DOM), and surface them anyways.

Test: TextExtractionTests.ExtractTransparentCheckboxOverVisualProxy

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::paintsVisibleContent):
(WebCore::TextExtraction::visualProxyForTransparentControl):
(WebCore::TextExtraction::extractItemData):
(WebCore::TextExtraction::extractRecursive):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::ExtractTransparentCheckboxOverVisualProxy)):

Canonical link: <a href="https://commits.webkit.org/320421@main">https://commits.webkit.org/320421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecb481fa094c33f1d9937e864811acd490c6565a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184662 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194994 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148927 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8762e4ca-e945-4614-b03e-6883875c38c0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186524 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144300 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100187 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/255d0263-9f5f-4141-98f6-acdd7606a916) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187617 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124583 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a2f5d30d-29e1-4796-b8e8-8a53b02fd45e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46678 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44820 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44452 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6050 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196940 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58252 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153764 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41177 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58954 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41067 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153422 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47940 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131242 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127760 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57455 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19473 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56816 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57064 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56891 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->