### PR TITLE
[Safer CPP] Address more warnings in Source/WebKit reported by the newer static analysis

### DIFF
--- a/Source/WTF/wtf/OSObjectPtr.h
+++ b/Source/WTF/wtf/OSObjectPtr.h
@@ -199,6 +199,18 @@ template<typename T, typename RetainTraits> inline OSObjectPtr<T, RetainTraits> 
     return OSObjectPtr<T, RetainTraits> { typename OSObjectPtr<T, RetainTraits>::AdoptOSObject { }, WTF::move(ptr) };
 }
 
+template<typename T, typename RetainTraits>
+ALWAYS_INLINE CLANG_POINTER_CONVERSION OSObjectPtr<T, RetainTraits> protect(const OSObjectPtr<T, RetainTraits>& ptr)
+{
+    return ptr;
+}
+
+template<typename T, typename RetainTraits>
+OSObjectPtr<T, RetainTraits> protect(OSObjectPtr<T, RetainTraits>&&)
+{
+    static_assert(WTF::unreachableForType<T>, "Calling protect() on an rvalue is unnecessary; the caller already owns the value.");
+}
+
 template<typename T, typename U, typename RetainTraits>
 SUPPRESS_NODELETE ALWAYS_INLINE void NODELETE lazyInitialize(const OSObjectPtr<T, RetainTraits>& ptr, OSObjectPtr<U, RetainTraits>&& obj)
 {

--- a/Source/WebCore/Modules/permissions/PermissionController.h
+++ b/Source/WebCore/Modules/permissions/PermissionController.h
@@ -48,7 +48,7 @@ public:
     WEBCORE_EXPORT static void setSharedController(Ref<PermissionController>&&);
     
     virtual ~PermissionController() = default;
-    virtual void query(ClientOrigin&&, PermissionDescriptor, const WeakPtr<Page>&, PermissionQuerySource, CompletionHandler<void(std::optional<PermissionState>)>&&) = 0;
+    virtual void query(ClientOrigin&&, PermissionDescriptor, Page*, PermissionQuerySource, CompletionHandler<void(std::optional<PermissionState>)>&&) = 0;
     virtual void addObserver(PermissionObserver&) = 0;
     virtual void removeObserver(PermissionObserver&) = 0;
     virtual void storageAccessPermissionChanged(const RegistrableDomain&, const RegistrableDomain&) = 0;
@@ -64,7 +64,7 @@ public:
     static Ref<DummyPermissionController> create() { return adoptRef(*new DummyPermissionController); }
 private:
     DummyPermissionController() = default;
-    void query(ClientOrigin&&, PermissionDescriptor, const WeakPtr<Page>&, PermissionQuerySource, CompletionHandler<void(std::optional<PermissionState>)>&& callback) final { callback({ }); }
+    void query(ClientOrigin&&, PermissionDescriptor, Page*, PermissionQuerySource, CompletionHandler<void(std::optional<PermissionState>)>&& callback) final { callback({ }); }
     void addObserver(PermissionObserver&) final { }
     void removeObserver(PermissionObserver&) final { }
     void storageAccessPermissionChanged(const RegistrableDomain&, const RegistrableDomain&) final { }

--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -252,9 +252,9 @@ void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, Re
             return;
         }
 
-        auto page = source == PermissionQuerySource::DedicatedWorker || source == PermissionQuerySource::Window ? WeakPtr { *document.page() } : nullptr;
+        RefPtr page = source == PermissionQuerySource::DedicatedWorker || source == PermissionQuerySource::Window ? document.page() : nullptr;
 
-        PermissionController::singleton().query(ClientOrigin { document.topOrigin().data(), WTF::move(originData) }, permissionDescriptor, page, source, [contextIdentifier, permissionDescriptor, weakThis = WTF::move(weakThis), promiseIdentifier, source, page, document = Ref { document }](auto permissionState) mutable {
+        PermissionController::singleton().query(ClientOrigin { document.topOrigin().data(), WTF::move(originData) }, permissionDescriptor, page, source, [contextIdentifier, permissionDescriptor, weakThis = WTF::move(weakThis), promiseIdentifier, source, weakPage = WeakPtr { page.get() }, document = Ref { document }](auto permissionState) mutable {
             ASSERT(isMainThread());
 
             auto result = processPermissionQueryResult(permissionState, permissionDescriptor, document);
@@ -269,12 +269,12 @@ void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, Re
                 return;
             }
 
-            ScriptExecutionContext::ensureOnContextThread(contextIdentifier, [weakThis = WTF::move(weakThis), promiseIdentifier, permissionState = *result, permissionDescriptor, source, page = WTF::move(page)](auto& context) mutable {
+            ScriptExecutionContext::ensureOnContextThread(contextIdentifier, [weakThis = WTF::move(weakThis), promiseIdentifier, permissionState = *result, permissionDescriptor, source, weakPage = WTF::move(weakPage)](auto& context) mutable {
                 RefPtr protectedThis = weakThis;
                 if (!protectedThis)
                     return;
                 if (RefPtr promise = protectedThis->m_queryPromises.take(promiseIdentifier))
-                    promise->resolve<IDLInterface<PermissionStatus>>(PermissionStatus::create(context, permissionState, permissionDescriptor, source, WTF::move(page)));
+                    promise->resolve<IDLInterface<PermissionStatus>>(PermissionStatus::create(context, permissionState, permissionDescriptor, source, WTF::move(weakPage)));
             });
         });
     };

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
@@ -74,7 +74,7 @@ void WakeLock::request(WakeLockType lockType, Ref<DeferredPromise>&& promise)
     // FIXME: The permission check can likely be dropped once the specification gets updated to only
     // require transient activation (https://github.com/w3c/screen-wake-lock/pull/326).
     bool hasTransientActivation = document->window() && protect(document->window())->hasTransientActivation();
-    PermissionController::singleton().query(document->clientOrigin(), PermissionDescriptor { PermissionName::ScreenWakeLock }, *document->page(), PermissionQuerySource::Window, [this, protectedThis = Ref { *this }, document = Ref { *document }, hasTransientActivation, promise = WTF::move(promise), lockType](std::optional<PermissionState> permission) mutable {
+    PermissionController::singleton().query(document->clientOrigin(), PermissionDescriptor { PermissionName::ScreenWakeLock }, protect(document->page()), PermissionQuerySource::Window, [this, protectedThis = Ref { *this }, document = Ref { *document }, hasTransientActivation, promise = WTF::move(promise), lockType](std::optional<PermissionState> permission) mutable {
         if (!permission || *permission == PermissionState::Prompt) {
             if (hasTransientActivation || m_wasPreviouslyAuthorizedDueToTransientActivation) {
                 m_wasPreviouslyAuthorizedDueToTransientActivation = true;

--- a/Source/WebCore/page/PointerLockController.h
+++ b/Source/WebCore/page/PointerLockController.h
@@ -62,8 +62,8 @@ public:
     ~PointerLockController();
     void requestPointerLock(Element* target, PointerLockOptions&&, Ref<DeferredPromise>&&);
 
-    void NODELETE ref() const;
-    void deref() const;
+    WEBCORE_EXPORT void NODELETE ref() const;
+    WEBCORE_EXPORT void deref() const;
 
     void requestPointerUnlock();
     void requestPointerUnlockAndForceCursorVisible();

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -328,11 +328,12 @@ RefPtr<ServiceWorkerFetchTask> WebSWServerConnection::createFetchTask(NetworkRes
 
 void WebSWServerConnection::startFetch(ServiceWorkerFetchTask& task, SWServerWorker& worker)
 {
-    auto runServerWorkerAndStartFetch = [weakThis = WeakPtr { *this }, task = WeakPtr { task }](bool success) mutable {
+    auto runServerWorkerAndStartFetch = [weakThis = WeakPtr { *this }, weakTask = WeakPtr { task }](bool success) mutable {
+        RefPtr task = weakTask;
         if (!task)
             return;
 
-        RefPtr protectedThis = weakThis.get();
+        RefPtr protectedThis = weakThis;
         if (!protectedThis) {
             task->cannotHandle();
             return;
@@ -690,10 +691,12 @@ void WebSWServerConnection::subscribeToPushService(WebCore::ServiceWorkerRegistr
     }
 
     session->notificationManager().subscribeToPushService(registration->scopeURLWithoutFragment(), WTF::move(applicationServerKey), [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler), registrableDomain = RegistrableDomain(registration->data().scopeURL)] (std::expected<PushSubscriptionData, ExceptionData>&& result) mutable {
-        if (RefPtr resourceLoadStatistics = weakThis && weakThis->session() ? weakThis->session()->resourceLoadStatistics() : nullptr; result && resourceLoadStatistics) {
-            return resourceLoadStatistics->setMostRecentWebPushInteractionTime(WTF::move(registrableDomain), [result = WTF::move(result), completionHandler = WTF::move(completionHandler)] () mutable {
-                completionHandler(WTF::move(result));
-            });
+        if (RefPtr protectedThis = weakThis) {
+            if (RefPtr resourceLoadStatistics = protectedThis->session() ? protectedThis->session()->resourceLoadStatistics() : nullptr; result && resourceLoadStatistics) {
+                return resourceLoadStatistics->setMostRecentWebPushInteractionTime(WTF::move(registrableDomain), [result = WTF::move(result), completionHandler = WTF::move(completionHandler)] () mutable {
+                    completionHandler(WTF::move(result));
+                });
+            }
         }
         completionHandler(WTF::move(result));
     });

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -80,13 +80,13 @@ WebSWServerToContextConnection::~WebSWServerToContextConnection()
 template<typename T>
 void WebSWServerToContextConnection::sendToParentProcess(T&& message)
 {
-    networkProcess()->parentProcessConnection()->send(WTF::move(message), 0);
+    protect(networkProcess()->parentProcessConnection())->send(WTF::move(message), 0);
 }
 
 template<typename T, typename C>
 void WebSWServerToContextConnection::sendWithAsyncReplyToParentProcess(T&& message, C&& callback)
 {
-    networkProcess()->parentProcessConnection()->sendWithAsyncReply(WTF::move(message), WTF::move(callback), 0);
+    protect(networkProcess()->parentProcessConnection())->sendWithAsyncReply(WTF::move(message), WTF::move(callback), 0);
 }
 
 void WebSWServerToContextConnection::stop()
@@ -247,7 +247,7 @@ void WebSWServerToContextConnection::fireBackgroundFetchClickEvent(ServiceWorker
 void WebSWServerToContextConnection::terminateWorker(ServiceWorkerIdentifier serviceWorkerIdentifier)
 {
     if (!m_processingFunctionalEventCount++)
-        m_connection->networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::StartServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
+        protect(m_connection->networkProcess().parentProcessConnection())->send(Messages::NetworkProcessProxy::StartServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
 
     send(Messages::WebSWContextManagerConnection::TerminateWorker(serviceWorkerIdentifier));
 }
@@ -281,7 +281,7 @@ void WebSWServerToContextConnection::workerTerminated(ServiceWorkerIdentifier se
     SWServerToContextConnection::workerTerminated(serviceWorkerIdentifier);
 
     if (!--m_processingFunctionalEventCount)
-        m_connection->networkProcess().parentProcessConnection()->send(Messages::NetworkProcessProxy::EndServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
+        protect(m_connection->networkProcess().parentProcessConnection())->send(Messages::NetworkProcessProxy::EndServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
 }
 
 void WebSWServerToContextConnection::didFinishActivation(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier)

--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -136,13 +136,13 @@ void Connection::cancelSendSource()
     m_sendPort = MACH_PORT_NULL;
     if (!m_sendSource)
         return;
-    dispatch_source_cancel(m_sendSource.get());
+    dispatch_source_cancel(protect(m_sendSource));
     m_sendSource = nullptr;
 }
 
 void Connection::cancelReceiveSource()
 {
-    dispatch_source_cancel(m_receiveSource.get());
+    dispatch_source_cancel(protect(m_receiveSource));
     m_receiveSource = nullptr;
     m_receivePort = MACH_PORT_NULL;
 }
@@ -208,11 +208,12 @@ void Connection::platformOpen()
     // Change the message queue length for the receive port.
     setMachPortQueueLength(m_receivePort, largeOutgoingMessageQueueCountThreshold);
 
-    m_receiveSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_RECV, m_receivePort, 0, protect(m_connectionQueue->dispatchQueue()).get()));
-    dispatch_source_set_event_handler(m_receiveSource.get(), [this, protectedThis = Ref { *this }] {
+    OSObjectPtr receiveSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_RECV, m_receivePort, 0, protect(m_connectionQueue->dispatchQueue()).get()));
+    m_receiveSource = receiveSource;
+    dispatch_source_set_event_handler(receiveSource, [this, protectedThis = Ref { *this }] {
         receiveSourceEventHandler();
     });
-    dispatch_source_set_cancel_handler(m_receiveSource.get(), [protectedThis = Ref { *this }, receivePort = m_receivePort] {
+    dispatch_source_set_cancel_handler(receiveSource, [protectedThis = Ref { *this }, receivePort = m_receivePort] {
 #if !PLATFORM(WATCHOS)
         mach_port_unguard(mach_task_self(), receivePort, reinterpret_cast<mach_port_context_t>(protectedThis.ptr()));
 #endif
@@ -221,7 +222,7 @@ void Connection::platformOpen()
     });
 
     m_connectionQueue->dispatch([strongRef = Ref { *this }, this] {
-        dispatch_resume(m_receiveSource.get());
+        dispatch_resume(protect(m_receiveSource));
     });
 
     // Cache the audit token in case the XPC connection will be closed.
@@ -448,17 +449,18 @@ void Connection::initializeSendSource()
         return;
     RELEASE_ASSERT(m_sendPort != MACH_PORT_NULL);
 
-    m_sendSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_SEND, m_sendPort, DISPATCH_MACH_SEND_POSSIBLE, protect(m_connectionQueue->dispatchQueue()).get()));
-    dispatch_source_set_registration_handler(m_sendSource.get(), [this, protectedThis = Ref { *this }] {
+    OSObjectPtr sendSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_SEND, m_sendPort, DISPATCH_MACH_SEND_POSSIBLE, protect(m_connectionQueue->dispatchQueue()).get()));
+    m_sendSource = sendSource;
+    dispatch_source_set_registration_handler(sendSource, [this, protectedThis = Ref { *this }] {
         if (!m_sendSource)
             return;
         resumeSendSource();
     });
-    dispatch_source_set_event_handler(m_sendSource.get(), [this, protectedThis = Ref { *this }] {
+    dispatch_source_set_event_handler(sendSource, [this, protectedThis = Ref { *this }] {
         if (!m_sendSource)
             return;
 
-        unsigned long data = dispatch_source_get_data(m_sendSource.get());
+        unsigned long data = dispatch_source_get_data(protect(m_sendSource));
 
         if (data & DISPATCH_MACH_SEND_POSSIBLE) {
             // FIXME: Figure out why we get spurious DISPATCH_MACH_SEND_POSSIBLE events.
@@ -468,11 +470,11 @@ void Connection::initializeSendSource()
     });
 
     mach_port_t sendPort = m_sendPort;
-    dispatch_source_set_cancel_handler(m_sendSource.get(), ^{
+    dispatch_source_set_cancel_handler(sendSource, ^{
         // Release our send right.
         deallocateSendRightSafely(sendPort);
     });
-    dispatch_resume(m_sendSource.get());
+    dispatch_resume(sendSource);
 }
 
 void Connection::resumeSendSource()
@@ -728,7 +730,7 @@ std::optional<audit_token_t> Connection::getAuditToken()
         return std::nullopt;
 
     audit_token_t auditToken;
-    xpc_connection_get_audit_token(m_xpcConnection.get(), &auditToken);
+    xpc_connection_get_audit_token(protect(m_xpcConnection), &auditToken);
     m_auditToken = auditToken;
     return WTF::move(auditToken);
 }
@@ -736,9 +738,9 @@ std::optional<audit_token_t> Connection::getAuditToken()
 #if !USE(EXTENSIONKIT_PROCESS_TERMINATION)
 bool Connection::kill(std::optional<MessageName> invalidMessageName)
 {
-    if (m_xpcConnection) {
+    if (OSObjectPtr xpcConnection = m_xpcConnection) {
         auto reasonCode = invalidMessageName ? WebKit::ReasonCode::MessageCheckKilled : WebKit::ReasonCode::ConnectionKilled;
-        terminateWithReason(m_xpcConnection.get(), reasonCode, "Connection::kill", invalidMessageName);
+        terminateWithReason(xpcConnection, reasonCode, "Connection::kill", invalidMessageName);
         m_didRequestProcessTermination = true;
         return true;
     }
@@ -748,10 +750,8 @@ bool Connection::kill(std::optional<MessageName> invalidMessageName)
 
 pid_t Connection::remoteProcessID() const
 {
-    if (!m_xpcConnection)
-        return 0;
-
-    return xpc_connection_get_pid(m_xpcConnection.get());
+    OSObjectPtr xpcConnection = m_xpcConnection;
+    return xpcConnection ? xpc_connection_get_pid(xpcConnection) : 0;
 }
 
 std::optional<Connection::ConnectionIdentifierPair> Connection::createConnectionIdentifierPair()

--- a/Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm
+++ b/Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm
@@ -57,7 +57,7 @@
 {
     if (_caretType == WebCore::CaretAnimatorType::Dictation) {
         if (_webView)
-            _webView->page().setCaretBlinkingSuspended(false);
+            protect(_webView->page())->setCaretBlinkingSuspended(false);
         return;
     }
 
@@ -77,26 +77,26 @@
 
     _caretType = WebCore::CaretAnimatorType::Default;
     if (_webView)
-        _webView->page().setCaretAnimatorType(WebCore::CaretAnimatorType::Default);
+        protect(_webView->page())->setCaretAnimatorType(WebCore::CaretAnimatorType::Default);
 }
 
 - (void)dictationDidPause
 {
     if (_webView)
-        _webView->page().setCaretBlinkingSuspended(true);
+        protect(_webView->page())->setCaretBlinkingSuspended(true);
 }
 
 - (void)dictationDidResume
 {
     if (_caretType == WebCore::CaretAnimatorType::Dictation) {
         if (_webView)
-            _webView->page().setCaretBlinkingSuspended(false);
+            protect(_webView->page())->setCaretBlinkingSuspended(false);
         return;
     }
 
     _caretType = WebCore::CaretAnimatorType::Dictation;
     if (_webView)
-        _webView->page().setCaretAnimatorType(WebCore::CaretAnimatorType::Dictation);
+        protect(_webView->page())->setCaretAnimatorType(WebCore::CaretAnimatorType::Dictation);
 }
 
 @end

--- a/Source/WebKit/Shared/API/c/WKSharedAPICast.h
+++ b/Source/WebKit/Shared/API/c/WKSharedAPICast.h
@@ -178,7 +178,7 @@ private:
 
 /* Special cases. */
 
-inline ProxyingRefPtr<API::String> toAPI(StringImpl* string)
+inline ProxyingRefPtr<API::String> toAPI(const String& string)
 {
     return ProxyingRefPtr<API::String>(API::String::create(string));
 }

--- a/Source/WebKit/Shared/API/c/mac/WKWebArchiveRef.cpp
+++ b/Source/WebKit/Shared/API/c/mac/WKWebArchiveRef.cpp
@@ -55,7 +55,7 @@ WKWebArchiveRef WKWebArchiveCreateWithData(WKDataRef dataRef)
 
 WKWebArchiveRef WKWebArchiveCreateFromRange(WKBundleRangeHandleRef rangeHandleRef)
 {
-    Ref webArchive = API::WebArchive::create(makeSimpleRange(WebKit::toImpl(rangeHandleRef)->coreRange()));
+    Ref webArchive = API::WebArchive::create(makeSimpleRange(protect(WebKit::toImpl(rangeHandleRef)->coreRange())));
     return WebKit::toAPILeakingRef(WTF::move(webArchive));
 }
 

--- a/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeaturesWebKit.h
+++ b/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeaturesWebKit.h
@@ -54,7 +54,7 @@ public:
 
 private:
     friend struct IPC::ArgumentCoder<PaymentSetupFeatures>;
-    RetainPtr<NSArray> m_platformFeatures;
+    const RetainPtr<NSArray> m_platformFeatures;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp
@@ -86,7 +86,7 @@ void WebPaymentCoordinatorProxy::openPaymentSetup(const String& merchantIdentifi
 
 void WebPaymentCoordinatorProxy::showPaymentUI(WebCore::PageIdentifier destinationID, WebPageProxyIdentifier webPageProxyID, const URL& originatingURL, const Vector<URL>& linkIconURLs, const WebCore::ApplePaySessionPaymentRequest& paymentRequest, CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (auto& coordinator = activePaymentCoordinatorProxy())
+    if (RefPtr coordinator = activePaymentCoordinatorProxy())
         coordinator->didReachFinalState();
     activePaymentCoordinatorProxy() = *this;
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUPipelineLayoutDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPipelineLayoutDescriptor.cpp
@@ -65,10 +65,10 @@ std::optional<WebCore::WebGPU::PipelineLayoutDescriptor> ConvertFromBackingConte
     if (pipelineLayoutDescriptor.bindGroupLayouts) {
         bindGroupLayouts.reserveInitialCapacity(pipelineLayoutDescriptor.bindGroupLayouts->size());
         for (const auto& backingBindGroupLayout : *pipelineLayoutDescriptor.bindGroupLayouts) {
-            WeakPtr entry = convertBindGroupLayoutFromBacking(backingBindGroupLayout);
+            RefPtr entry = convertBindGroupLayoutFromBacking(backingBindGroupLayout);
             if (!entry)
                 return std::nullopt;
-            bindGroupLayouts.append(*entry);
+            bindGroupLayouts.append(entry.releaseNonNull());
         }
 
         optionalBindGroupLayouts = bindGroupLayouts;

--- a/Source/WebKit/Shared/WebGPU/WebGPUPresentationContextDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPresentationContextDescriptor.cpp
@@ -36,7 +36,7 @@ namespace WebKit::WebGPU {
 
 std::optional<PresentationContextDescriptor> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::PresentationContextDescriptor& presentationContextDescriptor)
 {
-    auto identifier = convertToBacking(presentationContextDescriptor.compositorIntegration);
+    auto identifier = convertToBacking(protect(presentationContextDescriptor.compositorIntegration));
 
     return { { identifier } };
 }

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -514,7 +514,7 @@ static void getSandboxProfileOrProfilePath(const SandboxInitializationParameters
 {
     switch (parameters.mode()) {
     case SandboxInitializationParameters::ProfileSelectionMode::UseDefaultSandboxProfilePath:
-        profileOrProfilePath = [webKit2BundleSingleton() pathForResource:[[NSBundle mainBundle] bundleIdentifier] ofType:@"sb"];
+        profileOrProfilePath = [webKit2BundleSingleton() pathForResource:protect([[NSBundle mainBundle] bundleIdentifier]).get() ofType:@"sb"];
         isProfilePath = true;
         return;
     case SandboxInitializationParameters::ProfileSelectionMode::UseOverrideSandboxProfilePath:
@@ -619,10 +619,10 @@ static String getUserDirectorySuffix(const AuxiliaryProcessInitializationParamet
         return suffix.left(suffix.find('/'));
     }
 
-    String clientIdentifier = codeSigningIdentifier(parameters.connectionIdentifier.xpcConnection.get());
+    String clientIdentifier = codeSigningIdentifier(OSObjectPtr { parameters.connectionIdentifier.xpcConnection }.get());
     if (clientIdentifier.isNull())
         clientIdentifier = parameters.clientIdentifier;
-    return makeString([[NSBundle mainBundle] bundleIdentifier], '+', clientIdentifier);
+    return makeString(protect([[NSBundle mainBundle] bundleIdentifier]).get(), '+', clientIdentifier);
 }
 
 static void closeOpenDirectoryConnections()

--- a/Source/WebKit/UIProcess/API/C/WKContext.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContext.cpp
@@ -145,7 +145,7 @@ void WKContextSetHistoryClient(WKContextRef contextRef, const WKContextHistoryCl
             if (!m_client.didUpdateHistoryTitle)
                 return;
 
-            m_client.didUpdateHistoryTitle(WebKit::toAPI(&processPool), WebKit::toAPI(&page), WebKit::toAPI(title.impl()), WebKit::toURLRef(url), WebKit::toAPI(&frame), m_client.base.clientInfo);
+            m_client.didUpdateHistoryTitle(WebKit::toAPI(&processPool), WebKit::toAPI(&page), WebKit::toAPI(title), WebKit::toURLRef(url), WebKit::toAPI(&frame), m_client.base.clientInfo);
         }
 
         void populateVisitedLinks(WebKit::WebProcessPool& processPool) override
@@ -214,14 +214,14 @@ void WKContextSetDownloadClient(WKContextRef context, const WKContextDownloadCli
             if (!m_client.decideDestinationWithSuggestedFilename)
                 return completionHandler(WebKit::AllowOverwrite::No, { });
             bool allowOverwrite = false;
-            auto destination = adoptWK(m_client.decideDestinationWithSuggestedFilename(m_context, WebKit::toAPI(&downloadProxy), WebKit::toAPI(filename.impl()), &allowOverwrite, m_client.base.clientInfo));
+            auto destination = adoptWK(m_client.decideDestinationWithSuggestedFilename(m_context, WebKit::toAPI(&downloadProxy), WebKit::toAPI(filename), &allowOverwrite, m_client.base.clientInfo));
             completionHandler(allowOverwrite ? WebKit::AllowOverwrite::Yes : WebKit::AllowOverwrite::No, WebKit::toWTFString(destination.get()));
         }
         void didCreateDestination(WebKit::DownloadProxy& downloadProxy, const String& path) final
         {
             if (!m_client.didCreateDestination)
                 return;
-            m_client.didCreateDestination(m_context, WebKit::toAPI(&downloadProxy), WebKit::toAPI(path.impl()), m_client.base.clientInfo);
+            m_client.didCreateDestination(m_context, WebKit::toAPI(&downloadProxy), WebKit::toAPI(path), m_client.base.clientInfo);
         }
         void didFinish(WebKit::DownloadProxy& downloadProxy) final
         {

--- a/Source/WebKit/UIProcess/API/C/WKDownloadRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKDownloadRef.cpp
@@ -107,7 +107,7 @@ void WKDownloadSetClient(WKDownloadRef download, WKDownloadClientBase* client)
                 completionHandler(WebKit::AllowOverwrite::No, { });
                 return;
             }
-            auto destination = adoptRef(toImpl(m_client.decideDestinationWithResponse(toAPI(download), toAPI(response), toAPI(suggestedFilename.impl()), m_client.base.clientInfo)));
+            RefPtr destination = adoptRef(toImpl(m_client.decideDestinationWithResponse(toAPI(download), toAPI(response), toAPI(suggestedFilename), m_client.base.clientInfo)));
             if (!destination) {
                 completionHandler(WebKit::AllowOverwrite::No, { });
                 return;

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -204,7 +204,7 @@ WKTypeID WKPageGetTypeID()
 
 WKContextRef WKPageGetContext(WKPageRef pageRef)
 {
-    return toAPI(protect(toImpl(pageRef)->configuration().processPool()).ptr());
+    return toAPI(protect(protect(toImpl(pageRef)->configuration())->processPool()).ptr());
 }
 
 WKPageGroupRef WKPageGetPageGroup(WKPageRef pageRef)
@@ -214,7 +214,7 @@ WKPageGroupRef WKPageGetPageGroup(WKPageRef pageRef)
 
 WKPageConfigurationRef WKPageCopyPageConfiguration(WKPageRef pageRef)
 {
-    return toAPILeakingRef(toImpl(pageRef)->configuration().copy());
+    return toAPILeakingRef(protect(toImpl(pageRef)->configuration())->copy());
 }
 
 void WKPageLoadURL(WKPageRef pageRef, WKURLRef URLRef)
@@ -405,7 +405,7 @@ void WKPageGoForward(WKPageRef pageRef)
 
 bool WKPageCanGoForward(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->backForwardListWrapper().forwardItem();
+    return protect(toImpl(pageRef)->backForwardListWrapper())->forwardItem();
 }
 
 void WKPageGoBack(WKPageRef pageRef)
@@ -421,7 +421,7 @@ void WKPageGoBack(WKPageRef pageRef)
 
 bool WKPageCanGoBack(WKPageRef pageRef)
 {
-    return toImpl(pageRef)->backForwardListWrapper().backItem();
+    return protect(toImpl(pageRef)->backForwardListWrapper())->backItem();
 }
 
 void WKPageGoToBackForwardListItem(WKPageRef pageRef, WKBackForwardListItemRef itemRef)
@@ -1108,7 +1108,7 @@ void WKPageSetPageFindClient(WKPageRef pageRef, const WKPageFindClientBase* wkCl
             if (!m_client.didFindString)
                 return;
             
-            m_client.didFindString(toAPI(page), toAPI(string.impl()), matchCount, m_client.base.clientInfo);
+            m_client.didFindString(toAPI(page), toAPI(string), matchCount, m_client.base.clientInfo);
         }
 
         void didFailToFindString(WebPageProxy* page, const String& string) override
@@ -1116,7 +1116,7 @@ void WKPageSetPageFindClient(WKPageRef pageRef, const WKPageFindClientBase* wkCl
             if (!m_client.didFailToFindString)
                 return;
             
-            m_client.didFailToFindString(toAPI(page), toAPI(string.impl()), m_client.base.clientInfo);
+            m_client.didFailToFindString(toAPI(page), toAPI(string), m_client.base.clientInfo);
         }
 
         void didCountStringMatches(WebPageProxy* page, const String& string, uint32_t matchCount) override
@@ -1124,7 +1124,7 @@ void WKPageSetPageFindClient(WKPageRef pageRef, const WKPageFindClientBase* wkCl
             if (!m_client.didCountStringMatches)
                 return;
 
-            m_client.didCountStringMatches(toAPI(page), toAPI(string.impl()), matchCount, m_client.base.clientInfo);
+            m_client.didCountStringMatches(toAPI(page), toAPI(string), matchCount, m_client.base.clientInfo);
         }
     };
 
@@ -1153,7 +1153,7 @@ void WKPageSetPageFindMatchesClient(WKPageRef pageRef, const WKPageFindMatchesCl
                 });
                 return API::Array::create(WTF::move(apiRects));
             });
-            m_client.didFindStringMatches(toAPI(page), toAPI(string.impl()), toAPI(API::Array::create(WTF::move(matches)).ptr()), index, m_client.base.clientInfo);
+            m_client.didFindStringMatches(toAPI(page), toAPI(string), toAPI(API::Array::create(WTF::move(matches)).ptr()), index, m_client.base.clientInfo);
         }
 
         void didGetImageForMatchResult(WebPageProxy* page, WebImage* image, int32_t index) override
@@ -1469,7 +1469,7 @@ void WKPageSetPagePolicyClient(WKPageRef pageRef, const WKPagePolicyClientBase* 
 
             Ref<API::URLRequest> request = API::URLRequest::create(resourceRequest);
 
-            m_client.decidePolicyForNewWindowAction(toAPI(&page), toAPI(&frame), toAPI(navigationAction->data().navigationType), toAPI(navigationAction->data().modifiers), toAPI(navigationAction->data().mouseButton), toAPI(request.ptr()), toAPI(frameName.impl()), toAPI(listener.ptr()), nullptr, m_client.base.clientInfo);
+            m_client.decidePolicyForNewWindowAction(toAPI(&page), toAPI(&frame), toAPI(navigationAction->data().navigationType), toAPI(navigationAction->data().modifiers), toAPI(navigationAction->data().mouseButton), toAPI(request.ptr()), toAPI(frameName), toAPI(listener.ptr()), nullptr, m_client.base.clientInfo);
         }
 
         void decidePolicyForResponse(WebPageProxy& page, WebFrameProxy& frame, const WebCore::ResourceResponse& resourceResponse, const WebCore::ResourceRequest& resourceRequest, bool canShowMIMEType, Ref<WebFramePolicyListenerProxy>&& listener) override
@@ -1829,19 +1829,19 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             if (m_client.runJavaScriptAlert) {
                 RefPtr<RunJavaScriptAlertResultListener> listener = RunJavaScriptAlertResultListener::create(WTF::move(completionHandler));
                 RefPtr<API::SecurityOrigin> securityOrigin = API::SecurityOrigin::create(frameInfo.securityOrigin);
-                m_client.runJavaScriptAlert(toAPI(&page), toAPI(message.impl()), toAPI(frame), toAPI(securityOrigin.get()), toAPI(listener.get()), m_client.base.clientInfo);
+                m_client.runJavaScriptAlert(toAPI(&page), toAPI(message), toAPI(frame), toAPI(securityOrigin.get()), toAPI(listener.get()), m_client.base.clientInfo);
                 return;
             }
 
             if (m_client.runJavaScriptAlert_deprecatedForUseWithV5) {
                 RefPtr<API::SecurityOrigin> securityOrigin = API::SecurityOrigin::create(frameInfo.securityOrigin);
-                m_client.runJavaScriptAlert_deprecatedForUseWithV5(toAPI(&page), toAPI(message.impl()), toAPI(frame), toAPI(securityOrigin.get()), m_client.base.clientInfo);
+                m_client.runJavaScriptAlert_deprecatedForUseWithV5(toAPI(&page), toAPI(message), toAPI(frame), toAPI(securityOrigin.get()), m_client.base.clientInfo);
                 completionHandler();
                 return;
             }
             
             if (m_client.runJavaScriptAlert_deprecatedForUseWithV0) {
-                m_client.runJavaScriptAlert_deprecatedForUseWithV0(toAPI(&page), toAPI(message.impl()), toAPI(frame), m_client.base.clientInfo);
+                m_client.runJavaScriptAlert_deprecatedForUseWithV0(toAPI(&page), toAPI(message), toAPI(frame), m_client.base.clientInfo);
                 completionHandler();
                 return;
             }
@@ -1855,20 +1855,20 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             if (m_client.runJavaScriptConfirm) {
                 RefPtr<RunJavaScriptConfirmResultListener> listener = RunJavaScriptConfirmResultListener::create(WTF::move(completionHandler));
                 RefPtr<API::SecurityOrigin> securityOrigin = API::SecurityOrigin::create(frameInfo.securityOrigin);
-                m_client.runJavaScriptConfirm(toAPI(&page), toAPI(message.impl()), toAPI(frame), toAPI(securityOrigin.get()), toAPI(listener.get()), m_client.base.clientInfo);
+                m_client.runJavaScriptConfirm(toAPI(&page), toAPI(message), toAPI(frame), toAPI(securityOrigin.get()), toAPI(listener.get()), m_client.base.clientInfo);
                 return;
             }
 
             if (m_client.runJavaScriptConfirm_deprecatedForUseWithV5) {
                 RefPtr<API::SecurityOrigin> securityOrigin = API::SecurityOrigin::create(frameInfo.securityOrigin);
-                bool result = m_client.runJavaScriptConfirm_deprecatedForUseWithV5(toAPI(&page), toAPI(message.impl()), toAPI(frame), toAPI(securityOrigin.get()), m_client.base.clientInfo);
+                bool result = m_client.runJavaScriptConfirm_deprecatedForUseWithV5(toAPI(&page), toAPI(message), toAPI(frame), toAPI(securityOrigin.get()), m_client.base.clientInfo);
                 
                 completionHandler(result);
                 return;
             }
             
             if (m_client.runJavaScriptConfirm_deprecatedForUseWithV0) {
-                bool result = m_client.runJavaScriptConfirm_deprecatedForUseWithV0(toAPI(&page), toAPI(message.impl()), toAPI(frame), m_client.base.clientInfo);
+                bool result = m_client.runJavaScriptConfirm_deprecatedForUseWithV0(toAPI(&page), toAPI(message), toAPI(frame), m_client.base.clientInfo);
 
                 completionHandler(result);
                 return;
@@ -1882,13 +1882,13 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             if (m_client.runJavaScriptPrompt) {
                 RefPtr<RunJavaScriptPromptResultListener> listener = RunJavaScriptPromptResultListener::create(WTF::move(completionHandler));
                 RefPtr<API::SecurityOrigin> securityOrigin = API::SecurityOrigin::create(frameInfo.securityOrigin);
-                m_client.runJavaScriptPrompt(toAPI(&page), toAPI(message.impl()), toAPI(defaultValue.impl()), toAPI(frame), toAPI(securityOrigin.get()), toAPI(listener.get()), m_client.base.clientInfo);
+                m_client.runJavaScriptPrompt(toAPI(&page), toAPI(message), toAPI(defaultValue), toAPI(frame), toAPI(securityOrigin.get()), toAPI(listener.get()), m_client.base.clientInfo);
                 return;
             }
 
             if (m_client.runJavaScriptPrompt_deprecatedForUseWithV5) {
                 RefPtr<API::SecurityOrigin> securityOrigin = API::SecurityOrigin::create(frameInfo.securityOrigin);
-                RefPtr<API::String> string = adoptRef(toImpl(m_client.runJavaScriptPrompt_deprecatedForUseWithV5(toAPI(&page), toAPI(message.impl()), toAPI(defaultValue.impl()), toAPI(frame), toAPI(securityOrigin.get()), m_client.base.clientInfo)));
+                RefPtr<API::String> string = adoptRef(toImpl(m_client.runJavaScriptPrompt_deprecatedForUseWithV5(toAPI(&page), toAPI(message), toAPI(defaultValue), toAPI(frame), toAPI(securityOrigin.get()), m_client.base.clientInfo)));
                 
                 if (string)
                     completionHandler(string->string());
@@ -1898,7 +1898,7 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             }
             
             if (m_client.runJavaScriptPrompt_deprecatedForUseWithV0) {
-                RefPtr<API::String> string = adoptRef(toImpl(m_client.runJavaScriptPrompt_deprecatedForUseWithV0(toAPI(&page), toAPI(message.impl()), toAPI(defaultValue.impl()), toAPI(frame), m_client.base.clientInfo)));
+                RefPtr<API::String> string = adoptRef(toImpl(m_client.runJavaScriptPrompt_deprecatedForUseWithV0(toAPI(&page), toAPI(message), toAPI(defaultValue), toAPI(frame), m_client.base.clientInfo)));
                 
                 if (string)
                     completionHandler(string->string());
@@ -1914,7 +1914,7 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
         {
             if (!m_client.addMessageToConsole)
                 return;
-            m_client.addMessageToConsole(toAPI(&page), toAPI(message.impl()), m_client.base.clientInfo);
+            m_client.addMessageToConsole(toAPI(&page), toAPI(message), m_client.base.clientInfo);
         }
 
         void setStatusText(WebPageProxy* page, const String& text) final
@@ -1922,7 +1922,7 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             if (!m_client.setStatusText)
                 return;
 
-            m_client.setStatusText(toAPI(page), toAPI(text.impl()), m_client.base.clientInfo);
+            m_client.setStatusText(toAPI(page), toAPI(text), m_client.base.clientInfo);
         }
 
         void mouseDidMoveOverElement(WebPageProxy& page, const WebHitTestResultData& data, OptionSet<WebKit::WebEventModifier> modifiers) final
@@ -1947,7 +1947,7 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             if (!m_client.tooltipDidChange)
                 return;
 
-            m_client.tooltipDidChange(toAPI(&page), toAPI(tooltip.impl()), m_client.base.clientInfo);
+            m_client.tooltipDidChange(toAPI(&page), toAPI(tooltip), m_client.base.clientInfo);
         }
 
         void didNotHandleKeyEvent(WebPageProxy* page, const NativeWebKeyboardEvent& event) final
@@ -1996,12 +1996,12 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
         {
             if (m_client.runBeforeUnloadConfirmPanel) {
                 RefPtr<RunBeforeUnloadConfirmPanelResultListener> listener = RunBeforeUnloadConfirmPanelResultListener::create(WTF::move(completionHandler));
-                m_client.runBeforeUnloadConfirmPanel(toAPI(&page), toAPI(message.impl()), toAPI(frame), toAPI(listener.get()), m_client.base.clientInfo);
+                m_client.runBeforeUnloadConfirmPanel(toAPI(&page), toAPI(message), toAPI(frame), toAPI(listener.get()), m_client.base.clientInfo);
                 return;
             }
 
             if (m_client.runBeforeUnloadConfirmPanel_deprecatedForUseWithV6) {
-                bool result = m_client.runBeforeUnloadConfirmPanel_deprecatedForUseWithV6(toAPI(&page), toAPI(message.impl()), toAPI(frame), m_client.base.clientInfo);
+                bool result = m_client.runBeforeUnloadConfirmPanel_deprecatedForUseWithV6(toAPI(&page), toAPI(message), toAPI(frame), m_client.base.clientInfo);
                 completionHandler(result);
                 return;
             }
@@ -2024,7 +2024,7 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
                 return;
             }
 
-            completionHandler(m_client.exceededDatabaseQuota(toAPI(page), toAPI(frame), toAPI(origin), toAPI(databaseName.impl()), toAPI(databaseDisplayName.impl()), currentQuota, currentOriginUsage, currentDatabaseUsage, expectedUsage, m_client.base.clientInfo));
+            completionHandler(m_client.exceededDatabaseQuota(toAPI(page), toAPI(frame), toAPI(origin), toAPI(databaseName), toAPI(databaseDisplayName), currentQuota, currentOriginUsage, currentDatabaseUsage, expectedUsage, m_client.base.clientInfo));
         }
 
         bool runOpenPanel(WebPageProxy& page, WebFrameProxy* frame, FrameInfoData&&, API::OpenPanelParameters* parameters, WebOpenPanelResultListenerProxy* listener) final
@@ -2071,7 +2071,7 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             }
 
             auto listener = RequestStorageAccessConfirmResultListener::create(WTF::move(completionHandler));
-            m_client.requestStorageAccessConfirm(toAPI(&page), toAPI(frame), toAPI(requestingDomain.string().impl()), toAPI(currentDomain.string().impl()), toAPI(listener.ptr()), m_client.base.clientInfo);
+            m_client.requestStorageAccessConfirm(toAPI(&page), toAPI(frame), toAPI(requestingDomain.string()), toAPI(currentDomain.string()), toAPI(listener.ptr()), m_client.base.clientInfo);
         }
 
 #if ENABLE(DEVICE_ORIENTATION)
@@ -2144,7 +2144,7 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             if (!m_client.saveDataToFileInDownloadsFolder)
                 return;
 
-            m_client.saveDataToFileInDownloadsFolder(toAPI(page), toAPI(suggestedFilename.impl()), toAPI(mimeType.impl()), toURLRef(originatingURL.string()), toAPI(&data), m_client.base.clientInfo);
+            m_client.saveDataToFileInDownloadsFolder(toAPI(page), toAPI(suggestedFilename), toAPI(mimeType), toURLRef(originatingURL.string()), toAPI(&data), m_client.base.clientInfo);
         }
 
         void pinnedStateDidChange(WebPageProxy& page) final
@@ -2795,7 +2795,7 @@ static void callAsyncJavaScript(bool withUserGesture, WKPageRef page, WKStringRe
 
         Vector<std::pair<String, JavaScriptEvaluationResult>> result;
         for (auto& [key, value] : dictionary->map()) {
-            if (auto js = JavaScriptEvaluationResult::extract(value.get()))
+            if (auto js = JavaScriptEvaluationResult::extract(protect(value.get())))
                 result.append({ key, WTF::move(*js) });
         }
         return { WTF::move(result) };
@@ -3261,7 +3261,7 @@ ProcessID WKPageGetProcessIdentifier(WKPageRef page)
 ProcessID WKPageGetGPUProcessIdentifier(WKPageRef page)
 {
 #if ENABLE(GPU_PROCESS)
-    RefPtr gpuProcess = toImpl(page)->configuration().processPool().gpuProcess();
+    RefPtr gpuProcess = protect(toImpl(page)->configuration().processPool())->gpuProcess();
     if (!gpuProcess)
         return 0;
     return gpuProcess->processID();
@@ -3291,7 +3291,7 @@ void WKPageDumpPrivateClickMeasurement(WKPageRef pageRef, WKPageDumpPrivateClick
         return callback(nullptr, callbackContext);
 
     pageForTesting->dumpPrivateClickMeasurement([callbackContext, callback] (const String& privateClickMeasurement) {
-        callback(WebKit::toAPI(privateClickMeasurement.impl()), callbackContext);
+        callback(WebKit::toAPI(privateClickMeasurement), callbackContext);
     });
 }
 
@@ -3663,6 +3663,6 @@ void WKPageSetCursorDidChangeCallbackForTesting(WKPageRef page, WKPageCursorDidC
         if (cursor.imageScaleFactor() != 1)
             info.append(" scale="_s, cursor.imageScaleFactor());
 #endif
-        callback(toAPI(info.toString().impl()), clientInfo);
+        callback(toAPI(info.toString()), clientInfo);
     });
 }

--- a/Source/WebKit/UIProcess/API/C/WKUserContentControllerRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKUserContentControllerRef.cpp
@@ -53,7 +53,7 @@ WKUserContentControllerRef WKUserContentControllerCreate()
 
 WKArrayRef WKUserContentControllerCopyUserScripts(WKUserContentControllerRef userContentControllerRef)
 {
-    return toAPILeakingRef(toImpl(userContentControllerRef)->userScripts().copy());
+    return toAPILeakingRef(protect(toImpl(userContentControllerRef)->userScripts())->copy());
 }
 
 void WKUserContentControllerAddUserScript(WKUserContentControllerRef userContentControllerRef, WKUserScriptRef userScriptRef)

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
@@ -219,7 +219,7 @@ void WKWebsiteDataStoreSetStatisticsVeryPrevalentResource(WKWebsiteDataStoreRef 
 void WKWebsiteDataStoreDumpResourceLoadStatistics(WKWebsiteDataStoreRef dataStoreRef, void* context, WKWebsiteDataStoreDumpResourceLoadStatisticsFunction callback)
 {
     protect(WebKit::toImpl(dataStoreRef))->dumpResourceLoadStatistics([context, callback] (const String& resourceLoadStatistics) {
-        callback(WebKit::toAPI(resourceLoadStatistics.impl()), context);
+        callback(WebKit::toAPI(resourceLoadStatistics), context);
     });
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm
@@ -65,7 +65,7 @@ void Attachment::doWithFileWrapper(NOESCAPE Function<void(NSFileWrapper *)>&& fu
 {
     Locker locker { m_fileWrapperLock };
 
-    function(m_fileWrapper.get());
+    function(protect(m_fileWrapper).get());
 }
 
 WTF::String Attachment::mimeType() const
@@ -101,10 +101,11 @@ WTF::String Attachment::fileName() const
 {
     Locker locker { m_fileWrapperLock };
 
-    if ([m_fileWrapper filename].length)
-        return [m_fileWrapper filename];
+    RetainPtr fileWrapper = m_fileWrapper;
+    if ([fileWrapper filename].length)
+        return [fileWrapper filename];
 
-    return [m_fileWrapper preferredFilename];
+    return [fileWrapper preferredFilename];
 }
 
 void Attachment::setFileWrapperAndUpdateContentType(NSFileWrapper *fileWrapper, NSString *contentType)
@@ -114,7 +115,7 @@ void Attachment::setFileWrapperAndUpdateContentType(NSFileWrapper *fileWrapper, 
         if (fileWrapper.directory)
             updatedContentType = UTTypeDirectory.identifier;
         else if (fileWrapper.regularFile) {
-            if (RetainPtr<NSString> pathExtension = (fileWrapper.filename.length ? fileWrapper.filename : fileWrapper.preferredFilename).pathExtension)
+            if (RetainPtr<NSString> pathExtension = protect(protect(fileWrapper.filename).get().length ? fileWrapper.filename : fileWrapper.preferredFilename).get().pathExtension)
                 updatedContentType = WebCore::MIMETypeRegistry::mimeTypeForExtension(WTF::String(pathExtension.get())).createNSString();
             if (!updatedContentType.get().length)
                 updatedContentType = UTTypeData.identifier;
@@ -129,15 +130,16 @@ std::optional<uint64_t> Attachment::fileSizeForDisplay() const
 {
     Locker locker { m_fileWrapperLock };
 
-    if (![m_fileWrapper isRegularFile]) {
+    RetainPtr fileWrapper = m_fileWrapper;
+    if (![fileWrapper isRegularFile]) {
         // FIXME: We should display a size estimate for directory-type file wrappers.
         return std::nullopt;
     }
 
-    if (auto fileSize = [[m_fileWrapper fileAttributes][NSFileSize] unsignedLongLongValue])
+    if (auto fileSize = [[fileWrapper fileAttributes][NSFileSize] unsignedLongLongValue])
         return fileSize;
 
-    return [m_fileWrapper regularFileContents].length;
+    return [fileWrapper regularFileContents].length;
 }
 
 RefPtr<WebCore::FragmentedSharedBuffer> Attachment::associatedElementData() const
@@ -149,10 +151,11 @@ RefPtr<WebCore::FragmentedSharedBuffer> Attachment::associatedElementData() cons
     {
         Locker locker { m_fileWrapperLock };
 
-        if (![m_fileWrapper isRegularFile])
+        RetainPtr fileWrapper = m_fileWrapper;
+        if (![fileWrapper isRegularFile])
             return nullptr;
 
-        data = [m_fileWrapper regularFileContents];
+        data = [fileWrapper regularFileContents];
     }
 
     if (!data)
@@ -165,10 +168,11 @@ RetainPtr<NSData> Attachment::associatedElementNSData() const
 {
     Locker locker { m_fileWrapperLock };
 
-    if (![m_fileWrapper isRegularFile])
+    RetainPtr fileWrapper = m_fileWrapper;
+    if (![fileWrapper isRegularFile])
         return nil;
 
-    return [m_fileWrapper regularFileContents];
+    return [fileWrapper regularFileContents];
 }
 
 bool Attachment::isEmpty() const
@@ -184,10 +188,11 @@ RefPtr<WebCore::SharedBuffer> Attachment::createSerializedRepresentation() const
     {
         Locker locker { m_fileWrapperLock };
 
-        if (!m_fileWrapper || !m_webPage)
+        RetainPtr fileWrapper = m_fileWrapper;
+        if (!fileWrapper || !m_webPage)
             return nullptr;
 
-        serializedData = [NSKeyedArchiver archivedDataWithRootObject:m_fileWrapper.get() requiringSecureCoding:YES error:nullptr];
+        serializedData = [NSKeyedArchiver archivedDataWithRootObject:fileWrapper.get() requiringSecureCoding:YES error:nullptr];
     }
     if (!serializedData)
         return nullptr;
@@ -224,7 +229,7 @@ void Attachment::cloneFileWrapperTo(Attachment& other)
     other.m_isCreatedFromSerializedRepresentation = m_isCreatedFromSerializedRepresentation;
 
     Locker locker { m_fileWrapperLock };
-    other.setFileWrapper(m_fileWrapper.get());
+    other.setFileWrapper(protect(m_fileWrapper));
 }
 
 bool Attachment::shouldUseFileWrapperIconForDirectory() const
@@ -237,7 +242,7 @@ bool Attachment::shouldUseFileWrapperIconForDirectory() const
 
     {
         Locker locker { m_fileWrapperLock };
-        if (![m_fileWrapper isDirectory])
+        if (![protect(m_fileWrapper) isDirectory])
             return false;
     }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/APIContentRuleListStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APIContentRuleListStoreCocoa.mm
@@ -52,10 +52,11 @@ WTF::String ContentRuleListStore::defaultStorePath()
         return [url URLByAppendingPathComponent:@"ContentRuleLists" isDirectory:YES];
     }();
 
-    if (![[NSFileManager defaultManager] createDirectoryAtURL:contentRuleListStoreURL.get().get() withIntermediateDirectories:YES attributes:nil error:nullptr])
+    RetainPtr localContentRuleListStoreURL = contentRuleListStoreURL.get();
+    if (![[NSFileManager defaultManager] createDirectoryAtURL:localContentRuleListStoreURL.get() withIntermediateDirectories:YES attributes:nil error:nullptr])
         LOG_ERROR("Failed to create directory %@", contentRuleListStoreURL.get().get());
 
-    return [contentRuleListStoreURL.get() absoluteURL].path;
+    return [localContentRuleListStoreURL absoluteURL].path;
 }
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -168,7 +168,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 - (_WKProcessPoolConfiguration *)_configuration
 {
-    return wrapper(_processPool->configuration().copy()).autorelease();
+    return wrapper(protect(_processPool->configuration())->copy()).autorelease();
 }
 ALLOW_DEPRECATED_DECLARATIONS_END
 
@@ -406,7 +406,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)_clearWebProcessCache
 {
-    _processPool->webProcessCache().clear();
+    protect(_processPool->webProcessCache())->clear();
 }
 
 - (void)_setCachedProcessLifetimeForTesting:(NSTimeInterval)lifetime

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -5772,7 +5772,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 - (void)_clearBackForwardCache
 {
     THROW_IF_SUSPENDED;
-    _page->configuration().processPool().backForwardCache().removeEntriesForPage(*_page);
+    protect(_page->configuration().processPool().backForwardCache())->removeEntriesForPage(*_page);
 }
 
 + (BOOL)_handlesSafeBrowsing

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1138,7 +1138,7 @@ struct WKWebsiteData {
 
 - (_WKWebsiteDataStoreConfiguration *)_configuration
 {
-    return wrapper(_websiteDataStore->configuration().copy()).autorelease();
+    return wrapper(protect(_websiteDataStore->configuration())->copy()).autorelease();
 }
 
 + (WKNotificationManagerRef)_sharedServiceWorkerNotificationManager

--- a/Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
@@ -43,7 +43,7 @@ void AuthenticationChallengeProxy::sendClientCertificateCredentialOverXpc(IPC::C
     OSObjectPtr message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), ClientCertificateAuthentication::XPCMessageNameKey, ClientCertificateAuthentication::XPCMessageNameValue);
     xpc_dictionary_set_uint64(message.get(), ClientCertificateAuthentication::XPCChallengeIDKey, challengeID.toUInt64());
-    xpc_dictionary_set_value(message.get(), ClientCertificateAuthentication::XPCSecKeyProxyEndpointKey, OSObjectPtr<xpc_endpoint_t> { RetainPtr { secKeyProxyStore.get() }.get().endpoint._endpoint }.get());
+    xpc_dictionary_set_value(message.get(), ClientCertificateAuthentication::XPCSecKeyProxyEndpointKey, OSObjectPtr<xpc_endpoint_t> { protect(RetainPtr { secKeyProxyStore.get() }.get().endpoint).get()._endpoint }.get());
     OSObjectPtr certificateDataArray = adoptOSObject(xpc_array_create(nullptr, 0));
     RetainPtr nsCredential = credential.nsCredential();
     for (id certificate in nsCredential.get().certificates) {

--- a/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
@@ -131,7 +131,7 @@ static NSString *browsingWarningTitleText(SSBServiceLookupResult *result)
 static NSString *browsingWarningTitleText(BrowsingWarning::Data data)
 {
     return WTF::switchOn(data, [&] (BrowsingWarning::SafeBrowsingWarningData data) {
-        return browsingWarningTitleText(data.result.get());
+        return browsingWarningTitleText(protect(data.result));
     }, [&] (BrowsingWarning::HTTPSNavigationFailureData) {
         return WEB_UI_NSSTRING(@"This Connection Is Not Secure", "Not Secure Connection warning page title");
     });
@@ -151,7 +151,7 @@ static NSString *browsingWarningText(SSBServiceLookupResult *result)
 static NSString *browsingWarningText(BrowsingWarning::Data data)
 {
     return WTF::switchOn(data, [&] (BrowsingWarning::SafeBrowsingWarningData data) {
-        return browsingWarningText(data.result.get());
+        return browsingWarningText(protect(data.result));
     }, [&] (BrowsingWarning::HTTPSNavigationFailureData) {
         return WEB_UI_NSSTRING(@"This website does not support connecting securely over HTTPS. The information you see and enter on this website, including credit cards, phone numbers, and passwords, can be read and altered by other people.", "Not Secure Connection warning text");
     });
@@ -201,7 +201,7 @@ static NSMutableAttributedString *browsingDetailsText(const URL& url, SSBService
 static NSMutableAttributedString *browsingDetailsText(const URL& url, BrowsingWarning::Data data)
 {
     if (auto* safeBrowsingData = std::get_if<BrowsingWarning::SafeBrowsingWarningData>(&data))
-        return browsingDetailsText(url, safeBrowsingData->result.get());
+        return browsingDetailsText(url, protect(safeBrowsingData->result));
     return nil;
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -993,9 +993,8 @@ void WebPageProxy::setUpHighlightsObserver()
     WeakPtr weakThis { *this };
     auto updateAppHighlightsVisibility = ^(BOOL isVisible) {
         ensureOnMainRunLoop([weakThis, isVisible] {
-            if (!weakThis)
-                return;
-            weakThis->setAppHighlightsVisibility(isVisible ? WebCore::HighlightVisibility::Visible : WebCore::HighlightVisibility::Hidden);
+            if (RefPtr protectedThis = weakThis)
+                protectedThis->setAppHighlightsVisibility(isVisible ? WebCore::HighlightVisibility::Visible : WebCore::HighlightVisibility::Hidden);
         });
     };
     

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -847,8 +847,8 @@ void WebProcessPool::registerNotificationObservers()
 
 #if !PLATFORM(IOS_FAMILY)
     m_powerObserver = makeUnique<WebCore::PowerObserver>([weakThis = WeakPtr { *this }] {
-        if (weakThis)
-            weakThis->sendToAllProcesses(Messages::WebProcess::SystemWillPowerOn());
+        if (RefPtr protectedThis = weakThis)
+            protectedThis->sendToAllProcesses(Messages::WebProcess::SystemWillPowerOn());
     });
     m_systemSleepListener = PAL::SystemSleepListener::create(*this);
     // Listen for enhanced accessibility changes and propagate them to the WebProcess.

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
@@ -318,7 +318,7 @@ void WebExtensionContext::scriptingGetRegisteredScripts(const Vector<String>& sc
     if (scriptIDs.isEmpty()) {
         // Return all registered scripts if no filter is specififed.
         for (auto& entry : m_registeredScriptsMap)
-            scripts.append(entry.value.get().parameters());
+            scripts.append(protect(entry.value.get())->parameters());
     } else {
         for (auto& scriptID : scriptIDs) {
             RefPtr registeredScript = m_registeredScriptsMap.get(scriptID);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -690,7 +690,7 @@ void WebExtensionContext::tabsMove(Vector<WebExtensionTabIdentifier> tabIdentifi
             return tab->delegate();
         }).get();
 
-        if (!moveTabsToIndexInWindow(tabDelegates, destinationWindow.get()))
+        if (!moveTabsToIndexInWindow(tabDelegates, protect(destinationWindow).get()))
             return;
     }
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm
@@ -72,7 +72,7 @@ Ref<WebExtensionControllerConfiguration> WebExtensionControllerConfiguration::co
 
     result->setStorageDirectory(storageDirectory());
     result->setWebViewConfiguration([m_webViewConfiguration copy]);
-    result->setDefaultWebsiteDataStore(m_defaultWebsiteDataStore.get());
+    result->setDefaultWebsiteDataStore(protect(m_defaultWebsiteDataStore));
 
     return result.releaseNonNull();
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -157,7 +157,7 @@ void executeScript(const SourcePairs& scriptPairs, WKWebView *webView, API::Cont
 
             if (parameters.function) {
                 RetainPtr javaScript = adoptNS([[NSString alloc] initWithFormat:@"return (%@)(...arguments)", parameters.function.value().createNSString().get()]);
-                NSArray *arguments = parameters.arguments ? parseJSON(parameters.arguments.value(), JSONOptions::FragmentsAllowed) : @[ ];
+                NSArray *arguments = parameters.arguments ? parseJSON(protect(parameters.arguments.value()), JSONOptions::FragmentsAllowed) : @[ ];
 
                 [webView _callAsyncJavaScript:javaScript.get() arguments:@{ @"arguments": arguments } inFrame:frameInfo inContentWorld:executionWorld->wrapper() withUserGesture:userGesture completionHandler:makeBlockPtr([injectionResults, aggregator, frameInfo](id resultOfExecution, NSError *error) mutable {
                     injectionResults->results.append(toInjectionResultParameters(resultOfExecution, frameInfo, error.localizedDescription));

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -935,12 +935,12 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
     };
 
     for (auto& deniedPermissionEntry : deniedPermissionMatchPatterns) {
-        if (urlMatchesPatternIgnoringWildcardHostPatterns(deniedPermissionEntry.key))
+        if (urlMatchesPatternIgnoringWildcardHostPatterns(protect(deniedPermissionEntry.key)))
             return cacheResultAndReturn(PermissionState::DeniedExplicitly);
     }
 
     for (auto& grantedPermissionEntry : grantedPermissionMatchPatterns) {
-        if (urlMatchesPatternIgnoringWildcardHostPatterns(grantedPermissionEntry.key))
+        if (urlMatchesPatternIgnoringWildcardHostPatterns(protect(grantedPermissionEntry.key)))
             return cacheResultAndReturn(PermissionState::GrantedExplicitly);
     }
 
@@ -954,12 +954,12 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
     };
 
     for (auto& deniedPermissionEntry : deniedPermissionMatchPatterns) {
-        if (urlMatchesWildcardHostPatterns(deniedPermissionEntry.key))
+        if (urlMatchesWildcardHostPatterns(protect(deniedPermissionEntry.key)))
             return cacheResultAndReturn(PermissionState::DeniedImplicitly);
     }
 
     for (auto& grantedPermissionEntry : grantedPermissionMatchPatterns) {
-        if (urlMatchesWildcardHostPatterns(grantedPermissionEntry.key))
+        if (urlMatchesWildcardHostPatterns(protect(grantedPermissionEntry.key)))
             return cacheResultAndReturn(PermissionState::GrantedImplicitly);
     }
 
@@ -1033,12 +1033,12 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
     };
 
     for (auto& deniedPermissionEntry : deniedPermissionMatchPatterns) {
-        if (urlMatchesPatternIgnoringWildcardHostPatterns(deniedPermissionEntry.key))
+        if (urlMatchesPatternIgnoringWildcardHostPatterns(protect(deniedPermissionEntry.key)))
             return PermissionState::DeniedExplicitly;
     }
 
     for (auto& grantedPermissionEntry : grantedPermissionMatchPatterns) {
-        if (urlMatchesPatternIgnoringWildcardHostPatterns(grantedPermissionEntry.key))
+        if (urlMatchesPatternIgnoringWildcardHostPatterns(protect(grantedPermissionEntry.key)))
             return PermissionState::GrantedExplicitly;
     }
 
@@ -1053,12 +1053,12 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
     };
 
     for (auto& deniedPermissionEntry : deniedPermissionMatchPatterns) {
-        if (urlMatchesWildcardHostPatterns(deniedPermissionEntry.key))
+        if (urlMatchesWildcardHostPatterns(protect(deniedPermissionEntry.key)))
             return PermissionState::DeniedImplicitly;
     }
 
     for (auto& grantedPermissionEntry : grantedPermissionMatchPatterns) {
-        if (urlMatchesWildcardHostPatterns(grantedPermissionEntry.key))
+        if (urlMatchesWildcardHostPatterns(protect(grantedPermissionEntry.key)))
             return PermissionState::GrantedImplicitly;
     }
 
@@ -1686,7 +1686,7 @@ WebExtensionContextParameters WebExtensionContext::parameters(IncludePrivilegedI
         extension->serializeManifest(),
         extension->manifestVersion(),
         m_storageAccessLevels,
-        extensionController()->configuration().defaultWebsiteDataStore().sessionID(),
+        protect(extensionController()->configuration())->defaultWebsiteDataStore().sessionID(),
         backgroundPageIdentifier(destinationProcess),
 #if ENABLE(INSPECTOR_EXTENSIONS)
         inspectorPageIdentifiers(),

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -521,7 +521,7 @@ void ProvisionalPageProxy::didCommitLoadForFrame(IPC::Connection& connection, Fr
 
         bool frameProcessChanged = m_frameProcess.ptr() != pageMainFrameProcess.ptr();
         if (frameProcessChanged)
-            pageMainFrame->setProcess(m_frameProcess);
+            pageMainFrame->setProcess(protect(m_frameProcess));
 
         // Record that this page needs a remote-page transition. The actual
         // IPC + transitionPageToRemotePage() call is deferred to

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -738,7 +738,7 @@ void ViewGestureController::willEndSwipeGesture(WebBackForwardListItem& targetIt
     // FIXME: Like on iOS, we should ensure that even if one of the timeouts fires,
     // we never show the old page content, instead showing the snapshot background color.
 
-    if (auto* snapshot = targetItem.snapshot())
+    if (RefPtr snapshot = targetItem.snapshot())
         m_backgroundColorForCurrentSnapshot = snapshot->backgroundColor();
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
@@ -262,8 +262,8 @@ void AuthenticatorPresenterCoordinator::selectAssertionResponse(Vector<Ref<Authe
 
 void AuthenticatorPresenterCoordinator::requestLAContextForUserVerification(CompletionHandler<void(LAContext *)>&& completionHandler)
 {
-    if (m_laContext) {
-        completionHandler(m_laContext.get());
+    if (RetainPtr laContext = m_laContext) {
+        completionHandler(laContext.get());
         return;
     }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
@@ -58,20 +58,20 @@
         return nil;
     _card = card;
     _invalidationHandler = WTF::move(handler);
-    [_card addObserver:self forKeyPath:@"valid" options:NSKeyValueObservingOptionNew context:nil];
+    [protect(_card) addObserver:self forKeyPath:@"valid" options:NSKeyValueObservingOptionNew context:nil];
     return self;
 }
 
 - (void)dealloc
 {
-    [_card removeObserver:self forKeyPath:@"valid"];
+    [protect(_card) removeObserver:self forKeyPath:@"valid"];
     [super dealloc];
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
     if ([keyPath isEqualToString:@"valid"]) {
-        BOOL valid = [[change objectForKey:NSKeyValueChangeNewKey] boolValue];
+        BOOL valid = [protect([change objectForKey:NSKeyValueChangeNewKey]) boolValue];
         if (!valid) {
             @synchronized(self) {
                 if (_invalidationHandler) {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm
@@ -95,7 +95,7 @@ void CcidService::restartDiscoveryInternal()
 void CcidService::removeObservers()
 {
     if (m_slotsObserver) {
-        [[TKSmartCardSlotManager defaultManager] removeObserver:m_slotsObserver.get() forKeyPath:@"slotNames"];
+        [[TKSmartCardSlotManager defaultManager] removeObserver:protect(m_slotsObserver) forKeyPath:@"slotNames"];
         m_slotsObserver.clear();
     }
     for (auto observer : m_slotObservers.values())
@@ -111,7 +111,7 @@ void CcidService::platformStartDiscovery()
     m_connection = nullptr;
     removeObservers();
     m_slotsObserver = adoptNS([[_WKSmartCardSlotObserver alloc] initWithService:this]);
-    [[TKSmartCardSlotManager defaultManager] addObserver:m_slotsObserver.get() forKeyPath:@"slotNames" options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionInitial context:nil];
+    [[TKSmartCardSlotManager defaultManager] addObserver:protect(m_slotsObserver) forKeyPath:@"slotNames" options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionInitial context:nil];
 }
 
 void CcidService::onValidCard(RetainPtr<TKSmartCard>&& smartCard, RetainPtr<TKSmartCardSlot>&& slot)
@@ -149,7 +149,7 @@ void CcidService::updateSlots(NSArray *slots)
     for (auto& slotPair : m_slotObservers) {
         if (!slotsSet.contains(slotPair.key)) {
             staleSlots.add(slotPair.key);
-            [slotPair.value removeObserver];
+            [protect(slotPair.value) removeObserver];
         }
     }
     for (const String& slot : staleSlots)
@@ -203,7 +203,7 @@ void CcidService::updateSlots(NSArray *slots)
 
     if (!m_service)
         return;
-    int state = [change[NSKeyValueChangeNewKey] intValue];
+    int state = [protect(change[NSKeyValueChangeNewKey]) intValue];
     switch (state) {
     case TKSmartCardSlotStateMissing:
         RELEASE_LOG(WebAuthn, "_WKSmartCardSlotStateObserver: state=Missing");
@@ -239,7 +239,7 @@ void CcidService::updateSlots(NSArray *slots)
 - (void)removeObserver
 {
     if (m_slot) {
-        [m_slot removeObserver:self forKeyPath:@"state"];
+        [protect(m_slot) removeObserver:self forKeyPath:@"state"];
         m_slot.clear();
     }
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -87,7 +87,7 @@
         return nil;
 
     if (page)
-        m_view = page->cocoaView();
+        m_view = protect(page)->cocoaView();
     m_completionHandler = WTF::move(completionHandler);
 
     return self;
@@ -552,13 +552,12 @@ void WebAuthenticatorCoordinatorProxy::unpauseConditionalAssertion()
 
 void WebAuthenticatorCoordinatorProxy::makeActiveConditionalAssertion()
 {
-    if (auto& activeProxy = activeConditionalMediationProxy()) {
+    if (RefPtr activeProxy = activeConditionalMediationProxy()) {
         if (activeProxy == this && !m_paused)
             return;
         activeProxy->pauseConditionalAssertion([weakThis = WeakPtr { *this }] () {
-            if (!weakThis)
-                return;
-            weakThis->unpauseConditionalAssertion();
+            if (RefPtr protectedThis = weakThis)
+                protectedThis->unpauseConditionalAssertion();
         });
         return;
     }

--- a/Source/WebKit/UIProcess/WebContextInjectedBundleClient.cpp
+++ b/Source/WebKit/UIProcess/WebContextInjectedBundleClient.cpp
@@ -47,7 +47,7 @@ void WebContextInjectedBundleClient::didReceiveMessageFromInjectedBundle(WebProc
     if (!m_client.didReceiveMessageFromInjectedBundle)
         return;
 
-    m_client.didReceiveMessageFromInjectedBundle(toAPI(&processPool), toAPI(messageName.impl()), toAPI(messageBody), m_client.base.clientInfo);
+    m_client.didReceiveMessageFromInjectedBundle(toAPI(&processPool), toAPI(messageName), toAPI(messageBody), m_client.base.clientInfo);
 }
 
 void WebContextInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle(WebProcessPool& processPool, const String& messageName, API::Object* messageBody, CompletionHandler<void(RefPtr<API::Object>)>&& completionHandler)
@@ -57,11 +57,11 @@ void WebContextInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBun
 
     if (m_client.didReceiveSynchronousMessageFromInjectedBundle) {
         WKTypeRef returnDataRef = nullptr;
-        m_client.didReceiveSynchronousMessageFromInjectedBundle(toAPI(&processPool), toAPI(messageName.impl()), toAPI(messageBody), &returnDataRef, m_client.base.clientInfo);
+        m_client.didReceiveSynchronousMessageFromInjectedBundle(toAPI(&processPool), toAPI(messageName), toAPI(messageBody), &returnDataRef, m_client.base.clientInfo);
         return completionHandler(adoptRef(toImpl(returnDataRef)));
     }
 
-    m_client.didReceiveSynchronousMessageFromInjectedBundleWithListener(toAPI(&processPool), toAPI(messageName.impl()), toAPI(messageBody), toAPI(API::MessageListener::create(WTF::move(completionHandler)).ptr()), m_client.base.clientInfo);
+    m_client.didReceiveSynchronousMessageFromInjectedBundleWithListener(toAPI(&processPool), toAPI(messageName), toAPI(messageBody), toAPI(API::MessageListener::create(WTF::move(completionHandler)).ptr()), m_client.base.clientInfo);
 }
 
 RefPtr<API::Object> WebContextInjectedBundleClient::getInjectedBundleInitializationUserData(WebProcessPool& processPool)

--- a/Source/WebKit/UIProcess/WebDataListSuggestionsDropdown.cpp
+++ b/Source/WebKit/UIProcess/WebDataListSuggestionsDropdown.cpp
@@ -46,7 +46,7 @@ void WebDataListSuggestionsDropdown::show(WebCore::DataListSuggestionInformation
 void WebDataListSuggestionsDropdown::close()
 {
     auto targetFrameID = std::exchange(m_targetFrameID, std::nullopt);
-    if (auto page = std::exchange(m_page, nullptr))
+    if (RefPtr page = std::exchange(m_page, nullptr))
         page->didCloseSuggestions(targetFrameID);
 }
 

--- a/Source/WebKit/UIProcess/WebDateTimePicker.cpp
+++ b/Source/WebKit/UIProcess/WebDateTimePicker.cpp
@@ -46,7 +46,7 @@ void WebDateTimePicker::showDateTimePicker(WebCore::DateTimeChooserParameters&& 
 
 void WebDateTimePicker::endPicker()
 {
-    if (auto page = std::exchange(m_page, nullptr))
+    if (RefPtr page = std::exchange(m_page, nullptr))
         page->didEndDateTimePicker();
 }
 

--- a/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.cpp
@@ -58,7 +58,7 @@ void WebFramePolicyListenerProxy::didReceiveAppBoundDomainResult(std::optional<N
 
     if (m_policyResult && m_doneWaitingForSafeBrowsing && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
         if (m_reply)
-            m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
+            m_reply(WebCore::PolicyAction::Use, protect(m_policyResult->first), m_policyResult->second, isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
     } else
         m_isNavigatingToAppBoundDomain = isNavigatingToAppBoundDomain;
 }
@@ -68,7 +68,7 @@ void WebFramePolicyListenerProxy::didReceiveSafeBrowsingResults()
     ASSERT(isMainRunLoop());
     if (m_policyResult && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
         if (m_reply)
-            m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
+            m_reply(WebCore::PolicyAction::Use, protect(m_policyResult->first), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
     }
 
     m_doneWaitingForSafeBrowsing = true;
@@ -81,7 +81,7 @@ void WebFramePolicyListenerProxy::didReceiveInitialLinkDecorationFilteringData()
 
     if (m_policyResult && m_isNavigatingToAppBoundDomain && m_doneWaitingForSafeBrowsing && m_doneWaitingForSiteHasStorage && m_doneWaitingForEnhancedSecurityLink) {
         if (m_reply)
-            m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
+            m_reply(WebCore::PolicyAction::Use, protect(m_policyResult->first), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
         return;
     }
 
@@ -95,7 +95,7 @@ void WebFramePolicyListenerProxy::didReceiveSiteHasStorageResults()
 
     if (m_policyResult && m_doneWaitingForSafeBrowsing && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForEnhancedSecurityLink) {
         if (m_reply)
-            m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
+            m_reply(WebCore::PolicyAction::Use, protect(m_policyResult->first), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
         return;
     }
 
@@ -109,7 +109,7 @@ void WebFramePolicyListenerProxy::didReceiveEnhancedSecurityLinkResults()
 
     if (m_policyResult && m_doneWaitingForSafeBrowsing && m_isNavigatingToAppBoundDomain && m_doneWaitingForLinkDecorationFilteringData && m_doneWaitingForSiteHasStorage) {
         if (m_reply)
-            m_reply(WebCore::PolicyAction::Use, m_policyResult->first.get(), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
+            m_reply(WebCore::PolicyAction::Use, protect(m_policyResult->first), m_policyResult->second, *m_isNavigatingToAppBoundDomain, WasNavigationIntercepted::No);
         return;
     }
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -625,7 +625,7 @@ void WebFrameProxy::didCreateSubframe(WebCore::FrameIdentifier frameID, String&&
     if ((frameID.toUInt64() >> 32) != process().coreProcessIdentifier().toUInt64())
         return;
 
-    Ref child = WebFrameProxy::create(*page, m_frameProcess, frameID, effectiveSandboxFlags, effectiveReferrerPolicy, scrollingMode, nullptr, this, IsMainFrame::No, std::nullopt);
+    Ref child = WebFrameProxy::create(*page, protect(m_frameProcess), frameID, effectiveSandboxFlags, effectiveReferrerPolicy, scrollingMode, nullptr, this, IsMainFrame::No, std::nullopt);
     child->m_parentFrame = *this;
     child->m_frameName = WTF::move(frameName);
     page->inspectorController().didCreateFrame(child);

--- a/Source/WebKit/UIProcess/WebPageDiagnosticLoggingClient.cpp
+++ b/Source/WebKit/UIProcess/WebPageDiagnosticLoggingClient.cpp
@@ -42,7 +42,7 @@ void WebPageDiagnosticLoggingClient::logDiagnosticMessage(WebPageProxy* page, co
     if (!m_client.logDiagnosticMessage)
         return;
 
-    m_client.logDiagnosticMessage(toAPI(page), toAPI(message.impl()), toAPI(description.impl()), m_client.base.clientInfo);
+    m_client.logDiagnosticMessage(toAPI(page), toAPI(message), toAPI(description), m_client.base.clientInfo);
 }
 
 void WebPageDiagnosticLoggingClient::logDiagnosticMessageWithResult(WebPageProxy* page, const String& message, const String& description, WebCore::DiagnosticLoggingResultType result)
@@ -50,7 +50,7 @@ void WebPageDiagnosticLoggingClient::logDiagnosticMessageWithResult(WebPageProxy
     if (!m_client.logDiagnosticMessageWithResult)
         return;
 
-    m_client.logDiagnosticMessageWithResult(toAPI(page), toAPI(message.impl()), toAPI(description.impl()), toAPI(result), m_client.base.clientInfo);
+    m_client.logDiagnosticMessageWithResult(toAPI(page), toAPI(message), toAPI(description), toAPI(result), m_client.base.clientInfo);
 }
 
 void WebPageDiagnosticLoggingClient::logDiagnosticMessageWithValue(WebPageProxy* page, const String& message, const String& description, const String& value)
@@ -58,7 +58,7 @@ void WebPageDiagnosticLoggingClient::logDiagnosticMessageWithValue(WebPageProxy*
     if (!m_client.logDiagnosticMessageWithValue)
         return;
 
-    m_client.logDiagnosticMessageWithValue(toAPI(page), toAPI(message.impl()), toAPI(description.impl()), toAPI(value.impl()), m_client.base.clientInfo);
+    m_client.logDiagnosticMessageWithValue(toAPI(page), toAPI(message), toAPI(description), toAPI(value), m_client.base.clientInfo);
 }
 
 void WebPageDiagnosticLoggingClient::logDiagnosticMessageWithEnhancedPrivacy(WebPageProxy* page, const String& message, const String& description)
@@ -66,7 +66,7 @@ void WebPageDiagnosticLoggingClient::logDiagnosticMessageWithEnhancedPrivacy(Web
     if (!m_client.logDiagnosticMessageWithEnhancedPrivacy)
         return;
 
-    m_client.logDiagnosticMessageWithEnhancedPrivacy(toAPI(page), toAPI(message.impl()), toAPI(description.impl()), m_client.base.clientInfo);
+    m_client.logDiagnosticMessageWithEnhancedPrivacy(toAPI(page), toAPI(message), toAPI(description), m_client.base.clientInfo);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp
+++ b/Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp
@@ -43,7 +43,7 @@ void WebPageInjectedBundleClient::didReceiveMessageFromInjectedBundle(WebPagePro
     if (!m_client.didReceiveMessageFromInjectedBundle)
         return;
 
-    m_client.didReceiveMessageFromInjectedBundle(toAPI(page), toAPI(messageName.impl()), toAPI(messageBody), m_client.base.clientInfo);
+    m_client.didReceiveMessageFromInjectedBundle(toAPI(page), toAPI(messageName), toAPI(messageBody), m_client.base.clientInfo);
 }
 
 void WebPageInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle(WebPageProxy* page, const String& messageName, API::Object* messageBody, bool fromMainFrameProcess, CompletionHandler<void(RefPtr<API::Object>)>&& completionHandler)
@@ -55,13 +55,13 @@ void WebPageInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle
 
     if (m_client.didReceiveSynchronousMessageFromInjectedBundle) {
         WKTypeRef returnDataRef = nullptr;
-        m_client.didReceiveSynchronousMessageFromInjectedBundle(toAPI(page), toAPI(messageName.impl()), toAPI(messageBody), &returnDataRef, m_client.base.clientInfo);
+        m_client.didReceiveSynchronousMessageFromInjectedBundle(toAPI(page), toAPI(messageName), toAPI(messageBody), &returnDataRef, m_client.base.clientInfo);
         return completionHandler(adoptRef(toImpl(returnDataRef)));
     }
 
     if (m_client.didReceiveSynchronousMessageFromInjectedBundleWithListenerFromMainFrameProcess)
-        return m_client.didReceiveSynchronousMessageFromInjectedBundleWithListenerFromMainFrameProcess(toAPI(page), toAPI(messageName.impl()), toAPI(messageBody), fromMainFrameProcess, toAPI(API::MessageListener::create(WTF::move(completionHandler)).ptr()), m_client.base.clientInfo);
+        return m_client.didReceiveSynchronousMessageFromInjectedBundleWithListenerFromMainFrameProcess(toAPI(page), toAPI(messageName), toAPI(messageBody), fromMainFrameProcess, toAPI(API::MessageListener::create(WTF::move(completionHandler)).ptr()), m_client.base.clientInfo);
 
-    m_client.didReceiveSynchronousMessageFromInjectedBundleWithListener(toAPI(page), toAPI(messageName.impl()), toAPI(messageBody), toAPI(API::MessageListener::create(WTF::move(completionHandler)).ptr()), m_client.base.clientInfo);
+    m_client.didReceiveSynchronousMessageFromInjectedBundleWithListener(toAPI(page), toAPI(messageName), toAPI(messageBody), toAPI(API::MessageListener::create(WTF::move(completionHandler)).ptr()), m_client.base.clientInfo);
 }
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1507,7 +1507,7 @@ void WebPageProxy::launchProcess(const Site& site, ProcessLaunchReason reason)
 
     auto pendingInjectedBundleMessage = WTF::move(m_pendingInjectedBundleMessages);
     for (auto& message : pendingInjectedBundleMessage)
-        send(Messages::WebPage::PostInjectedBundleMessage(message.messageName, UserData(process->transformObjectsToHandles(message.messageBody.get()).get())));
+        send(Messages::WebPage::PostInjectedBundleMessage(message.messageName, UserData(process->transformObjectsToHandles(protect(message.messageBody)).get())));
 }
 
 bool WebPageProxy::suspendCurrentPageIfPossible(API::Navigation& navigation, RefPtr<WebFrameProxy>&& mainFrame, ShouldDelayClosingUntilFirstLayerFlush shouldDelayClosingUntilFirstLayerFlush)
@@ -4113,7 +4113,7 @@ void WebPageProxy::executeEditCommand(const String& commandName, const String& a
         if (!protectedThis || !protectedThis->hasRunningProcess())
             return callbackFunction();
 
-        protectedThis->sendWithAsyncReplyToProcessContainingFrame(targetFrameID, Messages::WebPage::ExecuteEditCommandWithCallback(commandName, argument), [callbackFunction = WTF::move(callbackFunction), backgroundActivity = protect(weakThis->processContainingFrame(targetFrameID)->throttler())->backgroundActivity("WebPageProxy::executeEditCommand"_s)] () mutable {
+        protectedThis->sendWithAsyncReplyToProcessContainingFrame(targetFrameID, Messages::WebPage::ExecuteEditCommandWithCallback(commandName, argument), [callbackFunction = WTF::move(callbackFunction), backgroundActivity = protect(protectedThis->processContainingFrame(targetFrameID)->throttler())->backgroundActivity("WebPageProxy::executeEditCommand"_s)] () mutable {
             callbackFunction();
         });
     };
@@ -6230,9 +6230,9 @@ void WebPageProxy::receivedPolicyDecision(PolicyAction action, API::Navigation* 
         RefPtr<DownloadProxy> download;
 
         if (navigation && (navigation->targetItem() || navigation->isRequestFromClientOrUserInput()))
-            download = protect(m_configuration->processPool())->createDownloadProxy(m_websiteDataStore, navigationAction->request(), downloadOriginatingPage(navigation).ptr(), std::nullopt);
+            download = protect(m_configuration->processPool())->createDownloadProxy(protect(m_websiteDataStore), navigationAction->request(), downloadOriginatingPage(navigation).ptr(), std::nullopt);
         else
-            download = protect(m_configuration->processPool())->createDownloadProxy(m_websiteDataStore, navigationAction->request(), downloadOriginatingPage(navigation).ptr(), navigation ? navigation->originatingFrameInfo() : std::optional(navigationAction->data().originatingFrameInfoData));
+            download = protect(m_configuration->processPool())->createDownloadProxy(protect(m_websiteDataStore), navigationAction->request(), downloadOriginatingPage(navigation).ptr(), navigation ? navigation->originatingFrameInfo() : std::optional(navigationAction->data().originatingFrameInfoData));
 
         download->setDidStartCallback([weakThis = WeakPtr { *this }, navigationAction = WTF::move(navigationAction)] (auto* downloadProxy) {
             RefPtr protectedThis = weakThis.get();
@@ -6289,9 +6289,9 @@ void WebPageProxy::receivedNavigationResponsePolicyDecision(WebCore::PolicyActio
         RefPtr<DownloadProxy> download;
 
         if (navigation && (navigation->targetItem() || navigation->isRequestFromClientOrUserInput()))
-            download = protect(m_configuration->processPool())->createDownloadProxy(m_websiteDataStore, request, downloadOriginatingPage(navigation).ptr(), std::nullopt);
+            download = protect(m_configuration->processPool())->createDownloadProxy(protect(m_websiteDataStore), request, downloadOriginatingPage(navigation).ptr(), std::nullopt);
         else
-            download = protect(m_configuration->processPool())->createDownloadProxy(m_websiteDataStore, request, downloadOriginatingPage(navigation).ptr(), navigation ? navigation->originatingFrameInfo() : std::nullopt);
+            download = protect(m_configuration->processPool())->createDownloadProxy(protect(m_websiteDataStore), request, downloadOriginatingPage(navigation).ptr(), navigation ? navigation->originatingFrameInfo() : std::nullopt);
 
         download->setDidStartCallback([weakThis = WeakPtr { *this }, navigationResponse = navigationResponse.copyRef()] (auto* downloadProxy) {
             RefPtr protectedThis = weakThis.get();
@@ -6582,7 +6582,7 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
         // FIXME: Work out timing of responding with the last policy delegate, etc
         ASSERT(!existingNetworkResourceLoadIdentifierToResume || !navigation->substituteData());
         if (auto& substituteData = navigation->substituteData())
-            provisionalPage->loadData(navigation, SharedBuffer::create(Vector(substituteData->content)), substituteData->MIMEType, substituteData->encoding, substituteData->baseURL, substituteData->userData.get(), shouldTreatAsContinuingLoad, isNavigatingToAppBoundDomain(), WTF::move(websitePolicies), substituteData->sessionHistoryVisibility);
+            provisionalPage->loadData(navigation, SharedBuffer::create(Vector(substituteData->content)), substituteData->MIMEType, substituteData->encoding, substituteData->baseURL, protect(substituteData->userData), shouldTreatAsContinuingLoad, isNavigatingToAppBoundDomain(), WTF::move(websitePolicies), substituteData->sessionHistoryVisibility);
         else if (navigation->currentRequest().isEmpty()) {
             WEBPAGEPROXY_RELEASE_LOG_ERROR(Loading, "continueNavigationInNewProcess: Tearing down provisional load because the navigation request URL is empty");
             m_provisionalPage = nullptr;
@@ -13173,7 +13173,7 @@ void WebPageProxy::contextMenuItemSelected(const WebContextMenuItemData& item, c
     }
 
     if (downloadInfo) {
-        Ref download = protect(m_configuration->processPool())->download(m_websiteDataStore, this, URL { downloadInfo->url }, frameInfo, downloadInfo->suggestedFilename);
+        Ref download = protect(m_configuration->processPool())->download(protect(m_websiteDataStore), this, URL { downloadInfo->url }, frameInfo, downloadInfo->suggestedFilename);
         download->setDidStartCallback([weakThis = WeakPtr { *this }] (auto* download) {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis || !download)
@@ -15234,8 +15234,8 @@ void WebPageProxy::queryPermission(const ClientOrigin& clientOrigin, const Permi
             result = PermissionState::Prompt;
         else if (*result == PermissionState::Prompt && shouldChangePromptToGrant)
             result = PermissionState::Granted;
-        if (result == PermissionState::Granted && isNotificationPermission && weakThis)
-            weakThis->pageWillLikelyUseNotifications();
+        if (RefPtr protectedThis = weakThis; result == PermissionState::Granted && isNotificationPermission && protectedThis)
+            protectedThis->pageWillLikelyUseNotifications();
         completionHandler(*result);
     };
 

--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -540,7 +540,7 @@ void WebProcessCache::CachedProcess::evictionTimerFired()
 {
     ASSERT(m_process);
     auto process = m_process.copyRef();
-    process->processPool().webProcessCache().removeProcess(*process, ShouldShutDownProcess::Yes);
+    protect(process->processPool().webProcessCache())->removeProcess(*process, ShouldShutDownProcess::Yes);
 }
 
 #if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -938,7 +938,7 @@ void WebProcessProxy::shutDown()
     didStopRunningProcess();
 
     if (m_isInProcessCache) {
-        processPool().webProcessCache().removeProcess(*this, WebProcessCache::ShouldShutDownProcess::No);
+        protect(processPool().webProcessCache())->removeProcess(*this, WebProcessCache::ShouldShutDownProcess::No);
         ASSERT(!m_isInProcessCache);
     }
 
@@ -1271,13 +1271,14 @@ void WebProcessProxy::assumeReadAccessToBaseURL(WebPageProxy& page, const String
     if (!dataStore)
         return completionHandler();
     auto afterAllowAccess = [weakThis = WeakPtr { *this }, weakPage = WeakPtr { page }, path, completionHandler = WTF::move(completionHandler)] mutable {
-        if (!weakThis || !weakPage)
+        RefPtr page = weakPage;
+        if (!weakThis || !page)
             return completionHandler();
 
         // Client loads an alternate string. This doesn't grant universal file read, but the web process is assumed
         // to have read access to this directory already.
         weakThis->m_localPathsWithAssumedReadAccess.add(path);
-        weakPage->addPreviouslyVisitedPath(path);
+        page->addPreviouslyVisitedPath(path);
         completionHandler();
     };
 
@@ -1326,14 +1327,15 @@ void WebProcessProxy::assumeReadAccessToBaseURLs(WebPageProxy& page, const Vecto
 
     auto messagePaths = paths;
     protect(dataStore->networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(coreProcessIdentifier(), WTF::move(messagePaths)), [weakThis = WeakPtr { *this }, weakPage = WeakPtr { page }, paths = WTF::move(paths), completionHandler = WTF::move(completionHandler)] mutable {
-        if (!weakThis || !weakPage)
+        RefPtr page = weakPage;
+        if (!weakThis || !page)
             return completionHandler();
 
         // Client loads an alternate string. This doesn't grant universal file read, but the web process is assumed
         // to have read access to this directory already.
         for (auto& path : paths) {
             weakThis->m_localPathsWithAssumedReadAccess.add(path);
-            weakPage->addPreviouslyVisitedPath(path);
+            page->addPreviouslyVisitedPath(path);
         }
         completionHandler();
     });
@@ -2976,7 +2978,8 @@ void WebProcessProxy::createSpeechRecognitionServer(SpeechRecognitionServerIdent
     m_speechRecognitionServerMap.ensure(identifier, [&]() {
 #if ENABLE(MEDIA_STREAM)
         auto createRealtimeMediaSource = [weakPage = WeakPtr { targetPage }](WebCore::SpeechRecognitionConnectionClientIdentifier clientIdentifier) {
-            return weakPage ? weakPage->createRealtimeMediaSourceForSpeechRecognition(clientIdentifier) : CaptureSourceOrError { { "Page is invalid"_s, WebCore::MediaAccessDenialReason::InvalidAccess } };
+            RefPtr page = weakPage;
+            return page ? page->createRealtimeMediaSourceForSpeechRecognition(clientIdentifier) : CaptureSourceOrError { { "Page is invalid"_s, WebCore::MediaAccessDenialReason::InvalidAccess } };
         };
         Ref speechRecognitionServer = SpeechRecognitionServer::create(*this, identifier, WTF::move(permissionChecker), WTF::move(checkIfMockCaptureDevicesEnabled), WTF::move(createRealtimeMediaSource));
 #else

--- a/Source/WebKit/UIProcess/WebURLSchemeHandler.cpp
+++ b/Source/WebKit/UIProcess/WebURLSchemeHandler.cpp
@@ -51,7 +51,7 @@ void WebURLSchemeHandler::startTask(WebPageProxy& page, WebProcessProxy& process
     ASSERT(!pageEntry.iterator->value.contains(taskIdentifier));
     pageEntry.iterator->value.add(taskIdentifier);
 
-    platformStartTask(page, result.iterator->value);
+    platformStartTask(page, protect(result.iterator->value));
 }
 
 void WebURLSchemeHandler::stopAllTasksForPage(WebPageProxy& page, WebProcessProxy* process)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2665,7 +2665,7 @@ void WebsiteDataStore::forwardAppBoundDomainsToITPIfInitialized(CompletionHandle
         store->setAppBoundDomainsForITP(domains, [callbackAggregator] { });
     };
 
-    propagateAppBoundDomains(protectedGlobalDefaultDataStore().get(), *appBoundDomains);
+    propagateAppBoundDomains(protect(protectedGlobalDefaultDataStore()), *appBoundDomains);
 
     for (auto& store : allDataStores().values())
         propagateAppBoundDomains(protect(store).ptr(), *appBoundDomains);

--- a/Source/WebKit/UIProcess/glib/WebTextCheckerClient.cpp
+++ b/Source/WebKit/UIProcess/glib/WebTextCheckerClient.cpp
@@ -99,7 +99,7 @@ void WebTextCheckerClient::checkSpellingOfString(uint64_t tag, const String& tex
     if (!m_client.checkSpellingOfString)
         return;
 
-    m_client.checkSpellingOfString(tag, toAPI(text.impl()), &misspellingLocation, &misspellingLength, m_client.base.clientInfo);
+    m_client.checkSpellingOfString(tag, toAPI(text), &misspellingLocation, &misspellingLength, m_client.base.clientInfo);
 }
 
 void WebTextCheckerClient::checkGrammarOfString(uint64_t tag, const String& text, Vector<WebCore::GrammarDetail>& grammarDetails, int32_t& badGrammarLocation, int32_t& badGrammarLength)
@@ -111,7 +111,7 @@ void WebTextCheckerClient::checkGrammarOfString(uint64_t tag, const String& text
         return;
 
     WKArrayRef wkGrammarDetailsRef = 0;
-    m_client.checkGrammarOfString(tag, toAPI(text.impl()), &wkGrammarDetailsRef, &badGrammarLocation, &badGrammarLength, m_client.base.clientInfo);
+    m_client.checkGrammarOfString(tag, toAPI(text), &wkGrammarDetailsRef, &badGrammarLocation, &badGrammarLength, m_client.base.clientInfo);
 
     RefPtr<API::Array> wkGrammarDetails = adoptRef(toImpl(wkGrammarDetailsRef));
     size_t numGrammarDetails = wkGrammarDetails->size();
@@ -140,7 +140,7 @@ void WebTextCheckerClient::updateSpellingUIWithMisspelledWord(uint64_t tag, cons
     if (!m_client.updateSpellingUIWithMisspelledWord)
         return;
 
-    m_client.updateSpellingUIWithMisspelledWord(tag, toAPI(misspelledWord.impl()), m_client.base.clientInfo);
+    m_client.updateSpellingUIWithMisspelledWord(tag, toAPI(misspelledWord), m_client.base.clientInfo);
 }
 
 void WebTextCheckerClient::updateSpellingUIWithGrammarString(uint64_t tag, const String& badGrammarPhrase, const WebCore::GrammarDetail& grammarDetail)
@@ -148,7 +148,7 @@ void WebTextCheckerClient::updateSpellingUIWithGrammarString(uint64_t tag, const
     if (!m_client.updateSpellingUIWithGrammarString)
         return;
 
-    m_client.updateSpellingUIWithGrammarString(tag, toAPI(badGrammarPhrase.impl()), toAPI(grammarDetail), m_client.base.clientInfo);
+    m_client.updateSpellingUIWithGrammarString(tag, toAPI(badGrammarPhrase), toAPI(grammarDetail), m_client.base.clientInfo);
 }
 
 void WebTextCheckerClient::guessesForWord(uint64_t tag, const String& word, Vector<String>& guesses)
@@ -156,7 +156,7 @@ void WebTextCheckerClient::guessesForWord(uint64_t tag, const String& word, Vect
     if (!m_client.guessesForWord)
         return;
 
-    RefPtr<API::Array> wkGuesses = adoptRef(toImpl(m_client.guessesForWord(tag, toAPI(word.impl()), m_client.base.clientInfo)));
+    RefPtr<API::Array> wkGuesses = adoptRef(toImpl(m_client.guessesForWord(tag, toAPI(word), m_client.base.clientInfo)));
     size_t numGuesses = wkGuesses->size();
     for (size_t i = 0; i < numGuesses; ++i)
         guesses.append(wkGuesses->at<API::String>(i)->string());
@@ -167,7 +167,7 @@ void WebTextCheckerClient::learnWord(uint64_t tag, const String& word)
     if (!m_client.learnWord)
         return;
 
-    m_client.learnWord(tag, toAPI(word.impl()), m_client.base.clientInfo);
+    m_client.learnWord(tag, toAPI(word), m_client.base.clientInfo);
 }
 
 void WebTextCheckerClient::ignoreWord(uint64_t tag, const String& word)
@@ -175,7 +175,7 @@ void WebTextCheckerClient::ignoreWord(uint64_t tag, const String& word)
     if (!m_client.ignoreWord)
         return;
 
-    m_client.ignoreWord(tag, toAPI(word.impl()), m_client.base.clientInfo);
+    m_client.ignoreWord(tag, toAPI(word), m_client.base.clientInfo);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm
@@ -90,7 +90,7 @@
 
 - (void)addTextAnimationForAnimationID:(NSUUID *)uuid withData:(const WebCore::TextAnimationData&)data
 {
-    if (data.style == WebCore::TextAnimationType::Initial && _webView->page().writingToolsTextReplacementsFinished()) {
+    if (data.style == WebCore::TextAnimationType::Initial && protect(_webView->page())->writingToolsTextReplacementsFinished()) {
         // When the session has finished sending all of the partial replacements, the `TextAnimationController` may still
         // request an initial text animation for the remaining "unreplaced" range of the context range (which may or may
         // not actually end up getting replaced for a given partial replacement). However, this "unreplaced" range will
@@ -235,7 +235,7 @@
         return;
     }
 
-    _webView->page().getTextIndicatorForID(*uuid, [protectedSelf = retainPtr(self), completionHandler = makeBlockPtr(completionHandler)] (RefPtr<WebCore::TextIndicator> textIndicator) {
+    protect(_webView->page())->getTextIndicatorForID(*uuid, [protectedSelf = retainPtr(self), completionHandler = makeBlockPtr(completionHandler)] (RefPtr<WebCore::TextIndicator> textIndicator) {
         if (!textIndicator) {
             completionHandler(nil);
             return;
@@ -273,7 +273,7 @@
     WebCore::IntSize bitmapSize(rect.size.width, rect.size.height);
     bitmapSize.scale(deviceScale, deviceScale);
 
-    _webView->page().takeSnapshot(WebCore::IntRect(rect), bitmapSize, WebKit::SnapshotOption::Shareable, [rect, completionHandler = makeBlockPtr(completionHandler)](CGImageRef image) {
+    protect(_webView->page())->takeSnapshot(WebCore::IntRect(rect), bitmapSize, WebKit::SnapshotOption::Shareable, [rect, completionHandler = makeBlockPtr(completionHandler)](CGImageRef image) {
         if (!image) {
             completionHandler(nil);
             return;
@@ -294,7 +294,7 @@
         return;
     }
 
-    _webView->page().updateUnderlyingTextVisibilityForTextAnimationID(*uuid, isTextVisible, [completionHandler = makeBlockPtr(completionHandler)] () {
+    protect(_webView->page())->updateUnderlyingTextVisibilityForTextAnimationID(*uuid, isTextVisible, [completionHandler = makeBlockPtr(completionHandler)] () {
         if (completionHandler)
             completionHandler();
     });

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1113,17 +1113,17 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     if ([textStyle isSelectedForSegment:0] != _textIsBold) {
         _textIsBold = !_textIsBold;
-        _webViewImpl->page().executeEditCommand("ToggleBold"_s, emptyString());
+        protect(_webViewImpl->page())->executeEditCommand("ToggleBold"_s, emptyString());
     }
 
     if ([textStyle isSelectedForSegment:1] != _textIsItalic) {
         _textIsItalic = !_textIsItalic;
-        _webViewImpl->page().executeEditCommand("ToggleItalic"_s, emptyString());
+        protect(_webViewImpl->page())->executeEditCommand("ToggleItalic"_s, emptyString());
     }
 
     if ([textStyle isSelectedForSegment:2] != _textIsUnderlined) {
         _textIsUnderlined = !_textIsUnderlined;
-        _webViewImpl->page().executeEditCommand("ToggleUnderline"_s, emptyString());
+        protect(_webViewImpl->page())->executeEditCommand("ToggleUnderline"_s, emptyString());
     }
 }
 
@@ -1181,7 +1181,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return;
 
     _textColor = self.colorPickerItem.color;
-    _webViewImpl->page().executeEditCommand("ForeColor"_s, WebCore::serializationForHTML(WebCore::colorFromCocoaColor(_textColor.get())));
+    protect(_webViewImpl->page())->executeEditCommand("ForeColor"_s, WebCore::serializationForHTML(WebCore::colorFromCocoaColor(_textColor.get())));
 }
 
 - (NSViewController *)textListViewController

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -353,7 +353,7 @@ WebCore::AccessibilityObject* WebAutomationSessionProxy::getAccessibilityObjectF
         return nullptr;
     }
 
-    WeakPtr frame = frameID ? WebProcess::singleton().webFrame(*frameID) : &page->mainWebFrame();
+    RefPtr frame = frameID ? WebProcess::singleton().webFrame(*frameID) : &page->mainWebFrame();
     if (!frame || !frame->coreLocalFrame() || !frame->coreLocalFrame()->view()) {
         errorType = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::WindowNotFound);
         return nullptr;
@@ -1169,7 +1169,7 @@ void WebAutomationSessionProxy::getCookiesForFrame(WebCore::PageIdentifier pageI
     // This returns the same list of cookies as when evaluating `document.cookies` in JavaScript.
     Vector<WebCore::Cookie> foundCookies;
     if (!document->cookieURL().isEmpty())
-        page->corePage()->cookieJar().getRawCookies(*document, document->cookieURL(), foundCookies);
+        protect(page->corePage()->cookieJar())->getRawCookies(*document, document->cookieURL(), foundCookies);
 
     completionHandler(std::nullopt, foundCookies);
 }
@@ -1192,7 +1192,7 @@ void WebAutomationSessionProxy::deleteCookie(WebCore::PageIdentifier pageID, std
         return;
     }
 
-    page->corePage()->cookieJar().deleteCookie(*document, document->cookieURL(), cookieName, [completionHandler = WTF::move(completionHandler)] () mutable {
+    protect(page->corePage()->cookieJar())->deleteCookie(*document, document->cookieURL(), cookieName, [completionHandler = WTF::move(completionHandler)] () mutable {
         completionHandler(std::nullopt);
     });
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -182,7 +182,7 @@ void WebExtensionContextProxy::internalDispatchRuntimeMessageEvent(WebExtensionC
             // callbackAggregatorWrapper ensures that callbackAggregator remains in scope.
             auto senderInfo = toWebAPI(listener->globalContext(), senderParameters);
             auto returnValue = listener->call(toJSValueRef(listener->globalContext(), message), senderInfo, toJSValueRef(listener->globalContext(), ^(JSValue *replyMessage) {
-                callbackAggregatorWrapper.get().aggregator(replyMessage, IsDefaultReply::No);
+                protect(callbackAggregatorWrapper.get().aggregator).get()(replyMessage, IsDefaultReply::No);
             }));
 
             if (JSValueIsBoolean(listener->globalContext(), returnValue) && JSValueToBoolean(listener->globalContext(), returnValue)) {
@@ -197,7 +197,7 @@ void WebExtensionContextProxy::internalDispatchRuntimeMessageEvent(WebExtensionC
             anyListenerHandledMessage = true;
 
             auto resolveBlock = ^(JSValue *replyMessage) {
-                callbackAggregatorWrapper.get().aggregator(replyMessage, IsDefaultReply::No);
+                protect(callbackAggregatorWrapper.get().aggregator).get()(replyMessage, IsDefaultReply::No);
             };
 
             auto rejectBlock = ^(JSValue *error) {

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -86,7 +86,7 @@ public:
 
     bool isURLForThisExtension(const URL&) const;
 
-    RefPtr<JSON::Object> manifest() const { return m_manifest ? m_manifest.get()->asObject() : nullptr; }
+    RefPtr<JSON::Object> manifest() const { return m_manifest ? protect(m_manifest)->asObject() : nullptr; }
 
     double manifestVersion() const { return m_manifestVersion; }
     bool supportsManifestVersion(double version) const { return manifestVersion() >= version; }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -233,7 +233,7 @@ RefPtr<WebCore::VideoFrame> RemoteGraphicsContextGLProxy::surfaceBufferToVideoFr
     auto [result] = sendResult.takeReply();
     if (!result)
         return nullptr;
-    return RemoteVideoFrameProxy::create(WebProcess::singleton().ensureGPUProcessConnection().connection(), protect(protect(WebProcess::singleton().ensureGPUProcessConnection())->videoFrameObjectHeapProxy()), WTF::move(*result));
+    return RemoteVideoFrameProxy::create(protect(WebProcess::singleton().ensureGPUProcessConnection().connection()), protect(protect(WebProcess::singleton().ensureGPUProcessConnection())->videoFrameObjectHeapProxy()), WTF::move(*result));
 }
 #endif
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleClient.cpp
@@ -62,7 +62,7 @@ void InjectedBundleClient::didReceiveMessage(InjectedBundle& bundle, const Strin
     if (!m_client.didReceiveMessage)
         return;
 
-    m_client.didReceiveMessage(toAPI(&bundle), toAPI(messageName.impl()), toAPI(messageBody.get()), m_client.base.clientInfo);
+    m_client.didReceiveMessage(toAPI(&bundle), toAPI(messageName), toAPI(messageBody.get()), m_client.base.clientInfo);
 }
 
 void InjectedBundleClient::didReceiveMessageToPage(InjectedBundle& bundle, WebPage& page, const String& messageName, RefPtr<API::Object>&& messageBody)
@@ -70,7 +70,7 @@ void InjectedBundleClient::didReceiveMessageToPage(InjectedBundle& bundle, WebPa
     if (!m_client.didReceiveMessageToPage)
         return;
 
-    m_client.didReceiveMessageToPage(toAPI(&bundle), toAPI(&page), toAPI(messageName.impl()), toAPI(messageBody.get()), m_client.base.clientInfo);
+    m_client.didReceiveMessageToPage(toAPI(&bundle), toAPI(&page), toAPI(messageName), toAPI(messageBody.get()), m_client.base.clientInfo);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.cpp
@@ -84,7 +84,7 @@ bool InjectedBundlePageEditorClient::shouldInsertNode(WebPage& page, Node& node,
 bool InjectedBundlePageEditorClient::shouldInsertText(WebPage& page, const String& text, const std::optional<SimpleRange>& rangeToReplace, EditorInsertAction action)
 {
     if (m_client.shouldInsertText)
-        return m_client.shouldInsertText(toAPI(&page), toAPI(text.impl()), toAPI(createHandle(rangeToReplace).get()), toAPI(action), m_client.base.clientInfo);
+        return m_client.shouldInsertText(toAPI(&page), toAPI(text), toAPI(createHandle(rangeToReplace).get()), toAPI(action), m_client.base.clientInfo);
     return true;
 }
 
@@ -112,25 +112,25 @@ bool InjectedBundlePageEditorClient::shouldApplyStyle(WebPage& page, const Style
 void InjectedBundlePageEditorClient::didBeginEditing(WebPage& page, const String& notificationName)
 {
     if (m_client.didBeginEditing)
-        m_client.didBeginEditing(toAPI(&page), toAPI(notificationName.impl()), m_client.base.clientInfo);
+        m_client.didBeginEditing(toAPI(&page), toAPI(notificationName), m_client.base.clientInfo);
 }
 
 void InjectedBundlePageEditorClient::didEndEditing(WebPage& page, const String& notificationName)
 {
     if (m_client.didEndEditing)
-        m_client.didEndEditing(toAPI(&page), toAPI(notificationName.impl()), m_client.base.clientInfo);
+        m_client.didEndEditing(toAPI(&page), toAPI(notificationName), m_client.base.clientInfo);
 }
 
 void InjectedBundlePageEditorClient::didChange(WebPage& page, const String& notificationName)
 {
     if (m_client.didChange)
-        m_client.didChange(toAPI(&page), toAPI(notificationName.impl()), m_client.base.clientInfo);
+        m_client.didChange(toAPI(&page), toAPI(notificationName), m_client.base.clientInfo);
 }
 
 void InjectedBundlePageEditorClient::didChangeSelection(WebPage& page, const String& notificationName)
 {
     if (m_client.didChangeSelection)
-        m_client.didChangeSelection(toAPI(&page), toAPI(notificationName.impl()), m_client.base.clientInfo);
+        m_client.didChangeSelection(toAPI(&page), toAPI(notificationName), m_client.base.clientInfo);
 }
 
 void InjectedBundlePageEditorClient::willWriteToPasteboard(WebPage& page, const std::optional<SimpleRange>& range)

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageLoaderClient.cpp
@@ -74,7 +74,7 @@ void InjectedBundlePageLoaderClient::willLoadDataRequest(WebPage& page, const Re
         data = API::Data::createWithoutCopying(contiguousBufferSpan, [contiguousBuffer = WTF::move(contiguousBuffer)] { });
     }
 
-    m_client.willLoadDataRequest(toAPI(&page), toAPI(request), toAPI(data.get()), toAPI(MIMEType.impl()), toAPI(encodingName.impl()), toURLRef(unreachableURL.string()), toAPI(userData), m_client.base.clientInfo);
+    m_client.willLoadDataRequest(toAPI(&page), toAPI(request), toAPI(data.get()), toAPI(MIMEType), toAPI(encodingName), toURLRef(unreachableURL.string()), toAPI(userData), m_client.base.clientInfo);
 }
 
 void InjectedBundlePageLoaderClient::didStartProvisionalLoadForFrame(WebPage& page, WebFrame& frame, RefPtr<API::Object>& userData)
@@ -171,7 +171,7 @@ void InjectedBundlePageLoaderClient::didReceiveTitleForFrame(WebPage& page, cons
         return;
 
     WKTypeRef userDataToPass = nullptr;
-    m_client.didReceiveTitleForFrame(toAPI(&page), toAPI(title.impl()), toAPI(&frame), &userDataToPass, m_client.base.clientInfo);
+    m_client.didReceiveTitleForFrame(toAPI(&page), toAPI(title), toAPI(&frame), &userDataToPass, m_client.base.clientInfo);
     userData = adoptRef(toImpl(userDataToPass));
 }
 
@@ -317,7 +317,7 @@ bool InjectedBundlePageLoaderClient::shouldForceUniversalAccessFromLocalURL(WebP
     if (!m_client.shouldForceUniversalAccessFromLocalURL)
         return false;
 
-    return m_client.shouldForceUniversalAccessFromLocalURL(toAPI(&page), toAPI(url.impl()), m_client.base.clientInfo);
+    return m_client.shouldForceUniversalAccessFromLocalURL(toAPI(&page), toAPI(url), m_client.base.clientInfo);
 }
 
 void InjectedBundlePageLoaderClient::featuresUsedInPage(WebPage& page, const Vector<String>& features)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
@@ -126,12 +126,13 @@ void WebInspectorUIExtensionController::registerExtension(const Inspector::Exten
         JSON::Value::create(displayName),
     };
     protect(m_frontendClient->frontendAPIDispatcher())->dispatchCommandWithResultAsync("registerExtension"_s, WTF::move(arguments), [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](WebCore::InspectorFrontendAPIDispatcher::EvaluationResult&& result) mutable {
-        if (!weakThis || !result) {
+        RefPtr protectedThis = weakThis;
+        if (!protectedThis || !result) {
             completionHandler(makeUnexpected(Inspector::ExtensionError::ContextDestroyed));
             return;
         }
 
-        if (auto parsedError = weakThis->parseExtensionErrorFromEvaluationResult(result)) {
+        if (auto parsedError = protectedThis->parseExtensionErrorFromEvaluationResult(result)) {
             completionHandler(makeUnexpected(parsedError.value()));
             return;
         }
@@ -149,12 +150,13 @@ void WebInspectorUIExtensionController::unregisterExtension(const Inspector::Ext
 
     Vector<Ref<JSON::Value>> arguments { JSON::Value::create(extensionID) };
     protect(m_frontendClient->frontendAPIDispatcher())->dispatchCommandWithResultAsync("unregisterExtension"_s, WTF::move(arguments), [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](WebCore::InspectorFrontendAPIDispatcher::EvaluationResult&& result) mutable {
-        if (!weakThis || !result) {
+        RefPtr protectedThis = weakThis;
+        if (!protectedThis || !result) {
             completionHandler(makeUnexpected(Inspector::ExtensionError::ContextDestroyed));
             return;
         }
 
-        if (auto parsedError = weakThis->parseExtensionErrorFromEvaluationResult(result)) {
+        if (auto parsedError = protectedThis->parseExtensionErrorFromEvaluationResult(result)) {
             completionHandler(makeUnexpected(parsedError.value()));
             return;
         }
@@ -189,25 +191,26 @@ void WebInspectorUIExtensionController::createTabForExtension(const Inspector::E
         JSON::Value::create(sourceURL.string()),
     };
     protect(m_frontendClient->frontendAPIDispatcher())->dispatchCommandWithResultAsync("createTabForExtension"_s, WTF::move(arguments), [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](WebCore::InspectorFrontendAPIDispatcher::EvaluationResult&& result) mutable {
-        if (!weakThis || !result) {
+        RefPtr protectedThis = weakThis;
+        if (!protectedThis || !result) {
             completionHandler(makeUnexpected(Inspector::ExtensionError::ContextDestroyed));
             return;
         }
 
-        if (auto parsedError = weakThis->parseExtensionErrorFromEvaluationResult(result)) {
+        if (auto parsedError = protectedThis->parseExtensionErrorFromEvaluationResult(result)) {
             completionHandler(makeUnexpected(parsedError.value()));
             return;
         }
 
         // Expected result is either an ErrorString or {extensionTabID: <string>}.
-        auto objectResult = weakThis->unwrapEvaluationResultAsObject(result);
+        auto objectResult = protectedThis->unwrapEvaluationResultAsObject(result);
         if (!objectResult) {
             LOG(Inspector, "Unexpected non-object value returned from InspectorFrontendAPI.createTabForExtension().");
             completionHandler(makeUnexpected(Inspector::ExtensionError::InternalError));
             return;
         }
 
-        auto* frontendGlobalObject = protect(weakThis->m_frontendClient->frontendAPIDispatcher())->frontendGlobalObject();
+        auto* frontendGlobalObject = protect(protectedThis->m_frontendClient->frontendAPIDispatcher())->frontendGlobalObject();
         JSC::JSValue foundProperty = objectResult->get(frontendGlobalObject, JSC::Identifier::fromString(frontendGlobalObject->vm(), "result"_s));
         if (!foundProperty || !foundProperty.isString()) {
             completionHandler(makeUnexpected(Inspector::ExtensionError::InternalError));
@@ -240,12 +243,13 @@ void WebInspectorUIExtensionController::evaluateScriptForExtension(const Inspect
     };
 
     protect(m_frontendClient->frontendAPIDispatcher())->dispatchCommandWithResultAsync("evaluateScriptForExtension"_s, WTF::move(arguments), [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](WebCore::InspectorFrontendAPIDispatcher::EvaluationResult&& result) mutable {
-        if (!weakThis) {
+        RefPtr protectedThis = weakThis;
+        if (!protectedThis) {
             completionHandler(makeUnexpected(std::nullopt), Inspector::ExtensionError::ContextDestroyed);
             return;
         }
 
-        auto* frontendGlobalObject = protect(weakThis->m_frontendClient->frontendAPIDispatcher())->frontendGlobalObject();
+        auto* frontendGlobalObject = protect(protectedThis->m_frontendClient->frontendAPIDispatcher())->frontendGlobalObject();
         if (!frontendGlobalObject) {
             completionHandler(makeUnexpected(std::nullopt), Inspector::ExtensionError::ContextDestroyed);
             return;
@@ -253,7 +257,7 @@ void WebInspectorUIExtensionController::evaluateScriptForExtension(const Inspect
         
         JSC::JSLockHolder lock(frontendGlobalObject);
 
-        if (auto parsedError = weakThis->parseExtensionErrorFromEvaluationResult(result)) {
+        if (auto parsedError = protectedThis->parseExtensionErrorFromEvaluationResult(result)) {
             if (!result.value().has_value()) {
                 auto exceptionDetails = result.value().error();
                 LOG(Inspector, "Internal error encountered while evaluating upon the frontend at %s:%d:%d: %s", exceptionDetails.sourceURL.utf8().data(), exceptionDetails.lineNumber, exceptionDetails.columnNumber, exceptionDetails.message.utf8().data());
@@ -265,7 +269,7 @@ void WebInspectorUIExtensionController::evaluateScriptForExtension(const Inspect
         }
 
         // Expected result is either an ErrorString or {result: <any>}.
-        auto objectResult = weakThis->unwrapEvaluationResultAsObject(result);
+        auto objectResult = protectedThis->unwrapEvaluationResultAsObject(result);
         if (!objectResult) {
             LOG(Inspector, "Unexpected non-object value returned from InspectorFrontendAPI.evaluateScriptForExtension().");
             completionHandler(makeUnexpected(std::nullopt), Inspector::ExtensionError::InternalError);
@@ -314,18 +318,19 @@ void WebInspectorUIExtensionController::reloadForExtension(const Inspector::Exte
     };
 
     protect(m_frontendClient->frontendAPIDispatcher())->dispatchCommandWithResultAsync("reloadForExtension"_s, WTF::move(arguments), [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](WebCore::InspectorFrontendAPIDispatcher::EvaluationResult&& result) mutable {
-        if (!weakThis) {
+        RefPtr protectedThis = weakThis;
+        if (!protectedThis) {
             completionHandler(Inspector::ExtensionError::ContextDestroyed);
             return;
         }
 
-        auto* frontendGlobalObject = protect(weakThis->m_frontendClient->frontendAPIDispatcher())->frontendGlobalObject();
+        auto* frontendGlobalObject = protect(protectedThis->m_frontendClient->frontendAPIDispatcher())->frontendGlobalObject();
         if (!frontendGlobalObject) {
             completionHandler(Inspector::ExtensionError::ContextDestroyed);
             return;
         }
 
-        if (auto parsedError = weakThis->parseExtensionErrorFromEvaluationResult(result)) {
+        if (auto parsedError = protectedThis->parseExtensionErrorFromEvaluationResult(result)) {
             LOG(Inspector, "Internal error encountered while evaluating upon the frontend: %s", Inspector::extensionErrorToString(*parsedError).utf8().data());
             completionHandler(parsedError);
             return;
@@ -347,18 +352,19 @@ void WebInspectorUIExtensionController::showExtensionTab(const Inspector::Extens
     };
 
     protect(m_frontendClient->frontendAPIDispatcher())->dispatchCommandWithResultAsync("showExtensionTab"_s, WTF::move(arguments), [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](WebCore::InspectorFrontendAPIDispatcher::EvaluationResult&& result) mutable {
-        if (!weakThis) {
+        RefPtr protectedThis = weakThis;
+        if (!protectedThis) {
             completionHandler(makeUnexpected(Inspector::ExtensionError::ContextDestroyed));
             return;
         }
 
-        auto* frontendGlobalObject = protect(weakThis->m_frontendClient->frontendAPIDispatcher())->frontendGlobalObject();
+        auto* frontendGlobalObject = protect(protectedThis->m_frontendClient->frontendAPIDispatcher())->frontendGlobalObject();
         if (!frontendGlobalObject) {
             completionHandler(makeUnexpected(Inspector::ExtensionError::ContextDestroyed));
             return;
         }
 
-        if (auto parsedError = weakThis->parseExtensionErrorFromEvaluationResult(result)) {
+        if (auto parsedError = protectedThis->parseExtensionErrorFromEvaluationResult(result)) {
             if (!result.value().has_value()) {
                 auto exceptionDetails = result.value().error();
                 LOG(Inspector, "Internal error encountered while showing extension tab at %s:%d:%d: %s", exceptionDetails.sourceURL.utf8().data(), exceptionDetails.lineNumber, exceptionDetails.columnNumber, exceptionDetails.message.utf8().data());
@@ -388,18 +394,19 @@ void WebInspectorUIExtensionController::navigateTabForExtension(const Inspector:
         JSON::Value::create(sourceURL.string()),
     };
     protect(m_frontendClient->frontendAPIDispatcher())->dispatchCommandWithResultAsync("navigateTabForExtension"_s, WTF::move(arguments), [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](WebCore::InspectorFrontendAPIDispatcher::EvaluationResult&& result) mutable {
-        if (!weakThis) {
+        RefPtr protectedThis = weakThis;
+        if (!protectedThis) {
             completionHandler(Inspector::ExtensionError::ContextDestroyed);
             return;
         }
 
-        auto* frontendGlobalObject = protect(weakThis->m_frontendClient->frontendAPIDispatcher())->frontendGlobalObject();
+        auto* frontendGlobalObject = protect(protectedThis->m_frontendClient->frontendAPIDispatcher())->frontendGlobalObject();
         if (!frontendGlobalObject) {
             completionHandler(Inspector::ExtensionError::ContextDestroyed);
             return;
         }
 
-        if (auto parsedError = weakThis->parseExtensionErrorFromEvaluationResult(result)) {
+        if (auto parsedError = protectedThis->parseExtensionErrorFromEvaluationResult(result)) {
             LOG(Inspector, "Internal error encountered while evaluating upon the frontend: %s", Inspector::extensionErrorToString(*parsedError).utf8().data());
             completionHandler(parsedError);
             return;
@@ -424,12 +431,13 @@ void WebInspectorUIExtensionController::evaluateScriptInExtensionTab(const Inspe
     };
 
     protect(m_frontendClient->frontendAPIDispatcher())->dispatchCommandWithResultAsync("evaluateScriptInExtensionTab"_s, WTF::move(arguments), [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](WebCore::InspectorFrontendAPIDispatcher::EvaluationResult&& result) mutable {
-        if (!weakThis) {
+        RefPtr protectedThis = weakThis;
+        if (!protectedThis) {
             completionHandler(makeUnexpected(std::nullopt), Inspector::ExtensionError::ContextDestroyed);
             return;
         }
 
-        auto* frontendGlobalObject = protect(weakThis->m_frontendClient->frontendAPIDispatcher())->frontendGlobalObject();
+        auto* frontendGlobalObject = protect(protectedThis->m_frontendClient->frontendAPIDispatcher())->frontendGlobalObject();
         if (!frontendGlobalObject) {
             completionHandler(makeUnexpected(std::nullopt), Inspector::ExtensionError::ContextDestroyed);
             return;
@@ -437,7 +445,7 @@ void WebInspectorUIExtensionController::evaluateScriptInExtensionTab(const Inspe
 
         JSC::JSLockHolder lock(frontendGlobalObject);
 
-        if (auto parsedError = weakThis->parseExtensionErrorFromEvaluationResult(result)) {
+        if (auto parsedError = protectedThis->parseExtensionErrorFromEvaluationResult(result)) {
             if (!result.value().has_value()) {
                 auto exceptionDetails = result.value().error();
                 LOG(Inspector, "Internal error encountered while evaluating upon the frontend: at %s:%d:%d: %s", exceptionDetails.sourceURL.utf8().data(), exceptionDetails.lineNumber, exceptionDetails.columnNumber, exceptionDetails.message.utf8().data());
@@ -449,7 +457,7 @@ void WebInspectorUIExtensionController::evaluateScriptInExtensionTab(const Inspe
         }
 
         // Expected result is either an ErrorString or {result: <any>} or {error: string}.
-        auto objectResult = weakThis->unwrapEvaluationResultAsObject(result);
+        auto objectResult = protectedThis->unwrapEvaluationResultAsObject(result);
         if (!objectResult) {
             LOG(Inspector, "Unexpected non-object value returned from InspectorFrontendAPI.evaluateScriptInExtensionTab().");
             completionHandler(makeUnexpected(std::nullopt), Inspector::ExtensionError::InternalError);

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -532,7 +532,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
 
     // FIXME: All loaders should provide their origin if navigation mode is cors/no-cors/same-origin.
     // As a temporary approach, we use the document origin if available or the HTTP Origin header otherwise.
-    if (auto* loader = dynamicDowncast<SubresourceLoader>(resourceLoader)) {
+    if (RefPtr loader = dynamicDowncast<SubresourceLoader>(resourceLoader)) {
         loadParameters.sourceOrigin = loader->origin();
 
         if (auto* headers = loader->originalHeaders())

--- a/Source/WebKit/WebProcess/Network/WebSocketChannelManager.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannelManager.cpp
@@ -40,7 +40,7 @@ void WebSocketChannelManager::addChannel(WebSocketChannel& channel)
 void WebSocketChannelManager::networkProcessCrashed()
 {
     auto channels = WTF::move(m_channels);
-    for (auto& channel : channels.values())
+    for (RefPtr channel : channels.values())
         channel->networkProcessCrashed();
 }
 

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -305,7 +305,7 @@ public:
 
 private:
     WebUserMessageHandlerDescriptorProxy(WebUserContentController& controller, const AtomString& name, InjectedBundleScriptWorld& world, ScriptMessageHandlerIdentifier identifier)
-        : WebCore::UserMessageHandlerDescriptor(name, world.coreWorld())
+        : WebCore::UserMessageHandlerDescriptor(name, protect(world.coreWorld()))
         , m_controller(controller)
         , m_identifier(identifier)
     {
@@ -697,7 +697,7 @@ void WebUserContentController::forEachUserMessageHandler(NOESCAPE const Function
 {
     for (auto& userMessageHandlerVector : m_userMessageHandlers.values()) {
         for (auto& pair : userMessageHandlerVector)
-            functor(pair.second.get());
+            functor(protect(pair.second.get()));
     }
 }
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1788,7 +1788,7 @@ std::optional<ScrollbarOverlayStyle> WebChromeClient::preferredScrollbarOverlayS
 
 Color WebChromeClient::underlayColor() const
 {
-    auto* page = m_page.get();
+    RefPtr page = m_page;
     return page ? page->underlayColor() : Color();
 }
 
@@ -2041,7 +2041,7 @@ RefPtr<API::Object> userDataFromJSONData(JSON::Value& value)
         auto result = API::Dictionary::create();
         RefPtr jsonObject = value.asObject();
         for (auto [key, value] : *jsonObject)
-            result->add(key, userDataFromJSONData(value));
+            result->add(key, userDataFromJSONData(protect(value)));
         return result;
     }
     case JSON::Value::Type::Array: {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp
@@ -79,19 +79,19 @@ std::optional<GeolocationPositionData> WebGeolocationClient::lastPosition()
 void WebGeolocationClient::requestPermission(Geolocation& geolocation)
 {
     if (m_page)
-        m_page->geolocationPermissionRequestManager().startRequestForGeolocation(geolocation);
+        protect(m_page->geolocationPermissionRequestManager())->startRequestForGeolocation(geolocation);
 }
 
 void WebGeolocationClient::revokeAuthorizationToken(const String& authorizationToken)
 {
     if (m_page)
-        m_page->geolocationPermissionRequestManager().revokeAuthorizationToken(authorizationToken);
+        protect(m_page->geolocationPermissionRequestManager())->revokeAuthorizationToken(authorizationToken);
 }
 
 void WebGeolocationClient::cancelPermissionRequest(Geolocation& geolocation)
 {
     if (m_page)
-        m_page->geolocationPermissionRequestManager().cancelRequestForGeolocation(geolocation);
+        protect(m_page->geolocationPermissionRequestManager())->cancelRequestForGeolocation(geolocation);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -681,7 +681,7 @@ void WebLocalFrameLoaderClient::dispatchDidCommitLoad(std::optional<HasInsecureC
     auto& cspOriginsThatUpgradeInsecureNavigations = protect(protect(m_localFrame->document())->contentSecurityPolicy())->insecureNavigationRequestsToUpgrade();
 
     RefPtr<FrameState> redirectReplaceFrameState;
-    if (RefPtr page = m_localFrame->page(); page && page->settings().useUIProcessForBackForwardItemLoading() && m_localFrame->loader().shouldReplaceHistoryItemInChildFrame()) {
+    if (RefPtr page = m_localFrame->page(); page && page->settings().useUIProcessForBackForwardItemLoading() && protect(m_localFrame->loader())->shouldReplaceHistoryItemInChildFrame()) {
         if (RefPtr currentItem = m_localFrame->loader().history().currentItem()) {
             redirectReplaceFrameState = toFrameState(*currentItem);
             redirectReplaceFrameState->children.clear();
@@ -1073,7 +1073,7 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const Nav
 
 void WebLocalFrameLoaderClient::applyWebsitePolicies(WebsitePoliciesData&& websitePolicies)
 {
-    RefPtr documentLoader = m_localFrame->loader().loaderForWebsitePolicies();
+    RefPtr documentLoader = protect(m_localFrame->loader())->loaderForWebsitePolicies();
     if (!documentLoader)
         return;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp
@@ -67,7 +67,7 @@ WebPermissionController::~WebPermissionController()
     WebProcess::singleton().removeMessageReceiver(Messages::WebPermissionController::messageReceiverName());
 }
 
-void WebPermissionController::query(WebCore::ClientOrigin&& origin, WebCore::PermissionDescriptor descriptor, const WeakPtr<WebCore::Page>& page, WebCore::PermissionQuerySource source, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&& completionHandler)
+void WebPermissionController::query(WebCore::ClientOrigin&& origin, WebCore::PermissionDescriptor descriptor, WebCore::Page* page, WebCore::PermissionQuerySource source, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&& completionHandler)
 {
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
     if (WebCore::DeprecatedGlobalSettings::builtInNotificationsEnabled() && (descriptor.name == WebCore::PermissionName::Notifications || descriptor.name == WebCore::PermissionName::Push)) {
@@ -126,7 +126,7 @@ void WebPermissionController::notifyObserversIfNeeded(WebCore::PermissionName pe
         if (!observer->page() && (source == WebCore::PermissionQuerySource::Window || source == WebCore::PermissionQuerySource::DedicatedWorker))
             continue;
 
-        query(WebCore::ClientOrigin { observer->origin() }, WebCore::PermissionDescriptor { permissionName }, observer->page(), source, [weakObserver = WeakPtr { observer.get() }](auto newState) {
+        query(WebCore::ClientOrigin { observer->origin() }, WebCore::PermissionDescriptor { permissionName }, protect(observer->page()), source, [weakObserver = WeakPtr { observer.get() }](auto newState) {
             CheckedPtr observer = weakObserver.get();
             if (observer && newState != observer->currentState())
                 observer->stateChanged(*newState);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h
@@ -59,7 +59,7 @@ private:
     explicit WebPermissionController(WebProcess&);
 
     // WebCore::PermissionController
-    void query(WebCore::ClientOrigin&&, WebCore::PermissionDescriptor, const WeakPtr<WebCore::Page>&, WebCore::PermissionQuerySource, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&&) final;
+    void query(WebCore::ClientOrigin&&, WebCore::PermissionDescriptor, WebCore::Page*, WebCore::PermissionQuerySource, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&&) final;
     void addObserver(WebCore::PermissionObserver&) final;
     void removeObserver(WebCore::PermissionObserver&) final;
     void storageAccessPermissionChanged(const WebCore::RegistrableDomain&, const WebCore::RegistrableDomain&) final;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -2332,7 +2332,7 @@ void WebPage::getInformationFromImageData(const Vector<uint8_t>& data, Completio
     if (m_isClosed)
         return completionHandler(makeUnexpected(ImageDecodingError::Internal));
 
-    if (SVGImage::isDataDecodable(m_page->settings(), data.span()))
+    if (SVGImage::isDataDecodable(protect(m_page->settings()), data.span()))
         return completionHandler(std::make_pair(String { "public.svg-image"_s }, Vector<IntSize> { }));
 
     completionHandler(utiAndAvailableSizesFromImageData(data.span()));

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
@@ -394,10 +394,11 @@ void WebCookieJar::addChangeListenerWithAccess(const URL& url, const URL& firstP
             return;
     }
 
-    auto completionHandler = [protectedThis = Ref { *this }, this, host, listener = WeakPtr { listener }] (bool listenerAdded)  {
+    auto completionHandler = [protectedThis = Ref { *this }, this, host, weakListener = WeakPtr { listener }] (bool listenerAdded)  {
         if (!listenerAdded)
             return;
 
+        RefPtr listener = weakListener;
         if (!listener)
             return;
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -164,7 +164,7 @@ void WebFrame::initWithCoreMainFrame(WebPage& page, Frame& coreFrame)
 {
     m_coreFrame = coreFrame;
     m_coreFrame->tree().setSpecifiedName(nullAtom());
-    if (auto* localFrame = dynamicDowncast<LocalFrame>(coreFrame))
+    if (RefPtr localFrame = dynamicDowncast<LocalFrame>(coreFrame))
         localFrame->init();
 }
 
@@ -807,7 +807,7 @@ void WebFrame::convertMainResourceLoadToDownload(DocumentLoader* documentLoader,
 
     std::optional<NavigatingToAppBoundDomain> isAppBound = NavigatingToAppBoundDomain::No;
     isAppBound = m_isNavigatingToAppBoundDomain;
-    webProcess.ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::ConvertMainResourceLoadToDownload(mainResourceLoadIdentifier, policyDownloadID, request, topOrigin, response, isAppBound), 0);
+    protect(webProcess.ensureNetworkProcessConnection().connection())->send(Messages::NetworkConnectionToWebProcess::ConvertMainResourceLoadToDownload(mainResourceLoadIdentifier, policyDownloadID, request, topOrigin, response, isAppBound), 0);
 }
 
 void WebFrame::addConsoleMessage(MessageSource messageSource, MessageLevel messageLevel, const String& message, uint64_t requestID)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2499,7 +2499,7 @@ void WebPage::loadDataInFrame(std::span<const uint8_t> data, String&& type, Stri
     Ref sharedBuffer = SharedBuffer::create(data);
     ResourceResponse response(URL { baseURL }, WTF::move(type), sharedBuffer->size(), WTF::move(encodingName));
     SubstituteData substituteData(WTF::move(sharedBuffer), URL { baseURL }, WTF::move(response), SubstituteData::SessionHistoryVisibility::Hidden);
-    frame->coreLocalFrame()->loader().load(FrameLoadRequest(*frame->coreLocalFrame(), ResourceRequest(WTF::move(baseURL)), WTF::move(substituteData)));
+    protect(frame->coreLocalFrame()->loader())->load(FrameLoadRequest(protect(*frame->coreLocalFrame()), ResourceRequest(WTF::move(baseURL)), WTF::move(substituteData)));
 }
 
 void WebPage::applyMonitorUnloadToIFrameElement(FrameIdentifier frameID, WebCore::IFrameUnloadReason reason)
@@ -2728,11 +2728,11 @@ void WebPage::loadAlternateHTML(LoadParameters&& loadParameters)
         ASSERT_NOT_REACHED();
         return;
     }
-    m_mainFrame->coreLocalFrame()->loader().setProvisionalLoadErrorBeingHandledURL(provisionalLoadErrorURL);
+    protect(m_mainFrame->coreLocalFrame()->loader())->setProvisionalLoadErrorBeingHandledURL(provisionalLoadErrorURL);
 
     ResourceResponse response(URL(), WTF::move(loadParameters.MIMEType), sharedBuffer->size(), WTF::move(loadParameters.encodingName));
     loadDataImpl(loadParameters.navigationID, loadParameters.shouldTreatAsContinuingLoad, WTF::move(loadParameters.websitePolicies), sharedBuffer.releaseNonNull(), ResourceRequest(WTF::move(baseURL)), WTF::move(response), WTF::move(unreachableURL), loadParameters.userData, loadParameters.isNavigatingToAppBoundDomain, WebCore::SubstituteData::SessionHistoryVisibility::Hidden);
-    m_mainFrame->coreLocalFrame()->loader().setProvisionalLoadErrorBeingHandledURL({ });
+    protect(m_mainFrame->coreLocalFrame()->loader())->setProvisionalLoadErrorBeingHandledURL({ });
 }
 
 void WebPage::loadSimulatedRequestAndResponse(LoadParameters&& loadParameters, ResourceResponse&& simulatedResponse)
@@ -2792,7 +2792,7 @@ void WebPage::reload(WebCore::NavigationIdentifier navigationID, OptionSet<WebCo
     m_sandboxExtensionTracker.beginReload(mainFrame.ptr(), WTF::move(sandboxExtensionHandle));
     if (m_page && mainFrame->coreLocalFrame()) {
         bool isRequestFromClientOrUserInput = true;
-        mainFrame->coreLocalFrame()->loader().reload(reloadOptions, isRequestFromClientOrUserInput);
+        protect(mainFrame->coreLocalFrame()->loader())->reload(reloadOptions, isRequestFromClientOrUserInput);
     } else
         ASSERT_NOT_REACHED();
 
@@ -2827,7 +2827,7 @@ void WebPage::goToBackForwardItem(GoToBackForwardItemParameters&& parameters)
     {
         auto ignoreHistoryItemChangesForScope = m_historyItemClient->ignoreChangesForScope();
         ASSERT(!corePage()->settings().useUIProcessForBackForwardItemLoading() || parameters.frameState->children.isEmpty());
-        item = toHistoryItem(m_historyItemClient, parameters.frameState);
+        item = toHistoryItem(m_historyItemClient, protect(parameters.frameState));
         if (RefPtr localMainFrame = corePage()->localMainFrame(); localMainFrame && item)
             localMainFrame->loader().setNavigationUpgradeToHTTPSBehavior(item->url().protocolIs("http"_s) ? NavigationUpgradeToHTTPSBehavior::Disabled : NavigationUpgradeToHTTPSBehavior::BasedOnPolicy);
     }
@@ -3408,8 +3408,9 @@ void WebPage::setEnableHorizontalRubberBanding(bool enableHorizontalRubberBandin
 
 void WebPage::setBackgroundExtendsBeyondPage(bool backgroundExtendsBeyondPage)
 {
-    if (m_page->settings().backgroundShouldExtendBeyondPage() != backgroundExtendsBeyondPage)
-        m_page->settings().setBackgroundShouldExtendBeyondPage(backgroundExtendsBeyondPage);
+    RefPtr settings = m_page->settings();
+    if (settings->backgroundShouldExtendBeyondPage() != backgroundExtendsBeyondPage)
+        settings->setBackgroundShouldExtendBeyondPage(backgroundExtendsBeyondPage);
 }
 
 void WebPage::setPaginationMode(Pagination::Mode mode)
@@ -4615,7 +4616,7 @@ bool WebPage::logicalScroll(Page* page, ScrollLogicalDirection direction, Scroll
 
 bool WebPage::scrollBy(WebCore::ScrollDirection scrollDirection, WebCore::ScrollGranularity scrollGranularity)
 {
-    return scroll(m_page.get(), static_cast<ScrollDirection>(scrollDirection), static_cast<ScrollGranularity>(scrollGranularity));
+    return scroll(protect(m_page), static_cast<ScrollDirection>(scrollDirection), static_cast<ScrollGranularity>(scrollGranularity));
 }
 
 void WebPage::centerSelectionInVisibleArea()
@@ -6342,7 +6343,7 @@ void WebPage::didChooseDate(const String& date)
 
 void WebPage::didEndDateTimePicker()
 {
-    if (auto chooser = std::exchange(m_activeDateTimeChooser, nullptr))
+    if (RefPtr chooser = std::exchange(m_activeDateTimeChooser, nullptr))
         chooser->didEndChooser();
 }
 
@@ -8549,7 +8550,7 @@ void WebPage::testProcessIncomingSyncMessagesWhenWaitingForSyncReply(CompletionH
 
 std::optional<SimpleRange> WebPage::currentSelectionAsRange()
 {
-    RefPtr frame = frameWithSelection(m_page.get());
+    RefPtr frame = frameWithSelection(protect(m_page));
     if (!frame)
         return std::nullopt;
 
@@ -8990,17 +8991,17 @@ void WebPage::allowGamepadAccess()
 #if ENABLE(POINTER_LOCK)
 void WebPage::didAcquirePointerLock()
 {
-    corePage()->pointerLockController().didAcquirePointerLock();
+    protect(corePage()->pointerLockController())->didAcquirePointerLock();
 }
 
 void WebPage::didNotAcquirePointerLock()
 {
-    corePage()->pointerLockController().didNotAcquirePointerLock();
+    protect(corePage()->pointerLockController())->didNotAcquirePointerLock();
 }
 
 void WebPage::didLosePointerLock()
 {
-    corePage()->pointerLockController().didLosePointerLock();
+    protect(corePage()->pointerLockController())->didLosePointerLock();
 }
 #endif
 
@@ -9414,19 +9415,19 @@ void WebPage::systemPreviewActionTriggered(WebCore::SystemPreviewInfo previewInf
 #if ENABLE(SPEECH_SYNTHESIS)
 void WebPage::speakingErrorOccurred()
 {
-    if (auto observer = corePage()->speechSynthesisClient()->observer())
+    if (RefPtr observer = protect(corePage()->speechSynthesisClient())->observer())
         observer->speakingErrorOccurred();
 }
 
 void WebPage::boundaryEventOccurred(bool wordBoundary, unsigned charIndex, unsigned charLength)
 {
-    if (auto observer = corePage()->speechSynthesisClient()->observer())
+    if (RefPtr observer = protect(corePage()->speechSynthesisClient())->observer())
         observer->boundaryEventOccurred(wordBoundary, charIndex, charLength);
 }
 
 void WebPage::voicesDidChange()
 {
-    if (auto observer = corePage()->speechSynthesisClient()->observer())
+    if (RefPtr observer = protect(corePage()->speechSynthesisClient())->observer())
         observer->voicesChanged();
 }
 #endif

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -965,7 +965,7 @@ void WebProcess::registerURLSchemeAsCORSEnabled(const String& urlScheme)
 {
     if (LegacySchemeRegistry::registerURLSchemeAsCORSEnabled(urlScheme) == LegacySchemeRegistry::SchemeRegisteredForTheFirstTime::No)
         return;
-    ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterURLSchemesAsCORSEnabled({ urlScheme }), 0);
+    protect(ensureNetworkProcessConnection())->connection().send(Messages::NetworkConnectionToWebProcess::RegisterURLSchemesAsCORSEnabled({ urlScheme }), 0);
 }
 
 void WebProcess::registerURLSchemeAsAlwaysRevalidated(const String& urlScheme) const
@@ -1204,7 +1204,7 @@ void WebProcess::removeWebFrame(FrameIdentifier frameID, WebPage* page)
     if (!frame)
         return;
     if (frame->coreLocalFrame() && m_networkProcessConnection)
-        m_networkProcessConnection->connection().send(Messages::NetworkConnectionToWebProcess::ClearFrameLoadRecordsForStorageAccess(frameID), 0);
+        protect(m_networkProcessConnection->connection())->send(Messages::NetworkConnectionToWebProcess::ClearFrameLoadRecordsForStorageAccess(frameID), 0);
 
     // We can end up here after our connection has closed when WebCore's frame life-support timer
     // fires when the application is shutting down. There's no need (and no way) to update the UI
@@ -1420,7 +1420,7 @@ NetworkProcessConnection& WebProcess::ensureNetworkProcessConnection()
 #if HAVE(AUDIT_TOKEN)
         m_networkProcessConnection->setNetworkProcessAuditToken(connectionInfo.auditToken ? std::optional(connectionInfo.auditToken->auditToken()) : std::nullopt);
 #endif
-        m_networkProcessConnection->connection().send(Messages::NetworkConnectionToWebProcess::RegisterURLSchemesAsCORSEnabled(WebCore::LegacySchemeRegistry::allURLSchemesRegisteredAsCORSEnabled()), 0);
+        protect(m_networkProcessConnection->connection())->send(Messages::NetworkConnectionToWebProcess::RegisterURLSchemesAsCORSEnabled(WebCore::LegacySchemeRegistry::allURLSchemesRegisteredAsCORSEnabled()), 0);
 
         if (!Document::allDocuments().isEmpty() || SharedWorkerThreadProxy::hasInstances())
             protect(protect(m_networkProcessConnection.get())->serviceWorkerConnection())->registerServiceWorkerClients();
@@ -1432,9 +1432,9 @@ NetworkProcessConnection& WebProcess::ensureNetworkProcessConnection()
 #endif
 #if ENABLE(LAUNCHSERVICES_SANDBOX_EXTENSION_BLOCKING)
         if (auto auditToken = auditTokenForSelf()) {
-            m_networkProcessConnection->connection().send(Messages::NetworkConnectionToWebProcess::CheckInWebProcess(*auditToken), 0);
+            protect(m_networkProcessConnection->connection())->send(Messages::NetworkConnectionToWebProcess::CheckInWebProcess(*auditToken), 0);
             if (!m_pendingDisplayName.isNull())
-                m_networkProcessConnection->connection().send(Messages::NetworkConnectionToWebProcess::UpdateActivePages(std::exchange(m_pendingDisplayName, String()), { }, *auditToken), 0);
+                protect(m_networkProcessConnection->connection())->send(Messages::NetworkConnectionToWebProcess::UpdateActivePages(std::exchange(m_pendingDisplayName, String()), { }, *auditToken), 0);
         }
 #endif
     }
@@ -1885,7 +1885,7 @@ void WebProcess::accessibilityRelayProcessSuspended(bool suspended)
     }
 
     // Take the first webpage. We only need to have the process on the other side relay this for the WebProcess.
-    AXRelayProcessSuspendedNotification(m_pageMap.begin()->value, AXRelayProcessSuspendedNotification::AutomaticallySend::No).sendProcessSuspendMessage(suspended);
+    AXRelayProcessSuspendedNotification(protect(m_pageMap.begin()->value), AXRelayProcessSuspendedNotification::AutomaticallySend::No).sendProcessSuspendMessage(suspended);
 }
 
 void WebProcess::markAllLayersVolatile(CompletionHandler<void()>&& completionHandler)
@@ -2215,7 +2215,7 @@ void WebProcess::prefetchDNS(const String& hostname)
         return;
 
     if (m_dnsPrefetchedHosts.add(hostname).isNewEntry)
-        ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::PrefetchDNS(hostname), 0);
+        protect(ensureNetworkProcessConnection())->connection().send(Messages::NetworkConnectionToWebProcess::PrefetchDNS(hostname), 0);
     // The DNS prefetched hosts cache is only to avoid asking for the same hosts too many times
     // in a very short period of time, producing a lot of IPC traffic. So we clear this cache after
     // some time of no DNS requests.
@@ -2271,7 +2271,7 @@ void WebProcess::establishRemoteWorkerContextConnectionToNetworkProcess(RemoteWo
 
 void WebProcess::registerServiceWorkerClients(CompletionHandler<void(bool)>&& completionHandler)
 {
-    ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::PingPongForServiceWorkers { }, WTF::move(completionHandler));
+    protect(ensureNetworkProcessConnection())->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::PingPongForServiceWorkers { }, WTF::move(completionHandler));
 }
 
 void WebProcess::addServiceWorkerRegistration(WebCore::ServiceWorkerRegistrationIdentifier identifier)
@@ -2404,7 +2404,7 @@ void WebProcess::setAppBadge(WebCore::Frame* frame, const WebCore::SecurityOrigi
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
     if (DeprecatedGlobalSettings::builtInNotificationsEnabled()) {
         if (m_sessionID)
-            ensureNetworkProcessConnection().connection().send(Messages::NotificationManagerMessageHandler::SetAppBadge({ origin, badge }), m_sessionID->toUInt64());
+            protect(ensureNetworkProcessConnection())->connection().send(Messages::NotificationManagerMessageHandler::SetAppBadge({ origin, badge }), m_sessionID->toUInt64());
         return;
     }
 #endif

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -739,7 +739,7 @@ void WebProcess::updateProcessName(IsInProcessInitialization isInProcessInitiali
         auto auditToken = auditTokenForSelf();
         if (!auditToken)
             return;
-        ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::UpdateActivePages(displayName, { }, *auditToken), 0);
+        protect(ensureNetworkProcessConnection())->connection().send(Messages::NetworkConnectionToWebProcess::UpdateActivePages(displayName, { }, *auditToken), 0);
         return;
     }
 #if ENABLE(LAUNCHSERVICES_SANDBOX_EXTENSION_BLOCKING)
@@ -1001,7 +1001,7 @@ void WebProcess::getProcessDisplayName(CompletionHandler<void(String&&)>&& compl
     auto auditToken = auditTokenForSelf();
     if (!auditToken)
         return completionHandler({ });
-    ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::GetProcessDisplayName(*auditToken), WTF::move(completionHandler));
+    protect(ensureNetworkProcessConnection())->connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::GetProcessDisplayName(*auditToken), WTF::move(completionHandler));
 #else
     completionHandler({ });
 #endif
@@ -1014,7 +1014,7 @@ void WebProcess::updateActivePages(const String& overrideDisplayName)
     auto auditToken = auditTokenForSelf();
     if (!auditToken)
         return;
-    ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::UpdateActivePages(overrideDisplayName, activePagesOrigins(m_pageMap), *auditToken), 0);
+    protect(ensureNetworkProcessConnection())->connection().send(Messages::NetworkConnectionToWebProcess::UpdateActivePages(overrideDisplayName, activePagesOrigins(m_pageMap), *auditToken), 0);
 #else
     if (!overrideDisplayName) {
         RunLoop::mainSingleton().dispatch([activeOrigins = activePagesOrigins(m_pageMap)] {

--- a/Source/WebKit/webpushd/ApplePushServiceConnection.mm
+++ b/Source/WebKit/webpushd/ApplePushServiceConnection.mm
@@ -72,13 +72,14 @@ namespace WebPushD {
 ApplePushServiceConnection::ApplePushServiceConnection(const String& incomingPushServiceName)
 {
     m_connection = adoptNS([[APSConnection alloc] initWithEnvironmentName:APSEnvironmentProduction namedDelegatePort:incomingPushServiceName.createNSString().get() queue:mainDispatchQueueSingleton()]);
-    m_delegate = adoptNS([[_WKAPSConnectionDelegate alloc] initWithConnection:this]);
-    [m_connection setDelegate:m_delegate.get()];
+    RetainPtr delegate = adoptNS([[_WKAPSConnectionDelegate alloc] initWithConnection:this]);
+    m_delegate = delegate;
+    [protect(m_connection) setDelegate:delegate.get()];
 }
 
 ApplePushServiceConnection::~ApplePushServiceConnection()
 {
-    [m_connection setDelegate:nil];
+    [protect(m_connection) setDelegate:nil];
 }
 
 static RetainPtr<APSURLTokenInfo> makeTokenInfo(const String& topic, const Vector<uint8_t>& vapidPublicKey)
@@ -94,7 +95,7 @@ void ApplePushServiceConnection::subscribe(const String& topic, const Vector<uin
     auto identifier = ++m_handlerIdentifier;
     m_subscribeHandlers.add(identifier, WTF::move(subscribeHandler));
 
-    [m_connection requestURLTokenForInfo:makeTokenInfo(topic, vapidPublicKey).get() completion:makeBlockPtr([weakThis = WeakPtr { *this }, identifier] (APSURLToken *token, NSError *error) {
+    [protect(m_connection) requestURLTokenForInfo:makeTokenInfo(topic, vapidPublicKey).get() completion:makeBlockPtr([weakThis = WeakPtr { *this }, identifier] (APSURLToken *token, NSError *error) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -112,7 +113,7 @@ void ApplePushServiceConnection::unsubscribe(const String& topic, const Vector<u
     auto identifier = ++m_handlerIdentifier;
     m_unsubscribeHandlers.add(identifier, WTF::move(unsubscribeHandler));
 
-    [m_connection invalidateURLTokenForInfo:makeTokenInfo(topic, vapidPublicKey).get() completion:makeBlockPtr([weakThis = WeakPtr { *this }, identifier] (BOOL success, NSError *error) {
+    [protect(m_connection) invalidateURLTokenForInfo:makeTokenInfo(topic, vapidPublicKey).get() completion:makeBlockPtr([weakThis = WeakPtr { *this }, identifier] (BOOL success, NSError *error) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -124,47 +125,47 @@ void ApplePushServiceConnection::unsubscribe(const String& topic, const Vector<u
 
 Vector<String> ApplePushServiceConnection::enabledTopics()
 {
-    return makeVector<String>(retainPtr([m_connection enabledTopics]).get());
+    return makeVector<String>(retainPtr([protect(m_connection) enabledTopics]).get());
 }
 
 Vector<String> ApplePushServiceConnection::ignoredTopics()
 {
-    return makeVector<String>(retainPtr([m_connection ignoredTopics]).get());
+    return makeVector<String>(retainPtr([protect(m_connection) ignoredTopics]).get());
 }
 
 Vector<String> ApplePushServiceConnection::opportunisticTopics()
 {
-    return makeVector<String>(retainPtr([m_connection opportunisticTopics]).get());
+    return makeVector<String>(retainPtr([protect(m_connection) opportunisticTopics]).get());
 }
 
 Vector<String> ApplePushServiceConnection::nonWakingTopics()
 {
-    return makeVector<String>(retainPtr([m_connection nonWakingTopics]).get());
+    return makeVector<String>(retainPtr([protect(m_connection) nonWakingTopics]).get());
 }
 
 void ApplePushServiceConnection::setEnabledTopics(Vector<String>&& topics)
 {
-    [m_connection _setEnabledTopics:createNSArray(WTF::move(topics)).get()];
+    [protect(m_connection) _setEnabledTopics:createNSArray(WTF::move(topics)).get()];
 }
 
 void ApplePushServiceConnection::setIgnoredTopics(Vector<String>&& topics)
 {
-    [m_connection _setIgnoredTopics:createNSArray(WTF::move(topics)).get()];
+    [protect(m_connection) _setIgnoredTopics:createNSArray(WTF::move(topics)).get()];
 }
 
 void ApplePushServiceConnection::setOpportunisticTopics(Vector<String>&& topics)
 {
-    [m_connection _setOpportunisticTopics:createNSArray(WTF::move(topics)).get()];
+    [protect(m_connection) _setOpportunisticTopics:createNSArray(WTF::move(topics)).get()];
 }
 
 void ApplePushServiceConnection::setNonWakingTopics(Vector<String>&& topics)
 {
-    [m_connection _setNonWakingTopics:createNSArray(WTF::move(topics)).get()];
+    [protect(m_connection) _setNonWakingTopics:createNSArray(WTF::move(topics)).get()];
 }
 
 void ApplePushServiceConnection::setTopicLists(TopicLists&& topicLists)
 {
-    [m_connection setEnabledTopics:createNSArray(WTF::move(topicLists.enabledTopics)).get() ignoredTopics:createNSArray(WTF::move(topicLists.ignoredTopics)).get() opportunisticTopics:createNSArray(WTF::move(topicLists.opportunisticTopics)).get() nonWakingTopics:createNSArray(WTF::move(topicLists.nonWakingTopics)).get()];
+    [protect(m_connection) setEnabledTopics:createNSArray(WTF::move(topicLists.enabledTopics)).get() ignoredTopics:createNSArray(WTF::move(topicLists.ignoredTopics)).get() opportunisticTopics:createNSArray(WTF::move(topicLists.opportunisticTopics)).get() nonWakingTopics:createNSArray(WTF::move(topicLists.nonWakingTopics)).get()];
 }
 
 } // namespace WebPushD


### PR DESCRIPTION
#### fcef99916e4a378f32ffc98858e691635608ed06
<pre>
[Safer CPP] Address more warnings in Source/WebKit reported by the newer static analysis
<a href="https://bugs.webkit.org/show_bug.cgi?id=323300">https://bugs.webkit.org/show_bug.cgi?id=323300</a>

Reviewed by Timothy Hatcher.

* Source/WebCore/Modules/permissions/PermissionController.h:
* Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp:
(WebCore::WakeLock::request):
* Source/WebCore/page/PointerLockController.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::resolveUnregistrationJobInClient):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::sendToParentProcess):
(WebKit::WebSWServerToContextConnection::sendWithAsyncReplyToParentProcess):
(WebKit::WebSWServerToContextConnection::terminateWorker):
(WebKit::WebSWServerToContextConnection::workerTerminated):
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::Connection::cancelSendSource):
(IPC::Connection::cancelReceiveSource):
(IPC::Connection::platformOpen):
(IPC::Connection::initializeSendSource):
(IPC::Connection::getAuditToken):
(IPC::Connection::kill):
(IPC::Connection::remoteProcessID const):
* Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm:
(-[_WKWebViewTextInputNotifications dictationDidStart]):
(-[_WKWebViewTextInputNotifications dictationDidEnd]):
(-[_WKWebViewTextInputNotifications dictationDidPause]):
(-[_WKWebViewTextInputNotifications dictationDidResume]):
* Source/WebKit/Shared/API/c/WKSharedAPICast.h:
(WebKit::toAPI):
* Source/WebKit/Shared/API/c/mac/WKWebArchiveRef.cpp:
(WKWebArchiveCreateFromRange):
* Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeaturesWebKit.h:
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp:
(WebKit::WebPaymentCoordinatorProxy::showPaymentUI):
* Source/WebKit/Shared/WebGPU/WebGPUPipelineLayoutDescriptor.cpp:
(WebKit::WebGPU::ConvertFromBackingContext::convertFromBacking):
* Source/WebKit/Shared/WebGPU/WebGPUPresentationContextDescriptor.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::getSandboxProfileOrProfilePath):
(WebKit::getUserDirectorySuffix):
* Source/WebKit/UIProcess/API/C/WKContext.cpp:
(WKContextSetHistoryClient):
(WKContextSetDownloadClient):
* Source/WebKit/UIProcess/API/C/WKDownloadRef.cpp:
(WKDownloadSetClient):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageGetContext):
(WKPageCopyPageConfiguration):
(WKPageCanGoForward):
(WKPageCanGoBack):
(WKPageSetPageFindClient):
(WKPageSetPageFindMatchesClient):
(WKPageSetPagePolicyClient):
(WKPageSetPageUIClient):
(callAsyncJavaScript):
(WKPageGetGPUProcessIdentifier):
(WKPageDumpPrivateClickMeasurement):
(WKPageSetCursorDidChangeCallbackForTesting):
* Source/WebKit/UIProcess/API/C/WKUserContentControllerRef.cpp:
(WKUserContentControllerCopyUserScripts):
* Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp:
(WKWebsiteDataStoreDumpResourceLoadStatistics):
* Source/WebKit/UIProcess/API/Cocoa/APIAttachmentCocoa.mm:
(API::Attachment::doWithFileWrapper const):
(API::Attachment::fileName const):
(API::Attachment::setFileWrapperAndUpdateContentType):
(API::Attachment::fileSizeForDisplay const):
(API::Attachment::associatedElementData const):
(API::Attachment::associatedElementNSData const):
(API::Attachment::createSerializedRepresentation const):
(API::Attachment::cloneFileWrapperTo):
(API::Attachment::shouldUseFileWrapperIconForDirectory const):
* Source/WebKit/UIProcess/API/Cocoa/APIContentRuleListStoreCocoa.mm:
(API::ContentRuleListStore::defaultStorePath):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(-[WKProcessPool _configuration]):
(-[WKProcessPool _clearWebProcessCache]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _clearBackForwardCache]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _configuration]):
* Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm:
(WebKit::AuthenticationChallengeProxy::sendClientCertificateCredentialOverXpc):
* Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm:
(WebKit::browsingWarningTitleText):
(WebKit::browsingWarningText):
(WebKit::browsingDetailsText):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::setUpHighlightsObserver):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::scriptingGetRegisteredScripts):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsMove):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm:
(WebKit::WebExtensionControllerConfiguration::copy const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::executeScript):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::permissionState):
(WebKit::WebExtensionContext::parameters const):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::willEndSwipeGesture):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm:
(WebKit::AuthenticatorPresenterCoordinator::requestLAContextForUserVerification):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm:
(-[WKSmartCardObserver initWithCard:invalidationHandler:]):
(-[WKSmartCardObserver dealloc]):
(-[WKSmartCardObserver observeValueForKeyPath:ofObject:change:context:]):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm:
(WebKit::CcidService::removeObservers):
(WebKit::CcidService::platformStartDiscovery):
(WebKit::CcidService::updateSlots):
(-[_WKSmartCardSlotStateObserver observeValueForKeyPath:ofObject:change:context:]):
(-[_WKSmartCardSlotStateObserver removeObserver]):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(-[_WKASDelegate initWithPage:completionHandler:]):
(WebKit::WebAuthenticatorCoordinatorProxy::makeActiveConditionalAssertion):
* Source/WebKit/UIProcess/WebContextInjectedBundleClient.cpp:
(WebKit::WebContextInjectedBundleClient::didReceiveMessageFromInjectedBundle):
(WebKit::WebContextInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle):
* Source/WebKit/UIProcess/WebDataListSuggestionsDropdown.cpp:
(WebKit::WebDataListSuggestionsDropdown::close):
* Source/WebKit/UIProcess/WebDateTimePicker.cpp:
(WebKit::WebDateTimePicker::endPicker):
* Source/WebKit/UIProcess/WebFramePolicyListenerProxy.cpp:
(WebKit::WebFramePolicyListenerProxy::didReceiveAppBoundDomainResult):
(WebKit::WebFramePolicyListenerProxy::didReceiveSafeBrowsingResults):
(WebKit::WebFramePolicyListenerProxy::didReceiveInitialLinkDecorationFilteringData):
(WebKit::WebFramePolicyListenerProxy::didReceiveSiteHasStorageResults):
(WebKit::WebFramePolicyListenerProxy::didReceiveEnhancedSecurityLinkResults):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::didCreateSubframe):
* Source/WebKit/UIProcess/WebPageDiagnosticLoggingClient.cpp:
(WebKit::WebPageDiagnosticLoggingClient::logDiagnosticMessage):
(WebKit::WebPageDiagnosticLoggingClient::logDiagnosticMessageWithResult):
(WebKit::WebPageDiagnosticLoggingClient::logDiagnosticMessageWithValue):
(WebKit::WebPageDiagnosticLoggingClient::logDiagnosticMessageWithEnhancedPrivacy):
* Source/WebKit/UIProcess/WebPageInjectedBundleClient.cpp:
(WebKit::WebPageInjectedBundleClient::didReceiveMessageFromInjectedBundle):
(WebKit::WebPageInjectedBundleClient::didReceiveSynchronousMessageFromInjectedBundle):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::launchProcess):
(WebKit::WebPageProxy::executeEditCommand):
(WebKit::WebPageProxy::receivedPolicyDecision):
(WebKit::WebPageProxy::receivedNavigationResponsePolicyDecision):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::contextMenuItemSelected):
(WebKit::WebPageProxy::queryPermission):
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::CachedProcess::evictionTimerFired):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shutDown):
(WebKit::WebProcessProxy::assumeReadAccessToBaseURL):
(WebKit::WebProcessProxy::assumeReadAccessToBaseURLs):
(WebKit::WebProcessProxy::createSpeechRecognitionServer):
* Source/WebKit/UIProcess/WebURLSchemeHandler.cpp:
(WebKit::WebURLSchemeHandler::startTask):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::forwardAppBoundDomainsToITPIfInitialized):
* Source/WebKit/UIProcess/glib/WebTextCheckerClient.cpp:
(WebKit::WebTextCheckerClient::checkSpellingOfString):
(WebKit::WebTextCheckerClient::checkGrammarOfString):
(WebKit::WebTextCheckerClient::updateSpellingUIWithMisspelledWord):
(WebKit::WebTextCheckerClient::updateSpellingUIWithGrammarString):
(WebKit::WebTextCheckerClient::guessesForWord):
(WebKit::WebTextCheckerClient::learnWord):
(WebKit::WebTextCheckerClient::ignoreWord):
* Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm:
(-[WKTextAnimationManager addTextAnimationForAnimationID:withData:]):
(-[WKTextAnimationManager textPreviewsForChunk:completion:]):
(-[WKTextAnimationManager textPreviewForRect:completion:]):
(-[WKTextAnimationManager updateIsTextVisible:forChunk:completion:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKTextTouchBarItemController _wkChangeTextStyle:]):
(-[WKTextTouchBarItemController _wkChangeColor:]):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::getAccessibilityObjectForNode):
(WebKit::WebAutomationSessionProxy::getCookiesForFrame):
(WebKit::WebAutomationSessionProxy::deleteCookie):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeMessageEvent):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::surfaceBufferToVideoFrame):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleClient.cpp:
(WebKit::InjectedBundleClient::didReceiveMessage):
(WebKit::InjectedBundleClient::didReceiveMessageToPage):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.cpp:
(WebKit::InjectedBundlePageEditorClient::shouldInsertText):
(WebKit::InjectedBundlePageEditorClient::didBeginEditing):
(WebKit::InjectedBundlePageEditorClient::didEndEditing):
(WebKit::InjectedBundlePageEditorClient::didChange):
(WebKit::InjectedBundlePageEditorClient::didChangeSelection):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageLoaderClient.cpp:
(WebKit::InjectedBundlePageLoaderClient::willLoadDataRequest):
(WebKit::InjectedBundlePageLoaderClient::didReceiveTitleForFrame):
(WebKit::InjectedBundlePageLoaderClient::shouldForceUniversalAccessFromLocalURL):
* Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp:
(WebKit::WebInspectorUIExtensionController::registerExtension):
(WebKit::WebInspectorUIExtensionController::unregisterExtension):
(WebKit::WebInspectorUIExtensionController::createTabForExtension):
(WebKit::WebInspectorUIExtensionController::evaluateScriptForExtension):
(WebKit::WebInspectorUIExtensionController::reloadForExtension):
(WebKit::WebInspectorUIExtensionController::showExtensionTab):
(WebKit::WebInspectorUIExtensionController::navigateTabForExtension):
(WebKit::WebInspectorUIExtensionController::evaluateScriptInExtensionTab):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
* Source/WebKit/WebProcess/Network/WebSocketChannelManager.cpp:
(WebKit::WebSocketChannelManager::networkProcessCrashed):
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserMessageHandlerDescriptorProxy::WebUserMessageHandlerDescriptorProxy):
(WebKit::WebUserContentController::forEachUserMessageHandler const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::underlayColor const):
(WebKit::userDataFromJSONData):
* Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp:
(WebKit::WebGeolocationClient::requestPermission):
(WebKit::WebGeolocationClient::revokeAuthorizationToken):
(WebKit::WebGeolocationClient::cancelPermissionRequest):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDidCommitLoad):
(WebKit::WebLocalFrameLoaderClient::applyWebsitePolicies):
* Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.cpp:
(WebKit::WebPermissionController::query):
* Source/WebKit/WebProcess/WebCoreSupport/WebPermissionController.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getInformationFromImageData):
* Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp:
(WebKit::WebCookieJar::addChangeListenerWithAccess):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::initWithCoreMainFrame):
(WebKit::WebFrame::convertMainResourceLoadToDownload):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadDataInFrame):
(WebKit::WebPage::loadAlternateHTML):
(WebKit::WebPage::reload):
(WebKit::WebPage::goToBackForwardItem):
(WebKit::WebPage::setBackgroundExtendsBeyondPage):
(WebKit::WebPage::scrollBy):
(WebKit::WebPage::didEndDateTimePicker):
(WebKit::WebPage::currentSelectionAsRange):
(WebKit::WebPage::didAcquirePointerLock):
(WebKit::WebPage::didNotAcquirePointerLock):
(WebKit::WebPage::didLosePointerLock):
(WebKit::WebPage::speakingErrorOccurred):
(WebKit::WebPage::boundaryEventOccurred):
(WebKit::WebPage::voicesDidChange):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::registerURLSchemeAsCORSEnabled):
(WebKit::WebProcess::removeWebFrame):
(WebKit::WebProcess::ensureNetworkProcessConnection):
(WebKit::WebProcess::accessibilityRelayProcessSuspended):
(WebKit::WebProcess::prefetchDNS):
(WebKit::WebProcess::registerServiceWorkerClients):
(WebKit::WebProcess::setAppBadge):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):
* Source/WebKit/webpushd/ApplePushServiceConnection.mm:
(WebPushD::ApplePushServiceConnection::ApplePushServiceConnection):
(WebPushD::ApplePushServiceConnection::~ApplePushServiceConnection):
(WebPushD::ApplePushServiceConnection::subscribe):
(WebPushD::ApplePushServiceConnection::unsubscribe):
(WebPushD::ApplePushServiceConnection::enabledTopics):
(WebPushD::ApplePushServiceConnection::ignoredTopics):
(WebPushD::ApplePushServiceConnection::opportunisticTopics):
(WebPushD::ApplePushServiceConnection::nonWakingTopics):
(WebPushD::ApplePushServiceConnection::setEnabledTopics):
(WebPushD::ApplePushServiceConnection::setIgnoredTopics):
(WebPushD::ApplePushServiceConnection::setOpportunisticTopics):
(WebPushD::ApplePushServiceConnection::setNonWakingTopics):
(WebPushD::ApplePushServiceConnection::setTopicLists):

Canonical link: <a href="https://commits.webkit.org/320614@main">https://commits.webkit.org/320614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/486c7403ed9ef48fb650a94b9c9ececc212948be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195603 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/532c2a26-3692-4c0d-8a20-c1d387be5423) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58916 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144781 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e834c72e-5c0d-4916-951b-01ec7a65ef90) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188232 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125074 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc9884bf-f218-4b06-82e9-361ecd3f4ca8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47196 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45259 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6987 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13879 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157563 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44947 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6657 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46535 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51845 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49639 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197552 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58853 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154294 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41333 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59562 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153945 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48440 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131879 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128670 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58041 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19967 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57412 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57655 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57479 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->