### PR TITLE
AX: Add layout tests for accessibility attributes that had none (AXContents, AXTabs), and new coverage for editable design-mode web areas

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/design-mode-editable-ancestor-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/design-mode-editable-ancestor-expected.txt
@@ -1,0 +1,16 @@
+This test ensures turning on design mode gives content an editable ancestor even though no element carries contenteditable, because the web area itself becomes the editable root.
+
+With design mode off nothing above the paragraph is editable.
+PASS: editableAncestorRole() === 'none'
+
+With design mode on the web area is the editable root.
+PASS: editableAncestorRole() === 'AXRole: AXWebArea'
+PASS: highestEditableAncestorRole() === 'AXRole: AXWebArea'
+
+Turning it back off removes the editable ancestor again.
+PASS: editableAncestorRole() === 'none'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/design-mode-editable-ancestor.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/design-mode-editable-ancestor.html
@@ -1,0 +1,52 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">Text that design mode makes editable.</p>
+
+<script>
+var output = "This test ensures turning on design mode gives content an editable ancestor even though no element carries contenteditable, because the web area itself becomes the editable root.\n\n";
+
+function editableAncestorRole()
+{
+    var ancestor = accessibilityController.accessibleElementById("target").editableAncestor();
+    return ancestor ? ancestor.role : "none";
+}
+
+function highestEditableAncestorRole()
+{
+    var ancestor = accessibilityController.accessibleElementById("target").highestEditableAncestor();
+    return ancestor ? ancestor.role : "none";
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    output += "With design mode off nothing above the paragraph is editable.\n";
+    output += expect("editableAncestorRole()", "'none'");
+
+    setTimeout(async function() {
+        document.designMode = "on";
+
+        output += "\nWith design mode on the web area is the editable root.\n";
+        output += await expectAsync("editableAncestorRole()", "'AXRole: AXWebArea'");
+        output += expect("highestEditableAncestorRole()", "'AXRole: AXWebArea'");
+
+        document.designMode = "off";
+
+        output += "\nTurning it back off removes the editable ancestor again.\n";
+        output += await expectAsync("editableAncestorRole()", "'none'");
+
+        document.getElementById("target").style.display = "none";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/scroll-view-contents-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/scroll-view-contents-expected.txt
@@ -1,0 +1,11 @@
+This test ensures the scroll view's AXContents is its children with the scroll bars removed, so an assistive technology asking for content does not get the scroll bars back.
+
+PASS: countOfRole('AXChildren', 'AXScrollBar') === 2
+PASS: countOfRole('AXContents', 'AXScrollBar') === 0
+PASS: countOfRole('AXContents', 'AXWebArea') === 1
+PASS: lengthOf('AXContents') === lengthOf('AXChildren') - 2 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/scroll-view-contents.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/scroll-view-contents.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+#oversized { width: 200vw; height: 200vh; }
+</style>
+</head>
+<body>
+
+<div id="oversized"></div>
+
+<script>
+var output = "This test ensures the scroll view's AXContents is its children with the scroll bars removed, so an assistive technology asking for content does not get the scroll bars back.\n\n";
+
+function countOfRole(attributeName, role)
+{
+    var elements = scrollArea.uiElementArrayAttributeValue(attributeName);
+    return elements.filter(element => element.role === `AXRole: ${role}`).length;
+}
+
+function lengthOf(attributeName)
+{
+    return scrollArea.uiElementArrayAttributeValue(attributeName).length;
+}
+
+if (window.accessibilityController) {
+    var scrollArea = accessibilityController.rootElement;
+
+    output += expect("countOfRole('AXChildren', 'AXScrollBar')", "2");
+    output += expect("countOfRole('AXContents', 'AXScrollBar')", "0");
+    output += expect("countOfRole('AXContents', 'AXWebArea')", "1");
+    output += expect("lengthOf('AXContents') === lengthOf('AXChildren') - 2", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/tab-list-tabs-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/tab-list-tabs-expected.txt
@@ -1,0 +1,11 @@
+This test ensures a tab list's AXTabs is only its tab items, and that AXContents reports the same set, so a non-tab child of a tab list is not offered as a tab.
+
+PASS: lengthOf('AXChildren') === 3
+PASS: titlesOf('AXChildren') === 'First, Second, Not a tab'
+PASS: titlesOf('AXTabs') === 'First, Second'
+PASS: titlesOf('AXContents') === 'First, Second'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/tab-list-tabs.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/tab-list-tabs.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="target" role="tablist">
+<button role="tab">First</button>
+<button role="tab">Second</button>
+<button>Not a tab</button>
+</div>
+
+<script>
+var output = "This test ensures a tab list's AXTabs is only its tab items, and that AXContents reports the same set, so a non-tab child of a tab list is not offered as a tab.\n\n";
+
+function titlesOf(attributeName)
+{
+    var elements = tabList.uiElementArrayAttributeValue(attributeName);
+    return elements.map(element => element.title.replace("AXTitle: ", "")).join(", ");
+}
+
+function lengthOf(attributeName)
+{
+    return tabList.uiElementArrayAttributeValue(attributeName).length;
+}
+
+if (window.accessibilityController) {
+    var tabList = accessibilityController.accessibleElementById("target");
+
+    output += expect("lengthOf('AXChildren')", "3");
+    output += expect("titlesOf('AXChildren')", "'First, Second, Not a tab'");
+    output += expect("titlesOf('AXTabs')", "'First, Second'");
+    output += expect("titlesOf('AXContents')", "'First, Second'");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/design-mode-editable-ancestor-expected.txt
+++ b/LayoutTests/accessibility/mac/design-mode-editable-ancestor-expected.txt
@@ -1,0 +1,16 @@
+This test ensures turning on design mode gives content an editable ancestor even though no element carries contenteditable, because the web area itself becomes the editable root.
+
+With design mode off nothing above the paragraph is editable.
+PASS: editableAncestorRole() === 'none'
+
+With design mode on the web area is the editable root.
+PASS: editableAncestorRole() === 'AXRole: AXWebArea'
+PASS: highestEditableAncestorRole() === 'AXRole: AXWebArea'
+
+Turning it back off removes the editable ancestor again.
+PASS: editableAncestorRole() === 'none'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/design-mode-editable-ancestor.html
+++ b/LayoutTests/accessibility/mac/design-mode-editable-ancestor.html
@@ -1,0 +1,52 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">Text that design mode makes editable.</p>
+
+<script>
+var output = "This test ensures turning on design mode gives content an editable ancestor even though no element carries contenteditable, because the web area itself becomes the editable root.\n\n";
+
+function editableAncestorRole()
+{
+    var ancestor = accessibilityController.accessibleElementById("target").editableAncestor();
+    return ancestor ? ancestor.role : "none";
+}
+
+function highestEditableAncestorRole()
+{
+    var ancestor = accessibilityController.accessibleElementById("target").highestEditableAncestor();
+    return ancestor ? ancestor.role : "none";
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    output += "With design mode off nothing above the paragraph is editable.\n";
+    output += expect("editableAncestorRole()", "'none'");
+
+    setTimeout(async function() {
+        document.designMode = "on";
+
+        output += "\nWith design mode on the web area is the editable root.\n";
+        output += await expectAsync("editableAncestorRole()", "'AXRole: AXWebArea'");
+        output += expect("highestEditableAncestorRole()", "'AXRole: AXWebArea'");
+
+        document.designMode = "off";
+
+        output += "\nTurning it back off removes the editable ancestor again.\n";
+        output += await expectAsync("editableAncestorRole()", "'none'");
+
+        document.getElementById("target").style.display = "none";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/scroll-view-contents-expected.txt
+++ b/LayoutTests/accessibility/mac/scroll-view-contents-expected.txt
@@ -1,0 +1,11 @@
+This test ensures the scroll view's AXContents is its children with the scroll bars removed, so an assistive technology asking for content does not get the scroll bars back.
+
+PASS: countOfRole('AXChildren', 'AXScrollBar') === 2
+PASS: countOfRole('AXContents', 'AXScrollBar') === 0
+PASS: countOfRole('AXContents', 'AXWebArea') === 1
+PASS: lengthOf('AXContents') === lengthOf('AXChildren') - 2 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/scroll-view-contents.html
+++ b/LayoutTests/accessibility/mac/scroll-view-contents.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+#oversized { width: 200vw; height: 200vh; }
+</style>
+</head>
+<body>
+
+<div id="oversized"></div>
+
+<script>
+var output = "This test ensures the scroll view's AXContents is its children with the scroll bars removed, so an assistive technology asking for content does not get the scroll bars back.\n\n";
+
+function countOfRole(attributeName, role)
+{
+    var elements = scrollArea.uiElementArrayAttributeValue(attributeName);
+    return elements.filter(element => element.role === `AXRole: ${role}`).length;
+}
+
+function lengthOf(attributeName)
+{
+    return scrollArea.uiElementArrayAttributeValue(attributeName).length;
+}
+
+if (window.accessibilityController) {
+    var scrollArea = accessibilityController.rootElement;
+
+    output += expect("countOfRole('AXChildren', 'AXScrollBar')", "2");
+    output += expect("countOfRole('AXContents', 'AXScrollBar')", "0");
+    output += expect("countOfRole('AXContents', 'AXWebArea')", "1");
+    output += expect("lengthOf('AXContents') === lengthOf('AXChildren') - 2", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/tab-list-tabs-expected.txt
+++ b/LayoutTests/accessibility/mac/tab-list-tabs-expected.txt
@@ -1,0 +1,11 @@
+This test ensures a tab list's AXTabs is only its tab items, and that AXContents reports the same set, so a non-tab child of a tab list is not offered as a tab.
+
+PASS: lengthOf('AXChildren') === 3
+PASS: titlesOf('AXChildren') === 'First, Second, Not a tab'
+PASS: titlesOf('AXTabs') === 'First, Second'
+PASS: titlesOf('AXContents') === 'First, Second'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/tab-list-tabs.html
+++ b/LayoutTests/accessibility/mac/tab-list-tabs.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="target" role="tablist">
+<button role="tab">First</button>
+<button role="tab">Second</button>
+<button>Not a tab</button>
+</div>
+
+<script>
+var output = "This test ensures a tab list's AXTabs is only its tab items, and that AXContents reports the same set, so a non-tab child of a tab list is not offered as a tab.\n\n";
+
+function titlesOf(attributeName)
+{
+    var elements = tabList.uiElementArrayAttributeValue(attributeName);
+    return elements.map(element => element.title.replace("AXTitle: ", "")).join(", ");
+}
+
+function lengthOf(attributeName)
+{
+    return tabList.uiElementArrayAttributeValue(attributeName).length;
+}
+
+if (window.accessibilityController) {
+    var tabList = accessibilityController.accessibleElementById("target");
+
+    output += expect("lengthOf('AXChildren')", "3");
+    output += expect("titlesOf('AXChildren')", "'First, Second, Not a tab'");
+    output += expect("titlesOf('AXTabs')", "'First, Second'");
+    output += expect("titlesOf('AXContents')", "'First, Second'");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 4b594da11bb25377198f0a4a47617f8cf7085d90
<pre>
AX: Add layout tests for accessibility attributes that had none (AXContents, AXTabs), and new coverage for editable design-mode web areas
<a href="https://bugs.webkit.org/show_bug.cgi?id=323343">https://bugs.webkit.org/show_bug.cgi?id=323343</a>
<a href="https://rdar.apple.com/186583544">rdar://186583544</a>

Reviewed by Chris Fleizach.

scroll-view-contents.html:
AXContents had zero tests prior to this one.

tab-list-tabs.html:
AXTabs had zero tests prior to this one.

design-mode-editable-ancestor.html:
AXEditableAncestor and AXHighestEditableAncestor had two tests each, so unlike the two
above the attribute is not new here -- the branch is. editableAncestor() matches an
ancestor that is either a text control or an editable web area, and document.designMode
is the only way to reach the second without contenteditable. No existing test does this.

* LayoutTests/accessibility/isolated-tree/mac/design-mode-editable-ancestor-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/design-mode-editable-ancestor.html: Added.
* LayoutTests/accessibility/isolated-tree/mac/scroll-view-contents-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/scroll-view-contents.html: Added.
* LayoutTests/accessibility/isolated-tree/mac/tab-list-tabs-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/tab-list-tabs.html: Added.
* LayoutTests/accessibility/mac/design-mode-editable-ancestor-expected.txt: Added.
* LayoutTests/accessibility/mac/design-mode-editable-ancestor.html: Added.
* LayoutTests/accessibility/mac/scroll-view-contents-expected.txt: Added.
* LayoutTests/accessibility/mac/scroll-view-contents.html: Added.
* LayoutTests/accessibility/mac/tab-list-tabs-expected.txt: Added.
* LayoutTests/accessibility/mac/tab-list-tabs.html: Added.

Canonical link: <a href="https://commits.webkit.org/320467@main">https://commits.webkit.org/320467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cadc7d9c94653e9e4efb7dad97d1d6059b1ced85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58697 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195111 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58428 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144391 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48055 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/164993 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124673 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46778 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44898 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157151 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44546 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6167 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49240 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197061 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58369 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164485 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153867 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41211 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59071 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41163 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153524 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48037 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127916 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57571 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19564 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56930 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57181 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57007 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->