### PR TITLE
AX: In isolated tree mode, AXIndexForTextMarker returns 0 for a text marker in an empty text field at the end of the document

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/offset-from-root-outside-text-run-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/offset-from-root-outside-text-run-expected.txt
@@ -1,0 +1,9 @@
+This test ensures we can get the index of a text marker that points to an object with no runs/text.
+
+PASS: pObject.indexForTextMarker(endMarker) === 11
+PASS: inputObject.indexForTextMarker(inputStart) === 11
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello world

--- a/LayoutTests/accessibility/isolated-tree/offset-from-root-outside-text-run.html
+++ b/LayoutTests/accessibility/isolated-tree/offset-from-root-outside-text-run.html
@@ -1,0 +1,30 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="p" style="display: inline-block;">Hello world</p><input id="input" type="text" value="" style="display: inline-block;"/>
+
+<script>
+let output = "This test ensures we can get the index of a text marker that points to an object with no runs/text.\n\n";
+
+if (window.accessibilityController) {
+    var pObject = accessibilityController.accessibleElementById("p");
+    const range1 = pObject.textMarkerRangeForElement(pObject);
+    var endMarker = pObject.endTextMarkerForTextMarkerRange(range1);
+    output += expect("pObject.indexForTextMarker(endMarker)", "11");
+
+    var inputObject = accessibilityController.accessibleElementById("input");
+    const range2 = inputObject.textMarkerRangeForElement(inputObject);
+    var inputStart = inputObject.endTextMarkerForTextMarkerRange(range2);
+    output += expect("inputObject.indexForTextMarker(inputStart)", "11");
+
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -1138,8 +1138,16 @@ unsigned AXTextMarker::offsetFromRoot() const
     if (!isValid())
         return 0;
     auto target = toTextRunMarker();
-    if (!target.isValid())
-        return 0;
+    if (!target.isValid()) {
+        // Nothing at or after this marker has text (e.g. it points at an empty text field that ends
+        // the document), so toTextRunMarker() had nothing to anchor to. Anchor backwards instead, as
+        // every character in the document precedes this position, so its index is the end of the
+        // last run before it.
+        RefPtr previous = findObjectWithRuns(*isolatedObject(), AXDirection::Previous);
+        if (!previous)
+            return 0;
+        target = AXTextMarker { *previous, previous->textRuns()->totalLength() };
+    }
 
     RefPtr tree = std::get<RefPtr<AXIsolatedTree>>(axTreeForID(treeID()));
     RefPtr root = tree ? tree->rootNode() : nullptr;


### PR DESCRIPTION
#### 4a276aa3fda7e8737df19898b289d8c9671ebd82
<pre>
AX: In isolated tree mode, AXIndexForTextMarker returns 0 for a text marker in an empty text field at the end of the document
<a href="https://bugs.webkit.org/show_bug.cgi?id=323328">https://bugs.webkit.org/show_bug.cgi?id=323328</a>
<a href="https://rdar.apple.com/186571569">rdar://186571569</a>

Reviewed by Dominic Mazzoni.

AXIndexForTextMarker on the accessibility thread is AXTextMarker::offsetFromRoot,
which begins by anchoring the marker to real text with toTextRunMarker(). That
function only ever searches forward, so a marker on an object with no text of its
own and no text after it *an empty text field that ends the document, for
example) has nothing to anchor to, and offsetFromRoot returned 0 rather than the
index of the position.

When forward anchoring finds nothing, anchor backwards instead, to the end of the
last run before the marker, as every character in the document precedes such a
position, so that run&apos;s end is its index.

Fixes accessibility/isolated-tree/offset-from-root-outside-text-run.html in isolated tree mode.

* LayoutTests/accessibility/isolated-tree/offset-from-root-outside-text-run-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/offset-from-root-outside-text-run.html: Added.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::offsetFromRoot const):

Canonical link: <a href="https://commits.webkit.org/320443@main">https://commits.webkit.org/320443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a927a2f5ecdf3e8c9ac906ada6931eb4bc30e2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58668 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195083 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/149011 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/104f7767-b9a0-406e-80bb-0b8fa4a0fdcb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186610 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58399 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144371 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100252 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/63ca1bc9-ccbf-4cb7-b0cb-bb95629e2131) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187703 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124653 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f1008e6-bed0-4add-98bf-43daa37613c1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46758 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157131 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44527 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6138 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197032 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153839 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41192 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59042 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41144 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153497 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48015 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131331 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127884 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57542 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19545 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56902 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57153 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56978 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->