### PR TITLE
ipc/invalid-fullscreen-enum.html times out

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6193,7 +6193,6 @@ webkit.org/b/239959 ipc/stream-sync-crash-no-timeout.html [ Skip ]
 ipc/start-message-testing.html [ Skip ]
 
 # Fixing timeouts/crashes is tracked by https://bugs.webkit.org/show_bug.cgi?id=267714 (rdar://120486467)
-ipc/invalid-fullscreen-enum.html [ Pass Timeout ]
 ipc/invalid-message-to-addTrackBuffer.html [ Pass Timeout ]
 ipc/removeMediaUsageManagerSession-test.html [ Skip ]
 

--- a/LayoutTests/ipc/invalid-fullscreen-enum.html
+++ b/LayoutTests/ipc/invalid-fullscreen-enum.html
@@ -30,39 +30,41 @@ function timeout1() {
   o39=document.createElement('iframe');
   document.body.appendChild(o39);
   IPC.sendMessage('UI',destinationId,IPC.messages.VideoPresentationManagerProxy_SetupFullscreenWithID.name,
-                  [{type: 'uint64_t',value: contextId},                                                                             // PlaybackSessionContextIdentifier contextId
-                   {type: 'uint32_t',value: 8},                                                                                     // WebKit::LayerHostingContextID videoLayerID
+                  [{type: 'uint64_t',value: contextId},                                                                             // WebCore::MediaPlayerClientIdentifier identifier
+                   {type: 'uint32_t',value: 8},                                                                                     // WebCore::HostingContext hostingContext
                    {type: 'float',value: 338},{type: 'float',value: -429},{type: 'float',value: 117},{type: 'float',value: 1411},   // WebCore::FloatRect& screenRect
                    {type: 'float',value: 557},{type: 'float',value: 885},                                                           // WebCore::FloatSize& initialSize
                    {type: 'float',value: 215},{type: 'float',value: 537},                                                           // WebCore::FloatSize& videoDimensions
-                   {type: 'float',value: 299},                                                                                      // float hostingDeviceScaleFactor
+                   {type: 'float',value: 299},                                                                                      // float hostingScaleFactor
                    {type: 'uint32_t',value: 2n},                                                                                    // HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode
                    {type: 'bool',value: 0},                                                                                         // bool allowsPictureInPicture
                    {type: 'bool',value: 1},                                                                                         // bool standby
-                   {type: 'bool',value: 1}                                                                                          // bool blocksReturnToFullscreenFromPictureInPicture
+                   {type: 'bool',value: 1},                                                                                         // bool blocksReturnToFullscreenFromPictureInPicture
+                   {type: 'bool',value: 0}                                                                                          // bool hasObjectViewBox
                  ]);
   window.setTimeout(timeout2,200);
 }
 function timeout2() {
   window.open('empty.html',"InsertTab",'heigth=100,width=200');
   IPC.sendMessage('UI',destinationId,IPC.messages.VideoPresentationManagerProxy_SetupFullscreenWithID.name,
-                  [{type: 'uint64_t',value: contextId},                                                                             // PlaybackSessionContextIdentifier contextId
-                   {type: 'uint32_t',value: 8},                                                                                     // WebKit::LayerHostingContextID videoLayerID
+                  [{type: 'uint64_t',value: contextId},                                                                             // WebCore::MediaPlayerClientIdentifier identifier
+                   {type: 'uint32_t',value: 8},                                                                                     // WebCore::HostingContext hostingContext
                    {type: 'float',value: 2659},{type: 'float',value: 2032},{type: 'float',value: 69},{type: 'float',value: 713},    // WebCore::FloatRect& screenRect
                    {type: 'float',value: 3444},{type: 'float',value: 23},                                                           // WebCore::FloatSize& initialSize
                    {type: 'float',value: 463},{type: 'float',value: 938},                                                           // WebCore::FloatSize& videoDimensions
-                   {type: 'float',value: 950},                                                                                      // float hostingDeviceScaleFactor
+                   {type: 'float',value: 950},                                                                                      // float hostingScaleFactor
                    {type: 'uint32_t',value: 68n},                                                                                   // HTMLMediaElementEnums::VideoFullscreenMode videoFullscreenMode
                    {type: 'bool',value: 1},                                                                                         // bool allowsPictureInPicture
                    {type: 'bool',value: 0},                                                                                         // bool standby
-                   {type: 'bool',value: 0}]);                                                                                       // bool blocksReturnToFullscreenFromPictureInPicture
+                   {type: 'bool',value: 0},                                                                                         // bool blocksReturnToFullscreenFromPictureInPicture
+                   {type: 'bool',value: 0}]);                                                                                       // bool hasObjectViewBox
   o70=document.createElement('iframe');
   document.body.appendChild(o70);
   o8.srcObject=o9.captureStream();
   window.setTimeout(timeout3,200);
 }
 function timeout3() {
-  IPC.sendMessage('UI',IPC.webPageProxyID,IPC.messages.WebPageProxy_SetWindowFrame.name,[{type: 'float',value: 1142},{type: 'float',value: 1330},{type: 'float',value: 168},{type: 'float',value: 1869}]);
+  IPC.sendMessage('UI',IPC.webPageProxyID,IPC.messages.WebPageProxy_SetWindowFrameIPC.name,[{type: 'float',value: 1142},{type: 'float',value: 1330},{type: 'float',value: 168},{type: 'float',value: 1869}]);
   window.setTimeout(timeout4,500);
 }
 function timeout4() {

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -874,9 +874,13 @@ void VideoPresentationManager::didCleanupFullscreen(WebCore::MediaPlayerClientId
         videoElement->didExitFullscreenOrPictureInPicture();
 
     interface->setFullscreenStandby(false);
-    if (interface->fullscreenMode() != HTMLMediaElementEnums::VideoFullscreenModeInWindow) {
+    auto currentMode = interface->fullscreenMode();
+    if (currentMode != HTMLMediaElementEnums::VideoFullscreenModeInWindow) {
         interface->setFullscreenMode(HTMLMediaElementEnums::VideoFullscreenModeNone);
-        removeClientForContext(contextId);
+        // A client is only added when the mode leaves VideoFullscreenModeNone, so only remove one
+        // when it returns to it.
+        if (currentMode != HTMLMediaElementEnums::VideoFullscreenModeNone)
+            removeClientForContext(contextId);
     }
 
     if (!videoElement || !targetIsFullscreen || mode == HTMLMediaElementEnums::VideoFullscreenModeNone || mode == HTMLMediaElementEnums::VideoFullscreenModeInWindow) {


### PR DESCRIPTION
#### 9ad4c9e6356e537de7eb9e1d0c7df0052c8536f3
<pre>
ipc/invalid-fullscreen-enum.html times out
<a href="https://bugs.webkit.org/show_bug.cgi?id=323291">https://bugs.webkit.org/show_bug.cgi?id=323291</a>
<a href="https://rdar.apple.com/186542675">rdar://186542675</a>

Reviewed by NOBODY (OOPS!).

The IPC messages were out of date, leading to timeout.
Now that the messages are up to date, the code asserts. Fix the assert.

* LayoutTests/TestExpectations:
* LayoutTests/ipc/invalid-fullscreen-enum.html:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::didCleanupFullscreen):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ad4c9e6356e537de7eb9e1d0c7df0052c8536f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195046 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/148977 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/59988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58362 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144340 "Found 1 new test failure: ipc/invalid-fullscreen-enum.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100225 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187666 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48010 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124622 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46732 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44857 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157106 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44497 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6102 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196995 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58303 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164436 "Exiting early after 10 failures. 10 tests run. 1 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153809 "Found 1 new test failure: ipc/invalid-fullscreen-enum.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59005 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41119 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153466 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/47990 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131294 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127830 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57505 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19516 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56866 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57117 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56941 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->