### PR TITLE
Cherry-pick 305413.1005@safari-7624.5.1.10-branch (a26cf8dc190a). https://bugs.webkit.org/show_bug.cgi?id=317320

### DIFF
--- a/LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash-expected.txt
+++ b/LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash.html
+++ b/LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+// The victim's JS wrapper is created in the parent realm so it never roots the iframe's window.
+let victim = document.createElement('div');
+window.__victim = victim;
+
+let f = document.createElement('iframe');
+f.srcdoc =
+    '<meta http-equiv="Content-Security-Policy" content="require-trusted-types-for \'script\'">' +
+    '<body>' +
+    '<' + 'script>document.body.appendChild(parent.__victim); parent.__factory = trustedTypes;</' + 'script>';
+f.onload = () => setTimeout(() => setTimeout(go, 0), 0);
+document.body.appendChild(f);
+
+function callback() {
+    document.adoptNode(victim);
+    f.remove();
+    f = null;
+    if (window.GCController)
+        GCController.collect();
+    return null;
+}
+
+function go() {
+    // Register the iframe's default policy via the parent-realm createPolicy binding so the
+    // callback's stored JSDOMGlobalObject is the parent's window.
+    TrustedTypePolicyFactory.prototype.createPolicy.call(window.__factory, 'default', { createScript: callback });
+    window.__factory = null;
+    window.__victim = null;
+    if (window.GCController)
+        GCController.collect();
+    // Triggers the TrustedScript default-policy callback while the only protection for the
+    // iframe's Document is the raw ScriptExecutionContext& held by trustedTypeCompliantString.
+    try { victim.setAttribute('onclick', 'x'); } catch (e) { }
+    document.body.textContent = 'PASS if no crash';
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+</body>

--- a/LayoutTests/http/tests/webshare/shareddatareader-didfinishloading-crash-expected.txt
+++ b/LayoutTests/http/tests/webshare/shareddatareader-didfinishloading-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes it it does not crash.

--- a/LayoutTests/http/tests/webshare/shareddatareader-didfinishloading-crash.html
+++ b/LayoutTests/http/tests/webshare/shareddatareader-didfinishloading-crash.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<html>
+<body>
+<p>This test passes it it does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+// Large logical File so the async blob load is still in flight when window.stop() runs.
+let chunk = new Blob([new ArrayBuffer(1 << 20)]);
+let big = chunk;
+for (let i = 0; i < 13; i++)
+    big = new Blob([big, big]);   // 8 GiB logical
+let hugeFile = new File([big], "huge.bin", {type: "application/octet-stream"});
+
+// Child iframe; retain only its Navigator.
+let f = document.createElement('iframe');
+document.body.appendChild(f);
+let childNav = f.contentWindow.navigator;
+
+// Cross-realm share(): receiver = child Navigator, [CallWith=CurrentDocument] binds the parent Document,
+// so the blob load is registered against the parent and survives child-frame removal.
+internals.withUserGesture(() => {
+    Navigator.prototype.share.call(childNav, { files: [hugeFile] });
+});
+
+// Drop the child realm; after GC, the only remaining Ref<Navigator> is the one captured
+// inside ShareDataReader::m_completionHandler.
+childNav = null;
+f.remove();
+f = null;
+for (let i = 0; i < 10; i++)  {
+    if (window.GCController)
+        GCController.collect();
+}
+
+// Yield, GC again, then cancel the in-flight blob load via window.stop().
+// FileReaderLoader::failed -> BlobLoader::didFail -> ShareDataReader::didFinishLoading (error branch)
+// invokes and destroys the local completionHandler, which releases the last Ref<Navigator>;
+// ~Navigator -> ~m_loader -> ~ShareDataReader frees `this`; the next statement cancel() is a UAF.
+setTimeout(() => {
+    for (let i = 0; i < 10; i++) {
+        if (window.GCController)
+            GCController.collect();
+    }
+    
+    window.stop();
+    if (window.testRunner)
+        testRunner.notifyDone();
+}, 100);
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -94,7 +94,7 @@ ExceptionOr<void> Attr::setValue(const AtomString& value)
             auto type = trustedTypeForAttribute(element->nodeName(), qualifiedName().localName(),
                 element->namespaceURI(), qualifiedName().namespaceURI());
             if (!type.attributeType.isNull()) {
-                auto compliantValue = trustedTypesCompliantAttributeValue(protect(document())->contextDocument(), type.attributeType, value,
+                auto compliantValue = trustedTypesCompliantAttributeValue(protect(protect(document())->contextDocument()), type.attributeType, value,
                     type.sink);
                 if (compliantValue.hasException())
                     return compliantValue.releaseException();

--- a/Source/WebCore/page/ShareDataReader.cpp
+++ b/Source/WebCore/page/ShareDataReader.cpp
@@ -51,8 +51,9 @@ void ShareDataReader::start(Document* document, ShareDataWithParsedURL&& shareDa
     int count = 0;
     m_pendingFileLoads.reserveInitialCapacity(m_shareData.shareData.files.size());
     for (auto& blob : m_shareData.shareData.files) {
-        Ref blobLoader = BlobLoader::create([this, count, fileName = blob->name()](BlobLoader&) {
-            this->didFinishLoading(count, fileName);
+        Ref blobLoader = BlobLoader::create([weakThis = WeakPtr { *this }, count, fileName = blob->name()](BlobLoader&) {
+            if (RefPtr protectedThis = weakThis)
+                protectedThis->didFinishLoading(count, fileName);
         });
         m_pendingFileLoads.append(blobLoader.copyRef());
         blobLoader->start(blob, document, FileReaderLoader::ReadAsArrayBuffer);

--- a/Source/WebCore/page/ShareDataReader.h
+++ b/Source/WebCore/page/ShareDataReader.h
@@ -27,6 +27,7 @@
 
 #include "ShareData.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
@@ -36,7 +37,7 @@ class Document;
 class ScriptExecutionContext;
 template<typename> class ExceptionOr;
 
-class ShareDataReader : public RefCounted<ShareDataReader> {
+class ShareDataReader : public RefCountedAndCanMakeWeakPtr<ShareDataReader> {
 public:
     static Ref<ShareDataReader> create(CompletionHandler<void(ExceptionOr<ShareDataWithParsedURL&>)>&& completionHandler) { return adoptRef(*new ShareDataReader(WTF::move(completionHandler))); }
     ~ShareDataReader();

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -41,6 +41,7 @@
 #include <WebCore/DiagnosticLoggingClient.h>
 #include <WebCore/DiagnosticLoggingKeys.h>
 #include <wtf/Borrow.h>
+#include <WebCore/Page.h>
 #include <wtf/DebugUtilities.h>
 #include <wtf/HexNumber.h>
 #include <wtf/SetForScope.h>
@@ -759,8 +760,12 @@ void WebBackForwardList::backForwardAddItem(IPC::Connection& connection, Ref<Fra
         backForwardAddItemShared(connection, WTF::move(navigatedFrameState), webPageProxy->didLoadWebArchive() ? LoadedWebArchive::Yes : LoadedWebArchive::No);
 }
 
-static bool messageCheckItemURLs(Ref<FrameState>& frameState, Ref<WebProcessProxy>& process)
+static constexpr unsigned maxFrameStateDepthForMessageCheck = WebCore::Page::maxFrameDepth;
+
+static bool messageCheckItemURLs(Ref<FrameState>& frameState, Ref<WebProcessProxy>& process, unsigned depth = 0)
 {
+    MESSAGE_CHECK_WITH_RETURN_VALUE(process, depth < maxFrameStateDepthForMessageCheck, false);
+
     URL itemURL { frameState->urlString };
     URL itemOriginalURL { frameState->originalURLString };
 #if PLATFORM(COCOA)
@@ -775,6 +780,11 @@ static bool messageCheckItemURLs(Ref<FrameState>& frameState, Ref<WebProcessProx
 #if PLATFORM(COCOA)
     }
 #endif
+
+    for (auto& child : frameState->children) {
+        if (!messageCheckItemURLs(child, process, depth + 1))
+            return false;
+    }
     return true;
 }
 


### PR DESCRIPTION
#### 1b78c03f880e0ab78dc98b24d598608f4798b1bf
<pre>
Cherry-pick 305413.1005@safari-7624.5.1.10-branch (a26cf8dc190a). <a href="https://bugs.webkit.org/show_bug.cgi?id=317320">https://bugs.webkit.org/show_bug.cgi?id=317320</a>

    Use-after-free of ScriptExecutionContext in trustedTypeCompliantString
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317320">https://bugs.webkit.org/show_bug.cgi?id=317320</a>
    <a href="https://rdar.apple.com/177766868">rdar://177766868</a>

    Reviewed by Chris Dumez.

    The method processValueWithDefaultPolicy can end up deleting the ScriptExecutionContext passed as parameter.
    This patch fixes this by adding protection of ScriptExecutionContext.

    Test: fast/html/trusted-types-set-attribute-iframe-removal-crash.html

    * LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash.html: Added.
    * LayoutTests/fast/html/trusted-types-set-attribute-iframe-removal-crash-expected.txt: Added.
    * Source/WebCore/dom/Attr.cpp:
    (WebCore::Attr::setValue):
    * Source/WebCore/dom/Element.cpp:
    (WebCore::Element::setAttribute):
    (WebCore::Element::setAttributeNode):
    (WebCore::Element::setAttributeNodeNS):
    (WebCore::Element::setAttributeNS):
    * Source/WebCore/dom/TrustedType.cpp:
    (WebCore::trustedTypeCompliantString):
    (WebCore::requireTrustedTypesForPreNavigationCheckPasses):

    Identifier: 305413.1005@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.191@webkitglib/2.54">https://commits.webkit.org/317695.191@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 17e7d4e6383c64971b5c0f28b783ab0bc1c15ee9
<pre>
Cherry-pick 305413.994@safari-7624.5.1.10-branch (890fde552386). <a href="https://bugs.webkit.org/show_bug.cgi?id=317270">https://bugs.webkit.org/show_bug.cgi?id=317270</a>

    [WebCore] use-after-free in ShareDataReader::didFinishLoading: cancel() called on freed this after completionHandler destruction
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317270">https://bugs.webkit.org/show_bug.cgi?id=317270</a>
    <a href="https://rdar.apple.com/177909918">rdar://177909918</a>

    Reviewed by Per Arne Vollan and Ben Nham.

    Make sure we capture `weakThis` in the lambda instead of `this`, then
    convert to a RefPtr before calling `didfinishLoading()` so that `this`
    cannot be destroyed *while* running `didfinishLoading()`.

    Test: http/tests/webshare/shareddatareader-didfinishloading-crash.html

    * LayoutTests/http/tests/webshare/shareddatareader-didfinishloading-crash-expected.txt: Added.
    * LayoutTests/http/tests/webshare/shareddatareader-didfinishloading-crash.html: Added.
    * Source/WebCore/page/ShareDataReader.cpp:
    (WebCore::ShareDataReader::start):
    * Source/WebCore/page/ShareDataReader.h:

    Identifier: 305413.994@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.190@webkitglib/2.54">https://commits.webkit.org/317695.190@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 5e01f586357f4132e3cc8a252e3c76a4250d4dca
<pre>
Cherry-pick 305413.993@safari-7624.5-branch (ce08c270d322). <a href="https://bugs.webkit.org/show_bug.cgi?id=317142">https://bugs.webkit.org/show_bug.cgi?id=317142</a>

    Incomplete fix of WebKit bug 315528 (Message check file urls in back/forward list messages)
    <a href="https://rdar.apple.com/177953315">rdar://177953315</a>

    Reviewed by Chris Dumez.

    Apply the message check to sub-items in the history item tree, and other validations of the tree.

    Test: Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm

    * Source/WebKit/UIProcess/WebBackForwardList.cpp:
    (WebKit::messageCheckItemURLs):
    * Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
    ((WKBackForwardList, MessageCheckRejectsNestedFileURLChild)):
    ((WKBackForwardList, MessageCheckRejectsDeeplyNestedFileURLChild)):
    ((WKBackForwardList, MessageCheckRejectsExcessiveChildDepth)):
    ((WKBackForwardList, MessageCheckAcceptsBenignNestedChildren)):

    Identifier: 305413.993@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.189@webkitglib/2.54">https://commits.webkit.org/317695.189@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5cb21b9a2fb9f417923f572f5c59f7b2d54e298

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184807 "2 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/58727 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52557 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195141 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149722 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186669 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60083 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58456 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144415 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149722 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187762 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60083 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/52557 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124700 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60083 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58456 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/52557 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60083 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52557 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6197 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/51392 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/58456 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197090 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/58397 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/52557 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153890 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59101 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52557 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153547 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28088 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59101 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/131390 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127949 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/57599 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/52557 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/56957 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57208 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57034 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->