### PR TITLE
[css-values-5] Support tree counting functions in container queries

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-container-query-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-container-query-expected.txt
@@ -1,6 +1,8 @@
 
-FAIL sibling-index() in @container width query assert_equals: expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL sibling-count() in @container width query assert_equals: expected "rgb(0, 255, 0)" but got "rgb(0, 0, 0)"
+PASS sibling-index() in @container width query
+PASS sibling-count() in @container width query
 PASS sibling-index() in @container style() query
 PASS sibling-count() in @container style() query
+PASS sibling-index() in @container style() query range
+PASS sibling-count() in @container style() query range
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-container-query-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-container-query-invalidation-expected.txt
@@ -4,7 +4,7 @@ PASS sibling-count() in @container width query initially not matching
 PASS sibling-index() in @container style() query initially not matching
 PASS sibling-count() in @container style() query initially not matching
 FAIL sibling-index() in @container width query matching after removal assert_equals: expected "rgb(0, 128, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL sibling-count() in @container width query matching after removal assert_equals: expected "rgb(0, 255, 0)" but got "rgb(0, 0, 0)"
+FAIL sibling-count() in @container width query matching after removal assert_equals: expected "rgba(0, 0, 0, 0)" but got "rgb(0, 128, 0)"
 FAIL sibling-index() in @container style() query matching after removal assert_equals: expected "yes" but got "no"
 FAIL sibling-count() in @container style() query matching after removal assert_equals: expected "yes" but got "no"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-container-query.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-container-query.html
@@ -22,6 +22,8 @@
   span {
     --match-100: no;
     --match-400: no;
+    --range-100: no;
+    --range-400: no;
   }
   @container (width = calc(100px * sibling-index())) {
     span { background-color: green; }
@@ -34,6 +36,12 @@
   }
   @container style(--length: calc(200px * sibling-count())) {
     span { --match-400: yes; }
+  }
+  @container style(--length = calc(100px * sibling-index())) {
+    span { --range-100: yes; }
+  }
+  @container style(--length = calc(200px * sibling-count())) {
+    span { --range-400: yes; }
   }
 </style>
 <div style="color:black">
@@ -64,4 +72,14 @@
     assert_equals(getComputedStyle(t2).getPropertyValue("--match-100"), "no");
     assert_equals(getComputedStyle(t2).getPropertyValue("--match-400"), "yes");
   }, "sibling-count() in @container style() query");
+
+  test(() => {
+    assert_equals(getComputedStyle(t1).getPropertyValue("--range-100"), "yes");
+    assert_equals(getComputedStyle(t1).getPropertyValue("--range-400"), "no");
+  }, "sibling-index() in @container style() query range");
+
+  test(() => {
+    assert_equals(getComputedStyle(t2).getPropertyValue("--range-100"), "no");
+    assert_equals(getComputedStyle(t2).getPropertyValue("--range-400"), "yes");
+  }, "sibling-count() in @container style() query range");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-if-style-query-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-if-style-query-expected.txt
@@ -1,0 +1,6 @@
+
+PASS sibling-index() in an if() style() comparison
+PASS sibling-index() inside mod() in an if() style() comparison
+PASS sibling-index() compared against a registered custom property
+PASS sibling-count() in an if() style() comparison
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-if-style-query.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-if-style-query.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<title>CSS Values and Units Test: tree counting functions in if() style() conditions</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#tree-counting">
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#if-notation">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  @property --len { syntax: "<length>"; initial-value: 0px; inherits: false; }
+  #target li {
+    --len: calc(100px * sibling-index());
+    --index-is-two: if(style(sibling-index() = 2): yes; else: no);
+    --even: if(style(mod(sibling-index(), 2) = 0): yes; else: no);
+    --matches-len: if(style(--len = calc(100px * sibling-index())): yes; else: no);
+    --matches-shifted: if(style(--len = calc(100px * (sibling-index() + 1))): yes; else: no);
+    --count-is-three: if(style(sibling-count() = 3): yes; else: no);
+  }
+</style>
+<ul id="target"><li></li><li></li><li></li></ul>
+<script>
+const items = [...document.querySelectorAll("#target li")];
+const value = (element, name) => getComputedStyle(element).getPropertyValue(name).trim();
+
+test(() => {
+  assert_array_equals(items.map(item => value(item, "--index-is-two")), ["no", "yes", "no"]);
+}, "sibling-index() in an if() style() comparison");
+
+test(() => {
+  assert_array_equals(items.map(item => value(item, "--even")), ["no", "yes", "no"]);
+}, "sibling-index() inside mod() in an if() style() comparison");
+
+test(() => {
+  assert_array_equals(items.map(item => value(item, "--matches-len")), ["yes", "yes", "yes"]);
+  assert_array_equals(items.map(item => value(item, "--matches-shifted")), ["no", "no", "no"]);
+}, "sibling-index() compared against a registered custom property");
+
+test(() => {
+  assert_array_equals(items.map(item => value(item, "--count-is-three")), ["yes", "yes", "yes"]);
+}, "sibling-count() in an if() style() comparison");
+</script>

--- a/Source/WebCore/css/MediaQueryParserContext.h
+++ b/Source/WebCore/css/MediaQueryParserContext.h
@@ -40,6 +40,11 @@ public:
     WEBCORE_EXPORT MediaQueryParserContext(const Document&);
 
     CSSParserContext context;
+
+    // Container query conditions have an element context (the query container), so unlike media
+    // queries they allow the tree counting functions.
+    // https://github.com/w3c/csswg-drafts/issues/10982
+    bool treeCountingFunctionsAllowed { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -1347,7 +1347,7 @@ std::optional<TypedChild> parseCalcFunction(CSSParserTokenRange& tokens, CSSValu
             return { };
         if (state.propertyParserState.currentRule != StyleRuleType::Style && state.propertyParserState.currentRule != StyleRuleType::Keyframe)
             return { };
-        if (state.propertyParserState.currentProperty == CSSPropertyInvalid)
+        if (state.propertyParserState.currentProperty == CSSPropertyInvalid && !state.propertyParserState.treeCountingFunctionsAllowed)
             return { };
         state.requiresConversionData = true;
         return consumeZeroArguments<SiblingCount>(tokens, depth, state);
@@ -1360,7 +1360,7 @@ std::optional<TypedChild> parseCalcFunction(CSSParserTokenRange& tokens, CSSValu
             return { };
         if (state.propertyParserState.currentRule != StyleRuleType::Style && state.propertyParserState.currentRule != StyleRuleType::Keyframe)
             return { };
-        if (state.propertyParserState.currentProperty == CSSPropertyInvalid)
+        if (state.propertyParserState.currentProperty == CSSPropertyInvalid && !state.propertyParserState.treeCountingFunctionsAllowed)
             return { };
         state.requiresConversionData = true;
         return consumeZeroArguments<SiblingIndex>(tokens, depth, state);

--- a/Source/WebCore/css/parser/CSSPropertyParserState.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserState.h
@@ -50,8 +50,16 @@ struct PropertyParserState {
     unsigned cssRandomFunctionCount { 0 };
 
     // Set where there is no element to key a random draw to: a @container style() query value or an @property initial value.
-    // FIXME: Should cover every function needing an element context, like the tree counting ones, not just random(). https://github.com/w3c/csswg-drafts/issues/10982
+    // FIXME: Which of the functions needing an element context are allowed in which context is still
+    // being worked out, and each one has its own control until then.
+    // https://github.com/w3c/csswg-drafts/issues/10982
     bool randomFunctionsDisallowed { false };
+
+    // Set where there is an element to resolve against but no property being parsed, which is the case
+    // for the values in a container query condition.
+    // "RESOLVED: Explicitly allow tree-counting functions in container queries"
+    // https://github.com/w3c/csswg-drafts/issues/10982
+    bool treeCountingFunctionsAllowed { false };
 
     // Used by non-CSS users of the CSS parsers like `DOMMatrix` to limit <length> and <length-percentage> parsing to only absolute units.
     bool absoluteLengthUnitsOnly { false };

--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -197,7 +197,11 @@ static std::optional<StyleRangeValue> evaluateStyleRangeValue(const Vector<CSSPa
         return { };
 
     auto& conversionData = context.conversionData;
-    auto parserState = CSS::PropertyParserState { .context = protect(context.document.get())->cssParserContext() };
+
+    auto parserState = CSS::PropertyParserState {
+        .context = protect(context.document.get())->cssParserContext(),
+        .treeCountingFunctionsAllowed = true,
+    };
 
     auto isFullyConsumed = [](CSSParserTokenRange consumed) {
         consumed.consumeWhitespace();
@@ -276,8 +280,9 @@ struct StyleFeatureSchema : public FeatureSchema {
     // https://drafts.csswg.org/css-mixins/#resolve-function-styles
     static const Style::LocalPropertyRegistry* localPropertyRegistry(const FeatureEvaluationContext& context)
     {
-        CheckedPtr builderState = context.conversionData.styleBuilderState();
-        return builderState ? builderState->localPropertyRegistry() : nullptr;
+        // Both evaluators that reach a style() feature, container queries and if(), have a builder state.
+        CheckedRef builderState = *context.conversionData.styleBuilderState();
+        return builderState->localPropertyRegistry();
     }
 
     // FeatureSchema conformance

--- a/Source/WebCore/css/query/ContainerQueryParser.cpp
+++ b/Source/WebCore/css/query/ContainerQueryParser.cpp
@@ -198,8 +198,13 @@ std::optional<ContainerQuery> ContainerQueryParser::consumeContainerQuery(CSSPar
     return queries;
 }
 
-std::optional<ContainerCondition> ContainerQueryParser::consumeContainerCondition(CSSParserTokenRange& range, const MediaQueryParserContext& context)
+std::optional<ContainerCondition> ContainerQueryParser::consumeContainerCondition(CSSParserTokenRange& range, const MediaQueryParserContext& parentContext)
 {
+    // "RESOLVED: Explicitly allow tree-counting functions in container queries"
+    // https://github.com/w3c/csswg-drafts/issues/10982
+    auto context = parentContext;
+    context.treeCountingFunctionsAllowed = true;
+
     auto consumeName = [&] {
         if (range.peek().type() == LeftParenthesisToken || range.peek().type() == FunctionToken)
             return nullAtom();

--- a/Source/WebCore/css/query/GenericMediaQueryParser.cpp
+++ b/Source/WebCore/css/query/GenericMediaQueryParser.cpp
@@ -103,6 +103,7 @@ static std::optional<Value> consumeValue(CSSParserTokenRange& range, const Media
 
     auto parserState = CSS::PropertyParserState {
         .context = context.context,
+        .treeCountingFunctionsAllowed = context.treeCountingFunctionsAllowed,
     };
 
     if (auto value = consumeUnresolvedRatioWithBothNumeratorAndDenominator(range, parserState))

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -36,6 +36,7 @@
 #include "NodeDocument.h"
 #include "NodeRenderStyle.h"
 #include "RenderView.h"
+#include "StyleBuilderState.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StyleRule.h"
 #include "StyleScope.h"
@@ -50,6 +51,8 @@ ContainerQueryEvaluator::ContainerQueryEvaluator(const Element& element, Selecti
     , m_evaluationState(evaluationState)
 {
 }
+
+ContainerQueryEvaluator::~ContainerQueryEvaluator() = default;
 
 bool ContainerQueryEvaluator::evaluate(const CQ::ContainerQuery& containerQuery) const
 {
@@ -113,15 +116,18 @@ auto ContainerQueryEvaluator::featureEvaluationContextForCondition(const CQ::Con
         return styleForContainer(*rootElement, condition.requirements, m_evaluationState);
     }();
 
+    // Give the condition an element context, which is what the functions that resolve against the
+    // query container need.
+    m_builderState = BuilderState::create(const_cast<ComputedStyle&>(*containerStyle), BuilderContext {
+        .document = document.get(),
+        .parentStyle = containerParentStyle.get(),
+        .rootElementStyle = rootStyle.get(),
+        .element = container.get(),
+    }).moveToUniquePtr();
+
     return MQ::FeatureEvaluationContext {
         .document = document.get(),
-        .conversionData = CSSToLengthConversionData {
-            *containerStyle,
-            rootStyle.get(),
-            containerParentStyle.get(),
-            document->renderView(),
-            container.get()
-        },
+        .conversionData = m_builderState->cssToLengthConversionData(),
         .renderer = container->renderer(),
     };
 }

--- a/Source/WebCore/style/ContainerQueryEvaluator.h
+++ b/Source/WebCore/style/ContainerQueryEvaluator.h
@@ -28,6 +28,7 @@
 #include "GenericMediaQueryEvaluator.h"
 #include "StyleScopeOrdinal.h"
 #include "StyleUpdate.h"
+#include <memory>
 #include <wtf/Ref.h>
 
 namespace WebCore {
@@ -35,6 +36,8 @@ namespace WebCore {
 class Element;
 
 namespace Style {
+
+class BuilderState;
 
 struct ContainerQueryEvaluationState {
     Vector<Ref<const Element>> sizeQueryContainers;
@@ -45,6 +48,7 @@ class ContainerQueryEvaluator : public MQ::GenericMediaQueryEvaluator<ContainerQ
 public:
     enum class SelectionMode : uint8_t { Element, PseudoElement, PartPseudoElement };
     ContainerQueryEvaluator(const Element&, SelectionMode, ScopeOrdinal, ContainerQueryEvaluationState*);
+    ~ContainerQueryEvaluator();
 
     bool evaluate(const CQ::ContainerQuery&) const;
 
@@ -57,6 +61,11 @@ private:
     const SelectionMode m_selectionMode;
     const ScopeOrdinal m_scopeOrdinal;
     ContainerQueryEvaluationState* m_evaluationState { nullptr };
+
+    // No style is being built while a condition is evaluated, but the functions that resolve against
+    // the query container need a BuilderState to reach it. The conversion data only points at it, so
+    // it is owned here.
+    mutable std::unique_ptr<BuilderState> m_builderState;
 };
 
 }


### PR DESCRIPTION
#### a2b3ca6b9e95d8b94200d874fd95e3dd36f873ab
<pre>
[css-values-5] Support tree counting functions in container queries
<a href="https://bugs.webkit.org/show_bug.cgi?id=323319">https://bugs.webkit.org/show_bug.cgi?id=323319</a>
<a href="https://rdar.apple.com/186564084">rdar://186564084</a>

Reviewed by Alan Baradlay.

They should work per <a href="https://github.com/w3c/csswg-drafts/issues/10982.">https://github.com/w3c/csswg-drafts/issues/10982.</a>

Two things stopped them. They were rejected at parse time by a currentProperty test standing in for
&quot;no element to resolve against&quot;, which a container query condition does have. Replace it with an
explicit treeCountingFunctionsAllowed. Media queries keep rejecting them, which is what makes them
evaluate to unknown.

Resolving one also needs a BuilderState and ContainerQueryEvaluator built its conversion data
without one. Make it for the container and take the conversion data from that, like
IfConditionEvaluator does. The style() declaration form was already doing this the long way around
with a Builder of its own, which is why that form worked and nothing else did.

Invalidation on sibling changes is still missing.

Test: imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-if-style-query.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-container-query-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-container-query-invalidation-expected.txt:

Still failing, but later: the queries now match, they just don&apos;t invalidate.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-container-query.html:

Cover the style() range form too, which nothing tested.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-if-style-query-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/tree-counting/sibling-function-if-style-query.html: Added.
* Source/WebCore/css/MediaQueryParserContext.h:
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::parseCalcFunction):
* Source/WebCore/css/parser/CSSPropertyParserState.h:
* Source/WebCore/css/query/ContainerQueryFeatures.cpp:
(WebCore::CQ::Features::evaluateStyleRangeValue):
(WebCore::CQ::Features::StyleFeatureSchema::localPropertyRegistry):

Both evaluators that reach a style() feature have a builder state now, so stop testing for it.

* Source/WebCore/css/query/ContainerQueryParser.cpp:
(WebCore::CQ::ContainerQueryParser::consumeContainerCondition):
* Source/WebCore/css/query/GenericMediaQueryParser.cpp:
(WebCore::MQ::consumeValue):
* Source/WebCore/style/ContainerQueryEvaluator.cpp:
(WebCore::Style::ContainerQueryEvaluator::featureEvaluationContextForCondition const):
* Source/WebCore/style/ContainerQueryEvaluator.h:

Canonical link: <a href="https://commits.webkit.org/320493@main">https://commits.webkit.org/320493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5b2b792c819005b82aefc0ccd12205b8e8d52c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195117 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f61e8da-dee2-4fe0-98ab-6a5aa2aa3eb0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186645 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58434 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144403 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/df23eafb-3b06-4980-b78a-f0d271f2cabe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48065 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165002 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124685 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/013d357f-9602-4685-89d1-c19ea86cfdc1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46788 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44903 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157161 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44555 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6173 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51368 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197067 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58375 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164494 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153873 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41233 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59077 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153530 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48044 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131366 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127922 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57577 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19573 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56936 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57187 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57013 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->