### PR TITLE
AX: In isolated tree mode, a base-appearance select's value lags behind its popover collapsing

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/base-select-option-press-closes-popover.html
+++ b/LayoutTests/accessibility/isolated-tree/base-select-option-press-closes-popover.html
@@ -1,8 +1,8 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
 <html>
 <head>
-<script src="../resources/accessibility-helper.js"></script>
-<script src="../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
 <style>
 select, select::picker(select) {
     appearance: base-select;

--- a/LayoutTests/resources/accessibility-helper.js
+++ b/LayoutTests/resources/accessibility-helper.js
@@ -360,6 +360,19 @@ function findBaseSelectMenu(select) {
     return null;
 }
 
+// Same as findBaseSelectMenu, but waits until the menu has the given number of menu items.
+// With the isolated tree enabled, the select's expanded state is committed in an earlier
+// cycle than the newly rendered popover contents, so a menu found the moment the select
+// reports itself expanded can still have no children.
+async function waitForBaseSelectMenu(select, menuItemCount) {
+    var menu = null;
+    await waitFor(() => {
+        menu = findBaseSelectMenu(select);
+        return menu && menu.childrenCount === menuItemCount;
+    });
+    return menu;
+}
+
 // Executes the operation and waits until an accessibility notification of the provided
 // `notificationName` is received. A notification listener is added to the passed
 // AccessibilityUIElement if not null, or a global listener is installed, before

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2920,14 +2920,18 @@ void AXObjectCache::onSelectedOptionChanged(Element& element)
 
 void AXObjectCache::onSelectedOptionChanged(HTMLSelectElement& select, int optionIndex)
 {
-    if (RefPtr axMenuList = dynamicDowncast<AccessibilityMenuList>(get(select))) {
+    if (RefPtr axMenuList = dynamicDowncast<AccessibilityMenuList>(get(select)))
         axMenuList->didUpdateActiveOption(optionIndex);
-        return;
+    else {
+        // Base-appearance selects don't use AccessibilityMenuList (which normally handles this),
+        // so post the value change notification directly.
+        deferMenuListValueChange(&select);
     }
 
-    // Base-appearance selects don't use AccessibilityMenuList (which normally handles this),
-    // so post the value change notification directly.
-    deferMenuListValueChange(&select);
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    // Make sure the string value is updated in the same cycle as the expanded-state change.
+    updateIsolatedTree(get(select), AXProperty::StringValue);
+#endif
 }
 
 void AXObjectCache::onSlottedContentChange(const HTMLSlotElement& slot)


### PR DESCRIPTION
#### be5630f6e9415e204e4e213c73d6706d4302070c
<pre>
AX: In isolated tree mode, a base-appearance select&apos;s value lags behind its popover collapsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=323332">https://bugs.webkit.org/show_bug.cgi?id=323332</a>
<a href="https://rdar.apple.com/186574679">rdar://186574679</a>

Reviewed by Dominic Mazzoni.

Pressing an option in a base-appearance select through the accessibility API
publishes two facts about the same widget on two different channels.
AXProperty::IsExpanded is queued from the ExpandedChanged case of
updateIsolatedTree, which runs off the notification post timer, while
AXProperty::StringValue is only refreshed by handleMenuListValueChanged, which
deferMenuListValueChange defers to performDeferredCacheUpdate.

The result is that the isolated tree reports the popover as collapsed while its value still
names the previously selected option, so a client that reads the value in
response to the collapse, which is what VoiceOver does, announces the wrong
option.

Fix this by queueing the value update in onSelectedOptionChanged, which runs synchronously with
the selection change, so it lands in the same commit as IsExpanded rather than
two commits later.

318871@main landed LayoutTests/accessibility/isolated-tree/base-select-option-press-closes-popover-expected.txt
without the corresponding .html, since the test did not pass with the isolated
tree enabled. Add the missing .html now that it does. The existing baseline is
already correct.

The same expanded-before-contents split affects the test&apos;s setup: the select
reports itself expanded before the popover&apos;s newly rendered options have been
committed to the isolated tree, so findBaseSelectMenu can hand back a menu with
no children and menu.childAtIndex(0) is null. Add waitForBaseSelectMenu, which
polls until the menu has its options, and use it in both copies of the test so
they stay in sync.

* LayoutTests/accessibility/base-select-option-press-closes-popover.html:
* LayoutTests/accessibility/isolated-tree/base-select-option-press-closes-popover.html: Added.
* LayoutTests/resources/accessibility-helper.js:
(waitForBaseSelectMenu):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onSelectedOptionChanged):

Canonical link: <a href="https://commits.webkit.org/320563@main">https://commits.webkit.org/320563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1528fbbdf0817bf1898da536c8650b81c284dccd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195394 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/33918077-8bf8-491f-a99e-f62e8d29d5b6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144615 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3dc5d39-4997-4cc1-8332-7b273483e0b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165204 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124903 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/73d655c1-0f59-4e2b-bc44-e1b3096a9aa1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47017 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45093 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157386 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44774 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6449 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51642 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49464 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197344 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58646 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164710 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154110 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41289 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59355 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41378 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153766 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48264 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131648 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128286 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57841 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19793 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57204 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57454 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57278 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->