### PR TITLE
[JSC] Avoid atomizing import names twice

### DIFF
--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -355,10 +355,12 @@ JSWebAssemblyInstance* JSWebAssemblyInstance::tryCreate(VM& vm, Structure* insta
 
     // For each import i in module.imports:
     {
+        const auto importNames = jsModule->importNames(vm);
         IdentifierSet specifiers;
-        for (auto& import : moduleInformation.imports) {
-            auto moduleName = Identifier::fromString(vm, makeAtomString(import.module));
-            auto fieldName = Identifier::fromString(vm, makeAtomString(import.field));
+        for (size_t importIndex = 0; importIndex < moduleInformation.imports.size(); ++importIndex) {
+            const auto& import = moduleInformation.imports[importIndex];
+            const auto& moduleName = importNames[importIndex].module;
+            const auto& fieldName = importNames[importIndex].field;
             bool skipRequestedModule = false;
             if (fromModuleLoader) {
                 if (startsWith(import.module.span(), "wasm-js:"_s))

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp
@@ -111,6 +111,20 @@ Wasm::Module& JSWebAssemblyModule::module()
     return m_module.get();
 }
 
+std::span<const JSWebAssemblyModule::ImportName> JSWebAssemblyModule::importNames(VM& vm)
+{
+    const auto& imports = moduleInformation().imports;
+    if (m_importNames.size() != imports.size()) {
+        m_importNames = FixedVector<ImportName>::map(imports, [&](const Wasm::Import& import) {
+            return ImportName {
+                Identifier::fromString(vm, makeAtomString(import.module)),
+                Identifier::fromString(vm, makeAtomString(import.field)),
+            };
+        });
+    }
+    return m_importNames.span();
+}
+
 template<typename Visitor>
 void JSWebAssemblyModule::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h
@@ -35,6 +35,7 @@
 #include <JavaScriptCore/MemoryMode.h>
 #include <JavaScriptCore/WasmFormat.h>
 #include <wtf/Bag.h>
+#include <wtf/FixedVector.h>
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/text/WTFString.h>
@@ -75,12 +76,20 @@ public:
 
     JS_EXPORT_PRIVATE Wasm::Module& NODELETE module();
 
+    struct ImportName {
+        Identifier module;
+        Identifier field;
+    };
+
+    std::span<const ImportName> importNames(VM&) LIFETIME_BOUND;
+
 private:
     JSWebAssemblyModule(VM&, Structure*, Ref<Wasm::Module>&&);
     void finishCreation(VM&);
 
     const Ref<Wasm::Module> m_module;
     WriteBarrier<SymbolTable> m_exportSymbolTable;
+    FixedVector<ImportName> m_importNames;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -169,11 +169,10 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
         return makeString(before, ' ', import.module, ':', import.field, ' ', after);
     };
 
-    for (const auto& import : moduleInformation.imports) {
-        AtomString moduleNameString = makeAtomString(import.module);
-        Identifier moduleName = Identifier::fromString(vm, moduleNameString);
-        // Do not create a fieldName identifier at this point.
-        // If it's an importedStringConstant, it's a waste to make it an atom string.
+    const auto importNames = module->importNames(vm);
+    for (size_t importIndex = 0; importIndex < moduleInformation.imports.size(); ++importIndex) {
+        const auto& import = moduleInformation.imports[importIndex];
+        const Identifier& moduleName = importNames[importIndex].module;
 
         // Imports related to builtins or importedStringConstants are special and bypass
         // the normal procedure of looking up a value in importObject.
@@ -191,7 +190,7 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
             continue;
         }
 
-        Identifier fieldName = Identifier::fromString(vm, makeAtomString(import.field));
+        const Identifier& fieldName = importNames[importIndex].field;
         JSValue value;
         if (creationMode == Wasm::CreationMode::FromJS) {
             // 1. Let o be the resultant value of performing Get(importObject, i.module_name).


### PR DESCRIPTION
#### a4741842d2bb89f352763c390c55fe12dfa884a3
<pre>
[JSC] Avoid atomizing import names twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=323281">https://bugs.webkit.org/show_bug.cgi?id=323281</a>
<a href="https://rdar.apple.com/186533756">rdar://186533756</a>

Reviewed by Mark Lam.

This patch avoids atomizing wasm import names twice by having
FixedVector with Identifier pairs.

* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::tryCreate):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp:
(JSC::JSWebAssemblyModule::importNames):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):

Canonical link: <a href="https://commits.webkit.org/320402@main">https://commits.webkit.org/320402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b4fd2fb4c6b31e26d8ec5c91addc358c209279b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195003 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148936 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144305 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124588 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46684 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/6545 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13394 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157061 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44458 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6059 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45941 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196950 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58261 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153769 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58963 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153427 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28057 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47950 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131251 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127771 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57464 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19479 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56825 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57073 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56900 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->