### PR TITLE
[Text Extraction] iOS: Override several mouse-related media queries when loading desktop-class content with background text extraction

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8264,6 +8264,15 @@ ShouldPrintBackgrounds:
     WebCore:
       default: false
 
+ShouldReportDesktopClassPointingDevice:
+  type: bool
+  status: embedder
+  humanReadableName: "Report Desktop Class Pointing Device"
+  humanReadableDescription: "Report a mouse-like pointing device to the hover and pointer media features"
+  defaultValue:
+    WebCore:
+      default: false
+
 ShouldReportViewportSizeAsScreenSize:
   type: bool
   status: embedder

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -231,9 +231,10 @@ static const IdentifierSchema& anyHoverFeatureSchema()
         FixedVector { CSSValueNone, CSSValueHover },
         OptionSet<MediaQueryDynamicDependency>(),
         [](auto& context) {
-            if (context.document->quirks().shouldSupportHoverMediaQueries())
+            Ref frame = *context.document->frame();
+            if (context.document->quirks().shouldSupportHoverMediaQueries() || frame->settings().shouldReportDesktopClassPointingDevice())
                 return MatchingIdentifiers { CSSValueHover };
-            RefPtr page = context.document->frame()->page();
+            RefPtr page = frame->page();
             bool isSupported = page && page->chrome().client().hoverSupportedByAnyAvailablePointingDevice();
             return MatchingIdentifiers { isSupported ? CSSValueHover : CSSValueNone };
         }
@@ -248,7 +249,11 @@ static const IdentifierSchema& anyPointerFeatureSchema()
         FixedVector { CSSValueNone, CSSValueFine, CSSValueCoarse },
         OptionSet<MediaQueryDynamicDependency>(),
         [](auto& context) {
-            RefPtr page = context.document->frame()->page();
+            Ref frame = *context.document->frame();
+            if (frame->settings().shouldReportDesktopClassPointingDevice())
+                return MatchingIdentifiers { CSSValueFine };
+
+            RefPtr page = frame->page();
             auto pointerCharacteristics = page ? page->chrome().client().pointerCharacteristicsOfAllAvailablePointingDevices() : OptionSet<PointerCharacteristics>();
 
             MatchingIdentifiers identifiers;
@@ -443,9 +448,10 @@ static const IdentifierSchema& hoverFeatureSchema()
         FixedVector { CSSValueNone, CSSValueHover },
         OptionSet<MediaQueryDynamicDependency>(),
         [](auto& context) {
-            if (context.document->quirks().shouldSupportHoverMediaQueries())
+            Ref frame = *context.document->frame();
+            if (context.document->quirks().shouldSupportHoverMediaQueries() || frame->settings().shouldReportDesktopClassPointingDevice())
                 return MatchingIdentifiers { CSSValueHover };
-            RefPtr page = context.document->frame()->page();
+            RefPtr page = frame->page();
             bool isSupported =  page && page->chrome().client().hoverSupportedByPrimaryPointingDevice();
             return MatchingIdentifiers { isSupported ? CSSValueHover : CSSValueNone };
         }
@@ -525,7 +531,11 @@ static const IdentifierSchema& pointerFeatureSchema()
         FixedVector { CSSValueNone, CSSValueFine, CSSValueCoarse },
         OptionSet<MediaQueryDynamicDependency>(),
         [](auto& context) {
-            RefPtr page = context.document->frame()->page();
+            Ref frame = *context.document->frame();
+            if (frame->settings().shouldReportDesktopClassPointingDevice())
+                return MatchingIdentifiers { CSSValueFine };
+
+            RefPtr page = frame->page();
             auto pointerCharacteristics = page ? page->chrome().client().pointerCharacteristicsOfPrimaryPointingDevice() : OptionSet<PointerCharacteristics>();
             MatchingIdentifiers identifiers;
             if (pointerCharacteristics.contains(PointerCharacteristics::Fine))

--- a/Source/WebKit/Shared/WebsitePoliciesData.cpp
+++ b/Source/WebKit/Shared/WebsitePoliciesData.cpp
@@ -118,6 +118,9 @@ void WebsitePoliciesData::applyToSettings(const WebsitePoliciesData& websitePoli
 
     if (auto overrideValue = websitePolicies.overrideShouldReportViewportSizeAsScreenSize)
         settings.setShouldReportViewportSizeAsScreenSize(*overrideValue);
+
+    if (auto overrideValue = websitePolicies.overrideShouldReportDesktopClassPointingDevice)
+        settings.setShouldReportDesktopClassPointingDevice(*overrideValue);
 }
 
 void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePolicies, WebCore::DocumentLoader& documentLoader)
@@ -251,6 +254,9 @@ void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePol
 
     if (auto overrideValue = websitePolicies.overrideShouldReportViewportSizeAsScreenSize)
         frame->settings().setShouldReportViewportSizeAsScreenSize(*overrideValue);
+
+    if (auto overrideValue = websitePolicies.overrideShouldReportDesktopClassPointingDevice)
+        frame->settings().setShouldReportDesktopClassPointingDevice(*overrideValue);
 
     documentLoader.applyPoliciesToSettings();
 }

--- a/Source/WebKit/Shared/WebsitePoliciesData.h
+++ b/Source/WebKit/Shared/WebsitePoliciesData.h
@@ -76,6 +76,7 @@ public:
     std::optional<bool> overrideShouldReportZeroMaxTouchPoints;
 #endif
     std::optional<bool> overrideShouldReportViewportSizeAsScreenSize;
+    std::optional<bool> overrideShouldReportDesktopClassPointingDevice;
     std::optional<bool> globalPrivacyControlEnabled;
     WebsiteAutoplayPolicy autoplayPolicy { WebsiteAutoplayPolicy::Default };
     WebsitePopUpPolicy popUpPolicy { WebsitePopUpPolicy::Default };

--- a/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
+++ b/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
@@ -74,6 +74,7 @@ struct WebKit::WebsitePoliciesData {
     std::optional<bool> overrideShouldReportZeroMaxTouchPoints;
 #endif
     std::optional<bool> overrideShouldReportViewportSizeAsScreenSize;
+    std::optional<bool> overrideShouldReportDesktopClassPointingDevice;
     std::optional<bool> globalPrivacyControlEnabled;
     WebKit::WebsiteAutoplayPolicy autoplayPolicy;
     WebKit::WebsitePopUpPolicy popUpPolicy;

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -162,6 +162,8 @@ public:
 
     void setOverrideShouldReportViewportSizeAsScreenSize(bool value) { m_data.overrideShouldReportViewportSizeAsScreenSize = value; }
 
+    void setOverrideShouldReportDesktopClassPointingDevice(bool value) { m_data.overrideShouldReportDesktopClassPointingDevice = value; }
+
     WebKit::WebsiteInlineMediaPlaybackPolicy inlineMediaPlaybackPolicy() const { return m_data.inlineMediaPlaybackPolicy; }
     void setInlineMediaPlaybackPolicy(WebKit::WebsiteInlineMediaPlaybackPolicy policy) { m_data.inlineMediaPlaybackPolicy = policy; }
 

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1590,6 +1590,7 @@ WebContentMode WebPageProxy::effectiveContentModeAfterAdjustingPolicies(API::Web
         policies.setOverrideShouldReportZeroMaxTouchPoints(shouldEmulateDesktopClassHardware);
 #endif
         policies.setOverrideShouldReportViewportSizeAsScreenSize(shouldEmulateDesktopClassHardware && !desktopClassBrowsingSupported());
+        policies.setOverrideShouldReportDesktopClassPointingDevice(shouldEmulateDesktopClassHardware);
     };
 
     if (needsSiteSpecificQuirks) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -3329,6 +3329,11 @@ static bool isSmallScreenDevice()
     return UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone;
 }
 
+static bool matchesMediaQuery(TestWKWebView *webView, NSString *query)
+{
+    return [[webView objectByEvaluatingJavaScript:[NSString stringWithFormat:@"matchMedia('%@').matches", query]] boolValue];
+}
+
 static void expectDesktopClassHardwareEmulation(TestWKWebView *webView)
 {
 #if ENABLE(IOS_TOUCH_EVENTS)
@@ -3337,6 +3342,13 @@ static void expectDesktopClassHardwareEmulation(TestWKWebView *webView)
 #if ENABLE(TOUCH_EVENTS)
     EXPECT_FALSE(touchEventDOMAttributesAreExposed(webView));
 #endif
+
+    EXPECT_TRUE(matchesMediaQuery(webView, @"(pointer: fine)"));
+    EXPECT_TRUE(matchesMediaQuery(webView, @"(any-pointer: fine)"));
+    EXPECT_TRUE(matchesMediaQuery(webView, @"(hover: hover)"));
+    EXPECT_TRUE(matchesMediaQuery(webView, @"(any-hover: hover)"));
+    EXPECT_FALSE(matchesMediaQuery(webView, @"(pointer: coarse)"));
+    EXPECT_FALSE(matchesMediaQuery(webView, @"(hover: none)"));
 
     if (!isSmallScreenDevice())
         return;
@@ -3357,6 +3369,11 @@ static void expectNoDesktopClassHardwareEmulation(TestWKWebView *webView)
 #if ENABLE(TOUCH_EVENTS)
     EXPECT_TRUE(touchEventDOMAttributesAreExposed(webView));
 #endif
+
+    EXPECT_TRUE(matchesMediaQuery(webView, @"(pointer: coarse)"));
+    EXPECT_TRUE(matchesMediaQuery(webView, @"(hover: none)"));
+    EXPECT_FALSE(matchesMediaQuery(webView, @"(pointer: fine)"));
+    EXPECT_FALSE(matchesMediaQuery(webView, @"(hover: hover)"));
 
     if (!isSmallScreenDevice())
         return;


### PR DESCRIPTION
#### ae4e64022c2f5abe9db96726c5f066812875a375
<pre>
[Text Extraction] iOS: Override several mouse-related media queries when loading desktop-class content with background text extraction
<a href="https://bugs.webkit.org/show_bug.cgi?id=323355">https://bugs.webkit.org/show_bug.cgi?id=323355</a>
<a href="https://rdar.apple.com/186475042">rdar://186475042</a>

Reviewed by Abrar Rahman Protyasha and Richard Robinson.

Override several mouse, hover and pointer-related media queries to behave more like Mac in the case
where:

- Background text extraction is enabled
- The client requests desktop content mode

Instead of `(pointer: coarse)` and `(hover: none)`, we&apos;ll instead get `(pointer: fine)` and
`(hover: hover)`.

Test: TextExtractionTests.DesktopClassHardwareEmulationInDesktopContentMode

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::anyHoverFeatureSchema):
(WebCore::MQ::Features::anyPointerFeatureSchema):
(WebCore::MQ::Features::hoverFeatureSchema):
(WebCore::MQ::Features::pointerFeatureSchema):
* Source/WebKit/Shared/WebsitePoliciesData.cpp:
(WebKit::WebsitePoliciesData::applyToSettings):
(WebKit::WebsitePoliciesData::applyToDocumentLoader):
* Source/WebKit/Shared/WebsitePoliciesData.h:
* Source/WebKit/Shared/WebsitePoliciesData.serialization.in:
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::effectiveContentModeAfterAdjustingPolicies):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:

Canonical link: <a href="https://commits.webkit.org/320464@main">https://commits.webkit.org/320464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3eb5491e43ff1c6643fafe00cfbe23d782fe8ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195145 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e23d84c-8fca-4107-a64e-86c15cb2b890) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60087 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58460 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144428 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d2f6322a-0370-4338-a081-20fcfc99c086) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48092 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165023 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124713 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/abc7b30d-ef69-4c34-b03c-575110e724f0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46816 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/6662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13513 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157188 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44581 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6201 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46079 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197094 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58401 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153899 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41207 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59105 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41193 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153556 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48073 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131394 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127954 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57603 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19599 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56961 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57212 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57038 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->