### PR TITLE
[GTK][WPE] Restore dataTransfer.files for trusted file drops

### DIFF
--- a/Source/WebCore/dom/DataTransfer.h
+++ b/Source/WebCore/dom/DataTransfer.h
@@ -125,6 +125,9 @@ private:
     {
 #if PLATFORM(COCOA)
         return !forDrag() || forFileDrag();
+#elif PLATFORM(GTK) || PLATFORM(WPE)
+        // Paste stays denied: the GTK3 clipboard still maps uri-list to paths.
+        return forFileDrag();
 #else
         // Check https://webkit.org/b/271957 before allowing file access for your port.
         return false;

--- a/Source/WebCore/platform/glib/DragDataGLib.cpp
+++ b/Source/WebCore/platform/glib/DragDataGLib.cpp
@@ -33,19 +33,27 @@ bool DragData::containsColor() const
     return false;
 }
 
+static bool allowsFilenameAccess(const DragData& drag)
+{
+    // A drag that started in this application is web content.
+    return !drag.flags().contains(DragApplicationFlags::IsSource);
+}
+
 bool DragData::containsFiles() const
 {
-    return !m_disallowFileAccess && m_platformDragData->hasFilenames();
+    return !m_disallowFileAccess && allowsFilenameAccess(*this) && m_platformDragData->hasFilenames();
 }
 
 unsigned DragData::numberOfFiles() const
 {
-    return !m_disallowFileAccess ? m_platformDragData->filenames().size() : 0;
+    if (m_disallowFileAccess || !allowsFilenameAccess(*this))
+        return 0;
+    return m_platformDragData->filenames().size();
 }
 
 Vector<String> DragData::asFilenames() const
 {
-    if (m_disallowFileAccess)
+    if (m_disallowFileAccess || !allowsFilenameAccess(*this))
         return { };
     return m_platformDragData->filenames();
 }

--- a/Source/WebCore/platform/glib/PasteboardGLib.cpp
+++ b/Source/WebCore/platform/glib/PasteboardGLib.cpp
@@ -484,8 +484,17 @@ String Pasteboard::readStringInCustomData(const String& type)
 
 Pasteboard::FileContentState Pasteboard::fileContentState()
 {
-    if (m_selectionData)
-        return m_selectionData->filenames().isEmpty() ? FileContentState::NoFileOrImageData : FileContentState::MayContainFilePaths;
+    if (m_selectionData) {
+        if (m_selectionData->hasFilenames())
+            return FileContentState::MayContainFilePaths;
+
+        // Not a grant. MayContainFilePaths only narrows DataTransfer::types(), so the
+        // web-writable uri-list may answer it. Matches PasteboardCocoa.
+        if (SelectionData::uriListContainsFileURI(m_selectionData->uriList()))
+            return FileContentState::MayContainFilePaths;
+
+        return FileContentState::NoFileOrImageData;
+    }
 
     auto types = platformStrategies()->pasteboardStrategy()->types(m_name);
     if (types.contains("text/uri-list"_s)) {

--- a/Source/WebCore/platform/glib/SelectionData.cpp
+++ b/Source/WebCore/platform/glib/SelectionData.cpp
@@ -24,13 +24,51 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/text/StringCommon.h>
 #include <wtf/unicode/CharacterNames.h>
 
 namespace WebCore {
 
+// g_filename_from_uri() discards the authority when the hostname out parameter is
+// null, so file://attacker.example/etc/passwd would resolve to /etc/passwd. RFC 8089
+// only lets an empty authority or "localhost" mean this machine.
+String SelectionData::localPathFromURIListLine(const String& line)
+{
+    URL url { line };
+    if (!url.isValid())
+        return { };
+
+    GUniqueOutPtr<GError> error;
+    GUniqueOutPtr<gchar> hostname;
+    GUniquePtr<gchar> filename(g_filename_from_uri(line.utf8().data(), &hostname.outPtr(), &error.outPtr()));
+    if (error || !filename)
+        return { };
+
+    if (hostname && hostname.get()[0] && !equalLettersIgnoringASCIICase(String::fromUTF8(hostname.get()), "localhost"_s))
+        return { };
+
+    return String::fromUTF8(filename.get());
+}
+
+// Broader than localPathFromURIListLine() on purpose. A receiving application may
+// resolve a remote-host file URI locally, so export strips anything file shaped.
+static bool isFileURIListLine(const String& line)
+{
+    URL url { line };
+    if (!url.isValid())
+        return false;
+
+    if (url.protocolIs("file"_s))
+        return true;
+
+    GUniqueOutPtr<GError> error;
+    GUniquePtr<gchar> filename(g_filename_from_uri(line.utf8().data(), nullptr, &error.outPtr()));
+    return !error && filename;
+}
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SelectionData);
 
-SelectionData::SelectionData(const String& text, const String& markup, const URL& url, const String& uriList, RefPtr<WebCore::Image>&& image, RefPtr<WebCore::SharedBuffer>&& buffer, bool canSmartReplace)
+SelectionData::SelectionData(const String& text, const String& markup, const URL& url, const String& uriList, Vector<String>&& filenames, RefPtr<WebCore::Image>&& image, RefPtr<WebCore::SharedBuffer>&& buffer, bool canSmartReplace)
 {
     if (!text.isEmpty())
         setText(text);
@@ -40,6 +78,9 @@ SelectionData::SelectionData(const String& text, const String& markup, const URL
         setURL(url, String());
     if (!uriList.isEmpty())
         setURIList(uriList);
+    // After setURIList(), which must not touch m_filenames.
+    if (!filenames.isEmpty())
+        setFilenames(WTF::move(filenames));
     if (image)
         setImage(WTF::move(image));
     if (buffer)
@@ -58,22 +99,13 @@ void SelectionData::setText(const String& newText)
     replaceNonBreakingSpaceWithSpace(m_text);
 }
 
-void SelectionData::setURIList(const String& uriListString)
+static void updateURLFromURIList(const String& uriListString, URL& url, bool& urlIsSet)
 {
-    m_uriList = uriListString;
-
-    // This code is originally from: platform/chromium/ChromiumDataObject.cpp.
-    // FIXME: We should make this code cross-platform eventually.
+    if (urlIsSet)
+        return;
 
     // Line separator is \r\n per RFC 2483 - however, for compatibility
     // reasons we also allow just \n here.
-
-    // Process the input and copy the first valid URL into the url member.
-    // In case no URLs can be found, subsequent calls to getData("URL")
-    // will get an empty string. This is in line with the HTML5 spec (see
-    // "The DragEvent and DataTransfer interfaces"). Also extract all filenames
-    // from the URI list.
-    bool setURL = hasURL();
     for (auto& line : uriListString.split('\n')) {
         line = line.trim(deprecatedIsSpaceOrNewline);
         if (line.isEmpty())
@@ -81,19 +113,106 @@ void SelectionData::setURIList(const String& uriListString)
         if (line[0] == '#')
             continue;
 
-        URL url { line };
-        if (url.isValid()) {
-            if (!setURL) {
-                m_url = url;
-                setURL = true;
-            }
+        URL parsed { line };
+        if (!parsed.isValid())
+            continue;
 
-            GUniqueOutPtr<GError> error;
-            GUniquePtr<gchar> filename(g_filename_from_uri(line.utf8().data(), 0, &error.outPtr()));
-            if (!error && filename)
-                m_filenames.append(String::fromUTF8(filename.get()));
-        }
+        url = WTF::move(parsed);
+        urlIsSet = true;
+        return;
     }
+}
+
+Vector<String> SelectionData::filenamesFromURIList(const String& uriListString)
+{
+    // This code is originally from: platform/chromium/ChromiumDataObject.cpp.
+    Vector<String> filenames;
+    for (auto& line : uriListString.split('\n')) {
+        line = line.trim(deprecatedIsSpaceOrNewline);
+        if (line.isEmpty())
+            continue;
+        if (line[0] == '#')
+            continue;
+
+        auto path = localPathFromURIListLine(line);
+        if (!path.isNull())
+            filenames.append(WTF::move(path));
+    }
+    return filenames;
+}
+
+void SelectionData::setURIList(const String& uriListString)
+{
+    m_uriList = uriListString;
+
+    // Process the input and copy the first valid URL into the url member.
+    // In case no URLs can be found, subsequent calls to getData("URL")
+    // will get an empty string. This is in line with the HTML5 spec (see
+    // "The DragEvent and DataTransfer interfaces").
+    //
+    // Script can write text/uri-list through DataTransfer.setData(), so file:// lines
+    // are not promoted into m_filenames here. See CVE-2025-13947.
+    bool setURL = hasURL();
+    updateURLFromURIList(uriListString, m_url, setURL);
+}
+
+void SelectionData::setFilenames(Vector<String>&& filenames)
+{
+    m_filenames = WTF::move(filenames);
+}
+
+void SelectionData::setFilenamesFromURIList(const String& uriListString)
+{
+    m_filenames = filenamesFromURIList(uriListString);
+}
+
+void SelectionData::setTrustedDrop(const String& uriListString, Vector<String>&& portalFilenames)
+{
+    setURIList(uriListString);
+
+    // The portal list is the grant when present. A parallel uri-list could only widen it.
+    if (!portalFilenames.isEmpty()) {
+        setFilenames(WTF::move(portalFilenames));
+        return;
+    }
+
+    setFilenamesFromURIList(uriListString);
+}
+
+String SelectionData::uriListWithoutFilenames(const String& uriListString)
+{
+    StringBuilder builder;
+    for (auto& line : uriListString.split('\n')) {
+        auto trimmed = line.trim(deprecatedIsSpaceOrNewline);
+        if (trimmed.isEmpty())
+            continue;
+        if (trimmed[0] == '#')
+            continue;
+
+        if (isFileURIListLine(trimmed))
+            continue;
+
+        if (!builder.isEmpty())
+            builder.append("\r\n"_s);
+        builder.append(trimmed);
+    }
+    return builder.toString();
+}
+
+// Answers from web-writable text, so callers may only narrow on a true result.
+bool SelectionData::uriListContainsFileURI(const String& uriListString)
+{
+    for (auto& line : uriListString.split('\n')) {
+        auto trimmed = line.trim(deprecatedIsSpaceOrNewline);
+        if (trimmed.isEmpty())
+            continue;
+        if (trimmed[0] == '#')
+            continue;
+
+        if (isFileURIListLine(trimmed))
+            return true;
+    }
+    return false;
 }
 
 void SelectionData::setURL(const URL& url, const String& label)

--- a/Source/WebCore/platform/glib/SelectionData.h
+++ b/Source/WebCore/platform/glib/SelectionData.h
@@ -53,6 +53,16 @@ public:
     bool hasFilenames() const { return !m_filenames.isEmpty(); }
     void clearURIList() { m_uriList = emptyString(); }
 
+    // Trusted UIProcess drops only. Web-authored setData() never reaches these.
+    void setFilenames(Vector<String>&&);
+    void setFilenamesFromURIList(const String&);
+    void setTrustedDrop(const String& uriList, Vector<String>&& portalFilenames);
+    void clearFilenames() { m_filenames.clear(); }
+    static Vector<String> filenamesFromURIList(const String&);
+    static String localPathFromURIListLine(const String&);
+    static String uriListWithoutFilenames(const String&);
+    static bool uriListContainsFileURI(const String&);
+
     void setImage(RefPtr<Image>&& newImage) { m_image = WTF::move(newImage); }
     const RefPtr<Image>& image() const { return m_image; }
     bool hasImage() const { return m_image; }
@@ -74,7 +84,7 @@ public:
     void clearAll();
     void clearAllExceptFilenames();
 
-    SelectionData(const String& text, const String& markup, const URL&, const String& uriList, RefPtr<WebCore::Image>&&, RefPtr<WebCore::SharedBuffer>&&, bool);
+    SelectionData(const String& text, const String& markup, const URL&, const String& uriList, Vector<String>&& filenames, RefPtr<WebCore::Image>&&, RefPtr<WebCore::SharedBuffer>&&, bool);
     SelectionData() = default;
 
 private:

--- a/Source/WebKit/Shared/glib/SelectionData.serialization.in
+++ b/Source/WebKit/Shared/glib/SelectionData.serialization.in
@@ -26,6 +26,7 @@ class WebCore::SelectionData {
     String markup()
     URL url()
     String uriList()
+    Vector<String> filenames()
     RefPtr<WebCore::Image> image()
     RefPtr<WebCore::SharedBuffer> customData()
     bool canSmartReplace()

--- a/Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp
@@ -57,11 +57,16 @@ DragSource::DragSource(GtkWidget* webView)
             break;
         }
         case DragTargetType::URIList: {
-            CString uriList = drag.m_selectionData->uriList().utf8();
+            auto sanitizedURIList = SelectionData::uriListWithoutFilenames(drag.m_selectionData->uriList());
+            if (sanitizedURIList.isEmpty())
+                break;
+            CString uriList = sanitizedURIList.utf8();
             gtk_selection_data_set(data, gdk_atom_intern_static_string("text/uri-list"), 8, reinterpret_cast<const guchar*>(uriList.data()), uriList.length());
             break;
         }
         case DragTargetType::NetscapeURL: {
+            if (drag.m_selectionData->url().protocolIsFile())
+                break;
             auto urlString = drag.m_selectionData->url().string();
             auto url = makeString(urlString, '\n', drag.m_selectionData->hasText() ? drag.m_selectionData->text() : urlString).utf8();
             gtk_selection_data_set(data, gdk_atom_intern_static_string("_NETSCAPE_URL"), 8, reinterpret_cast<const guchar*>(url.data()), url.length());
@@ -126,9 +131,9 @@ void DragSource::begin(SelectionData&& selectionData, OptionSet<DragOperation> o
         gtk_target_list_add_text_targets(list.get(), DragTargetType::Text);
     if (m_selectionData->hasMarkup())
         gtk_target_list_add(list.get(), gdk_atom_intern_static_string("text/html"), 0, DragTargetType::Markup);
-    if (m_selectionData->hasURIList())
+    if (m_selectionData->hasURIList() && !SelectionData::uriListWithoutFilenames(m_selectionData->uriList()).isEmpty())
         gtk_target_list_add_uri_targets(list.get(), DragTargetType::URIList);
-    if (m_selectionData->hasURL())
+    if (m_selectionData->hasURL() && !m_selectionData->url().protocolIsFile())
         gtk_target_list_add(list.get(), gdk_atom_intern_static_string("_NETSCAPE_URL"), 0, DragTargetType::NetscapeURL);
     if (m_selectionData->hasImage())
         gtk_target_list_add_image_targets(list.get(), DragTargetType::Image, TRUE);

--- a/Source/WebKit/UIProcess/API/gtk/DragSourceGtk4.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DragSourceGtk4.cpp
@@ -82,13 +82,17 @@ void DragSource::begin(SelectionData&& selectionData, OptionSet<DragOperation> o
         providers.append(gdk_content_provider_new_for_bytes("text/html", bytes.get()));
     }
 
+    // Web content must not export file:// URIs, as a uri-list or a GdkFileList.
     if (m_selectionData->hasURIList()) {
-        CString uriList = m_selectionData->uriList().utf8();
-        GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(uriList.data(), uriList.length()));
-        providers.append(gdk_content_provider_new_for_bytes("text/uri-list", bytes.get()));
+        auto sanitizedURIList = SelectionData::uriListWithoutFilenames(m_selectionData->uriList());
+        if (!sanitizedURIList.isEmpty()) {
+            CString uriList = sanitizedURIList.utf8();
+            GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(uriList.data(), uriList.length()));
+            providers.append(gdk_content_provider_new_for_bytes("text/uri-list", bytes.get()));
+        }
     }
 
-    if (m_selectionData->hasURL()) {
+    if (m_selectionData->hasURL() && !m_selectionData->url().protocolIsFile()) {
         CString urlString = m_selectionData->url().string().utf8();
         gchar* url = g_strdup_printf("%s\n%s", urlString.data(), m_selectionData->hasText() ? m_selectionData->text().utf8().data() : urlString.data());
         IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")

--- a/Source/WebKit/UIProcess/API/gtk/DropTarget.h
+++ b/Source/WebKit/UIProcess/API/gtk/DropTarget.h
@@ -31,6 +31,9 @@
 #include <WebCore/IntPoint.h>
 #include <WebCore/SelectionData.h>
 #include <wtf/Forward.h>
+#if USE(GTK4)
+#include "DropTargetState.h"
+#endif
 #include <wtf/Noncopyable.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -69,6 +72,7 @@ private:
     void loadData(const char* mimeType, CompletionHandler<void(GRefPtr<GBytes>&&)>&&);
     void loadData(CompletionHandler<void(Vector<String>&&)>&&);
     void didLoadData();
+    void finishUnfinishedDrop();
 #else
     void dataReceived(WebCore::IntPoint&&, GtkSelectionData*, unsigned, unsigned);
     void leaveTimerFired();
@@ -87,6 +91,9 @@ private:
 #if USE(GTK4)
     GRefPtr<GCancellable> m_cancellable;
     StringBuilder m_uriListBuilder;
+    Vector<String> m_portalFilenames;
+    bool m_transferredFilesFromPortal { false };
+    DropTargetState m_state;
 #else
     RunLoop::Timer m_leaveTimer;
 #endif

--- a/Source/WebKit/UIProcess/API/gtk/DropTargetGtk3.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DropTargetGtk3.cpp
@@ -47,6 +47,14 @@ using namespace WebCore;
 
 enum DropTargetType { Markup, Text, URIList, NetscapeURL, SmartPaste, Custom };
 
+static OptionSet<DragApplicationFlags> applicationFlagsForDrop(GdkDragContext* context)
+{
+    OptionSet<DragApplicationFlags> flags;
+    if (context && gtk_drag_get_source_widget(context))
+        flags.add(DragApplicationFlags::IsSource);
+    return flags;
+}
+
 DropTarget::DropTarget(GtkWidget* webView)
     : m_webView(webView)
     , m_leaveTimer(RunLoop::mainSingleton(), "DropTarget::LeaveTimer"_s, this, &DropTarget::leaveTimerFired)
@@ -154,7 +162,7 @@ void DropTarget::enter(IntPoint&& position, unsigned time)
     ASSERT(page);
     page->resetCurrentDragInformation();
 
-    DragData dragData(&m_selectionData.value(), *m_position, convertWidgetPointToScreenPoint(m_webView, *m_position), gdkDragActionToDragOperation(gdk_drag_context_get_actions(m_drop.get())));
+    DragData dragData(&m_selectionData.value(), *m_position, convertWidgetPointToScreenPoint(m_webView, *m_position), gdkDragActionToDragOperation(gdk_drag_context_get_actions(m_drop.get())), applicationFlagsForDrop(m_drop.get()));
     page->dragEntered(dragData);
 }
 
@@ -168,7 +176,7 @@ void DropTarget::update(IntPoint&& position, unsigned time)
     auto* page = webkitWebViewBaseGetPage(WEBKIT_WEB_VIEW_BASE(m_webView));
     ASSERT(page);
 
-    DragData dragData(&m_selectionData.value(), *m_position, convertWidgetPointToScreenPoint(m_webView, *m_position), gdkDragActionToDragOperation(gdk_drag_context_get_actions(m_drop.get())));
+    DragData dragData(&m_selectionData.value(), *m_position, convertWidgetPointToScreenPoint(m_webView, *m_position), gdkDragActionToDragOperation(gdk_drag_context_get_actions(m_drop.get())), applicationFlagsForDrop(m_drop.get()));
     page->dragUpdated(dragData);
 }
 
@@ -196,8 +204,10 @@ void DropTarget::dataReceived(IntPoint&& position, GtkSelectionData* data, unsig
     case DropTargetType::URIList: {
         gint length;
         const auto* uriListData = gtk_selection_data_get_data_with_length(data, &length);
-        if (length > 0)
-            m_selectionData->setURIList(String(unsafeMakeSpan(uriListData, length)));
+        if (length > 0) {
+            // GTK3 has no portal file list, so the uri-list is the grant.
+            m_selectionData->setTrustedDrop(String(unsafeMakeSpan(uriListData, length)), { });
+        }
         break;
     }
     case DropTargetType::NetscapeURL: {
@@ -248,7 +258,7 @@ void DropTarget::leaveTimerFired()
     ASSERT(page);
 
     SelectionData emptyData;
-    DragData dragData(m_selectionData ? &m_selectionData.value() : &emptyData, *m_position, convertWidgetPointToScreenPoint(m_webView, *m_position), { });
+    DragData dragData(m_selectionData ? &m_selectionData.value() : &emptyData, *m_position, convertWidgetPointToScreenPoint(m_webView, *m_position), { }, applicationFlagsForDrop(m_drop.get()));
     page->dragExited(dragData);
     page->resetCurrentDragInformation();
 
@@ -276,7 +286,7 @@ void DropTarget::drop(IntPoint&& position, unsigned time)
     auto* page = webkitWebViewBaseGetPage(WEBKIT_WEB_VIEW_BASE(m_webView));
     ASSERT(page);
 
-    OptionSet<DragApplicationFlags> flags;
+    OptionSet<DragApplicationFlags> flags = applicationFlagsForDrop(m_drop.get());
     if (gdk_drag_context_get_selected_action(m_drop.get()) == GDK_ACTION_COPY)
         flags.add(DragApplicationFlags::IsCopyKeyDown);
     DragData dragData(&m_selectionData.value(), position, convertWidgetPointToScreenPoint(m_webView, position), gdkDragActionToDragOperation(gdk_drag_context_get_actions(m_drop.get())), flags);

--- a/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
@@ -43,6 +43,15 @@ using namespace WebCore;
 
 enum DropTargetType { Markup, Text, URIList, NetscapeURL, SmartPaste };
 
+static OptionSet<DragApplicationFlags> applicationFlagsForDrop(GdkDrop* drop)
+{
+    OptionSet<DragApplicationFlags> flags;
+    // Non-null when the drag started in this application.
+    if (drop && gdk_drop_get_drag(drop))
+        flags.add(DragApplicationFlags::IsSource);
+    return flags;
+}
+
 DropTarget::DropTarget(GtkWidget* webView)
     : m_webView(webView)
 {
@@ -103,16 +112,32 @@ DropTarget::DropTarget(GtkWidget* webView)
 DropTarget::~DropTarget()
 {
     g_cancellable_cancel(m_cancellable.get());
+    finishUnfinishedDrop();
+}
+
+// A deferred drop outlives the ::drop handler, so every teardown path has to finish it.
+void DropTarget::finishUnfinishedDrop()
+{
+    if (!m_state.takeUnfinishedDrop())
+        return;
+
+    if (m_drop)
+        gdk_drop_finish(m_drop.get(), static_cast<GdkDragAction>(0));
 }
 
 void DropTarget::accept(GdkDrop* drop, std::optional<WebCore::IntPoint> position, unsigned)
 {
+    g_cancellable_cancel(m_cancellable.get());
+    finishUnfinishedDrop();
+
     m_drop = drop;
     m_position = position;
     m_selectionData = SelectionData();
     m_dataRequestCount = 0;
     m_cancellable = adoptGRef(g_cancellable_new());
     m_uriListBuilder.clear();
+    m_portalFilenames.clear();
+    m_transferredFilesFromPortal = false;
 
     // WebCore needs the selection data to decide, so we need to preload the
     // data of targets we support. Once all data requests are done we start
@@ -148,7 +173,6 @@ void DropTarget::accept(GdkDrop* drop, std::optional<WebCore::IntPoint> position
         "org.webkitgtk.WebKit.custom-pasteboard-data"_s,
     };
 
-    bool transferredFilesFromPortal = false;
     for (const ASCIILiteral& mimeType : supportedMimeTypes) {
         if (!gdk_content_formats_contain_mime_type(formats, mimeType))
             continue;
@@ -156,7 +180,7 @@ void DropTarget::accept(GdkDrop* drop, std::optional<WebCore::IntPoint> position
         // Reading from the File Transfer portal is a bit special. When either portal
         // mimetypes are present, GTK serializes them using the GdkFileList type. If
         // this type is present, ignore file:// URIs from the "text/uri-list" later on.
-        if (!transferredFilesFromPortal && std::ranges::find(portalMIMETypes, mimeType) != portalMIMETypes.end()) {
+        if (!m_transferredFilesFromPortal && std::ranges::find(portalMIMETypes, mimeType) != portalMIMETypes.end()) {
             ASSERT(gdk_content_formats_contain_gtype(formats, GDK_TYPE_FILE_LIST));
 
             m_dataRequestCount++;
@@ -164,21 +188,25 @@ void DropTarget::accept(GdkDrop* drop, std::optional<WebCore::IntPoint> position
                 if (g_cancellable_is_cancelled(cancellable.get()))
                     return;
 
-                // Convert files transferred by the File Transfer portal into URIs
                 for (auto& fileUri : fileUris) {
                     if (!m_uriListBuilder.isEmpty())
                         m_uriListBuilder.append("\r\n"_s);
                     m_uriListBuilder.append(fileUri);
+
+                    // GTK also deserializes text/uri-list into a GdkFileList, so the
+                    // import rule applies here too.
+                    if (auto filename = WebCore::SelectionData::localPathFromURIListLine(fileUri); !filename.isNull())
+                        m_portalFilenames.append(WTF::move(filename));
                 }
 
                 didLoadData();
             });
-            transferredFilesFromPortal = true;
+            m_transferredFilesFromPortal = true;
             continue;
         }
 
         m_dataRequestCount++;
-        loadData(mimeType, [this, transferredFilesFromPortal, mimeType, cancellable = m_cancellable](GRefPtr<GBytes>&& data) {
+        loadData(mimeType, [this, mimeType, cancellable = m_cancellable](GRefPtr<GBytes>&& data) {
             if (g_cancellable_is_cancelled(cancellable.get()))
                 return;
 
@@ -219,7 +247,7 @@ void DropTarget::accept(GdkDrop* drop, std::optional<WebCore::IntPoint> position
 
                         // If we have file transfers from the portal, ignore file:// URIs.
                         URL url { line };
-                        if (transferredFilesFromPortal && url.isValid()) {
+                        if (m_transferredFilesFromPortal && url.isValid()) {
                             GUniqueOutPtr<GError> error;
                             GUniquePtr<gchar> filename(g_filename_from_uri(line.utf8().data(), 0, &error.outPtr()));
                             if (!error && filename)
@@ -240,6 +268,12 @@ void DropTarget::accept(GdkDrop* drop, std::optional<WebCore::IntPoint> position
 
             didLoadData();
         });
+    }
+
+    m_state.didAccept(m_dataRequestCount > 0);
+    if (!m_dataRequestCount) {
+        // Nothing to wait for; didLoadData() will not run.
+        m_cancellable = nullptr;
     }
 }
 
@@ -313,46 +347,51 @@ void DropTarget::didLoadData()
 
     // Build the URI list after collecting everything from transferred files,
     // and the uri-list mimetype
-    if (!m_uriListBuilder.isEmpty()) {
-        m_selectionData->setURIList(m_uriListBuilder.toString());
+    if (!m_uriListBuilder.isEmpty() || !m_portalFilenames.isEmpty()) {
+        m_selectionData->setTrustedDrop(m_uriListBuilder.toString(), WTF::move(m_portalFilenames));
         m_uriListBuilder.clear();
     }
 
     m_cancellable = nullptr;
+    m_state.didFinishLoadingData();
 
     if (!m_position) {
         // Enter hasn't been emitted yet, so just wait for it.
         return;
     }
 
-    // Call enter again.
+    // Call enter again, also for a deferred drop: DragController needs dragEntered
+    // before performDragOperation.
     enter(IntPoint(m_position.value()));
+
+    if (m_state.takeDeferredDrop())
+        drop(IntPoint(m_position.value()));
 }
 
 void DropTarget::enter(IntPoint&& position, unsigned)
 {
     m_position = WTF::move(position);
-    if (m_cancellable)
+    if (m_state.isWaitingForData())
         return;
 
     auto* page = webkitWebViewBaseGetPage(WEBKIT_WEB_VIEW_BASE(m_webView));
     ASSERT(page);
     page->resetCurrentDragInformation();
 
-    DragData dragData(&m_selectionData.value(), *m_position, *m_position, gdkDragActionToDragOperation(gdk_drop_get_actions(m_drop.get())));
+    DragData dragData(&m_selectionData.value(), *m_position, *m_position, gdkDragActionToDragOperation(gdk_drop_get_actions(m_drop.get())), applicationFlagsForDrop(m_drop.get()));
     page->dragEntered(dragData);
 }
 
 void DropTarget::update(IntPoint&& position, unsigned)
 {
     m_position = WTF::move(position);
-    if (m_cancellable)
+    if (m_state.isWaitingForData())
         return;
 
     auto* page = webkitWebViewBaseGetPage(WEBKIT_WEB_VIEW_BASE(m_webView));
     ASSERT(page);
 
-    DragData dragData(&m_selectionData.value(), *m_position, *m_position, gdkDragActionToDragOperation(gdk_drop_get_actions(m_drop.get())));
+    DragData dragData(&m_selectionData.value(), *m_position, *m_position, gdkDragActionToDragOperation(gdk_drop_get_actions(m_drop.get())), applicationFlagsForDrop(m_drop.get()));
     page->dragUpdated(dragData);
 }
 
@@ -375,12 +414,14 @@ void DropTarget::didPerformAction()
 void DropTarget::leave()
 {
     g_cancellable_cancel(m_cancellable.get());
+    // Cancelling the reads means didLoadData() will not release a deferred drop.
+    finishUnfinishedDrop();
 
     auto* page = webkitWebViewBaseGetPage(WEBKIT_WEB_VIEW_BASE(m_webView));
     ASSERT(page);
 
     auto position = m_position.value_or(IntPoint());
-    DragData dragData(&m_selectionData.value(), position, position, { });
+    DragData dragData(&m_selectionData.value(), position, position, { }, applicationFlagsForDrop(m_drop.get()));
     page->dragExited(dragData);
     page->resetCurrentDragInformation();
 
@@ -388,19 +429,33 @@ void DropTarget::leave()
     m_position = std::nullopt;
     m_selectionData = std::nullopt;
     m_cancellable = nullptr;
+    m_uriListBuilder.clear();
+    m_portalFilenames.clear();
+    m_transferredFilesFromPortal = false;
 }
 
 void DropTarget::drop(IntPoint&& position, unsigned)
 {
     m_position = WTF::move(position);
+    // Wait for the mime loads to finish; didLoadData() performs the drop.
+    if (m_state.didRequestDrop())
+        return;
+
     auto* page = webkitWebViewBaseGetPage(WEBKIT_WEB_VIEW_BASE(m_webView));
     ASSERT(page);
 
-    DragData dragData(&m_selectionData.value(), *m_position, *m_position, gdkDragActionToDragOperation(gdk_drop_get_actions(m_drop.get())));
+    DragData dragData(&m_selectionData.value(), *m_position, *m_position, gdkDragActionToDragOperation(gdk_drop_get_actions(m_drop.get())), applicationFlagsForDrop(m_drop.get()));
     page->performDragOperation(dragData, { }, { }, { });
-    gdk_drop_finish(m_drop.get(), gdk_drop_get_actions(m_drop.get()));
+    // gdk_drop_finish() requires a single action or 0. gdk_drop_get_actions() is a mask.
+    auto finishAction = dragOperationToSingleGdkDragAction(m_operation);
+    if (!finishAction)
+        finishAction = dragOperationToSingleGdkDragAction(gdkDragActionToDragOperation(gdk_drop_get_actions(m_drop.get())));
+    gdk_drop_finish(m_drop.get(), finishAction);
+    m_state.didFinishDrop();
 
     m_drop = nullptr;
+    m_portalFilenames.clear();
+    m_transferredFilesFromPortal = false;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/gtk/DropTargetState.h
+++ b/Source/WebKit/UIProcess/API/gtk/DropTargetState.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Hayden Barnes
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <utility>
+
+namespace WebKit {
+
+// GtkDropTargetAsync hands over the GdkDrop when ::drop returns TRUE and the source
+// then waits for one gdk_drop_finish(). The mime data is read asynchronously, so a
+// drop can arrive before it is complete and has to be deferred, and the finish is
+// owed on every teardown path. Free of GTK types so it can be unit tested.
+class DropTargetState {
+public:
+    void didAccept(bool waitingForData)
+    {
+        m_waitingForData = waitingForData;
+        m_deferredDrop = false;
+        m_unfinishedDrop = false;
+    }
+
+    void didFinishLoadingData() { m_waitingForData = false; }
+
+    // Returns true when the drop has to wait for the data.
+    bool didRequestDrop()
+    {
+        m_unfinishedDrop = true;
+        if (m_waitingForData)
+            m_deferredDrop = true;
+        return m_deferredDrop;
+    }
+
+    bool takeDeferredDrop()
+    {
+        return std::exchange(m_deferredDrop, false);
+    }
+
+    void didFinishDrop()
+    {
+        m_deferredDrop = false;
+        m_unfinishedDrop = false;
+    }
+
+    // True once for a drop that was taken over but never finished.
+    bool takeUnfinishedDrop()
+    {
+        m_waitingForData = false;
+        m_deferredDrop = false;
+        return std::exchange(m_unfinishedDrop, false);
+    }
+
+    bool isWaitingForData() const { return m_waitingForData; }
+
+private:
+    bool m_waitingForData { false };
+    bool m_deferredDrop { false };
+    bool m_unfinishedDrop { false };
+};
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -68,6 +68,7 @@
 #include "WebProcessPool.h"
 #include "WebUserContentControllerProxy.h"
 #include <WebCore/ActivityState.h>
+#include <WebCore/DragData.h>
 #include <WebCore/Image.h>
 #include <WebCore/NativeImage.h>
 #include <WebCore/NotImplemented.h>
@@ -2595,6 +2596,36 @@ void webkitWebViewBaseStartDrag(WebKitWebViewBase* webViewBase, SelectionData&& 
 void webkitWebViewBaseDidPerformDragControllerAction(WebKitWebViewBase* webViewBase)
 {
     webViewBase->priv->dropTarget->didPerformAction();
+}
+
+void webkitWebViewBaseSynthesizeFileDropForTesting(WebKitWebViewBase* webViewBase, const String& uriList, Vector<String>&& portalFilenames, FileDropSource source, int x, int y)
+{
+    RefPtr page = webViewBase->priv->pageProxy.get();
+    if (!page)
+        return;
+
+    // Same trust decision DropTarget makes, so the test runs the production logic.
+    SelectionData selectionData;
+    OptionSet<DragApplicationFlags> flags;
+
+    switch (source) {
+    case FileDropSource::External:
+        selectionData.setTrustedDrop(uriList, WTF::move(portalFilenames));
+        break;
+    case FileDropSource::WebOrSameApp:
+        selectionData.setTrustedDrop(uriList, WTF::move(portalFilenames));
+        flags.add(DragApplicationFlags::IsSource);
+        break;
+    case FileDropSource::UntrustedURIList:
+        selectionData.setURIList(uriList);
+        break;
+    }
+
+    IntPoint position(x, y);
+    DragData dragData(&selectionData, position, position, DragOperation::Copy, flags);
+    page->dragEntered(dragData);
+    page->dragUpdated(dragData);
+    page->performDragOperation(dragData, { }, { }, { });
 }
 #endif // ENABLE(DRAG_SUPPORT)
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBaseInternal.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBaseInternal.h
@@ -64,3 +64,8 @@ WK_EXPORT void webkitWebViewBaseSynthesizeTouchEvent(WebKitWebViewBase*, TouchEv
 
 WK_EXPORT SkImage* webkitWebViewBaseSnapshotForTesting(WebKitWebViewBase*);
 
+// Synthetic GDK events cannot drive a real drag (webkit.org/b/157179). UntrustedURIList
+// feeds the uri-list through setURIList() alone, the path DataTransfer.setData() takes.
+enum class FileDropSource : uint8_t { WebOrSameApp, External, UntrustedURIList };
+WK_EXPORT void webkitWebViewBaseSynthesizeFileDropForTesting(WebKitWebViewBase*, const String& uriList, Vector<String>&& portalFilenames, FileDropSource, int x, int y);
+

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4512,6 +4512,9 @@ void WebPageProxy::didPerformDragControllerAction(std::optional<WebCore::DragOpe
 void WebPageProxy::startDrag(SelectionData&& selectionData, OptionSet<WebCore::DragOperation> dragOperationMask, std::optional<ShareableBitmap::Handle>&& dragImageHandle, IntPoint&& dragImageHotspot)
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
+    // Filenames are a UIProcess grant and never valid coming up from the web process.
+    selectionData.clearFilenames();
+
     if (RefPtr pageClient = this->pageClient()) {
         RefPtr dragImage = dragImageHandle ? ShareableBitmap::create(WTF::move(*dragImageHandle)) : nullptr;
         pageClient->startDrag(WTF::move(selectionData), dragOperationMask, WTF::move(dragImage), WTF::move(dragImageHotspot));

--- a/Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp
+++ b/Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp
@@ -194,7 +194,7 @@ void Clipboard::write(WebCore::SelectionData&& selectionData, CompletionHandler<
     SetForScope frameWritingToClipboard(m_frameWritingToClipboard, WebPasteboardProxy::singleton().primarySelectionOwner());
 
     GRefPtr<GtkTargetList> list = adoptGRef(gtk_target_list_new(nullptr, 0));
-    if (selectionData.hasURIList())
+    if (selectionData.hasURIList() && !WebCore::SelectionData::uriListWithoutFilenames(selectionData.uriList()).isEmpty())
         gtk_target_list_add(list.get(), gdk_atom_intern_static_string("text/uri-list"), 0, ClipboardTargetType::URIList);
     if (selectionData.hasMarkup())
         gtk_target_list_add(list.get(), gdk_atom_intern_static_string("text/html"), 0, ClipboardTargetType::Markup);
@@ -238,7 +238,10 @@ void Clipboard::write(WebCore::SelectionData&& selectionData, CompletionHandler<
                 break;
             }
             case ClipboardTargetType::URIList: {
-                CString uriList = data.selectionData.uriList().utf8();
+                auto sanitizedURIList = WebCore::SelectionData::uriListWithoutFilenames(data.selectionData.uriList());
+                if (sanitizedURIList.isEmpty())
+                    break;
+                CString uriList = sanitizedURIList.utf8();
                 gtk_selection_data_set(selection, gdk_atom_intern_static_string("text/uri-list"), 8, reinterpret_cast<const guchar*>(uriList.data()), uriList.length());
                 break;
             }

--- a/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
+++ b/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
@@ -261,9 +261,12 @@ void Clipboard::write(WebCore::SelectionData&& selectionData, CompletionHandler<
     }
 
     if (selectionData.hasURIList()) {
-        CString uriList = selectionData.uriList().utf8();
-        GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(uriList.data(), uriList.length()));
-        providers.append(gdk_content_provider_new_for_bytes("text/uri-list", bytes.get()));
+        auto sanitizedURIList = WebCore::SelectionData::uriListWithoutFilenames(selectionData.uriList());
+        if (!sanitizedURIList.isEmpty()) {
+            CString uriList = sanitizedURIList.utf8();
+            GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(uriList.data(), uriList.length()));
+            providers.append(gdk_content_provider_new_for_bytes("text/uri-list", bytes.get()));
+        }
     }
 
     if (selectionData.hasImage()) {

--- a/Tools/TestWebKitAPI/PlatformGTK.cmake
+++ b/Tools/TestWebKitAPI/PlatformGTK.cmake
@@ -44,8 +44,10 @@ list(APPEND TestWebCore_SOURCES
     Tests/WebCore/ImageDecoderTests.cpp
 
     Tests/WebCore/glib/Damage.cpp
+    Tests/WebCore/glib/DropTargetState.cpp
     Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
     Tests/WebCore/glib/RunLoopObserver.cpp
+    Tests/WebCore/glib/SelectionData.cpp
     Tests/WebCore/glib/SkiaCompositingLayerDamage.cpp
     Tests/WebCore/glib/UserAgentQuirks.cpp
 
@@ -54,6 +56,10 @@ list(APPEND TestWebCore_SOURCES
     Tests/WebCore/gstreamer/GstMappedBuffer.cpp
 
     generic/main.cpp
+)
+
+list(APPEND TestWebCore_PRIVATE_INCLUDE_DIRECTORIES
+    "${CMAKE_SOURCE_DIR}/Source/WebKit"
 )
 
 list(APPEND TestWebCore_SYSTEM_INCLUDE_DIRECTORIES

--- a/Tools/TestWebKitAPI/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/PlatformWPE.cmake
@@ -42,6 +42,7 @@ list(APPEND TestWebCore_SOURCES
     Tests/WebCore/glib/Damage.cpp
     Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
     Tests/WebCore/glib/RunLoopObserver.cpp
+    Tests/WebCore/glib/SelectionData.cpp
     Tests/WebCore/glib/SkiaCompositingLayerDamage.cpp
     Tests/WebCore/glib/UserAgentQuirks.cpp
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/DropTargetState.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/DropTargetState.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2026 Hayden Barnes
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if PLATFORM(GTK)
+
+#include "Helpers/Test.h"
+
+#include <UIProcess/API/gtk/DropTargetState.h>
+
+namespace TestWebKitAPI {
+
+using WebKit::DropTargetState;
+
+// A drop after the data loaded runs straight away.
+TEST(DropTargetState, SynchronousDropIsNotDeferred)
+{
+    DropTargetState state;
+    state.didAccept(true);
+    state.didFinishLoadingData();
+
+    EXPECT_FALSE(state.isWaitingForData());
+    EXPECT_FALSE(state.didRequestDrop());
+    EXPECT_FALSE(state.takeDeferredDrop());
+
+    state.didFinishDrop();
+    EXPECT_FALSE(state.takeUnfinishedDrop());
+}
+
+// A drop during the mime loads waits and is handed back once.
+TEST(DropTargetState, DropDuringLoadIsDeferredAndReplayedOnce)
+{
+    DropTargetState state;
+    state.didAccept(true);
+
+    EXPECT_TRUE(state.isWaitingForData());
+    EXPECT_TRUE(state.didRequestDrop());
+
+    state.didFinishLoadingData();
+    EXPECT_TRUE(state.takeDeferredDrop());
+    EXPECT_FALSE(state.takeDeferredDrop());
+
+    state.didFinishDrop();
+    EXPECT_FALSE(state.takeUnfinishedDrop());
+}
+
+// Nothing to load means nothing to defer.
+TEST(DropTargetState, DropIsNotDeferredWhenNothingIsLoading)
+{
+    DropTargetState state;
+    state.didAccept(false);
+
+    EXPECT_FALSE(state.isWaitingForData());
+    EXPECT_FALSE(state.didRequestDrop());
+    EXPECT_FALSE(state.takeDeferredDrop());
+}
+
+// drag-leave cancels the reads. The GdkDrop still has to be finished.
+TEST(DropTargetState, LeaveAfterDeferredDropStillOwesFinish)
+{
+    DropTargetState state;
+    state.didAccept(true);
+    EXPECT_TRUE(state.didRequestDrop());
+
+    EXPECT_TRUE(state.takeUnfinishedDrop());
+    // Only once: leave() must not finish the same GdkDrop twice.
+    EXPECT_FALSE(state.takeUnfinishedDrop());
+    EXPECT_FALSE(state.takeDeferredDrop());
+    EXPECT_FALSE(state.isWaitingForData());
+}
+
+// A drag-leave without any drop owes nothing; the drag source keeps the drop.
+TEST(DropTargetState, LeaveWithoutDropOwesNothing)
+{
+    DropTargetState state;
+    state.didAccept(true);
+
+    EXPECT_FALSE(state.takeUnfinishedDrop());
+}
+
+// A finished drop is not finished again.
+TEST(DropTargetState, FinishedDropIsNotFinishedAgain)
+{
+    DropTargetState state;
+    state.didAccept(true);
+    state.didFinishLoadingData();
+    state.didRequestDrop();
+    state.didFinishDrop();
+
+    EXPECT_FALSE(state.takeUnfinishedDrop());
+}
+
+// Destruction while a deferred drop is outstanding still owes a finish.
+TEST(DropTargetState, DestroyWithDeferredDropOwesFinish)
+{
+    DropTargetState state;
+    state.didAccept(true);
+    state.didRequestDrop();
+
+    EXPECT_TRUE(state.takeUnfinishedDrop());
+}
+
+// A new drop starts clean.
+TEST(DropTargetState, AcceptResetsPreviousState)
+{
+    DropTargetState state;
+    state.didAccept(true);
+    state.didRequestDrop();
+    EXPECT_TRUE(state.takeUnfinishedDrop());
+
+    state.didAccept(true);
+    EXPECT_TRUE(state.isWaitingForData());
+    EXPECT_FALSE(state.takeDeferredDrop());
+    EXPECT_FALSE(state.takeUnfinishedDrop());
+}
+
+// Data finishing loading on its own does not invent a drop.
+TEST(DropTargetState, LoadingCompletionWithoutDropDoesNotDefer)
+{
+    DropTargetState state;
+    state.didAccept(true);
+    state.didFinishLoadingData();
+
+    EXPECT_FALSE(state.takeDeferredDrop());
+    EXPECT_FALSE(state.takeUnfinishedDrop());
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(GTK)

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/SelectionData.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/SelectionData.cpp
@@ -1,0 +1,392 @@
+/*
+ * Copyright (C) 2026 Hayden Barnes. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if PLATFORM(GTK) || PLATFORM(WPE)
+
+#include "Helpers/Test.h"
+
+#include <WebCore/DragData.h>
+#include <WebCore/SelectionData.h>
+#include <wtf/URL.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/WTFString.h>
+
+namespace TestWebKitAPI {
+using namespace WebCore;
+
+// A web-authored uri-list must not become filenames.
+
+TEST(SelectionData, SetURIListDoesNotPromoteFilenames)
+{
+    SelectionData data;
+    data.setURIList("file:///etc/passwd\r\nhttps://example.com/\r\n"_s);
+
+    EXPECT_TRUE(data.hasURIList());
+    EXPECT_TRUE(data.hasURL());
+    EXPECT_EQ(data.url().string(), "file:///etc/passwd"_s);
+    EXPECT_FALSE(data.hasFilenames());
+    EXPECT_TRUE(data.filenames().isEmpty());
+}
+
+TEST(SelectionData, SetURIListKeepsHttpURLWithoutFilenames)
+{
+    SelectionData data;
+    data.setURIList("https://example.com/path\n"_s);
+
+    EXPECT_TRUE(data.hasURL());
+    EXPECT_EQ(data.url().string(), "https://example.com/path"_s);
+    EXPECT_FALSE(data.hasFilenames());
+}
+
+TEST(SelectionData, TrustedSetFilenamesFromURIList)
+{
+    SelectionData data;
+    data.setURIList("file:///tmp/trusted.txt\r\nhttps://example.com/\r\n"_s);
+    EXPECT_FALSE(data.hasFilenames());
+
+    data.setFilenamesFromURIList(data.uriList());
+    EXPECT_TRUE(data.hasFilenames());
+    ASSERT_EQ(data.filenames().size(), 1u);
+    EXPECT_EQ(data.filenames()[0], "/tmp/trusted.txt"_s);
+}
+
+TEST(SelectionData, ExplicitSetFilenames)
+{
+    SelectionData data;
+    data.setURIList("file:///tmp/ignored-for-files.txt"_s);
+    data.setFilenames(Vector<String> { "/home/user/document.pdf"_s, "/home/user/photo.png"_s });
+
+    ASSERT_EQ(data.filenames().size(), 2u);
+    EXPECT_EQ(data.filenames()[0], "/home/user/document.pdf"_s);
+    EXPECT_EQ(data.filenames()[1], "/home/user/photo.png"_s);
+}
+
+TEST(SelectionData, FilenamesFromURIListSkipsCommentsAndNonFiles)
+{
+    auto filenames = SelectionData::filenamesFromURIList(
+        "# comment\n"
+        "https://example.com/a\n"
+        "file:///tmp/a.txt\n"
+        "\n"
+        "file:///tmp/b.txt\r\n"_s);
+
+    ASSERT_EQ(filenames.size(), 2u);
+    EXPECT_EQ(filenames[0], "/tmp/a.txt"_s);
+    EXPECT_EQ(filenames[1], "/tmp/b.txt"_s);
+}
+
+TEST(SelectionData, ClearFilenames)
+{
+    SelectionData data;
+    data.setFilenames(Vector<String> { "/tmp/x"_s });
+    EXPECT_TRUE(data.hasFilenames());
+    data.clearFilenames();
+    EXPECT_FALSE(data.hasFilenames());
+}
+
+TEST(SelectionData, URIListWithoutFilenamesStripsFileURLs)
+{
+    auto sanitized = SelectionData::uriListWithoutFilenames(
+        "file:///etc/passwd\r\nhttps://example.com/a\r\nfile:///tmp/x\r\n"_s);
+    EXPECT_EQ(sanitized, "https://example.com/a"_s);
+}
+
+TEST(SelectionData, URIListWithoutFilenamesEmptyWhenOnlyFiles)
+{
+    auto sanitized = SelectionData::uriListWithoutFilenames("file:///tmp/only\n"_s);
+    EXPECT_TRUE(sanitized.isEmpty());
+}
+
+// Mirrors SelectionData.serialization.in decode: filenames survive without setURIList promotion.
+TEST(SelectionData, IpcConstructorPreservesFilenamesWithoutURIListPromotion)
+{
+    SelectionData decoded(
+        String(),
+        String(),
+        URL(),
+        "file:///etc/passwd\r\nhttps://example.com/\r\n"_s,
+        Vector<String> { "/tmp/trusted-drop.txt"_s },
+        nullptr,
+        nullptr,
+        false);
+
+    EXPECT_TRUE(decoded.hasURIList());
+    EXPECT_TRUE(decoded.hasFilenames());
+    ASSERT_EQ(decoded.filenames().size(), 1u);
+    EXPECT_EQ(decoded.filenames()[0], "/tmp/trusted-drop.txt"_s);
+
+    SelectionData uriOnly(
+        String(),
+        String(),
+        URL(),
+        "file:///etc/passwd\r\n"_s,
+        Vector<String> { },
+        nullptr,
+        nullptr,
+        false);
+    EXPECT_TRUE(uriOnly.hasURIList());
+    EXPECT_FALSE(uriOnly.hasFilenames());
+}
+
+TEST(SelectionData, DragDataIsSourceDeniesFilenameAccess)
+{
+    SelectionData selection;
+    selection.setFilenames(Vector<String> { "/tmp/trusted-looking.txt"_s });
+
+    DragData external(&selection, { }, { }, { });
+    EXPECT_TRUE(external.containsFiles());
+    EXPECT_EQ(external.numberOfFiles(), 1u);
+
+    DragData local(&selection, { }, { }, { }, DragApplicationFlags::IsSource);
+    EXPECT_FALSE(local.containsFiles());
+    EXPECT_EQ(local.numberOfFiles(), 0u);
+    EXPECT_TRUE(local.asFilenames().isEmpty());
+}
+
+// The portal list wins over a parallel hostile uri-list.
+TEST(SelectionData, PortalFilenamesNotWidenedByHostileURIList)
+{
+    SelectionData data;
+    data.setURIList("file:///etc/passwd\r\nhttps://example.com/\r\nfile:///tmp/extra-from-uri-list.txt\r\n"_s);
+    data.setFilenames(Vector<String> { "/run/user/1000/doc/portal-only.txt"_s });
+
+    ASSERT_EQ(data.filenames().size(), 1u);
+    EXPECT_EQ(data.filenames()[0], "/run/user/1000/doc/portal-only.txt"_s);
+    EXPECT_FALSE(data.filenames().contains("/etc/passwd"_s));
+    EXPECT_FALSE(data.filenames().contains("/tmp/extra-from-uri-list.txt"_s));
+    EXPECT_TRUE(data.hasURIList());
+}
+
+// Export sanitize contract used by DragSource and clipboard write.
+TEST(SelectionData, UriListWithoutFilenamesKeepsHttpOnly)
+{
+    auto out = SelectionData::uriListWithoutFilenames(
+        "file:///etc/passwd\r\nhttps://example.com/a\r\nhttp://example.org/b\r\nfile:///tmp/x\r\n"_s);
+    EXPECT_TRUE(out.contains("https://example.com/a"_s));
+    EXPECT_TRUE(out.contains("http://example.org/b"_s));
+    EXPECT_FALSE(out.contains("file://"_s));
+    EXPECT_FALSE(out.contains("passwd"_s));
+}
+
+// An external drop after IPC: containsFiles only when not IsSource.
+TEST(SelectionData, TrustedDropShapeAfterIpcRoundTrip)
+{
+    SelectionData decoded(
+        String(),
+        String(),
+        URL(),
+        "file:///home/user/doc.txt\r\n"_s,
+        Vector<String> { "/home/user/doc.txt"_s },
+        nullptr,
+        nullptr,
+        false);
+
+    EXPECT_TRUE(decoded.hasFilenames());
+    DragData external(&decoded, { }, { }, { });
+    EXPECT_TRUE(external.containsFiles());
+    EXPECT_EQ(external.numberOfFiles(), 1u);
+
+    DragData asSource(&decoded, { }, { }, { }, DragApplicationFlags::IsSource);
+    EXPECT_FALSE(asSource.containsFiles());
+}
+
+// setTrustedDrop is the one entry point, so GTK3 and GTK4 cannot drift.
+
+TEST(SelectionData, TrustedDropPrefersPortalFilenames)
+{
+    SelectionData data;
+    data.setTrustedDrop("file:///etc/passwd\r\nfile:///tmp/extra.txt\r\n"_s,
+        Vector<String> { "/run/user/1000/doc/portal-only.txt"_s });
+
+    ASSERT_EQ(data.filenames().size(), 1u);
+    EXPECT_EQ(data.filenames()[0], "/run/user/1000/doc/portal-only.txt"_s);
+    EXPECT_FALSE(data.filenames().contains("/etc/passwd"_s));
+    EXPECT_FALSE(data.filenames().contains("/tmp/extra.txt"_s));
+}
+
+TEST(SelectionData, TrustedDropFallsBackToURIListWhenNoPortalList)
+{
+    SelectionData data;
+    data.setTrustedDrop("file:///home/user/a.txt\r\nfile:///home/user/b.txt\r\nhttps://example.com/\r\n"_s, { });
+
+    ASSERT_EQ(data.filenames().size(), 2u);
+    EXPECT_EQ(data.filenames()[0], "/home/user/a.txt"_s);
+    EXPECT_EQ(data.filenames()[1], "/home/user/b.txt"_s);
+    EXPECT_TRUE(data.hasURIList());
+}
+
+TEST(SelectionData, TrustedDropWithoutFilesGrantsNothing)
+{
+    SelectionData data;
+    data.setTrustedDrop("https://example.com/\r\n"_s, { });
+
+    EXPECT_FALSE(data.hasFilenames());
+    EXPECT_TRUE(data.hasURL());
+}
+
+TEST(SelectionData, TrustedDropWithOnlyPortalListHasNoURIList)
+{
+    SelectionData data;
+    data.setTrustedDrop(emptyString(), Vector<String> { "/run/user/1000/doc/only.txt"_s });
+
+    ASSERT_EQ(data.filenames().size(), 1u);
+    EXPECT_EQ(data.filenames()[0], "/run/user/1000/doc/only.txt"_s);
+    EXPECT_FALSE(data.hasURIList());
+}
+
+// A second drop must not inherit the previous grant.
+TEST(SelectionData, TrustedDropReplacesPreviousFilenames)
+{
+    SelectionData data;
+    data.setTrustedDrop("file:///home/user/first.txt\r\n"_s, { });
+    ASSERT_EQ(data.filenames().size(), 1u);
+
+    data.setTrustedDrop("https://example.com/\r\n"_s, { });
+    EXPECT_FALSE(data.hasFilenames());
+}
+
+// WebPageProxy::startDrag() clears filenames on the way up. The rest of the drag survives.
+TEST(SelectionData, ClearFilenamesKeepsTheRestOfTheDrag)
+{
+    SelectionData data;
+    data.setText("dragged text"_s);
+    data.setURIList("file:///home/user/secret.txt\r\nhttps://example.com/\r\n"_s);
+    data.setFilenames(Vector<String> { "/home/user/secret.txt"_s });
+    ASSERT_TRUE(data.hasFilenames());
+
+    data.clearFilenames();
+
+    EXPECT_FALSE(data.hasFilenames());
+    EXPECT_TRUE(data.hasText());
+    EXPECT_TRUE(data.hasURIList());
+}
+
+// file://attacker.example/etc/passwd must not resolve to /etc/passwd.
+TEST(SelectionData, RemoteHostFileURIIsNotAGrant)
+{
+    SelectionData data;
+    data.setTrustedDrop("file://attacker.example/etc/passwd\r\n"_s, { });
+    EXPECT_FALSE(data.hasFilenames());
+}
+
+// An empty authority is the ordinary form and must keep working.
+TEST(SelectionData, EmptyAuthorityFileURIIsAGrant)
+{
+    SelectionData data;
+    data.setTrustedDrop("file:///etc/hostname\r\n"_s, { });
+    ASSERT_TRUE(data.hasFilenames());
+    EXPECT_EQ(1u, data.filenames().size());
+    EXPECT_STREQ("/etc/hostname", data.filenames()[0].utf8().data());
+}
+
+// RFC 8089: localhost means this machine, case insensitive.
+TEST(SelectionData, LocalhostAuthorityFileURIIsAGrant)
+{
+    SelectionData data;
+    data.setTrustedDrop("file://localhost/etc/hostname\r\n"_s, { });
+    ASSERT_TRUE(data.hasFilenames());
+    EXPECT_EQ(1u, data.filenames().size());
+    EXPECT_STREQ("/etc/hostname", data.filenames()[0].utf8().data());
+
+    SelectionData upper;
+    upper.setTrustedDrop("file://LOCALHOST/etc/hostname\r\n"_s, { });
+    EXPECT_TRUE(upper.hasFilenames());
+}
+
+// Not a grant, but still not something to hand another application. Export is
+// broader than import.
+TEST(SelectionData, RemoteHostFileURIIsStrippedOnExport)
+{
+    auto stripped = SelectionData::uriListWithoutFilenames("file://attacker.example/etc/passwd\r\nhttps://webkit.org/\r\n"_s);
+    EXPECT_STREQ("https://webkit.org/", stripped.utf8().data());
+}
+
+// Whatever import grants, export must strip.
+TEST(SelectionData, EverythingGrantedOnImportIsStrippedOnExport)
+{
+    const char* lines[] = {
+        "file:///etc/hostname",
+        "file://localhost/etc/hostname",
+        "file://LOCALHOST/etc/hostname",
+        "file://attacker.example/etc/passwd",
+        "file:///home/user/a b c.txt",
+        "file:///home/user/%C3%A9.txt",
+        "https://webkit.org/",
+        "mailto:nobody@webkit.org",
+        "not a uri at all",
+    };
+
+    for (auto* line : lines) {
+        auto uriList = makeString(String::fromUTF8(line), "\r\n"_s);
+
+        SelectionData data;
+        data.setTrustedDrop(uriList, { });
+
+        auto stripped = SelectionData::uriListWithoutFilenames(uriList);
+        bool survivedExport = stripped.contains(String::fromUTF8(line));
+
+        if (data.hasFilenames())
+            EXPECT_FALSE(survivedExport) << "granted but not stripped: " << line;
+    }
+}
+
+// Pasteboard::fileContentState() uses this to narrow the type list, never to widen it.
+TEST(SelectionData, URIListContainsFileURI)
+{
+    EXPECT_TRUE(SelectionData::uriListContainsFileURI("file:///home/user/a.txt\r\n"_s));
+    EXPECT_TRUE(SelectionData::uriListContainsFileURI("https://webkit.org/\r\nfile:///home/user/a.txt\r\n"_s));
+
+    EXPECT_FALSE(SelectionData::uriListContainsFileURI("https://webkit.org/\r\n"_s));
+    EXPECT_FALSE(SelectionData::uriListContainsFileURI("# file:///home/user/a.txt\r\n"_s));
+    EXPECT_FALSE(SelectionData::uriListContainsFileURI(emptyString()));
+}
+
+// Host authority does not matter for narrowing.
+TEST(SelectionData, URIListContainsFileURICountsRemoteHosts)
+{
+    EXPECT_TRUE(SelectionData::uriListContainsFileURI("file://attacker.example/etc/passwd\r\n"_s));
+
+    SelectionData data;
+    data.setTrustedDrop("file://attacker.example/etc/passwd\r\n"_s, { });
+    EXPECT_FALSE(data.hasFilenames());
+}
+
+// A dragged local image has no filenames, but setURL() puts its src in the uri-list
+// and the text.
+TEST(SelectionData, LocalImageDragHasNoFilenamesButAFileURIList)
+{
+    SelectionData data;
+    data.setURL(URL { "file:///home/user/greenbox.png"_s }, emptyString());
+
+    EXPECT_FALSE(data.hasFilenames());
+    EXPECT_TRUE(SelectionData::uriListContainsFileURI(data.uriList()));
+    EXPECT_EQ(data.text(), "file:///home/user/greenbox.png"_s);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(GTK) || PLATFORM(WPE)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/gtk/TestDragAndDrop.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/gtk/TestDragAndDrop.cpp
@@ -1,0 +1,309 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WebViewTest.h"
+#include <glib/gstdio.h>
+#include <wtf/glib/GUniquePtr.h>
+#include <wtf/text/MakeString.h>
+
+// Each test isolates one defence. Revert that defence and the test must fail.
+
+class DragAndDropTest : public WebViewTest {
+public:
+    MAKE_GLIB_TEST_FIXTURE(DragAndDropTest);
+
+    DragAndDropTest()
+    {
+        m_tempDirectory.reset(g_dir_make_tmp("WebKitDragAndDropTest-XXXXXX", nullptr));
+        g_assert_nonnull(m_tempDirectory.get());
+    }
+
+    ~DragAndDropTest()
+    {
+        for (const auto& path : m_files)
+            g_unlink(path.utf8().data());
+        if (m_tempDirectory)
+            g_rmdir(m_tempDirectory.get());
+    }
+
+    // A real file, so a denied drop cannot be mistaken for a missing one.
+    String createFile(const char* name, const char* contents)
+    {
+        GUniquePtr<char> path(g_build_filename(m_tempDirectory.get(), name, nullptr));
+        g_assert_true(g_file_set_contents(path.get(), contents, -1, nullptr));
+        String result = String::fromUTF8(path.get());
+        m_files.append(result);
+        return result;
+    }
+
+    static String uriForPath(const String& path)
+    {
+        GUniquePtr<char> uri(g_filename_to_uri(path.utf8().data(), nullptr, nullptr));
+        g_assert_nonnull(uri.get());
+        return String::fromUTF8(uri.get());
+    }
+
+    // Installs a drop handler that records what dataTransfer exposed to the page.
+    void loadDropTarget()
+    {
+        static const char* html =
+            "<html><body style='margin:0'>"
+            "<div id='target' style='width:200px;height:200px'></div>"
+            "<script>"
+            "window.dropFileCount = -1;"
+            "window.dropFileNames = '';"
+            "window.dropFileContents = '';"
+            "document.addEventListener('dragover', e => e.preventDefault());"
+            "document.addEventListener('drop', e => {"
+            "  e.preventDefault();"
+            "  const files = e.dataTransfer.files;"
+            "  window.dropFileCount = files.length;"
+            "  window.dropFileNames = Array.from(files).map(f => f.name).join(',');"
+            "  let pending = files.length;"
+            "  if (!pending) { window.dropDone = true; return; }"
+            "  const parts = new Array(pending);"
+            "  Array.from(files).forEach((f, i) => {"
+            "    const reader = new FileReader();"
+            "    reader.onloadend = () => {"
+            "      parts[i] = reader.result || '';"
+            "      if (!--pending) {"
+            "        window.dropFileContents = parts.join('|');"
+            "        window.dropDone = true;"
+            "      }"
+            "    };"
+            "    reader.readAsText(f);"
+            "  });"
+            "});"
+            "</script></body></html>";
+
+        loadHtml(html, nullptr);
+        waitUntilLoadFinished();
+        showInWindow(200, 200);
+    }
+
+    double numberByEvaluatingJavaScript(const char* script)
+    {
+        GUniqueOutPtr<GError> error;
+        auto* value = runJavaScriptAndWaitUntilFinished(script, &error.outPtr());
+        g_assert_no_error(error.get());
+        g_assert_nonnull(value);
+        g_assert_true(jsc_value_is_number(value));
+        return jsc_value_to_double(value);
+    }
+
+    String stringByEvaluatingJavaScript(const char* script)
+    {
+        GUniqueOutPtr<GError> error;
+        auto* value = runJavaScriptAndWaitUntilFinished(script, &error.outPtr());
+        g_assert_no_error(error.get());
+        g_assert_nonnull(value);
+        GUniquePtr<char> string(jsc_value_to_string(value));
+        return String::fromUTF8(string.get());
+    }
+
+    // The drop and FileReader are both asynchronous, so poll.
+    void waitUntilDropHandled()
+    {
+        for (unsigned i = 0; i < 200; ++i) {
+            if (numberByEvaluatingJavaScript("window.dropDone ? 1 : 0") > 0)
+                return;
+            g_usleep(10000);
+        }
+        g_assert_not_reached();
+    }
+
+    int droppedFileCount() { return static_cast<int>(numberByEvaluatingJavaScript("window.dropFileCount")); }
+
+    GUniquePtr<char> m_tempDirectory;
+    Vector<String> m_files;
+};
+
+// The CVE-2025-13947 mechanism. No IsSource is set, so setURIList() refusing to
+// promote file:// lines is the only defence under test.
+static void testDragAndDropUntrustedURIListGrantsNoFiles(DragAndDropTest* test, gconstpointer)
+{
+    auto path = test->createFile("secret.txt", "sensitive contents");
+    auto uriList = DragAndDropTest::uriForPath(path);
+
+    test->loadDropTarget();
+    test->dropFiles(uriList.utf8().data(), { }, WebViewTest::DropSource::UntrustedURIList);
+    test->waitUntilDropHandled();
+
+    g_assert_cmpint(test->droppedFileCount(), ==, 0);
+    g_assert_cmpstr(test->stringByEvaluatingJavaScript("window.dropFileContents").utf8().data(), ==, "");
+}
+
+// A partial match must not become a partial grant.
+static void testDragAndDropUntrustedMultipleURIsGrantNoFiles(DragAndDropTest* test, gconstpointer)
+{
+    auto real = test->createFile("real.txt", "real contents");
+    auto uriList = makeString(DragAndDropTest::uriForPath(real), "\r\n"_s, "file:///etc/passwd\r\n"_s, "file:///nonexistent/path.txt\r\n"_s);
+
+    test->loadDropTarget();
+    test->dropFiles(uriList.utf8().data(), { }, WebViewTest::DropSource::UntrustedURIList);
+    test->waitUntilDropHandled();
+
+    g_assert_cmpint(test->droppedFileCount(), ==, 0);
+    g_assert_cmpstr(test->stringByEvaluatingJavaScript("window.dropFileContents").utf8().data(), ==, "");
+}
+
+// The drop is built through the trusted path, so IsSource alone keeps the file out.
+static void testDragAndDropSameAppDragIsDeniedFileAccess(DragAndDropTest* test, gconstpointer)
+{
+    auto path = test->createFile("secret.txt", "sensitive contents");
+    auto uriList = DragAndDropTest::uriForPath(path);
+
+    test->loadDropTarget();
+    test->dropFiles(uriList.utf8().data(), { }, WebViewTest::DropSource::WebOrSameApp);
+    test->waitUntilDropHandled();
+
+    g_assert_cmpint(test->droppedFileCount(), ==, 0);
+    g_assert_cmpstr(test->stringByEvaluatingJavaScript("window.dropFileContents").utf8().data(), ==, "");
+}
+
+// IsSource wins over a portal grant.
+static void testDragAndDropSameAppDragIsDeniedEvenWithPortalList(DragAndDropTest* test, gconstpointer)
+{
+    auto path = test->createFile("portal.txt", "portal contents");
+    auto uriList = DragAndDropTest::uriForPath(path);
+
+    test->loadDropTarget();
+    test->dropFiles(uriList.utf8().data(), { path }, WebViewTest::DropSource::WebOrSameApp);
+    test->waitUntilDropHandled();
+
+    g_assert_cmpint(test->droppedFileCount(), ==, 0);
+    g_assert_cmpstr(test->stringByEvaluatingJavaScript("window.dropFileContents").utf8().data(), ==, "");
+}
+
+// The file manager drop the workaround broke.
+static void testDragAndDropExternalFileDropGrantsFiles(DragAndDropTest* test, gconstpointer)
+{
+    auto path = test->createFile("dropped.txt", "hello from the file manager");
+    auto uriList = DragAndDropTest::uriForPath(path);
+
+    test->loadDropTarget();
+    test->dropFiles(uriList.utf8().data(), { }, WebViewTest::DropSource::External);
+    test->waitUntilDropHandled();
+
+    g_assert_cmpint(test->droppedFileCount(), ==, 1);
+    g_assert_cmpstr(test->stringByEvaluatingJavaScript("window.dropFileNames").utf8().data(), ==, "dropped.txt");
+    g_assert_cmpstr(test->stringByEvaluatingJavaScript("window.dropFileContents").utf8().data(), ==, "hello from the file manager");
+}
+
+// Order must match the uri-list.
+static void testDragAndDropExternalMultipleFilesGrantAll(DragAndDropTest* test, gconstpointer)
+{
+    auto first = test->createFile("first.txt", "one");
+    auto second = test->createFile("second.txt", "two");
+    auto uriList = makeString(DragAndDropTest::uriForPath(first), "\r\n"_s, DragAndDropTest::uriForPath(second), "\r\n"_s);
+
+    test->loadDropTarget();
+    test->dropFiles(uriList.utf8().data(), { }, WebViewTest::DropSource::External);
+    test->waitUntilDropHandled();
+
+    g_assert_cmpint(test->droppedFileCount(), ==, 2);
+    g_assert_cmpstr(test->stringByEvaluatingJavaScript("window.dropFileNames").utf8().data(), ==, "first.txt,second.txt");
+    g_assert_cmpstr(test->stringByEvaluatingJavaScript("window.dropFileContents").utf8().data(), ==, "one|two");
+}
+
+// The portal list is the grant. A parallel uri-list must not widen it.
+static void testDragAndDropPortalListIsNotWidenedByURIList(DragAndDropTest* test, gconstpointer)
+{
+    auto granted = test->createFile("granted.txt", "granted");
+    auto sneaked = test->createFile("sneaked.txt", "sneaked");
+    auto uriList = makeString(DragAndDropTest::uriForPath(granted), "\r\n"_s, DragAndDropTest::uriForPath(sneaked));
+
+    test->loadDropTarget();
+    test->dropFiles(uriList.utf8().data(), { granted }, WebViewTest::DropSource::External);
+    test->waitUntilDropHandled();
+
+    g_assert_cmpint(test->droppedFileCount(), ==, 1);
+    g_assert_cmpstr(test->stringByEvaluatingJavaScript("window.dropFileNames").utf8().data(), ==, "granted.txt");
+    g_assert_cmpstr(test->stringByEvaluatingJavaScript("window.dropFileContents").utf8().data(), ==, "granted");
+}
+
+// Replacement, not intersection.
+static void testDragAndDropPortalListIsNotReplacedByURIList(DragAndDropTest* test, gconstpointer)
+{
+    auto granted = test->createFile("granted.txt", "granted");
+    auto other = test->createFile("other.txt", "other");
+    auto uriList = DragAndDropTest::uriForPath(other);
+
+    test->loadDropTarget();
+    test->dropFiles(uriList.utf8().data(), { granted }, WebViewTest::DropSource::External);
+    test->waitUntilDropHandled();
+
+    g_assert_cmpint(test->droppedFileCount(), ==, 1);
+    g_assert_cmpstr(test->stringByEvaluatingJavaScript("window.dropFileNames").utf8().data(), ==, "granted.txt");
+    g_assert_cmpstr(test->stringByEvaluatingJavaScript("window.dropFileContents").utf8().data(), ==, "granted");
+}
+
+// A drop that carries no file:// at all must not manufacture one.
+static void testDragAndDropNonFileURIListGrantsNoFiles(DragAndDropTest* test, gconstpointer)
+{
+    test->loadDropTarget();
+    test->dropFiles("https://webkit.org/\r\n", { }, WebViewTest::DropSource::External);
+    test->waitUntilDropHandled();
+
+    g_assert_cmpint(test->droppedFileCount(), ==, 0);
+}
+
+// A file URI naming another host is not a grant even on the trusted path.
+static void testDragAndDropRemoteFileURIGrantsNoFiles(DragAndDropTest* test, gconstpointer)
+{
+    test->loadDropTarget();
+    test->dropFiles("file://attacker.example/etc/passwd\r\n", { }, WebViewTest::DropSource::External);
+    test->waitUntilDropHandled();
+
+    g_assert_cmpint(test->droppedFileCount(), ==, 0);
+}
+
+// Comments and blank lines are part of the text/uri-list format.
+static void testDragAndDropURIListCommentsAreIgnored(DragAndDropTest* test, gconstpointer)
+{
+    auto path = test->createFile("kept.txt", "kept");
+    auto uriList = makeString("# file:///etc/passwd\r\n"_s, "\r\n"_s, DragAndDropTest::uriForPath(path), "\r\n"_s);
+
+    test->loadDropTarget();
+    test->dropFiles(uriList.utf8().data(), { }, WebViewTest::DropSource::External);
+    test->waitUntilDropHandled();
+
+    g_assert_cmpint(test->droppedFileCount(), ==, 1);
+    g_assert_cmpstr(test->stringByEvaluatingJavaScript("window.dropFileNames").utf8().data(), ==, "kept.txt");
+}
+
+void beforeAll()
+{
+    DragAndDropTest::add("DragAndDrop", "untrusted-uri-list-grants-no-files", testDragAndDropUntrustedURIListGrantsNoFiles);
+    DragAndDropTest::add("DragAndDrop", "untrusted-multiple-uris-grant-no-files", testDragAndDropUntrustedMultipleURIsGrantNoFiles);
+    DragAndDropTest::add("DragAndDrop", "same-app-drag-is-denied-file-access", testDragAndDropSameAppDragIsDeniedFileAccess);
+    DragAndDropTest::add("DragAndDrop", "same-app-drag-is-denied-even-with-portal-list", testDragAndDropSameAppDragIsDeniedEvenWithPortalList);
+    DragAndDropTest::add("DragAndDrop", "external-file-drop-grants-files", testDragAndDropExternalFileDropGrantsFiles);
+    DragAndDropTest::add("DragAndDrop", "external-multiple-files-grant-all", testDragAndDropExternalMultipleFilesGrantAll);
+    DragAndDropTest::add("DragAndDrop", "portal-list-is-not-widened-by-uri-list", testDragAndDropPortalListIsNotWidenedByURIList);
+    DragAndDropTest::add("DragAndDrop", "portal-list-is-not-replaced-by-uri-list", testDragAndDropPortalListIsNotReplacedByURIList);
+    DragAndDropTest::add("DragAndDrop", "non-file-uri-list-grants-no-files", testDragAndDropNonFileURIListGrantsNoFiles);
+    DragAndDropTest::add("DragAndDrop", "remote-file-uri-grants-no-files", testDragAndDropRemoteFileURIGrantsNoFiles);
+    DragAndDropTest::add("DragAndDrop", "uri-list-comments-are-ignored", testDragAndDropURIListCommentsAreIgnored);
+}
+
+void afterAll()
+{
+}

--- a/Tools/TestWebKitAPI/glib/PlatformGTK.cmake
+++ b/Tools/TestWebKitAPI/glib/PlatformGTK.cmake
@@ -52,6 +52,7 @@ endif ()
 
 # UI process tests
 ADD_WK2_TEST(InspectorTestServer ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKit/WKWebView/gtk/InspectorTestServer.cpp)
+ADD_WK2_TEST(TestDragAndDrop ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKit/WKWebView/gtk/TestDragAndDrop.cpp)
 ADD_WK2_TEST(TestInspector ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKit/WKWebView/gtk/TestInspector.cpp)
 ADD_WK2_TEST(TestInspectorServer ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKit/WKWebView/gtk/TestInspectorServer.cpp)
 ADD_WK2_TEST(TestPrinting ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKit/WKWebView/gtk/TestPrinting.cpp)

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h
@@ -87,6 +87,10 @@ public:
 
 #if PLATFORM(GTK)
     void emitPopupMenuSignal();
+
+    // Synthetic GDK events cannot drive a real drag (webkit.org/b/157179).
+    enum class DropSource : uint8_t { WebOrSameApp, External, UntrustedURIList };
+    void dropFiles(const char* uriList, Vector<String>&& portalFilenames, DropSource, int x = 10, int y = 10);
 #endif
 
     JSCValue* runJavaScriptAndWaitUntilFinished(const char* javascript, GError**, WebKitWebView* = nullptr);

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/gtk/WebViewTestGtk.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/gtk/WebViewTestGtk.cpp
@@ -130,6 +130,24 @@ void WebViewTest::emitPopupMenuSignal()
     g_signal_emit_by_name(viewWidget, "popup-menu", &handled);
 }
 
+void WebViewTest::dropFiles(const char* uriList, Vector<String>&& portalFilenames, DropSource source, int x, int y)
+{
+    g_assert_nonnull(m_parentWindow);
+    FileDropSource dropSource;
+    switch (source) {
+    case DropSource::External:
+        dropSource = FileDropSource::External;
+        break;
+    case DropSource::WebOrSameApp:
+        dropSource = FileDropSource::WebOrSameApp;
+        break;
+    case DropSource::UntrustedURIList:
+        dropSource = FileDropSource::UntrustedURIList;
+        break;
+    }
+    webkitWebViewBaseSynthesizeFileDropForTesting(WEBKIT_WEB_VIEW_BASE(m_webView.get()), String::fromUTF8(uriList), WTF::move(portalFilenames), dropSource, x, y);
+}
+
 void WebViewTest::keyStroke(unsigned keyVal, OptionSet<Modifiers> keyModifiers)
 {
     g_assert_nonnull(m_parentWindow);


### PR DESCRIPTION
#### a9e2b8faf0546eb6f35f8e86a544514bfac4df49
<pre>
[GTK][WPE] Restore dataTransfer.files for trusted file drops
<a href="https://bugs.webkit.org/show_bug.cgi?id=323277">https://bugs.webkit.org/show_bug.cgi?id=323277</a>

Reviewed by nobody, yet.

CVE-2025-13947 was fixed by making DataTransfer::allowsFileAccess() return
false on every non-Cocoa port. That was the right call at the time and it
closed the hole. It also broke every legitimate file drop. Dragging a file from
Files or Nautilus into an upload area does nothing on WebKitGTK today, and
embedders that rely on drag and drop for uploads have no working path at all.

The underlying defect was not that file access was on. It was that
SelectionData had one channel where it needed two. setURIList() promoted any
file:// line it saw into m_filenames, and a page can write text/uri-list itself
through DataTransfer.setData() during its own drag. So a page could name
file:///etc/passwd, receive its own drag back, and read the file through
dataTransfer.files. The uri-list is web-writable. The filename list is a
filesystem grant. Treating them as the same thing is the bug.

This separates them. setURIList() no longer touches m_filenames, so nothing a
page writes can become a grant. Filenames are set only by setFilenames(),
setFilenamesFromURIList(), and setTrustedDrop(). Their production callers are
the two UIProcess drop targets, which are driven by a real GdkDrop or
GdkDragContext, and the IPC decode constructor. Filenames get their own field in
SelectionData.serialization.in and are applied after setURIList() on decode, so
a UIProcess grant survives the trip to the web process without being
reconstructed from web-writable text. That field travels in both directions, so
WebPageProxy::startDrag() clears it on the way up. Filenames are a grant the UI
process issues for a drop it observed, never something the web process gets to
assert. On GTK4 the portal file list wins whenever it is present, so a parallel
uri-list cannot widen a drop the user actually authorized. Web drag exports are
stripped of file:// lines and file: _NETSCAPE_URL, and never export a
GdkFileList, so a page cannot launder paths out to another application or back
into itself. DragData denies filename access outright when
DragApplicationFlags::IsSource is set. Only then does allowsFileAccess() return
forFileDrag() for GTK and WPE.

The import and export halves need to agree, and the way they agree is not
symmetry. Import is narrow: it decides what the page may read, so it refuses
anything it is not certain of. Export is broad: it decides what we hand to
another application, and that application will apply its own parser to the
string. The invariant is that everything import grants, export strips, and
export strips more besides. A unit test asserts exactly that over a table of
URI shapes, because this is the property that breaks silently.

The narrowing on import is worth spelling out. g_filename_from_uri() checks
that a file URI&apos;s authority is well formed and then, if the hostname out
parameter is null, discards it and returns the path anyway. So
file://attacker.example/home/user/.ssh/id_rsa yields /home/user/.ssh/id_rsa
with no error reported. Passing null there, which is what this code did, means
a URI naming someone else&apos;s host resolves against ours. RFC 8089 says an empty
authority or &quot;localhost&quot; means the local machine; anything else does not, and
its paths are not ours to hand out. Import now takes the hostname and rejects
the rest. Export deliberately does not apply that rule, because a receiving
application that passes null the way we used to will resolve such a line
locally on its side, so it is still a line we must not emit.

This is one commit on purpose. The layers are not independently safe. Restoring
allowsFileAccess() without the SelectionData split is CVE-2025-13947 again,
exactly. Split across a series, a partial backport or a single-commit revert
reintroduces the vulnerability while looking like a clean operation. Keeping it
atomic means there is no ordering a distribution can get wrong.

Paste is deliberately still denied. The GTK3 clipboard still maps uri-list to
paths, and that path needs its own audit before it can match the Cocoa policy.
The GTK expectation added by <a href="https://commits.webkit.org/303828@main">303828@main</a> for
paste-image-does-not-reveal-file-url still describes current behaviour and is
unchanged, because allowsFileAccess() returns forFileDrag(), which is false for
a paste. Ports other than GTK and WPE keep returning false, because they have not been
audited. The uri-list string itself remains visible to the page, as it is on
Cocoa; what no longer follows from it is file contents.

Drag and drop could not be tested in WebKitTestRunner, which is why the
original attempts to fix this narrowly could not be proven and the broad
disable was the only safe option. Synthetic GDK motion events are not handled
by GdkDragContext, so the drag protocol never advances (webkit.org/b/157179).
Rather than fight that, the new API test supplies the same inputs a real drop
supplies, the uri-list text, the portal file list, and whether the drag started
in this application, and then runs the production trust logic on them. The
assertions happen in JavaScript in the web process after a real IPC round trip,
so what is checked is what a page can actually observe.

Each test isolates a single defence and is named for the layer it pins. Each
defence was then reverted alone in a scratch tree, the tree rebuilt, and both
suites rerun with every API test in its own process, so an assertion abort in
one test cannot hide the result of the rest. Each revert turned red only the
tests whose assertions depend on that defence, and ten of the eleven API tests
went red under at least one revert. The eleventh, that a non-file uri-list
grants nothing, does not hang on any single defence. A test that passes for a
reason unrelated to its name still reads as proof, and the remote-host defect
above was found that way.

* Source/WebCore/dom/DataTransfer.h:
(WebCore::DataTransfer::allowsFileAccess const): Return forFileDrag() on GTK and WPE.
* Source/WebCore/platform/glib/DragDataGLib.cpp:
(WebCore::allowsFilenameAccess): Deny filename access for in-application drags.
(WebCore::DragData::containsFiles const):
(WebCore::DragData::numberOfFiles const):
(WebCore::DragData::asFilenames const):
* Source/WebCore/platform/glib/SelectionData.cpp:
(WebCore::SelectionData::SelectionData): Apply decoded filenames after setURIList().
(WebCore::SelectionData::setURIList): Stop promoting file:// URIs into m_filenames.
(WebCore::SelectionData::setFilenames):
(WebCore::SelectionData::setFilenamesFromURIList):
(WebCore::SelectionData::setTrustedDrop): Prefer the portal list over the uri-list.
(WebCore::SelectionData::filenamesFromURIList):
(WebCore::SelectionData::uriListWithoutFilenames): Strip file:// lines from exports.
* Source/WebCore/platform/glib/SelectionData.h:
* Source/WebKit/Shared/glib/SelectionData.serialization.in: Serialize filenames.
* Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp:
* Source/WebKit/UIProcess/API/gtk/DragSourceGtk4.cpp:
* Source/WebKit/UIProcess/API/gtk/DropTarget.h:
* Source/WebKit/UIProcess/API/gtk/DropTargetGtk3.cpp:
* Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp: Defer the drop until the
asynchronous mime loads finish, and finish with a unique GdkDragAction.
* Source/WebKit/UIProcess/API/gtk/DropTargetState.h: Added.
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseSynthesizeFileDropForTesting):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBaseInternal.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::startDrag): Clear filenames coming up from the web process.
* Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp:
* Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp:
* Tools/TestWebKitAPI/PlatformGTK.cmake:
* Tools/TestWebKitAPI/PlatformWPE.cmake:
* Tools/TestWebKitAPI/Tests/WebCore/glib/DropTargetState.cpp: Added.
* Tools/TestWebKitAPI/Tests/WebCore/glib/SelectionData.cpp: Added.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/gtk/TestDragAndDrop.cpp: Added.
* Tools/TestWebKitAPI/glib/PlatformGTK.cmake:
* Tools/TestWebKitAPI/glib/WebKitGLib/WebViewTest.h:
* Tools/TestWebKitAPI/glib/WebKitGLib/gtk/WebViewTestGtk.cpp:
(WebViewTest::dropFiles):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fbc998b47bde9323c4e87dbec5f414d7bafa2d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195208 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/149762 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58520 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144469 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100278 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165064 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124758 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46861 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44964 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44627 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6263 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197157 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58461 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153947 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59167 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153606 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48121 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131455 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/128029 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57663 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19645 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57022 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57273 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57099 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->