### PR TITLE
[Site Isolation] Web Inspector: Stack traces lose source locations for scripts owned by another target

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/target/resources/same-origin-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/resources/same-origin-frame.html
@@ -1,0 +1,8 @@
+<script>
+function triggerCrossFrameTrace() {
+    // Call back into this frame, so the console message is emitted by this frame's
+    // console while the parent's script is still on the stack.
+    parent.parentEvalFunction(function inSameOriginFrame() { console.trace("cross-frame"); });
+}
+</script>
+<p>Same-origin frame, sharing a process with the main frame but having its own frame target.</p>

--- a/LayoutTests/http/tests/site-isolation/inspector/target/target-process-id-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/target-process-id-expected.txt
@@ -1,0 +1,36 @@
+CONSOLE MESSAGE: cross-frame
+Test that targets report which process hosts them, and that script lookup widens only within a process.
+
+
+
+== Running test suite: SiteIsolation.Target.ProcessId
+-- Running test case: SiteIsolation.Target.ProcessId.SharedWithinAProcess
+PASS: Should find the main frame's target.
+PASS: Should find the same-origin iframe's target.
+PASS: Should find the cross-origin iframe's target.
+PASS: Page target should have a process identifier.
+PASS: Main frame target should have a process identifier.
+PASS: Cross-origin frame target should have a process identifier.
+PASS: Page target and main frame target should share a process.
+PASS: Same-origin frame target should share the main frame's process.
+PASS: Cross-origin frame target should be in its own process.
+
+-- Running test case: SiteIsolation.Target.ProcessId.ResolvesScriptOwnedByAnotherTargetInTheSameProcess
+PASS: Main frame target should have at least one parsed script.
+PASS: Page target should own no scripts of its own.
+PASS: Widening the search to the page target's process should find the script.
+
+-- Running test case: SiteIsolation.Target.ProcessId.NeverResolvesScriptFromAnotherProcess
+PASS: Cross-origin frame target should have the debugger-frame-script.js script.
+PASS: Lookup from the page target should not reach a script in the cross-origin iframe's process.
+
+-- Running test case: SiteIsolation.Target.ProcessId.ResolvesScriptAcrossFrameTargetsInOneProcess
+PASS: Console message should be delivered on the same-origin frame's target.
+PASS: Stack trace should contain the parent's eval'd function.
+PASS: The parent's frame should resolve to a source location rather than native code.
+PASS: The parent's frame should have a source location.
+PASS: The parent's script should have no URL, so only its identifier can resolve it.
+PASS: The parent's script should be owned by the main frame's target.
+PASS: The same-origin frame target should not own the parent's script.
+PASS: Widening the search within the process should find the parent's script.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/target/target-process-id.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/target-process-id.html
@@ -1,0 +1,112 @@
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+
+<script>
+    // An eval'd function with no URL, so only its script identifier can ever resolve it. It is
+    // compiled in the main frame's global object, so the main frame's target is what owns it.
+    window.parentEvalFunction = eval("(function parentEvalFunction(callback) { callback(); })");
+
+    function test() {
+        let suite = InspectorTest.createAsyncSuite("SiteIsolation.Target.ProcessId");
+
+        let mainFrameTarget = null;
+        let sameOriginTarget = null;
+        let crossOriginTarget = null;
+
+        suite.addTestCase({
+            name: "SiteIsolation.Target.ProcessId.SharedWithinAProcess",
+            description: "Targets report which process hosts them: the page target, the main frame target, and a same-origin iframe's target share one, and a cross-origin iframe's target has its own.",
+            async test() {
+                let frameTargets = WI.targets.filter((target) => target.type === WI.TargetType.Frame);
+                let urlTargetMap = await fetchDocumentURLsForTargets(frameTargets);
+                mainFrameTarget = urlTargetMap.get(WI.networkManager.mainFrame.url);
+                sameOriginTarget = await frameTargetForURLContaining("same-origin-frame.html");
+                crossOriginTarget = await frameTargetForURLContaining("debugger-frame.html");
+
+                InspectorTest.expectNotNull(mainFrameTarget, "Should find the main frame's target.");
+                InspectorTest.expectNotNull(sameOriginTarget, "Should find the same-origin iframe's target.");
+                InspectorTest.expectNotNull(crossOriginTarget, "Should find the cross-origin iframe's target.");
+
+                InspectorTest.expectNotNull(WI.pageTarget.processId, "Page target should have a process identifier.");
+                InspectorTest.expectNotNull(mainFrameTarget.processId, "Main frame target should have a process identifier.");
+                InspectorTest.expectNotNull(crossOriginTarget.processId, "Cross-origin frame target should have a process identifier.");
+
+                // The page target's backend connection only ever reaches the main frame's process.
+                InspectorTest.expectEqual(WI.pageTarget.processId, mainFrameTarget.processId, "Page target and main frame target should share a process.");
+                InspectorTest.expectEqual(sameOriginTarget.processId, mainFrameTarget.processId, "Same-origin frame target should share the main frame's process.");
+                InspectorTest.expectNotEqual(crossOriginTarget.processId, mainFrameTarget.processId, "Cross-origin frame target should be in its own process.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.Target.ProcessId.ResolvesScriptOwnedByAnotherTargetInTheSameProcess",
+            description: "A script identifier delivered on the page target resolves against the main frame target, which is what owns scripts under Site Isolation.",
+            async test() {
+                let scripts = WI.debuggerManager.dataForTarget(mainFrameTarget).scripts;
+                InspectorTest.expectGreaterThan(scripts.length, 0, "Main frame target should have at least one parsed script.");
+
+                let script = scripts[0];
+                InspectorTest.expectNull(WI.debuggerManager.scriptForIdentifier(script.id, WI.pageTarget), "Page target should own no scripts of its own.");
+                InspectorTest.expectEqual(WI.debuggerManager.scriptForIdentifierInSameProcess(script.id, WI.pageTarget), script, "Widening the search to the page target's process should find the script.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.Target.ProcessId.NeverResolvesScriptFromAnotherProcess",
+            description: "Script identifiers come from a process-global counter and collide across processes, so widening the search must never cross a process boundary.",
+            async test() {
+                let scripts = WI.debuggerManager.dataForTarget(crossOriginTarget).scripts;
+                let crossOriginScript = scripts.find((script) => script.url && script.url.includes("debugger-frame-script.js"));
+                InspectorTest.expectNotNull(crossOriginScript, "Cross-origin frame target should have the debugger-frame-script.js script.");
+
+                // Asserting "not this script" rather than "null" on purpose: the identifier may well
+                // also name an unrelated script in the main frame's process, which is the collision
+                // this scoping exists to survive.
+                let resolved = WI.debuggerManager.scriptForIdentifierInSameProcess(crossOriginScript.id, WI.pageTarget);
+                InspectorTest.expectNotEqual(resolved, crossOriginScript, "Lookup from the page target should not reach a script in the cross-origin iframe's process.");
+            }
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.Target.ProcessId.ResolvesScriptAcrossFrameTargetsInOneProcess",
+            description: "A synchronous same-origin call puts the parent's script on a stack trace that is delivered on the child's frame target, so resolution has to cross targets even once no domain reports on the page target.",
+            async test() {
+                // Match on the message text rather than taking the first MessageAdded, so an
+                // unrelated log from either frame cannot resolve this early.
+                let messagePromise = new Promise((resolve) => {
+                    WI.consoleManager.addEventListener(WI.ConsoleManager.Event.MessageAdded, function listener(event) {
+                        if (event.data.message.messageText !== "cross-frame")
+                            return;
+                        WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.MessageAdded, listener);
+                        resolve(event.data.message);
+                    });
+                });
+                InspectorTest.evaluateInPage(`document.getElementById("same-origin-frame").contentWindow.triggerCrossFrameTrace()`);
+                let message = await messagePromise;
+
+                InspectorTest.expectEqual(message.target, sameOriginTarget, "Console message should be delivered on the same-origin frame's target.");
+
+                let callFrame = message.stackTrace.callFrames.find((frame) => frame.functionName === "parentEvalFunction");
+                InspectorTest.expectNotNull(callFrame, "Stack trace should contain the parent's eval'd function.");
+                InspectorTest.expectFalse(callFrame.nativeCode, "The parent's frame should resolve to a source location rather than native code.");
+                InspectorTest.expectNotNull(callFrame.sourceCodeLocation, "The parent's frame should have a source location.");
+
+                // The narrow lookup is what the frontend used before process scoping existed, and it
+                // is what a reader might reach for again once the page target is gone. It misses here.
+                let script = callFrame.sourceCodeLocation.sourceCode;
+                InspectorTest.expectEmpty(script.url, "The parent's script should have no URL, so only its identifier can resolve it.");
+                InspectorTest.expectEqual(WI.debuggerManager.scriptForIdentifier(script.id, mainFrameTarget), script, "The parent's script should be owned by the main frame's target.");
+                InspectorTest.expectNull(WI.debuggerManager.scriptForIdentifier(script.id, sameOriginTarget), "The same-origin frame target should not own the parent's script.");
+                InspectorTest.expectEqual(WI.debuggerManager.scriptForIdentifierInSameProcess(script.id, sameOriginTarget), script, "Widening the search within the process should find the parent's script.");
+            }
+        });
+
+        suite.runTestCasesAndFinish();
+    }
+</script>
+
+<body onload="runTest()">
+<p>Test that targets report which process hosts them, and that script lookup widens only within a process.</p>
+<iframe id="same-origin-frame" src="resources/same-origin-frame.html"></iframe>
+<iframe src="http://localhost:8000/site-isolation/inspector/debugger/resources/debugger-frame.html"></iframe>
+</body>

--- a/Source/JavaScriptCore/inspector/InspectorTarget.h
+++ b/Source/JavaScriptCore/inspector/InspectorTarget.h
@@ -51,6 +51,11 @@ public:
     virtual String identifier() const = 0;
     virtual InspectorTargetType type() const = 0;
 
+    // Identifies the process hosting this target, so the frontend can tell which targets share one.
+    // Opaque for the same reason `identifier()` is: only the embedder can name a process. Empty when
+    // the embedder does not track this.
+    virtual String processId() const { return { }; }
+
     virtual bool isProvisional() const { return false; }
     bool isPaused() const { return m_isPaused; }
     void NODELETE pause();

--- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
@@ -122,6 +122,9 @@ static Ref<Protocol::Target::TargetInfo> buildTargetInfoObject(const InspectorTa
         result->setIsProvisional(true);
     if (target.isPaused())
         result->setIsPaused(true);
+    auto processId = target.processId();
+    if (!processId.isEmpty())
+        result->setProcessId(processId);
     return result;
 }
 

--- a/Source/JavaScriptCore/inspector/protocol/Target.json
+++ b/Source/JavaScriptCore/inspector/protocol/Target.json
@@ -11,7 +11,8 @@
                 { "name": "targetId", "type": "string", "description": "Unique identifier for the target." },
                 { "name": "type", "type": "string", "enum": ["page", "frame", "service-worker", "worker"] },
                 { "name": "isProvisional", "type": "boolean", "optional": true, "description": "Whether this is a provisional page target." },
-                { "name": "isPaused", "type": "boolean", "optional": true, "description": "Whether the target is paused on start and has to be explicitely resumed by inspector." }
+                { "name": "isPaused", "type": "boolean", "optional": true, "description": "Whether the target is paused on start and has to be explicitely resumed by inspector." },
+                { "name": "processId", "type": "string", "optional": true, "description": "Identifier of the process hosting this target. Opaque to the frontend, which only compares it for equality to decide whether two targets share a process." }
             ]
         }
     ],

--- a/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
@@ -174,14 +174,8 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         if (Array.isArray(stackTrace))
             stackTrace = {callFrames: stackTrace};
 
-        if (stackTrace) {
-            let supportedTarget = target;
-            if (!target.hasDomain("Debugger")) {
-                // FIXME: <https://webkit.org/b/298909> Add Debugger support for FrameTarget.
-                supportedTarget = WI.assumingMainTarget();
-            }
-            stackTrace = WI.StackTrace.fromPayload(supportedTarget, stackTrace);
-        }
+        if (stackTrace)
+            stackTrace = WI.StackTrace.fromPayload(target, stackTrace);
 
         const request = null;
         let message = new WI.ConsoleMessage(target, source, level, text, type, url, line, column, repeatCount, parameters, stackTrace, request, timestamp);

--- a/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
@@ -517,6 +517,42 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
         return this.dataForTarget(target).scriptForIdentifier(id);
     }
 
+    // A stack trace can name scripts that the target delivering it does not own. A JS stack walk
+    // crosses frame boundaries while script ownership does not: each frame target's debugger reports
+    // only its own frame's scripts, so a synchronous same-origin call leaves the caller's script on a
+    // stack trace delivered on the callee's target. Domains that still report on the page target,
+    // which owns no scripts under Site Isolation, are the other source of this and the more common
+    // one today -- but the cross-frame case remains once they have all migrated.
+    //
+    // Widening is safe only within a process: a script identifier is a JSC SourceID drawn from a
+    // process-global counter, so it names one script inside a process and collides freely across
+    // them. Crossing a process would resolve a frame to an unrelated script, which is worse than
+    // resolving it to nothing.
+    //
+    // Prefer `scriptForIdentifier` wherever the caller knows the target owns the identifier.
+    scriptForIdentifierInSameProcess(id, target)
+    {
+        let script = this.scriptForIdentifier(id, target);
+        if (script)
+            return script;
+
+        if (!target.processId)
+            return null;
+
+        // Iterate the map rather than `WI.targets` so that no `WI.DebuggerData` is created as a side
+        // effect for a target that has never reported a script.
+        for (let [otherTarget, targetData] of this._targetDebuggerDataMap) {
+            if (otherTarget === target || otherTarget.processId !== target.processId)
+                continue;
+
+            script = targetData.scriptForIdentifier(id);
+            if (script)
+                return script;
+        }
+
+        return null;
+    }
+
     scriptsForURL(url, target)
     {
         if (target instanceof WI.ImportedTarget)

--- a/Source/WebInspectorUI/UserInterface/Controllers/TargetManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/TargetManager.js
@@ -189,19 +189,22 @@ WI.TargetManager = class TargetManager extends WI.Object
     _createTarget(parentTarget, targetInfo, connection)
     {
         // COMPATIBILITY (iOS 13.0): `Target.TargetInfo.isProvisional` and `Target.TargetInfo.isPaused` did not exist yet.
-        let {targetId, type, isProvisional, isPaused} = targetInfo;
+        // COMPATIBILITY (macOS 26.4, iOS 26.4): `Target.TargetInfo.processId` did not exist yet.
+        let {targetId, type, isProvisional, isPaused, processId} = targetInfo;
 
         switch (type) {
         case InspectorBackend.Enum.Target.TargetInfoType.Page:
-            return new WI.PageTarget(parentTarget, targetId, WI.UIString("Page"), connection, {isProvisional, isPaused});
+            return new WI.PageTarget(parentTarget, targetId, WI.UIString("Page"), connection, {isProvisional, isPaused, processId});
+        // `WI.WorkerTarget` takes a URL and a display name separately, and a `Target.TargetInfo`
+        // carries no URL, so the name goes in the display name position.
         case InspectorBackend.Enum.Target.TargetInfoType.Worker:
-            return new WI.WorkerTarget(parentTarget, targetId, WI.UIString("Worker"), connection, {isPaused});
+            return new WI.WorkerTarget(parentTarget, targetId, null, WI.UIString("Worker"), connection, {isPaused, processId});
         case "serviceworker": // COMPATIBILITY (iOS 13): "serviceworker" was renamed to "service-worker".
         case InspectorBackend.Enum.Target.TargetInfoType.ServiceWorker:
-            return new WI.WorkerTarget(parentTarget, targetId, WI.UIString("ServiceWorker"), connection, {isPaused});
+            return new WI.WorkerTarget(parentTarget, targetId, null, WI.UIString("ServiceWorker"), connection, {isPaused, processId});
         case InspectorBackend.Enum.Target.TargetInfoType.Frame:
             // FIXME: <https://webkit.org/b/298977> Consider setting a more meaningful name for the frame target.
-            return new WI.FrameTarget(parentTarget, targetId, WI.UIString("Frame"), connection, {isProvisional, isPaused});
+            return new WI.FrameTarget(parentTarget, targetId, WI.UIString("Frame"), connection, {isProvisional, isPaused, processId});
         }
 
         throw "Unknown Target type: " + type;

--- a/Source/WebInspectorUI/UserInterface/Models/CallFrame.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CallFrame.js
@@ -246,7 +246,7 @@ WI.CallFrame = class CallFrame
         else if (url || scriptId) {
             let sourceCode = null;
             if (scriptId) {
-                sourceCode = WI.debuggerManager.scriptForIdentifier(scriptId, target);
+                sourceCode = WI.debuggerManager.scriptForIdentifierInSameProcess(scriptId, target);
                 if (sourceCode && sourceCode.resource)
                     sourceCode = sourceCode.resource;
             }

--- a/Source/WebInspectorUI/UserInterface/Protocol/Target.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/Target.js
@@ -25,7 +25,7 @@
 
 WI.Target = class Target extends WI.Object
 {
-    constructor(parentTarget, identifier, name, type, connection, {isPaused, isProvisional} = {})
+    constructor(parentTarget, identifier, name, type, connection, {isPaused, isProvisional, processId} = {})
     {
         console.assert(parentTarget === null || parentTarget instanceof WI.Target);
         console.assert(!isPaused || parentTarget.hasCommand("Target.setPauseOnStart"));
@@ -38,6 +38,12 @@ WI.Target = class Target extends WI.Object
         this._connection = connection;
         this._isPaused = !!isPaused;
         this._isProvisional = !!isProvisional;
+
+        // Targets the backend creates from another target rather than from a `Target.TargetInfo`
+        // (workers) are untagged, and run in their parent's process. Stays `undefined` when nothing
+        // in the chain knows, which leaves process-scoped lookups inert rather than wrong.
+        this._processId = processId ?? parentTarget?.processId;
+
         this._executionContext = null;
         this._mainResource = null;
         this._resourceCollection = new WI.ResourceCollection;
@@ -56,12 +62,8 @@ WI.Target = class Target extends WI.Object
         this._connection.target = this;
 
         // Agents we always expect in every target.
-        if (this.type !== WI.TargetType.Frame) {
-            // FIXME: <https://webkit.org/b/298910> Add Runtime support for FrameTarget.
-            // FIXME: <https://webkit.org/b/298909> Add Debugger support for FrameTarget.
-            console.assert(this.hasDomain("Target") || this.hasDomain("Runtime"));
-            console.assert(this.hasDomain("Target") || this.hasDomain("Debugger"));
-        }
+        console.assert(this.hasDomain("Target") || this.hasDomain("Runtime"));
+        console.assert(this.hasDomain("Target") || this.hasDomain("Debugger"));
     }
 
     // Target
@@ -210,6 +212,10 @@ WI.Target = class Target extends WI.Object
     get type() { return this._type; }
     get connection() { return this._connection; }
     get executionContext() { return this._executionContext; }
+
+    // Opaque identifier of the process hosting this target. Only meaningful when compared for
+    // equality against another target's, to tell whether the two share a process.
+    get processId() { return this._processId; }
 
     get resourceCollection() { return this._resourceCollection; }
     get extraScriptCollection() { return this._extraScriptCollection; }

--- a/Source/WebKit/UIProcess/Inspector/FrameInspectorTargetProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/FrameInspectorTargetProxy.cpp
@@ -81,4 +81,9 @@ bool FrameInspectorTargetProxy::isProvisional() const
     return m_isProvisional;
 }
 
+String FrameInspectorTargetProxy::processId() const
+{
+    return toProcessID(protect(m_targetProcess.get())->coreProcessIdentifier());
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/FrameInspectorTargetProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/FrameInspectorTargetProxy.h
@@ -48,6 +48,7 @@ public:
 
     void didCommitProvisionalTarget() override;
     bool isProvisional() const override;
+    String processId() const override;
 
     void connect(Inspector::FrontendChannel::ConnectionType) override;
     void disconnect() override;

--- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
@@ -48,4 +48,9 @@ InspectorTargetProxy::InspectorTargetProxy(const String& targetId, Inspector::In
 {
 }
 
+String InspectorTargetProxy::toProcessID(WebCore::ProcessIdentifier processID)
+{
+    return String::number(processID.toUInt64());
+}
+
 }

--- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h
@@ -26,7 +26,9 @@
 #pragma once
 
 #include <JavaScriptCore/InspectorTarget.h>
+#include <WebCore/ProcessIdentifier.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebKit {
 
@@ -40,6 +42,10 @@ public:
     String identifier() const final { return m_identifier; }
 
     virtual void didCommitProvisionalTarget() = 0;
+
+    // Single encoding of a process identity for `Inspector::InspectorTarget::processId()`, so every
+    // target type tags itself the same way and the frontend can compare the values for equality.
+    static String toProcessID(WebCore::ProcessIdentifier);
 
 protected:
     InspectorTargetProxy(const String& targetId, Inspector::InspectorTargetType);

--- a/Source/WebKit/UIProcess/Inspector/PageInspectorTargetProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/PageInspectorTargetProxy.cpp
@@ -114,4 +114,17 @@ bool PageInspectorTargetProxy::isProvisional() const
     return !!m_provisionalPage;
 }
 
+String PageInspectorTargetProxy::processId() const
+{
+    // Deliberately takes the same branch as connect() and sendMessageToTargetBackend(), so the
+    // reported process cannot drift from the one this target's messages actually travel to.
+    if (RefPtr provisionalPage = m_provisionalPage.get())
+        return toProcessID(protect(provisionalPage->process())->coreProcessIdentifier());
+
+    Ref page = m_page.get();
+    if (!page->hasRunningProcess())
+        return { };
+    return toProcessID(protect(page->legacyMainFrameProcess())->coreProcessIdentifier());
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/PageInspectorTargetProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/PageInspectorTargetProxy.h
@@ -48,6 +48,7 @@ public:
 
     void didCommitProvisionalTarget() override;
     bool isProvisional() const override;
+    String processId() const override;
 
     void connect(Inspector::FrontendChannel::ConnectionType) override;
     void disconnect() override;


### PR DESCRIPTION
#### 1b067ecd75023e8e3cdc631ef758e2f3e923b895
<pre>
[Site Isolation] Web Inspector: Stack traces lose source locations for scripts owned by another target
<a href="https://rdar.apple.com/186582847">rdar://186582847</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=323341">https://bugs.webkit.org/show_bug.cgi?id=323341</a>

Reviewed by NOBODY (OOPS!).

The frontend resolves a stack frame&apos;s script identifier only
against the target that delivered the stack trace. Under Site
Isolation this routinely fails: every domain still reporting on the
page target delivers identifiers the page target&apos;s WI.DebuggerData
has never seen, since PageDebuggerAgent doesn&apos;t attach under Site
Isolation and each frame&apos;s own FrameDebuggerAgent reports its scripts
instead. This is today&apos;s common case, and it goes away as domains
migrate to the frame target.

A second, permanent cause is that a JS stack walk crosses frame
boundaries while script ownership does not: a synchronous
same-origin call leaves the caller&apos;s script on a stack trace
delivered on the callee&apos;s target, with both targets fully migrated
and no page target involved. Resolution has to cross targets within
a process permanently, so the lookup added here to bridge this gap
is not a transitional shim.

WI.CallFrame.fromPayload falls back to two URL-keyed lookups, so
only frames with no URL (eval, new Function, sourceURL-tagged code
such as webpack&apos;s eval devtool) show the damage; a real subresource
still resolves. Canvas&apos;s &quot;created at&quot; backtrace is the only affected
caller with test coverage; Animation, Timeline, canvas Recording,
and Network request-initiator backtraces degrade the same way with
nothing to catch it.

Widen the script lookup, but only to targets sharing the delivering
target&apos;s process. A Debugger.ScriptId is a JSC SourceID drawn from a
process-global counter, so it names one script within a WebContent
process and collides freely across them; an unscoped search would
resolve a frame to an unrelated script, which is worse than
resolving it to nothing.

Scoping by process requires the frontend to know which process
hosts a target, which Target.TargetInfo doesn&apos;t currently say. Add
an optional processId to Target.TargetInfo and an opaque
InspectorTarget::processId() to supply it, kept a string for the
same reason identifier() is. FrameInspectorTargetProxy reports the
process it already sends to. PageInspectorTargetProxy takes the same
branch its connect() and sendMessageToTargetBackend() take -- the
one branch its connection actually reaches -- so the reported
process can&apos;t drift from where messages go.

The frontend defaults a target&apos;s processId to its parent&apos;s, which
is free and correct for worker targets, and leaves the widened
lookup inert against an older backend that sends no processId at
all.

The widened lookup is a new method rather than a change to
scriptForIdentifier, which also detects duplicate
Debugger.scriptParsed events and resolves breakpoints; widening
those would be a regression. Only the frame&apos;s source location
crosses targets -- the target recorded on the WI.CallFrame is still
the delivering one.

As a drive-by, retire two FIXMEs that assumed frame targets lack the
Runtime and Debugger domains (they don&apos;t, per the generated protocol
registration), and fix WI.WorkerTarget construction in
TargetManager._createTarget, which passed five arguments to a
six-parameter constructor and silently dropped isPaused. No backend
vends a worker target through Target.TargetInfo today, which is why
this went unnoticed.

The four inspector/canvas/create-context tests now pass under Site
Isolation; they carry lenient macOS expectations that predate Site
Isolation work, so they don&apos;t change signal on the mac queues. The
new test covers what they can&apos;t: that a page target, its main frame
target, and a same-origin iframe&apos;s target share one process while a
cross-origin iframe&apos;s target has its own, and that a cross-frame
stack trace delivered on a same-origin iframe&apos;s target still
resolves the parent&apos;s URL-less script -- the case that outlives the
page target.

- Note that canvases inside out-of-process iframes are still not
  reported at all, because the page target&apos;s connection only reaches the
  main frame&apos;s process; that is Canvas domain Site Isolation work and is
  not addressed here.

Test: http/tests/site-isolation/inspector/target/target-process-id.html

* LayoutTests/http/tests/site-isolation/inspector/target/resources/same-origin-frame.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/target/target-process-id-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/target/target-process-id.html: Added.
* Source/JavaScriptCore/inspector/InspectorTarget.h:
(Inspector::InspectorTarget::processId const):
* Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp:
(Inspector::buildTargetInfoObject):
* Source/JavaScriptCore/inspector/protocol/Target.json:
* Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js:
(WI.ConsoleManager.prototype.messageWasAdded):
* Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js:
(WI.DebuggerManager.prototype.scriptForIdentifierInSameProcess):
* Source/WebInspectorUI/UserInterface/Controllers/TargetManager.js:
(WI.TargetManager.prototype._createTarget):
* Source/WebInspectorUI/UserInterface/Models/CallFrame.js:
(WI.CallFrame.fromPayload):
(WI.CallFrame):
* Source/WebInspectorUI/UserInterface/Protocol/Target.js:
(WI.Target.prototype.get processId):
* Source/WebKit/UIProcess/Inspector/FrameInspectorTargetProxy.cpp:
(WebKit::FrameInspectorTargetProxy::processId const):
* Source/WebKit/UIProcess/Inspector/FrameInspectorTargetProxy.h:
* Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp:
(WebKit::InspectorTargetProxy::toProcessID):
* Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.h:
* Source/WebKit/UIProcess/Inspector/PageInspectorTargetProxy.cpp:
(WebKit::PageInspectorTargetProxy::processId const):
* Source/WebKit/UIProcess/Inspector/PageInspectorTargetProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b067ecd75023e8e3cdc631ef758e2f3e923b895

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195110 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/149706 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f4e3469-4b4c-4ee4-8b27-8b7c64a09a4e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144394 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100262 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/66f74e8d-c8eb-4133-bc4d-168cb8f77b21) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164994 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124676 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0b5cc5b-0cdb-4c14-ae79-dd14d2d4376e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46779 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44897 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7885 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13480 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157152 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44547 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6166 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46047 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197060 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58368 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164486 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153865 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59070 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153522 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48035 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131359 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127915 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57570 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19565 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56929 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57180 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57006 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->