### PR TITLE
DisplayList::RecorderImpl depends on initial state

### DIFF
--- a/Source/WebCore/html/canvas/PaintRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/PaintRenderingContext2D.cpp
@@ -72,7 +72,7 @@ CustomPaintCanvas& PaintRenderingContext2D::canvas() const
 GraphicsContext* PaintRenderingContext2D::drawingContext() const
 {
     if (!m_recordingContext)
-        m_recordingContext.emplace(canvasBase().size());
+        m_recordingContext.emplace(FloatRect { { }, canvasBase().size() });
     return &*m_recordingContext;
 }
 

--- a/Source/WebCore/platform/graphics/GraphicsContextState.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.cpp
@@ -49,6 +49,9 @@ void GraphicsContextState::repurpose(Purpose purpose)
         m_style = std::nullopt;
         m_dropShadow = std::nullopt;
         m_compositeMode = { CompositeOperator::SourceOver, BlendMode::Normal };
+        // A context this state is being recorded for performs the same reset when it begins the
+        // transparency layer, so these properties are no longer unknown inside the layer.
+        m_indeterminateProperties.remove({ Change::Alpha, Change::Style, Change::DropShadow, Change::CompositeMode });
     }
 #endif
 
@@ -89,7 +92,9 @@ void GraphicsContextState::mergeLastChanges(const GraphicsContextState& state)
     if (!changes)
         return;
     forEachProperty([&](Change change, auto property) {
-        if (!changes.contains(change) || this->*property == state.*property)
+        if (!changes.contains(change))
+            return;
+        if (this->*property == state.*property && !m_indeterminateProperties.contains(change))
             return;
         this->*property = state.*property;
         m_changeFlags.add(change);
@@ -99,7 +104,7 @@ void GraphicsContextState::mergeLastChanges(const GraphicsContextState& state)
 void GraphicsContextState::mergeAllChanges(const GraphicsContextState& state)
 {
     forEachProperty([&](Change change, auto property) {
-        if (this->*property == state.*property)
+        if (this->*property == state.*property && !m_indeterminateProperties.contains(change))
             return;
         this->*property = state.*property;
         m_changeFlags.add(change);
@@ -108,10 +113,13 @@ void GraphicsContextState::mergeAllChanges(const GraphicsContextState& state)
 
 void GraphicsContextState::filterLastChangesForMatching(const GraphicsContextState& state)
 {
-    if (!m_changeFlags)
+    // A property whose value in the other state is unknown cannot be filtered out by comparing
+    // against that state.
+    auto candidates = m_changeFlags - m_indeterminateProperties;
+    if (!candidates)
         return;
     forEachProperty([&](Change change, auto property) {
-        if (m_changeFlags.contains(change) && this->*property == state.*property)
+        if (candidates.contains(change) && this->*property == state.*property)
             m_changeFlags.remove(change);
     });
 }
@@ -126,10 +134,12 @@ void GraphicsContextState::copyPropertiesFrom(const GraphicsContextState& state,
     });
 }
 
-bool GraphicsContextState::propertiesEqual(const GraphicsContextState& other) const
+bool GraphicsContextState::propertiesEqualIgnoring(const GraphicsContextState& other, ChangeFlags ignoredProperties) const
 {
     bool equal = true;
-    forEachProperty([&](Change, auto property) {
+    forEachProperty([&](Change change, auto property) {
+        if (ignoredProperties.contains(change))
+            return;
         if (!(this->*property == other.*property))
             equal = false;
     });

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -72,11 +72,25 @@ public:
 
     WEBCORE_EXPORT GraphicsContextState(const ChangeFlags& = { }, InterpolationQuality = InterpolationQuality::Default);
 
+    // The initial state for a context that knows nothing about the state of the context its output
+    // will be applied to. Every property is indeterminate, so every setter is observed.
+    static GraphicsContextState initialIndeterminate()
+    {
+        GraphicsContextState state;
+        state.m_indeterminateProperties = ChangeFlags::all();
+        return state;
+    }
+
     void repurpose(Purpose);
     GraphicsContextState clone(Purpose) const;
 
     ChangeFlags changes() const { return m_changeFlags; }
     void didApplyChanges() { m_changeFlags = { }; }
+
+    // The mask travels with save() and restore(), matching what the other context does to its own
+    // state: a property established inside a save block is unknown again after the restore.
+    ChangeFlags indeterminateProperties() const { return m_indeterminateProperties; }
+    void markDeterminate(ChangeFlags properties) { m_indeterminateProperties.remove(properties); }
 
     SourceBrush& fillBrush() LIFETIME_BOUND { return m_fillBrush; }
     const SourceBrush& fillBrush() const LIFETIME_BOUND { return m_fillBrush; }
@@ -145,7 +159,7 @@ public:
     WEBCORE_EXPORT void copyPropertiesFrom(const GraphicsContextState&, ChangeFlags);
 
     // Whether every property holds the same value, ignoring changes() and purpose(). For assertions.
-    WEBCORE_EXPORT bool propertiesEqual(const GraphicsContextState&) const;
+    WEBCORE_EXPORT bool propertiesEqualIgnoring(const GraphicsContextState&, ChangeFlags ignoredProperties) const;
 
     Purpose purpose() const { return m_purpose; }
 
@@ -160,7 +174,7 @@ private:
     void setProperty(Change change, T GraphicsContextState::*property, const T& value)
     {
 #if !USE(CAIRO)
-        if (this->*property == value)
+        if (this->*property == value && !m_indeterminateProperties.contains(change))
             return;
 #endif
         this->*property = value;
@@ -171,7 +185,7 @@ private:
     void setProperty(Change change, T GraphicsContextState::*property, T&& value)
     {
 #if !USE(CAIRO)
-        if (this->*property == value)
+        if (this->*property == value && !m_indeterminateProperties.contains(change))
             return;
 #endif
         this->*property = std::forward<T>(value);
@@ -180,7 +194,11 @@ private:
 
     SourceBrush m_fillBrush { Color::black };
     SourceBrush m_strokeBrush { Color::black };
+    // Changes not appiled to the underlying platform context.
     ChangeFlags m_changeFlags;
+    // Properties whose value in the context this state is being applied to is unknown. A setter for
+    // such a property is never elided. Used for display list recording.
+    ChangeFlags m_indeterminateProperties;
     float m_strokeThickness { 0 };
     WindRule m_fillRule { WindRule::NonZero };
     StrokeStyle m_strokeStyle { StrokeStyle::SolidStroke };

--- a/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.cpp
@@ -46,7 +46,7 @@ std::unique_ptr<ImageBufferDisplayListBackend> ImageBufferDisplayListBackend::cr
 ImageBufferDisplayListBackend::ImageBufferDisplayListBackend(const Parameters& parameters, ControlFactory& controlFactory)
     : ImageBufferBackend(parameters)
     , m_controlFactory(controlFactory)
-    , m_drawingContext(parameters.backendSize)
+    , m_drawingContext(FloatRect { { }, parameters.backendSize })
 {
 }
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -2090,7 +2090,7 @@ void GraphicsLayerCA::recursiveCommitChanges(CommitState& commitState, const Tra
         TraceScope tracingScope(DisplayListRecordStart, DisplayListRecordEnd);
         m_displayList = nullptr;
         FloatRect initialClip(boundsOrigin(), size());
-        DisplayList::RecorderImpl context(GraphicsContextState(), initialClip, AffineTransform());
+        DisplayList::RecorderImpl context(initialClip);
         paintGraphicsLayerContents(context, FloatRect(FloatPoint(), size()));
         m_displayList = context.takeDisplayList();
     }

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -120,7 +120,7 @@ bool Recorder::updateStateForRestore(GraphicsContextState::Purpose purpose)
     GraphicsContext::restore(purpose);
     m_stateStack.removeLast();
     m_committedState.copyPropertiesFrom(m_state, committedChanges);
-    ASSERT(m_state.propertiesEqual(m_committedState));
+    ASSERT(m_state.propertiesEqualIgnoring(m_committedState, m_state.indeterminateProperties()));
     return true;
 }
 
@@ -134,6 +134,9 @@ void Recorder::commitStateChanges(GraphicsContextState::ChangeFlags changes)
 {
     m_committedState.copyPropertiesFrom(m_state, changes);
     currentState().committedChanges.add(changes);
+    // These properties have now been written out, so their value in the target is known until the
+    // enclosing save() is restored.
+    m_state.markDeterminate(changes);
     m_state.didApplyChanges();
 }
 
@@ -216,7 +219,7 @@ bool Recorder::updateStateForEndTransparencyLayer()
     m_stateStack.removeLast();
     GraphicsContext::restore(GraphicsContextState::Purpose::TransparencyLayer);
     m_committedState.copyPropertiesFrom(m_state, committedChanges);
-    ASSERT(m_state.propertiesEqual(m_committedState));
+    ASSERT(m_state.propertiesEqualIgnoring(m_committedState, m_state.indeterminateProperties()));
     return true;
 }
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -37,10 +37,11 @@ class RecorderImpl : public Recorder {
     WTF_MAKE_NONCOPYABLE(RecorderImpl);
 public:
     WEBCORE_EXPORT RecorderImpl(const GraphicsContextState&, const FloatRect& initialClip, const AffineTransform&, const ColorSpace& = ColorSpace::SRGB(), DrawGlyphsMode = DrawGlyphsMode::Normal);
-    RecorderImpl(FloatSize initialClipSize)
-        : RecorderImpl({ }, { { }, initialClipSize }, { }, ColorSpace::SRGB(), DrawGlyphsMode::Normal)
+    RecorderImpl(const FloatRect& initialClip)
+        : RecorderImpl(GraphicsContextState::initialIndeterminate(), initialClip, { }, ColorSpace::SRGB(), DrawGlyphsMode::Normal)
     {
     }
+
     WEBCORE_EXPORT virtual ~RecorderImpl();
 
     WEBCORE_EXPORT Ref<const DisplayList> takeDisplayList();

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -35,7 +35,7 @@ using namespace WebCore;
 
 Ref<RemoteDisplayListRecorder> RemoteDisplayListRecorder::create(RemoteDisplayListRecorderIdentifier identifier, RemoteRenderingBackend& renderingBackend)
 {
-    Ref instance = adoptRef(*new RemoteDisplayListRecorder(makeUniqueRef<DisplayList::RecorderImpl>(FloatSize { }), identifier, renderingBackend));
+    Ref instance = adoptRef(*new RemoteDisplayListRecorder(makeUniqueRef<DisplayList::RecorderImpl>(FloatRect { }), identifier, renderingBackend));
     instance->startListeningForIPC();
     return instance;
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteSnapshotRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteSnapshotRecorder.cpp
@@ -40,7 +40,7 @@ using namespace WebCore;
 
 Ref<RemoteSnapshotRecorder> RemoteSnapshotRecorder::create(RemoteSnapshotRecorderIdentifier identifier, RemoteSnapshot& snapshot, RemoteRenderingBackend& renderingBackend)
 {
-    Ref instance = adoptRef(*new RemoteSnapshotRecorder(makeUniqueRef<DisplayList::RecorderImpl>(FloatSize { }), identifier, snapshot, renderingBackend));
+    Ref instance = adoptRef(*new RemoteSnapshotRecorder(makeUniqueRef<DisplayList::RecorderImpl>(FloatRect { }), identifier, snapshot, renderingBackend));
     instance->startListeningForIPC();
     return instance;
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -36,7 +36,7 @@ using namespace WebCore;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteDisplayListRecorderProxy);
 
 RemoteDisplayListRecorderProxy::RemoteDisplayListRecorderProxy(RemoteRenderingBackendProxy& renderingBackend)
-    : RemoteGraphicsContextProxy(ColorSpace::SRGB(), std::nullopt, RenderingMode::Accelerated, { }, { }, DrawGlyphsMode::Normal, RemoteGraphicsContextIdentifier::generate(), renderingBackend)
+    : RemoteGraphicsContextProxy(GraphicsContextState::initialIndeterminate(), { }, { }, ColorSpace::SRGB(), DrawGlyphsMode::Normal, std::nullopt, RenderingMode::Accelerated, RemoteGraphicsContextIdentifier::generate(), renderingBackend)
 {
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
@@ -59,18 +59,18 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteGraphicsContextProxy);
 
-RemoteGraphicsContextProxy::RemoteGraphicsContextProxy(const ColorSpace& colorSpace, RenderingMode renderingMode, const FloatRect& initialClip, const AffineTransform& initialCTM, RemoteRenderingBackendProxy& renderingBackend)
-    : RemoteGraphicsContextProxy(colorSpace, std::nullopt, renderingMode, initialClip, initialCTM, DrawGlyphsMode::Deconstruct, RemoteGraphicsContextIdentifier::generate(), renderingBackend)
+RemoteGraphicsContextProxy::RemoteGraphicsContextProxy(const FloatRect& initialClip, const AffineTransform& initialCTM, const ColorSpace& colorSpace, RenderingMode renderingMode, RemoteRenderingBackendProxy& renderingBackend)
+    : RemoteGraphicsContextProxy({ }, initialClip, initialCTM, colorSpace, DrawGlyphsMode::Deconstruct, std::nullopt, renderingMode, RemoteGraphicsContextIdentifier::generate(), renderingBackend)
 {
 }
 
-RemoteGraphicsContextProxy::RemoteGraphicsContextProxy(const ColorSpace& colorSpace, WebCore::ContentsFormat contentsFormat, RenderingMode renderingMode, const FloatRect& initialClip, const AffineTransform& initialCTM, RemoteGraphicsContextIdentifier identifier, RemoteRenderingBackendProxy& renderingBackend)
-    : RemoteGraphicsContextProxy(colorSpace, contentsFormat, renderingMode, initialClip, initialCTM, DrawGlyphsMode::Deconstruct, identifier, renderingBackend)
+RemoteGraphicsContextProxy::RemoteGraphicsContextProxy(const FloatRect& initialClip, const AffineTransform& initialCTM, const ColorSpace& colorSpace, WebCore::ContentsFormat contentsFormat, RenderingMode renderingMode, RemoteGraphicsContextIdentifier identifier, RemoteRenderingBackendProxy& renderingBackend)
+    : RemoteGraphicsContextProxy({ }, initialClip, initialCTM, colorSpace, DrawGlyphsMode::Deconstruct, contentsFormat, renderingMode, identifier, renderingBackend)
 {
 }
 
-RemoteGraphicsContextProxy::RemoteGraphicsContextProxy(const ColorSpace& colorSpace, std::optional<ContentsFormat> contentsFormat, RenderingMode renderingMode, const FloatRect& initialClip, const AffineTransform& initialCTM, DrawGlyphsMode drawGlyphsMode, RemoteGraphicsContextIdentifier identifier, RemoteRenderingBackendProxy& renderingBackend)
-    : DisplayList::Recorder(IsDeferred::No, { }, initialClip, initialCTM, colorSpace, drawGlyphsMode)
+RemoteGraphicsContextProxy::RemoteGraphicsContextProxy(const GraphicsContextState& state, const FloatRect& initialClip, const AffineTransform& initialCTM, const ColorSpace& colorSpace, DrawGlyphsMode drawGlyphsMode, std::optional<ContentsFormat> contentsFormat, RenderingMode renderingMode, RemoteGraphicsContextIdentifier identifier, RemoteRenderingBackendProxy& renderingBackend)
+    : DisplayList::Recorder(IsDeferred::No, state, initialClip, initialCTM, colorSpace, drawGlyphsMode)
     , m_renderingMode(renderingMode)
     , m_identifier(identifier)
     , m_renderingBackend(renderingBackend)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.h
@@ -50,8 +50,8 @@ class SharedVideoFrameWriter;
 class RemoteGraphicsContextProxy : public WebCore::DisplayList::Recorder {
     WTF_MAKE_TZONE_ALLOCATED(RemoteGraphicsContextProxy);
 public:
-    RemoteGraphicsContextProxy(const WebCore::ColorSpace&, WebCore::RenderingMode, const WebCore::FloatRect& initialClip, const WebCore::AffineTransform&, RemoteRenderingBackendProxy&);
-    RemoteGraphicsContextProxy(const WebCore::ColorSpace&, WebCore::ContentsFormat, WebCore::RenderingMode, const WebCore::FloatRect& initialClip, const WebCore::AffineTransform&, RemoteGraphicsContextIdentifier, RemoteRenderingBackendProxy&);
+    RemoteGraphicsContextProxy(const WebCore::FloatRect& initialClip, const WebCore::AffineTransform&, const WebCore::ColorSpace&, WebCore::RenderingMode, RemoteRenderingBackendProxy&);
+    RemoteGraphicsContextProxy(const WebCore::FloatRect& initialClip, const WebCore::AffineTransform&, const WebCore::ColorSpace&, WebCore::ContentsFormat, WebCore::RenderingMode, RemoteGraphicsContextIdentifier, RemoteRenderingBackendProxy&);
     ~RemoteGraphicsContextProxy();
     RemoteGraphicsContextIdentifier identifier() const { return m_identifier; }
 
@@ -83,7 +83,7 @@ public:
     }
 
 protected:
-    RemoteGraphicsContextProxy(const WebCore::ColorSpace&, std::optional<WebCore::ContentsFormat>, WebCore::RenderingMode, const WebCore::FloatRect& initialClip, const WebCore::AffineTransform&, DrawGlyphsMode, RemoteGraphicsContextIdentifier, RemoteRenderingBackendProxy&);
+    RemoteGraphicsContextProxy(const WebCore::GraphicsContextState&, const WebCore::FloatRect& initialClip, const WebCore::AffineTransform&, const WebCore::ColorSpace&, DrawGlyphsMode, std::optional<WebCore::ContentsFormat>, WebCore::RenderingMode, RemoteGraphicsContextIdentifier, RemoteRenderingBackendProxy&);
 
     template<typename T> void send(T&& message);
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -125,7 +125,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteImageBufferProxyFlusher);
 
 RemoteImageBufferProxy::RemoteImageBufferProxy(Parameters parameters, const ImageBufferBackend::Info& info, RemoteRenderingBackendProxy& renderingBackend)
     : ImageBuffer(parameters, info, { }, nullptr)
-    , m_context(ImageBuffer::colorSpace(), ImageBuffer::renderingMode() , { { }, ImageBuffer::logicalSize() }, ImageBuffer::baseTransform(), renderingBackend)
+    , m_context({ { }, ImageBuffer::logicalSize() }, ImageBuffer::baseTransform(), ImageBuffer::colorSpace(), ImageBuffer::renderingMode(), renderingBackend)
     , m_renderingBackend(renderingBackend)
 {
     m_context.setClient(*this);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
@@ -288,7 +288,7 @@ void RemoteImageBufferSetProxy::willPrepareForDisplay()
         send(Messages::RemoteImageBufferSet::UpdateConfiguration(m_configuration));
         ImageBufferParameters parameters { m_configuration.logicalSize, m_configuration.resolutionScale, m_configuration.colorSpace, m_configuration.bufferFormat, m_configuration.renderingPurpose };
         auto transform = ImageBufferBackend::calculateBaseTransform(ImageBuffer::backendParameters(parameters));
-        m_context.emplace(m_configuration.colorSpace, m_configuration.contentsFormat, m_configuration.renderingMode, FloatRect { { }, m_configuration.logicalSize }, transform, m_contextIdentifier, *renderingBackend);
+        m_context.emplace(FloatRect { { }, m_configuration.logicalSize }, transform, m_configuration.colorSpace, m_configuration.contentsFormat, m_configuration.renderingMode, m_contextIdentifier, *renderingBackend);
     }
     m_remoteNeedsConfigurationUpdate = false;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteSnapshotRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteSnapshotRecorderProxy.cpp
@@ -37,7 +37,7 @@ using namespace WebCore;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteSnapshotRecorderProxy);
 
 RemoteSnapshotRecorderProxy::RemoteSnapshotRecorderProxy(RemoteRenderingBackendProxy& renderingBackend)
-    : RemoteGraphicsContextProxy(ColorSpace::SRGB(), std::nullopt, RenderingMode::DisplayList, { }, { }, DrawGlyphsMode::Normal, RemoteGraphicsContextIdentifier::generate(), renderingBackend)
+    : RemoteGraphicsContextProxy(GraphicsContextState::initialIndeterminate(), { }, { }, ColorSpace::SRGB(), DrawGlyphsMode::Normal, std::nullopt, RenderingMode::DisplayList, RemoteGraphicsContextIdentifier::generate(), renderingBackend)
 {
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
@@ -441,10 +441,262 @@ struct TrivialRotate {
     }
 };
 
+// When the recorder does not know the replay target's state, setting a state property to its default
+// value must still be recorded: the target may not be at that default.
+
+struct SetDefaultFillBrush {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.setFillColor(WebCore::Color::black);
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-inline-fill-color
+  (color #000000)))DL"_s;
+    }
+};
+
+struct SetDefaultFillRule {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.setFillRule(WebCore::WindRule::NonZero);
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-state
+  (change-flags [fill-rule])
+  (fill-rule NON-ZERO)))DL"_s;
+    }
+};
+
+struct SetDefaultStrokeBrush {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.setStrokeColor(WebCore::Color::black);
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-inline-stroke
+  (color #000000)))DL"_s;
+    }
+};
+
+struct SetDefaultStrokeThickness {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.setStrokeThickness(0);
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-inline-stroke
+  (thickness 0.00)))DL"_s;
+    }
+};
+
+struct SetDefaultStrokeStyle {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.setStrokeStyle(WebCore::StrokeStyle::SolidStroke);
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-state
+  (change-flags [stroke-style])
+  (stroke-style solid-stroke)))DL"_s;
+    }
+};
+
+struct SetDefaultCompositeMode {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.setCompositeOperation(WebCore::CompositeOperator::SourceOver, WebCore::BlendMode::Normal);
+    }
+
+    static String description()
+    {
+        // Note: the literals are split around the space TextStream emits after a nested group name,
+        // so that it does not end up as trailing whitespace in this file.
+        return R"DL(
+(set-state
+  (change-flags [composite-mode])
+  (composite-mode)DL" " " R"DL(
+    (composite-operation source-over)
+    (blend-mode normal))))DL"_s;
+    }
+};
+
+struct SetDefaultDropShadow {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.clearDropShadow();
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-state
+  (change-flags [drop-shadow])
+  (drop-shadow nullopt)))DL"_s;
+    }
+};
+
+struct SetDefaultStyle {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.setStyle(std::nullopt);
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-state
+  (change-flags [style])
+  (style nullopt)))DL"_s;
+    }
+};
+
+struct SetDefaultAlpha {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.setAlpha(1);
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-state
+  (change-flags [alpha])
+  (alpha 1.00)))DL"_s;
+    }
+};
+
+struct SetDefaultImageInterpolationQuality {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.setImageInterpolationQuality(WebCore::InterpolationQuality::Default);
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-state
+  (change-flags [image-interpolation-quality])
+  (image-interpolation-quality default)))DL"_s;
+    }
+};
+
+struct SetDefaultTextDrawingMode {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.setTextDrawingMode(WebCore::TextDrawingMode::Fill);
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-state
+  (change-flags [text-drawing-mode])
+  (text-drawing-mode [fill])))DL"_s;
+    }
+};
+
+struct SetDefaultShouldAntialias {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.setShouldAntialias(true);
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-state
+  (change-flags [should-antialias])
+  (should-antialias 1)))DL"_s;
+    }
+};
+
+struct SetDefaultShouldSmoothFonts {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.setShouldSmoothFonts(true);
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-state
+  (change-flags [should-smooth-fonts])
+  (should-smooth-fonts 1)))DL"_s;
+    }
+};
+
+struct SetDefaultShouldSubpixelQuantizeFonts {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        // shouldDumpItem() hides a set-state whose only change is should-subpixel-quantize-fonts, so
+        // set another property to its default value too to make the recorded item observable.
+        c.setFillRule(WebCore::WindRule::NonZero);
+        c.setShouldSubpixelQuantizeFonts(true);
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-state
+  (change-flags [fill-rule, should-subpixel-quantize-fonts])
+  (fill-rule NON-ZERO)
+  (should-subpixel-quantize-fonts 1)))DL"_s;
+    }
+};
+
+struct SetDefaultShadowsIgnoreTransforms {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.setShadowsIgnoreTransforms(false);
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-state
+  (change-flags [shadows-ignore-transforms])
+  (shadows-ignore-transforms 0)))DL"_s;
+    }
+};
+
+struct SetDefaultDrawLuminanceMask {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.setDrawLuminanceMask(false);
+    }
+
+    static String description()
+    {
+        return R"DL(
+(set-state
+  (change-flags [draw-luminance-mask])
+  (draw-luminance-mask 0)))DL"_s;
+    }
+};
+
 using AllOperations = testing::Types<NoCommands, ChangeAntialias, ChangeAntialiasBeforeSave,
     ChangeAntialiasBeforeAndAfterSave, ChangeAntialiasInEmptySaveRestore, DrawSystemImage, ChangeAntialiasBeforeClipRect,
     ChangeAntialiasBeforeClipOutRect, ChangeAntialiasBeforeClipOutPath, ChangeAntialiasBeforeClipPath,
-    ChangeAntialiasBeforeClipToImageBuffer, TrivialTranslate, TrivialScale, TrivialRotate, ResetClipRect>;
+    ChangeAntialiasBeforeClipToImageBuffer, TrivialTranslate, TrivialScale, TrivialRotate, ResetClipRect,
+    SetDefaultFillBrush, SetDefaultFillRule, SetDefaultStrokeBrush, SetDefaultStrokeThickness, SetDefaultStrokeStyle,
+    SetDefaultCompositeMode, SetDefaultDropShadow, SetDefaultStyle, SetDefaultAlpha, SetDefaultImageInterpolationQuality,
+    SetDefaultTextDrawingMode, SetDefaultShouldAntialias, SetDefaultShouldSmoothFonts, SetDefaultShouldSubpixelQuantizeFonts,
+    SetDefaultShadowsIgnoreTransforms, SetDefaultDrawLuminanceMask>;
 
 }
 
@@ -454,7 +706,7 @@ TYPED_TEST_P(DisplayListRecorderResultStateTest, StateThroughDisplayListIsPreser
 {
     auto refTarget = createReferenceTarget();
     auto& ref = refTarget->context();
-    WebCore::DisplayList::RecorderImpl tested { { testContextWidth, testContextHeight } };
+    WebCore::DisplayList::RecorderImpl tested { { 0, 0, testContextWidth, testContextHeight } };
     EXPECT_TRUE(checkEqualState(ref, tested));
 
     forBoth(ref, tested, this->operation());


### PR DESCRIPTION
#### 6d631db91774a727f4b75cfa594b4ff809adeb6c
<pre>
DisplayList::RecorderImpl depends on initial state
<a href="https://bugs.webkit.org/show_bug.cgi?id=323301">https://bugs.webkit.org/show_bug.cgi?id=323301</a>
<a href="https://rdar.apple.com/186549951">rdar://186549951</a>

Reviewed by Taher Ali and Matt Woodrow.

General purpose display list recording was not useful, because the
the RecorderImpl had an initial GraphicsContextState and the state
setters would elide updates to properties that matched the state.
Thus command like recorder.setFillColor(Color::transparentBlack) would
not produce an item because the initial state had black fill color.

Fix by adding a property list for unknown properties to
GraphicsContextState and checking that per property update.

Test: Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp

* Source/WebCore/platform/graphics/GraphicsContextState.cpp:
(WebCore::GraphicsContextState::repurpose):
(WebCore::GraphicsContextState::mergeLastChanges):
(WebCore::GraphicsContextState::mergeAllChanges):
(WebCore::GraphicsContextState::filterLastChangesForMatching):
(WebCore::GraphicsContextState::propertiesEqualIgnoring const):
(WebCore::GraphicsContextState::propertiesEqual const): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextState.h:
(WebCore::GraphicsContextState::initialIndeterminate):
(WebCore::GraphicsContextState::indeterminateProperties const):
(WebCore::GraphicsContextState::markDeterminate):
(WebCore::GraphicsContextState::setProperty):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::updateStateForRestore):
(WebCore::DisplayList::Recorder::commitStateChanges):
(WebCore::DisplayList::Recorder::updateStateForEndTransparencyLayer):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
(WebCore::DisplayList::RecorderImpl::RecorderImpl):
* Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp:

Canonical link: <a href="https://commits.webkit.org/320623@main">https://commits.webkit.org/320623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e2e122297b833539bd323cbbed43b408c9efb10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185355 "44 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195679 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e434ff13-9f66-495d-8453-ddf30d26421e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187217 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144852 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f4a53a5-60e2-49ee-ab60-a327530130c1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165440 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125145 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d0d568fe-8b81-47bf-af6d-038108ca3d19) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47260 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45320 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45011 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6732 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197628 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58931 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154363 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41338 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59640 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154013 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48504 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131964 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128794 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58118 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20033 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57490 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57733 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57557 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->