### PR TITLE
Remove dead reportingObservers local in ReportingScope::notifyReportObservers()

### DIFF
--- a/Source/WebCore/Modules/reporting/ReportingScope.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingScope.cpp
@@ -93,8 +93,6 @@ void ReportingScope::notifyReportObservers(Ref<Report>&& report)
 {
     // https://www.w3.org/TR/reporting-1/#notify-observers
     // Step 4.2: Notify reporting observers on scope with report
-    size_t reportingObservers = m_reportingObservers.size();
-    UNUSED_VARIABLE(reportingObservers);
 
     // Step 4.2.1
     auto possibleReportObservers = copyToVector(m_reportingObservers);


### PR DESCRIPTION
#### f492fdc1e11419bcc5693266ceed6f518d9fef0c
<pre>
Remove dead reportingObservers local in ReportingScope::notifyReportObservers()
<a href="https://bugs.webkit.org/show_bug.cgi?id=323292">https://bugs.webkit.org/show_bug.cgi?id=323292</a>
<a href="https://rdar.apple.com/186543781">rdar://186543781</a>

Reviewed by Chris Dumez.

The reportingObservers local was computed and immediately discarded via
UNUSED_VARIABLE, serving no purpose. Remove it.

* Source/WebCore/Modules/reporting/ReportingScope.cpp:
(WebCore::ReportingScope::notifyReportObservers):

Canonical link: <a href="https://commits.webkit.org/320476@main">https://commits.webkit.org/320476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9009b6509707ca2ebed6878e4f03427a06933039

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195023 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148954 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c7cc8b84-807a-4a09-a9c2-131b7e15946e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186552 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58340 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144323 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100209 "Exiting early after 60 failures. 60 tests run. 60 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/806e02b0-721a-44ed-97ff-1b9ac790e27e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124606 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52779750-107a-4181-8c38-721708ec3935) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46702 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44842 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44476 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6079 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49165 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196972 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58280 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153787 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41219 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58982 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153445 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47965 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131270 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127796 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57483 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19497 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56844 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57092 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56919 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->