### PR TITLE
ipc/removeMediaUsageManagerSession-test.html times out

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6195,7 +6195,6 @@ ipc/start-message-testing.html [ Skip ]
 # Fixing timeouts/crashes is tracked by https://bugs.webkit.org/show_bug.cgi?id=267714 (rdar://120486467)
 ipc/invalid-fullscreen-enum.html [ Pass Timeout ]
 ipc/invalid-message-to-addTrackBuffer.html [ Pass Timeout ]
-ipc/removeMediaUsageManagerSession-test.html [ Skip ]
 
 # Test is crashing since import.
 imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-csp.html [ Skip ]

--- a/LayoutTests/ipc/removeMediaUsageManagerSession-test.html
+++ b/LayoutTests/ipc/removeMediaUsageManagerSession-test.html
@@ -4,6 +4,7 @@
 <script>
 function fuzz() {
   if (window.testRunner) {
+      testRunner.dumpAsText();
       testRunner.waitUntilDone();
   }
   var calledParseMessage = false;
@@ -33,7 +34,6 @@ function parseMessage(msg) {
   o17 = view.getBigUint64(0, true);
 }
 function timeout1() {
-  IPC.sendSyncMessage('UI',IPC.webPageProxyID,IPC.messages.WebPageProxy_ReachedApplicationCacheOriginQuota.name,0.1,[{type: 'String',value: "text/html"},{type: 'uint64_t',value: 426},{type: 'uint64_t',value: 809}]);
   video.play();
   window.setTimeout(timeout2,300);
 }
@@ -43,9 +43,11 @@ function timeout2() {
   window.setTimeout(timeout3, 10);
 }
 function timeout3() {
-  IPC.sendMessage('UI',IPC.webPageProxyID,IPC.messages.WebPageProxy_RemoveMediaUsageManagerSession.name,[{type: 'uint64_t',value: o17}]);
+  // o17 is a MediaSessionIdentifier scraped from an outgoing UpdateMediaUsageManagerSessionState.
+  // If that message never arrived, removing an identifier the UI process never saw is just as
+  // valid an input for this test, so fall back to a bogus one rather than throwing.
+  IPC.sendMessage('UI',IPC.webPageProxyID,IPC.messages.WebPageProxy_RemoveMediaUsageManagerSession.name,[{type: 'uint64_t',value: o17 ?? 0x414141414141n}]);
   if (window.testRunner) {
-    testRunner.dumpAsText();
     testRunner.notifyDone();
   }
 }


### PR DESCRIPTION
#### d375d016dd2cae0c7fbf7179d6e9b929b89b67b0
<pre>
ipc/removeMediaUsageManagerSession-test.html times out
<a href="https://bugs.webkit.org/show_bug.cgi?id=323298">https://bugs.webkit.org/show_bug.cgi?id=323298</a>
<a href="https://rdar.apple.com/186546277">rdar://186546277</a>

Reviewed by NOBODY (OOPS!).

Update the test with more recent IPC messages.

* LayoutTests/TestExpectations:
* LayoutTests/ipc/removeMediaUsageManagerSession-test.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d375d016dd2cae0c7fbf7179d6e9b929b89b67b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195043 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148974 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7da1b4fe-c5c2-4447-8dfc-cf9f6f6916fa) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58359 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144335 "Found 1 new test failure: ipc/removeMediaUsageManagerSession-test.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100223 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c4234313-acd3-4289-b6e9-2d1409a056c4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187663 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48005 "Found 1 new test failure: ipc/removeMediaUsageManagerSession-test.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124617 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc52c6b2-f5d1-4c7a-8b36-7994926bcf41) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46724 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44854 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157098 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44498 "Found 1 new test failure: ipc/removeMediaUsageManagerSession-test.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6099 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196992 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58300 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164437 "Exiting early after 10 failures. 10 tests run. 1 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153805 "Found 1 new test failure: ipc/removeMediaUsageManagerSession-test.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59002 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41120 "Found 1 new test failure: ipc/removeMediaUsageManagerSession-test.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153462 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47980 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127827 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57502 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19517 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56863 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57114 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56938 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->