### PR TITLE
SVG image with a height of 0 and no width is sized as if it had no natural dimensions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/svg-img-zero-height-with-viewbox-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/svg-img-zero-height-with-viewbox-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS <svg height='0' viewBox='0 0 600 200'>
+PASS <svg width='20' height='0' viewBox='0 0 50 100'>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/svg-img-zero-height-with-viewbox.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/svg-img-zero-height-with-viewbox.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Natural dimensions of an SVG image with a height of 0</title>
+<link rel="help" href="https://drafts.csswg.org/css-images/#natural-dimensions">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/6286#issuecomment-866986544">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#container { width: 740px; }
+#container img { display: block; }
+</style>
+<div id="container"></div>
+<div id="log"></div>
+<script>
+// A height of 0 is a natural height of 0 rather than an absent natural height,
+// so the natural width is derived from it and the natural aspect ratio. When the
+// image has a natural width of its own, that width and the ratio give the
+// natural height instead, superseding the 0.
+const cases = [
+  { attrs: "height='0' viewBox='0 0 600 200'", size: [0, 0] },
+  { attrs: "width='20' height='0' viewBox='0 0 50 100'", size: [20, 40] },
+];
+
+const container = document.getElementById("container");
+
+for (const { attrs, size } of cases) {
+  promise_test(async () => {
+    const src = `data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' ${attrs}></svg>`;
+    // Load the image first, so that it is already available when the img element
+    // is attached and a single layout has to get the size right.
+    await new Promise(resolve => {
+      const preload = new Image();
+      preload.addEventListener("load", resolve, { once: true });
+      preload.addEventListener("error", resolve, { once: true });
+      preload.src = src;
+    });
+
+    const img = document.createElement("img");
+    img.src = src;
+    container.appendChild(img);
+
+    assert_array_equals([img.offsetWidth, img.offsetHeight], size);
+  }, `<svg ${attrs}>`);
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/w3c-import.log
@@ -148,6 +148,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/svg-img-with-external-stylesheet-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/svg-img-with-external-stylesheet-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/svg-img-with-external-stylesheet.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/svg-img-zero-height-with-viewbox.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-media.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-src-complete.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-source-set.html

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -483,8 +483,11 @@ bool RenderImage::shouldDisplayBrokenImageIcon() const
     return imageResource().errorOccurred();
 }
 
-// Per CSSWG resolution, we should respect 0px inline sizes.
-// See: https://github.com/w3c/csswg-drafts/issues/11236#issuecomment-2718502765
+// A width or height of 0 is a natural dimension of 0 rather than an absent one,
+// except that a natural height of 0 is superseded by one derived from the natural
+// width and aspect ratio. See:
+// https://github.com/w3c/csswg-drafts/issues/6286#issuecomment-866986544 and
+// https://github.com/w3c/csswg-drafts/issues/11236#issuecomment-2718502765
 bool RenderImage::shouldRespectZeroIntrinsicWidth() const
 {
     RefPtr cachedImage = this->cachedImage();
@@ -493,6 +496,18 @@ bool RenderImage::shouldRespectZeroIntrinsicWidth() const
     if (RefPtr svgImage = dynamicDowncast<SVGImage>(cachedImage->image())) {
         if (auto rootElement = svgImage->rootElement())
             return rootElement->hasIntrinsicWidth();
+    }
+    return false;
+}
+
+bool RenderImage::shouldRespectZeroIntrinsicHeight() const
+{
+    RefPtr cachedImage = this->cachedImage();
+    if (!cachedImage)
+        return false;
+    if (RefPtr svgImage = dynamicDowncast<SVGImage>(cachedImage->image())) {
+        if (auto rootElement = svgImage->rootElement())
+            return rootElement->hasIntrinsicHeight() && !rootElement->hasIntrinsicWidth();
     }
     return false;
 }

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -78,7 +78,8 @@ public:
     bool isShowingAltText() const;
 
     virtual bool shouldDisplayBrokenImageIcon() const;
-    bool shouldRespectZeroIntrinsicWidth() const override;
+    bool shouldRespectZeroIntrinsicWidth() const final;
+    bool shouldRespectZeroIntrinsicHeight() const final;
 
     String accessibilityDescription() const { return imageResource().image()->accessibilityDescription(); }
 

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -116,9 +116,11 @@ RenderReplaced::~RenderReplaced() = default;
 
 bool RenderReplaced::shouldRespectZeroIntrinsicWidth() const
 {
-    // Per CSSWG resolution, 0px intrinsic width should be respected for SVG
-    // items and coerce the intrinsic height to 0px as well. Note that this is
-    // not the case for 0px intrinsic height SVGs or for other RenderReplaced items.
+    return false;
+}
+
+bool RenderReplaced::shouldRespectZeroIntrinsicHeight() const
+{
     return false;
 }
 
@@ -786,7 +788,7 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(IsComputingIntrinsicSize 
     if (style.logicalWidth().isAuto()) {
         bool computedHeightIsAuto = style.logicalHeight().isAuto();
         bool hasIntrinsicWidth = constrainedSize.width() > 0 || (!constrainedSize.width() && shouldRespectZeroIntrinsicWidth()) || shouldApplySizeOrInlineSizeContainment();
-        bool hasIntrinsicHeight = constrainedSize.height() > 0 || shouldApplySizeContainment();
+        bool hasIntrinsicHeight = constrainedSize.height() > 0 || (!constrainedSize.height() && shouldRespectZeroIntrinsicHeight()) || shouldApplySizeContainment();
 
         // For flex or grid items where the logical height has been overriden then we should use that size to compute the replaced width as long as the flex or
         // grid item has an intrinsic size. It is possible (indeed, common) for an SVG graphic to have an intrinsic aspect ratio but not to have an intrinsic
@@ -882,7 +884,7 @@ LayoutUnit RenderReplaced::computeReplacedLogicalHeight(std::optional<LayoutUnit
 
     bool widthIsAuto = style().logicalWidth().isAuto();
     bool hasIntrinsicWidth = constrainedSize.width() > 0 || (!constrainedSize.width() && shouldRespectZeroIntrinsicWidth()) || shouldApplySizeOrInlineSizeContainment();
-    bool hasIntrinsicHeight = constrainedSize.height() > 0 || shouldApplySizeContainment();
+    bool hasIntrinsicHeight = constrainedSize.height() > 0 || (!constrainedSize.height() && shouldRespectZeroIntrinsicHeight()) || shouldApplySizeContainment();
 
     // See computeReplacedLogicalHeight() for a similar check for heights.
     if (auto overridinglogicalWidth = (!intrinsicRatio.isEmpty() && (isFlexItem() || isGridItem()) && hasIntrinsicSize(embeddedSVGRoot(), hasIntrinsicWidth, hasIntrinsicHeight) ? overridingBorderBoxLogicalWidth() : std::nullopt))

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -32,6 +32,7 @@ public:
     virtual ~RenderReplaced();
 
     virtual bool shouldRespectZeroIntrinsicWidth() const;
+    virtual bool shouldRespectZeroIntrinsicHeight() const;
 
     void computeReplacedOutOfFlowPositionedLogicalHeight(LogicalExtentComputedValues&) const;
     void computeReplacedOutOfFlowPositionedLogicalWidth(LogicalExtentComputedValues&) const;


### PR DESCRIPTION
#### 00af7a4b15fa54b9bbb20689f0fc8dc822474331
<pre>
SVG image with a height of 0 and no width is sized as if it had no natural dimensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=323310">https://bugs.webkit.org/show_bug.cgi?id=323310</a>

Reviewed by Alan Baradlay.

For an &lt;img&gt; whose SVG has height=&quot;0&quot;, a viewBox, and no width, layout
sized the box as if the image had no natural dimensions at all, filling
the containing block, instead of deriving a natural width of 0 from the
natural height of 0 and the natural aspect ratio. RenderReplaced
respects a specified 0 width but cannot tell a specified 0 height from
an absent one, while SVGImage::resolvedIntrinsicSize does derive it,
which is why naturalWidth and naturalHeight report 0x0 for the same
image. Chrome and Firefox report 0 as well.

299085@main added shouldRespectZeroIntrinsicWidth without a height
counterpart, so that a degenerate aspect ratio from a 0 block size falls
back to the viewBox ratio relative to an inline size, per
<a href="https://github.com/w3c/csswg-drafts/issues/6286#issuecomment-866986544.">https://github.com/w3c/csswg-drafts/issues/6286#issuecomment-866986544.</a>
That is correct when there is a natural width to derive the height from,
as in css/css-grid/alignment/grid-item-aspect-ratio-stretch-4.html.
Without one there is nothing to derive from and the natural height of 0
stands, so only respect it when there is no natural width.

This also explains an intermittent failure of the imported
naturalWidth-naturalHeight-width-height.html, whose three &quot;SVG image,
with natural height of 0, and aspect ratio from viewBox&quot; subtests
reported a width of 720 rather than 0 on some runs. With the SVG not yet
parsed when the box was laid out there was no aspect ratio yet and the
box came out 0x0; a warm memory cache made the image available up front
and produced 720. Nothing recomputed the width once the image arrived,
so whichever value the first layout produced stuck.

Test: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/svg-img-zero-height-with-viewbox.html

Test upstream: <a href="https://github.com/web-platform-tests/wpt/pull/62512">https://github.com/web-platform-tests/wpt/pull/62512</a>

Canonical link: <a href="https://commits.webkit.org/320642@main">https://commits.webkit.org/320642@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5792af009cbf116ba4ee5866e6af54124dfc0aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195786 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150227 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7f080cda-5332-46ed-abaa-128992424229) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187324 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144933 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100477 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8112f82d-036a-4e8b-94bf-2540523b00aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165514 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125225 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7678940c-5b07-4969-98f7-d1aeee404ee6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47342 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45397 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157709 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45086 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6837 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197734 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59038 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165022 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154454 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41357 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59747 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154103 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48580 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132090 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128971 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58225 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20108 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57597 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57840 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57664 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->