### PR TITLE
PrivateClickMeasurement destination secret token errors are logged with the wrong "source" label

### DIFF
--- a/Source/WebCore/loader/cocoa/PrivateClickMeasurementCocoa.mm
+++ b/Source/WebCore/loader/cocoa/PrivateClickMeasurementCocoa.mm
@@ -94,7 +94,7 @@ std::optional<String> PrivateClickMeasurement::calculateAndUpdateSourceSecretTok
 std::expected<PCM::DestinationSecretToken, String> PrivateClickMeasurement::calculateAndUpdateDestinationSecretToken(const String& serverResponseBase64URL, PCM::DestinationUnlinkableToken& unlinkableToken)
 {
     PCM::DestinationSecretToken secretToken;
-    auto errorMessage = calculateAndUpdateSecretToken(serverResponseBase64URL, unlinkableToken, secretToken, "source"_s);
+    auto errorMessage = calculateAndUpdateSecretToken(serverResponseBase64URL, unlinkableToken, secretToken, "destination"_s);
     if (errorMessage)
         return makeUnexpected(*errorMessage);
     return secretToken;


### PR DESCRIPTION
#### 3cd650b072c9dc10e2b8caf665d46ea3c7eefdea
<pre>
PrivateClickMeasurement destination secret token errors are logged with the wrong &quot;source&quot; label
<a href="https://bugs.webkit.org/show_bug.cgi?id=323286">https://bugs.webkit.org/show_bug.cgi?id=323286</a>
<a href="https://rdar.apple.com/186539945">rdar://186539945</a>

Reviewed by Alex Christensen.

calculateAndUpdateDestinationSecretToken() passed &quot;source&quot; as the
contextForLogMessage argument to calculateAndUpdateSecretToken(), so every
error string produced for a destination secret-token failure (&quot;Did not find
a source unlinkable token waiting token.&quot;, &quot;Could not decode source response
data.&quot;, etc.) misidentified its context as &quot;source&quot; instead of &quot;destination&quot;.

Pass &quot;destination&quot; to match the sibling
calculateAndUpdateDestinationUnlinkableToken().

* Source/WebCore/loader/cocoa/PrivateClickMeasurementCocoa.mm:
(WebCore::PrivateClickMeasurement::calculateAndUpdateDestinationSecretToken):

Canonical link: <a href="https://commits.webkit.org/320706@main">https://commits.webkit.org/320706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5f59c31a57a0f9cc82a40e71a6008045a3d823f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195017 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148949 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/557027ee-5a00-4b15-9e1d-4d7ed4f23737) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58334 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144316 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100205 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f5147e48-253a-471e-a1ee-4fade0dcbe8c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47983 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164922 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124599 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90443ad5-c049-471a-8b2d-d13b2a1ba86b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46699 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44837 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44472 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6072 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196963 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58274 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153783 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41409 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58976 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153441 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47958 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131264 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127784 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57477 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19493 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56838 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57086 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56913 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->