### PR TITLE
[WebDriver][BiDi] Enumerate dedicated worker realms in script.getRealms

### DIFF
--- a/Source/WebCore/automation/AutomationInstrumentation.cpp
+++ b/Source/WebCore/automation/AutomationInstrumentation.cpp
@@ -105,6 +105,28 @@ void AutomationInstrumentation::scriptRealmDestroyed(FrameIdentifier frameID, DO
     });
 }
 
+void AutomationInstrumentation::scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier, const SecurityOriginData& origin)
+{
+    if (!automationClient()) [[likely]]
+        return;
+
+    WTF::ensureOnMainThread([workerIdentifier = workerIdentifier.isolatedCopy(), ownerFrameIdentifier, origin = origin.isolatedCopy()] {
+        if (RefPtr client = automationClient().get())
+            client->scriptDedicatedWorkerRealmCreated(workerIdentifier, ownerFrameIdentifier, origin);
+    });
+}
+
+void AutomationInstrumentation::scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier)
+{
+    if (!automationClient()) [[likely]]
+        return;
+
+    WTF::ensureOnMainThread([workerIdentifier = workerIdentifier.isolatedCopy(), ownerFrameIdentifier] {
+        if (RefPtr client = automationClient().get())
+            client->scriptDedicatedWorkerRealmDestroyed(workerIdentifier, ownerFrameIdentifier);
+    });
+}
+
 } // namespace WebCore
 
 #endif

--- a/Source/WebCore/automation/AutomationInstrumentation.cpp
+++ b/Source/WebCore/automation/AutomationInstrumentation.cpp
@@ -34,6 +34,9 @@
 #if ENABLE(WEBDRIVER_BIDI)
 
 #include "DOMWrapperWorld.h"
+#include "DocumentPage.h"
+#include "FrameDestructionObserverInlines.h"
+#include "WorkerInspectorProxy.h"
 #include <JavaScriptCore/ConsoleMessage.h>
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <wtf/NeverDestroyed.h>
@@ -125,6 +128,38 @@ void AutomationInstrumentation::scriptDedicatedWorkerRealmDestroyed(const String
         if (RefPtr client = automationClient().get())
             client->scriptDedicatedWorkerRealmDestroyed(workerIdentifier, ownerFrameIdentifier);
     });
+}
+
+Vector<AutomationInstrumentation::DedicatedWorkerRealmData> AutomationInstrumentation::dedicatedWorkerRealms(PageIdentifier pageIdentifier)
+{
+    Vector<DedicatedWorkerRealmData> result;
+
+    for (Ref worker : WorkerInspectorProxy::proxiesForPage(pageIdentifier)) {
+        if (!worker->isExecutionReady())
+            continue;
+
+        const auto& origin = worker->automationSecurityOrigin();
+        if (!origin)
+            continue;
+
+        RefPtr context = worker->scriptExecutionContext();
+        RefPtr document = dynamicDowncast<Document>(context.get());
+        if (!document)
+            continue;
+
+        RefPtr frame = document->frame();
+        RefPtr page = document->page();
+        if (!frame || !frame->isMainFrame() || !page || !page->isControlledByAutomation())
+            continue;
+
+        result.append(DedicatedWorkerRealmData {
+            worker->identifier().isolatedCopy(),
+            frame->frameID(),
+            origin->isolatedCopy()
+        });
+    }
+
+    return result;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/automation/AutomationInstrumentation.h
+++ b/Source/WebCore/automation/AutomationInstrumentation.h
@@ -59,6 +59,8 @@ public:
     virtual void addMessageToConsole(const JSC::MessageSource&, const JSC::MessageLevel&, const String&, const JSC::MessageType&, const WallTime&) = 0;
     virtual void scriptRealmCreated(FrameIdentifier, const SecurityOriginData&) = 0;
     virtual void scriptRealmDestroyed(FrameIdentifier) = 0;
+    virtual void scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier, const SecurityOriginData&) = 0;
+    virtual void scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier) = 0;
 };
 
 
@@ -70,6 +72,8 @@ public:
     static void addMessageToConsole(const std::unique_ptr<Inspector::ConsoleMessage>&);
     static void scriptRealmCreated(FrameIdentifier, const SecurityOriginData&, DOMWrapperWorld&);
     static void scriptRealmDestroyed(FrameIdentifier, DOMWrapperWorld&);
+    static void scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier, const SecurityOriginData&);
+    static void scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/automation/AutomationInstrumentation.h
+++ b/Source/WebCore/automation/AutomationInstrumentation.h
@@ -35,13 +35,16 @@
 #include <JavaScriptCore/ConsoleMessage.h>
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <WebCore/FrameIdentifier.h>
+#include <WebCore/PageIdentifier.h>
 #include <WebCore/SecurityOriginData.h>
+#include <tuple>
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Function.h>
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/RefPtr.h>
+#include <wtf/Vector.h>
 #include <wtf/WallTime.h>
 
 namespace Inspector {
@@ -66,6 +69,8 @@ public:
 
 class WEBCORE_EXPORT AutomationInstrumentation {
 public:
+    using DedicatedWorkerRealmData = std::tuple<String, FrameIdentifier, SecurityOriginData>;
+
     static void NODELETE setClient(const AutomationInstrumentationClient&);
     static void NODELETE clearClient();
 
@@ -74,6 +79,7 @@ public:
     static void scriptRealmDestroyed(FrameIdentifier, DOMWrapperWorld&);
     static void scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier, const SecurityOriginData&);
     static void scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier);
+    static Vector<DedicatedWorkerRealmData> dedicatedWorkerRealms(PageIdentifier);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerInspectorProxy.cpp
+++ b/Source/WebCore/workers/WorkerInspectorProxy.cpp
@@ -26,7 +26,9 @@
 #include "config.h"
 #include "WorkerInspectorProxy.h"
 
+#include "AutomationInstrumentation.h"
 #include "DocumentPage.h"
+#include "FrameDestructionObserverInlines.h"
 #include "InspectorInstrumentation.h"
 #include "ScriptExecutionContext.h"
 #include "WorkerGlobalScope.h"
@@ -146,6 +148,25 @@ auto WorkerInspectorProxy::pageOrWorkerGlobalScopeIdentifier(ScriptExecutionCont
     return context.identifier();
 }
 
+#if ENABLE(WEBDRIVER_BIDI)
+static std::optional<FrameIdentifier> automationOwnerFrameIdentifier(const WorkerInspectorProxy& worker)
+{
+    // FIXME: Support dedicated workers owned by iframes and other workers once
+    // those owner realms are registered with the BiDi script agent.
+    RefPtr context = worker.scriptExecutionContext();
+    RefPtr document = dynamicDowncast<Document>(context.get());
+    if (!document)
+        return std::nullopt;
+
+    RefPtr frame = document->frame();
+    RefPtr page = document->page();
+    if (!frame || !frame->isMainFrame() || !page || !page->isControlledByAutomation())
+        return std::nullopt;
+
+    return frame->frameID();
+}
+#endif
+
 void WorkerInspectorProxy::workerStarted(ScriptExecutionContext& scriptExecutionContext, WorkerThread* thread, const URL& url, const String& name)
 {
     ASSERT(!m_workerThread);
@@ -155,9 +176,41 @@ void WorkerInspectorProxy::workerStarted(ScriptExecutionContext& scriptExecution
     m_workerThread = thread;
     m_url = url;
     m_name = name;
+    m_isExecutionReady = false;
+    m_wasTerminatedBeforeExecutionReady = false;
+    m_automationOwnerFrameIdentifier = std::nullopt;
+#if ENABLE(WEBDRIVER_BIDI)
+    m_automationOwnerFrameIdentifier = automationOwnerFrameIdentifier(*this);
+#endif
     addToProxyMap();
 
     InspectorInstrumentation::workerStarted(*this);
+}
+
+void WorkerInspectorProxy::workerBecameExecutionReady(const SecurityOriginData& origin)
+{
+    ASSERT(!m_scriptExecutionContext || m_scriptExecutionContext->isContextThread());
+    ASSERT(m_workerThread || m_wasTerminatedBeforeExecutionReady);
+    if (m_isExecutionReady)
+        return;
+
+    m_isExecutionReady = true;
+
+#if ENABLE(WEBDRIVER_BIDI)
+    if (m_automationOwnerFrameIdentifier) {
+        AutomationInstrumentation::scriptDedicatedWorkerRealmCreated(m_identifier, *m_automationOwnerFrameIdentifier, origin);
+        if (m_wasTerminatedBeforeExecutionReady)
+            AutomationInstrumentation::scriptDedicatedWorkerRealmDestroyed(m_identifier, *m_automationOwnerFrameIdentifier);
+    }
+#else
+    UNUSED_PARAM(origin);
+#endif
+
+    if (m_wasTerminatedBeforeExecutionReady) {
+        m_isExecutionReady = false;
+        m_wasTerminatedBeforeExecutionReady = false;
+        m_automationOwnerFrameIdentifier = std::nullopt;
+    }
 }
 
 void WorkerInspectorProxy::workerTerminated()
@@ -165,6 +218,17 @@ void WorkerInspectorProxy::workerTerminated()
     if (!m_workerThread)
         return;
 
+#if ENABLE(WEBDRIVER_BIDI)
+    if (m_isExecutionReady && m_automationOwnerFrameIdentifier)
+        AutomationInstrumentation::scriptDedicatedWorkerRealmDestroyed(m_identifier, *m_automationOwnerFrameIdentifier);
+#endif
+
+    if (!m_isExecutionReady)
+        m_wasTerminatedBeforeExecutionReady = true;
+
+    m_isExecutionReady = false;
+    if (!m_wasTerminatedBeforeExecutionReady)
+        m_automationOwnerFrameIdentifier = std::nullopt;
     InspectorInstrumentation::workerTerminated(*this);
     removeFromProxyMap();
 

--- a/Source/WebCore/workers/WorkerInspectorProxy.cpp
+++ b/Source/WebCore/workers/WorkerInspectorProxy.cpp
@@ -179,6 +179,7 @@ void WorkerInspectorProxy::workerStarted(ScriptExecutionContext& scriptExecution
     m_isExecutionReady = false;
     m_wasTerminatedBeforeExecutionReady = false;
     m_automationOwnerFrameIdentifier = std::nullopt;
+    m_automationSecurityOrigin = std::nullopt;
 #if ENABLE(WEBDRIVER_BIDI)
     m_automationOwnerFrameIdentifier = automationOwnerFrameIdentifier(*this);
 #endif
@@ -194,22 +195,28 @@ void WorkerInspectorProxy::workerBecameExecutionReady(const SecurityOriginData& 
     if (m_isExecutionReady)
         return;
 
+#if ENABLE(WEBDRIVER_BIDI)
+    if (m_automationOwnerFrameIdentifier)
+        m_automationSecurityOrigin = origin.isolatedCopy();
+#else
+    UNUSED_PARAM(origin);
+#endif
+
     m_isExecutionReady = true;
 
 #if ENABLE(WEBDRIVER_BIDI)
     if (m_automationOwnerFrameIdentifier) {
-        AutomationInstrumentation::scriptDedicatedWorkerRealmCreated(m_identifier, *m_automationOwnerFrameIdentifier, origin);
+        AutomationInstrumentation::scriptDedicatedWorkerRealmCreated(m_identifier, *m_automationOwnerFrameIdentifier, *m_automationSecurityOrigin);
         if (m_wasTerminatedBeforeExecutionReady)
             AutomationInstrumentation::scriptDedicatedWorkerRealmDestroyed(m_identifier, *m_automationOwnerFrameIdentifier);
     }
-#else
-    UNUSED_PARAM(origin);
 #endif
 
     if (m_wasTerminatedBeforeExecutionReady) {
         m_isExecutionReady = false;
         m_wasTerminatedBeforeExecutionReady = false;
         m_automationOwnerFrameIdentifier = std::nullopt;
+        m_automationSecurityOrigin = std::nullopt;
     }
 }
 
@@ -227,8 +234,10 @@ void WorkerInspectorProxy::workerTerminated()
         m_wasTerminatedBeforeExecutionReady = true;
 
     m_isExecutionReady = false;
-    if (!m_wasTerminatedBeforeExecutionReady)
+    if (!m_wasTerminatedBeforeExecutionReady) {
         m_automationOwnerFrameIdentifier = std::nullopt;
+        m_automationSecurityOrigin = std::nullopt;
+    }
     InspectorInstrumentation::workerTerminated(*this);
     removeFromProxyMap();
 

--- a/Source/WebCore/workers/WorkerInspectorProxy.h
+++ b/Source/WebCore/workers/WorkerInspectorProxy.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "FrameIdentifier.h"
 #include "PageIdentifier.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include <wtf/CheckedPtr.h>
@@ -43,6 +44,7 @@
 namespace WebCore {
 
 class ScriptExecutionContext;
+class SecurityOriginData;
 class WorkerThread;
 
 enum class WorkerThreadStartMode;
@@ -81,7 +83,9 @@ public:
 
     WorkerThreadStartMode workerStartMode(ScriptExecutionContext&);
     void workerStarted(ScriptExecutionContext&, WorkerThread*, const URL&, const String& name);
+    void workerBecameExecutionReady(const SecurityOriginData&);
     void workerTerminated();
+    bool isExecutionReady() const { return m_isExecutionReady; }
 
     void resumeWorkerIfPaused();
     void connectToWorkerInspectorController(PageChannel&);
@@ -105,6 +109,9 @@ private:
     URL m_url;
     String m_name;
     CheckedPtr<PageChannel> m_pageChannel;
+    bool m_isExecutionReady { false };
+    bool m_wasTerminatedBeforeExecutionReady { false };
+    std::optional<FrameIdentifier> m_automationOwnerFrameIdentifier;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerInspectorProxy.h
+++ b/Source/WebCore/workers/WorkerInspectorProxy.h
@@ -28,6 +28,7 @@
 #include "FrameIdentifier.h"
 #include "PageIdentifier.h"
 #include "ScriptExecutionContextIdentifier.h"
+#include "SecurityOriginData.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/FastMalloc.h>
@@ -86,6 +87,7 @@ public:
     void workerBecameExecutionReady(const SecurityOriginData&);
     void workerTerminated();
     bool isExecutionReady() const { return m_isExecutionReady; }
+    const std::optional<SecurityOriginData>& automationSecurityOrigin() const { return m_automationSecurityOrigin; }
 
     void resumeWorkerIfPaused();
     void connectToWorkerInspectorController(PageChannel&);
@@ -112,6 +114,7 @@ private:
     bool m_isExecutionReady { false };
     bool m_wasTerminatedBeforeExecutionReady { false };
     std::optional<FrameIdentifier> m_automationOwnerFrameIdentifier;
+    std::optional<SecurityOriginData> m_automationSecurityOrigin;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -49,6 +49,7 @@
 #include "Page.h"
 #include "PlatformStrategies.h"
 #include "ScriptExecutionContext.h"
+#include "SecurityOriginData.h"
 #include "Settings.h"
 #include "SocketProvider.h"
 #include "StorageConnection.h"
@@ -186,7 +187,9 @@ void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::Ses
     }
 
     workerThreadCreated(thread.get());
-    thread->start();
+    thread->WorkerOrWorkletThread::start({ }, [this](SecurityOriginData&& origin) {
+        workerGlobalScopeCreated(WTF::move(origin));
+    });
 
     m_inspectorProxy->workerStarted(*scriptExecutionContext, thread.ptr(), scriptURL, name);
 }
@@ -459,6 +462,16 @@ void WorkerMessagingProxy::workerGlobalScopeDestroyed()
 
     ScriptExecutionContext::postTaskTo(*m_scriptExecutionContextIdentifier, [this](auto&) {
         workerGlobalScopeDestroyedInternal();
+    });
+}
+
+void WorkerMessagingProxy::workerGlobalScopeCreated(SecurityOriginData&& origin)
+{
+    if (!m_scriptExecutionContextIdentifier)
+        return;
+
+    ScriptExecutionContext::postTaskTo(*m_scriptExecutionContextIdentifier, [this, protectedThis = Ref { *this }, origin = WTF::move(origin).isolatedCopy()](auto&) {
+        m_inspectorProxy->workerBecameExecutionReady(origin);
     });
 }
 

--- a/Source/WebCore/workers/WorkerMessagingProxy.h
+++ b/Source/WebCore/workers/WorkerMessagingProxy.h
@@ -39,6 +39,7 @@
 namespace WebCore {
 
 class DedicatedWorkerThread;
+class SecurityOriginData;
 class WeakPtrImplWithEventTargetData;
 class WorkerInspectorProxy;
 class WorkerUserGestureForwarder;
@@ -76,6 +77,7 @@ private:
     void reportErrorToWorkerObject(const String&) final;
     void workerGlobalScopeClosed() final;
     void workerGlobalScopeDestroyed() final;
+    void workerGlobalScopeCreated(SecurityOriginData&&);
 
     // Implementation of WorkerDebuggerProxy.
     // (Only use these functions in the worker context thread.)

--- a/Source/WebCore/workers/WorkerOrWorkletThread.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WorkerOrWorkletThread.h"
 
+#include "SecurityOrigin.h"
 #include "ThreadGlobalData.h"
 #include "WorkerEventLoop.h"
 #include "WorkerLoaderProxy.h"
@@ -121,6 +122,9 @@ void WorkerOrWorkletThread::workerOrWorkletThread()
 
         downcast<WorkerMainRunLoop>(m_runLoop.get()).setGlobalScope(*globalScope());
 
+        if (auto callback = WTF::move(m_globalScopeCreatedCallback))
+            callback(protect(globalScope())->securityOrigin()->data().isolatedCopy());
+
         String exceptionMessage;
         evaluateScriptIfNecessary(exceptionMessage);
 
@@ -164,6 +168,9 @@ void WorkerOrWorkletThread::workerOrWorkletThread()
             scriptController->forbidExecution();
         }
     }
+
+    if (auto callback = WTF::move(m_globalScopeCreatedCallback))
+        callback(protect(globalScope())->securityOrigin()->data().isolatedCopy());
 
     if (shouldWaitForWebInspectorOnStartup()) {
         startRunningDebuggerTasks();
@@ -237,7 +244,7 @@ void WorkerOrWorkletThread::destroyWorkerGlobalScope(Ref<WorkerOrWorkletThread>&
     protector->detach();
 }
 
-void WorkerOrWorkletThread::start(Function<void(const String&)>&& evaluateCallback)
+void WorkerOrWorkletThread::start(Function<void(const String&)>&& evaluateCallback, Function<void(SecurityOriginData&&)>&& globalScopeCreatedCallback)
 {
     // Mutex protection is necessary to ensure that m_thread is initialized when the thread starts.
     Locker locker { m_threadCreationAndGlobalScopeLock };
@@ -246,6 +253,7 @@ void WorkerOrWorkletThread::start(Function<void(const String&)>&& evaluateCallba
         return;
 
     m_evaluateCallback = WTF::move(evaluateCallback);
+    m_globalScopeCreatedCallback = WTF::move(globalScopeCreatedCallback);
 
     auto thread = createThread();
 

--- a/Source/WebCore/workers/WorkerOrWorkletThread.h
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.h
@@ -44,6 +44,7 @@ class Thread;
 
 namespace WebCore {
 
+class SecurityOriginData;
 class WorkerDebuggerProxy;
 class WorkerLoaderProxy;
 
@@ -65,7 +66,7 @@ public:
     WorkerOrWorkletGlobalScope* globalScope() const { return m_globalScope.get(); }
     WorkerRunLoop& runLoop() LIFETIME_BOUND { return m_runLoop; }
 
-    void start(Function<void(const String&)>&& evaluateCallback = { });
+    void start(Function<void(const String&)>&& evaluateCallback = { }, Function<void(SecurityOriginData&&)>&& globalScopeCreatedCallback = { });
     void stop(Function<void()>&& terminatedCallback = { });
 
     void startRunningDebuggerTasks();
@@ -108,6 +109,7 @@ private:
     RefPtr<Thread> m_thread;
     const UniqueRef<WorkerRunLoop> m_runLoop;
     Function<void(const String&)> m_evaluateCallback;
+    Function<void(SecurityOriginData&&)> m_globalScopeCreatedCallback;
     Function<void()> m_stoppedCallback;
     BinarySemaphore m_suspensionSemaphore;
     ThreadSafeWeakHashSet<WorkerOrWorkletThread> m_childThreads;

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
@@ -849,6 +849,51 @@ String BidiScriptAgent::originStringFromSecurityOriginData(const WebCore::Securi
     return originData.toString();
 }
 
+std::optional<RealmIdentifier> BidiScriptAgent::registerDedicatedWorkerRealm(const DedicatedWorkerRealmKey& key, const BrowsingContext& ownerBrowsingContext, const WebCore::SecurityOriginData& origin, bool emitCreatedEvent)
+{
+    auto ownerRealmIterator = m_browsingContextToRealmId.find(ownerBrowsingContext);
+    if (ownerRealmIterator == m_browsingContextToRealmId.end()) {
+        m_pendingDedicatedWorkerRealms.set(key, PendingDedicatedWorkerRealmInfo { origin.isolatedCopy(), ownerBrowsingContext.isolatedCopy() });
+        return std::nullopt;
+    }
+
+    m_pendingDedicatedWorkerRealms.remove(key);
+
+    auto workerRealmIterator = m_dedicatedWorkerRealmIdentifiers.find(key);
+    auto realmIdentifier = workerRealmIterator == m_dedicatedWorkerRealmIdentifiers.end() ? RealmIdentifier::generate() : workerRealmIterator->value;
+    if (workerRealmIterator == m_dedicatedWorkerRealmIdentifiers.end())
+        m_dedicatedWorkerRealmIdentifiers.set(key, realmIdentifier);
+
+    auto activeRealmIterator = m_activeRealms.find(realmIdentifier);
+    if (activeRealmIterator != m_activeRealms.end()) {
+        if (emitCreatedEvent && !activeRealmIterator->value.creationNotified) {
+            activeRealmIterator->value.creationNotified = true;
+            sendRealmCreatedEvent(realmIdentifier, activeRealmIterator->value);
+        }
+        return realmIdentifier;
+    }
+
+    RealmInfo realmInfo {
+        originStringFromSecurityOriginData(origin),
+        Inspector::Protocol::BidiScript::RealmType::DedicatedWorker,
+        std::nullopt,
+        { },
+        { },
+        emitCreatedEvent
+    };
+    realmInfo.owners.append(ownerRealmIterator->value);
+    realmInfo.associatedBrowsingContexts.add(ownerBrowsingContext);
+    m_activeRealms.set(realmIdentifier, WTF::move(realmInfo));
+
+    if (emitCreatedEvent) {
+        activeRealmIterator = m_activeRealms.find(realmIdentifier);
+        ASSERT(activeRealmIterator != m_activeRealms.end());
+        sendRealmCreatedEvent(realmIdentifier, activeRealmIterator->value);
+    }
+
+    return realmIdentifier;
+}
+
 void BidiScriptAgent::processRealmsForPagesAsync(Deque<Ref<WebPageProxy>>&& pagesToProcess, std::optional<Inspector::Protocol::BidiScript::RealmType>&& optionalRealmType, std::optional<String>&& contextHandleFilter, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>&& accumulated, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>>>&& callback)
 {
     if (pagesToProcess.isEmpty()) {
@@ -951,49 +996,138 @@ void BidiScriptAgent::collectExecutionReadyFrameRealms(const FrameTreeNodeData& 
     }
 }
 
-void BidiScriptAgent::sendRealmCreatedEvent(const String& realmID, const WebCore::SecurityOriginData& origin, Inspector::Protocol::BidiScript::RealmType type, Inspector::Protocol::BidiBrowsingContext::BrowsingContext context)
+void BidiScriptAgent::sendRealmCreatedEvent(RealmIdentifier realmIdentifier, const RealmInfo& realmInfo)
 {
     RefPtr session = m_session.get();
     if (!session)
         return;
 
-    session->bidiProcessor().emitEventIfEnabled(BidiEventNames::Script::RealmCreated, { context }, [&]() {
-        session->bidiProcessor().scriptDomainNotifier().realmCreated(realmID, originStringFromSecurityOriginData(origin), type, context);
+    session->bidiProcessor().emitEventIfEnabled(BidiEventNames::Script::RealmCreated, realmInfo.associatedBrowsingContexts, [&]() {
+        RefPtr<JSON::ArrayOf<String>> owners;
+        if (!realmInfo.owners.isEmpty()) {
+            owners = JSON::ArrayOf<String>::create();
+            for (auto owner : realmInfo.owners)
+                owners->addItem(makeString("realm-"_s, owner.loggingString()));
+        }
+
+        session->bidiProcessor().scriptDomainNotifier().realmCreated(
+            makeString("realm-"_s, realmIdentifier.loggingString()),
+            realmInfo.origin,
+            realmInfo.type,
+            realmInfo.context.value_or(nullString()),
+            WTF::move(owners)
+        );
+    });
+}
+
+void BidiScriptAgent::sendRealmDestroyedEvent(RealmIdentifier realmIdentifier, const RealmInfo& realmInfo)
+{
+    RefPtr session = m_session.get();
+    if (!session)
+        return;
+
+    session->bidiProcessor().emitEventIfEnabled(BidiEventNames::Script::RealmDestroyed, realmInfo.associatedBrowsingContexts, [&]() {
+        session->bidiProcessor().scriptDomainNotifier().realmDestroyed(
+            makeString("realm-"_s, realmIdentifier.loggingString()),
+            realmInfo.context.value_or(nullString())
+        );
     });
 }
 
 void BidiScriptAgent::notifyRealmCreated(RealmIdentifier realmIdentifier, Inspector::Protocol::BidiBrowsingContext::BrowsingContext browsingContext, const WebCore::SecurityOriginData& origin)
 {
-    // The WebProcess owns realm identifier creation and passes the identifier across IPC.
-    String realmID = makeString("realm-"_s, realmIdentifier.loggingString());
-
-    // Track the current realm for this browsing context.
     m_browsingContextToRealmId.set(browsingContext, realmIdentifier);
 
-    RealmInfo realmInfo { origin.isolatedCopy(), Inspector::Protocol::BidiScript::RealmType::Window, browsingContext };
+    RealmInfo realmInfo {
+        originStringFromSecurityOriginData(origin),
+        Inspector::Protocol::BidiScript::RealmType::Window,
+        browsingContext,
+        { },
+        { },
+        true
+    };
+    realmInfo.associatedBrowsingContexts.add(browsingContext);
     m_activeRealms.set(realmIdentifier, WTF::move(realmInfo));
 
-    sendRealmCreatedEvent(realmID, origin, Inspector::Protocol::BidiScript::RealmType::Window, browsingContext);
+    auto activeRealmIterator = m_activeRealms.find(realmIdentifier);
+    ASSERT(activeRealmIterator != m_activeRealms.end());
+    sendRealmCreatedEvent(realmIdentifier, activeRealmIterator->value);
+
+    Vector<std::pair<DedicatedWorkerRealmKey, PendingDedicatedWorkerRealmInfo>> pendingWorkers;
+    for (const auto& entry : m_pendingDedicatedWorkerRealms) {
+        if (entry.value.ownerBrowsingContext == browsingContext)
+            pendingWorkers.append({ entry.key, entry.value });
+    }
+    for (const auto& [key, pendingWorker] : pendingWorkers) {
+        m_pendingDedicatedWorkerRealms.remove(key);
+        registerDedicatedWorkerRealm(key, pendingWorker.ownerBrowsingContext, pendingWorker.origin, true);
+    }
 }
 
 void BidiScriptAgent::notifyRealmDestroyed(RealmIdentifier realmIdentifier, Inspector::Protocol::BidiBrowsingContext::BrowsingContext browsingContext)
 {
-    RefPtr session = m_session.get();
-    if (!session)
+    removeDedicatedWorkerRealmsForBrowsingContext(browsingContext);
+
+    auto activeRealmIterator = m_activeRealms.find(realmIdentifier);
+    if (activeRealmIterator == m_activeRealms.end())
         return;
 
-    // Match the realm identifier that the WebProcess reported for this realm.
-    String realmID = makeString("realm-"_s, realmIdentifier.loggingString());
+    RealmInfo realmInfo = WTF::move(activeRealmIterator->value);
+    m_activeRealms.remove(activeRealmIterator);
 
-    // Remove the realm from active realms.
-    m_activeRealms.remove(realmIdentifier);
+    auto browsingContextIterator = m_browsingContextToRealmId.find(browsingContext);
+    if (browsingContextIterator != m_browsingContextToRealmId.end() && browsingContextIterator->value == realmIdentifier)
+        m_browsingContextToRealmId.remove(browsingContextIterator);
 
-    // Remove the browsing context mapping (realm will be regenerated on next navigation).
-    m_browsingContextToRealmId.remove(browsingContext);
+    sendRealmDestroyedEvent(realmIdentifier, realmInfo);
+}
 
-    session->bidiProcessor().emitEventIfEnabled(BidiEventNames::Script::RealmDestroyed, { browsingContext }, [&]() {
-        session->bidiProcessor().scriptDomainNotifier().realmDestroyed(realmID, browsingContext);
-    });
+void BidiScriptAgent::notifyDedicatedWorkerRealmCreated(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, BrowsingContext ownerBrowsingContext, const WebCore::SecurityOriginData& origin)
+{
+    DedicatedWorkerRealmKey key { ownerFrameIdentifier, workerIdentifier };
+    registerDedicatedWorkerRealm(key, ownerBrowsingContext, origin, true);
+}
+
+void BidiScriptAgent::notifyDedicatedWorkerRealmDestroyed(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier)
+{
+    DedicatedWorkerRealmKey key { ownerFrameIdentifier, workerIdentifier };
+    m_pendingDedicatedWorkerRealms.remove(key);
+
+    auto workerRealmIterator = m_dedicatedWorkerRealmIdentifiers.find(key);
+    if (workerRealmIterator == m_dedicatedWorkerRealmIdentifiers.end())
+        return;
+
+    auto realmIdentifier = workerRealmIterator->value;
+    m_dedicatedWorkerRealmIdentifiers.remove(workerRealmIterator);
+
+    auto activeRealmIterator = m_activeRealms.find(realmIdentifier);
+    if (activeRealmIterator == m_activeRealms.end())
+        return;
+
+    RealmInfo realmInfo = WTF::move(activeRealmIterator->value);
+    m_activeRealms.remove(activeRealmIterator);
+    sendRealmDestroyedEvent(realmIdentifier, realmInfo);
+}
+
+void BidiScriptAgent::removeDedicatedWorkerRealmsForBrowsingContext(const BrowsingContext& browsingContext)
+{
+    Vector<DedicatedWorkerRealmKey> workerKeys;
+    for (const auto& entry : m_dedicatedWorkerRealmIdentifiers) {
+        auto activeRealmIterator = m_activeRealms.find(entry.value);
+        if (activeRealmIterator != m_activeRealms.end() && activeRealmIterator->value.associatedBrowsingContexts.contains(browsingContext))
+            workerKeys.append(entry.key);
+    }
+
+    for (const auto& key : workerKeys)
+        notifyDedicatedWorkerRealmDestroyed(key.second, key.first);
+
+    Vector<DedicatedWorkerRealmKey> pendingWorkerKeys;
+    for (const auto& entry : m_pendingDedicatedWorkerRealms) {
+        if (entry.value.ownerBrowsingContext == browsingContext)
+            pendingWorkerKeys.append(entry.key);
+    }
+    for (const auto& key : pendingWorkerKeys)
+        m_pendingDedicatedWorkerRealms.remove(key);
 }
 
 std::optional<RealmIdentifier> BidiScriptAgent::realmIdentifierForBrowsingContext(const String& browsingContext) const
@@ -1008,15 +1142,24 @@ void BidiScriptAgent::emitEventsForActiveRealms(const HashSet<String>& contextFi
 {
     // Per W3C BiDi spec: when subscribing to script.realmCreated with subscribe priority 2,
     // emit events for all currently active realms.
-    for (const auto& entry : m_activeRealms) {
-        const RealmIdentifier& realmIdentifier = entry.key;
-        const RealmInfo& realmInfo = entry.value;
+    for (auto& entry : m_activeRealms) {
+        RealmIdentifier realmIdentifier = entry.key;
+        RealmInfo& realmInfo = entry.value;
 
-        if (!contextFilter.isEmpty() && !contextFilter.contains(realmInfo.context))
-            continue;
+        if (!contextFilter.isEmpty()) {
+            bool matchesContextFilter = false;
+            for (const auto& browsingContext : realmInfo.associatedBrowsingContexts) {
+                if (contextFilter.contains(browsingContext)) {
+                    matchesContextFilter = true;
+                    break;
+                }
+            }
+            if (!matchesContextFilter)
+                continue;
+        }
 
-        String realmID = makeString("realm-"_s, realmIdentifier.loggingString());
-        sendRealmCreatedEvent(realmID, realmInfo.origin, realmInfo.type, realmInfo.context);
+        sendRealmCreatedEvent(realmIdentifier, realmInfo);
+        realmInfo.creationNotified = true;
     }
 }
 

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
@@ -35,6 +35,7 @@
 #include "PageLoadState.h"
 #include "WebAutomationSession.h"
 #include "WebAutomationSessionMacros.h"
+#include "WebAutomationSessionProxyMessages.h"
 #include "WebDriverBidiProcessor.h"
 #include "WebDriverBidiProtocolObjects.h"
 #include "WebFrameMetrics.h"
@@ -573,10 +574,9 @@ void BidiScriptAgent::getRealms(const BrowsingContext& optionalBrowsingContext, 
 {
     // https://w3c.github.io/webdriver-bidi/#command-script-getRealms
 
-    // FIXME: Implement worker realm support (dedicated-worker, shared-worker, service-worker, worker).
-    // https://bugs.webkit.org/show_bug.cgi?id=304300
-    // Currently only window realms (main frames and iframes) are supported.
-    // Worker realm types require tracking worker global scopes and their owner sets.
+    // Dedicated workers owned directly by a top-level document are supported.
+    // FIXME: Implement iframe-owned and nested dedicated workers, shared workers,
+    // service workers, and generic worker realms.
 
     // FIXME: Implement worklet realm support (paint-worklet, audio-worklet, worklet).
     // https://bugs.webkit.org/show_bug.cgi?id=304301
@@ -601,8 +601,8 @@ void BidiScriptAgent::getRealms(const BrowsingContext& optionalBrowsingContext, 
         ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!resolvedPageForContext, WindowNotFound);
     }
 
-    // Early short-circuit: if a non-window realm type is requested, return empty (we currently only support window realms).
-    if (optionalRealmType && *optionalRealmType != Inspector::Protocol::BidiScript::RealmType::Window) {
+    // Unsupported realm types are valid filters, but there are no matching realms yet.
+    if (optionalRealmType && *optionalRealmType != Inspector::Protocol::BidiScript::RealmType::Window && *optionalRealmType != Inspector::Protocol::BidiScript::RealmType::DedicatedWorker) {
         auto realmsArray = JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>::create();
         callback(WTF::move(realmsArray));
         return;
@@ -849,6 +849,27 @@ String BidiScriptAgent::originStringFromSecurityOriginData(const WebCore::Securi
     return originData.toString();
 }
 
+RefPtr<Inspector::Protocol::BidiScript::RealmInfo> BidiScriptAgent::createProtocolRealmInfo(RealmIdentifier realmIdentifier, const RealmInfo& realm)
+{
+    auto protocolRealm = Inspector::Protocol::BidiScript::RealmInfo::create()
+        .setRealm(makeString("realm-"_s, realmIdentifier.loggingString()))
+        .setOrigin(realm.origin)
+        .setType(realm.type)
+        .release();
+
+    if (realm.context)
+        protocolRealm->setContext(*realm.context);
+
+    if (!realm.owners.isEmpty()) {
+        auto owners = JSON::ArrayOf<String>::create();
+        for (auto owner : realm.owners)
+            owners->addItem(makeString("realm-"_s, owner.loggingString()));
+        protocolRealm->setOwners(WTF::move(owners));
+    }
+
+    return protocolRealm;
+}
+
 std::optional<RealmIdentifier> BidiScriptAgent::registerDedicatedWorkerRealm(const DedicatedWorkerRealmKey& key, const BrowsingContext& ownerBrowsingContext, const WebCore::SecurityOriginData& origin, bool emitCreatedEvent)
 {
     auto ownerRealmIterator = m_browsingContextToRealmId.find(ownerBrowsingContext);
@@ -897,17 +918,12 @@ std::optional<RealmIdentifier> BidiScriptAgent::registerDedicatedWorkerRealm(con
 void BidiScriptAgent::processRealmsForPagesAsync(Deque<Ref<WebPageProxy>>&& pagesToProcess, std::optional<Inspector::Protocol::BidiScript::RealmType>&& optionalRealmType, std::optional<String>&& contextHandleFilter, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>&& accumulated, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>>>&& callback)
 {
     if (pagesToProcess.isEmpty()) {
-        // Assemble final array with window realms only.
         auto realmsArray = JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>::create();
         for (auto& realmInfo : accumulated) {
             if (!realmInfo)
                 continue;
-            if (optionalRealmType && *optionalRealmType != Inspector::Protocol::BidiScript::RealmType::Window)
-                continue; // Only window realms supported currently.
-
             realmsArray->addItem(realmInfo.releaseNonNull());
         }
-
         callback(WTF::move(realmsArray));
         return;
     }
@@ -915,19 +931,67 @@ void BidiScriptAgent::processRealmsForPagesAsync(Deque<Ref<WebPageProxy>>&& page
     Ref<WebPageProxy> currentPage = pagesToProcess.first();
     pagesToProcess.removeFirst();
 
-    currentPage->getAllFrameTrees([weakThis = WeakPtr { *this }, pagesToProcess = WTF::move(pagesToProcess), optionalRealmType = WTF::move(optionalRealmType), contextHandleFilter = WTF::move(contextHandleFilter), accumulated = WTF::move(accumulated), callback = WTF::move(callback)](Vector<FrameTreeNodeData>&& frameTrees) mutable {
+    currentPage->getAllFrameTrees([weakThis = WeakPtr { *this }, currentPage = currentPage.copyRef(), pagesToProcess = WTF::move(pagesToProcess), optionalRealmType = WTF::move(optionalRealmType), contextHandleFilter = WTF::move(contextHandleFilter), accumulated = WTF::move(accumulated), callback = WTF::move(callback)](Vector<FrameTreeNodeData>&& frameTrees) mutable {
         CheckedPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-        // Collect realms from main frames only (no iframes in this PR).
-        Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>> candidateRealms;
-        for (const auto& frameTree : frameTrees)
-            protectedThis->collectExecutionReadyFrameRealms(frameTree, candidateRealms, contextHandleFilter, false);
 
-        for (auto& realmInfo : candidateRealms)
-            accumulated.append(WTF::move(realmInfo));
+        bool includeWindowRealms = !optionalRealmType || *optionalRealmType == Inspector::Protocol::BidiScript::RealmType::Window;
+        if (includeWindowRealms) {
+            Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>> candidateRealms;
+            for (const auto& frameTree : frameTrees)
+                protectedThis->collectExecutionReadyFrameRealms(frameTree, candidateRealms, contextHandleFilter, false);
 
-        protectedThis->processRealmsForPagesAsync(WTF::move(pagesToProcess), WTF::move(optionalRealmType), WTF::move(contextHandleFilter), WTF::move(accumulated), WTF::move(callback));
+            for (auto& realmInfo : candidateRealms)
+                accumulated.append(WTF::move(realmInfo));
+        }
+
+        bool includeDedicatedWorkerRealms = !optionalRealmType || *optionalRealmType == Inspector::Protocol::BidiScript::RealmType::DedicatedWorker;
+        if (!includeDedicatedWorkerRealms) {
+            protectedThis->processRealmsForPagesAsync(WTF::move(pagesToProcess), WTF::move(optionalRealmType), WTF::move(contextHandleFilter), WTF::move(accumulated), WTF::move(callback));
+            return;
+        }
+
+        RefPtr session = protectedThis->m_session.get();
+        if (!session)
+            return;
+
+        auto ownerBrowsingContext = session->handleForWebPageProxy(currentPage);
+        if (ownerBrowsingContext.isEmpty()) {
+            protectedThis->processRealmsForPagesAsync(WTF::move(pagesToProcess), WTF::move(optionalRealmType), WTF::move(contextHandleFilter), WTF::move(accumulated), WTF::move(callback));
+            return;
+        }
+
+        protect(currentPage->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebAutomationSessionProxy::GetDedicatedWorkerRealms(currentPage->webPageIDInMainFrameProcess()), [weakThis, currentPage = currentPage.copyRef(), ownerBrowsingContext = ownerBrowsingContext.isolatedCopy(), pagesToProcess = WTF::move(pagesToProcess), optionalRealmType = WTF::move(optionalRealmType), contextHandleFilter = WTF::move(contextHandleFilter), accumulated = WTF::move(accumulated), callback = WTF::move(callback)](Vector<std::tuple<String, WebCore::FrameIdentifier, WebCore::SecurityOriginData>>&& workerRealms) mutable {
+            CheckedPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+
+            RefPtr session = protectedThis->m_session.get();
+            RefPtr currentOwnerPage = session ? session->webPageProxyForHandle(ownerBrowsingContext) : nullptr;
+            if (currentOwnerPage != currentPage.ptr()) {
+                protectedThis->processRealmsForPagesAsync(WTF::move(pagesToProcess), WTF::move(optionalRealmType), WTF::move(contextHandleFilter), WTF::move(accumulated), WTF::move(callback));
+                return;
+            }
+
+            for (auto& [workerIdentifier, ownerFrameIdentifier, origin] : workerRealms) {
+                RefPtr ownerFrame = WebFrameProxy::webFrame(ownerFrameIdentifier);
+                if (!ownerFrame || ownerFrame->page() != currentPage.ptr())
+                    continue;
+
+                DedicatedWorkerRealmKey key { ownerFrameIdentifier, workerIdentifier };
+                auto realmIdentifier = protectedThis->registerDedicatedWorkerRealm(key, ownerBrowsingContext, origin, false);
+                if (!realmIdentifier)
+                    continue;
+
+                auto activeRealmIterator = protectedThis->m_activeRealms.find(*realmIdentifier);
+                if (activeRealmIterator == protectedThis->m_activeRealms.end())
+                    continue;
+                accumulated.append(protectedThis->createProtocolRealmInfo(*realmIdentifier, activeRealmIterator->value));
+            }
+
+            protectedThis->processRealmsForPagesAsync(WTF::move(pagesToProcess), WTF::move(optionalRealmType), WTF::move(contextHandleFilter), WTF::move(accumulated), WTF::move(callback));
+        });
     });
 }
 
@@ -972,10 +1036,6 @@ std::optional<String> BidiScriptAgent::contextHandleForFrame(const FrameInfoData
 
 void BidiScriptAgent::collectExecutionReadyFrameRealms(const FrameTreeNodeData& frameTree, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>& realms, const std::optional<String>& contextHandleFilter, bool recurseSubframes)
 {
-    // FIXME: Per W3C BiDi spec, when contextHandleFilter is present, we should also include
-    // worker realms whose owner set includes the active document of that context.
-    // Currently only collecting window realms (frames).
-
     // Check if frame is execution ready per W3C BiDi spec step 1:
     // "Let environment settings be a list of all the environment settings objects that have their execution ready flag set."
     if (isFrameExecutionReady(frameTree.info)) {

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
@@ -35,6 +35,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/SecurityOriginData.h>
 #include <optional>
+#include <utility>
 #include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
@@ -63,9 +64,12 @@ class BidiScriptAgent final : public Inspector::BidiScriptBackendDispatcherHandl
 
 public:
     struct RealmInfo {
-        WebCore::SecurityOriginData origin;
+        String origin;
         Inspector::Protocol::BidiScript::RealmType type;
-        Inspector::Protocol::BidiBrowsingContext::BrowsingContext context;
+        std::optional<Inspector::Protocol::BidiBrowsingContext::BrowsingContext> context;
+        Vector<RealmIdentifier> owners;
+        HashSet<String> associatedBrowsingContexts;
+        bool creationNotified { false };
     };
 
 
@@ -83,6 +87,9 @@ public:
     // Realm lifecycle events.
     void notifyRealmCreated(RealmIdentifier, Inspector::Protocol::BidiBrowsingContext::BrowsingContext, const WebCore::SecurityOriginData&);
     void notifyRealmDestroyed(RealmIdentifier, Inspector::Protocol::BidiBrowsingContext::BrowsingContext);
+    void notifyDedicatedWorkerRealmCreated(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, Inspector::Protocol::BidiBrowsingContext::BrowsingContext ownerBrowsingContext, const WebCore::SecurityOriginData&);
+    void notifyDedicatedWorkerRealmDestroyed(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier);
+    void removeDedicatedWorkerRealmsForBrowsingContext(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&);
 
     // Lookup RealmIdentifier from browsing context (for UIProcess-initiated realm destruction).
     std::optional<RealmIdentifier> realmIdentifierForBrowsingContext(const String& browsingContext) const;
@@ -106,12 +113,21 @@ private:
         std::optional<Vector<String>> userContexts;
     };
 
-    void sendRealmCreatedEvent(const String& realmID, const WebCore::SecurityOriginData&, Inspector::Protocol::BidiScript::RealmType, Inspector::Protocol::BidiBrowsingContext::BrowsingContext);
+    using DedicatedWorkerRealmKey = std::pair<WebCore::FrameIdentifier, String>;
+
+    struct PendingDedicatedWorkerRealmInfo {
+        WebCore::SecurityOriginData origin;
+        Inspector::Protocol::BidiBrowsingContext::BrowsingContext ownerBrowsingContext;
+    };
+
+    void sendRealmCreatedEvent(RealmIdentifier, const RealmInfo&);
+    void sendRealmDestroyedEvent(RealmIdentifier, const RealmInfo&);
 
     void processRealmsForPagesAsync(Deque<Ref<WebPageProxy>>&& pagesToProcess, std::optional<Inspector::Protocol::BidiScript::RealmType>&& optionalRealmType, std::optional<String>&& contextHandleFilter, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>&& accumulated, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>>>&&);
     void collectExecutionReadyFrameRealms(const FrameTreeNodeData&, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>& realms, const std::optional<String>& contextHandleFilter, bool recurseSubframes = true);
     bool NODELETE isFrameExecutionReady(const FrameInfoData&);
     RefPtr<Inspector::Protocol::BidiScript::RealmInfo> createRealmInfoForFrame(const FrameInfoData&);
+    std::optional<RealmIdentifier> registerDedicatedWorkerRealm(const DedicatedWorkerRealmKey&, const Inspector::Protocol::BidiBrowsingContext::BrowsingContext& ownerBrowsingContext, const WebCore::SecurityOriginData&, bool emitCreatedEvent);
     std::optional<String> contextHandleForFrame(const FrameInfoData&);
     RealmIdentifier generateRealmIdForFrame(const FrameInfoData&);
     String generateRealmIdForBrowsingContext(const String& browsingContext);
@@ -132,6 +148,8 @@ private:
 
     // Track realm counters for navigation detection: frame ID -> counter
 
+    HashMap<DedicatedWorkerRealmKey, RealmIdentifier> m_dedicatedWorkerRealmIdentifiers;
+    HashMap<DedicatedWorkerRealmKey, PendingDedicatedWorkerRealmInfo> m_pendingDedicatedWorkerRealms;
     Vector<std::pair<PreloadScriptIdentifier, PreloadScriptInfo>> m_preloadScripts;
 };
 

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
@@ -128,6 +128,7 @@ private:
     bool NODELETE isFrameExecutionReady(const FrameInfoData&);
     RefPtr<Inspector::Protocol::BidiScript::RealmInfo> createRealmInfoForFrame(const FrameInfoData&);
     std::optional<RealmIdentifier> registerDedicatedWorkerRealm(const DedicatedWorkerRealmKey&, const Inspector::Protocol::BidiBrowsingContext::BrowsingContext& ownerBrowsingContext, const WebCore::SecurityOriginData&, bool emitCreatedEvent);
+    RefPtr<Inspector::Protocol::BidiScript::RealmInfo> createProtocolRealmInfo(RealmIdentifier, const RealmInfo&);
     std::optional<String> contextHandleForFrame(const FrameInfoData&);
     RealmIdentifier generateRealmIdForFrame(const FrameInfoData&);
     String generateRealmIdForBrowsingContext(const String& browsingContext);

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -1334,6 +1334,7 @@ void WebAutomationSession::contextDestroyedForPage(const WebPageProxy& page)
     auto [clientWindow, userContext] = getClientWindowAndUserContext(page);
 
     // Ensure the active realm is destroyed even if the WebProcess terminates first.
+    m_bidiProcessor->scriptAgent().removeDedicatedWorkerRealmsForBrowsingContext(contextHandle);
     if (auto realmID = m_bidiProcessor->scriptAgent().realmIdentifierForBrowsingContext(contextHandle))
         m_bidiProcessor->scriptAgent().notifyRealmDestroyed(*realmID, contextHandle);
 
@@ -3251,8 +3252,36 @@ void WebAutomationSession::scriptRealmDestroyed(WebCore::FrameIdentifier frameID
     if (it == scriptAgent.activeRealms().end())
         return; // Realm not found or already destroyed.
 
-    auto browsingContext = it->value.context;
-    scriptAgent.notifyRealmDestroyed(realmIdentifier, browsingContext);
+    if (!it->value.context)
+        return;
+    scriptAgent.notifyRealmDestroyed(realmIdentifier, *it->value.context);
+}
+
+void WebAutomationSession::scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, IPC::Untrusted<WebCore::SecurityOriginData>&& untrustedOrigin)
+{
+    auto origin = WTF::move(untrustedOrigin).unsafeExtractWithoutValidation(IPC::UnvalidatedReason::NeedsReview);
+
+    RefPtr ownerFrame = WebFrameProxy::webFrame(ownerFrameIdentifier);
+    if (!ownerFrame)
+        return;
+
+    if (!ownerFrame->isMainFrame())
+        return;
+
+    RefPtr page = ownerFrame->page();
+    if (!page || !page->isControlledByAutomation())
+        return;
+
+    auto ownerBrowsingContextIterator = m_webPageHandleMap.find(page->identifier());
+    if (ownerBrowsingContextIterator == m_webPageHandleMap.end())
+        return;
+
+    m_bidiProcessor->scriptAgent().notifyDedicatedWorkerRealmCreated(workerIdentifier, ownerFrameIdentifier, ownerBrowsingContextIterator->value, origin);
+}
+
+void WebAutomationSession::scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier)
+{
+    m_bidiProcessor->scriptAgent().notifyDedicatedWorkerRealmDestroyed(workerIdentifier, ownerFrameIdentifier);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -378,6 +378,8 @@ private:
 #if ENABLE(WEBDRIVER_BIDI)
     void scriptRealmCreated(WebCore::FrameIdentifier, RealmIdentifier, IPC::Untrusted<WebCore::SecurityOriginData>&&);
     void scriptRealmDestroyed(WebCore::FrameIdentifier, RealmIdentifier);
+    void scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, IPC::Untrusted<WebCore::SecurityOriginData>&&);
+    void scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier);
 #endif
 
     // Platform-dependent implementations.

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.messages.in
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.messages.in
@@ -30,5 +30,7 @@ messages -> WebAutomationSession {
 #if ENABLE(WEBDRIVER_BIDI)
     ScriptRealmCreated(WebCore::FrameIdentifier frameID, WebKit::RealmIdentifier realmIdentifier, IPC::Untrusted<WebCore::SecurityOriginData> origin)
     ScriptRealmDestroyed(WebCore::FrameIdentifier frameID, WebKit::RealmIdentifier realmIdentifier)
+    ScriptDedicatedWorkerRealmCreated(String workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, IPC::Untrusted<WebCore::SecurityOriginData> origin)
+    ScriptDedicatedWorkerRealmDestroyed(String workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier)
 #endif
 }

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiScript.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiScript.json
@@ -76,16 +76,24 @@
                 { "name": "realm", "$ref": "BidiScript.Realm", "description": "Unique identifier of the realm." },
                 { "name": "origin", "type": "string", "description": "The serialized origin of the realm." },
                 { "name": "type", "$ref": "BidiScript.RealmType", "description": "The type of the realm." },
-                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true, "description": "Browsing context of the realm. Not present for worklet/worker realms." }
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true, "description": "Browsing context of the realm. Not present for worklet/worker realms." },
+                { "name": "owners", "type": "array", "items": { "$ref": "BidiScript.Realm" }, "optional": true, "description": "Owner realms of a dedicated worker realm." }
             ]
         },
         {
             "id": "RealmType",
-            "description": "The type of a JavaScript realm. Currently only 'window' is supported; worker and worklet types will be added in future implementations.",
+            "description": "The type of a JavaScript realm.",
             "spec": "https://w3c.github.io/webdriver-bidi/#type-script-RealmType",
             "type": "string",
             "enum": [
-                "window"
+                "window",
+                "dedicated-worker",
+                "shared-worker",
+                "service-worker",
+                "worker",
+                "paint-worklet",
+                "audio-worklet",
+                "worklet"
             ]
         },
         {
@@ -292,7 +300,8 @@
                 { "name": "realm", "$ref": "BidiScript.Realm", "description": "Unique identifier of the realm." },
                 { "name": "origin", "type": "string", "description": "The serialized origin of the realm." },
                 { "name": "type", "$ref": "BidiScript.RealmType", "description": "The type of the realm." },
-                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true, "description": "Browsing context of the realm. Not present for worklet/worker realms." }
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true, "description": "Browsing context of the realm. Not present for worklet/worker realms." },
+                { "name": "owners", "type": "array", "items": { "$ref": "BidiScript.Realm" }, "optional": true, "description": "Owner realms of a dedicated worker realm." }
             ]
         },
         {

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -1231,6 +1231,16 @@ void WebAutomationSessionProxy::scriptRealmDestroyed(WebCore::FrameIdentifier fr
     protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebAutomationSession::ScriptRealmDestroyed(frameID, realmIdentifier), 0);
 }
 
+void WebAutomationSessionProxy::scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, const WebCore::SecurityOriginData& origin)
+{
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebAutomationSession::ScriptDedicatedWorkerRealmCreated(workerIdentifier, ownerFrameIdentifier, origin), 0);
+}
+
+void WebAutomationSessionProxy::scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier)
+{
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebAutomationSession::ScriptDedicatedWorkerRealmDestroyed(workerIdentifier, ownerFrameIdentifier), 0);
+}
+
 void WebAutomationSessionProxy::ensureRealmForInitialEmptyDocument(WebCore::PageIdentifier pageID)
 {
     RefPtr page = WebProcess::singleton().webPage(pageID);

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -1241,6 +1241,22 @@ void WebAutomationSessionProxy::scriptDedicatedWorkerRealmDestroyed(const String
     protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebAutomationSession::ScriptDedicatedWorkerRealmDestroyed(workerIdentifier, ownerFrameIdentifier), 0);
 }
 
+void WebAutomationSessionProxy::getDedicatedWorkerRealms(WebCore::PageIdentifier pageID, CompletionHandler<void(Vector<DedicatedWorkerRealmData>&&)>&& completionHandler)
+{
+    Vector<DedicatedWorkerRealmData> result;
+
+    RefPtr page = WebProcess::singleton().webPage(pageID);
+    RefPtr corePage = page ? page->corePage() : nullptr;
+    if (!corePage || !corePage->isControlledByAutomation()) {
+        completionHandler(WTF::move(result));
+        return;
+    }
+
+    result = AutomationInstrumentation::dedicatedWorkerRealms(pageID);
+
+    completionHandler(WTF::move(result));
+}
+
 void WebAutomationSessionProxy::ensureRealmForInitialEmptyDocument(WebCore::PageIdentifier pageID)
 {
     RefPtr page = WebProcess::singleton().webPage(pageID);

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
@@ -117,6 +117,8 @@ private:
     void addMessageToConsole(const JSC::MessageSource&, const JSC::MessageLevel&, const String&, const JSC::MessageType&, const WallTime&) override;
     void scriptRealmCreated(WebCore::FrameIdentifier, const WebCore::SecurityOriginData&) override;
     void scriptRealmDestroyed(WebCore::FrameIdentifier) override;
+    void scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, const WebCore::SecurityOriginData&) override;
+    void scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier) override;
     void ensureRealmForInitialEmptyDocument(WebCore::PageIdentifier);
 #endif
 

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
@@ -33,6 +33,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/PageIdentifier.h>
+#include <tuple>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
@@ -41,6 +42,7 @@
 #include "IdentifierTypes.h"
 #include <JavaScriptCore/ConsoleMessage.h>
 #include <WebCore/AutomationInstrumentation.h>
+#include <WebCore/SecurityOriginData.h>
 #endif
 
 namespace WebCore {
@@ -120,6 +122,9 @@ private:
     void scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, const WebCore::SecurityOriginData&) override;
     void scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier) override;
     void ensureRealmForInitialEmptyDocument(WebCore::PageIdentifier);
+
+    using DedicatedWorkerRealmData = std::tuple<String, WebCore::FrameIdentifier, WebCore::SecurityOriginData>;
+    void getDedicatedWorkerRealms(WebCore::PageIdentifier, CompletionHandler<void(Vector<DedicatedWorkerRealmData>&&)>&&);
 #endif
 
     String m_sessionIdentifier;

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.messages.in
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.messages.in
@@ -52,5 +52,6 @@ messages -> WebAutomationSessionProxy {
 
 #if ENABLE(WEBDRIVER_BIDI)
     EnsureRealmForInitialEmptyDocument(WebCore::PageIdentifier pageID)
+    GetDedicatedWorkerRealms(WebCore::PageIdentifier pageID) -> (Vector<std::tuple<String, WebCore::FrameIdentifier, WebCore::SecurityOriginData>> realms) Async
 #endif
 }

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -5473,7 +5473,7 @@
                 "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/304062"}}
             },
             "test_dedicated_worker": {
-                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/282981"}}
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/304300", "note": "The imported WPT expects the worker script URL instead of the serialized worker origin"}}
             },
             "test_shared_worker": {
                 "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/282981"}}
@@ -5520,7 +5520,7 @@
                 "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288067"}}
             },
             "test_dedicated_worker": {
-                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/282981"}}
+                "expected": { "all": { "status": ["PASS"]}}
             },
             "test_shared_worker": {
                 "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/282981"}}


### PR DESCRIPTION
[WebDriver][BiDi] Enumerate dedicated worker realms in script.getRealms
https://bugs.webkit.org/show_bug.cgi?id=304300

Reviewed by NOBODY (OOPS!).

This PR depends on #73051. Until that change lands and this branch is
rebased, the diff against main also contains its dedicated-worker lifecycle
changes.

Extend `script.getRealms` to include execution-ready dedicated workers
directly owned by automated top-level documents.

Collect each worker's identifier, owner frame, and cached global-scope
`SecurityOriginData` in WebCore. Return those snapshots asynchronously over
WebProcess-to-UIProcess IPC and reuse `BidiScriptAgent`'s lifecycle registry.
This keeps realm and owner identifiers stable across `script.realmCreated`,
`script.getRealms`, and `script.realmDestroyed`.

Apply context and dedicated-worker type filters. Discard an asynchronous
reply if its captured browsing context no longer maps to the same page.
Cache the origin before marking the worker execution-ready and serialize it
at the BiDi boundary.

The current imported WPT expects the full worker script URL instead of the
serialized worker origin. Leave the imported tests unchanged and document
that mismatch rather than returning a non-conforming protocol value.

This remains a partial implementation. Iframe-owned and nested dedicated
workers, shared and service workers, worklets, and worker-realm script
execution remain follow-up work.

* Source/WebCore/automation/AutomationInstrumentation.cpp:
(WebCore::AutomationInstrumentation::dedicatedWorkerRealms):
* Source/WebCore/automation/AutomationInstrumentation.h:
* Source/WebCore/workers/WorkerInspectorProxy.cpp:
(WebCore::WorkerInspectorProxy::workerStarted):
(WebCore::WorkerInspectorProxy::workerBecameExecutionReady):
(WebCore::WorkerInspectorProxy::workerTerminated):
* Source/WebCore/workers/WorkerInspectorProxy.h:
* Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp:
(WebKit::BidiScriptAgent::getRealms):
(WebKit::BidiScriptAgent::createProtocolRealmInfo):
(WebKit::BidiScriptAgent::processRealmsForPagesAsync):
(WebKit::BidiScriptAgent::collectExecutionReadyFrameRealms):
* Source/WebKit/UIProcess/Automation/BidiScriptAgent.h:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::getDedicatedWorkerRealms):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.messages.in:

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddace51b62e139f38249f92e2c4c96a39725201f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195443 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58754 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144652 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100344 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165238 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124945 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47061 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45124 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157428 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44808 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6499 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197395 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58691 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154152 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59400 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153805 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48300 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131698 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/128332 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57879 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19827 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57250 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57493 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->