### PR TITLE
AX: Add layout tests for boundary navigation over harder inputs (emoji, RTL)

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-line-boundaries-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-line-boundaries-expected.txt
@@ -1,0 +1,16 @@
+This test ensures line start and end stay logical positions after direction is flipped to right-to-left at runtime, rather than becoming the leftmost and rightmost positions on the line. The text is replaced at the same time so the assertion cannot pass against a value cached from before the flip.
+
+Left to right, the three wrapped lines are read in logical order.
+PASS: lineTextFrom(2) === 'aaa'
+PASS: lineTextFrom(6) === 'bbb'
+PASS: lineTextFrom(10) === 'ccc'
+
+Right to left, the first line is still the one the text starts with.
+PASS: lineTextFrom(2) === 'xxx'
+PASS: lineTextFrom(6) === 'yyy'
+PASS: lineTextFrom(10) === 'zzz'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-line-boundaries.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-line-boundaries.html
@@ -1,0 +1,53 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+#target { width: 6ch; font: 16px/1 monospace; }
+</style>
+</head>
+<body>
+
+<p id="target">aaa bbb ccc</p>
+
+<script>
+var output = "This test ensures line start and end stay logical positions after direction is flipped to right-to-left at runtime, rather than becoming the leftmost and rightmost positions on the line. The text is replaced at the same time so the assertion cannot pass against a value cached from before the flip.\n\n";
+
+function lineTextFrom(offset)
+{
+    var target = accessibilityController.accessibleElementById("target").childAtIndex(0);
+    var textStart = target.startTextMarkerForTextMarkerRange(target.textMarkerRangeForElement(target));
+    var marker = target.textMarkerForIndex(target.indexForTextMarker(textStart) + offset);
+    var lineEnd = target.nextLineEndTextMarkerForTextMarker(marker);
+    var lineStart = target.previousLineStartTextMarkerForTextMarker(lineEnd);
+    // The space at a soft wrap is included by the isolated tree and not by the live tree.
+    return target.stringForTextMarkerRange(target.textMarkerRangeForMarkers(lineStart, lineEnd)).trim();
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    output += "Left to right, the three wrapped lines are read in logical order.\n";
+    output += expect("lineTextFrom(2)", "'aaa'");
+    output += expect("lineTextFrom(6)", "'bbb'");
+    output += expect("lineTextFrom(10)", "'ccc'");
+
+    setTimeout(async function() {
+        document.getElementById("target").dir = "rtl";
+        document.getElementById("target").textContent = "xxx yyy zzz";
+
+        output += "\nRight to left, the first line is still the one the text starts with.\n";
+        output += await expectAsync("lineTextFrom(2)", "'xxx'");
+        output += expect("lineTextFrom(6)", "'yyy'");
+        output += expect("lineTextFrom(10)", "'zzz'");
+
+        document.getElementById("target").style.display = "none";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/paragraph-boundary-round-trip-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/paragraph-boundary-round-trip-expected.txt
@@ -1,0 +1,19 @@
+This test ensures that stepping to the next paragraph end and then back to the previous paragraph start lands on the start of the paragraph the marker began on. Paragraph boundaries come from rendered newlines, so a br element starts a new paragraph and a soft wrap does not, and both are covered.
+
+A soft wrap does not start a new paragraph, so every line recovers the same start.
+PASS: paragraphStartOffsetFrom('wrapped', 5) === 0
+PASS: paragraphStartOffsetFrom('wrapped', 40) === 0
+PASS: paragraphTextFrom('wrapped', 40) === 'One paragraph long enough to wrap onto more than one line.'
+
+A br element does start a new paragraph, so the two halves recover different starts.
+PASS: paragraphStartOffsetFrom('broken', 5) === 0
+PASS: paragraphStartOffsetFrom('broken', 25) === 18
+
+Each half is recovered whole, without the line break.
+PASS: paragraphTextFrom('broken', 5) === 'Before the break.'
+PASS: paragraphTextFrom('broken', 25) === 'After the break.'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/paragraph-boundary-round-trip.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/paragraph-boundary-round-trip.html
@@ -1,0 +1,62 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+#wrapped { width: 12ch; font: 16px/1 monospace; }
+</style>
+</head>
+<body>
+
+<p id="wrapped">One paragraph long enough to wrap onto more than one line.</p>
+<p id="broken">Before the break.<br>After the break.</p>
+
+<script>
+var output = "This test ensures that stepping to the next paragraph end and then back to the previous paragraph start lands on the start of the paragraph the marker began on. Paragraph boundaries come from rendered newlines, so a br element starts a new paragraph and a soft wrap does not, and both are covered.\n\n";
+
+function baseIndexOf(paragraphId)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    return paragraph.indexForTextMarker(paragraph.startTextMarkerForTextMarkerRange(paragraph.textMarkerRangeForElement(paragraph)));
+}
+
+function paragraphStartOffsetFrom(paragraphId, offset)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    var base = baseIndexOf(paragraphId);
+    var paragraphEnd = paragraph.nextParagraphEndTextMarkerForTextMarker(paragraph.textMarkerForIndex(base + offset));
+    return paragraph.indexForTextMarker(paragraph.previousParagraphStartTextMarkerForTextMarker(paragraphEnd)) - base;
+}
+
+function paragraphTextFrom(paragraphId, offset)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    var base = baseIndexOf(paragraphId);
+    var paragraphEnd = paragraph.nextParagraphEndTextMarkerForTextMarker(paragraph.textMarkerForIndex(base + offset));
+    var paragraphStart = paragraph.previousParagraphStartTextMarkerForTextMarker(paragraphEnd);
+    return paragraph.stringForTextMarkerRange(paragraph.textMarkerRangeForMarkers(paragraphStart, paragraphEnd)).trim();
+}
+
+if (window.accessibilityController) {
+    output += "A soft wrap does not start a new paragraph, so every line recovers the same start.\n";
+    output += expect("paragraphStartOffsetFrom('wrapped', 5)", "0");
+    output += expect("paragraphStartOffsetFrom('wrapped', 40)", "0");
+    output += expect("paragraphTextFrom('wrapped', 40)", "'One paragraph long enough to wrap onto more than one line.'");
+
+    output += "\nA br element does start a new paragraph, so the two halves recover different starts.\n";
+    output += expect("paragraphStartOffsetFrom('broken', 5)", "0");
+    output += expect("paragraphStartOffsetFrom('broken', 25)", "18");
+
+    output += "\nEach half is recovered whole, without the line break.\n";
+    output += expect("paragraphTextFrom('broken', 5)", "'Before the break.'");
+    output += expect("paragraphTextFrom('broken', 25)", "'After the break.'");
+
+    document.getElementById("wrapped").style.display = "none";
+    document.getElementById("broken").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/word-navigation-grapheme-boundaries-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/word-navigation-grapheme-boundaries-expected.txt
@@ -1,0 +1,11 @@
+This test ensures word navigation never stops inside a grapheme cluster. The joined emoji occupies code units 3 through 7, so a word end at 4, 5, 6 or 7 would place an assistive technology's cursor in the middle of one glyph.
+
+PASS: text().length === 14
+PASS: wordEndOffsets().includes(2) === true
+PASS: wordEndOffsets().includes(14) === true
+PASS: splitsGraphemeCluster() === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/word-navigation-grapheme-boundaries.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/word-navigation-grapheme-boundaries.html
@@ -1,0 +1,57 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">Hi &#x1F469;&#x200D;&#x1F4BB; there</p>
+
+<script>
+var output = "This test ensures word navigation never stops inside a grapheme cluster. The joined emoji occupies code units 3 through 7, so a word end at 4, 5, 6 or 7 would place an assistive technology's cursor in the middle of one glyph.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var baseIndex = target.indexForTextMarker(target.startTextMarkerForTextMarkerRange(targetRange));
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    function wordEndOffsets()
+    {
+        var offsets = [];
+        var marker = target.startTextMarkerForTextMarkerRange(targetRange);
+        for (var step = 0; step < 12; step++) {
+            marker = target.nextWordEndTextMarkerForTextMarker(marker);
+            var offset = target.indexForTextMarker(marker) - baseIndex;
+            if (offsets.length && offset <= offsets[offsets.length - 1])
+                break;
+            offsets.push(offset);
+            if (offset >= 14)
+                break;
+        }
+        return offsets;
+    }
+
+    function splitsGraphemeCluster()
+    {
+        return wordEndOffsets().some(offset => offset > 3 && offset < 8);
+    }
+
+    output += expect("text().length", "14");
+    output += expect("wordEndOffsets().includes(2)", "true");
+    output += expect("wordEndOffsets().includes(14)", "true");
+    output += expect("splitsGraphemeCluster()", "false");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/dynamic-rtl-line-boundaries-expected.txt
+++ b/LayoutTests/accessibility/mac/dynamic-rtl-line-boundaries-expected.txt
@@ -1,0 +1,16 @@
+This test ensures line start and end stay logical positions after direction is flipped to right-to-left at runtime, rather than becoming the leftmost and rightmost positions on the line. The text is replaced at the same time so the assertion cannot pass against a value cached from before the flip.
+
+Left to right, the three wrapped lines are read in logical order.
+PASS: lineTextFrom(2) === 'aaa'
+PASS: lineTextFrom(6) === 'bbb'
+PASS: lineTextFrom(10) === 'ccc'
+
+Right to left, the first line is still the one the text starts with.
+PASS: lineTextFrom(2) === 'xxx'
+PASS: lineTextFrom(6) === 'yyy'
+PASS: lineTextFrom(10) === 'zzz'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/dynamic-rtl-line-boundaries.html
+++ b/LayoutTests/accessibility/mac/dynamic-rtl-line-boundaries.html
@@ -1,0 +1,53 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+#target { width: 6ch; font: 16px/1 monospace; }
+</style>
+</head>
+<body>
+
+<p id="target">aaa bbb ccc</p>
+
+<script>
+var output = "This test ensures line start and end stay logical positions after direction is flipped to right-to-left at runtime, rather than becoming the leftmost and rightmost positions on the line. The text is replaced at the same time so the assertion cannot pass against a value cached from before the flip.\n\n";
+
+function lineTextFrom(offset)
+{
+    var target = accessibilityController.accessibleElementById("target").childAtIndex(0);
+    var textStart = target.startTextMarkerForTextMarkerRange(target.textMarkerRangeForElement(target));
+    var marker = target.textMarkerForIndex(target.indexForTextMarker(textStart) + offset);
+    var lineEnd = target.nextLineEndTextMarkerForTextMarker(marker);
+    var lineStart = target.previousLineStartTextMarkerForTextMarker(lineEnd);
+    // The space at a soft wrap is included by the isolated tree and not by the live tree.
+    return target.stringForTextMarkerRange(target.textMarkerRangeForMarkers(lineStart, lineEnd)).trim();
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    output += "Left to right, the three wrapped lines are read in logical order.\n";
+    output += expect("lineTextFrom(2)", "'aaa'");
+    output += expect("lineTextFrom(6)", "'bbb'");
+    output += expect("lineTextFrom(10)", "'ccc'");
+
+    setTimeout(async function() {
+        document.getElementById("target").dir = "rtl";
+        document.getElementById("target").textContent = "xxx yyy zzz";
+
+        output += "\nRight to left, the first line is still the one the text starts with.\n";
+        output += await expectAsync("lineTextFrom(2)", "'xxx'");
+        output += expect("lineTextFrom(6)", "'yyy'");
+        output += expect("lineTextFrom(10)", "'zzz'");
+
+        document.getElementById("target").style.display = "none";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/paragraph-boundary-round-trip-expected.txt
+++ b/LayoutTests/accessibility/mac/paragraph-boundary-round-trip-expected.txt
@@ -1,0 +1,19 @@
+This test ensures that stepping to the next paragraph end and then back to the previous paragraph start lands on the start of the paragraph the marker began on. Paragraph boundaries come from rendered newlines, so a br element starts a new paragraph and a soft wrap does not, and both are covered.
+
+A soft wrap does not start a new paragraph, so every line recovers the same start.
+PASS: paragraphStartOffsetFrom('wrapped', 5) === 0
+PASS: paragraphStartOffsetFrom('wrapped', 40) === 0
+PASS: paragraphTextFrom('wrapped', 40) === 'One paragraph long enough to wrap onto more than one line.'
+
+A br element does start a new paragraph, so the two halves recover different starts.
+PASS: paragraphStartOffsetFrom('broken', 5) === 0
+PASS: paragraphStartOffsetFrom('broken', 25) === 18
+
+Each half is recovered whole, without the line break.
+PASS: paragraphTextFrom('broken', 5) === 'Before the break.'
+PASS: paragraphTextFrom('broken', 25) === 'After the break.'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/paragraph-boundary-round-trip.html
+++ b/LayoutTests/accessibility/mac/paragraph-boundary-round-trip.html
@@ -1,0 +1,62 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+#wrapped { width: 12ch; font: 16px/1 monospace; }
+</style>
+</head>
+<body>
+
+<p id="wrapped">One paragraph long enough to wrap onto more than one line.</p>
+<p id="broken">Before the break.<br>After the break.</p>
+
+<script>
+var output = "This test ensures that stepping to the next paragraph end and then back to the previous paragraph start lands on the start of the paragraph the marker began on. Paragraph boundaries come from rendered newlines, so a br element starts a new paragraph and a soft wrap does not, and both are covered.\n\n";
+
+function baseIndexOf(paragraphId)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    return paragraph.indexForTextMarker(paragraph.startTextMarkerForTextMarkerRange(paragraph.textMarkerRangeForElement(paragraph)));
+}
+
+function paragraphStartOffsetFrom(paragraphId, offset)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    var base = baseIndexOf(paragraphId);
+    var paragraphEnd = paragraph.nextParagraphEndTextMarkerForTextMarker(paragraph.textMarkerForIndex(base + offset));
+    return paragraph.indexForTextMarker(paragraph.previousParagraphStartTextMarkerForTextMarker(paragraphEnd)) - base;
+}
+
+function paragraphTextFrom(paragraphId, offset)
+{
+    var paragraph = accessibilityController.accessibleElementById(paragraphId);
+    var base = baseIndexOf(paragraphId);
+    var paragraphEnd = paragraph.nextParagraphEndTextMarkerForTextMarker(paragraph.textMarkerForIndex(base + offset));
+    var paragraphStart = paragraph.previousParagraphStartTextMarkerForTextMarker(paragraphEnd);
+    return paragraph.stringForTextMarkerRange(paragraph.textMarkerRangeForMarkers(paragraphStart, paragraphEnd)).trim();
+}
+
+if (window.accessibilityController) {
+    output += "A soft wrap does not start a new paragraph, so every line recovers the same start.\n";
+    output += expect("paragraphStartOffsetFrom('wrapped', 5)", "0");
+    output += expect("paragraphStartOffsetFrom('wrapped', 40)", "0");
+    output += expect("paragraphTextFrom('wrapped', 40)", "'One paragraph long enough to wrap onto more than one line.'");
+
+    output += "\nA br element does start a new paragraph, so the two halves recover different starts.\n";
+    output += expect("paragraphStartOffsetFrom('broken', 5)", "0");
+    output += expect("paragraphStartOffsetFrom('broken', 25)", "18");
+
+    output += "\nEach half is recovered whole, without the line break.\n";
+    output += expect("paragraphTextFrom('broken', 5)", "'Before the break.'");
+    output += expect("paragraphTextFrom('broken', 25)", "'After the break.'");
+
+    document.getElementById("wrapped").style.display = "none";
+    document.getElementById("broken").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/word-navigation-grapheme-boundaries-expected.txt
+++ b/LayoutTests/accessibility/mac/word-navigation-grapheme-boundaries-expected.txt
@@ -1,0 +1,11 @@
+This test ensures word navigation never stops inside a grapheme cluster. The joined emoji occupies code units 3 through 7, so a word end at 4, 5, 6 or 7 would place an assistive technology's cursor in the middle of one glyph.
+
+PASS: text().length === 14
+PASS: wordEndOffsets().includes(2) === true
+PASS: wordEndOffsets().includes(14) === true
+PASS: splitsGraphemeCluster() === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/word-navigation-grapheme-boundaries.html
+++ b/LayoutTests/accessibility/mac/word-navigation-grapheme-boundaries.html
@@ -1,0 +1,57 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">Hi &#x1F469;&#x200D;&#x1F4BB; there</p>
+
+<script>
+var output = "This test ensures word navigation never stops inside a grapheme cluster. The joined emoji occupies code units 3 through 7, so a word end at 4, 5, 6 or 7 would place an assistive technology's cursor in the middle of one glyph.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var baseIndex = target.indexForTextMarker(target.startTextMarkerForTextMarkerRange(targetRange));
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    function wordEndOffsets()
+    {
+        var offsets = [];
+        var marker = target.startTextMarkerForTextMarkerRange(targetRange);
+        for (var step = 0; step < 12; step++) {
+            marker = target.nextWordEndTextMarkerForTextMarker(marker);
+            var offset = target.indexForTextMarker(marker) - baseIndex;
+            if (offsets.length && offset <= offsets[offsets.length - 1])
+                break;
+            offsets.push(offset);
+            if (offset >= 14)
+                break;
+        }
+        return offsets;
+    }
+
+    function splitsGraphemeCluster()
+    {
+        return wordEndOffsets().some(offset => offset > 3 && offset < 8);
+    }
+
+    output += expect("text().length", "14");
+    output += expect("wordEndOffsets().includes(2)", "true");
+    output += expect("wordEndOffsets().includes(14)", "true");
+    output += expect("splitsGraphemeCluster()", "false");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 60dd821e68ff0a6563ad4304805b9c08492b13d0
<pre>
AX: Add layout tests for boundary navigation over harder inputs (emoji, RTL)
<a href="https://bugs.webkit.org/show_bug.cgi?id=323338">https://bugs.webkit.org/show_bug.cgi?id=323338</a>
<a href="https://rdar.apple.com/186580426">rdar://186580426</a>

Reviewed by Dominic Mazzoni.

paragraph-boundary-round-trip.html:
Round trip for paragraphs. AXTextMarker::findParagraph derives paragraph boundaries
from rendered newlines, so a br element starts a new paragraph and a soft wrap does
not -- the test asserts both halves of that, which is what makes it novel coverage.

word-navigation-grapheme-boundaries.html:
No test exercised grapheme cluster boundaries. Asserts no word end falls inside a
joined emoji&apos;s code unit span, which would leave an AT cursor mid-glyph.

dynamic-rtl-line-boundaries.html:
One test combines RTL with a DOM mutation. Asserts line start and end stay logical
after direction flips at runtime.

* LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-line-boundaries-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-line-boundaries.html: Added.
* LayoutTests/accessibility/isolated-tree/mac/paragraph-boundary-round-trip-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/paragraph-boundary-round-trip.html: Added.
* LayoutTests/accessibility/isolated-tree/mac/word-navigation-grapheme-boundaries-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/word-navigation-grapheme-boundaries.html: Added.
* LayoutTests/accessibility/mac/dynamic-rtl-line-boundaries-expected.txt: Added.
* LayoutTests/accessibility/mac/dynamic-rtl-line-boundaries.html: Added.
* LayoutTests/accessibility/mac/paragraph-boundary-round-trip-expected.txt: Added.
* LayoutTests/accessibility/mac/paragraph-boundary-round-trip.html: Added.
* LayoutTests/accessibility/mac/word-navigation-grapheme-boundaries-expected.txt: Added.
* LayoutTests/accessibility/mac/word-navigation-grapheme-boundaries.html: Added.

Canonical link: <a href="https://commits.webkit.org/320544@main">https://commits.webkit.org/320544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/322269e38f153a6007d0055f59afb862b114903c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195102 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58418 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144385 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6390d955-e132-4167-9498-bab20cf27d4d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164989 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124667 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46775 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44892 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157148 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44542 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6157 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197051 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58359 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153855 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41277 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59061 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153513 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48038 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127906 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57561 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19560 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56921 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57172 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/56997 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->