### PR TITLE
Cherry-pick 305413.991@safari-7624.5-branch (43afeddf1aab). https://bugs.webkit.org/show_bug.cgi?id=315543

### DIFF
--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
@@ -772,6 +772,7 @@
 		6D9B474C9772B31D1F2AC404 /* es3fFboMultisampleTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BF04C6D8B521D83F2EC8173 /* es3fFboMultisampleTests.cpp */; };
 		6DA64073883FDF54168599CF /* es2fDepthStencilClearTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1FA34FD4B03534F80E4DCA39 /* es2fDepthStencilClearTests.cpp */; };
 		6E1B4911B80D8FDCDD1EA9FF /* egluCallLogWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 107146A881C2C2BB5CEEA7E1 /* egluCallLogWrapper.cpp */; };
+		4592BD742FC4F27700DC76EB /* IntegerOverflowClampTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4592BD732FC4F27700DC76EB /* IntegerOverflowClampTest.cpp */; };
 		6E27925927EA43F500B1BA86 /* BaseTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6E27925827EA43F500B1BA86 /* BaseTypes.cpp */; };
 		6E5B419BBE7661EF0F8D9BF1 /* xeTestCaseResult.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F38248B9AC4DE2D848347AF9 /* xeTestCaseResult.cpp */; };
 		6E6B4B668AD281FE2EB8C9A0 /* es2fNegativeBufferApiTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B9354306BB3F15EEA8B5E554 /* es2fNegativeBufferApiTests.cpp */; };
@@ -6492,6 +6493,7 @@
 				7BFAF5682DE59E0900327F7F /* IndexBufferOffsetTest.cpp */,
 				7BFAF5692DE59E0900327F7F /* IndexedPointsTest.cpp */,
 				7BFAF56A2DE59E0900327F7F /* InstancingTest.cpp */,
+				4592BD732FC4F27700DC76EB /* IntegerOverflowClampTest.cpp */,
 				7BFAF56B2DE59E0900327F7F /* KTXCompressedTextureTest.cpp */,
 				7BFAF56C2DE59E0900327F7F /* LineLoopTest.cpp */,
 				7BFAF56D2DE59E0900327F7F /* LinkAndRelinkTest.cpp */,
@@ -10540,6 +10542,7 @@
 				7BFAF5EE2DE59E0900327F7F /* IndexBufferOffsetTest.cpp in Sources */,
 				7BFAF5F42DE59E0900327F7F /* IndexedPointsTest.cpp in Sources */,
 				7BFAF5CE2DE59E0900327F7F /* InstancingTest.cpp in Sources */,
+				4592BD742FC4F27700DC76EB /* IntegerOverflowClampTest.cpp in Sources */,
 				7BFAF5D82DE59E0900327F7F /* KTXCompressedTextureTest.cpp in Sources */,
 				7BB9723D2DE4827800455D13 /* libEGL_autogen.cpp in Sources */,
 				7BB972362DE480F000455D13 /* libGLESv2_autogen.cpp in Sources */,

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/msl/EmitMetal.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/msl/EmitMetal.cpp
@@ -373,7 +373,7 @@ static const char *GetOperatorString(TOperator op,
         case TOperator::EOpLogicalAnd:
             return "&&";
         case TOperator::EOpNegative:
-            return "-";
+            return resultType.isSignedInt() ? "ANGLE_negateInt" : "-";
         case TOperator::EOpPositive:
             if (argType0->isMatrix())
             {
@@ -431,11 +431,13 @@ static const char *GetOperatorString(TOperator op,
 
         case TOperator::EOpDiv:
         case TOperator::EOpDivAssign:
-            return resultType.isSignedInt() ? "ANGLE_div" : "/";
+            return (resultType.isSignedInt() || resultType.getBasicType() == EbtUInt) ? "ANGLE_div"
+                                                                                      : "/";
 
         case TOperator::EOpIMod:
         case TOperator::EOpIModAssign:
-            return resultType.isSignedInt() ? "ANGLE_imod" : "%";
+            return (resultType.isSignedInt() || resultType.getBasicType() == EbtUInt) ? "ANGLE_imod"
+                                                                                      : "%";
 
         case TOperator::EOpEqual:
             if ((argType0->getStruct() && argType1->getStruct()) &&

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/msl/ProgramPrelude.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/msl/ProgramPrelude.cpp
@@ -295,6 +295,7 @@ class ProgramPrelude : public TIntermTraverser
     void addAssignInt();
     void subInt();
     void subAssignInt();
+    void negateInt();
     void loopForwardProgress();
 
   private:
@@ -454,8 +455,6 @@ ANGLE_ALWAYS_INLINE X ANGLE_mod(X x, Y y)
 // - the divisor is 0
 // - the dividend is INT_MIN and the divisor is -1 (integer overflow)
 // When the behavior would be undefined the result is `x`.
-// FIXME: This function should also handle INT_MIN / -1, but currently this hits a bug in the metal
-// compiler
 PROGRAM_PRELUDE_DECLARE(div,
                         R"(
 template<typename X, typename Y, typename Z = metal::conditional_t<metal::is_scalar_v<Y>, X, Y>>
@@ -463,8 +462,16 @@ ANGLE_ALWAYS_INLINE Z ANGLE_div(X x, Y y)
 {
     Z zx = Z(x);
     Z zy = Z(y);
-    auto predicate = zy == Z(0);
-    return zx / metal::select(zy, Z(1), predicate);
+    if constexpr (metal::is_signed_v<Z>) {
+        using U = metal::make_unsigned_t<Z>;
+        Z safeY = metal::select(zy, Z(1), zy == Z(0));
+        auto isNegOne = safeY == Z(-1);
+        safeY = metal::select(safeY, Z(1), isNegOne);
+        Z q = zx / safeY;
+        return metal::select(q, as_type<Z>(U(0) - U(zx)), isNegOne);
+    } else {
+        return zx / metal::select(zy, Z(1), zy == Z(0));
+    }
 }
 )")
 
@@ -473,8 +480,6 @@ ANGLE_ALWAYS_INLINE Z ANGLE_div(X x, Y y)
 // - the dividend is INT_MIN and the divisor is -1 (integer overflow)
 // - either of the operands is negative (undefined behavior in Metal)
 // When the behavior would be undefined the result is 0.
-// FIXME: This function should also handle INT_MIN % -1, but currently this hits a bug in the metal
-// compiler
 PROGRAM_PRELUDE_DECLARE(imod,
                         R"(
 template<typename X, typename Y, typename Z = metal::conditional_t<metal::is_scalar_v<Y>, X, Y>>
@@ -482,6 +487,7 @@ ANGLE_ALWAYS_INLINE Z ANGLE_imod(X x, Y y)
 {
     if constexpr (metal::is_signed_v<Z>) {
         Z y_or_one = metal::select(Z(y), Z(1), Z(y) == Z(0));
+        y_or_one = metal::select(y_or_one, Z(1), y_or_one == Z(-1));
         if (metal::any(((Z(x) | y_or_one) & Z(2147483648u)) != Z(0u)))
         {
             return as_type<Z>(
@@ -3046,6 +3052,16 @@ ANGLE_ALWAYS_INLINE thread X &ANGLE_subAssignInt(thread X &x, Y y)
 }
 )")
 
+// Avoid undefined behavior due to integer overflow.
+PROGRAM_PRELUDE_DECLARE(negateInt,
+                        R"(
+template <typename T>
+ANGLE_ALWAYS_INLINE T ANGLE_negateInt(T x)
+{
+    return as_type<T>(metal::make_unsigned_t<T>(0) - metal::make_unsigned_t<T>(x));
+}
+)")
+
 PROGRAM_PRELUDE_DECLARE(loopForwardProgress,
                         R"(
 ANGLE_ALWAYS_INLINE void ANGLE_loopForwardProgress()
@@ -3869,6 +3885,10 @@ void ProgramPrelude::visitOperator(TOperator op,
             if (argType0->isMatrix())
             {
                 negateMatrix();
+            }
+            if (argType0->isSignedInt())
+            {
+                negateInt();
             }
             break;
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/es3_format_type_combinations.json
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/es3_format_type_combinations.json
@@ -163,7 +163,7 @@
     ],
     "From GL_ANGLE_depth_texture and OES_depth_texture":
     [
-        [ "GL_DEPTH_COMPONENT32_OES",  "GL_DEPTH_COMPONENT", "GL_UNSIGNED_INT_24_8" ],
+        [ "GL_DEPTH_COMPONENT32_OES",  "GL_DEPTH_COMPONENT", "GL_UNSIGNED_INT" ],
         [ "GL_DEPTH_COMPONENT",        "GL_DEPTH_COMPONENT", "GL_UNSIGNED_SHORT" ],
         [ "GL_DEPTH_COMPONENT",        "GL_DEPTH_COMPONENT", "GL_UNSIGNED_INT" ]
     ],

--- a/Source/ThirdParty/ANGLE/src/libANGLE/format_map_autogen.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/format_map_autogen.cpp
@@ -762,18 +762,8 @@ bool ValidES3FormatCombination(GLenum format, GLenum type, GLenum internalFormat
                     {
                         case GL_DEPTH_COMPONENT24:
                         case GL_DEPTH_COMPONENT16:
-                        case GL_DEPTH_COMPONENT:
-                            return true;
-                        default:
-                            break;
-                    }
-                    break;
-                }
-                case GL_UNSIGNED_INT_24_8:
-                {
-                    switch (internalFormat)
-                    {
                         case GL_DEPTH_COMPONENT32_OES:
+                        case GL_DEPTH_COMPONENT:
                             return true;
                         default:
                             break;

--- a/Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests.gni
+++ b/Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests.gni
@@ -107,6 +107,7 @@ angle_end2end_tests_sources = [
   "gl_tests/IndexBufferOffsetTest.cpp",
   "gl_tests/IndexedPointsTest.cpp",
   "gl_tests/InstancingTest.cpp",
+  "gl_tests/IntegerOverflowClampTest.cpp",
   "gl_tests/KTXCompressedTextureTest.cpp",
   "gl_tests/LineLoopTest.cpp",
   "gl_tests/LinkAndRelinkTest.cpp",

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/DepthStencilFormatsTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/DepthStencilFormatsTest.cpp
@@ -1102,6 +1102,66 @@ TEST_P(DepthStencilFormatsTest, VerifyDepthStencilUploadData)
     EXPECT_PIXEL_RECT_EQ(0, 0, getWindowWidth(), getWindowHeight(), GLColor::black);
 }
 
+// TexImage2D with (D32_OES, DEPTH_COMPONENT, UNSIGNED_INT) should succeed.
+TEST_P(DepthStencilFormatsTest, DepthComponent32OES_UnsignedInt_Accepted)
+{
+    ANGLE_SKIP_TEST_IF(!IsGLExtensionEnabled("GL_OES_depth_texture") &&
+                       !IsGLExtensionEnabled("GL_ANGLE_depth_texture"));
+
+    GLTexture depthTex;
+    glBindTexture(GL_TEXTURE_2D, depthTex);
+
+    std::vector<GLuint> pixels(1, 0xffffffff);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT32_OES, 1, 1, 0, GL_DEPTH_COMPONENT,
+                 GL_UNSIGNED_INT, pixels.data());
+    ASSERT_GL_NO_ERROR();
+
+    GLTexture colorTex;
+    glBindTexture(GL_TEXTURE_2D, colorTex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+
+    GLFramebuffer fbo;
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTex, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depthTex, 0);
+    ASSERT_GL_FRAMEBUFFER_COMPLETE(GL_FRAMEBUFFER);
+
+    glEnable(GL_DEPTH_TEST);
+    glDepthFunc(GL_GEQUAL);
+    glClearColor(0, 1, 0, 1);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    ANGLE_GL_PROGRAM(programRed, essl1_shaders::vs::Simple(), essl1_shaders::fs::Red());
+
+    // Fail Depth Test: 0.99 >= 1.0 is false, color stays green
+    float depthValue = 0.99f;
+    drawQuad(programRed, essl1_shaders::PositionAttrib(), depthValue * 2 - 1);
+    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
+
+    // Pass Depth Test: 1.0 >= 1.0 is true, color becomes red
+    depthValue = 1.0f;
+    drawQuad(programRed, essl1_shaders::PositionAttrib(), depthValue * 2 - 1);
+    EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::red);
+
+    glDisable(GL_DEPTH_TEST);
+    ASSERT_GL_NO_ERROR();
+}
+
+// TexImage2D with (D32_OES, DEPTH_COMPONENT, UNSIGNED_INT_24_8) should fail.
+TEST_P(DepthStencilFormatsTest, DepthComponent32OES_UnsignedInt248_Rejected)
+{
+    ANGLE_SKIP_TEST_IF(!IsGLExtensionEnabled("GL_OES_depth_texture") &&
+                       !IsGLExtensionEnabled("GL_ANGLE_depth_texture"));
+
+    GLTexture tex;
+    glBindTexture(GL_TEXTURE_2D, tex);
+
+    std::vector<GLuint> pixels(64 * 4, 0);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT32_OES, 64, 4, 0, GL_DEPTH_COMPONENT,
+                 GL_UNSIGNED_INT_24_8, pixels.data());
+    EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+}
+
 // Verify that depth texture's data can be uploaded correctly
 TEST_P(DepthStencilFormatsTest, VerifyDepth32UploadData)
 {

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/IntegerOverflowClampTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/IntegerOverflowClampTest.cpp
@@ -1,0 +1,175 @@
+//
+// Copyright 2026 The ANGLE Project Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+
+// IntegerOverflowClampTest: Verifies that ANGLE_int_clamp array-bounds guards
+// survive integer UB operations in the Metal shader compiler's optimizer.
+
+#include "test_utils/ANGLETest.h"
+#include "test_utils/gl_raii.h"
+
+using namespace angle;
+
+namespace
+{
+
+class IntegerOverflowClampTest : public ANGLETest<>
+{
+  protected:
+    static constexpr uint32_t kIntMin = static_cast<uint32_t>(std::numeric_limits<int32_t>::min());
+
+    IntegerOverflowClampTest()
+    {
+        setWindowWidth(4);
+        setWindowHeight(1);
+        setConfigRedBits(8);
+        setConfigGreenBits(8);
+        setConfigBlueBits(8);
+        setConfigAlphaBits(8);
+    }
+
+    void runShader(const char *vs, const uint32_t *data, size_t dataSize, uint32_t expected)
+    {
+        constexpr char kFS[] = R"(#version 300 es
+precision highp float;
+void main() { }
+)";
+
+        std::vector<std::string> varyings = {"result"};
+        GLuint program =
+            CompileProgramWithTransformFeedback(vs, kFS, varyings, GL_SEPARATE_ATTRIBS);
+        ASSERT_NE(0u, program);
+
+        glUseProgram(program);
+
+        GLBuffer ubo;
+        glUniformBlockBinding(program, glGetUniformBlockIndex(program, "Data"), 0);
+        glBindBuffer(GL_UNIFORM_BUFFER, ubo);
+        glBufferData(GL_UNIFORM_BUFFER, dataSize, data, GL_STATIC_DRAW);
+        glBindBufferBase(GL_UNIFORM_BUFFER, 0, ubo);
+
+        GLBuffer transformFeedbackBuffer;
+        glBindBuffer(GL_TRANSFORM_FEEDBACK_BUFFER, transformFeedbackBuffer);
+        glBufferData(GL_TRANSFORM_FEEDBACK_BUFFER, sizeof(uint32_t), nullptr, GL_STATIC_DRAW);
+
+        GLTransformFeedback transformFeedback;
+        glBindTransformFeedback(GL_TRANSFORM_FEEDBACK, transformFeedback);
+        glBindBufferBase(GL_TRANSFORM_FEEDBACK_BUFFER, 0, transformFeedbackBuffer);
+
+        glEnable(GL_RASTERIZER_DISCARD);
+        glBeginTransformFeedback(GL_POINTS);
+        glDrawArrays(GL_POINTS, 0, 1);
+        glEndTransformFeedback();
+        glDisable(GL_RASTERIZER_DISCARD);
+        glBindTransformFeedback(GL_TRANSFORM_FEEDBACK, 0);
+        ASSERT_GL_NO_ERROR();
+
+        glBindBuffer(GL_TRANSFORM_FEEDBACK_BUFFER, transformFeedbackBuffer);
+        const void *mapped =
+            glMapBufferRange(GL_TRANSFORM_FEEDBACK_BUFFER, 0, sizeof(uint32_t), GL_MAP_READ_BIT);
+        ASSERT_NE(nullptr, mapped);
+        uint32_t actual = *static_cast<const uint32_t *>(mapped);
+        glUnmapBuffer(GL_TRANSFORM_FEEDBACK_BUFFER);
+
+        EXPECT_EQ(expected, actual)
+            << "Got 0x" << std::hex << actual << ", expected 0x" << expected;
+
+        glDeleteProgram(program);
+    }
+};
+
+// Test that negating INT_MIN does not let the optimizer fold away array bounds clamping.
+TEST_P(IntegerOverflowClampTest, NegateIntMin)
+{
+    constexpr char kVS[] = R"(#version 300 es
+precision highp int;
+flat out uint result;
+uniform Data { uvec4 values[2]; } ubo;
+void main() {
+    int value = int(ubo.values[0].x);
+    int index = value;
+    if (value < 0)
+        index = -value;
+    result = uint(index) ^ ubo.values[index].x;
+})";
+
+    std::vector<uint32_t> data(32, kIntMin);
+    runShader(kVS, data.data(), data.size() * sizeof(uint32_t), 0u);
+}
+
+// Test that dividing INT_MIN by -1 does not let the optimizer fold away array bounds clamping.
+TEST_P(IntegerOverflowClampTest, DivByMinusOne)
+{
+    constexpr char kVS[] = R"(#version 300 es
+precision highp int;
+flat out uint result;
+uniform Data { uvec4 values[2]; } ubo;
+void main() {
+    int value = int(ubo.values[0].x);
+    int index = value;
+    if (value < 0)
+        index = value / -1;
+    result = uint(index) ^ ubo.values[index].x;
+})";
+
+    std::vector<uint32_t> data(32, kIntMin);
+    runShader(kVS, data.data(), data.size() * sizeof(uint32_t), 0u);
+}
+
+// Test that INT_MIN mod -1 does not let the optimizer fold away array bounds clamping.
+TEST_P(IntegerOverflowClampTest, ModByMinusOne)
+{
+    constexpr char kVS[] = R"(#version 300 es
+precision highp int;
+flat out uint result;
+uniform Data { uvec4 values[2]; } ubo;
+void main() {
+    int value = int(ubo.values[0].x);
+    int index = value % -1;
+    result = uint(index) ^ ubo.values[index].x;
+})";
+
+    std::vector<uint32_t> data(32, kIntMin);
+    runShader(kVS, data.data(), data.size() * sizeof(uint32_t), kIntMin);
+}
+
+// Test that unsigned divide-by-zero does not let the optimizer fold away array bounds clamping.
+TEST_P(IntegerOverflowClampTest, UnsignedDivByZero)
+{
+    constexpr char kVS[] = R"(#version 300 es
+precision highp int;
+flat out uint result;
+uniform Data { uvec4 values[2]; } ubo;
+void main() {
+    uint value = ubo.values[0].x;
+    uint index = 1u / (value ^ 0x80000000u);
+    result = index ^ ubo.values[index].x;
+})";
+
+    std::vector<uint32_t> data(32, kIntMin);
+    runShader(kVS, data.data(), data.size() * sizeof(uint32_t), kIntMin | 1u);
+}
+
+// Test that unsigned mod-by-zero does not let the optimizer fold away array bounds clamping.
+TEST_P(IntegerOverflowClampTest, UnsignedModByZero)
+{
+    constexpr char kVS[] = R"(#version 300 es
+precision highp int;
+flat out uint result;
+uniform Data { uvec4 values[2]; } ubo;
+void main() {
+    uint value = ubo.values[0].x;
+    uint index = 7u % (value ^ 0x80000000u);
+    result = index ^ ubo.values[index].x;
+})";
+
+    std::vector<uint32_t> data(32, kIntMin);
+    runShader(kVS, data.data(), data.size() * sizeof(uint32_t), kIntMin);
+}
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(IntegerOverflowClampTest);
+ANGLE_INSTANTIATE_TEST(IntegerOverflowClampTest, ES3_METAL());
+
+}  // namespace


### PR DESCRIPTION
#### e25e25cf6902de2120ae4b45d56c7d93c1d88bda
<pre>
Cherry-pick 305413.991@safari-7624.5-branch (43afeddf1aab). <a href="https://bugs.webkit.org/show_bug.cgi?id=315543">https://bugs.webkit.org/show_bug.cgi?id=315543</a>

    [ANGLE] MSL translator missing integer UB wrappers allow array bounds clamp elimination
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315543">https://bugs.webkit.org/show_bug.cgi?id=315543</a>
    <a href="https://rdar.apple.com/176813852">rdar://176813852</a>

    Reviewed by Kimmo Kinnunen.

    The MSL translator uses UB-safe wrapper functions to perform integer arithmetic via unsigned
    operations, preventing Metal&apos;s LLVM backend from exploiting undefined behavior to fold away
    the ANGLE_int_clamp array-bounds guard. Three operations are not routed through these wrappers:
    signed unary negate, signed division by -1, and unsigned div/mod. The resulting UB lets LLVM&apos;s
    optimizer eliminate the bounds clamp, allowing a WebGL2 page to index arbitrarily into GPU
    device memory.

    The fix routes all three operations through UB-safe wrappers: a new ANGLE_negateInt that negates
    via unsigned subtraction, an extended ANGLE_div that guards divisor -1 in addition to 0, and
    routing unsigned div/mod through the existing ANGLE_div/ANGLE_imod whose unsigned branches already
    mask zero divisors.

    The new wrappers are tested in IntegerOverflowClampTest.cpp.

    * Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj:
    * Source/ThirdParty/ANGLE/src/compiler/translator/msl/EmitMetal.cpp:
    (GetOperatorString):
    * Source/ThirdParty/ANGLE/src/compiler/translator/msl/ProgramPrelude.cpp:
    (PROGRAM_PRELUDE_DECLARE):
    * Source/ThirdParty/ANGLE/src/tests/angle_end2end_tests.gni:
    * Source/ThirdParty/ANGLE/src/tests/gl_tests/IntegerOverflowClampTest.cpp: Added.
    (angle::IntegerOverflowClampTest::IntegerOverflowClampTest):
    (angle::IntegerOverflowClampTest::runShader):

    Identifier: 305413.991@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.187@webkitglib/2.54">https://commits.webkit.org/317695.187@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 37a200263b1c424bb5ef91ffc0d1bb71f78b09eb
<pre>
Cherry-pick 305413.982@safari-7624.5.1.10-branch (8b1c27595893). <a href="https://bugs.webkit.org/show_bug.cgi?id=315712">https://bugs.webkit.org/show_bug.cgi?id=315712</a>

    [ANGLE] Fix GL_DEPTH_COMPONENT32_OES format validation to reject GL_UNSIGNED_INT_24_8
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315712">https://bugs.webkit.org/show_bug.cgi?id=315712</a>
    <a href="https://rdar.apple.com/176813583">rdar://176813583</a>

    Reviewed by Kimmo Kinnunen.

    es3_format_type_combinations.json incorrectly pairs GL_DEPTH_COMPONENT32_OES with GL_UNSIGNED_INT_24_8,
    allowing TexImage2D with internalformat=GL_DEPTH_COMPONENT32_OES, format=GL_DEPTH_COMPONENT, and
    type=GL_UNSIGNED_INT_24_8 to pass ES3 format validation. GL_UNSIGNED_INT_24_8 is only valid with
    GL_DEPTH_STENCIL (per OpenGL ES 3.0.6, Table 3.6). Metal backend&apos;s load-function table has no converter
    for this combination and falls through to UnreachableLoadFunction which in release-mode is a no-op,
    causing an uninitialized malloc&apos;d buffer to be uploaded into the GPU process depth texture.

    Change the JSON entry from GL_UNSIGNED_INT_24_8 to GL_UNSIGNED_INT and regenerate format_map_autogen.cpp.
    The invalid combination is now rejected with GL_INVALID_OPERATION before any buffer allocation occurs.

    * Source/ThirdParty/ANGLE/src/libANGLE/es3_format_type_combinations.json:
    * Source/ThirdParty/ANGLE/src/libANGLE/format_map_autogen.cpp:
    (gl::ValidES3FormatCombination):
    * Source/ThirdParty/ANGLE/src/tests/gl_tests/DepthStencilFormatsTest.cpp:

    Identifier: 305413.982@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.186@webkitglib/2.54">https://commits.webkit.org/317695.186@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/197747bed9c84d2602934a7bfbaea6b78a9c7202

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184713 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/58633 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52467 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195063 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/148979 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/59990 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58364 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144355 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/148979 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187668 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/59990 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/52467 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124637 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/59990 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58364 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/52467 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/59990 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52467 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6104 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/58364 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/196997 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/58305 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/52467 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153811 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59007 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52467 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153468 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28070 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59007 "The change is no longer eligible for processing.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127832 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/57507 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/52467 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/56868 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57119 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/56943 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->