### PR TITLE
Remove dead declared-but-undefined member functions from ResourceMonitorThrottler

### DIFF
--- a/Source/WebCore/loader/ResourceMonitorThrottler.h
+++ b/Source/WebCore/loader/ResourceMonitorThrottler.h
@@ -43,10 +43,6 @@ public:
     ResourceMonitorThrottler(String&& databaseDirectoryPath, size_t count, Seconds duration, size_t maxHosts);
     ~ResourceMonitorThrottler();
 
-    void openDatabase(String&& path);
-    void closeDatabase();
-    void recordAccess(const String& host, ContinuousApproximateTime);
-
     bool tryAccess(const String& host, ContinuousApproximateTime);
     void clearAllData();
 
@@ -74,14 +70,11 @@ private:
         ContinuousApproximateTime newestAccessTime() const { return m_newestAccessTime; }
 
     private:
-        void removeExpired(ContinuousApproximateTime);
-
         PriorityQueue<ContinuousApproximateTime, std::greater<ContinuousApproximateTime>> m_accessTimes;
         ContinuousApproximateTime m_newestAccessTime { -ContinuousApproximateTime::infinity() };
     };
 
     AccessThrottler& throttlerForHost(const String& host);
-    void removeExpiredThrottler();
     void removeOldestThrottler();
     void maintainHosts(ContinuousApproximateTime);
 


### PR DESCRIPTION
#### d9f0af20a0d11b23f2b3a3c80c976be1751742a3
<pre>
Remove dead declared-but-undefined member functions from ResourceMonitorThrottler
<a href="https://bugs.webkit.org/show_bug.cgi?id=323288">https://bugs.webkit.org/show_bug.cgi?id=323288</a>
<a href="https://rdar.apple.com/186540356">rdar://186540356</a>

Reviewed by Abrar Rahman Protyasha.

These five members are declared in the header but never defined or
called. Remove the stale declarations. No behavior change.

* Source/WebCore/loader/ResourceMonitorThrottler.h:

Canonical link: <a href="https://commits.webkit.org/320463@main">https://commits.webkit.org/320463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29acd2b0a2443ec0fe161cb97db8a3750a01898b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195018 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148950 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/458eb810-2831-4062-95d1-df01a18dc80b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186547 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144317 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100206 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ea556fb5-a117-48ef-9908-9e3d126f430f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47981 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164924 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124600 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/833b4933-6f05-4a38-bab2-1ba26be93260) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46697 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44839 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44474 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6073 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196964 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58275 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153784 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41205 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58977 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153442 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47962 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131401 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127785 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57478 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19495 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56839 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57087 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56914 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->