### PR TITLE
[JSC] Split validation and evaluation of wasm constant expression

### DIFF
--- a/JSTests/wasm/gc/extended-const-expr-replay-simd.js
+++ b/JSTests/wasm/gc/extended-const-expr-replay-simd.js
@@ -1,0 +1,23 @@
+//@ skip unless $isSIMDPlatform
+//@ requireOptions("--useWasmSIMD=1")
+
+import * as assert from "../assert.js";
+import { compile } from "./wast-wrapper.js";
+
+// v128.const only reaches the constant expression evaluator as an operand of a larger expression,
+// so it has to be tested inside one rather than as a lone initializer.
+const module = compile(`(module
+  (type $vectors (array (mut v128)))
+  (global $vectors (ref $vectors)
+    (array.new_fixed $vectors 2 (v128.const i32x4 1 2 3 4) (v128.const i32x4 5 6 7 8)))
+  (func (export "lane") (param i32) (result i32)
+    (i32x4.extract_lane 0 (array.get $vectors (global.get $vectors) (local.get 0)))))`);
+
+const first = new WebAssembly.Instance(module);
+assert.eq(first.exports.lane(0), 1);
+assert.eq(first.exports.lane(1), 5);
+
+// The expression is evaluated again for the second instance, from the same bytes.
+const second = new WebAssembly.Instance(module);
+assert.eq(second.exports.lane(0), 1);
+assert.eq(second.exports.lane(1), 5);

--- a/JSTests/wasm/gc/extended-const-expr-replay.js
+++ b/JSTests/wasm/gc/extended-const-expr-replay.js
@@ -1,0 +1,120 @@
+import * as assert from "../assert.js";
+import { compile } from "./wast-wrapper.js";
+
+// A constant expression that the parser cannot fold to a single value is validated once and then
+// evaluated again for each instance. Only multi-instruction expressions take that path - a lone
+// `i32.const` or `ref.func` is folded by the section parser - so every operation under test is a
+// field of one big `struct.new` to make sure it really is evaluated the slow way.
+
+const wat = `(module
+  (type $point (struct (field $x i32) (field $y i64)))
+  (type $empty (struct (field $a i32) (field $b f64)))
+  (type $bytes (array i8))
+  (type $floats (array (mut f64)))
+  (type $sig (func (result i32)))
+  (type $bag (struct
+    (field $i32Const i32)
+    (field $i64Const i64)
+    (field $f32Const f32)
+    (field $f64Const f64)
+    (field $nullRef (ref null $point))
+    (field $funcRef (ref func))
+    (field $fromGlobal i32)
+    (field $i31 (ref i31))
+    (field $structDefault (ref $empty))
+    (field $arrayNew (ref $bytes))
+    (field $arrayDefault (ref $floats))
+    (field $arrayFixed (ref $floats))
+    (field $external externref)
+    (field $internalized (ref null any))
+    (field $i32Arith i32)
+    (field $i64Arith i64)))
+
+  (global $imported (import "m" "g") i32)
+
+  (func $callee (type $sig) (i32.const 7))
+
+  (global $bag (ref $bag) (struct.new $bag
+    (i32.const 11)
+    (i64.const 22)
+    (f32.const 1.5)
+    (f64.const 2.25)
+    (ref.null $point)
+    (ref.func $callee)
+    (global.get $imported)
+    (ref.i31 (i32.const 23))
+    (struct.new_default $empty)
+    (array.new $bytes (i32.const 3) (i32.const 9))
+    (array.new_default $floats (i32.const 2))
+    (array.new_fixed $floats 3 (f64.const 1) (f64.const 2) (f64.const 4))
+    (extern.convert_any (ref.i31 (i32.const 5)))
+    (any.convert_extern (extern.convert_any (ref.i31 (i32.const 6))))
+    (i32.mul (i32.add (i32.const 5) (i32.const 3)) (i32.sub (i32.const 4) (i32.const 1)))
+    (i64.mul (i64.add (i64.const 5) (i64.const 3)) (i64.sub (i64.const 4) (i64.const 1)))))
+
+  (func (export "i32Const") (result i32) (struct.get $bag $i32Const (global.get $bag)))
+  (func (export "i64Const") (result i64) (struct.get $bag $i64Const (global.get $bag)))
+  (func (export "f32Const") (result f32) (struct.get $bag $f32Const (global.get $bag)))
+  (func (export "f64Const") (result f64) (struct.get $bag $f64Const (global.get $bag)))
+  (func (export "nullRefIsNull") (result i32) (ref.is_null (struct.get $bag $nullRef (global.get $bag))))
+  (func (export "callFuncRef") (result i32)
+    (call_ref $sig (ref.cast (ref $sig) (struct.get $bag $funcRef (global.get $bag)))))
+  (func (export "fromGlobal") (result i32) (struct.get $bag $fromGlobal (global.get $bag)))
+  (func (export "i31") (result i32) (i31.get_s (struct.get $bag $i31 (global.get $bag))))
+  (func (export "structDefaultA") (result i32)
+    (struct.get $empty 0 (struct.get $bag $structDefault (global.get $bag))))
+  (func (export "structDefaultB") (result f64)
+    (struct.get $empty 1 (struct.get $bag $structDefault (global.get $bag))))
+  (func (export "arrayNewLen") (result i32) (array.len (struct.get $bag $arrayNew (global.get $bag))))
+  (func (export "arrayNewAt") (param i32) (result i32)
+    (array.get_u $bytes (struct.get $bag $arrayNew (global.get $bag)) (local.get 0)))
+  (func (export "arrayDefaultAt") (param i32) (result f64)
+    (array.get $floats (struct.get $bag $arrayDefault (global.get $bag)) (local.get 0)))
+  (func (export "arrayFixedLen") (result i32) (array.len (struct.get $bag $arrayFixed (global.get $bag))))
+  (func (export "arrayFixedAt") (param i32) (result f64)
+    (array.get $floats (struct.get $bag $arrayFixed (global.get $bag)) (local.get 0)))
+  (func (export "external") (result externref) (struct.get $bag $external (global.get $bag)))
+  (func (export "internalized") (result i32)
+    (i31.get_s (ref.cast (ref i31) (struct.get $bag $internalized (global.get $bag)))))
+  (func (export "i32Arith") (result i32) (struct.get $bag $i32Arith (global.get $bag)))
+  (func (export "i64Arith") (result i64) (struct.get $bag $i64Arith (global.get $bag)))
+  (func (export "bag") (result (ref $bag)) (global.get $bag))
+)`;
+
+const module = compile(wat);
+
+function check(instance, importedValue) {
+    const e = instance.exports;
+    assert.eq(e.i32Const(), 11);
+    assert.eq(e.i64Const(), 22n);
+    assert.eq(e.f32Const(), 1.5);
+    assert.eq(e.f64Const(), 2.25);
+    assert.eq(e.nullRefIsNull(), 1);
+    assert.eq(e.callFuncRef(), 7);
+    assert.eq(e.fromGlobal(), importedValue);
+    assert.eq(e.i31(), 23);
+    assert.eq(e.structDefaultA(), 0);
+    assert.eq(e.structDefaultB(), 0);
+    assert.eq(e.arrayNewLen(), 9);
+    assert.eq(e.arrayNewAt(0), 3);
+    assert.eq(e.arrayNewAt(8), 3);
+    assert.eq(e.arrayDefaultAt(0), 0);
+    assert.eq(e.arrayDefaultAt(1), 0);
+    assert.eq(e.arrayFixedLen(), 3);
+    assert.eq(e.arrayFixedAt(0), 1);
+    assert.eq(e.arrayFixedAt(1), 2);
+    assert.eq(e.arrayFixedAt(2), 4);
+    assert.eq(e.external(), 5);
+    assert.eq(e.internalized(), 6);
+    assert.eq(e.i32Arith(), 24);
+    assert.eq(e.i64Arith(), 24n);
+}
+
+const first = new WebAssembly.Instance(module, { m: { g: 1 } });
+check(first, 1);
+
+// Evaluating the same expression again has to produce the same values, and fresh objects.
+const second = new WebAssembly.Instance(module, { m: { g: 2 } });
+check(second, 2);
+check(first, 1);
+assert.falsy(first.exports.bag() === second.exports.bag());

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -44,14 +44,198 @@
 
 namespace JSC { namespace Wasm {
 
-class ConstExprGenerator {
+class ConstExprInterpreter {
     WTF_FORBID_HEAP_ALLOCATION;
 public:
-    using ErrorType = String;
-    using PartialResult = std::expected<void, ErrorType>;
-    using UnexpectedResult = std::unexpected<ErrorType>;
-    using CallType = CallLinkInfo::CallType;
+    using UnexpectedResult = std::unexpected<String>;
 
+    ConstExprInterpreter(size_t offsetInSource, const ModuleInformation& info, JSWebAssemblyInstance* instance)
+        : m_offsetInSource(offsetInSource)
+        , m_info(info)
+        , m_instance(instance)
+    {
+    }
+
+    std::expected<uint64_t, String> run(std::span<const uint8_t> bytes)
+    {
+        Vector<ConstExprValue, 16> stack;
+        auto pop = [&] ALWAYS_INLINE_LAMBDA {
+            ASSERT(!stack.isEmpty());
+            return stack.takeLast();
+        };
+        // Immediates are decoded without the length and overflow checks WTF::LEBDecoder makes,
+        // because validation already accepted them. Most are a single byte.
+        size_t offset = 0;
+        auto varUInt32 = [&] ALWAYS_INLINE_LAMBDA -> uint32_t {
+            uint8_t byte = bytes[offset++];
+            if (!(byte & 0x80)) [[likely]]
+                return byte;
+            uint32_t value = byte & 0x7f;
+            unsigned shift = 7;
+            do {
+                byte = bytes[offset++];
+                value |= static_cast<uint32_t>(byte & 0x7f) << shift;
+                shift += 7;
+            } while (byte & 0x80);
+            return value;
+        };
+        auto varInt64 = [&] ALWAYS_INLINE_LAMBDA -> int64_t {
+            uint8_t byte = bytes[offset++];
+            if (!(byte & 0x80)) [[likely]]
+                return static_cast<int8_t>(byte << 1) >> 1;
+            int64_t value = byte & 0x7f;
+            unsigned shift = 7;
+            do {
+                byte = bytes[offset++];
+                value |= static_cast<int64_t>(byte & 0x7f) << shift;
+                shift += 7;
+            } while (byte & 0x80);
+            if (shift < 64 && (byte & 0x40))
+                value |= -(static_cast<int64_t>(1) << shift);
+            return value;
+        };
+        auto varInt32 = [&] ALWAYS_INLINE_LAMBDA {
+            return static_cast<int32_t>(varInt64());
+        };
+        auto uint32 = [&] ALWAYS_INLINE_LAMBDA {
+            uint32_t value;
+            memcpySpan(asMutableByteSpan(value), bytes.subspan(offset, sizeof(value)));
+            offset += sizeof(value);
+            return value;
+        };
+        auto uint64 = [&] ALWAYS_INLINE_LAMBDA {
+            uint64_t value;
+            memcpySpan(asMutableByteSpan(value), bytes.subspan(offset, sizeof(value)));
+            offset += sizeof(value);
+            return value;
+        };
+
+        for (;;) {
+            ASSERT(offset < bytes.size());
+            OpType op = static_cast<OpType>(bytes[offset++]);
+            ConstExprValue result;
+
+            switch (op) {
+            case I32Const:
+                stack.append(ConstExprValue(static_cast<uint64_t>(varInt32())));
+                continue;
+            case I64Const:
+                stack.append(ConstExprValue(static_cast<uint64_t>(varInt64())));
+                continue;
+            case F32Const:
+                stack.append(ConstExprValue(static_cast<uint64_t>(uint32())));
+                continue;
+            case F64Const:
+                stack.append(ConstExprValue(uint64()));
+                continue;
+            case RefNull:
+                varInt32(); // Heap type, which only affects the static type of the null.
+                stack.append(ConstExprValue(static_cast<uint64_t>(JSValue::encode(jsNull()))));
+                continue;
+            case RefFunc:
+                result = refFunc(FunctionSpaceIndex(varUInt32()));
+                break;
+            case GetGlobal:
+                result = loadGlobal(varUInt32());
+                break;
+            case I32Add:
+            case I64Add: {
+                ConstExprValue rhs = pop();
+                result = pop() + rhs;
+                break;
+            }
+            case I32Sub:
+            case I64Sub: {
+                ConstExprValue rhs = pop();
+                result = pop() - rhs;
+                break;
+            }
+            case I32Mul:
+            case I64Mul: {
+                ConstExprValue rhs = pop();
+                result = pop() * rhs;
+                break;
+            }
+            case ExtSIMD: {
+                uint32_t extOp = varUInt32();
+                ASSERT_UNUSED(extOp, static_cast<ExtSIMDOpType>(extOp) == ExtSIMDOpType::V128Const);
+                v128_t vector;
+                memcpySpan(asMutableByteSpan(vector), bytes.subspan(offset, sizeof(vector)));
+                offset += sizeof(vector);
+                stack.append(ConstExprValue(vector));
+                continue;
+            }
+            case ExtGC: {
+                switch (static_cast<ExtGCOpType>(varUInt32())) {
+                case ExtGCOpType::RefI31:
+                    result = refI31(pop());
+                    break;
+                case ExtGCOpType::AnyConvertExtern:
+                    result = anyConvertExtern(pop());
+                    break;
+                case ExtGCOpType::ExternConvertAny:
+                    // extern.convert_any leaves the operand exactly as it is.
+                    continue;
+                case ExtGCOpType::StructNewDefault:
+                    result = createNewStruct(TypeSignatureIndex(varUInt32()));
+                    if (result.isInvalid()) [[unlikely]]
+                        return failedToAllocate("struct"_s, offset);
+                    break;
+                case ExtGCOpType::StructNew: {
+                    TypeSignatureIndex typeIndex(varUInt32());
+                    size_t fieldCount = m_info.rtt(typeIndex).fieldCount();
+                    ASSERT(stack.size() >= fieldCount);
+                    result = createNewStruct(typeIndex, stack.subspan(stack.size() - fieldCount));
+                    if (result.isInvalid()) [[unlikely]]
+                        return failedToAllocate("struct"_s, offset);
+                    stack.shrink(stack.size() - fieldCount);
+                    break;
+                }
+                case ExtGCOpType::ArrayNew: {
+                    TypeSignatureIndex typeIndex(varUInt32());
+                    // array.new pushes the element value before the size.
+                    ConstExprValue size = pop();
+                    ConstExprValue value = pop();
+                    result = createNewArray(typeIndex, static_cast<uint32_t>(size.getValue()), value);
+                    if (result.isInvalid()) [[unlikely]]
+                        return failedToAllocate("array"_s, offset);
+                    break;
+                }
+                case ExtGCOpType::ArrayNewDefault: {
+                    TypeSignatureIndex typeIndex(varUInt32());
+                    result = createNewDefaultArray(typeIndex, static_cast<uint32_t>(pop().getValue()));
+                    if (result.isInvalid()) [[unlikely]]
+                        return failedToAllocate("array"_s, offset);
+                    break;
+                }
+                case ExtGCOpType::ArrayNewFixed: {
+                    TypeSignatureIndex typeIndex(varUInt32());
+                    size_t elementCount = varUInt32();
+                    ASSERT(stack.size() >= elementCount);
+                    result = createNewArray(typeIndex, stack.subspan(stack.size() - elementCount));
+                    if (result.isInvalid()) [[unlikely]]
+                        return failedToAllocate("array"_s, offset);
+                    stack.shrink(stack.size() - elementCount);
+                    break;
+                }
+                default:
+                    RELEASE_ASSERT_NOT_REACHED();
+                }
+                break;
+            }
+            case End:
+                ASSERT(stack.size() == 1);
+                ASSERT(stack.last().type() != ConstExprValue::Vector);
+                return stack.last().getValue();
+            default:
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+
+            stack.append(result);
+        }
+    }
+
+private:
     enum InvalidTag { InvalidConstExpr };
 
     // Represents values that a constant expression may evaluate to.
@@ -89,41 +273,41 @@ public:
             , m_bits(JSValue::encode(value))
         { }
 
-        bool NODELETE isInvalid()
+        bool NODELETE isInvalid() const
         {
             return m_type == ConstExprValueType::Invalid;
         }
 
-        uint64_t NODELETE getValue()
+        uint64_t NODELETE getValue() const
         {
             ASSERT(m_type == ConstExprValueType::Numeric || m_type == ConstExprValueType::Ref);
             return m_bits;
         }
 
-        v128_t NODELETE getVector()
+        v128_t NODELETE getVector() const
         {
             ASSERT(m_type == ConstExprValueType::Vector);
             return m_vector;
         }
 
-        ConstExprValueType NODELETE type()
+        ConstExprValueType NODELETE type() const
         {
             return m_type;
         }
 
-        ConstExprValue NODELETE operator+(ConstExprValue value)
+        ConstExprValue NODELETE operator+(ConstExprValue value) const
         {
             ASSERT(m_type == ConstExprValueType::Numeric);
             return ConstExprValue(m_bits + value.getValue());
         }
 
-        ConstExprValue NODELETE operator-(ConstExprValue value)
+        ConstExprValue NODELETE operator-(ConstExprValue value) const
         {
             ASSERT(m_type == ConstExprValueType::Numeric);
             return ConstExprValue(m_bits - value.getValue());
         }
 
-        ConstExprValue NODELETE operator*(ConstExprValue value)
+        ConstExprValue NODELETE operator*(ConstExprValue value) const
         {
             ASSERT(m_type == ConstExprValueType::Numeric);
             return ConstExprValue(m_bits * value.getValue());
@@ -137,7 +321,139 @@ public:
         };
     };
 
-    using ExpressionType = ConstExprValue;
+    // Allocation is the only way evaluation can fail. The offset is passed in so that the message
+    // names the same byte position the module parser would have reported.
+    [[nodiscard]] NEVER_INLINE UnexpectedResult failedToAllocate(ASCIILiteral kind, size_t offset) const
+    {
+        return UnexpectedResult(makeString("WebAssembly.Module doesn't parse at byte "_s, String::number(m_offsetInSource + offset), ": Failed to allocate new "_s, kind));
+    }
+
+    ConstExprValue loadGlobal(uint32_t index)
+    {
+        if (m_info.globals[index].type.kind() == TypeKind::V128)
+            return ConstExprValue(m_instance->loadV128Global(index));
+        return ConstExprValue(m_instance->loadI64Global(index));
+    }
+
+    ConstExprValue refFunc(FunctionSpaceIndex index)
+    {
+        JSValue wrapper = m_instance->ensureFunctionWrapper(index);
+        ASSERT(!wrapper.isNull());
+        ASSERT(wrapper.isObject());
+        m_keepAlive.appendWithCrashOnOverflow(asObject(wrapper));
+        return ConstExprValue(wrapper);
+    }
+
+    ConstExprValue refI31(ConstExprValue value)
+    {
+        JSValue i31 = JSValue((((static_cast<int32_t>(value.getValue()) & 0x7fffffff) << 1) >> 1));
+        ASSERT(i31.isInt32());
+        return ConstExprValue(i31);
+    }
+
+    ConstExprValue anyConvertExtern(ConstExprValue reference)
+    {
+        // extern.internalize only rewrites doubles that fit an i31, so anything already known to be
+        // an object reference passes through unchanged, and reusing it avoids a second keep-alive
+        // entry for the same object.
+        if (reference.type() == ConstExprValue::Numeric)
+            return ConstExprValue(externInternalize(reference.getValue()));
+        return reference;
+    }
+
+    // The allocating operations return an invalid value rather than an error, so that run() reports
+    // the failure at the byte offset of the operation it is currently evaluating.
+    ConstExprValue trackAllocation(JSValue result)
+    {
+        if (result.isNull()) [[unlikely]]
+            return ConstExprValue(InvalidConstExpr);
+        m_keepAlive.appendWithCrashOnOverflow(asObject(result));
+        return ConstExprValue(result);
+    }
+
+    ConstExprValue createNewArray(WebAssemblyGCStructure* structure, uint32_t size, ConstExprValue value)
+    {
+        if (value.type() == ConstExprValue::Vector)
+            return trackAllocation(arrayNew(m_instance, structure, size, value.getVector()));
+        return trackAllocation(arrayNew(m_instance, structure, size, value.getValue()));
+    }
+
+    ConstExprValue createNewArray(TypeSignatureIndex typeIndex, uint32_t size, ConstExprValue value)
+    {
+        return createNewArray(m_instance->gcObjectStructure(typeIndex.rawIndex()), size, value);
+    }
+
+    ConstExprValue createNewDefaultArray(TypeSignatureIndex typeIndex, uint32_t size)
+    {
+        auto* structure = m_instance->gcObjectStructure(typeIndex.rawIndex());
+        auto elementType = structure->rtt().elementType().type.unpacked();
+        ConstExprValue initValue { };
+        if (isRefType(elementType))
+            initValue = { static_cast<uint64_t>(JSValue::encode(jsNull())) };
+        if (elementType == Wasm::Types::V128)
+            initValue = { vectorAllZeros() };
+        return createNewArray(structure, size, initValue);
+    }
+
+    ConstExprValue createNewArray(TypeSignatureIndex typeIndex, std::span<const ConstExprValue> elements)
+    {
+        auto* structure = m_instance->gcObjectStructure(typeIndex.rawIndex());
+        bool isV128 = structure->rtt().elementType().type.unpacked().isV128();
+        ConstExprValue result = createNewArray(structure, elements.size(), isV128 ? ConstExprValue(vectorAllZeros()) : ConstExprValue());
+        if (result.isInvalid()) [[unlikely]]
+            return result;
+
+        JSWebAssemblyArray* array = uncheckedDowncast<JSWebAssemblyArray>(JSValue::decode(result.getValue()));
+        VM& vm = array->vm();
+        for (size_t i = 0; i < elements.size(); ++i) {
+            if (isV128)
+                array->set(vm, i, elements[i].getVector());
+            else
+                array->set(vm, i, elements[i].getValue());
+        }
+        return result;
+    }
+
+    ConstExprValue createNewStruct(TypeSignatureIndex typeIndex)
+    {
+        auto* structure = m_instance->gcObjectStructure(typeIndex.rawIndex());
+        return trackAllocation(structNew(m_instance, structure, static_cast<bool>(UseDefaultValue::Yes), nullptr));
+    }
+
+    ConstExprValue createNewStruct(TypeSignatureIndex typeIndex, std::span<const ConstExprValue> fields)
+    {
+        ConstExprValue result = createNewStruct(typeIndex);
+        if (result.isInvalid()) [[unlikely]]
+            return result;
+
+        JSWebAssemblyStruct* structObject = uncheckedDowncast<JSWebAssemblyStruct>(JSValue::decode(result.getValue()));
+        for (size_t i = 0; i < fields.size(); ++i) {
+            if (fields[i].type() == ConstExprValue::Vector)
+                structObject->set(i, fields[i].getVector());
+            else
+                structObject->set(i, fields[i].getValue());
+        }
+        return result;
+    }
+
+    const size_t m_offsetInSource;
+    const ModuleInformation& m_info;
+    JSWebAssemblyInstance* const m_instance;
+    MarkedArgumentBufferWithSize<16> m_keepAlive;
+};
+
+class ConstExprGenerator {
+    WTF_FORBID_HEAP_ALLOCATION;
+public:
+    using ErrorType = String;
+    using PartialResult = std::expected<void, ErrorType>;
+    using UnexpectedResult = std::unexpected<ErrorType>;
+    using CallType = CallLinkInfo::CallType;
+
+    // Validation only type checks the expression, so no value ever flows through the parser.
+    // Evaluation is ConstExprInterpreter, which walks the same bytes without the parser.
+    struct ExpressionType { };
+
     using ResultList = Vector<ExpressionType, 8>;
 
     // Structured blocks should not appear in the constant expression except
@@ -173,11 +489,6 @@ public:
     using CatchHandler = FunctionParser<ConstExprGenerator>::CatchHandler;
     using ArgumentList = FunctionParser<ConstExprGenerator>::ArgumentList;
 
-    enum class Mode : uint8_t {
-        Validate,
-        Evaluate
-    };
-
     static constexpr bool shouldFuseBranchCompare = false;
     static constexpr bool NODELETE tierSupportsSIMD() { return true; }
     static constexpr bool validateFunctionBodySize = false;
@@ -188,7 +499,8 @@ protected:
     [[nodiscard]] NEVER_INLINE UnexpectedResult fail(Args... args) const
     {
         using namespace FailureHelper; // See ADL comment in WasmParser.h.
-        return UnexpectedResult(makeString("WebAssembly.Module doesn't parse at byte "_s, String::number(m_parser->offset() + m_offsetInSource), ": "_s, makeString(args)...));
+        size_t offset = m_offsetInSource + m_parser->offset();
+        return UnexpectedResult(makeString("WebAssembly.Module doesn't parse at byte "_s, String::number(offset), ": "_s, makeString(args)...));
     }
 #define WASM_COMPILE_FAIL_IF(condition, ...) do { \
         if (condition) [[unlikely]]                  \
@@ -196,55 +508,18 @@ protected:
     } while (0)
 
 public:
-    ConstExprGenerator(Mode mode, size_t offsetInSource, const ModuleInformation& info)
-        : m_mode(mode)
-        , m_offsetInSource(offsetInSource)
+    ConstExprGenerator(size_t offsetInSource, const ModuleInformation& info)
+        : m_offsetInSource(offsetInSource)
         , m_info(info)
     {
-        ASSERT(mode == Mode::Validate);
     }
 
-    ConstExprGenerator(Mode mode, size_t offsetInSource, const ModuleInformation& info, JSWebAssemblyInstance* instance)
-        : m_mode(mode)
-        , m_offsetInSource(offsetInSource)
-        , m_info(info)
-        , m_instance(instance)
-    {
-        ASSERT(mode == Mode::Evaluate);
-    }
-
-    ExpressionType NODELETE result() const { return m_result; }
     const Vector<FunctionSpaceIndex>& NODELETE declaredFunctions() const { return m_declaredFunctions; }
     void NODELETE setParser(FunctionParser<ConstExprGenerator>* parser) { m_parser = parser; };
 
     bool NODELETE addArguments(const RTT&) { RELEASE_ASSERT_NOT_REACHED(); }
 
-    ExpressionType NODELETE addConstant(Type type, uint64_t value)
-    {
-        switch (type.kind()) {
-        case TypeKind::I32:
-        case TypeKind::I64:
-        case TypeKind::F32:
-        case TypeKind::F64:
-            return ConstExprValue(value);
-        case TypeKind::Ref:
-        case TypeKind::RefNull:
-        case TypeKind::Structref:
-        case TypeKind::Arrayref:
-        case TypeKind::Funcref:
-        case TypeKind::Exnref:
-        case TypeKind::Externref:
-        case TypeKind::Eqref:
-        case TypeKind::Anyref:
-        case TypeKind::Noexnref:
-        case TypeKind::Noneref:
-        case TypeKind::Nofuncref:
-        case TypeKind::Noexternref:
-            return ConstExprValue(JSValue::encode(jsNull()));
-        default:
-            RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unimplemented constant type.\n");
-        }
-    }
+    ExpressionType NODELETE addConstant(Type, uint64_t) { return { }; }
 
 #define CONST_EXPR_STUB { return fail("Invalid instruction for constant expression"); }
 
@@ -262,18 +537,11 @@ public:
     [[nodiscard]] PartialResult setLocal(uint32_t, ExpressionType) CONST_EXPR_STUB
     [[nodiscard]] PartialResult teeLocal(uint32_t, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
-    [[nodiscard]] PartialResult getGlobal(uint32_t index, ExpressionType& result)
+    [[nodiscard]] PartialResult getGlobal(uint32_t index, ExpressionType&)
     {
         // Note that this check works for table initializers too, because no globals are registered when the table section is read and the count is 0.
         WASM_COMPILE_FAIL_IF(index >= m_info->globals.size(), "get_global's index ", index, " exceeds the number of globals ", m_info->globals.size());
         WASM_COMPILE_FAIL_IF(m_info->globals[index].mutability != Mutability::Immutable, "get_global import kind index ", index, " is mutable ");
-
-        if (m_mode == Mode::Evaluate) {
-            if (m_info->globals[index].type.kind() == TypeKind::V128)
-                result = ConstExprValue(m_instance->loadV128Global(index));
-            else
-                result = ConstExprValue(m_instance->loadI64Global(index));
-        }
 
         return { };
     }
@@ -301,80 +569,26 @@ public:
     [[nodiscard]] PartialResult addI64MulWideS(ExpressionType, ExpressionType, ExpressionType&, ExpressionType&) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addI64MulWideU(ExpressionType, ExpressionType, ExpressionType&, ExpressionType&) CONST_EXPR_STUB
 
-    [[nodiscard]] PartialResult addRefI31(ExpressionType value, ExpressionType& result)
+    [[nodiscard]] PartialResult addRefI31(ExpressionType, ExpressionType&)
     {
-        if (m_mode == Mode::Evaluate) {
-            JSValue i31 = JSValue((((static_cast<int32_t>(value.getValue()) & 0x7fffffff) << 1) >> 1));
-            ASSERT(i31.isInt32());
-            result = ConstExprValue(i31);
-        }
         return { };
     }
 
     [[nodiscard]] PartialResult addI31GetS(ExpressionType, ExpressionType&) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addI31GetU(ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
-    ExpressionType createNewArray(WebAssemblyGCStructure* structure, uint32_t size, ExpressionType value)
+    [[nodiscard]] PartialResult addArrayNew(TypeSignatureIndex, ExpressionType, ExpressionType, ExpressionType&)
     {
-        JSValue result;
-        if (value.type() == ConstExprValue::Vector)
-            result = arrayNew(m_instance, structure, size, value.getVector());
-        else
-            result = arrayNew(m_instance, structure, size, value.getValue());
-        if (result.isNull()) [[unlikely]]
-            return ConstExprValue(InvalidConstExpr);
-        m_keepAlive.appendWithCrashOnOverflow(asObject(result));
-        return ConstExprValue(result);
-    }
-
-    [[nodiscard]] PartialResult addArrayNew(TypeSignatureIndex typeIndex, ExpressionType size, ExpressionType value, ExpressionType& result)
-    {
-        if (m_mode == Mode::Evaluate) {
-            auto* structure = m_instance->gcObjectStructure(typeIndex.rawIndex());
-            result = createNewArray(structure, static_cast<uint32_t>(size.getValue()), value);
-            WASM_ALLOCATOR_FAIL_IF(result.isInvalid(), "Failed to allocate new array"_s);
-        }
         return { };
     }
 
-    [[nodiscard]] PartialResult addArrayNewDefault(TypeSignatureIndex typeIndex, ExpressionType size, ExpressionType& result)
+    [[nodiscard]] PartialResult addArrayNewDefault(TypeSignatureIndex, ExpressionType, ExpressionType&)
     {
-        if (m_mode == Mode::Evaluate) {
-            auto* structure = m_instance->gcObjectStructure(typeIndex.rawIndex());
-            const Wasm::RTT& arraySignature = structure->rtt();
-            auto elementType = arraySignature.elementType().type.unpacked();
-            ExpressionType initValue { };
-            if (isRefType(elementType))
-                initValue = { static_cast<uint64_t>(JSValue::encode(jsNull())) };
-            if (elementType == Wasm::Types::V128)
-                initValue = { vectorAllZeros() };
-            result = createNewArray(structure, static_cast<uint32_t>(size.getValue()), initValue);
-            WASM_ALLOCATOR_FAIL_IF(result.isInvalid(), "Failed to allocate new array"_s);
-        }
-
         return { };
     }
 
-    [[nodiscard]] PartialResult addArrayNewFixed(TypeSignatureIndex typeIndex, ArgumentList& args, ExpressionType& result)
+    [[nodiscard]] PartialResult addArrayNewFixed(TypeSignatureIndex, ArgumentList&, ExpressionType&)
     {
-        if (m_mode == Mode::Evaluate) {
-            auto* structure = m_instance->gcObjectStructure(typeIndex.rawIndex());
-            const Wasm::RTT& arraySignature = structure->rtt();
-            if (arraySignature.elementType().type.unpacked().isV128()) {
-                result = createNewArray(structure, args.size(), { vectorAllZeros() });
-                WASM_ALLOCATOR_FAIL_IF(result.isInvalid(), "Failed to allocate new array"_s);
-                JSWebAssemblyArray* arrayObject = uncheckedDowncast<JSWebAssemblyArray>(JSValue::decode(result.getValue()));
-                for (size_t i = 0; i < args.size(); i++)
-                    arrayObject->set(arrayObject->vm(), i, args[i].value().getVector());
-            } else {
-                result = createNewArray(structure, args.size(), { });
-                WASM_ALLOCATOR_FAIL_IF(result.isInvalid(), "Failed to allocate new array"_s);
-                JSWebAssemblyArray* arrayObject = uncheckedDowncast<JSWebAssemblyArray>(JSValue::decode(result.getValue()));
-                for (size_t i = 0; i < args.size(); i++)
-                    arrayObject->set(arrayObject->vm(), i, args[i].value().getValue());
-            }
-        }
-
         return { };
     }
 
@@ -388,40 +602,13 @@ public:
     [[nodiscard]] PartialResult addArrayInitElem(TypeSignatureIndex, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType) CONST_EXPR_STUB;
     [[nodiscard]] PartialResult addArrayInitData(TypeSignatureIndex, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType) CONST_EXPR_STUB;
 
-    ExpressionType createNewStruct(TypeSignatureIndex typeIndex)
+    [[nodiscard]] PartialResult addStructNewDefault(TypeSignatureIndex, ExpressionType&)
     {
-        auto* structure = m_instance->gcObjectStructure(typeIndex.rawIndex());
-        JSValue result = structNew(m_instance, structure, static_cast<bool>(UseDefaultValue::Yes), nullptr);
-        if (result.isNull()) [[unlikely]]
-            return ConstExprValue(InvalidConstExpr);
-        m_keepAlive.appendWithCrashOnOverflow(asObject(result));
-        return ConstExprValue(result);
-    }
-
-    [[nodiscard]] PartialResult addStructNewDefault(TypeSignatureIndex typeIndex, ExpressionType& result)
-    {
-        if (m_mode == Mode::Evaluate) {
-            result = createNewStruct(typeIndex);
-            WASM_ALLOCATOR_FAIL_IF(result.isInvalid(), "Failed to allocate new struct"_s);
-        }
-
         return { };
     }
 
-    [[nodiscard]] PartialResult addStructNew(TypeSignatureIndex typeIndex, ArgumentList& args, ExpressionType& result)
+    [[nodiscard]] PartialResult addStructNew(TypeSignatureIndex, ArgumentList&, ExpressionType&)
     {
-        if (m_mode == Mode::Evaluate) {
-            result = createNewStruct(typeIndex);
-            WASM_ALLOCATOR_FAIL_IF(result.isInvalid(), "Failed to allocate new struct"_s);
-            JSWebAssemblyStruct* structObject = uncheckedDowncast<JSWebAssemblyStruct>(JSValue::decode(result.getValue()));
-            for (size_t i = 0; i < args.size(); i++) {
-                if (args[i].value().type() == ConstExprValue::Vector)
-                    structObject->set(i, args[i].value().getVector());
-                else
-                    structObject->set(i, args[i].value().getValue());
-            }
-        }
-
         return { };
     }
 
@@ -430,72 +617,50 @@ public:
     [[nodiscard]] PartialResult addRefTest(ExpressionType, bool, int32_t, bool, ExpressionType&) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addRefCast(ExpressionType, bool, int32_t, ExpressionType&) CONST_EXPR_STUB
 
-    [[nodiscard]] PartialResult addAnyConvertExtern(ExpressionType reference, ExpressionType& result)
+    [[nodiscard]] PartialResult addAnyConvertExtern(ExpressionType, ExpressionType&)
     {
-        if (m_mode == Mode::Evaluate) {
-            if (reference.type() == ConstExprValue::Numeric)
-                result = ConstExprValue(externInternalize(reference.getValue()));
-            else
-                // To avoid creating a new Strong handle, we pass the original reference.
-                // This is valid because we know extern.internalize is a no-op on object
-                // references, but if this changes in the future this will need to change.
-                result = reference;
-        }
         return { };
     }
 
-    [[nodiscard]] PartialResult addExternConvertAny(ExpressionType reference, ExpressionType& result)
+    [[nodiscard]] PartialResult addExternConvertAny(ExpressionType, ExpressionType&)
     {
-        result = reference;
         return { };
     }
 
     [[nodiscard]] PartialResult addSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
-    [[nodiscard]] PartialResult addI32Add(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    [[nodiscard]] PartialResult addI32Add(ExpressionType, ExpressionType, ExpressionType&)
     {
-        if (m_mode == Mode::Evaluate)
-            result = lhs + rhs;
         return { };
     }
-    [[nodiscard]] PartialResult addI64Add(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    [[nodiscard]] PartialResult addI64Add(ExpressionType, ExpressionType, ExpressionType&)
     {
-        if (m_mode == Mode::Evaluate)
-            result = lhs + rhs;
         return { };
     }
 
     [[nodiscard]] PartialResult addF32Add(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addF64Add(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
-    [[nodiscard]] PartialResult addI32Sub(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    [[nodiscard]] PartialResult addI32Sub(ExpressionType, ExpressionType, ExpressionType&)
     {
-        if (m_mode == Mode::Evaluate)
-            result = lhs - rhs;
         return { };
     }
 
-    [[nodiscard]] PartialResult addI64Sub(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    [[nodiscard]] PartialResult addI64Sub(ExpressionType, ExpressionType, ExpressionType&)
     {
-        if (m_mode == Mode::Evaluate)
-            result = lhs - rhs;
         return { };
     }
 
     [[nodiscard]] PartialResult addF32Sub(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addF64Sub(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
-    [[nodiscard]] PartialResult addI32Mul(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    [[nodiscard]] PartialResult addI32Mul(ExpressionType, ExpressionType, ExpressionType&)
     {
-        if (m_mode == Mode::Evaluate)
-            result = lhs * rhs;
         return { };
     }
 
-    [[nodiscard]] PartialResult addI64Mul(ExpressionType lhs, ExpressionType rhs, ExpressionType& result)
+    [[nodiscard]] PartialResult addI64Mul(ExpressionType, ExpressionType, ExpressionType&)
     {
-        if (m_mode == Mode::Evaluate)
-            result = lhs * rhs;
         return { };
     }
 
@@ -621,17 +786,9 @@ public:
     [[nodiscard]] PartialResult addRefAsNonNull(ExpressionType, ExpressionType&) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addRefEq(ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
 
-    [[nodiscard]] PartialResult addRefFunc(FunctionSpaceIndex index, ExpressionType& result)
+    [[nodiscard]] PartialResult addRefFunc(FunctionSpaceIndex index, ExpressionType&)
     {
-        if (m_mode == Mode::Evaluate) {
-            JSValue wrapper = m_instance->ensureFunctionWrapper(index);
-            ASSERT(!wrapper.isNull());
-            ASSERT(wrapper.isObject());
-            m_keepAlive.appendWithCrashOnOverflow(asObject(wrapper));
-            result = ConstExprValue(wrapper);
-        } else
-            m_declaredFunctions.append(index);
-
+        m_declaredFunctions.append(index);
         return { };
     }
 
@@ -668,9 +825,8 @@ public:
 
     [[nodiscard]] PartialResult endBlock(ControlEntry& entry, std::span<TypedExpression> enclosedStack)
     {
-        ASSERT(enclosedStack.size() == 1);
+        ASSERT_UNUSED(enclosedStack, enclosedStack.size() == 1);
         ASSERT_UNUSED(entry, ControlType::isTopLevel(entry.controlData));
-        m_result = enclosedStack.front().value();
         return { };
     }
 
@@ -703,11 +859,9 @@ public:
     [[nodiscard]] PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint64_t, uint8_t, uint8_t) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint64_t, ExpressionType&, uint8_t) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint64_t, ExpressionType&, uint8_t) CONST_EXPR_STUB
-    [[nodiscard]] ExpressionType NODELETE addSIMDConstant(v128_t vector)
+    [[nodiscard]] ExpressionType NODELETE addSIMDConstant(v128_t)
     {
         RELEASE_ASSERT(Options::useWasmSIMD());
-        if (m_mode == Mode::Evaluate)
-            return ConstExprValue(vector);
         return { };
     }
     [[nodiscard]] PartialResult addSIMDExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&) CONST_EXPR_STUB
@@ -731,21 +885,18 @@ public:
     void NODELETE didFinishParsingLocals() { }
     void NODELETE didPopValueFromStack(ExpressionType, ASCIILiteral) { }
 
+
 private:
     FunctionParser<ConstExprGenerator>* m_parser { nullptr };
-    Mode m_mode;
     size_t m_offsetInSource { 0 };
-    ExpressionType m_result;
     const Ref<const ModuleInformation> m_info;
-    JSWebAssemblyInstance* m_instance { nullptr };
     bool m_shouldError = false;
     Vector<FunctionSpaceIndex> m_declaredFunctions;
-    MarkedArgumentBufferWithSize<16> m_keepAlive;
 };
 
 std::expected<void, String> parseExtendedConstExpr(std::span<const uint8_t> source, size_t offsetInSource, size_t& offset, ModuleInformation& info, Type expectedType)
 {
-    ConstExprGenerator generator(ConstExprGenerator::Mode::Validate, offsetInSource, info);
+    ConstExprGenerator generator(offsetInSource, info);
     FunctionParser<ConstExprGenerator> parser(generator, source, BlockSignature { expectedType }, info);
     WASM_FAIL_IF_HELPER_FAILS(parser.parseConstantExpression());
     offset = parser.offset();
@@ -756,17 +907,10 @@ std::expected<void, String> parseExtendedConstExpr(std::span<const uint8_t> sour
     return { };
 }
 
-std::expected<uint64_t, String> evaluateExtendedConstExpr(const ModuleInformation::ConstantExpressionAndSourceOffset& constantExpressionAndSourceOffset, JSWebAssemblyInstance* instance, const ModuleInformation& info, Type expectedType)
+std::expected<uint64_t, String> evaluateExtendedConstExpr(const ModuleInformation::ConstantExpressionAndSourceOffset& constantExpressionAndSourceOffset, JSWebAssemblyInstance* instance, const ModuleInformation& info)
 {
-    size_t offsetInSource = constantExpressionAndSourceOffset.second;
-    ConstExprGenerator generator(ConstExprGenerator::Mode::Evaluate, offsetInSource, info, instance);
-    FunctionParser<ConstExprGenerator> parser(generator, constantExpressionAndSourceOffset.first.span(), BlockSignature { expectedType }, info);
-    WASM_FAIL_IF_HELPER_FAILS(parser.parseConstantExpression());
-
-    ConstExprGenerator::ExpressionType result = generator.result();
-    ASSERT(result.type() != ConstExprGenerator::ExpressionType::Vector);
-
-    return { result.getValue() };
+    ConstExprInterpreter interpreter(constantExpressionAndSourceOffset.second, info, instance);
+    return interpreter.run(constantExpressionAndSourceOffset.first.span());
 }
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.h
@@ -36,7 +36,7 @@ class JSWebAssemblyInstance;
 namespace Wasm {
 
 std::expected<void, String> parseExtendedConstExpr(std::span<const uint8_t>, size_t, size_t&, ModuleInformation&, Type);
-std::expected<uint64_t, String> evaluateExtendedConstExpr(const ModuleInformation::ConstantExpressionAndSourceOffset&, JSWebAssemblyInstance*, const ModuleInformation&, Type);
+std::expected<uint64_t, String> evaluateExtendedConstExpr(const ModuleInformation::ConstantExpressionAndSourceOffset&, JSWebAssemblyInstance*, const ModuleInformation&);
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -760,23 +760,23 @@ void JSWebAssemblyInstance::copyElementSegment(JSWebAssemblyArray* array, const 
     }
 }
 
-std::expected<uint64_t, String> JSWebAssemblyInstance::evaluateConstantExpression(uint64_t constantExpressionIndex, Type expectedType)
+std::expected<uint64_t, String> JSWebAssemblyInstance::evaluateConstantExpression(uint64_t constantExpressionIndex)
 {
     const auto& constantExpression = m_moduleInformation->constantExpressions[constantExpressionIndex];
-    return evaluateExtendedConstExpr(constantExpression, this, m_moduleInformation.get(), expectedType);
+    return evaluateExtendedConstExpr(constantExpression, this, m_moduleInformation.get());
 }
 
 bool JSWebAssemblyInstance::ensureConstantExpressionValue(uint64_t constantExpressionIndex, Type expectedType, uint64_t& result)
 {
     // The memo is scanned by the GC as a JSValue, so only reference-typed results may go in it.
-    ASSERT(isRefType(expectedType));
+    ASSERT_UNUSED(expectedType, isRefType(expectedType));
 
     if (auto found = m_constantExpressionValues.getOptional(constantExpressionIndex)) {
         result = JSValue::encode(found.value().get());
         return true;
     }
 
-    auto evalResult = evaluateConstantExpression(constantExpressionIndex, expectedType);
+    auto evalResult = evaluateConstantExpression(constantExpressionIndex);
     if (!evalResult.has_value()) [[unlikely]]
         return false;
     result = evalResult.value();

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -197,7 +197,7 @@ public:
     bool copyDataSegment(JSWebAssemblyArray*, uint32_t segmentIndex, uint32_t offset, uint32_t lengthInBytes, uint8_t* values);
     void copyElementSegment(JSWebAssemblyArray*, const Wasm::Element& segment, uint32_t srcOffset, uint32_t length, uint64_t* values);
 
-    std::expected<uint64_t, String> evaluateConstantExpression(uint64_t constantExpressionIndex, Wasm::Type expectedType);
+    std::expected<uint64_t, String> evaluateConstantExpression(uint64_t constantExpressionIndex);
 
     bool isImportFunction(uint32_t functionIndex) const
     {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -604,7 +604,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
             case Wasm::TableInformation::FromExtendedExpression: {
                 ASSERT(initialBitsOrImportNumber < moduleInformation.constantExpressions.size());
                 uint64_t constantExpressionIndex = initialBitsOrImportNumber;
-                evaluateConstantExpression(globalObject, constantExpressionIndex, moduleInformation.tables[i].wasmType(), initialBitsOrImportNumber);
+                evaluateConstantExpression(globalObject, constantExpressionIndex, initialBitsOrImportNumber);
                 RETURN_IF_EXCEPTION(scope, void());
                 break;
             }
@@ -666,7 +666,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
                 initialBits = JSValue::encode(m_instance->ensureFunctionWrapper(functionSpaceIndex));
             } else if (global.initializationType == Wasm::GlobalInformation::FromExtendedExpression) {
                 ASSERT(global.initialBits.initialBitsOrImportNumber < moduleInformation.constantExpressions.size());
-                evaluateConstantExpression(globalObject, global.initialBits.initialBitsOrImportNumber, global.type, initialBits);
+                evaluateConstantExpression(globalObject, global.initialBits.initialBitsOrImportNumber, initialBits);
                 RETURN_IF_EXCEPTION(scope, void());
             } else
                 initialBits = global.initialBits.initialBitsOrImportNumber;
@@ -831,12 +831,12 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
     }
 }
 
-JSValue WebAssemblyModuleRecord::evaluateConstantExpression(JSGlobalObject* globalObject, uint64_t constantExpressionIndex, Wasm::Type expectedType, uint64_t& result)
+JSValue WebAssemblyModuleRecord::evaluateConstantExpression(JSGlobalObject* globalObject, uint64_t constantExpressionIndex, uint64_t& result)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto evalResult = m_instance->evaluateConstantExpression(constantExpressionIndex, expectedType);
+    auto evalResult = m_instance->evaluateConstantExpression(constantExpressionIndex);
     if (!evalResult.has_value()) [[unlikely]]
         return JSValue(throwException(globalObject, scope, createJSWebAssemblyRuntimeError(globalObject, vm, makeString("couldn't evaluate constant expression: "_s, evalResult.error()))));
 
@@ -890,7 +890,7 @@ JSValue WebAssemblyModuleRecord::evaluate(JSGlobalObject* globalObject)
                     elementIndex = static_cast<uint32_t>(offset.constValue());
             } else {
                 uint64_t result;
-                evaluateConstantExpression(globalObject, offset.constantExpressionIndex(), isTable64 ? Wasm::Types::I64 : Wasm::Types::I32, result);
+                evaluateConstantExpression(globalObject, offset.constantExpressionIndex(), result);
                 RETURN_IF_EXCEPTION(scope, void());
                 elementIndex = isTable64 ? result : static_cast<uint32_t>(result);
             }
@@ -926,7 +926,7 @@ JSValue WebAssemblyModuleRecord::evaluate(JSGlobalObject* globalObject)
                     offset = static_cast<uint32_t>(segment->offsetIfActive()->constValue());
             } else {
                 uint64_t result;
-                evaluateConstantExpression(globalObject, segment->offsetIfActive()->constantExpressionIndex(), isMemory64 ? Wasm::Types::I64 : Wasm::Types::I32, result);
+                evaluateConstantExpression(globalObject, segment->offsetIfActive()->constantExpressionIndex(), result);
                 RETURN_IF_EXCEPTION(scope, void());
                 offset = isMemory64 ? result : static_cast<uint32_t>(result);
             }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.h
@@ -76,7 +76,7 @@ private:
     WebAssemblyModuleRecord(VM&, Structure*, const Identifier&);
 
     void finishCreation(JSGlobalObject*, VM&, const Wasm::ModuleInformation&);
-    JSValue evaluateConstantExpression(JSGlobalObject*, uint64_t constantExpressionIndex, Wasm::Type, uint64_t&);
+    JSValue evaluateConstantExpression(JSGlobalObject*, uint64_t constantExpressionIndex, uint64_t&);
 
     WriteBarrier<JSWebAssemblyInstance> m_instance;
     WriteBarrier<JSObject> m_startFunction;


### PR DESCRIPTION
#### 23b9690343a3b05b81f169079c1a84d91c9eb08a
<pre>
[JSC] Split validation and evaluation of wasm constant expression
<a href="https://bugs.webkit.org/show_bug.cgi?id=323289">https://bugs.webkit.org/show_bug.cgi?id=323289</a>
<a href="https://rdar.apple.com/186541346">rdar://186541346</a>

Reviewed by Keith Miller.

Complex wasm binaries include significant amount of constant
expressions. For example, Dart-flute-todomvc-wasm&apos;s binary includes
4000~ constant expression, thus making it fast is critical for
performance.

This patch accelerates constant expression by splitting validator and interpreter.
Validator can run without any actual values and interpreter does not
need to have costly validation. Also since constant expressions are only
including straight forward wasm instructions, interpreter is just
reading and running the wasm instructions and even there is no control
flow instructions.

Now ConstExprGenerator is only validating the constant expressions.
Removing Value representation and removing m_mode as it is now
Validation only. Instead, we have ConstExprInterpreter which runs
constant expressions by reading the already validated wasm instruction span.

Tests: JSTests/wasm/gc/extended-const-expr-replay-simd.js
       JSTests/wasm/gc/extended-const-expr-replay.js

* JSTests/wasm/gc/extended-const-expr-replay-simd.js: Added.
* JSTests/wasm/gc/extended-const-expr-replay.js: Added.
(check):
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp:
(JSC::Wasm::ConstExprInterpreter::ConstExprInterpreter):
(JSC::Wasm::ConstExprInterpreter::run):
(JSC::Wasm::ConstExprInterpreter::ConstExprValue::isInvalid const):
(JSC::Wasm::ConstExprInterpreter::ConstExprValue::getValue const):
(JSC::Wasm::ConstExprInterpreter::ConstExprValue::getVector const):
(JSC::Wasm::ConstExprInterpreter::ConstExprValue::type const):
(JSC::Wasm::ConstExprInterpreter::ConstExprValue::operator+ const):
(JSC::Wasm::ConstExprInterpreter::ConstExprValue::operator- const):
(JSC::Wasm::ConstExprInterpreter::ConstExprValue::operator* const):
(JSC::Wasm::ConstExprInterpreter::failedToAllocate const):
(JSC::Wasm::ConstExprInterpreter::loadGlobal):
(JSC::Wasm::ConstExprInterpreter::refFunc):
(JSC::Wasm::ConstExprInterpreter::refI31):
(JSC::Wasm::ConstExprInterpreter::anyConvertExtern):
(JSC::Wasm::ConstExprInterpreter::trackAllocation):
(JSC::Wasm::ConstExprInterpreter::createNewArray):
(JSC::Wasm::ConstExprInterpreter::createNewDefaultArray):
(JSC::Wasm::ConstExprInterpreter::createNewStruct):
(JSC::Wasm::ConstExprGenerator::fail const):
(JSC::Wasm::ConstExprGenerator::ConstExprGenerator):
(JSC::Wasm::ConstExprGenerator::addConstant):
(JSC::Wasm::ConstExprGenerator::getGlobal):
(JSC::Wasm::ConstExprGenerator::addRefI31):
(JSC::Wasm::ConstExprGenerator::addArrayNew):
(JSC::Wasm::ConstExprGenerator::addArrayNewDefault):
(JSC::Wasm::ConstExprGenerator::addArrayNewFixed):
(JSC::Wasm::ConstExprGenerator::addStructNewDefault):
(JSC::Wasm::ConstExprGenerator::addStructNew):
(JSC::Wasm::ConstExprGenerator::addAnyConvertExtern):
(JSC::Wasm::ConstExprGenerator::addExternConvertAny):
(JSC::Wasm::ConstExprGenerator::addI32Add):
(JSC::Wasm::ConstExprGenerator::addI64Add):
(JSC::Wasm::ConstExprGenerator::addI32Sub):
(JSC::Wasm::ConstExprGenerator::addI64Sub):
(JSC::Wasm::ConstExprGenerator::addI32Mul):
(JSC::Wasm::ConstExprGenerator::addI64Mul):
(JSC::Wasm::ConstExprGenerator::addRefFunc):
(JSC::Wasm::ConstExprGenerator::endBlock):
(JSC::Wasm::ConstExprGenerator::addSIMDConstant):
(JSC::Wasm::parseExtendedConstExpr):
(JSC::Wasm::evaluateExtendedConstExpr):
(JSC::Wasm::ConstExprGenerator::ConstExprValue::ConstExprValue): Deleted.
(JSC::Wasm::ConstExprGenerator::ConstExprValue::isInvalid): Deleted.
(JSC::Wasm::ConstExprGenerator::ConstExprValue::getValue): Deleted.
(JSC::Wasm::ConstExprGenerator::ConstExprValue::getVector): Deleted.
(JSC::Wasm::ConstExprGenerator::ConstExprValue::type): Deleted.
(JSC::Wasm::ConstExprGenerator::ConstExprValue::operator+): Deleted.
(JSC::Wasm::ConstExprGenerator::ConstExprValue::operator-): Deleted.
(JSC::Wasm::ConstExprGenerator::ConstExprValue::operator*): Deleted.
(JSC::Wasm::ConstExprGenerator::result const): Deleted.
(JSC::Wasm::ConstExprGenerator::createNewArray): Deleted.
(JSC::Wasm::ConstExprGenerator::createNewStruct): Deleted.
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::evaluateConstantExpression):
(JSC::JSWebAssemblyInstance::ensureConstantExpressionValue):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeExports):
(JSC::WebAssemblyModuleRecord::evaluateConstantExpression):
(JSC::WebAssemblyModuleRecord::evaluate):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.h:

Canonical link: <a href="https://commits.webkit.org/320453@main">https://commits.webkit.org/320453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca9f9f4c0f67b5eb80996a724c61b9a35cf431f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148951 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6044bda9-1997-45cf-b651-dc62dcf177e7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144320 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100207 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d7f5a44e-6b16-4232-93f7-d0ad4f3b5dad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164925 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124603 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ec97e738-0bfb-42d5-b9c6-6d23135e6b16) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46701 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44841 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6564 "Found 1 new JSC stress test failure: Too many failures: 2103 jsc tests failed (failure)") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13411 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44475 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6076 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/45957 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51268 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196969 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58277 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153785 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58979 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153443 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28082 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47964 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131267 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127788 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57480 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19496 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56841 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57089 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56916 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->