### PR TITLE
[Site Isolation] Re-enable UseUIProcessForBackForwardItemLoading auto-couple in test harness

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -9630,7 +9630,8 @@ UseSystemAppearance:
 
 UseUIProcessForBackForwardItemLoading:
   type: bool
-  status: unstable
+  status: testable
+  category: security
   exposed: [ WebKit ]
   humanReadableName: "Use UIProcess for Back/Forward Item Loading"
   humanReadableDescription: "Enable UIProcess-side BackForwardListFrameItem lookup for child frames during Back/Forward navigation"


### PR DESCRIPTION
#### 72c92db8b1c11e74dc65eaebd13e6237f48586cb
<pre>
[Site Isolation] Re-enable UseUIProcessForBackForwardItemLoading auto-couple in test harness
<a href="https://bugs.webkit.org/show_bug.cgi?id=316588">https://bugs.webkit.org/show_bug.cgi?id=316588</a>
<a href="https://rdar.apple.com/179043211">rdar://179043211</a>

Reviewed by NOBODY (OOPS!).

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72c92db8b1c11e74dc65eaebd13e6237f48586cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194976 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148909 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e214a083-378f-47e1-8b56-f1b89fff65d0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58294 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144282 "Found 6 new test failures: fast/loader/site-isolation/form-state-restore-with-frames.html http/tests/navigation/forward-and-cancel.html imported/w3c/web-platform-tests/content-security-policy/inheritance/history-iframe.sub.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-traversal-during-onnavigate.html imported/w3c/web-platform-tests/navigation-timing/nav2-test-timing-persistent.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100170 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bbc17a97-b28d-418d-811c-d5769be34452) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47945 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124565 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/754ac0ba-3f3e-4197-87cf-9fbd8ce6d3cb) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46660 "Found 2 new test failures: imported/w3c/web-platform-tests/content-security-policy/inheritance/history-iframe.sub.html imported/w3c/web-platform-tests/navigation-timing/nav2-test-timing-persistent.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44816 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6524 "Found 1 new JSC stress test failure: Too many failures: 2103 jsc tests failed (failure)") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13372 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157038 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44436 "Found 5 new test failures: fast/loader/site-isolation/form-state-restore-with-frames.html imported/w3c/web-platform-tests/content-security-policy/inheritance/history-iframe.sub.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-traversal-during-onnavigate.html imported/w3c/web-platform-tests/navigation-timing/nav2-test-timing-persistent.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6032 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45914 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51225 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49127 "Found 9 new test failures: fast/loader/site-isolation/form-state-restore-with-frames.html http/tests/navigation/changing-frame-hierarchy-in-onload.html http/tests/navigation/post-frames-goback1-uncached.html http/tests/navigation/post-frames-goback1.html imported/w3c/web-platform-tests/content-security-policy/inheritance/history-iframe.sub.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-traversal-during-onnavigate.html imported/w3c/web-platform-tests/navigation-timing/nav2-test-timing-persistent.html imported/w3c/web-platform-tests/navigation-timing/navigation-type-post-backforward.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196922 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58234 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153746 "Found 4 new test failures: http/tests/navigation/forward-and-cancel.html imported/w3c/web-platform-tests/content-security-policy/inheritance/history-iframe.sub.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html imported/w3c/web-platform-tests/navigation-timing/nav2-test-timing-persistent.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58936 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41052 "Found 4 new test failures: fast/loader/site-isolation/form-state-restore-with-frames.html imported/w3c/web-platform-tests/content-security-policy/inheritance/history-iframe.sub.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html imported/w3c/web-platform-tests/navigation-timing/nav2-test-timing-persistent.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153404 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47924 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131224 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127732 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57437 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19457 "Found 2 new test failures: imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html imported/w3c/web-platform-tests/navigation-timing/nav2-test-timing-persistent.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56798 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57046 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56873 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->