### PR TITLE
AX: Add layout tests for line / sentence / word text marker boundary round trips

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/line-boundary-round-trip-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/line-boundary-round-trip-expected.txt
@@ -1,0 +1,32 @@
+This test ensures that stepping to the next line end and then back to the previous line start lands on the start of the line the marker began on, from any position within that line. Lines broken by a br element and lines broken only by wrapping are both covered.
+
+Lines broken by a br element.
+PASS: lineStartOffsetFrom('broken', 0) === 0
+PASS: lineStartOffsetFrom('broken', 3) === 0
+PASS: lineStartOffsetFrom('broken', 6) === 6
+PASS: lineStartOffsetFrom('broken', 9) === 6
+PASS: lineStartOffsetFrom('broken', 12) === 12
+PASS: lineStartOffsetFrom('broken', 16) === 12
+
+The recovered range spans the whole line, and stops before the line break.
+PASS: lineTextFrom('broken', 3) === 'Alpha'
+PASS: lineTextFrom('broken', 9) === 'Bravo'
+PASS: lineTextFrom('broken', 16) === 'Charlie'
+
+Lines broken only by wrapping.
+PASS: lineStartOffsetFrom('wrapped', 0) === 0
+PASS: lineStartOffsetFrom('wrapped', 2) === 0
+PASS: lineStartOffsetFrom('wrapped', 4) === 4
+PASS: lineStartOffsetFrom('wrapped', 6) === 4
+PASS: lineStartOffsetFrom('wrapped', 8) === 8
+PASS: lineStartOffsetFrom('wrapped', 10) === 8
+
+The recovered range spans the whole wrapped line.
+PASS: wrappedLineTextFrom(2) === 'aaa'
+PASS: wrappedLineTextFrom(6) === 'bbb'
+PASS: wrappedLineTextFrom(10) === 'ccc'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/line-boundary-round-trip.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/line-boundary-round-trip.html
@@ -1,0 +1,81 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+#wrapped { width: 6ch; font: 16px/1 monospace; }
+</style>
+</head>
+<body>
+
+<p id="broken">Alpha<br>Bravo<br>Charlie</p>
+<p id="wrapped">aaa bbb ccc</p>
+
+<script>
+var output = "This test ensures that stepping to the next line end and then back to the previous line start lands on the start of the line the marker began on, from any position within that line. Lines broken by a br element and lines broken only by wrapping are both covered.\n\n";
+
+function baseIndexOf(paragraphId)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    return paragraph.indexForTextMarker(paragraph.startTextMarkerForTextMarkerRange(paragraph.textMarkerRangeForElement(paragraph)));
+}
+
+function lineStartOffsetFrom(paragraphId, offset)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    var base = baseIndexOf(paragraphId);
+    var lineEnd = paragraph.nextLineEndTextMarkerForTextMarker(paragraph.textMarkerForIndex(base + offset));
+    return paragraph.indexForTextMarker(paragraph.previousLineStartTextMarkerForTextMarker(lineEnd)) - base;
+}
+
+function lineTextFrom(paragraphId, offset)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    var base = baseIndexOf(paragraphId);
+    var lineEnd = paragraph.nextLineEndTextMarkerForTextMarker(paragraph.textMarkerForIndex(base + offset));
+    var lineStart = paragraph.previousLineStartTextMarkerForTextMarker(lineEnd);
+    return paragraph.stringForTextMarkerRange(paragraph.textMarkerRangeForMarkers(lineStart, lineEnd));
+}
+
+function wrappedLineTextFrom(offset)
+{
+    // The space at a soft wrap is included by the isolated tree and not by the live tree.
+    return lineTextFrom("wrapped", offset).trim();
+}
+
+if (window.accessibilityController) {
+    output += "Lines broken by a br element.\n";
+    output += expect("lineStartOffsetFrom('broken', 0)", "0");
+    output += expect("lineStartOffsetFrom('broken', 3)", "0");
+    output += expect("lineStartOffsetFrom('broken', 6)", "6");
+    output += expect("lineStartOffsetFrom('broken', 9)", "6");
+    output += expect("lineStartOffsetFrom('broken', 12)", "12");
+    output += expect("lineStartOffsetFrom('broken', 16)", "12");
+
+    output += "\nThe recovered range spans the whole line, and stops before the line break.\n";
+    output += expect("lineTextFrom('broken', 3)", "'Alpha'");
+    output += expect("lineTextFrom('broken', 9)", "'Bravo'");
+    output += expect("lineTextFrom('broken', 16)", "'Charlie'");
+
+    output += "\nLines broken only by wrapping.\n";
+    output += expect("lineStartOffsetFrom('wrapped', 0)", "0");
+    output += expect("lineStartOffsetFrom('wrapped', 2)", "0");
+    output += expect("lineStartOffsetFrom('wrapped', 4)", "4");
+    output += expect("lineStartOffsetFrom('wrapped', 6)", "4");
+    output += expect("lineStartOffsetFrom('wrapped', 8)", "8");
+    output += expect("lineStartOffsetFrom('wrapped', 10)", "8");
+
+    output += "\nThe recovered range spans the whole wrapped line.\n";
+    output += expect("wrappedLineTextFrom(2)", "'aaa'");
+    output += expect("wrappedLineTextFrom(6)", "'bbb'");
+    output += expect("wrappedLineTextFrom(10)", "'ccc'");
+
+    document.getElementById("broken").style.display = "none";
+    document.getElementById("wrapped").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/sentence-boundary-round-trip-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/sentence-boundary-round-trip-expected.txt
@@ -1,0 +1,26 @@
+This test ensures that stepping to the next sentence end and then back to the previous sentence start lands on the start of the sentence the marker began on, from any position within that sentence. A sentence ended by a br element and a sentence that soft wraps across several lines are both covered, because a sentence boundary is not a line boundary.
+
+Sentences separated by a br element.
+PASS: sentenceStartOffsetFrom('broken', 0) === 0
+PASS: sentenceStartOffsetFrom('broken', 7) === 0
+PASS: sentenceStartOffsetFrom('broken', 16) === 16
+PASS: sentenceStartOffsetFrom('broken', 23) === 16
+
+The recovered range is the sentence, without the line break.
+PASS: sentenceTextFrom('broken', 7) === 'First sentence.'
+PASS: sentenceTextFrom('broken', 23) === 'Second sentence.'
+
+Sentences that soft wrap across lines.
+PASS: sentenceStartOffsetFrom('wrapped', 0) === 0
+PASS: sentenceStartOffsetFrom('wrapped', 7) === 0
+PASS: sentenceStartOffsetFrom('wrapped', 16) === 16
+PASS: sentenceStartOffsetFrom('wrapped', 23) === 16
+
+The recovered range spans the whole sentence, across the lines it wrapped onto.
+PASS: sentenceTextFrom('wrapped', 7) === 'Third sentence.'
+PASS: sentenceTextFrom('wrapped', 23) === 'Fourth sentence.'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/sentence-boundary-round-trip.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/sentence-boundary-round-trip.html
@@ -1,0 +1,70 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+#wrapped { width: 9ch; font: 16px/1 monospace; }
+</style>
+</head>
+<body>
+
+<p id="broken">First sentence.<br>Second sentence.</p>
+<p id="wrapped">Third sentence. Fourth sentence.</p>
+
+<script>
+var output = "This test ensures that stepping to the next sentence end and then back to the previous sentence start lands on the start of the sentence the marker began on, from any position within that sentence. A sentence ended by a br element and a sentence that soft wraps across several lines are both covered, because a sentence boundary is not a line boundary.\n\n";
+
+function baseIndexOf(paragraphId)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    return paragraph.indexForTextMarker(paragraph.startTextMarkerForTextMarkerRange(paragraph.textMarkerRangeForElement(paragraph)));
+}
+
+function sentenceStartOffsetFrom(paragraphId, offset)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    var base = baseIndexOf(paragraphId);
+    var sentenceEnd = paragraph.nextSentenceEndTextMarkerForTextMarker(paragraph.textMarkerForIndex(base + offset));
+    return paragraph.indexForTextMarker(paragraph.previousSentenceStartTextMarkerForTextMarker(sentenceEnd)) - base;
+}
+
+function sentenceTextFrom(paragraphId, offset)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    var base = baseIndexOf(paragraphId);
+    var sentenceEnd = paragraph.nextSentenceEndTextMarkerForTextMarker(paragraph.textMarkerForIndex(base + offset));
+    var sentenceStart = paragraph.previousSentenceStartTextMarkerForTextMarker(sentenceEnd);
+    // A sentence range carries whatever separates it from the next one, a space or a line break.
+    return paragraph.stringForTextMarkerRange(paragraph.textMarkerRangeForMarkers(sentenceStart, sentenceEnd)).trim();
+}
+
+if (window.accessibilityController) {
+    output += "Sentences separated by a br element.\n";
+    output += expect("sentenceStartOffsetFrom('broken', 0)", "0");
+    output += expect("sentenceStartOffsetFrom('broken', 7)", "0");
+    output += expect("sentenceStartOffsetFrom('broken', 16)", "16");
+    output += expect("sentenceStartOffsetFrom('broken', 23)", "16");
+
+    output += "\nThe recovered range is the sentence, without the line break.\n";
+    output += expect("sentenceTextFrom('broken', 7)", "'First sentence.'");
+    output += expect("sentenceTextFrom('broken', 23)", "'Second sentence.'");
+
+    output += "\nSentences that soft wrap across lines.\n";
+    output += expect("sentenceStartOffsetFrom('wrapped', 0)", "0");
+    output += expect("sentenceStartOffsetFrom('wrapped', 7)", "0");
+    output += expect("sentenceStartOffsetFrom('wrapped', 16)", "16");
+    output += expect("sentenceStartOffsetFrom('wrapped', 23)", "16");
+
+    output += "\nThe recovered range spans the whole sentence, across the lines it wrapped onto.\n";
+    output += expect("sentenceTextFrom('wrapped', 7)", "'Third sentence.'");
+    output += expect("sentenceTextFrom('wrapped', 23)", "'Fourth sentence.'");
+
+    document.getElementById("broken").style.display = "none";
+    document.getElementById("wrapped").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/word-boundary-round-trip-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/word-boundary-round-trip-expected.txt
@@ -1,0 +1,32 @@
+This test ensures that stepping to the next word end and then back to the previous word start lands on the start of the word the marker began on, from any position within that word. Words separated by a br element and words separated by a soft wrap are both covered, because neither kind of line break should move a word boundary.
+
+Words separated by a br element.
+PASS: wordStartOffsetFrom('broken', 0) === 0
+PASS: wordStartOffsetFrom('broken', 3) === 0
+PASS: wordStartOffsetFrom('broken', 6) === 6
+PASS: wordStartOffsetFrom('broken', 9) === 6
+PASS: wordStartOffsetFrom('broken', 12) === 12
+PASS: wordStartOffsetFrom('broken', 16) === 12
+
+The recovered range is the word, without the line break.
+PASS: wordTextFrom('broken', 3) === 'Alpha'
+PASS: wordTextFrom('broken', 9) === 'bravo'
+PASS: wordTextFrom('broken', 16) === 'charlie'
+
+Words separated by a soft wrap.
+PASS: wordStartOffsetFrom('wrapped', 0) === 0
+PASS: wordStartOffsetFrom('wrapped', 3) === 0
+PASS: wordStartOffsetFrom('wrapped', 6) === 6
+PASS: wordStartOffsetFrom('wrapped', 8) === 6
+PASS: wordStartOffsetFrom('wrapped', 11) === 11
+PASS: wordStartOffsetFrom('wrapped', 15) === 11
+
+The recovered range is the word, and the wrap adds nothing to it.
+PASS: wordTextFrom('wrapped', 3) === 'delta'
+PASS: wordTextFrom('wrapped', 8) === 'echo'
+PASS: wordTextFrom('wrapped', 15) === 'foxtrot'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/word-boundary-round-trip.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/word-boundary-round-trip.html
@@ -1,0 +1,75 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+#wrapped { width: 7ch; font: 16px/1 monospace; }
+</style>
+</head>
+<body>
+
+<p id="broken">Alpha<br>bravo<br>charlie</p>
+<p id="wrapped">delta echo foxtrot</p>
+
+<script>
+var output = "This test ensures that stepping to the next word end and then back to the previous word start lands on the start of the word the marker began on, from any position within that word. Words separated by a br element and words separated by a soft wrap are both covered, because neither kind of line break should move a word boundary.\n\n";
+
+function baseIndexOf(paragraphId)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    return paragraph.indexForTextMarker(paragraph.startTextMarkerForTextMarkerRange(paragraph.textMarkerRangeForElement(paragraph)));
+}
+
+function wordStartOffsetFrom(paragraphId, offset)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    var base = baseIndexOf(paragraphId);
+    var wordEnd = paragraph.nextWordEndTextMarkerForTextMarker(paragraph.textMarkerForIndex(base + offset));
+    return paragraph.indexForTextMarker(paragraph.previousWordStartTextMarkerForTextMarker(wordEnd)) - base;
+}
+
+function wordTextFrom(paragraphId, offset)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    var base = baseIndexOf(paragraphId);
+    var wordEnd = paragraph.nextWordEndTextMarkerForTextMarker(paragraph.textMarkerForIndex(base + offset));
+    var wordStart = paragraph.previousWordStartTextMarkerForTextMarker(wordEnd);
+    return paragraph.stringForTextMarkerRange(paragraph.textMarkerRangeForMarkers(wordStart, wordEnd));
+}
+
+if (window.accessibilityController) {
+    output += "Words separated by a br element.\n";
+    output += expect("wordStartOffsetFrom('broken', 0)", "0");
+    output += expect("wordStartOffsetFrom('broken', 3)", "0");
+    output += expect("wordStartOffsetFrom('broken', 6)", "6");
+    output += expect("wordStartOffsetFrom('broken', 9)", "6");
+    output += expect("wordStartOffsetFrom('broken', 12)", "12");
+    output += expect("wordStartOffsetFrom('broken', 16)", "12");
+
+    output += "\nThe recovered range is the word, without the line break.\n";
+    output += expect("wordTextFrom('broken', 3)", "'Alpha'");
+    output += expect("wordTextFrom('broken', 9)", "'bravo'");
+    output += expect("wordTextFrom('broken', 16)", "'charlie'");
+
+    output += "\nWords separated by a soft wrap.\n";
+    output += expect("wordStartOffsetFrom('wrapped', 0)", "0");
+    output += expect("wordStartOffsetFrom('wrapped', 3)", "0");
+    output += expect("wordStartOffsetFrom('wrapped', 6)", "6");
+    output += expect("wordStartOffsetFrom('wrapped', 8)", "6");
+    output += expect("wordStartOffsetFrom('wrapped', 11)", "11");
+    output += expect("wordStartOffsetFrom('wrapped', 15)", "11");
+
+    output += "\nThe recovered range is the word, and the wrap adds nothing to it.\n";
+    output += expect("wordTextFrom('wrapped', 3)", "'delta'");
+    output += expect("wordTextFrom('wrapped', 8)", "'echo'");
+    output += expect("wordTextFrom('wrapped', 15)", "'foxtrot'");
+
+    document.getElementById("broken").style.display = "none";
+    document.getElementById("wrapped").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/line-boundary-round-trip-expected.txt
+++ b/LayoutTests/accessibility/mac/line-boundary-round-trip-expected.txt
@@ -1,0 +1,32 @@
+This test ensures that stepping to the next line end and then back to the previous line start lands on the start of the line the marker began on, from any position within that line. Lines broken by a br element and lines broken only by wrapping are both covered.
+
+Lines broken by a br element.
+PASS: lineStartOffsetFrom('broken', 0) === 0
+PASS: lineStartOffsetFrom('broken', 3) === 0
+PASS: lineStartOffsetFrom('broken', 6) === 6
+PASS: lineStartOffsetFrom('broken', 9) === 6
+PASS: lineStartOffsetFrom('broken', 12) === 12
+PASS: lineStartOffsetFrom('broken', 16) === 12
+
+The recovered range spans the whole line, and stops before the line break.
+PASS: lineTextFrom('broken', 3) === 'Alpha'
+PASS: lineTextFrom('broken', 9) === 'Bravo'
+PASS: lineTextFrom('broken', 16) === 'Charlie'
+
+Lines broken only by wrapping.
+PASS: lineStartOffsetFrom('wrapped', 0) === 0
+PASS: lineStartOffsetFrom('wrapped', 2) === 0
+PASS: lineStartOffsetFrom('wrapped', 4) === 4
+PASS: lineStartOffsetFrom('wrapped', 6) === 4
+PASS: lineStartOffsetFrom('wrapped', 8) === 8
+PASS: lineStartOffsetFrom('wrapped', 10) === 8
+
+The recovered range spans the whole wrapped line.
+PASS: wrappedLineTextFrom(2) === 'aaa'
+PASS: wrappedLineTextFrom(6) === 'bbb'
+PASS: wrappedLineTextFrom(10) === 'ccc'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/line-boundary-round-trip.html
+++ b/LayoutTests/accessibility/mac/line-boundary-round-trip.html
@@ -1,0 +1,81 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+#wrapped { width: 6ch; font: 16px/1 monospace; }
+</style>
+</head>
+<body>
+
+<p id="broken">Alpha<br>Bravo<br>Charlie</p>
+<p id="wrapped">aaa bbb ccc</p>
+
+<script>
+var output = "This test ensures that stepping to the next line end and then back to the previous line start lands on the start of the line the marker began on, from any position within that line. Lines broken by a br element and lines broken only by wrapping are both covered.\n\n";
+
+function baseIndexOf(paragraphId)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    return paragraph.indexForTextMarker(paragraph.startTextMarkerForTextMarkerRange(paragraph.textMarkerRangeForElement(paragraph)));
+}
+
+function lineStartOffsetFrom(paragraphId, offset)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    var base = baseIndexOf(paragraphId);
+    var lineEnd = paragraph.nextLineEndTextMarkerForTextMarker(paragraph.textMarkerForIndex(base + offset));
+    return paragraph.indexForTextMarker(paragraph.previousLineStartTextMarkerForTextMarker(lineEnd)) - base;
+}
+
+function lineTextFrom(paragraphId, offset)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    var base = baseIndexOf(paragraphId);
+    var lineEnd = paragraph.nextLineEndTextMarkerForTextMarker(paragraph.textMarkerForIndex(base + offset));
+    var lineStart = paragraph.previousLineStartTextMarkerForTextMarker(lineEnd);
+    return paragraph.stringForTextMarkerRange(paragraph.textMarkerRangeForMarkers(lineStart, lineEnd));
+}
+
+function wrappedLineTextFrom(offset)
+{
+    // The space at a soft wrap is included by the isolated tree and not by the live tree.
+    return lineTextFrom("wrapped", offset).trim();
+}
+
+if (window.accessibilityController) {
+    output += "Lines broken by a br element.\n";
+    output += expect("lineStartOffsetFrom('broken', 0)", "0");
+    output += expect("lineStartOffsetFrom('broken', 3)", "0");
+    output += expect("lineStartOffsetFrom('broken', 6)", "6");
+    output += expect("lineStartOffsetFrom('broken', 9)", "6");
+    output += expect("lineStartOffsetFrom('broken', 12)", "12");
+    output += expect("lineStartOffsetFrom('broken', 16)", "12");
+
+    output += "\nThe recovered range spans the whole line, and stops before the line break.\n";
+    output += expect("lineTextFrom('broken', 3)", "'Alpha'");
+    output += expect("lineTextFrom('broken', 9)", "'Bravo'");
+    output += expect("lineTextFrom('broken', 16)", "'Charlie'");
+
+    output += "\nLines broken only by wrapping.\n";
+    output += expect("lineStartOffsetFrom('wrapped', 0)", "0");
+    output += expect("lineStartOffsetFrom('wrapped', 2)", "0");
+    output += expect("lineStartOffsetFrom('wrapped', 4)", "4");
+    output += expect("lineStartOffsetFrom('wrapped', 6)", "4");
+    output += expect("lineStartOffsetFrom('wrapped', 8)", "8");
+    output += expect("lineStartOffsetFrom('wrapped', 10)", "8");
+
+    output += "\nThe recovered range spans the whole wrapped line.\n";
+    output += expect("wrappedLineTextFrom(2)", "'aaa'");
+    output += expect("wrappedLineTextFrom(6)", "'bbb'");
+    output += expect("wrappedLineTextFrom(10)", "'ccc'");
+
+    document.getElementById("broken").style.display = "none";
+    document.getElementById("wrapped").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/sentence-boundary-round-trip-expected.txt
+++ b/LayoutTests/accessibility/mac/sentence-boundary-round-trip-expected.txt
@@ -1,0 +1,26 @@
+This test ensures that stepping to the next sentence end and then back to the previous sentence start lands on the start of the sentence the marker began on, from any position within that sentence. A sentence ended by a br element and a sentence that soft wraps across several lines are both covered, because a sentence boundary is not a line boundary.
+
+Sentences separated by a br element.
+PASS: sentenceStartOffsetFrom('broken', 0) === 0
+PASS: sentenceStartOffsetFrom('broken', 7) === 0
+PASS: sentenceStartOffsetFrom('broken', 16) === 16
+PASS: sentenceStartOffsetFrom('broken', 23) === 16
+
+The recovered range is the sentence, without the line break.
+PASS: sentenceTextFrom('broken', 7) === 'First sentence.'
+PASS: sentenceTextFrom('broken', 23) === 'Second sentence.'
+
+Sentences that soft wrap across lines.
+PASS: sentenceStartOffsetFrom('wrapped', 0) === 0
+PASS: sentenceStartOffsetFrom('wrapped', 7) === 0
+PASS: sentenceStartOffsetFrom('wrapped', 16) === 16
+PASS: sentenceStartOffsetFrom('wrapped', 23) === 16
+
+The recovered range spans the whole sentence, across the lines it wrapped onto.
+PASS: sentenceTextFrom('wrapped', 7) === 'Third sentence.'
+PASS: sentenceTextFrom('wrapped', 23) === 'Fourth sentence.'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/sentence-boundary-round-trip.html
+++ b/LayoutTests/accessibility/mac/sentence-boundary-round-trip.html
@@ -1,0 +1,70 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+#wrapped { width: 9ch; font: 16px/1 monospace; }
+</style>
+</head>
+<body>
+
+<p id="broken">First sentence.<br>Second sentence.</p>
+<p id="wrapped">Third sentence. Fourth sentence.</p>
+
+<script>
+var output = "This test ensures that stepping to the next sentence end and then back to the previous sentence start lands on the start of the sentence the marker began on, from any position within that sentence. A sentence ended by a br element and a sentence that soft wraps across several lines are both covered, because a sentence boundary is not a line boundary.\n\n";
+
+function baseIndexOf(paragraphId)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    return paragraph.indexForTextMarker(paragraph.startTextMarkerForTextMarkerRange(paragraph.textMarkerRangeForElement(paragraph)));
+}
+
+function sentenceStartOffsetFrom(paragraphId, offset)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    var base = baseIndexOf(paragraphId);
+    var sentenceEnd = paragraph.nextSentenceEndTextMarkerForTextMarker(paragraph.textMarkerForIndex(base + offset));
+    return paragraph.indexForTextMarker(paragraph.previousSentenceStartTextMarkerForTextMarker(sentenceEnd)) - base;
+}
+
+function sentenceTextFrom(paragraphId, offset)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    var base = baseIndexOf(paragraphId);
+    var sentenceEnd = paragraph.nextSentenceEndTextMarkerForTextMarker(paragraph.textMarkerForIndex(base + offset));
+    var sentenceStart = paragraph.previousSentenceStartTextMarkerForTextMarker(sentenceEnd);
+    // A sentence range carries whatever separates it from the next one, a space or a line break.
+    return paragraph.stringForTextMarkerRange(paragraph.textMarkerRangeForMarkers(sentenceStart, sentenceEnd)).trim();
+}
+
+if (window.accessibilityController) {
+    output += "Sentences separated by a br element.\n";
+    output += expect("sentenceStartOffsetFrom('broken', 0)", "0");
+    output += expect("sentenceStartOffsetFrom('broken', 7)", "0");
+    output += expect("sentenceStartOffsetFrom('broken', 16)", "16");
+    output += expect("sentenceStartOffsetFrom('broken', 23)", "16");
+
+    output += "\nThe recovered range is the sentence, without the line break.\n";
+    output += expect("sentenceTextFrom('broken', 7)", "'First sentence.'");
+    output += expect("sentenceTextFrom('broken', 23)", "'Second sentence.'");
+
+    output += "\nSentences that soft wrap across lines.\n";
+    output += expect("sentenceStartOffsetFrom('wrapped', 0)", "0");
+    output += expect("sentenceStartOffsetFrom('wrapped', 7)", "0");
+    output += expect("sentenceStartOffsetFrom('wrapped', 16)", "16");
+    output += expect("sentenceStartOffsetFrom('wrapped', 23)", "16");
+
+    output += "\nThe recovered range spans the whole sentence, across the lines it wrapped onto.\n";
+    output += expect("sentenceTextFrom('wrapped', 7)", "'Third sentence.'");
+    output += expect("sentenceTextFrom('wrapped', 23)", "'Fourth sentence.'");
+
+    document.getElementById("broken").style.display = "none";
+    document.getElementById("wrapped").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/word-boundary-round-trip-expected.txt
+++ b/LayoutTests/accessibility/mac/word-boundary-round-trip-expected.txt
@@ -1,0 +1,32 @@
+This test ensures that stepping to the next word end and then back to the previous word start lands on the start of the word the marker began on, from any position within that word. Words separated by a br element and words separated by a soft wrap are both covered, because neither kind of line break should move a word boundary.
+
+Words separated by a br element.
+PASS: wordStartOffsetFrom('broken', 0) === 0
+PASS: wordStartOffsetFrom('broken', 3) === 0
+PASS: wordStartOffsetFrom('broken', 6) === 6
+PASS: wordStartOffsetFrom('broken', 9) === 6
+PASS: wordStartOffsetFrom('broken', 12) === 12
+PASS: wordStartOffsetFrom('broken', 16) === 12
+
+The recovered range is the word, without the line break.
+PASS: wordTextFrom('broken', 3) === 'Alpha'
+PASS: wordTextFrom('broken', 9) === 'bravo'
+PASS: wordTextFrom('broken', 16) === 'charlie'
+
+Words separated by a soft wrap.
+PASS: wordStartOffsetFrom('wrapped', 0) === 0
+PASS: wordStartOffsetFrom('wrapped', 3) === 0
+PASS: wordStartOffsetFrom('wrapped', 6) === 6
+PASS: wordStartOffsetFrom('wrapped', 8) === 6
+PASS: wordStartOffsetFrom('wrapped', 11) === 11
+PASS: wordStartOffsetFrom('wrapped', 15) === 11
+
+The recovered range is the word, and the wrap adds nothing to it.
+PASS: wordTextFrom('wrapped', 3) === 'delta'
+PASS: wordTextFrom('wrapped', 8) === 'echo'
+PASS: wordTextFrom('wrapped', 15) === 'foxtrot'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/word-boundary-round-trip.html
+++ b/LayoutTests/accessibility/mac/word-boundary-round-trip.html
@@ -1,0 +1,75 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+#wrapped { width: 7ch; font: 16px/1 monospace; }
+</style>
+</head>
+<body>
+
+<p id="broken">Alpha<br>bravo<br>charlie</p>
+<p id="wrapped">delta echo foxtrot</p>
+
+<script>
+var output = "This test ensures that stepping to the next word end and then back to the previous word start lands on the start of the word the marker began on, from any position within that word. Words separated by a br element and words separated by a soft wrap are both covered, because neither kind of line break should move a word boundary.\n\n";
+
+function baseIndexOf(paragraphId)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    return paragraph.indexForTextMarker(paragraph.startTextMarkerForTextMarkerRange(paragraph.textMarkerRangeForElement(paragraph)));
+}
+
+function wordStartOffsetFrom(paragraphId, offset)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    var base = baseIndexOf(paragraphId);
+    var wordEnd = paragraph.nextWordEndTextMarkerForTextMarker(paragraph.textMarkerForIndex(base + offset));
+    return paragraph.indexForTextMarker(paragraph.previousWordStartTextMarkerForTextMarker(wordEnd)) - base;
+}
+
+function wordTextFrom(paragraphId, offset)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    var base = baseIndexOf(paragraphId);
+    var wordEnd = paragraph.nextWordEndTextMarkerForTextMarker(paragraph.textMarkerForIndex(base + offset));
+    var wordStart = paragraph.previousWordStartTextMarkerForTextMarker(wordEnd);
+    return paragraph.stringForTextMarkerRange(paragraph.textMarkerRangeForMarkers(wordStart, wordEnd));
+}
+
+if (window.accessibilityController) {
+    output += "Words separated by a br element.\n";
+    output += expect("wordStartOffsetFrom('broken', 0)", "0");
+    output += expect("wordStartOffsetFrom('broken', 3)", "0");
+    output += expect("wordStartOffsetFrom('broken', 6)", "6");
+    output += expect("wordStartOffsetFrom('broken', 9)", "6");
+    output += expect("wordStartOffsetFrom('broken', 12)", "12");
+    output += expect("wordStartOffsetFrom('broken', 16)", "12");
+
+    output += "\nThe recovered range is the word, without the line break.\n";
+    output += expect("wordTextFrom('broken', 3)", "'Alpha'");
+    output += expect("wordTextFrom('broken', 9)", "'bravo'");
+    output += expect("wordTextFrom('broken', 16)", "'charlie'");
+
+    output += "\nWords separated by a soft wrap.\n";
+    output += expect("wordStartOffsetFrom('wrapped', 0)", "0");
+    output += expect("wordStartOffsetFrom('wrapped', 3)", "0");
+    output += expect("wordStartOffsetFrom('wrapped', 6)", "6");
+    output += expect("wordStartOffsetFrom('wrapped', 8)", "6");
+    output += expect("wordStartOffsetFrom('wrapped', 11)", "11");
+    output += expect("wordStartOffsetFrom('wrapped', 15)", "11");
+
+    output += "\nThe recovered range is the word, and the wrap adds nothing to it.\n";
+    output += expect("wordTextFrom('wrapped', 3)", "'delta'");
+    output += expect("wordTextFrom('wrapped', 8)", "'echo'");
+    output += expect("wordTextFrom('wrapped', 15)", "'foxtrot'");
+
+    document.getElementById("broken").style.display = "none";
+    document.getElementById("wrapped").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 7d9b535a65731303029650179df74902e0828281
<pre>
AX: Add layout tests for line / sentence / word text marker boundary round trips
<a href="https://bugs.webkit.org/show_bug.cgi?id=323335">https://bugs.webkit.org/show_bug.cgi?id=323335</a>
<a href="https://rdar.apple.com/186579669">rdar://186579669</a>

Reviewed by Chris Fleizach.

Each of these asserts that stepping forward to a unit&apos;s end and back to its start
returns to where it started, from any position inside the unit. The existing tests
walk one direction and dump what they see, so a drift moving both directions equally
reads as correct. Each covers a hard line break and a soft wrap, since a line break of
either kind is what most often moves a boundary.

line-boundary-round-trip.html:
AXNextLineEndTextMarkerForTextMarker and AXPreviousLineStartTextMarkerForTextMarker
each had tests, but nothing asserted they round-trip. Covers lines broken by a br element
and lines broken only by wrapping.

word-boundary-round-trip.html:
Same round trip testing for word APIs.

sentence-boundary-round-trip.html:
Same round trip testing for sentence APIs.

* LayoutTests/accessibility/isolated-tree/mac/line-boundary-round-trip-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/line-boundary-round-trip.html: Added.
* LayoutTests/accessibility/isolated-tree/mac/sentence-boundary-round-trip-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/sentence-boundary-round-trip.html: Added.
* LayoutTests/accessibility/isolated-tree/mac/word-boundary-round-trip-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/word-boundary-round-trip.html: Added.
* LayoutTests/accessibility/mac/line-boundary-round-trip-expected.txt: Added.
* LayoutTests/accessibility/mac/line-boundary-round-trip.html: Added.
* LayoutTests/accessibility/mac/sentence-boundary-round-trip-expected.txt: Added.
* LayoutTests/accessibility/mac/sentence-boundary-round-trip.html: Added.
* LayoutTests/accessibility/mac/word-boundary-round-trip-expected.txt: Added.
* LayoutTests/accessibility/mac/word-boundary-round-trip.html: Added.

Canonical link: <a href="https://commits.webkit.org/320466@main">https://commits.webkit.org/320466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89447cd4d7a3845fa0813a0c9e3d1b10131ccad4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195098 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149048 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca09df87-8834-45c0-841a-0304364c1fd7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144381 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149048 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90802579-6382-4fe6-8070-443f2fc59521) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187718 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124663 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b86551d8-4ae8-40e3-9e34-a6f3a2b9e13f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46771 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44888 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44539 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6153 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49229 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197047 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58355 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164478 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153851 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41209 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59057 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41156 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153509 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48029 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127902 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57557 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19557 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56917 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57168 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56993 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->