### PR TITLE
AX: In isolated tree mode, AXStringForTextMarkerRange drops the space after a bulleted list marker

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/listmarker-suffix-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/listmarker-suffix-expected.txt
@@ -1,0 +1,10 @@
+This test makes sure the right suffix is returned when fetching text marker strings for list items.
+
+PASS: list1.stringForTextMarkerRange(textRange) === `${bulletString} item 1`
+PASS: list2.stringForTextMarkerRange(textRange) === '1. item 2'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+item 1
+item 2

--- a/LayoutTests/accessibility/isolated-tree/listmarker-suffix.html
+++ b/LayoutTests/accessibility/isolated-tree/listmarker-suffix.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<ul style="disc">
+<li id="listitem1">item 1</li>
+</ul>
+
+<ol>
+<li id="listitem2">item 2</li>
+</ol>
+
+<script>
+let output = "This test makes sure the right suffix is returned when fetching text marker strings for list items.\n\n";
+
+if (window.accessibilityController) {
+    var list1 = accessibilityController.accessibleElementById("listitem1");
+    var textRange = list1.textMarkerRangeForElement(list1);
+    var bulletString = String.fromCharCode(0x2022);
+    output += expect("list1.stringForTextMarkerRange(textRange)", "`${bulletString} item 1`");
+
+    var list2 = accessibilityController.accessibleElementById("listitem2");
+    textRange = list2.textMarkerRangeForElement(list2);
+    output += expect("list2.stringForTextMarkerRange(textRange)", "'1. item 2'");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-range-selection-in-list-items-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-range-selection-in-list-items-expected.txt
@@ -1,0 +1,17 @@
+Tests setting and retrieving text selection in list items using TextMarkerRanges.
+
+Check that the selection range contains the text for the second item plus the list marker (bullet):
+PASS: selection === expectedSelection
+Check that the selection range contains the first item text plus the list marker (bullet):
+PASS: selection === expectedSelection
+Check that the selection range contains the static text plus the list marker (bullet):
+PASS: selection === expectedSelection
+Check that the selection range doesn't include the first character of the static text nor the list marker after moving the start of the range:
+PASS: selection === expectedSelection
+Check that the selection range contains the text for the item plus the list marker (bullet):
+PASS: selection === expectedSelection
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-range-selection-in-list-items.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-range-selection-in-list-items.html
@@ -1,0 +1,92 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ runSingly=true AccessibilityTextStitchingEnabled=false IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../mac/resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<ul id="list1">
+    <li id="item1">First item.</li>
+    <li id="item2">Second item.</li>
+    <li id="item3"><em>Third</em> item.</li>
+</ul>
+
+<script>
+let output = "Tests setting and retrieving text selection in list items using TextMarkerRanges.\n\n";
+const bullet = String.fromCharCode(0x2022);
+window.jsTestIsAsync = true;
+
+let list = null;
+let selectedRange = null;
+let selection = "";
+let expectedSelection = "";
+
+async function checkSelection() {
+    await waitFor(() => {
+        selectedRange = list.selectedTextMarkerRange();
+        selection = list.stringForTextMarkerRange(selectedRange);
+        return selection == expectedSelection;
+    });
+    output += expect("selection", "expectedSelection");
+}
+
+if (window.accessibilityController) {
+    // Select the second list item using DOM API.
+    selectTextInNode("item2");
+
+    setTimeout(async () => {
+        // Get the selection range via accessibility API and compare against expectedSelection.
+        list = accessibilityController.accessibleElementById("list1");
+
+        output += "Check that the selection range contains the text for the second item plus the list marker (bullet):\n";
+        expectedSelection = `${bullet} Second item.`;
+        await checkSelection();
+
+        // Set the selection to the first item via accessibility API.
+        let item = accessibilityController.accessibleElementById("item1");
+        let range = list.textMarkerRangeForElement(item);
+        list.setSelectedTextMarkerRange(range);
+
+        output += "Check that the selection range contains the first item text plus the list marker (bullet):\n";
+        expectedSelection = `${bullet} First item.`;
+        await checkSelection();
+
+        // Go down one level and select the range of the static text contained in the list item.
+        let text = item.childAtIndex(1);
+        // Note: childAtIndex(0) is the list marker. The list marker is an AX object backed by an anonymous RenderObject, i.e., it doesn't have an associated Node.
+        // Therefore, the list marker or bullet has no TextMarkerRange. The list marker bullet is included in the range of the static text.
+        range = text.textMarkerRangeForElement(text);
+        list.setSelectedTextMarkerRange(range);
+
+        output += "Check that the selection range contains the static text plus the list marker (bullet):\n";
+        expectedSelection = `${bullet} First item.`;
+        await checkSelection();
+
+        // Move the start of the range and select it. Note that both the first character of the text and the list marker are removed from the range text.
+        let start = list.startTextMarkerForTextMarkerRange(range);
+        start = list.nextTextMarker(start);
+        let end = list.endTextMarkerForTextMarkerRange(range);
+        range = list.textMarkerRangeForMarkers(start, end);
+        list.setSelectedTextMarkerRange(range);
+
+        output += "Check that the selection range doesn't include the first character of the static text nor the list marker after moving the start of the range:\n";
+        expectedSelection = `irst item.`;
+        await checkSelection();
+
+        // Select the third list item using DOM API.
+        selectTextInNode("item3");
+
+        output += "Check that the selection range contains the text for the item plus the list marker (bullet):\n";
+        expectedSelection = `${bullet} Third item.`;
+        await checkSelection();
+
+        debug(output);
+        document.getElementById("list1").style.visibility = "hidden";
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1560,6 +1560,14 @@ AXTextRuns AccessibilityRenderObject::textRuns()
             return { };
     }
 
+    for (CheckedPtr ancestor = renderText->parent(); ancestor && !ancestor->element(); ancestor = ancestor->parent()) {
+        // A marker that needs renderers for its content (a synthesized glyph, bidi text, or a `content`
+        // value) puts them in an anonymous inline-block inside the RenderListMarker, and that anonymous
+        // style carries no pseudo type for the ::marker case above to catch. We do so here instead.
+        if (ancestor->isRenderListMarker())
+            return { };
+    }
+
     // FIXME: Need to handle PseudoElementType::FirstLetter. Right now, it will be chopped off from the other
     // other text in the line, and AccessibilityRenderObject::computeIsIgnored ignores the
     // first-letter RenderText, meaning we can't recover it later by combining text across AX objects.


### PR DESCRIPTION
#### 5d59ee3a751171e60e7b4d09360241f202f86d02
<pre>
AX: In isolated tree mode, AXStringForTextMarkerRange drops the space after a bulleted list marker
<a href="https://bugs.webkit.org/show_bug.cgi?id=323274">https://bugs.webkit.org/show_bug.cgi?id=323274</a>
<a href="https://rdar.apple.com/186529088">rdar://186529088</a>

Reviewed by Chris Fleizach.

&lt;ul&gt;&lt;li id=&quot;item&quot;&gt;item 1&lt;/li&gt;&lt;/ul&gt;

The text marker range covering that list item stringifies as &quot;\u2022 item 1&quot; on the
main thread but as &quot;\u2022item 1&quot; with the isolated tree enabled.

AccessibilityRenderObject::textRuns() drops runs for generated content by asking
shouldExcludeTextRunsForPseudoElement() about renderText-&gt;parent()&apos;s pseudo type, and
PseudoElementType::Marker is one of the types it excludes. That only inspects the
immediate parent, though, and a marker that needs renderers for its content does not
parent them directly. RenderTreeBuilder::List::buildMarkerContentRenderers instead wraps them
in an anonymous inline-block built with createAnonymousStyleWithDisplay, and that
anonymous style carries no pseudo type. So the ::marker case never fires and the
marker&apos;s text becomes text runs of its own.

Walk out of the element-less generated content in textRuns() and return no runs when a
RenderListMarker is found.

This also fixes accessibility/mac/text-marker-range-selection-in-list-items.html.

* LayoutTests/accessibility/isolated-tree/listmarker-suffix-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/listmarker-suffix.html: Added.
* LayoutTests/accessibility/isolated-tree/mac/text-marker-range-selection-in-list-items-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/text-marker-range-selection-in-list-items.html: Added.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):

Canonical link: <a href="https://commits.webkit.org/320426@main">https://commits.webkit.org/320426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de1c339ea851669b6667dd96198668a7b2cf6d4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/194984 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148917 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f14d9089-e8fe-4bd7-af20-408bc629587e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186514 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58302 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144289 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100177 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a04ae23d-78c5-4b44-9311-8756b44bdf96) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124572 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e208b8a-2860-40fd-8238-a0c43796b9fe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46668 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44817 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44443 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6040 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196930 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58242 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164385 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153753 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41181 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58944 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153411 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47930 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131232 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127747 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57445 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19464 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56806 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57054 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56881 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->