### PR TITLE
[Site Isolation] Fix two child-frame back/forward crashes under UseUIProcessForBackForwardItemLoading

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3069,10 +3069,6 @@ void FrameLoader::checkLoadCompleteForThisFrame(LoadWillContinueInAnotherProcess
         if (!provisionalDocumentLoader->isLoadingInAPISense() || provisionalDocumentLoader->isStopping()) {
             FRAMELOADER_RELEASE_LOG_FORWARDABLE(FrameLoaderCheckLoadCompleteForThisFrameFailedProvisionalLoad, error.isTimeout(), error.isCancellation(), error.errorCode(), isHTTPSFirstApplicable);
 
-            // Provisional load failed before didBeginDocument() could clear the async-wait state;
-            // clear it here so this frame stops blocking its parent's completion.
-            clearAsyncBackForwardNavigationState();
-
             if (loadWillContinueInAnotherProcess == LoadWillContinueInAnotherProcess::No) {
                 auto willInternallyHandleFailure = (error.errorRecoveryMethod() == ResourceError::ErrorRecoveryMethod::NoRecovery || (error.errorRecoveryMethod() == ResourceError::ErrorRecoveryMethod::HTTPFallback && (!isHTTPSFirstApplicable || isHTTPFallbackInProgressOrUpgradeDisabled()))) ? WillInternallyHandleFailure::No : WillInternallyHandleFailure::Yes;
 
@@ -3099,6 +3095,10 @@ void FrameLoader::checkLoadCompleteForThisFrame(LoadWillContinueInAnotherProcess
                 if (!unreachableURL.isEmpty() && unreachableURL == provisionalDocumentLoader->request().url())
                     shouldReset = false;
             }
+
+            // Re-enters this function for this frame through the parent frame, so it must not run until the failure has
+            // been dispatched and the provisional load cleared.
+            clearAsyncBackForwardNavigationState();
         }
         if (shouldReset && item) {
             if (RefPtr page = m_frame->page())

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -102,6 +102,7 @@
 #include <WebCore/HTMLSelectElement.h>
 #include <WebCore/HTMLTextAreaElement.h>
 #include <WebCore/HandleUserInputEventResult.h>
+#include <WebCore/HistoryController.h>
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/ImageData.h>
 #include <WebCore/JSCSSStyleDeclaration.h>
@@ -759,13 +760,17 @@ void WebFrame::setHistoryItemForBackForwardNavigation(const FrameState& frameSta
     if (!localFrame || !page)
         return;
 
+    Ref frameLoader = localFrame->loader();
+
+    if (frameLoader->history().provisionalItem())
+        return;
+
     // Build HistoryItem from FrameState
     Ref historyItemClient = page->historyItemClient();
     auto ignoreHistoryItemChangesForScope = historyItemClient->ignoreChangesForScope();
     ASSERT(!page->corePage()->settings().useUIProcessForBackForwardItemLoading() || frameState.children.isEmpty());
     Ref historyItem = toHistoryItem(historyItemClient, protect(frameState));
 
-    Ref frameLoader = localFrame->loader();
     frameLoader->setRequestedHistoryItem(historyItem);
 }
 


### PR DESCRIPTION
#### 903ac5bb71b1148e51a55fa062f2030aa3da36b3
<pre>
[Site Isolation] Fix two child-frame back/forward crashes under UseUIProcessForBackForwardItemLoading
<a href="https://bugs.webkit.org/show_bug.cgi?id=323349">https://bugs.webkit.org/show_bug.cgi?id=323349</a>
<a href="https://rdar.apple.com/186589707">rdar://186589707</a>

Reviewed by NOBODY (OOPS!).

Enabling UseUIProcessForBackForwardItemLoading crashes debug builds on two child-frame
back/forward paths. Both are prerequisites for turning the preference on by default
(<a href="https://bugs.webkit.org/show_bug.cgi?id=316588).">https://bugs.webkit.org/show_bug.cgi?id=316588).</a>

FrameLoader::checkLoadCompleteForThisFrame() cleared the async-wait state before dispatching
the provisional load failure. clearAsyncBackForwardNavigationState() runs checkCompleted() on
the parent frame, which re-enters checkLoadCompleteForThisFrame() for the same frame, so the
inner pass dispatched the failure and the outer pass dispatched it a second time. The UIProcess
then received two DidFailProvisionalLoadForFrame messages for one provisional load and hit
ASSERT(m_state == State::Provisional) in FrameLoadState::didFailProvisionalLoad(). The existing
m_provisionalLoadErrorBeingHandledURL guard does not catch this because it is only set inside
dispatchDidFailProvisionalLoad(). Clear the state after the failure is dispatched and the
provisional load is cleared instead.

FrameLoader::loadDifferentDocumentItem() sets targetBackForwardItemIdentifier on every
back/forward navigation action, so WebPageProxy::decidePolicyForNavigationAction() answers a
child frame&apos;s own history.back() with a FrameState too.
WebFrame::setHistoryItemForBackForwardNavigation() turned that into a second HistoryItem and
replaced m_requestedHistoryItem while the first one was still the provisional item, failing
ASSERT(history().provisionalItem() == m_requestedHistoryItem) in
FrameLoader::retryAfterFailedCacheOnlyMainResourceLoad() when a POST item&apos;s cache-only load
misses. Only apply the FrameState when the frame has no provisional item, which is the
parent-driven dispatchBackForwardItemLoading() case the delivery exists for.

Covered by existing tests. With the preference enabled,
http/tests/navigation/post-frames-goback1.html and post-frames-goback1-uncached.html reproduce
the first crash and
imported/w3c/web-platform-tests/navigation-timing/navigation-type-post-backforward.html
reproduces the second; all three pass with this change. The preference is off by default, so
there is no behavior change without it.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::setHistoryItemForBackForwardNavigation):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/903ac5bb71b1148e51a55fa062f2030aa3da36b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195132 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/149718 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f06425f0-b91c-4a1d-9c8a-173b16ee341c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186660 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144411 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100265 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/455b07ca-4f63-4d6e-b295-ab676f8ce0bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165007 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124695 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba73ab4d-2259-4264-8be5-e873ab490d3f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46801 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44911 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157173 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44564 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6188 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51383 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197081 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58388 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153884 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59092 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41177 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153541 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48057 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131381 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127934 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57590 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19582 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56948 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57199 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57025 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->