### PR TITLE
Cherry-pick 305413.1077@safari-7624.5.1.10-branch (62fcbfe61a49). https://bugs.webkit.org/show_bug.cgi?id=318405

### DIFF
--- a/JSTests/stress/dfg-getscope-fold-stale-cfa-state.js
+++ b/JSTests/stress/dfg-getscope-fold-stale-cfa-state.js
@@ -1,0 +1,29 @@
+function opt(a1, a2, a3, a4, a5) {
+    try {
+        class Trans extends Array {
+        };
+        function inline() {
+            try {
+                a2(["Āሴ￿", a5]);
+            } catch (x) {
+            };
+        };
+        inline();
+    } catch (x) {
+    };
+    function foo(a, b) {
+        for (var x = 0; x < 10000; x++) {
+        };
+        return a == b;
+    }
+    foo(-1, a5);
+    class C {
+    };
+}
+
+for (let i = 0; i < 10000; i++) {
+    try {
+        opt(Function.prototype.apply, Function.prototype.toString, 1.1, '💩', Object.defineProperty);
+    } catch (e) {
+    }
+}

--- a/LayoutTests/fast/css/font-face-worker-serialization-thread-safety-expected.txt
+++ b/LayoutTests/fast/css/font-face-worker-serialization-thread-safety-expected.txt
@@ -1,0 +1,10 @@
+A worker serializing FontFace descriptors must not race the main thread on the process-global CSS serialization memoization map (CSSPrimitiveValue). Under ASan/TSan, the unfixed code reports a heap-use-after-free or double-free in HashTable::rehash; this test should run clean.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Did not crash during concurrent serialization.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/font-face-worker-serialization-thread-safety.html
+++ b/LayoutTests/fast/css/font-face-worker-serialization-thread-safety.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("A worker serializing FontFace descriptors must not race the main thread on the process-global CSS serialization memoization map (CSSPrimitiveValue). Under ASan/TSan, the unfixed code reports a heap-use-after-free or double-free in HashTable::rehash; this test should run clean.");
+
+jsTestIsAsync = true;
+
+// Each worker hammers customCSSText() off the main thread for ~800ms. It mixes two paths:
+//   - fractional percentages, which allocate a fresh heap CSSPrimitiveValue per value and, when
+//     overwritten, destroy it (map.add followed by map.remove) to churn the shared HashTable and
+//     provoke rehash() of the backing buffer.
+//   - integer percentages 0..255, which resolve to the shared StaticCSSValuePool objects that are
+//     also serialized on the main thread (the bit-field hazard).
+var workerSource = `
+    function pump() {
+        var deadline = performance.now() + 800;
+        while (performance.now() < deadline) {
+            var faces = [];
+            for (var i = 0; i < 256; ++i) {
+                var fractional = (i + 0.123456).toFixed(6) + "%";
+                var face = new FontFace("worker-" + i, "url(x)", { sizeAdjust: fractional });
+                face.sizeAdjust; // map.add(heap value)
+                faces.push(face);
+            }
+            for (var j = 0; j < faces.length; ++j) {
+                faces[j].sizeAdjust = (j + 0.654321).toFixed(6) + "%"; // destroys previous => map.remove
+                faces[j].sizeAdjust; // map.add(new heap value)
+            }
+            for (var k = 0; k < 256; ++k) {
+                // Shared static-pool objects, also touched on the main thread.
+                var shared = new FontFace("shared-" + k, "url(x)", { sizeAdjust: k + "%" });
+                shared.sizeAdjust;
+                shared.style;
+                shared.weight;
+                shared.width;
+            }
+        }
+        postMessage("done");
+    }
+    pump();
+`;
+
+var NUM_WORKERS = 4;
+var workersDone = 0;
+var blobURL = URL.createObjectURL(new Blob([workerSource], { type: "text/javascript" }));
+
+function onWorkerDone() {
+    if (++workersDone < NUM_WORKERS)
+        return;
+    testPassed("Did not crash during concurrent serialization.");
+    finishJSTest();
+}
+
+for (var w = 0; w < NUM_WORKERS; ++w) {
+    var worker = new Worker(blobURL);
+    worker.onmessage = onWorkerDone;
+}
+
+// Concurrently churn the shared map on the main thread: fractional percentages create and destroy
+// heap CSSPrimitiveValues, and integer percentages hit the same shared static-pool objects.
+var element = document.documentElement;
+var deadline = performance.now() + 800;
+while (performance.now() < deadline) {
+    for (var i = 0; i < 256; ++i) {
+        element.style.width = (i + 0.7777).toFixed(6) + "%"; // create heap value
+        element.style.getPropertyValue("width");             // map.add; next overwrite => map.remove
+    }
+    element.style.height = "100%";
+    for (var i = 0; i < 64; ++i)
+        element.style.getPropertyValue("height");            // shared static-pool object
+}
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash-expected.txt
+++ b/LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash.html
+++ b/LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+function gc()
+{
+    if (window.GCController)
+        GCController.collect();
+}
+
+async function go()
+{
+    // The offline render thread runs renderQuantum() in a tight loop on a dedicated
+    // thread, calling handlePostRenderTasks() (and thus handleDeferredDerefs()) on
+    // every quantum.
+    let context = new OfflineAudioContext(1, 48000 * 120, 48000);
+
+    // |target| holds the AudioParam (target.gain) whose ref-count is raced.
+    let target = new GainNode(context);
+    target.connect(context.destination);
+
+    let lockHog = new GainNode(context);
+
+    let done = false;
+    context.startRendering().then(() => { done = true; }, () => { done = true; });
+
+    for (let iteration = 0; iteration < 200 && !done; ++iteration) {
+        // |sources| each connect their output to target.gain so that
+        // (a) their outputs hold a Ref<AudioParam> in m_params and
+        // (b) target.gain pulls each source on the render thread, taking a
+        //     transient RefPtr<AudioNode> via protect(node()) inside pull().
+        let sources = [];
+        for (let i = 0; i < 16; ++i) {
+            let source = new GainNode(context);
+            source.connect(target.gain);
+            sources.push(source);
+        }
+
+        // Let handlePreRenderTasks() promote the new outputs into m_renderingOutputs.
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        // Hold the graph lock from the main thread so the render thread's
+        // AudioNode::deref() (from the protect() above) tryLock-fails and is
+        // queued onto m_deferredDerefList.
+        for (let i = 0; i < 4000; ++i)
+            lockHog.channelCount = (i & 1) ? 1 : 2;
+
+        // Drop the wrappers; ~JSGainNode runs AudioNode::deref() on the main thread.
+        // Any deferred-deref entries from above keep m_normalRefCount > 0 here.
+        sources = null;
+        gc();
+
+        // Once we stop touching the graph lock, the next handlePostRenderTasks() ->
+        // handleDeferredDerefs() drives a source's m_normalRefCount to 0 on the
+        // render thread, reaching markNodeForDeletionIfNecessary() ->
+        // AudioNodeOutput::disconnectAllParams() and ref'ing / deref'ing target.gain
+        // there. Touch the wrapper concurrently from the main thread.
+        let until = performance.now() + 8;
+        while (performance.now() < until) {
+            target.gain;
+            gc();
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+    }
+
+    document.body.textContent = "PASS if no crash.";
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+window.onload = go;
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1403,6 +1403,7 @@ private:
                 case NewAsyncFunction: {
                     node->convertToIdentityOn(node->child1()->child1().node());
                     node->child1().setUseKind(KnownCellUse);
+                    m_interpreter.execute(indexInBlock); // Catch the fact that we may overwrite a stale AbstractValue.
                     eliminated = true;
                     break;
                 }

--- a/Source/WebCore/Modules/webaudio/AudioParam.h
+++ b/Source/WebCore/Modules/webaudio/AudioParam.h
@@ -35,7 +35,7 @@
 #include <JavaScriptCore/Forward.h>
 #include <sys/types.h>
 #include <wtf/LoggerHelper.h>
-#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -46,7 +46,7 @@ enum class AutomationRateMode : bool { Fixed, Variable };
 
 class AudioParam final
     : public AudioSummingJunction
-    , public RefCounted<AudioParam>
+    , public ThreadSafeRefCounted<AudioParam, WTF::DestructionThread::Main>
 #if !RELEASE_LOG_DISABLED
     , private LoggerHelper
 #endif

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -43,7 +43,9 @@
 #include "RenderView.h"
 #include "StyleCalculationValue.h"
 #include "StyleLengthResolution.h"
+#include <type_traits>
 #include <wtf/Hasher.h>
+#include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/MakeString.h>
@@ -412,6 +414,7 @@ CSSPrimitiveValue::~CSSPrimitiveValue()
         break;
     }
     if (m_hasCachedCSSText) {
+        ASSERT(isMainThread());
         ASSERT(serializedPrimitiveValues().contains(this));
         serializedPrimitiveValues().remove(this);
     }
@@ -1050,11 +1053,20 @@ String CSSPrimitiveValue::customCSSText(const CSS::SerializationContext& context
     case CSSUnitType::CSS_PROPERTY_ID:
         return nameString(m_value.propertyID);
     default:
+        // The memoization map and m_hasCachedCSSText are not thread-safe, and worker threads can
+        // serialize FontFace descriptors concurrently with the main thread. Only memoize on the
+        // main thread; other threads serialize without touching the shared state.
+        if (!isMainThread())
+            return serializeInternal(context);
         auto& map = serializedPrimitiveValues();
         ASSERT(map.contains(this) == m_hasCachedCSSText);
         if (m_hasCachedCSSText)
             return map.get(this);
         String serializedValue = serializeInternal(context);
+        // m_hasCachedCSSText is written here without synchronization, so it must live in its own
+        // memory location (not a bit-field packed with concurrently-read members).
+        static_assert(std::is_member_object_pointer_v<decltype(&CSSPrimitiveValue::m_hasCachedCSSText)>,
+            "m_hasCachedCSSText must not be a bit-field");
         m_hasCachedCSSText = true;
         map.add(this, serializedValue);
         return serializedValue;

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -301,11 +301,12 @@ protected:
 
     // CSSPrimitiveValue:
     uint8_t m_primitiveUnitType : 7 { 0 }; // CSSUnitType
-    mutable uint8_t m_hasCachedCSSText : 1 { false };
     uint8_t m_isImplicitInitialValue : 1 { false };
 
     // CSSValueList and CSSValuePair:
     uint8_t m_valueSeparator : ValueSeparatorBits { 0 };
+
+    mutable uint8_t m_hasCachedCSSText { false };
 
 private:
     ClassType m_classType : ClassTypeBits;


### PR DESCRIPTION
#### a8ae94eba31199b13ea1c6323a594680fce490e0
<pre>
Cherry-pick 305413.1077@safari-7624.5.1.10-branch (62fcbfe61a49). <a href="https://bugs.webkit.org/show_bug.cgi?id=318405">https://bugs.webkit.org/show_bug.cgi?id=318405</a>

    use-after-free of AudioParam via cross-thread non-atomic ref/deref in AudioNodeOutput::disconnectAllParams()
    <a href="https://rdar.apple.com/177930032">rdar://177930032</a>

    Reviewed by Youenn Fablet.

    Make AudioParam use thread-safe refcounted.

    Test: webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash.html

    * LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash-expected.txt: Added.
    * LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash.html: Added.
    * Source/WebCore/Modules/webaudio/AudioParam.h:

    Identifier: 305413.1077@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1141@webkitglib/2.52">https://commits.webkit.org/305877.1141@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 3c52c9cfaecb9e2d87b986d80814140d164113a2
<pre>
Cherry-pick 305413.1032@safari-7624.5.1.10-branch (bc1c6b94e762). <a href="https://bugs.webkit.org/show_bug.cgi?id=317654">https://bugs.webkit.org/show_bug.cgi?id=317654</a>

    [WebCore] Unsynchronized access to process-global serializedPrimitiveValues() HashMap in CSSPrimitiveValue::customCSSText from Worker thread
    <a href="https://rdar.apple.com/177596584">rdar://177596584</a>

    Reviewed by Alan Baradlay.

    FontFace is Exposed=(Window,Worker), so its descriptor getters serialize
    CSSPrimitiveValues off the main thread via customCSSText(), racing the main
    thread on the unsynchronized process-global serialization map and the
    m_hasCachedCSSText flag. A concurrent HashTable rehash can free the backing
    buffer while another thread holds a bucket pointer, producing a
    heap-use-after-free or double-free.

    Only memoize on the main thread; other threads serialize directly without
    touching the shared state. Move m_hasCachedCSSText out of the bit-field group so
    the main thread can set it without racing reads of the adjacent bits of a shared
    static value.

    Test: fast/css/font-face-worker-serialization-thread-safety.html
    * LayoutTests/fast/css/font-face-worker-serialization-thread-safety-expected.txt: Added.
    * LayoutTests/fast/css/font-face-worker-serialization-thread-safety.html: Added.
    * Source/WebCore/css/CSSPrimitiveValue.cpp:
    (WebCore::CSSPrimitiveValue::~CSSPrimitiveValue):
    (WebCore::CSSPrimitiveValue::customCSSText const):
    * Source/WebCore/css/CSSValue.h:

    Identifier: 305413.1032@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1140@webkitglib/2.52">https://commits.webkit.org/305877.1140@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### fba8cb51df0521c4537718a4a9de7f94b6a344e6
<pre>
Cherry-pick 305413.1012@safari-7624.5.1.10-branch (3efb180e50d2). <a href="https://bugs.webkit.org/show_bug.cgi?id=316803">https://bugs.webkit.org/show_bug.cgi?id=316803</a>

    [JSC] Refresh AI state when folding GetScope to Identity
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316803">https://bugs.webkit.org/show_bug.cgi?id=316803</a>
    <a href="https://rdar.apple.com/178423757">rdar://178423757</a>

    Reviewed by Yusuke Suzuki.

    A GetScope could be constant folded to Identity. When this happens, the
    abstract interpreter isn&apos;t re-executed on the Identity node. If a previous run
    of the AI left the abstract value corresponding to the pre-replacement GetScope
    node as bottom, this stale bottom value can cause downstream consumers to
    assume the Identity is unreachable when it is.

    This PR re-executes AI after folding to Identity.

    Test: JSTests/stress/dfg-getscope-fold-stale-cfa-state.js

    * JSTests/stress/dfg-getscope-fold-stale-cfa-state.js: Added.
    (try.Trans):
    (try.inline):
    (foo):
    (C):
    (opt):
    (i.catch):
    * Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
    (JSC::DFG::ConstantFoldingPhase::foldConstants):

    Identifier: 305413.1012@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1139@webkitglib/2.52">https://commits.webkit.org/305877.1139@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/358c8ed154510686541b4b2169ce4de1454cc262

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184810 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/58730 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52560 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195144 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149723 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186672 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60086 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58459 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144438 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149723 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187765 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60086 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/52560 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124723 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60086 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58459 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6671 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/52560 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60086 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52560 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6200 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/46078 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/51395 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/58459 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197093 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/58400 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/52560 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153909 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59104 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52560 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153566 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28090 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59104 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/131393 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/127953 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/57602 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/52560 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/56960 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57211 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57037 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->