### PR TITLE
[EWS] JSC EWS can excuse a test failure on flakiness recorded by the pull request under test

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -3745,7 +3745,11 @@ class RunJavaScriptCoreTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, Sh
         # only stress failures, so the database holds no binary-test row to match one against.
         checked = stress_test_failures[:self.MAX_FAILURES_TO_CHECK_RESULTS_DB]
         unexplained = [test for test in checked if test in self.stressTestFailures_filtered]
-        flakes, flake_logs = yield ResultsDatabase.flaky_verdicts_for(unexplained, configuration=configuration, suite='javascriptcore-tests')
+        flakes, flake_logs = yield ResultsDatabase.flaky_verdicts_for(
+            unexplained, configuration=configuration, suite='javascriptcore-tests',
+            authors=self.getProperty('owners', []),
+            pr_number=self.getProperty('github.number', None),
+        )
         if flake_logs:
             yield self._addToLog(self.results_db_log_name, flake_logs)
 

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -2297,7 +2297,22 @@ class TestFilterJSCTestFailuresUsingResultsDB(BuildStepMixinAdditions, unittest.
         self.assertEqual(tests, [
             'stress/force-error.js.bytecode-cache', 'stress/dfg-osr-entry-hoisted-clobber.js.default',
         ])
-        self.assertEqual(kwargs, {'configuration': {'platform': 'mac', 'style': 'release'}, 'suite': 'javascriptcore-tests'})
+        self.assertEqual(kwargs, {
+            'configuration': {'platform': 'mac', 'style': 'release'}, 'suite': 'javascriptcore-tests',
+            'authors': [], 'pr_number': None,
+        })
+
+    @defer.inlineCallbacks
+    def test_the_jsc_read_forwards_the_change_identity(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(set())
+        self.setProperty('owners', ['jappleseed'])
+        self.setProperty('github.number', 42)
+
+        yield step.filter_failures_using_results_db(['stress/force-error.js.bytecode-cache'], ['testapi'])
+
+        self.assertEqual(len(self.flake_queries), 1)
+        _, kwargs = self.flake_queries[0]
+        self.assertEqual((kwargs['authors'], kwargs['pr_number']), (['jappleseed'], 42))
 
     @defer.inlineCallbacks
     def test_caps_the_number_of_flake_verdict_queries(self) -> Generator[Any, Any, None]:


### PR DESCRIPTION
#### 5a427de213e37450d207aa032ab7968adcc59c58
<pre>
[EWS] JSC EWS can excuse a test failure on flakiness recorded by the pull request under test
<a href="https://bugs.webkit.org/show_bug.cgi?id=323312">https://bugs.webkit.org/show_bug.cgi?id=323312</a>
&lt;<a href="https://rdar.apple.com/problem/186558747">rdar://problem/186558747</a>&gt;

Reviewed by Aakash Jain.

`RunJavaScriptCoreTests.filter_failures_using_results_db` asks
`ResultsDatabase.flaky_verdicts_for` for a verdict without passing `authors` or
`pr_number`, so the JSC queues never drop evidence recorded by the change under
judgement. A conviction there can rest entirely on rows an earlier build of the
same pull request wrote, which waves through a change that flakes only because
of itself. The layout-test and API call sites already pass both arguments; JSC
was the only one that did not.

Forward the change&apos;s identity from the same two properties the other two read,
so `_rows_by_type` drops a row whose `pr_number` is the pull request under test
or whose every recorded author is one of the change&apos;s own.

* Tools/CISupport/ews-build/steps.py:
(RunJavaScriptCoreTests.filter_failures_using_results_db):
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/320450@main">https://commits.webkit.org/320450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b370db233d027a253baa9275514912e1b4327f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58700 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195114 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186642 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58431 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48058 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/164997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124680 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46781 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157154 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44550 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6170 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197064 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/184183 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58372 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/153868 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41197 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59074 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153525 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48039 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127919 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57574 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19568 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56933 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57184 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57010 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->