### PR TITLE
Web Inspector: report rendered font character ranges

### DIFF
--- a/LayoutTests/inspector/css/getFontDataForNode-font-data-changed-expected.txt
+++ b/LayoutTests/inspector/css/getFontDataForNode-font-data-changed-expected.txt
@@ -1,0 +1,10 @@
+Test target-wide font-data invalidation after in-memory font activation.
+
+A
+
+== Running test suite: CSS.getFontDataForNode.FontDataChanged
+-- Running test case: CSS.getFontDataForNode.FontDataChanged.InMemoryFontActivation
+PASS: The in-memory font should not be active initially.
+PASS: CSS.fontDataChanged should invalidate cached font data.
+PASS: Refreshing should report the activated in-memory font.
+

--- a/LayoutTests/inspector/css/getFontDataForNode-font-data-changed.html
+++ b/LayoutTests/inspector/css/getFontDataForNode-font-data-changed.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+let inMemoryFontFace;
+
+async function prepareInMemoryFont(eventName)
+{
+    let inMemoryFontData = await fetch("../../resources/Ahem.otf").then((response) => response.arrayBuffer());
+    inMemoryFontFace = new FontFace("InspectorInMemory", inMemoryFontData);
+    await inMemoryFontFace.load();
+    TestPage.dispatchEventToFrontend(eventName);
+}
+
+function activateInMemoryFont(eventName)
+{
+    document.fonts.add(inMemoryFontFace);
+    TestPage.dispatchEventToFrontend(eventName);
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("CSS.getFontDataForNode.FontDataChanged");
+
+    suite.addTestCase({
+        name: "CSS.getFontDataForNode.FontDataChanged.InMemoryFontActivation",
+        description: "Activating an in-memory FontFace should invalidate cached font data without a Resource loading event.",
+        async test() {
+            const preparedEventName = "TestPage-InMemoryFontPrepared";
+            await Promise.all([
+                InspectorTest.awaitEvent(preparedEventName),
+                InspectorTest.evaluateInPage(`prepareInMemoryFont("${preparedEventName}")`),
+            ]);
+
+            let documentNode = await WI.domManager.requestDocument();
+            let nodeId = await documentNode.querySelector("#in-memory-font");
+            let node = WI.domManager.nodeForId(nodeId);
+            InspectorTest.assert(node, "Should find #in-memory-font.");
+
+            let nodeStyles = WI.cssManager.stylesForNode(node);
+            await nodeStyles.refreshIfNeeded();
+            InspectorTest.expectFalse(nodeStyles.renderedFonts.some((font) => font.name === "Ahem"), "The in-memory font should not be active initially.");
+
+            let needsRefreshPromise = nodeStyles.awaitEvent(WI.DOMNodeStyles.Event.NeedsRefresh);
+            const activatedEventName = "TestPage-InMemoryFontActivated";
+            await Promise.all([
+                needsRefreshPromise,
+                InspectorTest.awaitEvent(activatedEventName),
+                InspectorTest.evaluateInPage(`activateInMemoryFont("${activatedEventName}")`),
+            ]);
+            InspectorTest.expectTrue(nodeStyles.needsRefresh, "CSS.fontDataChanged should invalidate cached font data.");
+
+            await nodeStyles.refreshIfNeeded();
+            InspectorTest.expectTrue(nodeStyles.renderedFonts.some((font) => font.name === "Ahem"), "Refreshing should report the activated in-memory font.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<style>
+#in-memory-font {
+    font: 20px/1 InspectorInMemory, system-ui;
+}
+</style>
+</head>
+<body onload="runTest();">
+<p>Test target-wide font-data invalidation after in-memory font activation.</p>
+<span id="in-memory-font">A</span>
+</body>
+</html>
+

--- a/LayoutTests/inspector/css/getFontDataForNode-rendered-text-expected.txt
+++ b/LayoutTests/inspector/css/getFontDataForNode-rendered-text-expected.txt
@@ -1,0 +1,64 @@
+Test for rendered and missing character data from CSS.getFontDataForNode.
+
+ABBAC¥
+AC
+AB
+AB
+􏿽
+A
+D
+H
+𝐼
+BC
+
+== Running test suite: CSS.getFontDataForNode.RenderedText
+-- Running test setup.
+PASS: Test fonts should be loaded.
+-- Running test case: CSS.getFontDataForNode.RenderedText.NoText
+PASS: The computed primary font should omit characterRanges.
+PASS: A font without variation axes should omit variationAxes.
+PASS: renderedFonts should be omitted when no text is painted.
+PASS: missingCharacterRanges should be omitted when no characters are missing.
+
+-- Running test case: CSS.getFontDataForNode.RenderedText.FallbackRangesAndTextNode
+PASS: The computed primary font should omit rendered character ranges.
+PASS: Every rendered font should have nonempty characterRanges.
+PASS: missingCharacterRanges should be omitted when every character has a glyph.
+PASS: Adjacent and repeated Latin scalars should be coalesced and deduplicated.
+PASS: The actual fallback font should own the yen scalar.
+PASS: A direct Text-node query should match its parent element.
+
+-- Running test case: CSS.getFontDataForNode.RenderedText.VisibleDescendantsAndGeneratedText
+PASS: Only the displayed A, transformed B, generated C, and generated yen should be reported.
+
+-- Running test case: CSS.getFontDataForNode.RenderedText.EquivalentFontMetadata
+PASS: Equivalent concrete fonts should produce one rendered-font record.
+PASS: The shared rendered-font record should contain characters from every concrete font.
+
+-- Running test case: CSS.getFontDataForNode.RenderedText.SelectedText
+PASS: Selected text should report the same characters as unselected text.
+
+-- Running test case: CSS.getFontDataForNode.RenderedText.FontSourceURL
+PASS: The primary downloadable font should expose an absolute URL.
+PASS: The primary downloadable font should expose its final resource URL.
+PASS: The primary rendered font should expose an absolute URL.
+PASS: The primary rendered font should expose its final resource URL.
+PASS: A rendered font without variation axes should omit variationAxes.
+PASS: The fallback downloadable font should expose an absolute URL.
+PASS: The fallback downloadable font should expose its final resource URL.
+PASS: A rendered variable font should expose variationAxes.
+PASS: A system primary font should omit url.
+PASS: The system-font fixture should report at least one rendered font.
+PASS: Rendered system fonts should omit url.
+
+-- Running test case: CSS.getFontDataForNode.RenderedText.LigatureAndMissingGlyph
+PASS: The scalar starting the AB ligature glyph should be attributed to its actual font.
+PASS: A missing supplementary character should be reported as one Unicode scalar.
+
+-- Running test case: CSS.getFontDataForNode.RenderedText.UnsupportedContentDoesNotCrash
+PASS: The command should succeed for a subtree containing unsupported specialized renderers.
+PASS: Ordinary text alongside unsupported specialized renderers should still be reported.
+
+-- Running test case: CSS.getFontDataForNode.RenderedText.ForcesCurrentLayout
+PASS: The diagnostic paint should use current style and layout.
+

--- a/LayoutTests/inspector/css/getFontDataForNode-rendered-text.html
+++ b/LayoutTests/inspector/css/getFontDataForNode-rendered-text.html
@@ -1,0 +1,323 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+async function loadTestFonts(eventName)
+{
+    try {
+        await Promise.all([
+            document.fonts.load("20px InspectorSegmented", "ABC\u00A5"),
+            document.fonts.load("20px InspectorLigature", "AB"),
+            document.fonts.load("20px InspectorMissing", "\u{10FFFD}"),
+        ]);
+        TestPage.log("PASS: Test fonts should be loaded.");
+    } catch {
+        TestPage.log("FAIL: Test fonts should be loaded.");
+    }
+
+    document.body.offsetWidth;
+    TestPage.dispatchEventToFrontend(eventName);
+}
+
+function test()
+{
+    const target = WI.assumingMainTarget();
+    let documentNode;
+
+    let suite = InspectorTest.createAsyncSuite("CSS.getFontDataForNode.RenderedText");
+
+    async function ensureDocumentSubtree()
+    {
+        if (documentNode)
+            return;
+
+        documentNode = await WI.domManager.requestDocument();
+        const entireSubtreeDepth = -1;
+        await target.DOMAgent.requestChildNodes(documentNode.id, entireSubtreeDepth);
+    }
+
+    async function nodeForSelector(selector)
+    {
+        await ensureDocumentSubtree();
+        let nodeId = await documentNode.querySelector(selector);
+        let node = WI.domManager.nodeForId(nodeId);
+        InspectorTest.assert(node, `Should find DOM node for '${selector}'.`);
+        return node;
+    }
+
+    async function textNodeForSelector(selector)
+    {
+        let element = await nodeForSelector(selector);
+        let textNode = element.children?.find((child) => child.nodeType() === Node.TEXT_NODE);
+        InspectorTest.assert(textNode, `Should find text node for '${selector}'.`);
+        return textNode;
+    }
+
+    function getFontData(node)
+    {
+        return target.CSSAgent.getFontDataForNode.invoke({nodeId: node.id});
+    }
+
+    function formatCodePoint(codePoint)
+    {
+        return `U+${codePoint.toString(16).toUpperCase().padStart(4, "0")}`;
+    }
+
+    function normalizeCharacterRanges(ranges)
+    {
+        return [...ranges].sort((a, b) => a.start - b.start || a.end - b.end).map(({start, end}) => {
+            let formattedStart = formatCodePoint(start);
+            let formattedEnd = formatCodePoint(end);
+            return start === end ? formattedStart : `${formattedStart}-${formattedEnd}`;
+        });
+    }
+
+    function normalizeRenderedFonts(data)
+    {
+        return (data.renderedFonts || []).map((font) => ({
+            name: font.displayName ?? font.name,
+            synthesizedBold: !!font.synthesizedBold,
+            synthesizedOblique: !!font.synthesizedOblique,
+            ranges: normalizeCharacterRanges(font.characterRanges),
+        })).sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+    }
+
+    function renderedCharacters(data)
+    {
+        let result = new Set;
+        for (let font of data.renderedFonts || []) {
+            for (let {start, end} of font.characterRanges) {
+                for (let character = start; character <= end; ++character)
+                    result.add(character);
+            }
+        }
+        return result;
+    }
+
+    function renderedFontNamed(data, name)
+    {
+        return (data.renderedFonts || []).find((font) => (font.displayName ?? font.name) === name);
+    }
+
+    async function loadFonts()
+    {
+        const eventName = "TestPage-FontsLoaded";
+        await Promise.all([
+            InspectorTest.awaitEvent(eventName),
+            InspectorTest.evaluateInPage(`loadTestFonts("${eventName}")`),
+        ]);
+        await ensureDocumentSubtree();
+    }
+
+    suite.addTestCase({
+        name: "CSS.getFontDataForNode.RenderedText.NoText",
+        description: "Empty rendered-font result arrays should be omitted.",
+        setup: loadFonts,
+        async test() {
+            let data = await getFontData(await nodeForSelector("#empty"));
+            InspectorTest.expectFalse(data.primaryFont.characterRanges, "The computed primary font should omit characterRanges.");
+            InspectorTest.expectFalse(data.primaryFont.variationAxes, "A font without variation axes should omit variationAxes.");
+            InspectorTest.expectFalse(data.renderedFonts, "renderedFonts should be omitted when no text is painted.");
+            InspectorTest.expectFalse(data.missingCharacterRanges, "missingCharacterRanges should be omitted when no characters are missing.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CSS.getFontDataForNode.RenderedText.FallbackRangesAndTextNode",
+        description: "Actual primary and fallback fonts should report coalesced Unicode-scalar ranges for an element or its Text child.",
+        async test() {
+            let element = await nodeForSelector("#segmented");
+            let elementData = await getFontData(element);
+            let textData = await getFontData(await textNodeForSelector("#segmented"));
+
+            InspectorTest.expectFalse(elementData.primaryFont.characterRanges, "The computed primary font should omit rendered character ranges.");
+            InspectorTest.expectTrue(elementData.renderedFonts.every((font) => font.characterRanges.length), "Every rendered font should have nonempty characterRanges.");
+            InspectorTest.expectFalse(elementData.missingCharacterRanges, "missingCharacterRanges should be omitted when every character has a glyph.");
+
+            let ahem = renderedFontNamed(elementData, "Ahem");
+            let boxis = renderedFontNamed(elementData, "Boxis");
+            InspectorTest.expectTrue(!!ahem && JSON.stringify(normalizeCharacterRanges(ahem.characterRanges)) === JSON.stringify(["U+0041-U+0043"]), "Adjacent and repeated Latin scalars should be coalesced and deduplicated.");
+            InspectorTest.expectTrue(!!boxis && JSON.stringify(normalizeCharacterRanges(boxis.characterRanges)) === JSON.stringify(["U+00A5"]), "The actual fallback font should own the yen scalar.");
+
+            InspectorTest.expectEqual(JSON.stringify(normalizeRenderedFonts(textData)), JSON.stringify(normalizeRenderedFonts(elementData)), "A direct Text-node query should match its parent element.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CSS.getFontDataForNode.RenderedText.VisibleDescendantsAndGeneratedText",
+        description: "A subtree paint should include visible descendants, transformed text, and ordinary pseudo content while excluding hidden text.",
+        async test() {
+            let data = await getFontData(await nodeForSelector("#visibility"));
+            let actual = [...renderedCharacters(data)].sort((a, b) => a - b);
+            let expected = [0x41, 0x42, 0x43, 0xA5];
+            InspectorTest.expectEqual(JSON.stringify(actual), JSON.stringify(expected), "Only the displayed A, transformed B, generated C, and generated yen should be reported.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CSS.getFontDataForNode.RenderedText.EquivalentFontMetadata",
+        description: "Concrete fonts with equivalent inspector metadata should share one rendered-font record.",
+        async test() {
+            let data = await getFontData(await nodeForSelector("#equivalent-font-metadata"));
+            let ahemFonts = data.renderedFonts.filter((font) => (font.displayName ?? font.name) === "Ahem");
+            InspectorTest.expectEqual(ahemFonts.length, 1, "Equivalent concrete fonts should produce one rendered-font record.");
+            InspectorTest.expectEqual(JSON.stringify(normalizeCharacterRanges(ahemFonts[0].characterRanges)), JSON.stringify(["U+0041", "U+0043"]), "The shared rendered-font record should contain characters from every concrete font.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CSS.getFontDataForNode.RenderedText.SelectedText",
+        description: "Interactively selected text should remain part of the rendered-font result.",
+        async test() {
+            await InspectorTest.evaluateInPage(`getSelection().selectAllChildren(document.getElementById("segmented"))`);
+            let data;
+            try {
+                data = await getFontData(await nodeForSelector("#segmented"));
+            } finally {
+                await InspectorTest.evaluateInPage(`getSelection().removeAllRanges()`);
+            }
+
+            let actual = [...renderedCharacters(data)].sort((a, b) => a - b);
+            InspectorTest.expectEqual(JSON.stringify(actual), JSON.stringify([0x41, 0x42, 0x43, 0xA5]), "Selected text should report the same characters as unselected text.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CSS.getFontDataForNode.RenderedText.FontSourceURL",
+        description: "Downloadable fonts should expose an absolute final source URL while system fonts omit it.",
+        async test() {
+            let downloadableData = await getFontData(await nodeForSelector("#segmented"));
+            let ahem = renderedFontNamed(downloadableData, "Ahem");
+            let boxis = renderedFontNamed(downloadableData, "Boxis");
+            InspectorTest.expectTrue(URL.canParse(downloadableData.primaryFont.url), "The primary downloadable font should expose an absolute URL.");
+            InspectorTest.expectTrue(downloadableData.primaryFont.url?.endsWith("/resources/Ahem.otf"), "The primary downloadable font should expose its final resource URL.");
+            InspectorTest.expectTrue(URL.canParse(ahem?.url), "The primary rendered font should expose an absolute URL.");
+            InspectorTest.expectTrue(ahem?.url?.endsWith("/resources/Ahem.otf"), "The primary rendered font should expose its final resource URL.");
+            InspectorTest.expectFalse(ahem.variationAxes, "A rendered font without variation axes should omit variationAxes.");
+            InspectorTest.expectTrue(URL.canParse(boxis?.url), "The fallback downloadable font should expose an absolute URL.");
+            InspectorTest.expectTrue(boxis?.url?.endsWith("/animations/font-variations/resources/Boxis-VF.ttf"), "The fallback downloadable font should expose its final resource URL.");
+            InspectorTest.expectTrue(boxis?.variationAxes?.length > 0, "A rendered variable font should expose variationAxes.");
+
+            let systemData = await getFontData(await nodeForSelector("#system-font"));
+            InspectorTest.expectFalse(systemData.primaryFont.url, "A system primary font should omit url.");
+            InspectorTest.expectTrue(systemData.renderedFonts.length > 0, "The system-font fixture should report at least one rendered font.");
+            InspectorTest.expectTrue(systemData.renderedFonts.every((font) => !font.url), "Rendered system fonts should omit url.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CSS.getFontDataForNode.RenderedText.LigatureAndMissingGlyph",
+        description: "The diagnostic-paint MVP should report the scalar starting a ligature glyph, while a missing supplementary scalar should remain one scalar. Shaping backends may also attribute the rest of the ligature's cluster to its font.",
+        async test() {
+            let ligatureData = await getFontData(await nodeForSelector("#ligature"));
+            let ligatureRanges = ligatureData.renderedFonts.flatMap((font) => normalizeCharacterRanges(font.characterRanges));
+            let serializedLigatureRanges = JSON.stringify(ligatureRanges);
+            InspectorTest.expectTrue(serializedLigatureRanges === JSON.stringify(["U+0041"]) || serializedLigatureRanges === JSON.stringify(["U+0041-U+0042"]), "The scalar starting the AB ligature glyph should be attributed to its actual font.");
+
+            let missingData = await getFontData(await nodeForSelector("#missing"));
+            InspectorTest.expectEqual(JSON.stringify(normalizeCharacterRanges(missingData.missingCharacterRanges)), JSON.stringify(["U+10FFFD"]), "A missing supplementary character should be reported as one Unicode scalar.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CSS.getFontDataForNode.RenderedText.UnsupportedContentDoesNotCrash",
+        description: "Representative specialized descendants should not prevent ordinary subtree text from being collected.",
+        async test() {
+            let data = await getFontData(await nodeForSelector("#unsupported"));
+            InspectorTest.expectTrue(!!data, "The command should succeed for a subtree containing unsupported specialized renderers.");
+            InspectorTest.expectTrue(renderedCharacters(data).has(0x44), "Ordinary text alongside unsupported specialized renderers should still be reported.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "CSS.getFontDataForNode.RenderedText.ForcesCurrentLayout",
+        description: "A query should synchronously use ordinary text changed since the last layout.",
+        async test() {
+            await InspectorTest.evaluateInPage(`document.getElementById("dirty").textContent = "BC"; document.getElementById("dirty").style.paddingLeft = "1px"`);
+            let data = await getFontData(await nodeForSelector("#dirty"));
+            let actual = [...renderedCharacters(data)].sort((a, b) => a - b);
+            InspectorTest.expectEqual(JSON.stringify(actual), JSON.stringify([0x42, 0x43]), "The diagnostic paint should use current style and layout.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+<style>
+@font-face {
+    font-family: "InspectorSegmented";
+    src: url("../../resources/Ahem.otf") format("opentype");
+    unicode-range: U+0020-007E;
+}
+
+@font-face {
+    font-family: "InspectorSegmented";
+    src: url("../../animations/font-variations/resources/Boxis-VF.ttf") format("truetype");
+    unicode-range: U+00A5;
+}
+
+@font-face {
+    font-family: "InspectorLigature";
+    src: url("../../fast/text/resources/Ahem-GSUB-ligatures.ttf") format("truetype");
+}
+
+@font-face {
+    font-family: "InspectorMissing";
+    src: url("../../resources/Ahem.otf") format("opentype");
+}
+
+#fixtures {
+    font: 20px/1 "InspectorSegmented";
+}
+
+#hidden {
+    display: none;
+}
+
+#visibility-hidden {
+    visibility: hidden;
+}
+
+#uppercase {
+    text-transform: uppercase;
+}
+
+#pseudo::before {
+    content: "C";
+}
+
+#pseudo::after {
+    content: "\00A5";
+}
+
+#ligature {
+    font-family: "InspectorLigature";
+}
+
+#missing {
+    font-family: "InspectorMissing";
+}
+
+#dirty {
+    margin-bottom: 10px;
+}
+</style>
+</head>
+<body onload="runTest();">
+<p>Test for rendered and missing character data from CSS.getFontDataForNode.</p>
+<div id="fixtures">
+<span id="empty"></span>
+<div id="segmented">ABBAC¥</div>
+<div id="equivalent-font-metadata"><span style="font-size: 10px">A</span><span style="font-size: 30px">C</span></div>
+<div id="visibility"><span>A</span><span id="hidden">H</span><span id="visibility-hidden">V</span><span id="uppercase">b</span><span id="pseudo"></span></div>
+<div id="ligature">AB</div>
+<div id="missing">􏿽</div>
+<div id="system-font" style="font-family: system-ui">A</div>
+<div id="unsupported">D<input value="E"><img alt="F" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="><canvas>G</canvas><svg width="20" height="20"><text x="0" y="15">H</text></svg><math><mi>I</mi></math></div>
+<div id="dirty">A</div>
+</div>
+</body>
+</html>
+

--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -264,14 +264,25 @@
             ]
         },
         {
+            "id": "CharacterRange",
+            "type": "object",
+            "description": "An inclusive range of Unicode scalar values.",
+            "properties": [
+                { "name": "start", "type": "integer", "description": "The first Unicode scalar value in the range." },
+                { "name": "end", "type": "integer", "description": "The last Unicode scalar value in the range." }
+            ]
+        },
+        {
             "id": "Font",
             "type": "object",
             "description": "A representation of WebCore::Font. Conceptually this is backed by either a font file on disk or from the network.",
             "properties": [
                 { "name": "displayName", "type": "string", "description": "The display name defined by the font." },
-                { "name": "variationAxes", "type": "array", "items": { "$ref": "FontVariationAxis" }, "description": "The variation axes defined by the font." },
+                { "name": "url", "type": "string", "optional": true, "description": "The absolute final URL of the resource backing the font." },
+                { "name": "variationAxes", "type": "array", "items": { "$ref": "FontVariationAxis" }, "optional": true, "description": "The variation axes defined by the font." },
                 { "name": "synthesizedBold", "type": "boolean", "optional": true, "description": "Whether the font has synthesized its boldness or not." },
-                { "name": "synthesizedOblique", "type": "boolean", "optional": true, "description": "Whether the font has synthesized its obliqueness or not" }
+                { "name": "synthesizedOblique", "type": "boolean", "optional": true, "description": "Whether the font has synthesized its obliqueness or not." },
+                { "name": "characterRanges", "type": "array", "items": { "$ref": "CharacterRange" }, "optional": true, "description": "The nonempty ranges of Unicode scalar values rendered with this font." }
             ]
         },
         {
@@ -355,13 +366,15 @@
         },
         {
             "name": "getFontDataForNode",
-            "description": "Returns the primary font of the computed font cascade for a DOM node identified by <code>nodeId</code>.",
+            "description": "Returns the primary font of the computed font cascade for a DOM node identified by <code>nodeId</code> and the fonts used to render text in its subtree.",
             "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "DOM.NodeId" }
             ],
             "returns": [
-                { "name": "primaryFont", "$ref": "Font", "description": "Computed primary font for the specified DOM node." }
+                { "name": "primaryFont", "$ref": "Font", "description": "Computed primary font for the specified DOM node." },
+                { "name": "renderedFonts", "type": "array", "items": { "$ref": "Font" }, "optional": true, "description": "Fonts that rendered at least one character in the specified DOM node's subtree." },
+                { "name": "missingCharacterRanges", "type": "array", "items": { "$ref": "CharacterRange" }, "optional": true, "description": "Ranges of Unicode scalar values for which no font supplied a glyph." }
             ]
         },
         {
@@ -491,6 +504,11 @@
         }
     ],
     "events": [
+        {
+            "name": "fontDataChanged",
+            "description": "Fired when font data previously returned by this target may have changed.",
+            "targetTypes": ["frame", "page"]
+        },
         {
             "name": "mediaQueryResultChanged",
             "description": "Fires whenever a MediaQuery result changes (for example, after a browser window has been resized.) The current implementation considers only viewport-dependent media features."

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1993,6 +1993,7 @@ inspector/InspectorCanvasCallTracer.cpp
 inspector/InspectorFrontendAPIDispatcher.cpp
 inspector/InspectorFrontendClientLocal.cpp
 inspector/InspectorFrontendHost.cpp
+inspector/InspectorFontData.cpp @header:RenderStyleGetters
 inspector/InspectorHistory.cpp
 inspector/InspectorIdentifierRegistry.cpp
 inspector/InspectorInstrumentation.cpp @header:RenderStyleGetters

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -6319,6 +6319,7 @@
 		DD05637D29B6B88100A98258 /* InlineDisplayContent.h in Headers */ = {isa = PBXBuildFile; fileRef = DD05637C29B6B88100A98258 /* InlineDisplayContent.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD05FE0D0B8BA3C6009ACDFE /* WebCoreObjCExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = DD05FE0B0B8BA3C6009ACDFE /* WebCoreObjCExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD14265D2F81000000C1D6A8 /* InspectorNativeFunctionParameters.json in Headers */ = {isa = PBXBuildFile; fileRef = DD14265E2F81000000C1D6A8 /* InspectorNativeFunctionParameters.json */; settings = {ATTRIBUTES = (Private, ); }; };
+		DF0A1001314F000000000001 /* InspectorFontData.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0A1003314F000000000001 /* InspectorFontData.h */; };
 		DD17C082286EC57400D60B58 /* build in Copy PDF.js */ = {isa = PBXBuildFile; fileRef = DD17C07C286EC51900D60B58 /* build */; };
 		DD17C083286EC57700D60B58 /* LICENSE in Copy PDF.js */ = {isa = PBXBuildFile; fileRef = DD17C080286EC51B00D60B58 /* LICENSE */; };
 		DD17C084286EC57A00D60B58 /* web in Copy PDF.js */ = {isa = PBXBuildFile; fileRef = DD17C07E286EC51A00D60B58 /* web */; };
@@ -15611,6 +15612,8 @@
 		8225432CA9D4B4CF4628EC7F /* JSBeforeUnloadEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSBeforeUnloadEvent.cpp; sourceTree = "<group>"; };
 		82AB176F125C826700C5069D /* InspectorStyleSheet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorStyleSheet.cpp; sourceTree = "<group>"; };
 		82AB1770125C826700C5069D /* InspectorStyleSheet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InspectorStyleSheet.h; sourceTree = "<group>"; };
+		DF0A1002314F000000000001 /* InspectorFontData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorFontData.cpp; sourceTree = "<group>"; };
+		DF0A1003314F000000000001 /* InspectorFontData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InspectorFontData.h; sourceTree = "<group>"; };
 		82E3D8DC122EA0D1003AE5BC /* CSSPropertySourceData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CSSPropertySourceData.cpp; sourceTree = "<group>"; };
 		82E3D8DD122EA0D1003AE5BC /* CSSPropertySourceData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSSPropertySourceData.h; sourceTree = "<group>"; };
 		830030F31B7D33A600ED3AAC /* GenericCachedHTMLCollection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GenericCachedHTMLCollection.cpp; sourceTree = "<group>"; };
@@ -26466,6 +26469,8 @@
 				95AA570E25EEED31004E9283 /* InspectorCanvasCallTracer.h */,
 				BC08A72D2E888B5E005C4CD1 /* InspectorCanvasProcessedArguments.h */,
 				99D1B2D123AC143000811CF0 /* InspectorDebuggableType.h */,
+				DF0A1002314F000000000001 /* InspectorFontData.cpp */,
+				DF0A1003314F000000000001 /* InspectorFontData.h */,
 				994C6039253A277300BDF060 /* InspectorFrontendAPIDispatcher.cpp */,
 				994C6037253A277200BDF060 /* InspectorFrontendAPIDispatcher.h */,
 				F344C7121125B82C00F26EEE /* InspectorFrontendClient.h */,
@@ -46499,6 +46504,7 @@
 				A5B81CAB1FAA44620037D1E6 /* InspectorDOMAgent.h in Headers */,
 				A5B81CAC1FAA44620037D1E6 /* InspectorDOMDebuggerAgent.h in Headers */,
 				A5B81CAD1FAA44620037D1E6 /* InspectorDOMStorageAgent.h in Headers */,
+				DF0A1001314F000000000001 /* InspectorFontData.h in Headers */,
 				994C603A253A277300BDF060 /* InspectorFrontendAPIDispatcher.h in Headers */,
 				F344C7141125B82C00F26EEE /* InspectorFrontendClient.h in Headers */,
 				F344C75311294D9D00F26EEE /* InspectorFrontendClientLocal.h in Headers */,

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3442,6 +3442,7 @@ void Document::fontsNeedUpdate(FontSelector&)
 {
     ASSERT(!deletionHasBegun());
     invalidateMatchedPropertiesCacheAndForceStyleRecalc();
+    InspectorInstrumentation::fontDataChanged(*this);
 }
 
 void Document::invalidateMatchedPropertiesCacheAndForceStyleRecalc()

--- a/Source/WebCore/inspector/InspectorFontData.cpp
+++ b/Source/WebCore/inspector/InspectorFontData.cpp
@@ -1,0 +1,475 @@
+/*
+ * Copyright (C) 2026 Devin Rousso <webkit@devinrousso.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "InspectorFontData.h"
+
+#include "BidiResolver.h"
+#include "Document.h"
+#include "DocumentView.h"
+#include "Font.h"
+#include "FontCascade.h"
+#include "FontCascadeInlines.h"
+#include "FontCustomPlatformData.h"
+#include "FontPlatformData.h"
+#include "GlyphBuffer.h"
+#include "GraphicsContext.h"
+#include "LayoutRect.h"
+#include "LocalFrameView.h"
+#include "LocalFrameViewLayoutContext.h"
+#include "NodeInlines.h"
+#include "RenderObject.h"
+#include "StyleComputedStyleBase+GettersInlines.h"
+#include "TextRun.h"
+#include "TextRunIterator.h"
+#include <algorithm>
+#include <unicode/utf16.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/RefPtr.h>
+#include <wtf/Scope.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/unicode/CharacterNames.h>
+
+namespace WebCore {
+
+struct InspectorFontMetadata {
+    String displayName;
+    String url;
+    bool synthesizedBold { false };
+    bool synthesizedOblique { false };
+    Vector<FontPlatformData::FontVariationAxis> variationAxes;
+
+    friend bool operator==(const InspectorFontMetadata&, const InspectorFontMetadata&) = default;
+};
+
+using CharacterSet = HashSet<char32_t, DefaultHash<char32_t>, WTF::UnsignedWithZeroKeyHashTraits<char32_t>>;
+
+class RenderedFont final : public RefCounted<RenderedFont> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(RenderedFont);
+public:
+    static Ref<RenderedFont> create(InspectorFontMetadata&& metadata)
+    {
+        return adoptRef(*new RenderedFont(WTF::move(metadata)));
+    }
+
+    const InspectorFontMetadata& metadata() const { return m_metadata; }
+
+    const CharacterSet& characters() const { return m_characters; }
+    void addCharacter(char32_t character) { m_characters.add(character); }
+
+private:
+    explicit RenderedFont(InspectorFontMetadata&& metadata)
+        : m_metadata(WTF::move(metadata))
+    {
+    }
+
+    const InspectorFontMetadata m_metadata;
+    CharacterSet m_characters;
+};
+
+using RenderedFonts = HashMap<Ref<const Font>, Ref<RenderedFont>>;
+
+static InspectorFontMetadata metadataForFont(const Font& font)
+{
+    const auto& platformData = font.platformData();
+    InspectorFontMetadata metadata {
+        platformData.familyName(),
+        { },
+        platformData.syntheticBold(),
+        platformData.syntheticOblique(),
+        platformData.variationAxes(ShouldLocalizeAxisNames::Yes),
+    };
+
+    if (RefPtr customPlatformData = platformData.customPlatformData())
+        metadata.url = customPlatformData->sourceURL();
+
+    return metadata;
+}
+
+static Ref<Inspector::Protocol::CSS::Font> buildObjectForFont(const InspectorFontMetadata& metadata)
+{
+    auto result = Inspector::Protocol::CSS::Font::create()
+        .setDisplayName(metadata.displayName)
+        .release();
+
+    if (!metadata.url.isEmpty())
+        result->setUrl(metadata.url);
+
+    auto variationAxes = JSON::ArrayOf<Inspector::Protocol::CSS::FontVariationAxis>::create();
+    for (const auto& variationAxis : metadata.variationAxes) {
+        auto axis = Inspector::Protocol::CSS::FontVariationAxis::create()
+            .setTag(variationAxis.tag())
+            .setMinimumValue(variationAxis.minimumValue())
+            .setMaximumValue(variationAxis.maximumValue())
+            .setDefaultValue(variationAxis.defaultValue())
+            .release();
+
+        if (!variationAxis.name().isEmpty() && variationAxis.name() != variationAxis.tag())
+            axis->setName(variationAxis.name());
+
+        variationAxes->addItem(WTF::move(axis));
+    }
+    if (variationAxes->length())
+        result->setVariationAxes(WTF::move(variationAxes));
+
+    if (metadata.synthesizedBold)
+        result->setSynthesizedBold(metadata.synthesizedBold);
+
+    if (metadata.synthesizedOblique)
+        result->setSynthesizedOblique(metadata.synthesizedOblique);
+
+    return result;
+}
+
+static Ref<Inspector::Protocol::CSS::Font> buildObjectForFont(const Font& font)
+{
+    return buildObjectForFont(metadataForFont(font));
+}
+
+static RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::CharacterRange>> buildCharacterRanges(const CharacterSet& characters)
+{
+    Vector<char32_t> sortedCharacters;
+    sortedCharacters.reserveInitialCapacity(characters.size());
+    for (auto character : characters)
+        sortedCharacters.append(character);
+    std::sort(sortedCharacters.begin(), sortedCharacters.end());
+    if (sortedCharacters.isEmpty())
+        return nullptr;
+
+    auto result = JSON::ArrayOf<Inspector::Protocol::CSS::CharacterRange>::create();
+
+    char32_t rangeStart = sortedCharacters[0];
+    char32_t rangeEnd = rangeStart;
+    for (auto character : sortedCharacters.subspan(1)) {
+        if (character == rangeEnd + 1) {
+            rangeEnd = character;
+            continue;
+        }
+
+        result->addItem(Inspector::Protocol::CSS::CharacterRange::create()
+            .setStart(rangeStart)
+            .setEnd(rangeEnd)
+            .release());
+        rangeStart = rangeEnd = character;
+    }
+
+    result->addItem(Inspector::Protocol::CSS::CharacterRange::create()
+        .setStart(rangeStart)
+        .setEnd(rangeEnd)
+        .release());
+
+    return result;
+}
+
+static RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::Font>> buildRenderedFonts(const Vector<Ref<RenderedFont>>& renderedFonts)
+{
+    if (renderedFonts.isEmpty())
+        return nullptr;
+
+    auto result = JSON::ArrayOf<Inspector::Protocol::CSS::Font>::create();
+    for (const auto& renderedFont : renderedFonts) {
+        auto protocolFont = buildObjectForFont(renderedFont->metadata());
+
+        if (auto characterRanges = buildCharacterRanges(renderedFont->characters()))
+            protocolFont->setCharacterRanges(characterRanges.releaseNonNull());
+
+        result->addItem(WTF::move(protocolFont));
+    }
+    return result;
+}
+
+class InspectorFontUsageRecorder final : public GraphicsContext {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(InspectorFontUsageRecorder);
+public:
+    const RenderedFonts& renderedFonts() const { return m_renderedFonts; }
+    const CharacterSet& missingCharacters() const { return m_missingCharacters; }
+
+private:
+    Ref<RenderedFont> ensureRenderedFont(const Font& font)
+    {
+        if (auto iterator = m_renderedFonts.find(&font); iterator != m_renderedFonts.end())
+            return iterator->value.copyRef();
+
+        auto metadata = metadataForFont(font);
+
+        RefPtr<RenderedFont> renderedFont;
+        for (const auto& candidate : m_renderedFonts.values()) {
+            if (candidate->metadata() == metadata) {
+                renderedFont = candidate.copyRef();
+                break;
+            }
+        }
+        if (!renderedFont)
+            renderedFont = RenderedFont::create(WTF::move(metadata));
+
+        return m_renderedFonts.add(font, renderedFont.releaseNonNull()).iterator->value.copyRef();
+    }
+
+    FloatSize recordFontUsage(const FontCascade& font, const TextRun& run, const FloatPoint& point, unsigned from, std::optional<unsigned> to, FontCascade::CustomFontNotReadyAction customFontNotReadyAction)
+    {
+        unsigned destination = to.value_or(run.length());
+        auto glyphBuffer = font.layoutText(font.codePath(run, from, to), run, from, destination).glyphBuffer;
+        glyphBuffer.flatten();
+
+        recordFontUsage(run, glyphBuffer, from, destination, customFontNotReadyAction);
+
+        if (glyphBuffer.isEmpty())
+            return { };
+
+        FloatPoint startPoint = point + WebCore::size(glyphBuffer.initialAdvance());
+        font.drawGlyphBuffer(*this, glyphBuffer, startPoint, customFontNotReadyAction);
+        return startPoint - point;
+    }
+
+    void recordFontUsage(const TextRun& run, const GlyphBuffer& glyphBuffer, unsigned from, unsigned to, FontCascade::CustomFontNotReadyAction customFontNotReadyAction)
+    {
+        if (from >= to)
+            return;
+
+        Vector<unsigned> glyphIndexes;
+        glyphIndexes.reserveInitialCapacity(glyphBuffer.size());
+        for (unsigned i = 0; i < glyphBuffer.size(); ++i) {
+            if (auto offset = glyphBuffer.checkedStringOffsetAt(i, run.length()); offset && unsignedCast(*offset) < to)
+                glyphIndexes.append(i);
+        }
+        std::sort(glyphIndexes.begin(), glyphIndexes.end(), [&](unsigned a, unsigned b) {
+            return glyphBuffer.uncheckedStringOffsetAt(a) < glyphBuffer.uncheckedStringOffsetAt(b);
+        });
+
+        for (unsigned clusterIndex = 0; clusterIndex < glyphIndexes.size();) {
+            unsigned clusterOffset = glyphBuffer.uncheckedStringOffsetAt(glyphIndexes[clusterIndex]);
+
+            unsigned nextClusterIndex = clusterIndex + 1;
+            while (nextClusterIndex < glyphIndexes.size()) {
+                unsigned nextClusterOffset = glyphBuffer.uncheckedStringOffsetAt(glyphIndexes[nextClusterIndex]);
+                if (nextClusterOffset != clusterOffset)
+                    break;
+
+                ++nextClusterIndex;
+            }
+
+            unsigned clusterStart = std::max(clusterOffset, from);
+            unsigned clusterEnd = nextClusterIndex < glyphIndexes.size() ? std::min<unsigned>(glyphBuffer.uncheckedStringOffsetAt(glyphIndexes[nextClusterIndex]), to) : to;
+            if (clusterStart >= clusterEnd) {
+                clusterIndex = nextClusterIndex;
+                continue;
+            }
+
+            Vector<Ref<const Font>, 1> renderedFonts;
+            bool isMissing = false;
+            for (unsigned i = clusterIndex; i < nextClusterIndex; ++i) {
+                unsigned glyphIndex = glyphIndexes[i];
+
+                Ref font = glyphBuffer.fontAt(glyphIndex);
+                if (font->isInterstitial() && font->visibility() != Font::Visibility::Visible && customFontNotReadyAction != FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady)
+                    continue;
+
+                auto glyph = glyphBuffer.glyphAt(glyphIndex);
+                if (!glyph)
+                    isMissing = true;
+                else if (glyph != deletedGlyph && !renderedFonts.contains(font))
+                    renderedFonts.append(WTF::move(font));
+            }
+
+            auto collectCharacter = [&](char32_t character) {
+                if (U_IS_SURROGATE(character))
+                    character = replacementCharacter;
+
+                for (const auto& font : renderedFonts)
+                    ensureRenderedFont(font)->addCharacter(character);
+
+                if (isMissing)
+                    m_missingCharacters.add(character);
+            };
+
+            if (run.is8Bit()) {
+                for (unsigned offset = clusterStart; offset < clusterEnd; ++offset)
+                    collectCharacter(run.span8()[offset]);
+            } else {
+                auto characters = run.span16();
+                for (size_t offset = clusterStart; offset < clusterEnd;) {
+                    char32_t character;
+                    U16_NEXT(characters, offset, clusterEnd, character);
+                    collectCharacter(character);
+                }
+            }
+
+            clusterIndex = nextClusterIndex;
+        }
+    }
+
+#if USE(CG)
+    bool isCALayerContext() const final { return false; }
+#endif
+
+    bool paintingDisabled() const final { return true; }
+
+    void didUpdateState(GraphicsContextState&) final { }
+
+    void drawNativeImage(const NativeImage&, const FloatRect&, const FloatRect&, ImagePaintingOptions) final { }
+
+    void drawSystemImage(SystemImage&, const FloatRect&) final { }
+
+    void drawPattern(const NativeImage&, const FloatRect&, const FloatRect&, const AffineTransform&, const FloatPoint&, const FloatSize&, ImagePaintingOptions) final { }
+
+    IntRect clipBounds() const final { return { }; }
+
+#if USE(CG)
+    void applyStrokePattern() final { }
+    void applyFillPattern() final { }
+    void drawPath(const Path&) final { }
+#endif
+
+    void drawRect(const FloatRect&, float = 1) final { }
+    void drawLine(const FloatPoint&, const FloatPoint&) final { }
+    void drawEllipse(const FloatRect&) final { }
+    void fillPath(const Path&) final { }
+    void strokePath(const Path&) final { }
+    void fillRect(const FloatRect&, RequiresClipToRect) final { }
+    void fillRect(const FloatRect&, Gradient&, const AffineTransform&, RequiresClipToRect) final { }
+    void fillRect(const FloatRect&, const Color&) final { }
+    void fillRoundedRectImpl(const FloatRoundedRect&, const Color&) final { }
+    void strokeRect(const FloatRect&, float) final { }
+    void clipPath(const Path&, WindRule = WindRule::EvenOdd) final { }
+    void drawLinesForText(const FloatPoint&, float, std::span<const FloatSegment>, bool, bool, StrokeStyle) final { }
+    void setLineCap(LineCap) final { }
+    void setLineDash(const DashArray&, float) final { }
+    void setLineJoin(LineJoin) final { }
+    void setMiterLimit(float) final { }
+    void clipOut(const Path&) final { }
+    void scale(const FloatSize&) final { }
+    void rotate(float) final { }
+    void translate(float, float) final { }
+    void concatCTM(const AffineTransform&) final { }
+    void setCTM(const AffineTransform&) final { }
+    AffineTransform getCTM(IncludeDeviceScale = PossiblyIncludeDeviceScale) const final { return { }; }
+    void clearRect(const FloatRect&) final { }
+    void resetClip() final { }
+    void clip(const FloatRect&) final { }
+    void clipOut(const FloatRect&) final { }
+    void save(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final { }
+    void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore) final { }
+
+    void drawRaisedEllipse(const FloatRect&, const Color&, const Color&) final { }
+
+    FloatSize drawText(const FontCascade& font, const TextRun& run, const FloatPoint& point, unsigned from = 0, std::optional<unsigned> to = std::nullopt) final
+    {
+        return recordFontUsage(font, run, point, from, to, FontCascade::CustomFontNotReadyAction::DoNotPaintIfFontNotReady);
+    }
+
+    void drawGlyphs(const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint&, FontSmoothingMode) final { }
+    void drawDisplayList(const DisplayList::DisplayList&, ControlFactory&) final { }
+
+    void drawEmphasisMarks(const FontCascade&, const TextRun&, const AtomString&, const FloatPoint&, unsigned = 0, std::optional<unsigned> = std::nullopt) final { }
+    void drawBidiText(const FontCascade& font, const TextRun& run, const FloatPoint& point, FontCascade::CustomFontNotReadyAction customFontNotReadyAction = FontCascade::CustomFontNotReadyAction::DoNotPaintIfFontNotReady) final
+    {
+        BidiResolver<TextRunIterator, SimpleBidiCharacterRun> bidiResolver;
+        bidiResolver.setStatus(BidiStatus(run.direction(), run.directionalOverride()));
+        bidiResolver.setPositionIgnoringNestedIsolates(TextRunIterator(&run, 0));
+        bidiResolver.createBidiRunsForLine(TextRunIterator(&run, run.length()));
+
+        FloatPoint currentPoint = point;
+        for (const auto* bidiRun = bidiResolver.runs().firstRun(); bidiRun; bidiRun = bidiRun->next()) {
+            TextRun subrun = run.subRun(bidiRun->start(), bidiRun->stop() - bidiRun->start());
+            subrun.setDirection(bidiRun->level() % 2 ? TextDirection::RTL : TextDirection::LTR);
+            subrun.setDirectionalOverride(bidiRun->dirOverride(false));
+            currentPoint.move(recordFontUsage(font, subrun, currentPoint, 0, std::nullopt, customFontNotReadyAction));
+        }
+    }
+
+    void drawDotsForDocumentMarker(const FloatRect&, DocumentMarkerLineStyle) final { }
+
+    ImageDrawResult drawImage(Image&, const FloatRect&, const FloatRect&, ImagePaintingOptions = { ImageOrientation::Orientation::FromImage }) final { return ImageDrawResult::DidNothing; }
+
+    ImageDrawResult drawTiledImage(Image&, const FloatRect&, const FloatPoint&, const FloatSize&, const FloatSize&, ImagePaintingOptions = { }) final { return ImageDrawResult::DidNothing; }
+    ImageDrawResult drawTiledImage(Image&, const FloatRect&, const FloatRect&, const FloatSize&, Image::TileRule, Image::TileRule, ImagePaintingOptions = { }) final { return ImageDrawResult::DidNothing; }
+
+    void drawFocusRing(const Path&, float, const Color&, float) final { }
+    void drawFocusRing(const Vector<FloatRect>&, float, const Color&, float) final { }
+
+    void drawImageBuffer(ImageBuffer&, const FloatRect&, const FloatRect&, ImagePaintingOptions = { }) final { }
+
+    void clipRoundedRect(const FloatRoundedRect&) final { }
+    void clipOutRoundedRect(const FloatRoundedRect&) final { }
+    void clipToImageBuffer(ImageBuffer&, const FloatRect&) final { }
+
+    void fillRect(const FloatRect&, Gradient&) final { }
+    void fillRect(const FloatRect&, const Color&, CompositeOperator, BlendMode = BlendMode::Normal) final { }
+
+    void fillRoundedRect(const FloatRoundedRect&, const Color&, BlendMode = BlendMode::Normal) final { }
+    void fillRectWithRoundedHole(const FloatRect&, const FloatRoundedRect&, const Color&) final { }
+
+#if ENABLE(VIDEO)
+    void drawVideoFrame(const VideoFrame&, const FloatRect&, ImageOrientation, bool) final { }
+#endif
+
+    RenderedFonts m_renderedFonts;
+    CharacterSet m_missingCharacters;
+};
+
+std::optional<FontData> getFontData(Node& node)
+{
+    Ref document = node.document();
+    RefPtr view = document->view();
+    if (!view || !view->renderView() || view->isPainting() || view->layoutContext().isInLayout() || document->inStyleRecalc() || document->isResolvingTreeStyle())
+        return std::nullopt;
+
+    view->updateLayoutAndStyleIfNeededRecursive({ LayoutOptions::IgnorePendingStylesheets });
+    if (document->view() != view.get() || !view->renderView() || view->isPainting() || view->layoutContext().isInLayout() || document->inStyleRecalc() || document->isResolvingTreeStyle())
+        return std::nullopt;
+
+    InspectorFontUsageRecorder recorder;
+
+    if (CheckedPtr renderer = node.renderer()) {
+        LayoutRect elementRect;
+        auto paintingRect = snappedIntRect(renderer->subtreePaintRootRect(elementRect, RenderObject::RespectTransforms::Yes));
+
+        auto oldPaintBehavior = view->paintBehavior();
+        auto restorePaintBehavior = makeScopeExit([&] {
+            view->setPaintBehavior(oldPaintBehavior);
+        });
+        view->setPaintBehavior(oldPaintBehavior | PaintBehavior::ExcludeReplacedContentExceptForIFrames);
+        view->paintContentsForSnapshot(recorder, paintingRect, &node, LocalFrameView::ExcludeSelection, LocalFrameView::DocumentCoordinates);
+    }
+
+    CheckedPtr computedStyle = node.computedStyle();
+    if (!computedStyle)
+        return std::nullopt;
+
+    Vector<Ref<RenderedFont>> renderedFonts;
+    for (const auto& renderedFont : recorder.renderedFonts().values())
+        renderedFonts.appendIfNotContains(renderedFont);
+
+    return { {
+        buildObjectForFont(protect(protect(computedStyle->fontCascade())->primaryFont())),
+        buildRenderedFonts(renderedFonts),
+        buildCharacterRanges(recorder.missingCharacters()),
+    } };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/InspectorFontData.h
+++ b/Source/WebCore/inspector/InspectorFontData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Devin Rousso <webkit@devinrousso.com>. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,31 +23,21 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-.sidebar > .panel.details.style-font > .content .details-section > .content > .group > .row.simple > .label {
-    min-width: 105px; /* Width of `Historical Figures` or `Optical Size (opsz)` in English. */
-}
+#pragma once
 
-.sidebar > .panel.details.style-font > .content .details-section > .content > .group > .row.simple > .value .secondary {
-    color: var(--text-color-secondary);
-    word-break: normal;
-}
+#include <JavaScriptCore/InspectorProtocolObjects.h>
+#include <optional>
 
-.sidebar > .panel.details.style-font > .content .details-section > .content > .group > .row.simple > .value > .characters {
-    direction: ltr;
-    unicode-bidi: isolate;
-}
+namespace WebCore {
 
-.sidebar > .panel.details.style-font > .content .details-section > .content > .group > .row.simple > .value > .characters > span {
-    unicode-bidi: isolate;
-}
+class Node;
 
-.sidebar > .panel.details.style-font > .content .details-section > .content > .group > .row.simple > .value > .characters > .code-point {
-    display: inline-block;
-    margin-inline: 2px;
-    padding: 0 3px;
-    font-family: Menlo, monospace;
-    color: var(--text-color-secondary);
-    background-color: var(--background-color-alternate);
-    border: 1px solid var(--border-color-secondary);
-    border-radius: 3px;
-}
+struct FontData {
+    Ref<Inspector::Protocol::CSS::Font> primaryFont;
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::Font>> renderedFonts;
+    RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::CharacterRange>> missingCharacterRanges;
+};
+
+std::optional<FontData> getFontData(Node&);
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -305,6 +305,17 @@ void InspectorInstrumentation::frameWindowDiscardedImpl(InstrumentingAgents& ins
         consoleAgent->frameWindowDiscarded(*window);
 }
 
+void InspectorInstrumentation::fontDataChangedImpl(InstrumentingAgents& instrumentingAgents, Document& document)
+{
+    if (CheckedPtr cssAgent = instrumentingAgents.enabledCSSAgent())
+        cssAgent->fontDataChanged();
+
+    if (RefPtr frame = document.frame()) {
+        if (CheckedPtr frameCSSAgent = frame->inspectorController().instrumentingAgents().enabledFrameCSSAgent())
+            frameCSSAgent->fontDataChanged();
+    }
+}
+
 void InspectorInstrumentation::mediaQueryResultChangedImpl(InstrumentingAgents& instrumentingAgents, Document& document)
 {
     if (CheckedPtr cssAgent = instrumentingAgents.enabledCSSAgent())

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -150,6 +150,7 @@ public:
     static void didInvalidateStyleAttr(Element&);
     static void documentDetached(Document&);
     static void frameWindowDiscarded(LocalFrame&, LocalDOMWindow*);
+    static void fontDataChanged(Document&);
     static void mediaQueryResultChanged(Document&);
     static void activeStyleSheetsUpdated(Document&);
     static void didPushShadowRoot(Element& host, ShadowRoot&);
@@ -396,6 +397,7 @@ private:
     static void didInvalidateStyleAttrImpl(InstrumentingAgents&, Element&);
     static void documentDetachedImpl(InstrumentingAgents&, Document&);
     static void frameWindowDiscardedImpl(InstrumentingAgents&, LocalDOMWindow*);
+    static void fontDataChangedImpl(InstrumentingAgents&, Document&);
     static void mediaQueryResultChangedImpl(InstrumentingAgents&, Document&);
     static void activeStyleSheetsUpdatedImpl(InstrumentingAgents&, Document&);
     static void didPushShadowRootImpl(InstrumentingAgents&, Element& host, ShadowRoot&);
@@ -719,6 +721,13 @@ inline void InspectorInstrumentation::documentDetached(Document& document)
 inline void InspectorInstrumentation::frameWindowDiscarded(LocalFrame& frame, LocalDOMWindow* domWindow)
 {
     frameWindowDiscardedImpl(protect(instrumentingAgents(frame)), domWindow);
+}
+
+inline void InspectorInstrumentation::fontDataChanged(Document& document)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (RefPtr agents = instrumentingAgents(document))
+        fontDataChangedImpl(*agents, document);
 }
 
 inline void InspectorInstrumentation::mediaQueryResultChanged(Document& document)

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -46,15 +46,13 @@
 #include "ElementChildIteratorInlines.h"
 #include "ElementRareData.h"
 #include "EventTarget.h"
-#include "Font.h"
 #include "FontCache.h"
-#include "FontCascadeInlines.h"
-#include "FontPlatformData.h"
 #include "HTMLHeadElement.h"
 #include "HTMLHtmlElement.h"
 #include "HTMLSlotElement.h"
 #include "HTMLStyleElement.h"
 #include "InspectorDOMAgent.h"
+#include "InspectorFontData.h"
 #include "InspectorHistory.h"
 #include "InspectorIdentifierRegistry.h"
 #include "InspectorPageAgent.h"
@@ -161,6 +159,11 @@ void InspectorCSSAgent::documentDetached(Document& document)
     m_documentToKnownCSSStyleSheets.remove(&document);
     m_documentToInspectorStyleSheet.remove(document);
     m_documentsWithForcedPseudoStates.remove(&document);
+}
+
+void InspectorCSSAgent::fontDataChanged()
+{
+    m_frontendDispatcher->fontDataChanged();
 }
 
 void InspectorCSSAgent::mediaQueryResultChanged()
@@ -398,48 +401,18 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::C
     return inspectorStyle->buildArrayForComputedStyle();
 }
 
-static Ref<Inspector::Protocol::CSS::Font> buildObjectForFont(const Font& font)
-{
-    auto& fontPlatformData = font.platformData();
-    
-    auto resultVariationAxes = JSON::ArrayOf<Inspector::Protocol::CSS::FontVariationAxis>::create();
-    for (auto& variationAxis : fontPlatformData.variationAxes(ShouldLocalizeAxisNames::Yes)) {
-        auto axis = Inspector::Protocol::CSS::FontVariationAxis::create()
-            .setTag(variationAxis.tag())
-            .setMinimumValue(variationAxis.minimumValue())
-            .setMaximumValue(variationAxis.maximumValue())
-            .setDefaultValue(variationAxis.defaultValue())
-            .release();
-        
-        if (variationAxis.name().length() && variationAxis.name() != variationAxis.tag())
-            axis->setName(variationAxis.name());
-        
-        resultVariationAxes->addItem(WTF::move(axis));
-    }
-
-    auto protocolFont = Inspector::Protocol::CSS::Font::create()
-        .setDisplayName(font.platformData().familyName())
-        .setVariationAxes(WTF::move(resultVariationAxes))
-        .release();
-
-    protocolFont->setSynthesizedBold(fontPlatformData.syntheticBold());
-    protocolFont->setSynthesizedOblique(fontPlatformData.syntheticOblique());
-
-    return protocolFont;
-}
-
-Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::Font>> InspectorCSSAgent::getFontDataForNode(Inspector::Protocol::DOM::NodeId nodeId)
+Inspector::Protocol::ErrorStringOr<std::tuple<Ref<Inspector::Protocol::CSS::Font>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::Font>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::CharacterRange>>>> InspectorCSSAgent::getFontDataForNode(Inspector::Protocol::DOM::NodeId nodeId)
 {
     Inspector::Protocol::ErrorString errorString;
     RefPtr node = nodeForId(errorString, nodeId);
     if (!node)
         return makeUnexpected(errorString);
-    
-    CheckedPtr computedStyle = node->computedStyle();
-    if (!computedStyle)
-        return makeUnexpected("No computed style for node."_s);
-    
-    return buildObjectForFont(protect(computedStyle->fontCascade().primaryFont()));
+
+    auto result = getFontData(*node);
+    if (!result)
+        return makeUnexpected("Rendered font data is temporarily unavailable."_s);
+
+    return { { WTF::move(result->primaryFont), WTF::move(result->renderedFonts), WTF::move(result->missingCharacterRanges) } };
 }
 
 Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSStyleSheetHeader>>> InspectorCSSAgent::getAllStyleSheets()

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -101,7 +101,7 @@ public:
     Inspector::Protocol::ErrorStringOr<void> enable();
     Inspector::Protocol::ErrorStringOr<void> disable();
     Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSComputedStyleProperty>>> getComputedStyleForNode(Inspector::Protocol::DOM::NodeId);
-    Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::Font>> getFontDataForNode(Inspector::Protocol::DOM::NodeId);
+    Inspector::Protocol::ErrorStringOr<std::tuple<Ref<Inspector::Protocol::CSS::Font>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::Font>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::CharacterRange>>>> getFontDataForNode(Inspector::Protocol::DOM::NodeId);
     Inspector::Protocol::ErrorStringOr<std::tuple<RefPtr<Inspector::Protocol::CSS::CSSStyle> /* inlineStyle */, RefPtr<Inspector::Protocol::CSS::CSSStyle> /* attributesStyle */>> getInlineStylesForNode(Inspector::Protocol::DOM::NodeId);
     Inspector::Protocol::ErrorStringOr<std::tuple<RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::PseudoIdMatches>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::InheritedStyleEntry>>>> getMatchedStylesForNode(Inspector::Protocol::DOM::NodeId, std::optional<bool>&& includePseudo, std::optional<bool>&& includeInherited);
     Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSStyleSheetHeader>>> getAllStyleSheets();
@@ -123,6 +123,7 @@ public:
 
     // InspectorInstrumentation
     void documentDetached(Document&);
+    void fontDataChanged();
     void mediaQueryResultChanged();
     void activeStyleSheetsUpdated(Document&);
     bool forcePseudoState(const Element&, CSSSelector::PseudoClass);

--- a/Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp
@@ -43,18 +43,17 @@
 #include "DocumentPage.h"
 #include "ElementAncestorIteratorInlines.h"
 #include "ExtensionStyleSheets.h"
-#include "Font.h"
-#include "FontCascadeInlines.h"
-#include "FontPlatformData.h"
 #include "FrameDOMAgent.h"
 #include "HTMLHeadElement.h"
 #include "HTMLStyleElement.h"
 #include "InspectorDOMAgent.h"
+#include "InspectorFontData.h"
 #include "InspectorHistory.h"
 #include "InspectorIdentifierRegistry.h"
 #include "InstrumentingAgents.h"
 #include "LocalFrame.h"
 #include "LocalFrameInlines.h"
+#include "Node.h"
 #include "Page.h"
 #include "PageInspectorController.h"
 #include "PseudoElement.h"
@@ -198,41 +197,20 @@ Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSComputed
     return inspectorStyle->buildArrayForComputedStyle();
 }
 
-Inspector::CommandResult<Ref<Inspector::Protocol::CSS::Font>> FrameCSSAgent::getFontDataForNode(Inspector::Protocol::DOM::NodeId nodeId)
+Inspector::CommandResultOf<Ref<Inspector::Protocol::CSS::Font>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::Font>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::CharacterRange>>> FrameCSSAgent::getFontDataForNode(Inspector::Protocol::DOM::NodeId nodeId)
 {
-    Inspector::Protocol::ErrorString errorString;
-    RefPtr element = elementForId(errorString, nodeId);
-    if (!element)
-        return makeUnexpected(errorString);
+    CheckedPtr domAgent = Ref { m_instrumentingAgents.get() }->persistentFrameDOMAgent();
+    if (!domAgent)
+        return makeUnexpected("DOM domain must be enabled"_s);
+    RefPtr node = domAgent->nodeForId(nodeId);
+    if (!node)
+        return makeUnexpected("Missing node for given nodeId"_s);
 
-    CheckedPtr computedStyle = element->computedStyle();
-    if (!computedStyle)
-        return makeUnexpected("No computed style for node."_s);
+    auto result = getFontData(*node);
+    if (!result)
+        return makeUnexpected("Rendered font data is temporarily unavailable."_s);
 
-    Ref font = protect(computedStyle->fontCascade())->primaryFont();
-    auto& fontPlatformData = font->platformData();
-
-    auto resultVariationAxes = JSON::ArrayOf<Inspector::Protocol::CSS::FontVariationAxis>::create();
-    for (auto& variationAxis : fontPlatformData.variationAxes(ShouldLocalizeAxisNames::Yes)) {
-        auto axis = Inspector::Protocol::CSS::FontVariationAxis::create()
-            .setTag(variationAxis.tag())
-            .setMinimumValue(variationAxis.minimumValue())
-            .setMaximumValue(variationAxis.maximumValue())
-            .setDefaultValue(variationAxis.defaultValue())
-            .release();
-        if (variationAxis.name().length() && variationAxis.name() != variationAxis.tag())
-            axis->setName(variationAxis.name());
-        resultVariationAxes->addItem(WTF::move(axis));
-    }
-
-    auto protocolFont = Inspector::Protocol::CSS::Font::create()
-        .setDisplayName(fontPlatformData.familyName())
-        .setVariationAxes(WTF::move(resultVariationAxes))
-        .release();
-    protocolFont->setSynthesizedBold(fontPlatformData.syntheticBold());
-    protocolFont->setSynthesizedOblique(fontPlatformData.syntheticOblique());
-
-    return protocolFont;
+    return { { WTF::move(result->primaryFont), WTF::move(result->renderedFonts), WTF::move(result->missingCharacterRanges) } };
 }
 
 Inspector::CommandResultOf<RefPtr<Inspector::Protocol::CSS::CSSStyle>, RefPtr<Inspector::Protocol::CSS::CSSStyle>> FrameCSSAgent::getInlineStylesForNode(Inspector::Protocol::DOM::NodeId nodeId)
@@ -680,6 +658,14 @@ void FrameCSSAgent::documentDetached(Document& document)
     Vector<CSSStyleSheet*> emptyList;
     setActiveStyleSheetsForDocument(document, emptyList);
     m_documentToKnownCSSStyleSheets.remove(&document);
+}
+
+void FrameCSSAgent::fontDataChanged()
+{
+    if (documentIsReportedByPageCSSAgent())
+        return;
+
+    m_frontendDispatcher->fontDataChanged();
 }
 
 void FrameCSSAgent::mediaQueryResultChanged()

--- a/Source/WebCore/inspector/agents/frame/FrameCSSAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameCSSAgent.h
@@ -71,7 +71,7 @@ public:
     Inspector::CommandResult<void> enable() override;
     Inspector::CommandResult<void> disable() override;
     Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSComputedStyleProperty>>> getComputedStyleForNode(Inspector::Protocol::DOM::NodeId) override;
-    Inspector::CommandResult<Ref<Inspector::Protocol::CSS::Font>> getFontDataForNode(Inspector::Protocol::DOM::NodeId) override;
+    Inspector::CommandResultOf<Ref<Inspector::Protocol::CSS::Font>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::Font>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::CharacterRange>>> getFontDataForNode(Inspector::Protocol::DOM::NodeId) override;
     Inspector::CommandResultOf<RefPtr<Inspector::Protocol::CSS::CSSStyle>, RefPtr<Inspector::Protocol::CSS::CSSStyle>> getInlineStylesForNode(Inspector::Protocol::DOM::NodeId) override;
     Inspector::CommandResultOf<RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::RuleMatch>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::PseudoIdMatches>>, RefPtr<JSON::ArrayOf<Inspector::Protocol::CSS::InheritedStyleEntry>>> getMatchedStylesForNode(Inspector::Protocol::DOM::NodeId, std::optional<bool>&& includePseudo, std::optional<bool>&& includeInherited) override;
     Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSStyleSheetHeader>>> getAllStyleSheets() override;
@@ -94,6 +94,7 @@ public:
     // InspectorInstrumentation
     bool forcePseudoState(const Element&, CSSSelector::PseudoClass);
     void documentDetached(Document&);
+    void fontDataChanged();
     void mediaQueryResultChanged();
     void activeStyleSheetsUpdated(Document&);
 

--- a/Source/WebCore/loader/cache/CachedFont.cpp
+++ b/Source/WebCore/loader/cache/CachedFont.cpp
@@ -168,6 +168,13 @@ bool CachedFont::ensureCustomFontData(SharedBuffer* data)
         }
         }
 
+        if (RefPtr fontCustomPlatformData = m_fontCustomPlatformData) {
+            URL sourceURL = response().url();
+            if (sourceURL.isEmpty())
+                sourceURL = url();
+            fontCustomPlatformData->setSourceURL(sourceURL.string());
+        }
+
         m_hasCreatedFontDataWrappingResource = m_fontCustomPlatformData && wrapping;
         if (!m_fontCustomPlatformData) {
             if (m_fontParsingPolicy == FontParsingPolicy::LoadWithSafeFontParser) {

--- a/Source/WebCore/platform/graphics/FontCustomPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontCustomPlatformData.h
@@ -35,9 +35,9 @@
 #include <wtf/Platform.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/WTFString.h>
 
 #if PLATFORM(WIN)
-#include <wtf/text/WTFString.h>
 #elif USE(CORE_TEXT)
 #include <CoreFoundation/CFBase.h>
 #include <wtf/RetainPtr.h>
@@ -96,6 +96,13 @@ public:
     WEBCORE_EXPORT FontCustomPlatformSerializedData NODELETE serializedData() const;
     WEBCORE_EXPORT static std::optional<Ref<FontCustomPlatformData>> tryMakeFromSerializationData(FontCustomPlatformSerializedData&&, bool);
 
+    const String& sourceURL() const { return m_sourceURL; }
+    void setSourceURL(String sourceURL)
+    {
+        ASSERT(m_sourceURL.isEmpty());
+        m_sourceURL = WTF::move(sourceURL);
+    }
+
 #if USE(SKIA)
     sk_sp<SkTypeface> retrieveOrAddCachedTypeface(const Vector<SkFontArguments::VariationPosition::Coordinate>&);
     void clearVariationTypefacesCache() const;
@@ -118,6 +125,8 @@ public:
     FontPlatformData::CreationData creationData;
 
     RenderingResourceIdentifier m_renderingResourceIdentifier;
+
+    String m_sourceURL;
 };
 
 inline bool computeSyntheticBold(bool hasWeightVariationAxis, const FontDescription& fontDescription, const FontCreationContext& fontCreationContext)

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -297,6 +297,8 @@ public:
         float minimumValue() const { return m_minimumValue; }
         float maximumValue() const { return m_maximumValue; }
 
+        friend bool operator==(const FontVariationAxis&, const FontVariationAxis&) = default;
+
     private:
         const String m_name;
         const String m_tag;

--- a/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
@@ -112,7 +112,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
     bool syntheticItalic = computeSyntheticItalic(hasSlopeVariationAxis, description, fontCreationContext);
 
     auto size = description.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
-    FontPlatformData platformData(m_fontFace.get(), WTF::move(pattern), size, freeTypeFace->face_flags & FT_FACE_FLAG_FIXED_WIDTH, syntheticBold, syntheticItalic, description.orientation(), fontCreationContext.metricsOverrides());
+    FontPlatformData platformData(m_fontFace.get(), WTF::move(pattern), size, freeTypeFace->face_flags & FT_FACE_FLAG_FIXED_WIDTH, syntheticBold, syntheticItalic, description.orientation(), fontCreationContext.metricsOverrides(), this);
 
     platformData.updateSizeWithFontSizeAdjust(description.fontSizeAdjust(), description.usedSize());
     return platformData;

--- a/Source/WebCore/platform/text/BidiResolver.h
+++ b/Source/WebCore/platform/text/BidiResolver.h
@@ -161,8 +161,8 @@ public:
     unsigned start() const { return m_start; }
     unsigned stop() const { return m_stop; }
     unsigned char level() const { return m_level; }
-    bool reversed(bool visuallyOrdered) { return m_level % 2 && !visuallyOrdered; }
-    bool dirOverride(bool visuallyOrdered) { return m_override || visuallyOrdered; }
+    bool reversed(bool visuallyOrdered) const { return m_level % 2 && !visuallyOrdered; }
+    bool dirOverride(bool visuallyOrdered) const { return m_override || visuallyOrdered; }
 
     ConcreteRunType* next() const LIFETIME_BOUND { return m_next.get(); }
     std::unique_ptr<ConcreteRunType> takeNext() { return WTF::move(m_next); }

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -351,6 +351,10 @@ localizedStrings["Changes"] = "Changes";
 /* Title for Channels row in Media Sidebar */
 localizedStrings["Channels @ Media Sidebar"] = "Channels";
 localizedStrings["Character Data"] = "Character Data";
+/* Property title for character ranges for which no font glyph was found. */
+localizedStrings["Characters @ Missing Font Details Sidebar Property"] = "Characters";
+/* Property title for character ranges rendered by a font. */
+localizedStrings["Characters @ Rendered Font Details Sidebar Property"] = "Characters";
 localizedStrings["Charge \u201C%s\u201D to Callers"] = "Charge \u201C%s\u201D to Callers";
 localizedStrings["Checked"] = "Checked";
 /* A submenu item of 'Add' to append DOM nodes to the selected DOM node */
@@ -1119,6 +1123,8 @@ localizedStrings["Microtask Dispatched"] = "Microtask Dispatched";
 localizedStrings["Microtask Fired"] = "Microtask Fired";
 /* Min axis value @ Font Details Sidebar */
 localizedStrings["Minimum value of variation axis"] = "Minimum value of variation axis";
+/* Section title for characters for which no font glyph was found. */
+localizedStrings["Missing Characters @ Font Details Sidebar Section"] = "Missing Characters";
 localizedStrings["Missing result level"] = "Missing result level";
 localizedStrings["Mixed"] = "Mixed";
 localizedStrings["Modifications are saved automatically and will apply the next time the Console Snippet is run."] = "Modifications are saved automatically and will apply the next time the Console Snippet is run.";
@@ -1131,6 +1137,8 @@ localizedStrings["Multi-Entry"] = "Multi-Entry";
 localizedStrings["Name"] = "Name";
 /* Property title for the family name of the font. */
 localizedStrings["Name @ Font Details Sidebar Property"] = "Name";
+/* Property title for the family name of a rendered font. */
+localizedStrings["Name @ Rendered Font Details Sidebar Property"] = "Name";
 /* Label for the navigation sidebar. */
 localizedStrings["Navigation @ Sidebar"] = "Navigation";
 localizedStrings["Network"] = "Network";
@@ -1430,6 +1438,8 @@ localizedStrings["Remove Recording"] = "Remove Recording";
 localizedStrings["Removed ancestor "] = "Removed ancestor ";
 localizedStrings["Removed descendant "] = "Removed descendant ";
 localizedStrings["Render Pipeline %d"] = "Render Pipeline %d";
+/* Section title for text grouped by rendered font. */
+localizedStrings["Rendered Text @ Font Details Sidebar Section"] = "Rendered Text";
 localizedStrings["Rendering Frames"] = "Rendering Frames";
 localizedStrings["Repeating Conic Gradient"] = "Repeating Conic Gradient";
 localizedStrings["Repeating Linear Gradient"] = "Repeating Linear Gradient";
@@ -1669,8 +1679,12 @@ localizedStrings["Some examples of ways to use this script include (but are not 
 localizedStrings["Sort Ascending"] = "Sort Ascending";
 localizedStrings["Sort Descending"] = "Sort Descending";
 localizedStrings["Source"] = "Source";
+/* Property title for the source URL of the font. */
+localizedStrings["Source @ Font Details Sidebar Property"] = "Source";
 /* Title for Source row in Media Sidebar */
 localizedStrings["Source @ Media Sidebar"] = "Source";
+/* Property title for the source URL of a rendered font. */
+localizedStrings["Source @ Rendered Font Details Sidebar Property"] = "Source";
 localizedStrings["Source Map \u0022%s\u0022 has %s"] = "Source Map \u0022%s\u0022 has %s";
 localizedStrings["Source Map loading errors"] = "Source Map loading errors";
 localizedStrings["Source Maps:"] = "Source Maps:";

--- a/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
@@ -566,6 +566,16 @@ WI.CSSManager = class CSSManager extends WI.Object
 
     // CSSObserver
 
+    fontDataChanged(target)
+    {
+        for (let key in this._nodeStylesMap) {
+            let nodeStyles = this._nodeStylesMap[key];
+            if ((nodeStyles.node.owningTarget || WI.assumingMainTarget()) !== target)
+                continue;
+            nodeStyles.fontDataChanged();
+        }
+    }
+
     mediaQueryResultChanged()
     {
         for (var key in this._nodeStylesMap)

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
@@ -45,6 +45,8 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
         this._orderedStyles = [];
 
         this._computedPrimaryFont = null;
+        this._renderedFonts = [];
+        this._missingCharacterRanges = [];
 
         this._propertyNameToEffectivePropertyMap = {};
         this._usedCSSVariables = new Set;
@@ -143,6 +145,8 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
     get computedStyle() { return this._computedStyle; }
     get orderedStyles() { return this._orderedStyles; }
     get computedPrimaryFont() { return this._computedPrimaryFont; }
+    get renderedFonts() { return this._renderedFonts; }
+    get missingCharacterRanges() { return this._missingCharacterRanges; }
     get usedCSSVariables() { return this._usedCSSVariables; }
     get allCSSVariables() { return this._allCSSVariables; }
 
@@ -337,12 +341,19 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
             fetchedComputedStylesPromise.resolve({significantChange});
         }
 
-        function fetchedFontData(error, fontDataPayload)
+        function fetchedFontData(error, primaryFontPayload, renderedFontPayloads, missingCharacterRanges)
         {
-            if (fontDataPayload)
-                this._computedPrimaryFont = WI.Font.fromPayload(fontDataPayload);
-            else
+            if (error) {
                 this._computedPrimaryFont = null;
+                this._renderedFonts = [];
+                this._missingCharacterRanges = [];
+                fetchedFontDataPromise.resolve();
+                return;
+            }
+
+            this._computedPrimaryFont = WI.Font.fromPayload(primaryFontPayload);
+            this._renderedFonts = renderedFontPayloads?.map((payload) => WI.Font.fromPayload(payload)) || [];
+            this._missingCharacterRanges = missingCharacterRanges || [];
 
             fetchedFontDataPromise.resolve();
         }
@@ -445,6 +456,11 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
     // Protected
 
     mediaQueryResultDidChange()
+    {
+        this._markAsNeedsRefresh();
+    }
+
+    fontDataChanged()
     {
         this._markAsNeedsRefresh();
     }

--- a/Source/WebInspectorUI/UserInterface/Models/Font.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Font.js
@@ -25,34 +25,37 @@
 
 WI.Font = class Font
 {
-    constructor(name, variationAxes, {synthesizedBold, synthesizedOblique} = {})
+    constructor(name, {url, variationAxes, synthesizedBold, synthesizedOblique, characterRanges} = {})
     {
         this._name = name;
-        this._variationAxes = variationAxes;
-
-        // COMPATIBILITY (macOS 13.0, iOS 16.0): CSS.Font.synthesizedBold and CSS.Font.synthesizedOblique did not exist yet.
+        this._url = url || null;
+        this._variationAxes = variationAxes || [];
         this._synthesizedBold = !!synthesizedBold;
         this._synthesizedOblique = !!synthesizedOblique;
+        this._characterRanges = characterRanges || [];
     }
 
     // Static
 
     static fromPayload(payload)
     {
-        let variationAxes = payload.variationAxes.map((axisPayload) => WI.FontVariationAxis.fromPayload(axisPayload));
-
-        let synthesizedBold = payload.synthesizedBold;
-        let synthesizedOblique = payload.synthesizedOblique;
-
-        return new WI.Font(payload.displayName, variationAxes, {synthesizedBold, synthesizedOblique});
+        return new WI.Font(payload.displayName, {
+            url: payload.url,
+            variationAxes: payload.variationAxes?.map((axisPayload) => WI.FontVariationAxis.fromPayload(axisPayload)) || [],
+            synthesizedBold: payload.synthesizedBold,
+            synthesizedOblique: payload.synthesizedOblique,
+            characterRanges: payload.characterRanges,
+        });
     }
 
     // Public
 
     get name() { return this._name; }
+    get url() { return this._url; }
     get variationAxes() { return this._variationAxes; }
     get synthesizedBold() { return this._synthesizedBold; }
     get synthesizedOblique() { return this._synthesizedOblique; }
+    get characterRanges() { return this._characterRanges; }
 
     variationAxis(tag)
     {

--- a/Source/WebInspectorUI/UserInterface/Protocol/CSSObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/CSSObserver.js
@@ -27,6 +27,11 @@ WI.CSSObserver = class CSSObserver extends InspectorBackend.Dispatcher
 {
     // Events defined by the "CSS" domain.
 
+    fontDataChanged()
+    {
+        WI.cssManager.fontDataChanged(this._target);
+    }
+
     mediaQueryResultChanged()
     {
         WI.cssManager.mediaQueryResultChanged();

--- a/Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.js
@@ -94,7 +94,9 @@ WI.FontDetailsPanel = class FontDetailsPanel extends WI.StyleDetailsPanel
             }
         }
 
-        this._fontNameRow.value = this.nodeStyles.computedPrimaryFont.name;
+        let computedPrimaryFont = this.nodeStyles.computedPrimaryFont;
+        this._fontNameRow.value = computedPrimaryFont.name;
+        this._fontSourceRow.value = this._sourceValue(computedPrimaryFont.url);
 
         // Feature properties
         this._fontVariantLigaturesRow.value = this._formatLigatureValue(this._fontPropertiesMap.get("font-variant-ligatures"));
@@ -121,6 +123,30 @@ WI.FontDetailsPanel = class FontDetailsPanel extends WI.StyleDetailsPanel
             emptyRow.showEmptyMessage();
 
             this._fontVariationsGroup.rows = [emptyRow];
+        }
+
+        let renderedFonts = this.nodeStyles.renderedFonts;
+        if (renderedFonts.length) {
+            this._renderedFontsSection.element.hidden = false;
+            this._renderedFontsSection.groups = renderedFonts.map((font) => new WI.DetailsSectionGroup([
+                new WI.DetailsSectionSimpleRow(WI.UIString("Name", "Name @ Rendered Font Details Sidebar Property", "Property title for the family name of a rendered font."), font.name),
+                new WI.DetailsSectionSimpleRow(WI.UIString("Source", "Source @ Rendered Font Details Sidebar Property", "Property title for the source URL of a rendered font."), this._sourceValue(font.url)),
+                new WI.DetailsSectionSimpleRow(WI.UIString("Characters", "Characters @ Rendered Font Details Sidebar Property", "Property title for character ranges rendered by a font."), this._characterSequence(font.characterRanges)),
+            ]));
+        } else {
+            this._renderedFontsSection.element.hidden = true;
+            this._renderedFontsSection.groups = [];
+        }
+
+        let missingCharacterRanges = this.nodeStyles.missingCharacterRanges;
+        if (missingCharacterRanges.length) {
+            this._missingCharactersSection.element.hidden = false;
+            this._missingCharactersSection.groups = [new WI.DetailsSectionGroup([
+                new WI.DetailsSectionSimpleRow(WI.UIString("Characters", "Characters @ Missing Font Details Sidebar Property", "Property title for character ranges for which no font glyph was found."), this._characterSequence(missingCharacterRanges)),
+            ])];
+        } else {
+            this._missingCharactersSection.element.hidden = true;
+            this._missingCharactersSection.groups = [];
         }
     }
 
@@ -190,7 +216,8 @@ WI.FontDetailsPanel = class FontDetailsPanel extends WI.StyleDetailsPanel
 
         // Identity
         this._fontNameRow = new WI.DetailsSectionSimpleRow(WI.UIString("Name", "Name @ Font Details Sidebar Property", "Property title for the family name of the font."));
-        let previewGroup = new WI.DetailsSectionGroup([this._fontNameRow]);
+        this._fontSourceRow = new WI.DetailsSectionSimpleRow(WI.UIString("Source", "Source @ Font Details Sidebar Property", "Property title for the source URL of the font."));
+        let previewGroup = new WI.DetailsSectionGroup([this._fontNameRow, this._fontSourceRow]);
 
         let fontNameSection = new WI.DetailsSection("font-identity", WI.UIString("Identity", "Identity @ Font Details Sidebar Section", "Section title for font identity information."), [previewGroup]);
         this.element.appendChild(fontNameSection.element);
@@ -220,6 +247,14 @@ WI.FontDetailsPanel = class FontDetailsPanel extends WI.StyleDetailsPanel
 
         let fontVariationPropertiesSection = new WI.DetailsSection("font-variation-properties", WI.UIString("Variation Properties", "Variation Properties @ Font Details Sidebar Section", "Section title for font variation properties."), [this._fontVariationsGroup]);
         this.element.appendChild(fontVariationPropertiesSection.element);
+
+        this._renderedFontsSection = new WI.DetailsSection("font-rendered-fonts", WI.UIString("Rendered Text", "Rendered Text @ Font Details Sidebar Section", "Section title for text grouped by rendered font."));
+        this._renderedFontsSection.element.hidden = true;
+        this.element.appendChild(this._renderedFontsSection.element);
+
+        this._missingCharactersSection = new WI.DetailsSection("font-missing-characters", WI.UIString("Missing Characters", "Missing Characters @ Font Details Sidebar Section", "Section title for characters for which no font glyph was found."));
+        this._missingCharactersSection.element.hidden = true;
+        this.element.appendChild(this._missingCharactersSection.element);
     }
 
     // Private
@@ -237,6 +272,74 @@ WI.FontDetailsPanel = class FontDetailsPanel extends WI.StyleDetailsPanel
     get _fontFeaturesMap()
     {
         return this._fontStyles?.featuresMap ?? new Map;
+    }
+
+    _characterSequence(characterRanges)
+    {
+        if (!characterRanges.length)
+            return null;
+
+        let formatCodePoint = (value) => `U+${value.toString(16).toUpperCase().padStart(4, "0")}`;
+
+        let container = document.createElement("span");
+        container.classList.add("characters");
+
+        let lastCodePoint = -1;
+        for (let {start, end} of characterRanges.slice().sort((a, b) => a.start - b.start || a.end - b.end)) {
+            if (start < 0 || end > 0x10FFFF || start > end)
+                continue;
+
+            start = Math.max(start, lastCodePoint + 1);
+
+            for (let codePoint = start; codePoint <= end; ++codePoint) {
+                let formattedCodePoint = formatCodePoint(codePoint);
+                let character = String.fromCodePoint(codePoint);
+
+                let span = container.appendChild(document.createElement("span"));
+                span.title = formattedCodePoint;
+                if (this._isCharacterDisplayable(character))
+                    span.textContent = character;
+                else {
+                    span.classList.add("code-point");
+                    span.textContent = formattedCodePoint;
+                }
+            }
+
+            lastCodePoint = Math.max(lastCodePoint, end);
+        }
+
+        return container.childNodes.length ? container : null;
+    }
+
+    _isCharacterDisplayable(character)
+    {
+        if (!character.trim())
+            return false;
+
+        return !/[\p{Cc}\p{Cf}\p{Cs}\p{Cn}]/u.test(character);
+    }
+
+    _sourceValue(url)
+    {
+        if (!url)
+            return null;
+
+        let resource = this._fontResourceForURL(url);
+        if (resource)
+            return WI.createResourceLink(resource, "font-resource-link");
+
+        return WI.truncateURL(url);
+    }
+
+    _fontResourceForURL(url)
+    {
+        let isFontResource = (resource) => resource.type === WI.Resource.Type.Font;
+        let frame = this.nodeStyles.node.frame;
+        return frame?.resourcesForURL(url).find(isFontResource)
+            || frame?.resourcesForURL(WI.urlWithoutFragment(url)).find(isFontResource)
+            || WI.networkManager.resourcesForURL(url).find(isFontResource)
+            || WI.networkManager.resourcesForURL(WI.urlWithoutFragment(url)).find(isFontResource)
+            || null;
     }
 
     _createDetailsSectionRowForProperty(propertyName)


### PR DESCRIPTION
#### 5d4c906bfe2a39017bf011ff0965dd63e6ccec2d
<pre>
Web Inspector: report rendered font character ranges
<a href="https://bugs.webkit.org/show_bug.cgi?id=286608">https://bugs.webkit.org/show_bug.cgi?id=286608</a>

Reviewed by NOBODY (OOPS!).

`CSS.getFontDataForNode` only reports the computed primary font, not any fallback fonts, missing glyphs, or which characters each font renders.
More often than not, resolving issues with fonts need the latter instead of just only the former.

* Source/JavaScriptCore/inspector/protocol/CSS.json:
* Source/WebCore/inspector/InspectorFontData.h: Added.
(WebCore::FontData): Added.
* Source/WebCore/inspector/InspectorFontData.cpp: Added.
(WebCore::InspectorFontMetadata): Added.
(WebCore::InspectorFontMetadata::operator==): Added.
(WebCore::RenderedFont): Added.
(WebCore::RenderedFont::create): Added.
(WebCore::RenderedFont::metadata const): Added.
(WebCore::RenderedFont::characters const): Added.
(WebCore::RenderedFont::addCharacter): Added.
(WebCore::RenderedFont::RenderedFont): Added.
(WebCore::metadataForFont): Added.
(WebCore::buildObjectForFont): Added.
(WebCore::buildCharacterRanges): Added.
(WebCore::buildRenderedFonts): Added.
(WebCore::InspectorFontUsageRecorder): Added.
(WebCore::InspectorFontUsageRecorder::renderedFonts const): Added.
(WebCore::InspectorFontUsageRecorder::missingCharacters const): Added.
(WebCore::InspectorFontUsageRecorder::ensureRenderedFont): Added.
(WebCore::InspectorFontUsageRecorder::recordFontUsage): Added.
(WebCore::InspectorFontUsageRecorder::isCALayerContext const): Added.
(WebCore::InspectorFontUsageRecorder::paintingDisabled const): Added.
(WebCore::InspectorFontUsageRecorder::didUpdateState): Added.
(WebCore::InspectorFontUsageRecorder::drawNativeImage): Added.
(WebCore::InspectorFontUsageRecorder::drawSystemImage): Added.
(WebCore::InspectorFontUsageRecorder::drawPattern): Added.
(WebCore::InspectorFontUsageRecorder::clipBounds const): Added.
(WebCore::InspectorFontUsageRecorder::applyStrokePattern): Added.
(WebCore::InspectorFontUsageRecorder::applyFillPattern): Added.
(WebCore::InspectorFontUsageRecorder::drawPath): Added.
(WebCore::InspectorFontUsageRecorder::drawRect): Added.
(WebCore::InspectorFontUsageRecorder::drawLine): Added.
(WebCore::InspectorFontUsageRecorder::drawEllipse): Added.
(WebCore::InspectorFontUsageRecorder::fillPath): Added.
(WebCore::InspectorFontUsageRecorder::strokePath): Added.
(WebCore::InspectorFontUsageRecorder::fillRect): Added.
(WebCore::InspectorFontUsageRecorder::fillRoundedRectImpl): Added.
(WebCore::InspectorFontUsageRecorder::strokeRect): Added.
(WebCore::InspectorFontUsageRecorder::clipPath): Added.
(WebCore::InspectorFontUsageRecorder::drawLinesForText): Added.
(WebCore::InspectorFontUsageRecorder::setLineCap): Added.
(WebCore::InspectorFontUsageRecorder::setLineDash): Added.
(WebCore::InspectorFontUsageRecorder::setLineJoin): Added.
(WebCore::InspectorFontUsageRecorder::setMiterLimit): Added.
(WebCore::InspectorFontUsageRecorder::clipOut): Added.
(WebCore::InspectorFontUsageRecorder::scale): Added.
(WebCore::InspectorFontUsageRecorder::rotate): Added.
(WebCore::InspectorFontUsageRecorder::translate): Added.
(WebCore::InspectorFontUsageRecorder::concatCTM): Added.
(WebCore::InspectorFontUsageRecorder::setCTM): Added.
(WebCore::InspectorFontUsageRecorder::getCTM const): Added.
(WebCore::InspectorFontUsageRecorder::clearRect): Added.
(WebCore::InspectorFontUsageRecorder::resetClip): Added.
(WebCore::InspectorFontUsageRecorder::clip): Added.
(WebCore::InspectorFontUsageRecorder::save): Added.
(WebCore::InspectorFontUsageRecorder::restore): Added.
(WebCore::InspectorFontUsageRecorder::drawRaisedEllipse): Added.
(WebCore::InspectorFontUsageRecorder::drawText): Added.
(WebCore::InspectorFontUsageRecorder::drawGlyphs): Added.
(WebCore::InspectorFontUsageRecorder::drawDisplayList): Added.
(WebCore::InspectorFontUsageRecorder::drawEmphasisMarks): Added.
(WebCore::InspectorFontUsageRecorder::drawBidiText): Added.
(WebCore::InspectorFontUsageRecorder::drawDotsForDocumentMarker): Added.
(WebCore::InspectorFontUsageRecorder::drawImage): Added.
(WebCore::InspectorFontUsageRecorder::drawTiledImage): Added.
(WebCore::InspectorFontUsageRecorder::drawFocusRing): Added.
(WebCore::InspectorFontUsageRecorder::drawImageBuffer): Added.
(WebCore::InspectorFontUsageRecorder::clipRoundedRect): Added.
(WebCore::InspectorFontUsageRecorder::clipOutRoundedRect): Added.
(WebCore::InspectorFontUsageRecorder::clipToImageBuffer): Added.
(WebCore::InspectorFontUsageRecorder::fillRoundedRect): Added.
(WebCore::InspectorFontUsageRecorder::fillRectWithRoundedHole): Added.
(WebCore::InspectorFontUsageRecorder::drawVideoFrame): Added.
(WebCore::getFontData): Added.
* Source/WebCore/platform/text/BidiResolver.h:
(WebCore::BidiCharacterRun::reversed const):
(WebCore::BidiCharacterRun::dirOverride const):
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::fontDataChanged): Added.
(WebCore::buildObjectForFont): Removed.
(WebCore::InspectorCSSAgent::getFontDataForNode):
* Source/WebCore/inspector/agents/frame/FrameCSSAgent.h:
* Source/WebCore/inspector/agents/frame/FrameCSSAgent.cpp:
(WebCore::FrameCSSAgent::fontDataChanged): Added.
(WebCore::FrameCSSAgent::getFontDataForNode):
Collect shaped `GlyphBuffer` data through a non-painting `GraphicsContext` so font attribution follows rendering without changing general graphics code.
Deduplicate and merge the character ranges of `Font` that result in identical metadata.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::fontsNeedUpdate):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::fontDataChanged): Added.
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::fontDataChangedImpl): Added.
Dispatch `CSS.fontDataChanged` so cached results reflect loaded and in-memory font changes.

* Source/WebCore/loader/cache/CachedFont.cpp:
(WebCore::CachedFont::ensureCustomFontData):
* Source/WebCore/platform/graphics/FontCustomPlatformData.h:
(WebCore::FontCustomPlatformData::sourceURL const): Added.
(WebCore::FontCustomPlatformData::setSourceURL): Added.
* Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp:
(WebCore::FontCustomPlatformData::fontPlatformData):
* Source/WebCore/platform/graphics/FontPlatformData.h:
(WebCore::FontPlatformData::FontVariationAxis::operator==): Added.
Retain the final response URL with custom font data so downloadable fonts can be revealed in the Sources Tab.

* Source/WebInspectorUI/UserInterface/Protocol/CSSObserver.js:
(WI.CSSObserver.prototype.fontDataChanged): Added.
* Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js:
(WI.CSSManager.prototype.fontDataChanged): Added.
* Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js:
(WI.DOMNodeStyles.prototype.constructor):
(WI.DOMNodeStyles.prototype.get renderedFonts): Added.
(WI.DOMNodeStyles.prototype.get missingCharacterRanges): Added.
(WI.DOMNodeStyles.prototype.refresh):
(WI.DOMNodeStyles.prototype.refresh.fetchedFontData):
(WI.DOMNodeStyles.prototype.fontDataChanged): Added.
* Source/WebInspectorUI/UserInterface/Models/Font.js:
(WI.Font.prototype.constructor):
(WI.Font.fromPayload):
(WI.Font.prototype.get url): Added.
(WI.Font.prototype.get characterRanges): Added.
* Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.js:
(WI.FontDetailsPanel.prototype.update):
(WI.FontDetailsPanel.prototype.initialLayout):
(WI.FontDetailsPanel.prototype._characterSequence): Added.
(WI.FontDetailsPanel.prototype._isCharacterDisplayable): Added.
(WI.FontDetailsPanel.prototype._sourceValue): Added.
(WI.FontDetailsPanel.prototype._fontResourceForURL): Added.
* Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.css:
(.sidebar &gt; .panel.details.style-font &gt; .content .details-section &gt; .content &gt; .group &gt; .row.simple &gt; .value &gt; .characters): Added.
(.sidebar &gt; .panel.details.style-font &gt; .content .details-section &gt; .content &gt; .group &gt; .row.simple &gt; .value &gt; .characters &gt; span): Added.
(.sidebar &gt; .panel.details.style-font &gt; .content .details-section &gt; .content &gt; .group &gt; .row.simple &gt; .value &gt; .characters &gt; .code-point): Added.
Show the primary font source, rendered text grouped by font, and missing characters in the Font details sidebar panel.
Sort characters by Unicode scalar value and distinguish non-displayable values.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

* LayoutTests/inspector/css/getFontDataForNode-rendered-text.html: Added.
* LayoutTests/inspector/css/getFontDataForNode-rendered-text-expected.txt: Added.
* LayoutTests/inspector/css/getFontDataForNode-font-data-changed.html: Added.
* LayoutTests/inspector/css/getFontDataForNode-font-data-changed-expected.txt: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d4c906bfe2a39017bf011ff0965dd63e6ccec2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196479 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150747 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59795 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145480 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100839 "3 flakes 14 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166008 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125813 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47885 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45864 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7661 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14530 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45600 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7549 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47427 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52583 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198457 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59740 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165532 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155043 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60451 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42175 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154686 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49124 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132712 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129863 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58879 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20579 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58280 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58499 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58341 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->