### PR TITLE
DNR high priority static redirect rule not favored over low priority session redirect rule

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -314,6 +314,9 @@ ContentRuleListResults ContentExtensionsBackend::processContentRuleListsForLoad(
                     results.summary.modifyHeadersActions.append(action);
                 }
             }, [&] (const RedirectAction& redirectAction) {
+                if (results.summary.redirected)
+                    return;
+
                 if (initiatingDocumentLoader.allowsActiveContentRuleListActionsForURL(contentRuleListIdentifier, url)) {
                     if (results.summary.blockedLoad)
                         return;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -130,7 +130,7 @@ static NSString * const storageAccessLevelsKey = @"StorageAccessLevels";
 static constexpr NSInteger currentBackgroundContentListenerStateVersion = 4;
 
 // Update this value when any changes are made to the rule translation logic in _WKWebExtensionDeclarativeNetRequestRule.
-static constexpr NSInteger currentDeclarativeNetRequestRuleTranslatorVersion = 6;
+static constexpr NSInteger currentDeclarativeNetRequestRuleTranslatorVersion = 7;
 
 @interface _WKWebExtensionContextDelegate : NSObject <WKNavigationDelegate, WKUIDelegate> {
     WeakPtr<WebKit::WebExtensionContext> _webExtensionContext;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h
@@ -41,6 +41,7 @@ WK_EXTERN
 
 @property (nonatomic, readonly) NSInteger ruleID;
 @property (nonatomic, readonly) NSInteger priority;
+@property (nonatomic) NSUInteger declarationOrder;
 @property (nonatomic, readonly, copy) NSString *rulesetID;
 @property (nonatomic, readonly, copy) NSDictionary *action;
 @property (nonatomic, readonly, copy) NSDictionary *condition;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm
@@ -1208,10 +1208,19 @@ static BOOL isArrayOfRequestMethodsValid(NSArray<NSString *> *requestMethods)
     if (_priority > rule.priority)
         return NSOrderedAscending;
 
-    if (priorityForRuleType(_action[declarativeNetRequestRuleActionTypeKey]) < priorityForRuleType(rule.action[declarativeNetRequestRuleActionTypeKey]))
+    NSInteger actionTypePriority = priorityForRuleType(_action[declarativeNetRequestRuleActionTypeKey]);
+    NSInteger otherActionTypePriority = priorityForRuleType(rule.action[declarativeNetRequestRuleActionTypeKey]);
+    if (actionTypePriority < otherActionTypePriority)
         return NSOrderedDescending;
-    if (priorityForRuleType(_action[declarativeNetRequestRuleActionTypeKey]) > priorityForRuleType(rule.action[declarativeNetRequestRuleActionTypeKey]))
+    if (actionTypePriority > otherActionTypePriority)
         return NSOrderedAscending;
+
+    if (actionTypePriority == DeclarativeNetRequestRuleActionTypeRedirect) {
+        if (_declarationOrder > rule.declarationOrder)
+            return NSOrderedAscending;
+        if (_declarationOrder < rule.declarationOrder)
+            return NSOrderedDescending;
+    }
 
     return NSOrderedSame;
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.mm
@@ -79,6 +79,10 @@ using namespace WebKit;
     if (outErrorStrings)
         *outErrorStrings = [errorStrings copy];
 
+    [allValidatedRules enumerateObjectsUsingBlock:^(_WKWebExtensionDeclarativeNetRequestRule *rule, NSUInteger index, BOOL *stop) {
+        rule.declarationOrder = index;
+    }];
+
     allValidatedRules = [allValidatedRules sortedArrayUsingComparator:^NSComparisonResult(_WKWebExtensionDeclarativeNetRequestRule *a, _WKWebExtensionDeclarativeNetRequestRule *b) {
         return [a compare:b];
     }].mutableCopy;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -883,6 +883,487 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithEnhancedSecurity)
     runRedirectRule(true);
 }
 
+TEST(WKWebExtensionAPIDeclarativeNetRequest, HighPriorityStaticRedirectFavoredOverLowPrioritySessionRedirect)
+{
+    auto *correctPageScript = Util::constructScript(@[
+        @"<script>",
+        @"  browser.test.notifyPass()",
+        @"</script>"
+    ]);
+
+    auto *incorrectPageScript = Util::constructScript(@[
+        @"<script>",
+        @"  browser.test.notifyFail('Low-priority session redirect should not win over high-priority static redirect')",
+        @"</script>"
+    ]);
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body></body>"_s } },
+        { "/correct"_s, { { { "Content-Type"_s, "text/html"_s } }, correctPageScript } },
+        { "/incorrect"_s, { { { "Content-Type"_s, "text/html"_s } }, incorrectPageScript } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    auto *correctRedirectURL = server.request("/correct"_s).URL.absoluteString;
+    auto *incorrectRedirectURL = server.request("/incorrect"_s).URL.absoluteString;
+
+    auto *rules = @[ @{
+        @"id": @1,
+        @"priority": @200,
+
+        @"action": @{
+            @"type": @"redirect",
+            @"redirect": @{
+                @"url": correctRedirectURL
+            }
+        },
+
+        @"condition": @{
+            @"urlFilter": @"localhost",
+            @"resourceTypes": @[ @"main_frame" ]
+        }
+    } ];
+
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1",
+
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+
+        @"permissions": @[ @"declarativeNetRequestWithHostAccess" ],
+        @"host_permissions": @[ @"*://localhost/*" ],
+
+        @"declarative_net_request": @{
+            @"rule_resources": @[ @{
+                @"id": @"redirectRule",
+                @"enabled": @YES,
+                @"path": @"rules.json"
+            } ]
+        }
+    };
+
+    auto *addSessionRuleScript = [NSString stringWithFormat:@"await browser.declarativeNetRequest.updateSessionRules({ addRules: [{ id: 2, priority: 1, action: { type: 'redirect', redirect: { url: '%@' } }, condition: { urlFilter: 'localhost', resourceTypes: ['main_frame'] } }] })", incorrectRedirectURL];
+
+    auto *backgroundScript = Util::constructScript(@[
+        addSessionRuleScript,
+        @"browser.test.sendMessage('Load Tab')"
+    ]);
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"rules.json": rules
+    };
+
+    auto manager = Util::loadExtension(manifest, resources);
+
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIDeclarativeNetRequest, HighestPriorityRedirectWinsRegardlessOfDeclarationOrder)
+{
+    auto *correctPageScript = Util::constructScript(@[
+        @"<script>",
+        @"  browser.test.notifyPass()",
+        @"</script>"
+    ]);
+
+    auto *incorrectPageScript = Util::constructScript(@[
+        @"<script>",
+        @"  browser.test.notifyFail('Low-priority redirect should not win over high-priority redirect declared later')",
+        @"</script>"
+    ]);
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body></body>"_s } },
+        { "/correct"_s, { { { "Content-Type"_s, "text/html"_s } }, correctPageScript } },
+        { "/incorrect"_s, { { { "Content-Type"_s, "text/html"_s } }, incorrectPageScript } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    auto *correctRedirectURL = server.request("/correct"_s).URL.absoluteString;
+    auto *incorrectRedirectURL = server.request("/incorrect"_s).URL.absoluteString;
+
+    auto *rules = @[ @{
+        @"id": @1,
+        @"priority": @1,
+
+        @"action": @{
+            @"type": @"redirect",
+            @"redirect": @{
+                @"url": incorrectRedirectURL
+            }
+        },
+
+        @"condition": @{
+            @"urlFilter": @"localhost",
+            @"resourceTypes": @[ @"main_frame" ]
+        }
+    }, @{
+        @"id": @2,
+        @"priority": @100,
+
+        @"action": @{
+            @"type": @"redirect",
+            @"redirect": @{
+                @"url": correctRedirectURL
+            }
+        },
+
+        @"condition": @{
+            @"urlFilter": @"localhost",
+            @"resourceTypes": @[ @"main_frame" ]
+        }
+    } ];
+
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1",
+
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+
+        @"permissions": @[ @"declarativeNetRequestWithHostAccess" ],
+        @"host_permissions": @[ @"*://localhost/*" ],
+
+        @"declarative_net_request": @{
+            @"rule_resources": @[ @{
+                @"id": @"redirectRule",
+                @"enabled": @YES,
+                @"path": @"rules.json"
+            } ]
+        }
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.sendMessage('Load Tab')"
+    ]);
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"rules.json": rules
+    };
+
+    auto manager = Util::loadExtension(manifest, resources);
+
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIDeclarativeNetRequest, HigherPriorityNoOpRedirectSuppressesLowerPriorityRedirect)
+{
+    auto *correctPageScript = Util::constructScript(@[
+        @"<script>",
+        @"  browser.test.notifyPass()",
+        @"</script>"
+    ]);
+
+    auto *incorrectPageScript = Util::constructScript(@[
+        @"<script>",
+        @"  browser.test.notifyFail('Lower-priority redirect should not apply when a higher-priority no-op redirect matches')",
+        @"</script>"
+    ]);
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, correctPageScript } },
+        { "/incorrect"_s, { { { "Content-Type"_s, "text/html"_s } }, incorrectPageScript } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    auto *noOpRedirectURL = urlRequest.URL.absoluteString;
+    auto *incorrectRedirectURL = server.request("/incorrect"_s).URL.absoluteString;
+
+    auto *rules = @[ @{
+        @"id": @1,
+        @"priority": @2,
+
+        @"action": @{
+            @"type": @"redirect",
+            @"redirect": @{
+                @"url": noOpRedirectURL
+            }
+        },
+
+        @"condition": @{
+            @"urlFilter": @"localhost",
+            @"resourceTypes": @[ @"main_frame" ]
+        }
+    }, @{
+        @"id": @2,
+        @"priority": @1,
+
+        @"action": @{
+            @"type": @"redirect",
+            @"redirect": @{
+                @"url": incorrectRedirectURL
+            }
+        },
+
+        @"condition": @{
+            @"urlFilter": @"localhost",
+            @"resourceTypes": @[ @"main_frame" ]
+        }
+    } ];
+
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1",
+
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+
+        @"permissions": @[ @"declarativeNetRequestWithHostAccess" ],
+        @"host_permissions": @[ @"*://localhost/*" ],
+
+        @"declarative_net_request": @{
+            @"rule_resources": @[ @{
+                @"id": @"redirectRule",
+                @"enabled": @YES,
+                @"path": @"rules.json"
+            } ]
+        }
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.sendMessage('Load Tab')"
+    ]);
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"rules.json": rules
+    };
+
+    auto manager = Util::loadExtension(manifest, resources);
+
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIDeclarativeNetRequest, LowerPriorityRedirectDoesNotComposeOntoWinner)
+{
+    auto *correctPageScript = Util::constructScript(@[
+        @"<script>",
+        @"  browser.test.notifyPass()",
+        @"</script>"
+    ]);
+
+    auto *noRedirectPageScript = Util::constructScript(@[
+        @"<script>",
+        @"  browser.test.notifyFail('No redirect fired')",
+        @"</script>"
+    ]);
+
+    auto *composedPageScript = Util::constructScript(@[
+        @"<script>",
+        @"  browser.test.notifyFail('Lower-priority transform should not compose onto the winning redirect')",
+        @"</script>"
+    ]);
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, noRedirectPageScript } },
+        { "/winner"_s, { { { "Content-Type"_s, "text/html"_s } }, correctPageScript } },
+        { "/winner?b=2"_s, { { { "Content-Type"_s, "text/html"_s } }, composedPageScript } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    auto *winnerRedirectURL = server.request("/winner"_s).URL.absoluteString;
+
+    auto *rules = @[ @{
+        @"id": @1,
+        @"priority": @2,
+
+        @"action": @{
+            @"type": @"redirect",
+            @"redirect": @{
+                @"url": winnerRedirectURL
+            }
+        },
+
+        @"condition": @{
+            @"urlFilter": @"localhost",
+            @"resourceTypes": @[ @"main_frame" ]
+        }
+    }, @{
+        @"id": @2,
+        @"priority": @1,
+
+        @"action": @{
+            @"type": @"redirect",
+            @"redirect": @{
+                @"transform": @{
+                    @"queryTransform": @{
+                        @"addOrReplaceParams": @[ @{ @"key": @"b", @"value": @"2" } ]
+                    }
+                }
+            }
+        },
+
+        @"condition": @{
+            @"urlFilter": @"localhost",
+            @"resourceTypes": @[ @"main_frame" ]
+        }
+    } ];
+
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1",
+
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+
+        @"permissions": @[ @"declarativeNetRequestWithHostAccess" ],
+        @"host_permissions": @[ @"*://localhost/*" ],
+
+        @"declarative_net_request": @{
+            @"rule_resources": @[ @{
+                @"id": @"redirectRule",
+                @"enabled": @YES,
+                @"path": @"rules.json"
+            } ]
+        }
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.sendMessage('Load Tab')"
+    ]);
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"rules.json": rules
+    };
+
+    auto manager = Util::loadExtension(manifest, resources);
+
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIDeclarativeNetRequest, LastDeclaredRedirectWinsAmongEqualPriority)
+{
+    auto *correctPageScript = Util::constructScript(@[
+        @"<script>",
+        @"  browser.test.notifyPass()",
+        @"</script>"
+    ]);
+
+    auto *incorrectPageScript = Util::constructScript(@[
+        @"<script>",
+        @"  browser.test.notifyFail('First-declared redirect should not win over a later-declared redirect of equal priority')",
+        @"</script>"
+    ]);
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<body></body>"_s } },
+        { "/correct"_s, { { { "Content-Type"_s, "text/html"_s } }, correctPageScript } },
+        { "/incorrect"_s, { { { "Content-Type"_s, "text/html"_s } }, incorrectPageScript } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+    auto *correctRedirectURL = server.request("/correct"_s).URL.absoluteString;
+    auto *incorrectRedirectURL = server.request("/incorrect"_s).URL.absoluteString;
+
+    auto *rules = @[ @{
+        @"id": @1,
+        @"priority": @10,
+
+        @"action": @{
+            @"type": @"redirect",
+            @"redirect": @{
+                @"url": incorrectRedirectURL
+            }
+        },
+
+        @"condition": @{
+            @"urlFilter": @"localhost",
+            @"resourceTypes": @[ @"main_frame" ]
+        }
+    }, @{
+        @"id": @2,
+        @"priority": @10,
+
+        @"action": @{
+            @"type": @"redirect",
+            @"redirect": @{
+                @"url": correctRedirectURL
+            }
+        },
+
+        @"condition": @{
+            @"urlFilter": @"localhost",
+            @"resourceTypes": @[ @"main_frame" ]
+        }
+    } ];
+
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1",
+
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+
+        @"permissions": @[ @"declarativeNetRequestWithHostAccess" ],
+        @"host_permissions": @[ @"*://localhost/*" ],
+
+        @"declarative_net_request": @{
+            @"rule_resources": @[ @{
+                @"id": @"redirectRule",
+                @"enabled": @YES,
+                @"path": @"rules.json"
+            } ]
+        }
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.sendMessage('Load Tab')"
+    ]);
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"rules.json": rules
+    };
+
+    auto manager = Util::loadExtension(manifest, resources);
+
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager run];
+}
+
 TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostAccessPermission)
 {
     auto *pageScript = Util::constructScript(@[


### PR DESCRIPTION
#### 09e9de9492291368b7300a9da5ee6d0d6d7bd6ca
<pre>
DNR high priority static redirect rule not favored over low priority session redirect rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=313963">https://bugs.webkit.org/show_bug.cgi?id=313963</a>
<a href="https://rdar.apple.com/176176246">rdar://176176246</a>

Reviewed by Kiara Rose and Timothy Hatcher.

This patch makes declarativeNetRequest redirect rules honor rule priority. An
extension&apos;s static, session, and dynamic rules are compiled into one content rule
list ordered by priority, but processContentRuleListsForLoad recorded every matching
redirect and the apply step then applied each in turn, overwriting the request URL
each time, so the last and lowest priority redirect won. Now only the first, highest
priority, matching redirect is recorded, so it is the one that gets applied, mirroring
the existing guard on block actions.

Recording only the first matching redirect also changes how a priority tie is
resolved. Two redirects of equal priority previously resolved to the last-declared
rule, matching other browsers; taking the first matching redirect would instead favor
the first-declared rule. To preserve that behavior, equal-priority redirect rules are
now sorted with the later-declared rule first, so the last-declared redirect still
wins the tie. Each rule records its declaration order for this comparison, and
currentDeclarativeNetRequestRuleTranslatorVersion is bumped so previously compiled
rule lists recompile with the new ordering.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDeclarativeNetRequest.mm

* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::processContentRuleListsForLoad const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestRule.mm:
(-[_WKWebExtensionDeclarativeNetRequestRule compare:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestTranslator.mm:
(+[_WKWebExtensionDeclarativeNetRequestTranslator translateRules:errorStrings:]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, HighestPriorityRedirectWinsRegardlessOfDeclarationOrder)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, HigherPriorityNoOpRedirectSuppressesLowerPriorityRedirect)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, LowerPriorityRedirectDoesNotComposeOntoWinner)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, LastDeclaredRedirectWinsAmongEqualPriority)):

Canonical link: <a href="https://commits.webkit.org/320739@main">https://commits.webkit.org/320739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13d9a736ef1d63ee4fd0665dccc1fbdec948a0a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195948 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150353 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c79c02d5-4dde-4bc6-aeb4-76ab3abd7d8e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187498 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145057 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100568 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e8ca259-7adc-450f-a3c0-f222525080c9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165633 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125352 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/36ab6c73-d5ff-4f24-8407-2ad5684d89b3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47470 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45518 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157831 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45207 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7008 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52185 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49923 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197908 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59206 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154596 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59915 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41812 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154249 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28202 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48713 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132267 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129170 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58386 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20229 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57761 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58002 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57827 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->