### PR TITLE
AX: In isolated tree mode, drawFocusIfNeeded() bounds for a canvas fallback element can be delayed indefinitely

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/canvas-drawFocusIfNeeded-bounds-with-object-fit.html
+++ b/LayoutTests/accessibility/isolated-tree/canvas-drawFocusIfNeeded-bounds-with-object-fit.html
@@ -1,0 +1,47 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<canvas id="canvas" width="200" height="100" style="width: 400px; height: 400px; object-fit: contain;">
+    <button id="button">Canvas Button</button>
+</canvas>
+
+<script>
+var output = "This test ensures that drawFocusIfNeeded() accessibility bounds account for object-fit on the canvas.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    touchAccessibilityTree(accessibilityController.rootElement);
+
+    // Canvas backing store is 200x100. CSS box is 400x400 with object-fit: contain.
+    // The content scales by 2x (limited by width: 400/200=2, height would be 400/100=4)
+    // producing a 400x200 content area centered vertically in the 400x400 box.
+    // replacedContentRect should be (0, 100, 400, 200).
+    //
+    // A focus path at canvas (50, 25) with size (40, 20) maps to:
+    //   x: 0 + 50 * (400 / 200) = 100
+    //   y: 100 + 25 * (200 / 100) = 150
+    //   w: 40 * (400 / 200) = 80
+    //   h: 20 * (200 / 100) = 40
+    // Page position: (8 + 100, 8 + 150) = (108, 158), size (80, 40).
+    setTimeout(async function() {
+        output += await verifyCanvasFocusBounds({
+            canvasId: "canvas", canvasDescendantId: "button",
+            focusX: 50, focusY: 25, focusWidth: 40, focusHeight: 20,
+            expectedPageX: 108, expectedPageY: 158,
+            expectedWidth: 80, expectedHeight: 40,
+            variance: 1,
+        });
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/canvas-drawFocusIfNeeded-bounds-with-transform.html
+++ b/LayoutTests/accessibility/isolated-tree/canvas-drawFocusIfNeeded-bounds-with-transform.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<canvas id="canvas" width="400" height="300" style="transform: scale(2); transform-origin: 0 0;">
+    <button id="button">Canvas Button</button>
+</canvas>
+
+<script>
+var output = "This test ensures that drawFocusIfNeeded() accessibility bounds account for CSS transforms on the canvas.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    touchAccessibilityTree(accessibilityController.rootElement);
+
+    // The canvas is at (8, 8) due to body margin and has transform: scale(2)
+    // with transform-origin: 0 0. A focus path at canvas-local (100, 50) with
+    // size (80, 40) should appear at page position (8 + 100*2, 8 + 50*2) with
+    // size (80*2, 40*2).
+    setTimeout(async function() {
+        output += await verifyCanvasFocusBounds({
+            canvasId: "canvas", canvasDescendantId: "button",
+            focusX: 100, focusY: 50, focusWidth: 80, focusHeight: 40,
+            expectedPageX: 8 + 100 * 2, expectedPageY: 8 + 50 * 2,
+            expectedWidth: 80 * 2, expectedHeight: 40 * 2,
+            variance: 1,
+        });
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/canvas-drawFocusIfNeeded-bounds.html
+++ b/LayoutTests/accessibility/isolated-tree/canvas-drawFocusIfNeeded-bounds.html
@@ -1,0 +1,48 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<canvas id="canvas" width="400" height="300">
+    <button id="button">Canvas Button</button>
+</canvas>
+
+<script>
+var output = "This test ensures that drawFocusIfNeeded() correctly sets accessibility bounds for canvas fallback elements.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    touchAccessibilityTree(accessibilityController.rootElement);
+
+    var axCanvas = accessibilityController.accessibleElementById("canvas");
+    var canvasPageX = axCanvas.pageX;
+    var canvasPageY = axCanvas.pageY;
+
+    setTimeout(async function() {
+        output += await verifyCanvasFocusBounds({
+            canvasId: "canvas", canvasDescendantId: "button",
+            focusX: 100, focusY: 50, focusWidth: 80, focusHeight: 40,
+            expectedPageX: canvasPageX + 100, expectedPageY: canvasPageY + 50,
+            expectedWidth: 80, expectedHeight: 40,
+        });
+
+        output += "\nDynamic update: move the focus path to a new position.\n\n";
+
+        output += await verifyCanvasFocusBounds({
+            canvasId: "canvas", canvasDescendantId: "button",
+            focusX: 200, focusY: 150, focusWidth: 80, focusHeight: 40,
+            expectedPageX: canvasPageX + 200, expectedPageY: canvasPageY + 150,
+            expectedWidth: 80, expectedHeight: 40,
+        });
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -5693,7 +5693,7 @@ void AXObjectCache::performDeferredCacheUpdate(ForceLayout forceLayout)
     if (!document->view())
         return;
 
-    if (needsLayoutOrStyleRecalc(*document)) {
+    if (auto documentNeeds = needsLayoutOrStyleRecalc(*document)) {
         // Layout became dirty while waiting to performDeferredCacheUpdate, and we require clean layout
         // to update the accessibility tree correctly in this function.
         if ((m_cacheUpdateDeferredCount >= 3 || forceLayout == ForceLayout::Yes) && !Accessibility::inRenderTreeOrStyleUpdate(*document)) {
@@ -5701,8 +5701,12 @@ void AXObjectCache::performDeferredCacheUpdate(ForceLayout forceLayout)
             m_cacheUpdateDeferredCount = 0;
             document->updateLayoutIgnorePendingStylesheets();
         } else {
-            // Wait for layout to trigger another async cache update.
             ++m_cacheUpdateDeferredCount;
+            if (!documentNeeds.contains(DocumentNeeds::Layout) && !m_performCacheUpdateTimer.isActive()) {
+                // A pending style recalc may not necessarily trigger layout, so restart the timer explicitly
+                // to avoid stranding deferred changes.
+                m_performCacheUpdateTimer.startOneShot(0_s);
+            }
             return;
         }
     }

--- a/Source/WebCore/accessibility/AXUtilities.cpp
+++ b/Source/WebCore/accessibility/AXUtilities.cpp
@@ -520,13 +520,16 @@ String roleToString(AccessibilityRole role)
     return ""_s;
 }
 
-bool needsLayoutOrStyleRecalc(const Document& document)
+OptionSet<DocumentNeeds> needsLayoutOrStyleRecalc(const Document& document)
 {
+    OptionSet<DocumentNeeds> needs;
     if (RefPtr frameView = document.view()) {
         if (frameView->needsLayout() || frameView->layoutContext().isLayoutPending())
-            return true;
+            needs.add(DocumentNeeds::Layout);
     }
-    return document.hasPendingStyleRecalc();
+    if (document.hasPendingStyleRecalc())
+        needs.add(DocumentNeeds::StyleRecalc);
+    return needs;
 }
 
 std::optional<CursorType> cursorTypeFrom(const StyleProperties& properties)

--- a/Source/WebCore/accessibility/AXUtilities.h
+++ b/Source/WebCore/accessibility/AXUtilities.h
@@ -28,6 +28,7 @@
 #include <WebCore/Element.h>
 #include <WebCore/Node.h>
 #include <WebCore/RenderImage.h>
+#include <wtf/OptionSet.h>
 
 namespace WebCore {
 
@@ -72,7 +73,13 @@ bool hasARIAAccNameAttribute(Element&);
 
 bool isNodeFocused(Node&);
 
-bool needsLayoutOrStyleRecalc(const Document&);
+enum class DocumentNeeds : uint8_t {
+    Layout = 1 << 0,
+    StyleRecalc = 1 << 1,
+};
+// Whether the document needs some action before being considered clean enough to update the
+// accessibility tree from. Returns an empty set if the document is clean.
+OptionSet<DocumentNeeds> needsLayoutOrStyleRecalc(const Document&);
 
 bool NODELETE isRenderHidden(const Style::ComputedStyle*);
 // Checks both CSS display properties, and CSS visibility properties.


### PR DESCRIPTION
#### 6009380248ac33dc2cc9876ae881ed828993bff9
<pre>
AX: In isolated tree mode, drawFocusIfNeeded() bounds for a canvas fallback element can be delayed indefinitely
<a href="https://bugs.webkit.org/show_bug.cgi?id=323345">https://bugs.webkit.org/show_bug.cgi?id=323345</a>
<a href="https://rdar.apple.com/186587133">rdar://186587133</a>

Reviewed by Chris Fleizach and Dominic Mazzoni.

drawFocusIfNeeded() routes the focus ring&apos;s bounds to the accessibility tree
through AXObjectCache::deferCanvasFocusPathBoundsUpdate, which queues them for
performDeferredCacheUpdate. That function returns early when
needsLayoutOrStyleRecalc() is true, and the only thing that brings it back is a
layout.

The problem is that needsLayoutOrStyleRecalc() is also true for a pending style recalc,
and a style recalc can resolve without a layout following it, stranding the deferred changes
indefinitely (until something else triggers an update).

Fix this by restarting m_performCacheUpdateTimer when we deferred due to a pending style recalc.

Three new canvas tests pass in isolated tree mode.

* LayoutTests/accessibility/isolated-tree/canvas-drawFocusIfNeeded-bounds-with-object-fit.html: Added.
* LayoutTests/accessibility/isolated-tree/canvas-drawFocusIfNeeded-bounds-with-transform.html: Added.
* LayoutTests/accessibility/isolated-tree/canvas-drawFocusIfNeeded-bounds.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::performDeferredCacheUpdate):
* Source/WebCore/accessibility/AXUtilities.cpp:
(WebCore::needsLayoutOrStyleRecalc):
* Source/WebCore/accessibility/AXUtilities.h:

Canonical link: <a href="https://commits.webkit.org/320543@main">https://commits.webkit.org/320543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a30715d820966d023e41d4774c065b2e601c19f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195121 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/19f94b06-946a-4afd-8474-c3e94df57836) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186649 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58436 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144402 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7024ab33-ff1c-4073-a39a-0ebe28c33235) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124684 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bedbecc8-4f5b-4ebf-81b1-6bc911467a62) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46784 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44905 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157157 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44553 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6177 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197070 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58377 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164492 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153874 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41278 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59081 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153531 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48045 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131370 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127924 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57579 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19571 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56938 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57189 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57015 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->