### PR TITLE
Simplify icon "purpose" parsing in ApplicationManifestParser

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
@@ -362,33 +362,28 @@ Vector<ApplicationManifest::Icon> ApplicationManifestParser::parseIcons(const JS
         auto purposeValue = iconJSON->getValue("purpose"_s);
         OptionSet<ApplicationManifest::Icon::Purpose> purposes;
 
-        if (!purposeValue) {
+        if (!purposeValue)
             purposes.add(ApplicationManifest::Icon::Purpose::Any);
-            currentIcon.purposes = purposes;
+        else if (auto purposeStringValue = purposeValue->asString(); !purposeStringValue) {
+            logManifestPropertyNotAString("purpose"_s);
+            purposes.add(ApplicationManifest::Icon::Purpose::Any);
         } else {
-            auto purposeStringValue = purposeValue->asString();
-            if (!purposeStringValue) {
-                logManifestPropertyNotAString("purpose"_s);
-                purposes.add(ApplicationManifest::Icon::Purpose::Any);
-                currentIcon.purposes = purposes;
-            } else {
-                for (auto keyword : StringView(purposeStringValue).trim(isASCIIWhitespace<char16_t>).splitAllowingEmptyEntries(' ')) {
-                    if (equalLettersIgnoringASCIICase(keyword, "monochrome"_s))
-                        purposes.add(ApplicationManifest::Icon::Purpose::Monochrome);
-                    else if (equalLettersIgnoringASCIICase(keyword, "maskable"_s))
-                        purposes.add(ApplicationManifest::Icon::Purpose::Maskable);
-                    else if (equalLettersIgnoringASCIICase(keyword, "any"_s))
-                        purposes.add(ApplicationManifest::Icon::Purpose::Any);
-                    else
-                        logDeveloperWarning(makeString("\""_s, purposeStringValue, "\" is not a valid purpose."_s));
-                }
-
-                if (purposes.isEmpty())
-                    continue;
-
-                currentIcon.purposes = purposes;
+            for (auto keyword : StringView(purposeStringValue).trim(isASCIIWhitespace<char16_t>).splitAllowingEmptyEntries(' ')) {
+                if (equalLettersIgnoringASCIICase(keyword, "monochrome"_s))
+                    purposes.add(ApplicationManifest::Icon::Purpose::Monochrome);
+                else if (equalLettersIgnoringASCIICase(keyword, "maskable"_s))
+                    purposes.add(ApplicationManifest::Icon::Purpose::Maskable);
+                else if (equalLettersIgnoringASCIICase(keyword, "any"_s))
+                    purposes.add(ApplicationManifest::Icon::Purpose::Any);
+                else
+                    logDeveloperWarning(makeString("\""_s, purposeStringValue, "\" is not a valid purpose."_s));
             }
+
+            if (purposes.isEmpty())
+                continue;
         }
+
+        currentIcon.purposes = purposes;
 
         imageResources.append(WTF::move(currentIcon));
     }


### PR DESCRIPTION
#### f8e5626fddd9625271f3eb084950be6ba42b74b1
<pre>
Simplify icon &quot;purpose&quot; parsing in ApplicationManifestParser
<a href="https://bugs.webkit.org/show_bug.cgi?id=323299">https://bugs.webkit.org/show_bug.cgi?id=323299</a>
<a href="https://rdar.apple.com/186547640">rdar://186547640</a>

Reviewed by Chris Dumez.

The three code paths handling an icon&apos;s &quot;purpose&quot; member each duplicated
the `currentIcon.purposes = purposes;` assignment, nested two levels deep.
Hoist that assignment to a single statement after the branches and flatten
the else-if chain. No behavior change: a missing or non-string &quot;purpose&quot;
still defaults to Any, valid keywords are still collected, and an icon whose
&quot;purpose&quot; contains no valid keywords is still dropped.

* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseIcons):

Canonical link: <a href="https://commits.webkit.org/320482@main">https://commits.webkit.org/320482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b9e0a61757455808777e551b381563b8688d6e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52442 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195030 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148961 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58347 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144329 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100214 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/47992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164940 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124612 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46714 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44848 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157085 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44488 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6086 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196979 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58287 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153794 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41224 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/58989 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41109 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153452 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47973 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131277 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127806 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57490 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19506 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56851 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57099 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56926 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->