### PR TITLE
WPT fetch/range/non-matching-range-response.html subtest is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/non-matching-range-response-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/non-matching-range-response-expected.txt
@@ -1,5 +1,5 @@
 
 PASS Range requests with no rewrites should succeed
 PASS Range response out of range of request should succeed
-FAIL Range requests ignored (200 status) should succeed assert_equals: expected "ok" but got "timeout"
+PASS Range requests ignored (200 status) should succeed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/resources/video-with-range.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/resources/video-with-range.py
@@ -18,14 +18,21 @@ def main(request, response):
         status = 206
     else:
         status = 200
+    response_range_overridden = False
     for rewrite in rewrites:
         req_start, req_end = rewrite['request']
         if start == req_start or req_start == '*':
             if end == req_end or req_end == '*':
                 if 'response' in rewrite:
                     start, end = rewrite['response']
+                    response_range_overridden = True
                 if 'status' in rewrite:
                     status = rewrite['status']
+
+    if status == 200 and not response_range_overridden:
+        # By default, a server ignoring the range request must return the entire resource.
+        start = None
+        end = None
 
     start = int(start or 0)
     end = int(end or total_size)


### PR DESCRIPTION
#### d955a8125a72bbab7e59684882ea03078b0748d9
<pre>
WPT fetch/range/non-matching-range-response.html subtest is failing
<a href="https://rdar.apple.com/186542248">rdar://186542248</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=323290">https://bugs.webkit.org/show_bug.cgi?id=323290</a>

Reviewed by Anne van Kesteren.

fetch/range/non-matching-range-response.html is using fetch/range/resources/video-with-range.py to serve media requests.
This server can in one case  answer range requests with a 200 response, but the response body would only contain the bytes specified by the range request.
This is inconsistent as a server answering a range request with 200 should ignore the requested range.

Cocoa WebKit media engine is making a first request with a byte 0-1 range.
A 200 response containing only two bytes is served and the media load fails as there is not enough data.

We fix this by changing the server so that, should it answers a range request with a 200 response, it provides the whole media content as the response body.

* LayoutTests/imported/w3c/web-platform-tests/fetch/range/non-matching-range-response-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/range/resources/video-with-range.py:
(main):

Canonical link: <a href="https://commits.webkit.org/320414@main">https://commits.webkit.org/320414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f85bf03f5004b25be6669d986381dcb47644e601

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148953 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144322 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100208 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124605 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46705 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157082 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44479 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6078 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49166 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196971 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58279 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153786 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41170 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58981 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153444 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47963 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127790 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57482 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19500 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56843 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57091 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56918 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->