### PR TITLE
Add PixelFormat::RGBX to support opaque RGB pixel data

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7800,6 +7800,9 @@ ipc/create-image-buffer-crash.html [ Skip ]
 ipc/validate-media-constraint.html [ Skip ]
 ipc/validate-message-check-in-networkconnectiontowebprocess.html [ Skip ]
 
+# Testing MESSAGE_CHECK of sync messages is incorrect.
+webkit.org/b/323670 ipc/getpixelbuffer-layerbacking-heap-disclosure.html [ Skip ]
+
 # webkit.org/b/287275 [ Sequoia EWS] media/video-replaces-poster.html is a flaky crash
 media/video-presentation-mode.html [ Skip ]
 

--- a/LayoutTests/ipc/cocoa/indexed-colorspace-null-inner-crash.html
+++ b/LayoutTests/ipc/cocoa/indexed-colorspace-null-inner-crash.html
@@ -44,7 +44,7 @@
           }
         }
       },
-      bufferFormat: { pixelFormat: 0, useLosslessCompression: 0 },
+      bufferFormat: { pixelFormat: 1, useLosslessCompression: 0 },
       identifier: Math.floor(Math.random() * 0x1000000),
       contextIdentifier: Math.floor(Math.random() * 0x1000000)
     });

--- a/LayoutTests/ipc/convert-to-luminance-mask-float16.html
+++ b/LayoutTests/ipc/convert-to-luminance-mask-float16.html
@@ -28,7 +28,7 @@ window.setTimeout(async () => {
         renderingPurpose : 7,
         resolutionScale : 3.650556716916852e+32,
         colorSpace : { serializableColorSpace : { alias : { optionalValue : { m_cgColorSpace : { alias : { variantType : 'WebCore::ColorSpaceName', variant : 17 } } } } } },
-        bufferFormat : { pixelFormat : 3, useLosslessCompression : 0 },
+        bufferFormat : { pixelFormat : 4, useLosslessCompression : 0 },
         identifier: imageBufferIdentifier,
         contextIdentifier: contextIdentifier
     });

--- a/LayoutTests/ipc/create-image-buffer-crash.html
+++ b/LayoutTests/ipc/create-image-buffer-crash.html
@@ -18,14 +18,16 @@
     CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, { renderingBackendIdentifier: renderingBackendIdentifier, connectionHandle: connection });
     const remoteBackend = connection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
 
-    // The pixel formats to test
+    // The pixel formats to test.
     const pixelFormats = [
-      0, // RGBA8
-      1, // BGRX8
-      2, // BGRA8
-      3, // RGB10
-      4, // RGB10A8
-      5  // RGBA16F (if HDR_SUPPORT is enabled)
+      0, // RGBX8
+      1, // RGBA8
+      2, // BGRX8
+      3, // BGRA8
+      4, // RGBA16F, if ENABLE(PIXEL_FORMAT_RGBA16F)
+      5, // RGB10, if ENABLE(PIXEL_FORMAT_RGB10)
+      6, // RGB10A8, if ENABLE(PIXEL_FORMAT_RGB10A8)
+      7  // Always out of range.
     ];
 
     // Iterate through each pixel format and create image buffer

--- a/LayoutTests/ipc/dynamic-content-scaling-display-list-during-prepare-for-display.html
+++ b/LayoutTests/ipc/dynamic-content-scaling-display-list-during-prepare-for-display.html
@@ -52,7 +52,7 @@ promise_test(async t => {
                 }
             },
             contentsFormat: 1,
-            bufferFormat: { pixelFormat: 2, useLosslessCompression: 0 },
+            bufferFormat: { pixelFormat: 3, useLosslessCompression: 0 },
             renderingMode: 1,
             renderingPurpose: 3,
             includeDisplayList: 1,

--- a/LayoutTests/ipc/empty-svgfilterrenderer-expression-crash.html
+++ b/LayoutTests/ipc/empty-svgfilterrenderer-expression-crash.html
@@ -28,7 +28,7 @@
             renderingPurpose: 0,
             resolutionScale: 1,
             colorSpace: sRGBColorSpace(),
-            bufferFormat: { pixelFormat: 2, useLosslessCompression: 1 },
+            bufferFormat: { pixelFormat: 3, useLosslessCompression: 1 },
             identifier: 393236,
             contextIdentifier: 393237,
         });

--- a/LayoutTests/ipc/feComponentTransfer-empty-tableValues-accelerated.html
+++ b/LayoutTests/ipc/feComponentTransfer-empty-tableValues-accelerated.html
@@ -43,7 +43,7 @@ setTimeout(async () => {
             rrb.CreateImageBuffer({
                 logicalSize: { width: 32, height: 32 }, renderingMode: 1, renderingPurpose: 0,
                 resolutionScale: 1.0, colorSpace: sRGB,
-                bufferFormat: { pixelFormat: 2, useLosslessCompression: 0 },
+                bufferFormat: { pixelFormat: 3, useLosslessCompression: 0 },
                 identifier: id, contextIdentifier: ctx,
             });
             // Drain the unsolicited DidCreateBackend in-turn; otherwise it reaches the stream
@@ -100,7 +100,7 @@ setTimeout(async () => {
         shm.writeBytes(new Uint8Array(N).fill(0xAA));
         sc.newInterface('RemoteImageBuffer', DST).GetPixelBufferWithNewMemory({
             handle: { protection: 'ReadWrite', handle: shm },
-            outputFormat: { alphaFormat: 0, pixelFormat: 0, colorSpace: sRGB },
+            outputFormat: { alphaFormat: 0, pixelFormat: 1, colorSpace: sRGB },
             srcPoint: { x: 0, y: 0 }, srcSize: { width: 32, height: 32 },
         });
         const px = new Uint8Array(shm.readBytes(0, N));

--- a/LayoutTests/ipc/fecolormatrix-type-values-mismatch-crash.html
+++ b/LayoutTests/ipc/fecolormatrix-type-values-mismatch-crash.html
@@ -30,8 +30,8 @@
                 renderingPurpose: 0,
                 resolutionScale: 10,
                 colorSpace: sRGBColorSpace(),
-                pixelFormat: 1,
-                bufferFormat: { pixelFormat: 1, useLosslessCompression: 0 },
+                pixelFormat: 2,
+                bufferFormat: { pixelFormat: 2, useLosslessCompression: 0 },
                 identifier: imageBufferIdentifier,
                 contextIdentifier: contextIdentifier
             });

--- a/LayoutTests/ipc/getpixelbuffer-layerbacking-heap-disclosure.html
+++ b/LayoutTests/ipc/getpixelbuffer-layerbacking-heap-disclosure.html
@@ -22,7 +22,7 @@ window.setTimeout(async () => {
     const PF = {};
     for (const e of IPC.serializedEnumInfo['WebCore::PixelFormat'].valueMap) PF[e.name] = e.value;
     const CS = {};
-    for (const e of IPC.serializedEnumInfo['WebCore::ColorSpace'].valueMap) CS[e.name] = e.value;
+    for (const e of IPC.serializedEnumInfo['WebCore::ColorSpaceName'].valueMap) CS[e.name] = e.value;
     const RP = {};
     for (const e of IPC.serializedEnumInfo['WebCore::RenderingPurpose'].valueMap) RP[e.name] = e.value;
 
@@ -37,7 +37,7 @@ window.setTimeout(async () => {
     ];
     const SRGB_CS = {
         serializableColorSpace: { alias: { optionalValue: {
-            m_cgColorSpace: { alias: { variantType: 'WebCore::ColorSpace', variant: CS.SRGB } }
+            m_cgColorSpace: { alias: { variantType: 'WebCore::ColorSpaceName', variant: CS.SRGB } }
         } } }
     };
 

--- a/LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html
+++ b/LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html
@@ -28,7 +28,7 @@
             renderingPurpose: 0,
             resolutionScale: 1.0,
             colorSpace: sRGBColorSpace(),
-            bufferFormat: { pixelFormat: 1, useLosslessCompression: 0 },
+            bufferFormat: { pixelFormat: 2, useLosslessCompression: 0 },
             identifier: imageBufferIdentifier,
             contextIdentifier: contextIdentifier,
         });

--- a/LayoutTests/ipc/invalid-feConvolveMatrix-crash.html
+++ b/LayoutTests/ipc/invalid-feConvolveMatrix-crash.html
@@ -30,8 +30,8 @@
                 renderingPurpose: 0,
                 resolutionScale: 10,
                 colorSpace: sRGBColorSpace(),
-                pixelFormat: 1,
-                bufferFormat: { pixelFormat: 1, useLosslessCompression: 0 },
+                pixelFormat: 2,
+                bufferFormat: { pixelFormat: 2, useLosslessCompression: 0 },
                 identifier: imageBufferIdentifier,
                 contextIdentifier: contextIdentifier
             });

--- a/LayoutTests/ipc/invalid-svgfilter-expression-crash.html
+++ b/LayoutTests/ipc/invalid-svgfilter-expression-crash.html
@@ -28,7 +28,7 @@ window.setTimeout(async () => {
         renderingPurpose: 0,
         resolutionScale: 1.0,
         colorSpace: sRGBColorSpace(),
-        bufferFormat: { pixelFormat: 1, useLosslessCompression: 0 },
+        bufferFormat: { pixelFormat: 2, useLosslessCompression: 0 },
         identifier: imageBufferIdentifier,
         contextIdentifier: contextIdentifier
     });

--- a/LayoutTests/ipc/mark-surfaces-volatile-during-prepare-for-display.html
+++ b/LayoutTests/ipc/mark-surfaces-volatile-during-prepare-for-display.html
@@ -56,7 +56,7 @@ async function runTest() {
                 }
             },
             contentsFormat: 1,
-            bufferFormat: { pixelFormat: 2, useLosslessCompression: 0 },
+            bufferFormat: { pixelFormat: 3, useLosslessCompression: 0 },
             renderingMode: 1,
             renderingPurpose: 3,
         },

--- a/LayoutTests/ipc/move-to-image-buffer-cross-thread-font-crash.html
+++ b/LayoutTests/ipc/move-to-image-buffer-cross-thread-font-crash.html
@@ -30,7 +30,7 @@ if (window.testRunner) {
             renderingPurpose: 0,
             resolutionScale: 1,
             colorSpace: { serializableColorSpace: { alias: { optionalValue: { m_cgColorSpace: { alias: { variantType: 'WebCore::ColorSpaceName', variant: 17 } } } } } },
-            bufferFormat: { pixelFormat: 2, useLosslessCompression: 1 },
+            bufferFormat: { pixelFormat: 3, useLosslessCompression: 1 },
             identifier: imageBufferIdentifier,
             contextIdentifier
         });

--- a/LayoutTests/ipc/nested-display-list-draw-control-part-crash.html
+++ b/LayoutTests/ipc/nested-display-list-draw-control-part-crash.html
@@ -74,7 +74,7 @@ async function main() {
             renderingPurpose: 0,
             resolutionScale: 1.0,
             colorSpace: sRGBColorSpace(),
-            bufferFormat: { pixelFormat: 2, useLosslessCompression: 1 },
+            bufferFormat: { pixelFormat: 3, useLosslessCompression: 1 },
             identifier: imageBufferIdentifier,
             contextIdentifier: graphicsContextIdentifier
         });

--- a/LayoutTests/ipc/restore-empty-stack-crash.html
+++ b/LayoutTests/ipc/restore-empty-stack-crash.html
@@ -9,7 +9,7 @@
             o10=CoreIPC.newStreamConnection();
             CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0,{renderingBackendIdentifier:393219,connectionHandle:o10});
             o12=o10.newInterface("RemoteRenderingBackend", 393219);
-            o12.CreateImageBuffer({logicalSize:{width:32,height:18},renderingMode:3,renderingPurpose:1,resolutionScale:489626271805,colorSpace:sRGBColorSpace(),pixelFormat:1,bufferFormat:{pixelFormat:1,useLosslessCompression:0},identifier:393225,contextIdentifier:393226});
+            o12.CreateImageBuffer({logicalSize:{width:32,height:18},renderingMode:3,renderingPurpose:1,resolutionScale:489626271805,colorSpace:sRGBColorSpace(),pixelFormat:2,bufferFormat:{pixelFormat:2,useLosslessCompression:0},identifier:393225,contextIdentifier:393226});
             o10.connection.waitForMessage(393225, IPC.messages.RemoteImageBufferProxy_DidCreateBackend.name, 1);
             o31=o10.newInterface("RemoteGraphicsContext", 393226);
             o31.Restore({});

--- a/Source/WebCore/platform/graphics/ArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ArrayPixelBuffer.cpp
@@ -38,8 +38,10 @@ ArrayPixelBuffer::ArrayPixelBuffer(const PixelBufferFormat& format, const IntSiz
 RefPtr<ArrayPixelBuffer> ArrayPixelBuffer::tryCreate(const PixelBufferFormat& format, const IntSize& size)
 {
     switch (format.pixelFormat) {
-    case PixelFormat::BGRA8:
+    case PixelFormat::RGBX8:
     case PixelFormat::RGBA8:
+    case PixelFormat::BGRX8:
+    case PixelFormat::BGRA8:
         return ByteArrayPixelBuffer::tryCreate(format, size);
 
 #if ENABLE(PIXEL_FORMAT_RGBA16F)

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -490,9 +490,24 @@ void ImageBuffer::transformToColorSpace(const ColorSpace& newColorSpace)
     }
 }
 
+bool ImageBuffer::supportedPixelBufferFormats(PixelFormat pixelFormat)
+{
+    switch (pixelFormat) {
+    case PixelFormat::RGBA8:
+    case PixelFormat::BGRA8:
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    case PixelFormat::RGBA16F:
+#endif
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+
 RefPtr<PixelBuffer> ImageBuffer::getPixelBuffer(const PixelBufferFormat& destinationFormat, const IntRect& sourceRect, const ImageBufferAllocator& allocator) const
 {
-    ASSERT(PixelBuffer::supportedPixelFormat(destinationFormat.pixelFormat));
+    ASSERT(supportedPixelBufferFormats(destinationFormat.pixelFormat));
     auto sourceRectScaled = sourceRect;
     sourceRectScaled.scale(resolutionScale());
     auto destination = allocator.createPixelBuffer(destinationFormat, sourceRectScaled.size());

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -142,6 +142,9 @@ public:
     WEBCORE_EXPORT static IntSize calculateBackendSize(FloatSize logicalSize, float resolutionScale);
     WEBCORE_EXPORT static ImageBufferBackendParameters backendParameters(const Parameters&);
 
+    // Supported get, putPixelBuffer formats.
+    WEBCORE_EXPORT static bool NODELETE supportedPixelBufferFormats(PixelFormat);
+
     // These functions are used when clamping the ImageBuffer which is created for filter, masker or clipper.
     static bool sizeNeedsClamping(const FloatSize&);
     static bool sizeNeedsClamping(const FloatSize&, FloatSize& scale);

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -75,7 +75,7 @@ public:
 #if USE(CG)
     WEBCORE_EXPORT static RefPtr<NativeImage> create(RetainPtr<CVPixelBufferRef>, CGImageAlphaInfo, RetainPtr<CGColorSpaceRef>);
 #endif
-    WEBCORE_EXPORT static RefPtr<NativeImage> create(Ref<PixelBuffer>&&, bool hasAlpha);
+    WEBCORE_EXPORT static RefPtr<NativeImage> create(Ref<PixelBuffer>&&);
 
     WEBCORE_EXPORT virtual ~NativeImage();
 

--- a/Source/WebCore/platform/graphics/PixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/PixelBuffer.cpp
@@ -35,21 +35,23 @@ namespace WebCore {
 bool PixelBuffer::supportedPixelFormat(PixelFormat pixelFormat)
 {
     switch (pixelFormat) {
+    case PixelFormat::RGBX8:
     case PixelFormat::RGBA8:
+    case PixelFormat::BGRX8:
     case PixelFormat::BGRA8:
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
     case PixelFormat::RGBA16F:
 #endif
         return true;
 
-    case PixelFormat::BGRX8:
 #if ENABLE(PIXEL_FORMAT_RGB10)
     case PixelFormat::RGB10:
+        return false;
 #endif
 #if ENABLE(PIXEL_FORMAT_RGB10A8)
     case PixelFormat::RGB10A8:
-#endif
         return false;
+#endif
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -48,128 +48,42 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 
-template <auto... values>
-struct CountPackedEnums {
-    static constexpr unsigned count = sizeof...(values);
+namespace {
 
-    static_assert(count, "There must be at least one enum value.");
-    static_assert(std::ranges::equal(std::views::iota(0U, count), std::array { static_cast<unsigned>(values)... }), "Enum values must be 0..(count-1).");
-};
+enum class AlphaFormat : uint8_t { Opaque, Unpremultiplied, Premultiplied };
 
-using ConvertImagePixelsFunction = bool (*)(const ConstPixelBufferConversionView&, const PixelBufferConversionView&, const IntSize&);
-
-template <typename ConvertImagePixelsFunctionGetter>
-class ConvertImagePixelsFunctionTable {
-public:
-    consteval ConvertImagePixelsFunctionTable() : m_table(createTable()) { }
-
-    constexpr bool invoke(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize) const
-    {
-        unsigned sourceAlpha = static_cast<unsigned>(source.format.alphaFormat);
-        if (sourceAlpha >= alphaFormatCount)
-            return false;
-        unsigned sourcePixelFormat = static_cast<unsigned>(source.format.pixelFormat);
-        if (sourcePixelFormat >= pixelFormatCount)
-            return false;
-        unsigned destinationAlpha = static_cast<unsigned>(destination.format.alphaFormat);
-        if (destinationAlpha >= alphaFormatCount)
-            return false;
-        unsigned destinationPixelFormat = static_cast<unsigned>(destination.format.pixelFormat);
-        if (destinationPixelFormat >= pixelFormatCount)
-            return false;
-
-        return m_table[sourceAlpha][sourcePixelFormat][destinationAlpha][destinationPixelFormat](source, destination, destinationSize);
-    }
-
-private:
-    static constexpr unsigned alphaFormatCount = ConvertImagePixelsFunctionGetter::alphaFormatCount;
-    static constexpr unsigned pixelFormatCount = ConvertImagePixelsFunctionGetter::pixelFormatCount;
-
-    using TableDepth4 = std::array<ConvertImagePixelsFunction, pixelFormatCount>;
-    using TableDepth3 = std::array<TableDepth4, alphaFormatCount>;
-    using TableDepth2 = std::array<TableDepth3, pixelFormatCount>;
-    using Table = std::array<TableDepth2, alphaFormatCount>;
-
-    template <AlphaPremultiplication sourceAlphaPremultiplication, PixelFormat sourcePixelFormat, AlphaPremultiplication destinationAlphaPremultiplication, PixelFormat destinationPixelFormat>
-    static consteval ConvertImagePixelsFunction selectTableFunction()
-    {
-        // gcc error on the static_assert: "the address of
-        // ‘bool WebCore::convertImagePixelsUnacceleratedFunction(const ConstPixelBufferConversionView&, const PixelBufferConversionView&, const IntSize&) [with AlphaPremultiplication sourceAlphaPremultiplication = AlphaPremultiplication::Unpremultiplied; PixelFormat sourcePixelFormat = PixelFormat::BGRX8; AlphaPremultiplication destinationAlphaPremultiplication = AlphaPremultiplication::Unpremultiplied; PixelFormat destinationPixelFormat = PixelFormat::RGBA8]’
-        // will never be null [-Werror=address]"
-        // But that's just looking at a single instantiation which obviously returns a non-null function pointer in that case.
-        // We still want to make sure that stays true for all instantiations if the external ConvertImagePixelsFunctionGetter ever changes.
-IGNORE_GCC_WARNINGS_BEGIN("address")
-        static_assert(ConvertImagePixelsFunctionGetter::template selectFunction<sourceAlphaPremultiplication, sourcePixelFormat, destinationAlphaPremultiplication, destinationPixelFormat>(), "A non-null ConvertImagePixelsFunction must be provided for all combinations of template arguments");
-IGNORE_GCC_WARNINGS_END
-        return ConvertImagePixelsFunctionGetter::template selectFunction<sourceAlphaPremultiplication, sourcePixelFormat, destinationAlphaPremultiplication, destinationPixelFormat>();
-    }
-
-    template <AlphaPremultiplication sourceAlphaPremultiplication, PixelFormat sourcePixelFormat, AlphaPremultiplication destinationAlphaPremultiplication, uint8_t... is>
-    static consteval TableDepth4 createTableDepth4(std::integer_sequence<uint8_t, is...>)
-    {
-        TableDepth4 table;
-        ((table[is] = selectTableFunction<sourceAlphaPremultiplication, sourcePixelFormat, destinationAlphaPremultiplication, static_cast<PixelFormat>(is)>()), ...);
-        return table;
-    }
-
-    template <AlphaPremultiplication sourceAlphaPremultiplication, PixelFormat sourcePixelFormat, uint8_t... is>
-    static consteval TableDepth3 createTableDepth3(std::integer_sequence<uint8_t, is...>)
-    {
-        TableDepth3 table;
-        ((table[is] = createTableDepth4<sourceAlphaPremultiplication, sourcePixelFormat, static_cast<AlphaPremultiplication>(is) >(std::make_integer_sequence<uint8_t, pixelFormatCount>())), ...);
-        return table;
-    }
-
-    template <AlphaPremultiplication sourceAlphaPremultiplication, uint8_t... is>
-    static consteval TableDepth2 createTableDepth2(std::integer_sequence<uint8_t, is...>)
-    {
-        TableDepth2 table;
-        ((table[is] = createTableDepth3<sourceAlphaPremultiplication, static_cast<PixelFormat>(is)>(std::make_integer_sequence<uint8_t, alphaFormatCount>())), ...);
-        return table;
-    }
-
-    template <uint8_t... is>
-    static consteval Table createTableDepth1(std::integer_sequence<uint8_t, is...>)
-    {
-        Table table;
-        ((table[is] = createTableDepth2<static_cast<AlphaPremultiplication>(is)>(std::make_integer_sequence<uint8_t, pixelFormatCount>())), ...);
-        return table;
-    }
-
-    static consteval Table createTable()
-    {
-        return createTableDepth1(std::make_integer_sequence<uint8_t, alphaFormatCount>());
-    }
-
-    Table m_table;
-};
-
-static bool NODELETE copyImagePixels(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
+// Whether the color components already have the alpha applied to them.
+constexpr bool isAlphaApplied(AlphaFormat alphaFormat)
 {
-    ASSERT(source.format.pixelFormat == destination.format.pixelFormat || (source.format.pixelFormat == PixelFormat::BGRA8 && destination.format.pixelFormat == PixelFormat::BGRX8));
-    size_t bytesPerRow = static_cast<size_t>(destinationSize.width()) * PixelBuffer::bytesPerPixel(destination.format.pixelFormat);
-
-    if (bytesPerRow == source.bytesPerRow && bytesPerRow == destination.bytesPerRow) {
-        memcpySpan(destination.rows, source.rows.first(bytesPerRow * destinationSize.height()));
-        return true;
-    }
-
-    for (int y = 0; y < destinationSize.height(); ++y) {
-        auto sourceRow = source.rows.subspan(source.bytesPerRow * y);
-        auto destinationRow = destination.rows.subspan(destination.bytesPerRow * y);
-        memcpySpan(destinationRow, sourceRow.first(bytesPerRow));
-    }
-    return true;
+    return alphaFormat != AlphaFormat::Unpremultiplied;
 }
 
-#if ENABLE(PIXEL_FORMAT_RGBA16F) && !(USE(ACCELERATE) && USE(CG))
-// PixelFormat::RGBA16F is only enabled under HAVE(SUPPORT_HDR_DISPLAY), which is Cocoa-only, and
-// PLATFORM(COCOA) implies both USE(CG) and USE(ACCELERATE). RGBA16F conversions are therefore
-// handled entirely by convertImagePixelsAccelerated(), and the unaccelerated single-pixel functions
-// below only ever see 8-bits-per-component formats. If RGBA16F is ever enabled somewhere without
-// ACCELERATE or CG, those functions need to grow 16-bits-per-component variants.
-#error "PixelFormat::RGBA16F requires USE(ACCELERATE) && USE(CG)."
+constexpr AlphaFormat toAlphaFormat(AlphaPremultiplication alphaFormat, PixelFormat pixelFormat)
+{
+    if (pixelFormatIsOpaque(pixelFormat))
+        return AlphaFormat::Opaque;
+    if (alphaFormat == AlphaPremultiplication::Premultiplied)
+        return AlphaFormat::Premultiplied;
+    return AlphaFormat::Unpremultiplied;
+}
+
+}
+
+static bool NODELETE isSupportedConversionFormat(PixelFormat pixelFormat)
+{
+    switch (pixelFormat) {
+    case PixelFormat::RGBX8:
+    case PixelFormat::RGBA8:
+    case PixelFormat::BGRX8:
+    case PixelFormat::BGRA8:
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    case PixelFormat::RGBA16F:
 #endif
+        return true;
+    default:
+        return false;
+    }
+}
 
 #if USE(ACCELERATE) && USE(CG)
 
@@ -177,18 +91,21 @@ static inline vImage_CGImageFormat makeVImageCGImageFormat(const PixelBufferForm
 {
     auto [bitsPerComponent, bitsPerPixel, bitmapInfo] = [] (const PixelBufferFormat& format) -> std::tuple<decltype(vImage_CGImageFormat::bitsPerComponent), decltype(vImage_CGImageFormat::bitsPerPixel), CGBitmapInfo> {
         switch (format.pixelFormat) {
+        case PixelFormat::RGBX8:
+            return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Big) | static_cast<CGBitmapInfo>(kCGImageAlphaNoneSkipLast));
+
         case PixelFormat::RGBA8:
             if (format.alphaFormat == AlphaPremultiplication::Premultiplied)
                 return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Big) | static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedLast));
             return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Big) | static_cast<CGBitmapInfo>(kCGImageAlphaLast));
 
+        case PixelFormat::BGRX8:
+            return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(kCGImageAlphaNoneSkipFirst));
+
         case PixelFormat::BGRA8:
             if (format.alphaFormat == AlphaPremultiplication::Premultiplied)
                 return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedFirst));
             return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(kCGImageAlphaFirst));
-
-        case PixelFormat::BGRX8:
-            return std::make_tuple(8u, 32u, static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(kCGImageAlphaNoneSkipFirst));
 
 #if ENABLE(PIXEL_FORMAT_RGB10)
         case PixelFormat::RGB10:
@@ -265,43 +182,56 @@ static bool convertImagePixelsAcceleratedAnyToAny(const ConstPixelBufferConversi
     return true;
 }
 
-template <PixelFormat sourcePixelFormat, AlphaPremultiplication sourceAlphaPremultiplication, PixelFormat destinationPixelFormat, AlphaPremultiplication destinationAlphaPremultiplication>
-static bool convertImagePixelsAcceleratedDifferentFormats(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
+static bool convertImagePixelsAcceleratedMatchingSize(const ConstPixelBufferConversionView& sourceView, const PixelBufferConversionView& destinationView, const IntSize& destinationSize)
 {
-    static_assert(PixelBuffer::bytesPerPixelComponent(sourcePixelFormat) == PixelBuffer::bytesPerPixelComponent(destinationPixelFormat));
-    static_assert(!(pixelFormatIsOpaque(sourcePixelFormat) && sourceAlphaPremultiplication != AlphaPremultiplication::Premultiplied));
-    static_assert(!(sourcePixelFormat == PixelFormat::BGRX8 && destinationPixelFormat != PixelFormat::BGRX8));
-    static_assert(sourcePixelFormat != destinationPixelFormat || sourceAlphaPremultiplication != destinationAlphaPremultiplication);
-    static_assert(!(sourcePixelFormat == PixelFormat::BGRA8 && destinationPixelFormat == PixelFormat::BGRX8 && sourceAlphaPremultiplication == destinationAlphaPremultiplication));
+    auto sourceVImageBuffer = makeVImageBuffer(sourceView, destinationSize);
+    auto destinationVImageBuffer = makeVImageBuffer(destinationView, destinationSize);
 
-    auto sourceVImageBuffer = makeVImageBuffer(source, destinationSize);
-    auto destinationVImageBuffer = makeVImageBuffer(destination, destinationSize);
+    bool swapComponentOrder = pixelComponentOrder(sourceView.format.pixelFormat) != pixelComponentOrder(destinationView.format.pixelFormat);
+    auto sourceAlphaFormat = toAlphaFormat(sourceView.format.alphaFormat, sourceView.format.pixelFormat);
+    auto destinationAlphaFormat = toAlphaFormat(destinationView.format.alphaFormat, destinationView.format.pixelFormat);
 
-    if constexpr (sourceAlphaPremultiplication != destinationAlphaPremultiplication) {
+    if (sourceAlphaFormat == AlphaFormat::Opaque) {
+        // The component an opaque source has in place of alpha holds no meaningful value, so it must
+        // not be carried over. Insert an opaque alpha and possibly reorder.
+        constexpr std::array<uint8_t, 4> identityMap { 0, 1, 2, 3 };
+        constexpr std::array<uint8_t, 4> swappedMap { 2, 1, 0, 3 };
+        constexpr uint8_t lastChannelMask = 0x1; // 0x8 is the first of the four channels, 0x1 the last.
+        constexpr std::array<uint8_t, 4> opaqueAlpha { 0, 0, 0, 255 };
+        vImagePermuteChannelsWithMaskedInsert_ARGB8888(&sourceVImageBuffer, &destinationVImageBuffer, swapComponentOrder ? swappedMap.data() : identityMap.data(), lastChannelMask, opaqueAlpha.data(), kvImageNoFlags);
+        return true;
+    }
+
+    if (isAlphaApplied(sourceAlphaFormat) != isAlphaApplied(destinationAlphaFormat)) {
+        bool shouldUnpremultiply = !isAlphaApplied(destinationAlphaFormat);
+        switch (sourceView.format.pixelFormat) {
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
-        if constexpr (sourcePixelFormat == PixelFormat::RGBA16F) {
-            if constexpr (destinationAlphaPremultiplication == AlphaPremultiplication::Unpremultiplied)
+        case PixelFormat::RGBA16F:
+            if (shouldUnpremultiply)
                 vImageUnpremultiplyData_RGBA16F(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
             else
                 vImagePremultiplyData_RGBA16F(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
-        } else
+            break;
 #endif
-        if constexpr (destinationAlphaPremultiplication == AlphaPremultiplication::Unpremultiplied) {
-            if constexpr (sourcePixelFormat == PixelFormat::RGBA8)
+        case PixelFormat::RGBA8:
+            if (shouldUnpremultiply)
                 vImageUnpremultiplyData_RGBA8888(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
             else
-                vImageUnpremultiplyData_BGRA8888(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
-        } else {
-            if constexpr (sourcePixelFormat == PixelFormat::RGBA8)
                 vImagePremultiplyData_RGBA8888(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
+            break;
+        default:
+            ASSERT(sourceView.format.pixelFormat == PixelFormat::BGRA8);
+            if (shouldUnpremultiply)
+                vImageUnpremultiplyData_BGRA8888(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
             else
                 vImagePremultiplyData_BGRA8888(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
+            break;
         }
 
         sourceVImageBuffer = destinationVImageBuffer;
     }
 
-    if constexpr (pixelComponentOrder(sourcePixelFormat) != pixelComponentOrder(destinationPixelFormat)) {
+    if (swapComponentOrder) {
         constexpr std::array<uint8_t, 4> map { 2, 1, 0, 3 };
         vImagePermuteChannels_ARGB8888(&sourceVImageBuffer, &destinationVImageBuffer, map.data(), kvImageNoFlags);
     }
@@ -309,46 +239,13 @@ static bool convertImagePixelsAcceleratedDifferentFormats(const ConstPixelBuffer
     return true;
 }
 
-struct ConvertImagePixelsAcceleratedFunctions {
-    static constexpr unsigned alphaFormatCount = CountPackedEnums<AlphaPremultiplication::Premultiplied, AlphaPremultiplication::Unpremultiplied>::count;
-
-    static constexpr unsigned pixelFormatCount = CountPackedEnums<
-        PixelFormat::RGBA8, PixelFormat::BGRX8, PixelFormat::BGRA8
-#if ENABLE(PIXEL_FORMAT_RGBA16F)
-    , PixelFormat::RGBA16F
-#endif
-    >::count;
-
-    template <AlphaPremultiplication sourceAlphaPremultiplication, PixelFormat sourcePixelFormat, AlphaPremultiplication destinationAlphaPremultiplication, PixelFormat destinationPixelFormat>
-    static consteval ConvertImagePixelsFunction selectFunction()
-    {
-        if constexpr (sourcePixelFormat == destinationPixelFormat && sourceAlphaPremultiplication == destinationAlphaPremultiplication)
-            return copyImagePixels;
-        else if constexpr(sourcePixelFormat == destinationPixelFormat && pixelFormatIsOpaque(sourcePixelFormat) && pixelFormatIsOpaque(destinationPixelFormat))
-            return copyImagePixels;
-        else if constexpr (PixelBuffer::bytesPerPixelComponent(sourcePixelFormat) != PixelBuffer::bytesPerPixelComponent(destinationPixelFormat))
-            return convertImagePixelsAcceleratedAnyToAny;
-        else if constexpr (pixelFormatIsOpaque(destinationPixelFormat) && destinationAlphaPremultiplication == AlphaPremultiplication::Unpremultiplied)
-            return selectFunction<sourceAlphaPremultiplication, sourcePixelFormat, AlphaPremultiplication::Premultiplied, destinationPixelFormat>(); // If the destination is opaque, consider it premultiplied so that the source will be premultiplied as well to apply its alpha.
-        else if constexpr (pixelFormatIsOpaque(sourcePixelFormat) && sourceAlphaPremultiplication != destinationAlphaPremultiplication)
-            return selectFunction<destinationAlphaPremultiplication, sourcePixelFormat, destinationAlphaPremultiplication, destinationPixelFormat>(); // If the source is opaque (its alpha is effectively 255), just pretend that it's the same alpha format as the destination, as premultiplying or unpremultiplying wouldn't have any actual effect on color components.
-        else if constexpr (sourcePixelFormat == PixelFormat::BGRX8 && destinationPixelFormat != PixelFormat::BGRX8)
-            return convertImagePixelsAcceleratedAnyToAny;
-        else if constexpr (sourcePixelFormat == PixelFormat::BGRA8 && destinationPixelFormat == PixelFormat::BGRX8 && sourceAlphaPremultiplication == destinationAlphaPremultiplication)
-            return copyImagePixels;
-        else
-            return convertImagePixelsAcceleratedDifferentFormats<sourcePixelFormat, sourceAlphaPremultiplication, destinationPixelFormat, destinationAlphaPremultiplication>;
-    }
-};
-
-static constexpr ConvertImagePixelsFunctionTable<ConvertImagePixelsAcceleratedFunctions> convertImagePixelsFunctionTable;
-
-static bool convertImagePixelsAccelerated(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
+static bool platformConvertImagePixels(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
 {
-    if (source.format.colorSpace != destination.format.colorSpace)
-        return convertImagePixelsAcceleratedAnyToAny(source, destination, destinationSize);
+    if (source.format.colorSpace == destination.format.colorSpace
+        && PixelBuffer::bytesPerPixelComponent(source.format.pixelFormat) == PixelBuffer::bytesPerPixelComponent(destination.format.pixelFormat))
+        return convertImagePixelsAcceleratedMatchingSize(source, destination, destinationSize);
 
-    return convertImagePixelsFunctionTable.invoke(source, destination, destinationSize);
+    return convertImagePixelsAcceleratedAnyToAny(source, destination, destinationSize);
 }
 
 #elif USE(SKIA)
@@ -406,6 +303,11 @@ static bool convertImagePixelsSkia(const ConstPixelBufferConversionView& source,
 #endif // USE(SKIA)
 
 #if !(USE(ACCELERATE) && USE(CG))
+
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+#error "PixelFormat::RGBA16F unimplemented."
+#endif
+
 static constexpr uint8_t NODELETE premultiply(uint8_t unpremultiplied, uint8_t alpha)
 {
     // Same as vImagePremultiplyData_ARGB8888: (src * alpha + 127) / 255
@@ -418,31 +320,31 @@ static constexpr uint8_t NODELETE unpremultiply(uint8_t premultiplied, uint8_t a
     return (std::min(premultiplied, alpha) * 255 + alpha / 2) / alpha;
 }
 
-template <AlphaPremultiplication sourceAlphaPremultiplication, PixelFormat sourcePixelFormat, AlphaPremultiplication destinationAlphaPremultiplication, PixelFormat destinationPixelFormat>
-static bool NODELETE convertImagePixelsUnacceleratedFunction(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
+template <AlphaFormat sourceAlphaFormat, AlphaFormat destinationAlphaFormat, bool swapComponentOrder>
+static bool NODELETE convertImagePixelsUnacceleratedFunction(const ConstPixelBufferConversionView& sourceView, const PixelBufferConversionView& destinationView, const IntSize& destinationSize)
 {
-    static_assert(PixelBuffer::bytesPerPixelComponent(sourcePixelFormat) == 1);
-    static_assert(PixelBuffer::bytesPerPixel(sourcePixelFormat) == 4);
-    static_assert(PixelBuffer::bytesPerPixelComponent(destinationPixelFormat) == 1);
-    static_assert(PixelBuffer::bytesPerPixel(destinationPixelFormat) == 4);
+    // The caller has established that both formats are 8 bits per component, 4 bytes per pixel, with
+    // the alpha (or the ignored component that takes its place) in the last byte.
+    constexpr bool sourceAlphaApplied = isAlphaApplied(sourceAlphaFormat);
+    constexpr bool destinationAlphaApplied = isAlphaApplied(destinationAlphaFormat);
 
     size_t bytesPerRow = destinationSize.width() * 4;
     for (int y = 0; y < destinationSize.height(); ++y) {
-        auto sourceRow = source.rows.subspan(source.bytesPerRow * y);
-        auto destinationRow = destination.rows.subspan(destination.bytesPerRow * y);
+        auto sourceRow = sourceView.rows.subspan(sourceView.bytesPerRow * y);
+        auto destinationRow = destinationView.rows.subspan(destinationView.bytesPerRow * y);
         for (size_t x = 0; x < bytesPerRow; x += 4) {
             uint8_t alpha;
-            if constexpr (pixelFormatIsOpaque(sourcePixelFormat))
+            if constexpr (sourceAlphaFormat == AlphaFormat::Opaque)
                 alpha = 255;
             else
                 alpha = sourceRow[x + 3];
 
             uint8_t c0, c1, c2;
-            if constexpr (sourceAlphaPremultiplication == AlphaPremultiplication::Unpremultiplied && destinationAlphaPremultiplication == AlphaPremultiplication::Unpremultiplied) {
+            if constexpr (!sourceAlphaApplied && !destinationAlphaApplied) {
                 c0 = sourceRow[x + 0];
                 c1 = sourceRow[x + 1];
                 c2 = sourceRow[x + 2];
-            } else if constexpr (sourceAlphaPremultiplication == AlphaPremultiplication::Premultiplied && destinationAlphaPremultiplication == AlphaPremultiplication::Premultiplied) {
+            } else if constexpr (sourceAlphaApplied && destinationAlphaApplied) {
                 if (!alpha) {
                     c0 = 0;
                     c1 = 0;
@@ -452,7 +354,7 @@ static bool NODELETE convertImagePixelsUnacceleratedFunction(const ConstPixelBuf
                     c1 = sourceRow[x + 1];
                     c2 = sourceRow[x + 2];
                 }
-            } else if constexpr (sourceAlphaPremultiplication == AlphaPremultiplication::Premultiplied && destinationAlphaPremultiplication == AlphaPremultiplication::Unpremultiplied) {
+            } else if constexpr (sourceAlphaApplied && !destinationAlphaApplied) {
                 if (!alpha) {
                     c0 = 0;
                     c1 = 0;
@@ -467,7 +369,7 @@ static bool NODELETE convertImagePixelsUnacceleratedFunction(const ConstPixelBuf
                     c2 = unpremultiply(sourceRow[x + 2], alpha);
                 }
             } else {
-                static_assert(sourceAlphaPremultiplication == AlphaPremultiplication::Unpremultiplied && destinationAlphaPremultiplication == AlphaPremultiplication::Premultiplied);
+                static_assert(!sourceAlphaApplied && destinationAlphaApplied);
                 if (!alpha) {
                     c0 = 0;
                     c1 = 0;
@@ -483,7 +385,7 @@ static bool NODELETE convertImagePixelsUnacceleratedFunction(const ConstPixelBuf
                 }
             }
 
-            if constexpr (pixelComponentOrder(sourcePixelFormat) == pixelComponentOrder(destinationPixelFormat)) {
+            if constexpr (!swapComponentOrder) {
                 destinationRow[x + 0] = c0;
                 destinationRow[x + 1] = c1;
                 destinationRow[x + 2] = c2;
@@ -493,7 +395,7 @@ static bool NODELETE convertImagePixelsUnacceleratedFunction(const ConstPixelBuf
                 destinationRow[x + 2] = c0;
             }
 
-            if constexpr (!pixelFormatIsOpaque(destinationPixelFormat))
+            if constexpr (destinationAlphaFormat != AlphaFormat::Opaque)
                 destinationRow[x + 3] = alpha;
             else
                 destinationRow[x + 3] = 255; // Not strictly necessary, but this prevent exposing uninitialized memory.
@@ -503,57 +405,74 @@ static bool NODELETE convertImagePixelsUnacceleratedFunction(const ConstPixelBuf
     return true;
 }
 
-struct ConvertImagePixelsUnacceleratedFunctions {
-    static constexpr unsigned alphaFormatCount = CountPackedEnums<AlphaPremultiplication::Premultiplied, AlphaPremultiplication::Unpremultiplied>::count;
-
-    static constexpr unsigned pixelFormatCount = CountPackedEnums<PixelFormat::RGBA8, PixelFormat::BGRX8, PixelFormat::BGRA8>::count;
-
-    template <AlphaPremultiplication sourceAlphaPremultiplication, PixelFormat sourcePixelFormat, AlphaPremultiplication destinationAlphaPremultiplication, PixelFormat destinationPixelFormat>
-    static consteval ConvertImagePixelsFunction selectFunction()
-    {
-        static_assert(PixelBuffer::bytesPerPixelComponent(sourcePixelFormat) == PixelBuffer::bytesPerPixelComponent(destinationPixelFormat));
-
-        if constexpr (sourcePixelFormat == destinationPixelFormat && sourceAlphaPremultiplication == destinationAlphaPremultiplication)
-            return copyImagePixels;
-        else if constexpr(sourcePixelFormat == destinationPixelFormat && pixelFormatIsOpaque(sourcePixelFormat) && pixelFormatIsOpaque(destinationPixelFormat))
-            return copyImagePixels;
-        else if constexpr (pixelFormatIsOpaque(destinationPixelFormat) && destinationAlphaPremultiplication == AlphaPremultiplication::Unpremultiplied)
-            return selectFunction<sourceAlphaPremultiplication, sourcePixelFormat, AlphaPremultiplication::Premultiplied, destinationPixelFormat>(); // If the destination is opaque, consider it premultiplied so that the source will be premultiplied as well to apply its alpha.
-        else if constexpr (pixelFormatIsOpaque(sourcePixelFormat) && sourceAlphaPremultiplication != destinationAlphaPremultiplication)
-            return selectFunction<destinationAlphaPremultiplication, sourcePixelFormat, destinationAlphaPremultiplication, destinationPixelFormat>(); // If the source is opaque (its alpha is effectively 255), just pretend that it's the same alpha format as the destination, as premultiplying or unpremultiplying wouldn't have any actual effect on color components.
-        else
-            return convertImagePixelsUnacceleratedFunction<sourceAlphaPremultiplication, sourcePixelFormat, destinationAlphaPremultiplication, destinationPixelFormat>;
-    }
-};
-
-static constexpr ConvertImagePixelsFunctionTable<ConvertImagePixelsUnacceleratedFunctions> convertImagePixelsFunctionTable;
-
-static bool convertImagePixelsUnaccelerated(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
+template <bool swapComponentOrder>
+static bool convertImagePixelsUnacceleratedSelectAlphaFormats(AlphaFormat sourceAlphaFormat, AlphaFormat destinationAlphaFormat, const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
 {
+    using enum AlphaFormat;
+
+    switch (sourceAlphaFormat) {
+    case Opaque:
+        switch (destinationAlphaFormat) {
+        case Opaque:
+            return convertImagePixelsUnacceleratedFunction<Opaque, Opaque, swapComponentOrder>(source, destination, destinationSize);
+        case Unpremultiplied:
+            return convertImagePixelsUnacceleratedFunction<Opaque, Unpremultiplied, swapComponentOrder>(source, destination, destinationSize);
+        case Premultiplied:
+            return convertImagePixelsUnacceleratedFunction<Opaque, Premultiplied, swapComponentOrder>(source, destination, destinationSize);
+        }
+        break;
+    case Unpremultiplied:
+        switch (destinationAlphaFormat) {
+        case Opaque:
+            return convertImagePixelsUnacceleratedFunction<Unpremultiplied, Opaque, swapComponentOrder>(source, destination, destinationSize);
+        case Unpremultiplied:
+            return convertImagePixelsUnacceleratedFunction<Unpremultiplied, Unpremultiplied, swapComponentOrder>(source, destination, destinationSize);
+        case Premultiplied:
+            return convertImagePixelsUnacceleratedFunction<Unpremultiplied, Premultiplied, swapComponentOrder>(source, destination, destinationSize);
+        }
+        break;
+    case Premultiplied:
+        switch (destinationAlphaFormat) {
+        case Opaque:
+            return convertImagePixelsUnacceleratedFunction<Premultiplied, Opaque, swapComponentOrder>(source, destination, destinationSize);
+        case Unpremultiplied:
+            return convertImagePixelsUnacceleratedFunction<Premultiplied, Unpremultiplied, swapComponentOrder>(source, destination, destinationSize);
+        case Premultiplied:
+            return convertImagePixelsUnacceleratedFunction<Premultiplied, Premultiplied, swapComponentOrder>(source, destination, destinationSize);
+        }
+        break;
+    }
+
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
+static bool platformConvertImagePixels(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
+{
+#if USE(SKIA)
+    if (convertImagePixelsSkia(source, destination, destinationSize))
+        return true;
+#endif
+
     // FIXME: We don't currently support converting pixel data between different color spaces in the non-accelerated path.
     // This could be added using conversion functions from ColorConversion.h.
-    ASSERT(source.format.colorSpace == destination.format.colorSpace);
+    if (source.format.colorSpace != destination.format.colorSpace)
+        return false;
 
-    return convertImagePixelsFunctionTable.invoke(source, destination, destinationSize);
+    // Without ACCELERATE and CG there are no 16-bits-per-component formats, so every supported format
+    // is 8 bits per component and 4 bytes per pixel, which is what the conversion loop assumes.
+    ASSERT(PixelBuffer::bytesPerPixel(source.format.pixelFormat) == 4);
+    ASSERT(PixelBuffer::bytesPerPixel(destination.format.pixelFormat) == 4);
+
+    auto sourceAlphaFormat = toAlphaFormat(source.format.alphaFormat, source.format.pixelFormat);
+    auto destinationAlphaFormat = toAlphaFormat(destination.format.alphaFormat, destination.format.pixelFormat);
+    if (pixelComponentOrder(source.format.pixelFormat) != pixelComponentOrder(destination.format.pixelFormat))
+        return convertImagePixelsUnacceleratedSelectAlphaFormats<true>(sourceAlphaFormat, destinationAlphaFormat, source, destination, destinationSize);
+    return convertImagePixelsUnacceleratedSelectAlphaFormats<false>(sourceAlphaFormat, destinationAlphaFormat, source, destination, destinationSize);
 }
 #endif // !(USE(ACCELERATE) && USE(CG))
 
-static bool UNUSED_FUNCTION NODELETE isSupportedConversionFormat(PixelFormat pixelFormat)
-{
-    switch (pixelFormat) {
-    case PixelFormat::RGBA8:
-    case PixelFormat::BGRA8:
-    case PixelFormat::BGRX8:
-#if ENABLE(PIXEL_FORMAT_RGBA16F)
-    case PixelFormat::RGBA16F:
-#endif
-        return true;
-    default:
-        return false;
-    }
-}
-
-#if ENABLE(PIXEL_FORMAT_RGBA16F)
+// The rows the conversion reads and writes have to be inside the buffer the view describes.
 template<typename View>
 static bool NODELETE hasEnoughBytesForConversion(const View& view, const IntSize& destinationSize)
 {
@@ -564,7 +483,6 @@ static bool NODELETE hasEnoughBytesForConversion(const View& view, const IntSize
     requiredBytes += CheckedSize { static_cast<size_t>(destinationSize.width()) } * PixelBuffer::bytesPerPixel(view.format.pixelFormat);
     return !requiredBytes.hasOverflowed() && view.rows.size_bytes() >= requiredBytes.value();
 }
-#endif
 
 static void zeroImagePixels(const PixelBufferConversionView& destination, const IntSize& destinationSize)
 {
@@ -573,36 +491,46 @@ static void zeroImagePixels(const PixelBufferConversionView& destination, const 
         zeroSpan(destination.rows.subspan(static_cast<size_t>(y) * destination.bytesPerRow, rowFillBytes));
 }
 
+// Whether the contents can be copied verbatim, i.e. the two formats store the same components at
+// the same offsets, and the components already relate to the alpha the way the destination
+// describes. An opaque destination drops the alpha of the source, which gives the right color only
+// if the source has applied it to its color components already.
+static bool canCopyPixels(const PixelBufferFormat& sourceFormat, const PixelBufferFormat& destinationFormat)
+{
+    auto sourceAlphaFormat = toAlphaFormat(sourceFormat.alphaFormat, sourceFormat.pixelFormat);
+    auto destinationAlphaFormat = toAlphaFormat(destinationFormat.alphaFormat, destinationFormat.pixelFormat);
+#if USE(SKIA)
+    // Skia has no native BGRX color type, so the component a BGRX8 destination has in place of
+    // alpha is not ignored. Only contents that are opaque themselves can be copied into it.
+    if (destinationFormat.pixelFormat == PixelFormat::BGRX8 && sourceAlphaFormat != AlphaFormat::Opaque)
+        return false;
+#endif
+    return sourceFormat.colorSpace == destinationFormat.colorSpace
+        && PixelBuffer::bytesPerPixelComponent(sourceFormat.pixelFormat) == PixelBuffer::bytesPerPixelComponent(destinationFormat.pixelFormat)
+        && pixelComponentOrder(sourceFormat.pixelFormat) == pixelComponentOrder(destinationFormat.pixelFormat)
+        && (sourceAlphaFormat == destinationAlphaFormat || (sourceAlphaFormat == AlphaFormat::Premultiplied && destinationAlphaFormat == AlphaFormat::Opaque));
+}
+
 void convertImagePixels(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
 {
-    // We currently only support converting between RGBA8, BGRA8, BGRX8, and (where enabled) RGBA16F.
+    // We currently only support converting between RGBA8, BGRA8, RGBX8, BGRX8, and (where enabled) RGBA16F.
     ASSERT(isSupportedConversionFormat(source.format.pixelFormat));
     ASSERT(isSupportedConversionFormat(destination.format.pixelFormat));
 
-#if ENABLE(PIXEL_FORMAT_RGBA16F)
-    if (source.format.pixelFormat == PixelFormat::RGBA16F)
-        RELEASE_ASSERT(hasEnoughBytesForConversion(source, destinationSize), "Source buffer is too small for the requested conversion");
-    if (destination.format.pixelFormat == PixelFormat::RGBA16F)
-        RELEASE_ASSERT(hasEnoughBytesForConversion(destination, destinationSize), "Destination buffer is too small for the requested conversion");
-#endif
+    RELEASE_ASSERT(hasEnoughBytesForConversion(source, destinationSize), "Source buffer is too small for the requested conversion");
+    RELEASE_ASSERT(hasEnoughBytesForConversion(destination, destinationSize), "Destination buffer is too small for the requested conversion");
 
-#if USE(ACCELERATE) && USE(CG)
-    if (!convertImagePixelsAccelerated(source, destination, destinationSize))
-        zeroImagePixels(destination, destinationSize);
-#else
-    if (source.format.alphaFormat == destination.format.alphaFormat && source.format.pixelFormat == destination.format.pixelFormat && source.format.colorSpace == destination.format.colorSpace) {
-        copyImagePixels(source, destination, destinationSize);
-        return;
+    if (isSupportedConversionFormat(source.format.pixelFormat) && isSupportedConversionFormat(destination.format.pixelFormat)) {
+        if (canCopyPixels(source.format, destination.format)) {
+            copyRowsInternal(source.bytesPerRow, source.rows, destination.bytesPerRow, destination.rows, destinationSize.height(), destinationSize.width() * PixelBuffer::bytesPerPixel(destination.format.pixelFormat));
+            return;
+        }
+
+        if (platformConvertImagePixels(source, destination, destinationSize))
+            return;
     }
-#if USE(SKIA)
-    if (convertImagePixelsSkia(source, destination, destinationSize))
-        return;
-#endif
-    // FIXME: In Linux platform the following paths could be optimized with ORC.
 
-    if (!convertImagePixelsUnaccelerated(source, destination, destinationSize))
-        zeroImagePixels(destination, destinationSize);
-#endif
+    zeroImagePixels(destination, destinationSize);
 }
 
 void copyRowsInternal(unsigned sourceBytesPerRow, std::span<const uint8_t> source, unsigned destinationBytesPerRow, std::span<uint8_t> destination, unsigned rows, unsigned copyBytesPerRow)

--- a/Source/WebCore/platform/graphics/PixelFormat.cpp
+++ b/Source/WebCore/platform/graphics/PixelFormat.cpp
@@ -33,6 +33,9 @@ namespace WebCore {
 TextStream& operator<<(TextStream& ts, PixelFormat pixelFormat)
 {
     switch (pixelFormat) {
+    case PixelFormat::RGBX8:
+        ts << "RGBX8"_s;
+        break;
     case PixelFormat::RGBA8:
         ts << "RGBA8"_s;
         break;

--- a/Source/WebCore/platform/graphics/PixelFormat.h
+++ b/Source/WebCore/platform/graphics/PixelFormat.h
@@ -32,6 +32,7 @@
 namespace WebCore {
 
 enum class PixelFormat : uint8_t {
+    RGBX8,
     RGBA8,
     BGRX8,
     BGRA8,
@@ -51,6 +52,7 @@ enum class UseLosslessCompression : bool { No, Yes };
 constexpr ContentsFormat convertToContentsFormat(PixelFormat format)
 {
     switch (format) {
+    case PixelFormat::RGBX8:
     case PixelFormat::RGBA8:
     case PixelFormat::BGRX8:
     case PixelFormat::BGRA8:
@@ -76,6 +78,7 @@ constexpr ContentsFormat convertToContentsFormat(PixelFormat format)
 constexpr bool pixelFormatIsOpaque(PixelFormat format)
 {
     switch (format) {
+    case PixelFormat::RGBX8:
     case PixelFormat::BGRX8:
 #if ENABLE(PIXEL_FORMAT_RGB10)
     case PixelFormat::RGB10:
@@ -115,6 +118,7 @@ enum class AllowExtendedColorSpace : bool { No, Yes };
 constexpr AllowExtendedColorSpace allowExtendedColorSpace(PixelFormat format)
 {
     switch (format) {
+    case PixelFormat::RGBX8:
     case PixelFormat::RGBA8:
     case PixelFormat::BGRX8:
     case PixelFormat::BGRA8:

--- a/Source/WebCore/platform/graphics/TypedArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TypedArrayPixelBuffer.cpp
@@ -118,7 +118,7 @@ RefPtr<PixelBuffer> TypedArrayPixelBuffer<pixelBufferType, JSCTypedArrayAdaptor,
     return TypedArrayPixelBuffer::tryCreate(format(), size);
 }
 
-template class TypedArrayPixelBuffer<PixelBuffer::Type::ByteArray, JSC::Uint8ClampedAdaptor, PixelFormat::RGBA8, PixelFormat::BGRA8>;
+template class TypedArrayPixelBuffer<PixelBuffer::Type::ByteArray, JSC::Uint8ClampedAdaptor, PixelFormat::RGBX8, PixelFormat::RGBA8, PixelFormat::BGRX8, PixelFormat::BGRA8>;
 
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
 template class TypedArrayPixelBuffer<PixelBuffer::Type::Float16Array, JSC::Float16Adaptor, PixelFormat::RGBA16F>;

--- a/Source/WebCore/platform/graphics/TypedArrayPixelBuffer.h
+++ b/Source/WebCore/platform/graphics/TypedArrayPixelBuffer.h
@@ -53,8 +53,8 @@ private:
     TypedArrayPixelBuffer(const PixelBufferFormat&, const IntSize&, Ref<JSCTypedArray>&&);
 };
 
-using ByteArrayPixelBuffer = TypedArrayPixelBuffer<WebCore::PixelBuffer::Type::ByteArray, JSC::Uint8ClampedAdaptor, PixelFormat::RGBA8, PixelFormat::BGRA8>;
-extern template class TypedArrayPixelBuffer<WebCore::PixelBuffer::Type::ByteArray, JSC::Uint8ClampedAdaptor, PixelFormat::RGBA8, PixelFormat::BGRA8>;
+using ByteArrayPixelBuffer = TypedArrayPixelBuffer<WebCore::PixelBuffer::Type::ByteArray, JSC::Uint8ClampedAdaptor, PixelFormat::RGBX8, PixelFormat::RGBA8, PixelFormat::BGRX8, PixelFormat::BGRA8>;
+extern template class TypedArrayPixelBuffer<WebCore::PixelBuffer::Type::ByteArray, JSC::Uint8ClampedAdaptor, PixelFormat::RGBX8, PixelFormat::RGBA8, PixelFormat::BGRX8, PixelFormat::BGRA8>;
 
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
 using Float16ArrayPixelBuffer = TypedArrayPixelBuffer<PixelBuffer::Type::Float16Array, JSC::Float16Adaptor, PixelFormat::RGBA16F>;

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -370,7 +370,8 @@ bool GraphicsContextGLANGLE::releaseThreadResources(ReleaseThreadResourceBehavio
 RefPtr<PixelBuffer> GraphicsContextGLANGLE::readPixelsForPaintResults()
 {
     auto alphaFormat = contextAttributes().premultipliedAlpha ? AlphaPremultiplication::Premultiplied : AlphaPremultiplication::Unpremultiplied;
-    PixelBufferFormat format { alphaFormat, PixelFormat::RGBA8, ColorSpace::SRGB() };
+    auto pixelFormat = contextAttributes().alpha ? PixelFormat::RGBA8 : PixelFormat::RGBX8;
+    PixelBufferFormat format { alphaFormat, pixelFormat, ColorSpace::SRGB() };
     auto pixelBuffer = ByteArrayPixelBuffer::tryCreate(format, getInternalFramebufferSize());
     if (!pixelBuffer)
         return nullptr;
@@ -3467,7 +3468,7 @@ static void flipPixelBufferRows(PixelBuffer& pixelBuffer)
 {
     if (pixelBuffer.size().isEmpty())
         return;
-    ASSERT(pixelBuffer.format().pixelFormat == PixelFormat::RGBA8 || pixelBuffer.format().pixelFormat == PixelFormat::BGRA8);
+    ASSERT(PixelBuffer::bytesPerPixel(pixelBuffer.format().pixelFormat) == 4);
     // FIXME: Make PixelBufferConversions support negative rowBytes and in-place conversions.
     size_t rowStride = pixelBuffer.size().width() * 4;
     auto rowBuffer = MallocSpan<uint8_t>::malloc(rowStride);
@@ -3495,7 +3496,7 @@ RefPtr<NativeImage> GraphicsContextGLANGLE::copyNativeImage(SurfaceBuffer source
         return nullptr;
     // The first row of the read results is the bottom row of the image.
     flipPixelBufferRows(*pixelBuffer);
-    return NativeImage::create(pixelBuffer.releaseNonNull(), contextAttributes().alpha);
+    return NativeImage::create(pixelBuffer.releaseNonNull());
 }
 
 RefPtr<PixelBuffer> GraphicsContextGLANGLE::readRenderingResultsForPainting()

--- a/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp
@@ -38,34 +38,40 @@
 
 namespace WebCore {
 
-RefPtr<NativeImage> NativeImage::create(Ref<PixelBuffer>&& pixelBuffer, bool hasAlpha)
+RefPtr<NativeImage> NativeImage::create(Ref<PixelBuffer>&& pixelBuffer)
 {
     if (pixelBuffer->size().isEmpty())
         return nullptr;
     auto format = pixelBuffer->format();
+    bool hasAlpha = !pixelFormatIsOpaque(format.pixelFormat);
     // The cairo image surface formats are BGRA (CAIRO_FORMAT_ARGB32) and BGRX
     // (CAIRO_FORMAT_RGB24) on little-endian architectures, so contents that have their
     // components in the RGBA order are converted in place.
     bool needsComponentSwap = false;
     switch (format.pixelFormat) {
+    case PixelFormat::RGBX8:
     case PixelFormat::RGBA8:
         needsComponentSwap = true;
         break;
+    case PixelFormat::BGRX8:
     case PixelFormat::BGRA8:
         needsComponentSwap = false;
         break;
-    case PixelFormat::BGRX8:
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
     case PixelFormat::RGBA16F:
+        // cairo has no image surface format for the 16 bit float components.
+        return nullptr;
 #endif
 #if ENABLE(PIXEL_FORMAT_RGB10)
     case PixelFormat::RGB10:
+        ASSERT(!PixelBuffer::supportedPixelFormat(format.pixelFormat));
+        return nullptr;
 #endif
 #if ENABLE(PIXEL_FORMAT_RGB10A8)
     case PixelFormat::RGB10A8:
-#endif
         ASSERT(!PixelBuffer::supportedPixelFormat(format.pixelFormat));
         return nullptr;
+#endif
     }
 
     size_t totalBytes = pixelBuffer->bytes().size();

--- a/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/NativeImageCG.cpp
@@ -182,21 +182,17 @@ RefPtr<NativeImage> NativeImage::create(RetainPtr<CVPixelBufferRef> pixelBuffer,
     return NativeImage::create(WTF::move(image));
 }
 
-static CGImageAlphaInfo alphaInfoForAlphaLast(bool hasAlpha, bool isPremultiplied)
+static CGImageAlphaInfo alphaInfoForAlphaLast(bool isPremultiplied)
 {
-    if (!hasAlpha)
-        return kCGImageAlphaNoneSkipLast;
     return isPremultiplied ? kCGImageAlphaPremultipliedLast : kCGImageAlphaLast;
 }
 
-static CGImageAlphaInfo alphaInfoForAlphaFirst(bool hasAlpha, bool isPremultiplied)
+static CGImageAlphaInfo alphaInfoForAlphaFirst(bool isPremultiplied)
 {
-    if (!hasAlpha)
-        return kCGImageAlphaNoneSkipFirst;
     return isPremultiplied ? kCGImageAlphaPremultipliedFirst : kCGImageAlphaFirst;
 }
 
-RefPtr<NativeImage> NativeImage::create(Ref<PixelBuffer>&& pixelBuffer, bool hasAlpha)
+RefPtr<NativeImage> NativeImage::create(Ref<PixelBuffer>&& pixelBuffer)
 {
     if (pixelBuffer->size().isEmpty())
         return nullptr;
@@ -206,26 +202,33 @@ RefPtr<NativeImage> NativeImage::create(Ref<PixelBuffer>&& pixelBuffer, bool has
     // BGRA == kCGBitmapByteOrder32Little | kCGImageAlpha*First
     CGBitmapInfo bitmapInfo;
     switch (format.pixelFormat) {
+    case PixelFormat::RGBX8:
+        bitmapInfo = static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Big) | static_cast<CGBitmapInfo>(kCGImageAlphaNoneSkipLast);
+        break;
     case PixelFormat::RGBA8:
-        bitmapInfo = static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Big) | static_cast<CGBitmapInfo>(alphaInfoForAlphaLast(hasAlpha, isPremultiplied));
+        bitmapInfo = static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Big) | static_cast<CGBitmapInfo>(alphaInfoForAlphaLast(isPremultiplied));
+        break;
+    case PixelFormat::BGRX8:
+        bitmapInfo = static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(kCGImageAlphaNoneSkipFirst);
         break;
     case PixelFormat::BGRA8:
-        bitmapInfo = static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(alphaInfoForAlphaFirst(hasAlpha, isPremultiplied));
+        bitmapInfo = static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(alphaInfoForAlphaFirst(isPremultiplied));
         break;
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
     case PixelFormat::RGBA16F:
-        bitmapInfo = static_cast<CGBitmapInfo>(kCGBitmapByteOrder16Host) | static_cast<CGBitmapInfo>(kCGBitmapFloatComponents) | static_cast<CGBitmapInfo>(alphaInfoForAlphaLast(hasAlpha, isPremultiplied));
+        bitmapInfo = static_cast<CGBitmapInfo>(kCGBitmapByteOrder16Host) | static_cast<CGBitmapInfo>(kCGBitmapFloatComponents) | static_cast<CGBitmapInfo>(alphaInfoForAlphaLast(isPremultiplied));
         break;
 #endif
-    case PixelFormat::BGRX8:
 #if ENABLE(PIXEL_FORMAT_RGB10)
     case PixelFormat::RGB10:
+        ASSERT(!PixelBuffer::supportedPixelFormat(format.pixelFormat));
+        return nullptr;
 #endif
 #if ENABLE(PIXEL_FORMAT_RGB10A8)
     case PixelFormat::RGB10A8:
-#endif
         ASSERT(!PixelBuffer::supportedPixelFormat(format.pixelFormat));
         return nullptr;
+#endif
     }
 
     auto imageSize = pixelBuffer->size();

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -309,6 +309,8 @@ std::optional<IOSurface::Locker<Mode>> IOSurface::lock()
 constexpr IOSurface::Format convertToIOSurfaceFormat(PixelFormat format)
 {
     switch (format) {
+    case PixelFormat::RGBX8:
+        return IOSurface::Format::RGBX;
     case PixelFormat::RGBA8:
         return IOSurface::Format::RGBA;
     case PixelFormat::BGRX8:

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -407,6 +407,9 @@ RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<Pixel
 
     GstVideoFormat format;
     switch (pixelBuffer->format().pixelFormat) {
+    case PixelFormat::RGBX8:
+        format = GST_VIDEO_FORMAT_RGBx;
+        break;
     case PixelFormat::RGBA8:
         format = GST_VIDEO_FORMAT_RGBA;
         break;

--- a/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
@@ -56,15 +56,23 @@ RefPtr<NativeImage> NativeImage::createTransient(PlatformImagePtr&& platformImag
     return create(WTF::move(platformImage), grContext);
 }
 
-RefPtr<NativeImage> NativeImage::create(Ref<PixelBuffer>&& pixelBuffer, bool hasAlpha)
+RefPtr<NativeImage> NativeImage::create(Ref<PixelBuffer>&& pixelBuffer)
 {
     if (pixelBuffer->size().isEmpty())
         return nullptr;
     auto format = pixelBuffer->format();
     SkColorType colorType = kRGBA_8888_SkColorType;
     switch (format.pixelFormat) {
+    case PixelFormat::RGBX8:
+        colorType = kRGB_888x_SkColorType;
+        break;
     case PixelFormat::RGBA8:
         colorType = kRGBA_8888_SkColorType;
+        break;
+    case PixelFormat::BGRX8:
+        // Skia has no BGR color type with an ignored fourth component, so the contents are
+        // described as BGRA and the alpha component is required to be 255, see below.
+        colorType = kBGRA_8888_SkColorType;
         break;
     case PixelFormat::BGRA8:
         colorType = kBGRA_8888_SkColorType;
@@ -74,19 +82,22 @@ RefPtr<NativeImage> NativeImage::create(Ref<PixelBuffer>&& pixelBuffer, bool has
         colorType = kRGBA_F16_SkColorType;
         break;
 #endif
-    case PixelFormat::BGRX8:
 #if ENABLE(PIXEL_FORMAT_RGB10)
     case PixelFormat::RGB10:
+        ASSERT(!PixelBuffer::supportedPixelFormat(format.pixelFormat));
+        return nullptr;
 #endif
 #if ENABLE(PIXEL_FORMAT_RGB10A8)
     case PixelFormat::RGB10A8:
-#endif
         ASSERT(!PixelBuffer::supportedPixelFormat(format.pixelFormat));
         return nullptr;
+#endif
     }
     auto imageSize = pixelBuffer->size();
+    // kRGB_888x_SkColorType ignores the fourth component, but kBGRA_8888_SkColorType does not, so
+    // BGRX8 contents are required to have 255 in the component that holds no meaningful value.
     SkAlphaType alphaType = kUnpremul_SkAlphaType;
-    if (!hasAlpha)
+    if (pixelFormatIsOpaque(format.pixelFormat))
         alphaType = kOpaque_SkAlphaType;
     else if (format.alphaFormat == AlphaPremultiplication::Premultiplied)
         alphaType = kPremul_SkAlphaType;

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -108,7 +108,7 @@ void RemoteImageBuffer::getPixelBuffer(WebCore::PixelBufferFormat destinationFor
     assertIsCurrent(workQueue());
     auto memory = m_renderingBackend->sharedMemoryForGetPixelBuffer();
     MESSAGE_CHECK(memory, "No shared memory for getPixelBufferForImageBuffer");
-    MESSAGE_CHECK(WebCore::PixelBuffer::supportedPixelFormat(destinationFormat.pixelFormat), "Pixel format not supported");
+    MESSAGE_CHECK(WebCore::ImageBuffer::supportedPixelBufferFormats(destinationFormat.pixelFormat), "Pixel format not supported");
     MESSAGE_CHECK(m_imageBuffer->renderingMode() != RenderingMode::PDFDocument && m_imageBuffer->renderingMode() != RenderingMode::DisplayList, "Backend does not hold pixels");
     MESSAGE_CHECK(m_imageBuffer->renderingPurpose() != RenderingPurpose::LayerBacking, "We should not interact with the pixelBuffer for LayerBacking");
     WebCore::IntRect srcRect(srcPoint, srcSize);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1622,6 +1622,7 @@ enum class WebCore::AlphaPremultiplication : uint8_t {
 };
 
 enum class WebCore::PixelFormat : uint8_t {
+    RGBX8,
     RGBA8,
     BGRX8,
     BGRA8,

--- a/Tools/TestWebKitAPI/Tests/WebCore/NativeImageTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/NativeImageTests.cpp
@@ -45,10 +45,6 @@ using namespace WebCore;
 
 namespace {
 
-// The ways the contents of a pixel buffer can describe their alpha. Premultiplication does not
-// apply to contents that are drawn as opaque, so there are three cases and not four.
-enum class AlphaMode : uint8_t { NoAlpha, Unpremultiplied, Premultiplied };
-
 // A quadrant of the test pattern and the unpremultiplied color it is filled with. The
 // components of the color are the contents of the pixel buffer, so they are interpreted in the
 // color space of the buffer.
@@ -105,6 +101,7 @@ static const DrawTarget g_drawTargets[] = {
 #endif
 #if USE(CG)
     { RenderingMode::Accelerated, PixelFormat::BGRX8, false, "Accelerated_BGRX8"_s },
+    { RenderingMode::Accelerated, PixelFormat::RGBX8, false, "Accelerated_RGBX8"_s },
 #if ENABLE(PIXEL_FORMAT_RGB10)
     { RenderingMode::Accelerated, PixelFormat::RGB10, false, "Accelerated_RGB10"_s },
 #endif
@@ -114,12 +111,14 @@ static const DrawTarget g_drawTargets[] = {
 #endif
 };
 
-// The pixel formats NativeImage::create(Ref<PixelBuffer>&&, bool) supports. The other formats
-// are rejected instead of being drawn with the components in the wrong order.
+// The pixel formats NativeImage::create(Ref<PixelBuffer>&&) supports. The other formats are
+// rejected instead of being drawn with the components in the wrong order.
 static bool isSupportedImagePixelFormat(PixelFormat pixelFormat)
 {
     switch (pixelFormat) {
+    case PixelFormat::RGBX8:
     case PixelFormat::RGBA8:
+    case PixelFormat::BGRX8:
     case PixelFormat::BGRA8:
         return true;
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
@@ -138,13 +137,14 @@ static bool isSupportedImagePixelFormat(PixelFormat pixelFormat)
 
 // Fills the pixel buffer with the test pattern, storing the components in the order and with the
 // premultiplication that the format of the buffer specifies.
-static void fillTestPattern(PixelBuffer& pixelBuffer, std::span<const TestPattern> testPattern, bool hasAlpha)
+static void fillTestPattern(PixelBuffer& pixelBuffer, std::span<const TestPattern> testPattern)
 {
     auto format = pixelBuffer.format();
     auto size = pixelBuffer.size();
     auto bytes = pixelBuffer.bytes();
     auto bytesPerPixel = PixelBuffer::bytesPerPixel(format.pixelFormat);
-    bool isPremultiplied = format.alphaFormat == AlphaPremultiplication::Premultiplied;
+    bool hasAlpha = !pixelFormatIsOpaque(format.pixelFormat);
+    bool isPremultiplied = hasAlpha && format.alphaFormat == AlphaPremultiplication::Premultiplied;
     bool storeOpaqueAlpha = false;
     if (!hasAlpha) {
         // Skia requires the contents of an image without alpha to be opaque, while
@@ -205,14 +205,11 @@ static Color expectedColor(const Color& patternColor, bool imageHasAlpha)
 
 // NativeImage test fixture for tests that are variant to the format of the pixel buffer the
 // image is created from.
-class AnyPixelBufferFormatTest : public testing::TestWithParam<std::tuple<PixelFormat, AlphaMode>> {
+class AnyPixelBufferFormatTest : public testing::TestWithParam<std::tuple<PixelFormat, AlphaPremultiplication>> {
 protected:
     PixelFormat pixelFormat() const { return std::get<0>(GetParam()); }
-    AlphaMode alphaMode() const { return std::get<1>(GetParam()); }
-    bool hasAlpha() const { return alphaMode() != AlphaMode::NoAlpha; }
-    // How the contents of the pixel buffer describe their alpha. Without alpha the contents are
-    // drawn as opaque, so premultiplication does not apply to them.
-    AlphaPremultiplication alphaFormat() const { return alphaMode() == AlphaMode::Premultiplied ? AlphaPremultiplication::Premultiplied : AlphaPremultiplication::Unpremultiplied; }
+    bool hasAlpha() const { return !pixelFormatIsOpaque(pixelFormat()); }
+    AlphaPremultiplication alphaFormat() const { return std::get<1>(GetParam()); }
     RefPtr<PixelBuffer> createPixelBuffer(const IntSize&, const ColorSpace&) const;
     RefPtr<PixelBuffer> createTestPatternPixelBuffer(const IntSize&, const ColorSpace&, std::span<const TestPattern>) const;
 };
@@ -229,20 +226,20 @@ RefPtr<PixelBuffer> AnyPixelBufferFormatTest::createTestPatternPixelBuffer(const
     if (!pixelBuffer)
         return nullptr;
     if (isSupportedImagePixelFormat(pixelFormat()))
-        fillTestPattern(*pixelBuffer, testPattern, hasAlpha());
+        fillTestPattern(*pixelBuffer, testPattern);
     return pixelBuffer;
 }
 
 // Test that a NativeImage created from a PixelBuffer draws the contents of the buffer,
 // interpreting the component order and the alpha of the contents the way the format of the
-// buffer and the hasAlpha argument describe them.
+// buffer describes them.
 TEST_P(AnyPixelBufferFormatTest, CreateFromPixelBufferDraws)
 {
     constexpr IntSize testSize { 16, 16 };
     RefPtr pixelBuffer = createTestPatternPixelBuffer(testSize, ColorSpace::SRGB(), std::span { g_testPattern });
     ASSERT_NE(pixelBuffer, nullptr);
 
-    RefPtr image = NativeImage::create(pixelBuffer.releaseNonNull(), hasAlpha());
+    RefPtr image = NativeImage::create(pixelBuffer.releaseNonNull());
     if (!isSupportedImagePixelFormat(pixelFormat())) {
         EXPECT_EQ(image, nullptr);
         return;
@@ -256,6 +253,10 @@ TEST_P(AnyPixelBufferFormatTest, CreateFromPixelBufferDraws)
         SCOPED_TRACE(target.name.characters());
         auto buffer = ImageBuffer::create(testSize, target.renderingMode, RenderingPurpose::Unspecified, 1.f, ColorSpace::SRGB(), target.pixelFormat);
         ASSERT_NE(buffer, nullptr);
+        // ImageBuffer::create() falls back to another backend if the requested one cannot be had,
+        // which would silently drop the coverage this target is here for.
+        EXPECT_EQ(buffer->renderingMode(), target.renderingMode);
+        EXPECT_EQ(buffer->pixelFormat(), target.pixelFormat);
         buffer->context().drawNativeImage(*image, FloatRect { { }, testSize }, FloatRect { { }, testSize }, { CompositeOperator::Copy });
         for (auto& pattern : g_testPattern) {
             auto expected = expectedColor(pattern.color, hasAlpha());
@@ -279,7 +280,7 @@ TEST_P(AnyPixelBufferFormatTest, CreateFromEmptyPixelBufferFails)
         SCOPED_TRACE(::testing::Message() << "size: " << size.width() << "x" << size.height());
         RefPtr pixelBuffer = createPixelBuffer(size, ColorSpace::SRGB());
         ASSERT_NE(pixelBuffer, nullptr);
-        EXPECT_EQ(NativeImage::create(pixelBuffer.releaseNonNull(), hasAlpha()), nullptr);
+        EXPECT_EQ(NativeImage::create(pixelBuffer.releaseNonNull()), nullptr);
     }
 }
 
@@ -304,7 +305,7 @@ TEST_P(AnyPixelBufferFormatTest, CreateFromPixelBufferUsesPixelBufferColorSpace)
     RefPtr pixelBuffer = createTestPatternPixelBuffer(testSize, ColorSpace::DisplayP3(), std::span { g_displayP3TestPattern });
     ASSERT_NE(pixelBuffer, nullptr);
 
-    RefPtr image = NativeImage::create(pixelBuffer.releaseNonNull(), hasAlpha());
+    RefPtr image = NativeImage::create(pixelBuffer.releaseNonNull());
     ASSERT_NE(image, nullptr);
     EXPECT_TRUE(image->colorSpace() == ColorSpace::DisplayP3());
 
@@ -315,6 +316,10 @@ TEST_P(AnyPixelBufferFormatTest, CreateFromPixelBufferUsesPixelBufferColorSpace)
         SCOPED_TRACE(target.name.characters());
         auto buffer = ImageBuffer::create(testSize, target.renderingMode, RenderingPurpose::Unspecified, 1.f, ColorSpace::SRGB(), target.pixelFormat);
         ASSERT_NE(buffer, nullptr);
+        // ImageBuffer::create() falls back to another backend if the requested one cannot be had,
+        // which would silently drop the coverage this target is here for.
+        EXPECT_EQ(buffer->renderingMode(), target.renderingMode);
+        EXPECT_EQ(buffer->pixelFormat(), target.pixelFormat);
         buffer->context().drawNativeImage(*image, FloatRect { { }, testSize }, FloatRect { { }, testSize }, { CompositeOperator::Copy });
         for (auto& pattern : g_displayP3TestPattern) {
             auto rect = pattern.unitRect;
@@ -328,11 +333,17 @@ TEST_P(AnyPixelBufferFormatTest, CreateFromPixelBufferUsesPixelBufferColorSpace)
 
 static std::string anyPixelBufferFormatTestName(const testing::TestParamInfo<AnyPixelBufferFormatTest::ParamType>& info)
 {
-    auto [pixelFormat, alphaMode] = info.param;
+    auto [pixelFormat, alphaFormat] = info.param;
     std::string name;
     switch (pixelFormat) {
+    case PixelFormat::RGBX8:
+        name = "RGBX8";
+        break;
     case PixelFormat::RGBA8:
         name = "RGBA8";
+        break;
+    case PixelFormat::BGRX8:
+        name = "BGRX8";
         break;
     case PixelFormat::BGRA8:
         name = "BGRA8";
@@ -346,14 +357,11 @@ static std::string anyPixelBufferFormatTestName(const testing::TestParamInfo<Any
         name = "UnknownPixelFormat";
         break;
     }
-    switch (alphaMode) {
-    case AlphaMode::NoAlpha:
-        name += "_NoAlpha";
-        break;
-    case AlphaMode::Unpremultiplied:
+    switch (alphaFormat) {
+    case AlphaPremultiplication::Unpremultiplied:
         name += "_Unpremultiplied";
         break;
-    case AlphaMode::Premultiplied:
+    case AlphaPremultiplication::Premultiplied:
         name += "_Premultiplied";
         break;
     }
@@ -361,13 +369,13 @@ static std::string anyPixelBufferFormatTestName(const testing::TestParamInfo<Any
 }
 
 // The pixel formats a PixelBuffer can have. The formats without a pixel buffer representation,
-// e.g. BGRX8, cannot be tested as sources.
+// e.g. RGB10, cannot be tested as sources.
 static auto testedPixelFormats()
 {
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
-    return testing::Values(PixelFormat::RGBA8, PixelFormat::BGRA8, PixelFormat::RGBA16F);
+    return testing::Values(PixelFormat::RGBX8, PixelFormat::RGBA8, PixelFormat::BGRX8, PixelFormat::BGRA8, PixelFormat::RGBA16F);
 #else
-    return testing::Values(PixelFormat::RGBA8, PixelFormat::BGRA8);
+    return testing::Values(PixelFormat::RGBX8, PixelFormat::RGBA8, PixelFormat::BGRX8, PixelFormat::BGRA8);
 #endif
 }
 
@@ -375,7 +383,7 @@ INSTANTIATE_TEST_SUITE_P(NativeImageTests,
     AnyPixelBufferFormatTest,
     testing::Combine(
         testedPixelFormats(),
-        testing::Values(AlphaMode::NoAlpha, AlphaMode::Unpremultiplied, AlphaMode::Premultiplied)),
+        testing::Values(AlphaPremultiplication::Unpremultiplied, AlphaPremultiplication::Premultiplied)),
     anyPixelBufferFormatTestName);
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/PixelBufferConversionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PixelBufferConversionTests.cpp
@@ -84,6 +84,11 @@ TEST(PixelBufferConversionTests, convertImagePixels)
     EXPECT_EQ(convert(PixelFormat::RGBA8, AlphaPremultiplication::Premultiplied, PixelFormat::BGRX8, AlphaPremultiplication::Premultiplied), reorderedBytesOpaque);
     EXPECT_EQ(convert(PixelFormat::RGBA8, AlphaPremultiplication::Premultiplied, PixelFormat::BGRX8, AlphaPremultiplication::Unpremultiplied), reorderedBytesOpaque);
 
+    EXPECT_EQ(convert(PixelFormat::RGBA8, AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBX8, AlphaPremultiplication::Unpremultiplied), orderedBytesOpaque);
+    EXPECT_EQ(convert(PixelFormat::RGBA8, AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBX8, AlphaPremultiplication::Premultiplied), orderedBytesOpaque);
+    EXPECT_EQ(convert(PixelFormat::RGBA8, AlphaPremultiplication::Premultiplied, PixelFormat::RGBX8, AlphaPremultiplication::Premultiplied), orderedBytesOpaque);
+    EXPECT_EQ(convert(PixelFormat::RGBA8, AlphaPremultiplication::Premultiplied, PixelFormat::RGBX8, AlphaPremultiplication::Unpremultiplied), orderedBytesOpaque);
+
     EXPECT_EQ(convert(PixelFormat::BGRA8, AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, AlphaPremultiplication::Unpremultiplied), orderedBytesUnpremultiplied);
     EXPECT_EQ(convert(PixelFormat::BGRA8, AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, AlphaPremultiplication::Premultiplied), orderedBytesPremultiplied);
     EXPECT_EQ(convert(PixelFormat::BGRA8, AlphaPremultiplication::Premultiplied, PixelFormat::BGRA8, AlphaPremultiplication::Premultiplied), orderedBytesPremultiplied);
@@ -99,6 +104,11 @@ TEST(PixelBufferConversionTests, convertImagePixels)
     EXPECT_EQ(convert(PixelFormat::BGRA8, AlphaPremultiplication::Premultiplied, PixelFormat::BGRX8, AlphaPremultiplication::Premultiplied), orderedBytesOpaque);
     EXPECT_EQ(convert(PixelFormat::BGRA8, AlphaPremultiplication::Premultiplied, PixelFormat::BGRX8, AlphaPremultiplication::Unpremultiplied), orderedBytesOpaque);
 
+    EXPECT_EQ(convert(PixelFormat::BGRA8, AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBX8, AlphaPremultiplication::Unpremultiplied), reorderedBytesOpaque);
+    EXPECT_EQ(convert(PixelFormat::BGRA8, AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBX8, AlphaPremultiplication::Premultiplied), reorderedBytesOpaque);
+    EXPECT_EQ(convert(PixelFormat::BGRA8, AlphaPremultiplication::Premultiplied, PixelFormat::RGBX8, AlphaPremultiplication::Premultiplied), reorderedBytesOpaque);
+    EXPECT_EQ(convert(PixelFormat::BGRA8, AlphaPremultiplication::Premultiplied, PixelFormat::RGBX8, AlphaPremultiplication::Unpremultiplied), reorderedBytesOpaque);
+
     EXPECT_EQ(convert(PixelFormat::BGRX8, AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRX8, AlphaPremultiplication::Unpremultiplied), orderedBytesOpaque);
     EXPECT_EQ(convert(PixelFormat::BGRX8, AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRX8, AlphaPremultiplication::Premultiplied), orderedBytesOpaque);
     EXPECT_EQ(convert(PixelFormat::BGRX8, AlphaPremultiplication::Premultiplied, PixelFormat::BGRX8, AlphaPremultiplication::Premultiplied), orderedBytesOpaque);
@@ -113,13 +123,38 @@ TEST(PixelBufferConversionTests, convertImagePixels)
     EXPECT_EQ(convert(PixelFormat::BGRX8, AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, AlphaPremultiplication::Premultiplied), reorderedBytesOpaqueAlpha);
     EXPECT_EQ(convert(PixelFormat::BGRX8, AlphaPremultiplication::Premultiplied, PixelFormat::RGBA8, AlphaPremultiplication::Premultiplied), reorderedBytesOpaqueAlpha);
     EXPECT_EQ(convert(PixelFormat::BGRX8, AlphaPremultiplication::Premultiplied, PixelFormat::RGBA8, AlphaPremultiplication::Unpremultiplied), reorderedBytesOpaqueAlpha);
+
+    EXPECT_EQ(convert(PixelFormat::BGRX8, AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBX8, AlphaPremultiplication::Unpremultiplied), reorderedBytesOpaque);
+    EXPECT_EQ(convert(PixelFormat::BGRX8, AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBX8, AlphaPremultiplication::Premultiplied), reorderedBytesOpaque);
+    EXPECT_EQ(convert(PixelFormat::BGRX8, AlphaPremultiplication::Premultiplied, PixelFormat::RGBX8, AlphaPremultiplication::Premultiplied), reorderedBytesOpaque);
+    EXPECT_EQ(convert(PixelFormat::BGRX8, AlphaPremultiplication::Premultiplied, PixelFormat::RGBX8, AlphaPremultiplication::Unpremultiplied), reorderedBytesOpaque);
+
+    EXPECT_EQ(convert(PixelFormat::RGBX8, AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBX8, AlphaPremultiplication::Unpremultiplied), orderedBytesOpaque);
+    EXPECT_EQ(convert(PixelFormat::RGBX8, AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBX8, AlphaPremultiplication::Premultiplied), orderedBytesOpaque);
+    EXPECT_EQ(convert(PixelFormat::RGBX8, AlphaPremultiplication::Premultiplied, PixelFormat::RGBX8, AlphaPremultiplication::Premultiplied), orderedBytesOpaque);
+    EXPECT_EQ(convert(PixelFormat::RGBX8, AlphaPremultiplication::Premultiplied, PixelFormat::RGBX8, AlphaPremultiplication::Unpremultiplied), orderedBytesOpaque);
+
+    EXPECT_EQ(convert(PixelFormat::RGBX8, AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRX8, AlphaPremultiplication::Unpremultiplied), reorderedBytesOpaque);
+    EXPECT_EQ(convert(PixelFormat::RGBX8, AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRX8, AlphaPremultiplication::Premultiplied), reorderedBytesOpaque);
+    EXPECT_EQ(convert(PixelFormat::RGBX8, AlphaPremultiplication::Premultiplied, PixelFormat::BGRX8, AlphaPremultiplication::Premultiplied), reorderedBytesOpaque);
+    EXPECT_EQ(convert(PixelFormat::RGBX8, AlphaPremultiplication::Premultiplied, PixelFormat::BGRX8, AlphaPremultiplication::Unpremultiplied), reorderedBytesOpaque);
+
+    EXPECT_EQ(convert(PixelFormat::RGBX8, AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, AlphaPremultiplication::Unpremultiplied), orderedBytesOpaqueAlpha);
+    EXPECT_EQ(convert(PixelFormat::RGBX8, AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, AlphaPremultiplication::Premultiplied), orderedBytesOpaqueAlpha);
+    EXPECT_EQ(convert(PixelFormat::RGBX8, AlphaPremultiplication::Premultiplied, PixelFormat::RGBA8, AlphaPremultiplication::Premultiplied), orderedBytesOpaqueAlpha);
+    EXPECT_EQ(convert(PixelFormat::RGBX8, AlphaPremultiplication::Premultiplied, PixelFormat::RGBA8, AlphaPremultiplication::Unpremultiplied), orderedBytesOpaqueAlpha);
+
+    EXPECT_EQ(convert(PixelFormat::RGBX8, AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, AlphaPremultiplication::Unpremultiplied), reorderedBytesOpaqueAlpha);
+    EXPECT_EQ(convert(PixelFormat::RGBX8, AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, AlphaPremultiplication::Premultiplied), reorderedBytesOpaqueAlpha);
+    EXPECT_EQ(convert(PixelFormat::RGBX8, AlphaPremultiplication::Premultiplied, PixelFormat::BGRA8, AlphaPremultiplication::Premultiplied), reorderedBytesOpaqueAlpha);
+    EXPECT_EQ(convert(PixelFormat::RGBX8, AlphaPremultiplication::Premultiplied, PixelFormat::BGRA8, AlphaPremultiplication::Unpremultiplied), reorderedBytesOpaqueAlpha);
 }
 
 TEST(PixelBufferConversionTests, convertImagePixels2)
 {
-    auto convert = [&](PixelFormat sourceFormat, PixelFormat destinationFormat) -> std::vector<uint8_t> {
-        const PixelBufferFormat sourcePixelBufferFormat { AlphaPremultiplication::Unpremultiplied, sourceFormat, ColorSpace::SRGB() };
-        const PixelBufferFormat destinationPixelBufferFormat { AlphaPremultiplication::Unpremultiplied, destinationFormat, ColorSpace::SRGB() };
+    auto convert = [&](PixelFormat sourceFormat, PixelFormat destinationFormat, AlphaPremultiplication alphaFormat = AlphaPremultiplication::Unpremultiplied) -> std::vector<uint8_t> {
+        const PixelBufferFormat sourcePixelBufferFormat { alphaFormat, sourceFormat, ColorSpace::SRGB() };
+        const PixelBufferFormat destinationPixelBufferFormat { alphaFormat, destinationFormat, ColorSpace::SRGB() };
         const std::vector<uint8_t> sourceBytes = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
         std::vector<uint8_t> destinationBytes(8);
         constexpr int sourceBytesPerRow = 8;
@@ -134,6 +169,9 @@ TEST(PixelBufferConversionTests, convertImagePixels2)
 
     EXPECT_EQ(convert(PixelFormat::RGBA8, PixelFormat::RGBA8), (std::vector<uint8_t> { 1, 2, 3, 4, 9, 10, 11, 12 }));
     EXPECT_EQ(convert(PixelFormat::RGBA8, PixelFormat::BGRA8), (std::vector<uint8_t> { 3, 2, 1, 4, 11, 10, 9, 12 }));
+#if !USE(SKIA)
+    EXPECT_EQ(convert(PixelFormat::BGRA8, PixelFormat::BGRX8, AlphaPremultiplication::Premultiplied), (std::vector<uint8_t> { 1, 2, 3, 4, 9, 10, 11, 12 }));
+#endif
 }
 
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
@@ -228,6 +266,34 @@ TEST(PixelBufferConversionTests, convertImagePixelsFloat16ToAndFromByte)
         const std::vector<uint8_t> sourceBytes { 0, 128, 255, 255 };
         std::vector<uint8_t> destinationBytes(4 * sizeof(Float16));
         const ConstPixelBufferConversionView source { { AlphaPremultiplication::Premultiplied, PixelFormat::BGRA8, colorSpace }, u8BytesPerRow, sourceBytes };
+        const PixelBufferConversionView destination { { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA16F, colorSpace }, float16BytesPerRow, destinationBytes };
+
+        convertImagePixels(source, destination, { 1, 1 });
+
+        expectFloat16sNear(float16sFromByteVector(destinationBytes), { 1.0, 128.0 / 255.0, 0.0, 1.0 });
+    }
+
+    // RGBA16F to RGBX8: the components are scaled to [0, 255] and the alpha is dropped. The
+    // contents are premultiplied, so dropping the alpha composites them against black.
+    {
+        const auto sourceBytes = byteVectorFromFloat16s({ 0.5, 0.25, 0.0, 0.5 });
+        std::vector<uint8_t> destinationBytes(4);
+        const ConstPixelBufferConversionView source { { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA16F, colorSpace }, float16BytesPerRow, sourceBytes };
+        const PixelBufferConversionView destination { { AlphaPremultiplication::Premultiplied, PixelFormat::RGBX8, colorSpace }, u8BytesPerRow, destinationBytes };
+
+        convertImagePixels(source, destination, { 1, 1 });
+
+        EXPECT_NEAR(destinationBytes[0], 128U, 1);
+        EXPECT_NEAR(destinationBytes[1], 64U, 1);
+        EXPECT_EQ(destinationBytes[2], 0);
+    }
+
+    // RGBX8 to RGBA16F: the destination gets an opaque alpha, and the component the source has in
+    // place of alpha is ignored rather than read as one.
+    {
+        const std::vector<uint8_t> sourceBytes { 255, 128, 0, 7 };
+        std::vector<uint8_t> destinationBytes(4 * sizeof(Float16));
+        const ConstPixelBufferConversionView source { { AlphaPremultiplication::Premultiplied, PixelFormat::RGBX8, colorSpace }, u8BytesPerRow, sourceBytes };
         const PixelBufferConversionView destination { { AlphaPremultiplication::Premultiplied, PixelFormat::RGBA16F, colorSpace }, float16BytesPerRow, destinationBytes };
 
         convertImagePixels(source, destination, { 1, 1 });


### PR DESCRIPTION
#### 893cb75bec40fc7ef8e4ea2d63a81b9b1de137e4
<pre>
Add PixelFormat::RGBX to support opaque RGB pixel data
<a href="https://bugs.webkit.org/show_bug.cgi?id=323331">https://bugs.webkit.org/show_bug.cgi?id=323331</a>
<a href="https://rdar.apple.com/186573422">rdar://186573422</a>

Reviewed by Gerald Squelart and Sam Weinig.

Makes it possible to represent currently transferred pixel data with
PixelFormat instead of using platform specific types such as
CGBitmapInfo.

Now PixelBufferFormat can fully define the pixel format, with RGBX
marking &quot;skip alpha&quot; for RGB pixel data. Visible in
NativeImage::create(Ref&lt;PixelBuffer&gt;&amp;&amp;) constructor which does not need
redundant hasAlpha parameter.

In this commit, used in
GraphicsContextGLANGLE::readPixelsForPaintResults to capture
alpha=false WebGL context drawing/compositing buffer to NativeImage
on Skia platform.

Simplify PixelBufferConversion.cpp implementation to not have errorprone
template table generation + compiler workarounds. ACCELERATE path
does not need templates at all, since there is no innerloop to optimize.
All function call variants end up if&apos;ed similarly as when templates
removed. Unaccelerated path uses simple linear 16-way switch instead of
64 cell compiletime template table that contained duplicate entries and
error cases (zeroing).

To simplify the &quot;can use&quot; conditions for Accelerate, implement
opaque -&gt; non-opaque 8888 transfer via the specialized function that
sets the alpha to 255. This way there&apos;s no need to convoluted ifs
about source opaque needing to go to AnyToAny + comments explaining
this. This is appropriate for now added RGBX as well as before BGRX.

Tests: Tools/TestWebKitAPI/Tests/WebCore/NativeImageTests.cpp
       Tools/TestWebKitAPI/Tests/WebCore/PixelBufferConversionTests.cpp

* Source/WebCore/platform/graphics/ArrayPixelBuffer.cpp:
(WebCore::ArrayPixelBuffer::tryCreate):
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/PixelBuffer.cpp:
(WebCore::PixelBuffer::supportedPixelFormat):
* Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
(WebCore::canCopyPixelsBetweenFormats):
(WebCore::copyImagePixels):
(WebCore::makeVImageCGImageFormat):
(WebCore::convertImagePixelsAcceleratedDifferentFormats):
(WebCore::ConvertImagePixelsAcceleratedFunctions::selectFunction):
(WebCore::isSupportedConversionFormat):
(WebCore::convertImagePixels):
(WebCore::convertImagePixelsAcceleratedMatchingSize):
(WebCore::platformConvertImagePixels):
(WebCore::convertImagePixelsUnacceleratedFunction):
(WebCore::convertImagePixelsUnacceleratedSelectAlphaFormats):
(WebCore::hasEnoughBytesForConversion):
(WebCore::canCopyPixels):
(WebCore::CountPackedEnums::static_assert): Deleted.
(WebCore::ConvertImagePixelsFunctionTable::ConvertImagePixelsFunctionTable): Deleted.
(WebCore::ConvertImagePixelsFunctionTable::invoke const): Deleted.
(WebCore::ConvertImagePixelsFunctionTable::selectTableFunction): Deleted.
(WebCore::ConvertImagePixelsFunctionTable::createTableDepth4): Deleted.
(WebCore::ConvertImagePixelsFunctionTable::createTableDepth3): Deleted.
(WebCore::ConvertImagePixelsFunctionTable::createTableDepth2): Deleted.
(WebCore::ConvertImagePixelsFunctionTable::createTableDepth1): Deleted.
(WebCore::ConvertImagePixelsFunctionTable::createTable): Deleted.
(WebCore::convertImagePixelsAccelerated): Deleted.
(WebCore::ConvertImagePixelsUnacceleratedFunctions::selectFunction): Deleted.
(WebCore::convertImagePixelsUnaccelerated): Deleted.
* Source/WebCore/platform/graphics/PixelFormat.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/PixelFormat.h:
(WebCore::convertToContentsFormat):
(WebCore::pixelFormatIsOpaque):
(WebCore::allowExtendedColorSpace):
* Source/WebCore/platform/graphics/TypedArrayPixelBuffer.cpp:
* Source/WebCore/platform/graphics/TypedArrayPixelBuffer.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::readPixelsForPaintResults):
(WebCore::flipPixelBufferRows):
(WebCore::GraphicsContextGLANGLE::copyNativeImage):
* Source/WebCore/platform/graphics/cairo/NativeImageCairo.cpp:
(WebCore::NativeImage::create):
* Source/WebCore/platform/graphics/cg/NativeImageCG.cpp:
(WebCore::alphaInfoForAlphaLast):
(WebCore::alphaInfoForAlphaFirst):
(WebCore::NativeImage::create):
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
(WebCore::convertToIOSurfaceFormat):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrameGStreamer::createFromPixelBuffer):
* Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp:
(WebCore::NativeImage::create):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/Tests/WebCore/NativeImageTests.cpp:
(TestWebKitAPI::isSupportedImagePixelFormat):
(TestWebKitAPI::fillTestPattern):
(TestWebKitAPI::AnyPixelBufferFormatTest::hasAlpha const):
(TestWebKitAPI::AnyPixelBufferFormatTest::alphaFormat const):
(TestWebKitAPI::AnyPixelBufferFormatTest::createTestPatternPixelBuffer const):
(TestWebKitAPI::TEST_P):
(TestWebKitAPI::anyPixelBufferFormatTestName):
(TestWebKitAPI::testedPixelFormats):
(TestWebKitAPI::AnyPixelBufferFormatTest::alphaMode const): Deleted.
* Tools/TestWebKitAPI/Tests/WebCore/PixelBufferConversionTests.cpp:
(TestWebKitAPI::TEST(PixelBufferConversionTests, convertImagePixels)):
(TestWebKitAPI::TEST(PixelBufferConversionTests, convertImagePixels2)):
(TestWebKitAPI::TEST(PixelBufferConversionTests, convertImagePixelsFloat16ToAndFromByte)):
* LayoutTests/ipc/create-image-buffer-crash.html:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::supportedPixelBufferFormats):
(WebCore::ImageBuffer::getPixelBuffer const):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::getPixelBuffer):

Canonical link: <a href="https://commits.webkit.org/320656@main">https://commits.webkit.org/320656@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f117379a45d44f99035531710cc35c69a9f8bb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185530 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195853 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b6a1f49-d563-4310-ad1e-6e867c9b1b92) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59168 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/629f214a-dd70-4932-b5c8-fea042f2a729) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48667 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/125285 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3ac57c17-0474-4174-b125-25fbfdfc2c51) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47394 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157761 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45140 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6904 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197803 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59105 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165076 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154519 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41368 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59814 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154166 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48635 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132166 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129065 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58290 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20162 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57663 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57906 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57729 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->