### PR TITLE
AX: Add layout tests for form control state reaching accessibility

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/custom-validity-invalid-status-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/custom-validity-invalid-status-expected.txt
@@ -1,0 +1,19 @@
+This test ensures a validity message set with setCustomValidity makes a control report AXInvalid true, and that clearing the message restores AXInvalid false.
+
+A control with no constraint is valid.
+PASS: target.checkValidity() === true
+PASS: invalidStatus() === 'false'
+
+A custom validity message makes it invalid to accessibility too.
+PASS: target.checkValidity() === false
+PASS: target.validationMessage === 'Pick a different value'
+PASS: invalidStatus() === 'true'
+
+Clearing the message restores it.
+PASS: target.checkValidity() === true
+PASS: invalidStatus() === 'false'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/custom-validity-invalid-status.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/custom-validity-invalid-status.html
@@ -1,0 +1,50 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<input id="target" value="anything">
+
+<script>
+var output = "This test ensures a validity message set with setCustomValidity makes a control report AXInvalid true, and that clearing the message restores AXInvalid false.\n\n";
+
+function invalidStatus()
+{
+    return accessibilityController.accessibleElementById("target").stringAttributeValue("AXInvalid");
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var target = document.getElementById("target");
+
+    output += "A control with no constraint is valid.\n";
+    output += expect("target.checkValidity()", "true");
+    output += expect("invalidStatus()", "'false'");
+
+    setTimeout(async function() {
+        target.setCustomValidity("Pick a different value");
+
+        output += "\nA custom validity message makes it invalid to accessibility too.\n";
+        output += expect("target.checkValidity()", "false");
+        output += expect("target.validationMessage", "'Pick a different value'");
+        output += await expectAsync("invalidStatus()", "'true'");
+
+        target.setCustomValidity("");
+
+        output += "\nClearing the message restores it.\n";
+        output += expect("target.checkValidity()", "true");
+        output += await expectAsync("invalidStatus()", "'false'");
+
+        document.getElementById("target").style.display = "none";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/fieldset-disabled-propagation-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/fieldset-disabled-propagation-expected.txt
@@ -1,0 +1,13 @@
+This test ensures disabled on a fieldset reaches every descendant control's accessibility enabled state, except a control in the fieldset's first legend, which HTML exempts.
+
+PASS: isEnabled('in-fieldset') === false
+PASS: isEnabled('in-legend') === true
+PASS: isEnabled('outside') === true
+
+Removing disabled from the fieldset re-enables the descendant.
+PASS: isEnabled('in-fieldset') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/fieldset-disabled-propagation.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/fieldset-disabled-propagation.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<fieldset id="fieldset" disabled>
+<legend><input id="in-legend"></legend>
+<input id="in-fieldset">
+</fieldset>
+<input id="outside">
+
+<script>
+var output = "This test ensures disabled on a fieldset reaches every descendant control's accessibility enabled state, except a control in the fieldset's first legend, which HTML exempts.\n\n";
+
+function isEnabled(id)
+{
+    return accessibilityController.accessibleElementById(id).isEnabled;
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    output += expect("isEnabled('in-fieldset')", "false");
+    output += expect("isEnabled('in-legend')", "true");
+    output += expect("isEnabled('outside')", "true");
+
+    setTimeout(async function() {
+        document.getElementById("fieldset").disabled = false;
+
+        output += "\nRemoving disabled from the fieldset re-enables the descendant.\n";
+        output += await expectAsync("isEnabled('in-fieldset')", "true");
+
+        document.getElementById("fieldset").style.display = "none";
+        document.getElementById("outside").style.display = "none";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/required-control-invalid-status-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/required-control-invalid-status-expected.txt
@@ -1,0 +1,18 @@
+This test ensures a control that fails native constraint validation reports AXInvalid true without the author setting aria-invalid, and that AXInvalid and checkValidity() agree as the control becomes valid.
+
+A required control left empty is invalid to both the DOM and accessibility.
+PASS: target.checkValidity() === false
+PASS: invalidStatus() === 'true'
+
+Satisfying the constraint clears both.
+PASS: target.checkValidity() === true
+PASS: invalidStatus() === 'false'
+
+aria-invalid is authored, so it wins over the native state.
+PASS: target.checkValidity() === true
+PASS: invalidStatus() === 'spelling'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/required-control-invalid-status.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/required-control-invalid-status.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<input id="target" required>
+
+<script>
+var output = "This test ensures a control that fails native constraint validation reports AXInvalid true without the author setting aria-invalid, and that AXInvalid and checkValidity() agree as the control becomes valid.\n\n";
+
+function invalidStatus()
+{
+    return accessibilityController.accessibleElementById("target").stringAttributeValue("AXInvalid");
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var target = document.getElementById("target");
+
+    output += "A required control left empty is invalid to both the DOM and accessibility.\n";
+    output += expect("target.checkValidity()", "false");
+    output += expect("invalidStatus()", "'true'");
+
+    setTimeout(async function() {
+        target.value = "supplied";
+
+        output += "\nSatisfying the constraint clears both.\n";
+        output += expect("target.checkValidity()", "true");
+        output += await expectAsync("invalidStatus()", "'false'");
+
+        target.setAttribute("aria-invalid", "spelling");
+
+        output += "\naria-invalid is authored, so it wins over the native state.\n";
+        output += expect("target.checkValidity()", "true");
+        output += await expectAsync("invalidStatus()", "'spelling'");
+
+        document.getElementById("target").style.display = "none";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/custom-validity-invalid-status-expected.txt
+++ b/LayoutTests/accessibility/mac/custom-validity-invalid-status-expected.txt
@@ -1,0 +1,19 @@
+This test ensures a validity message set with setCustomValidity makes a control report AXInvalid true, and that clearing the message restores AXInvalid false.
+
+A control with no constraint is valid.
+PASS: target.checkValidity() === true
+PASS: invalidStatus() === 'false'
+
+A custom validity message makes it invalid to accessibility too.
+PASS: target.checkValidity() === false
+PASS: target.validationMessage === 'Pick a different value'
+PASS: invalidStatus() === 'true'
+
+Clearing the message restores it.
+PASS: target.checkValidity() === true
+PASS: invalidStatus() === 'false'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/custom-validity-invalid-status.html
+++ b/LayoutTests/accessibility/mac/custom-validity-invalid-status.html
@@ -1,0 +1,50 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<input id="target" value="anything">
+
+<script>
+var output = "This test ensures a validity message set with setCustomValidity makes a control report AXInvalid true, and that clearing the message restores AXInvalid false.\n\n";
+
+function invalidStatus()
+{
+    return accessibilityController.accessibleElementById("target").stringAttributeValue("AXInvalid");
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var target = document.getElementById("target");
+
+    output += "A control with no constraint is valid.\n";
+    output += expect("target.checkValidity()", "true");
+    output += expect("invalidStatus()", "'false'");
+
+    setTimeout(async function() {
+        target.setCustomValidity("Pick a different value");
+
+        output += "\nA custom validity message makes it invalid to accessibility too.\n";
+        output += expect("target.checkValidity()", "false");
+        output += expect("target.validationMessage", "'Pick a different value'");
+        output += await expectAsync("invalidStatus()", "'true'");
+
+        target.setCustomValidity("");
+
+        output += "\nClearing the message restores it.\n";
+        output += expect("target.checkValidity()", "true");
+        output += await expectAsync("invalidStatus()", "'false'");
+
+        document.getElementById("target").style.display = "none";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/fieldset-disabled-propagation-expected.txt
+++ b/LayoutTests/accessibility/mac/fieldset-disabled-propagation-expected.txt
@@ -1,0 +1,13 @@
+This test ensures disabled on a fieldset reaches every descendant control's accessibility enabled state, except a control in the fieldset's first legend, which HTML exempts.
+
+PASS: isEnabled('in-fieldset') === false
+PASS: isEnabled('in-legend') === true
+PASS: isEnabled('outside') === true
+
+Removing disabled from the fieldset re-enables the descendant.
+PASS: isEnabled('in-fieldset') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/fieldset-disabled-propagation.html
+++ b/LayoutTests/accessibility/mac/fieldset-disabled-propagation.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<fieldset id="fieldset" disabled>
+<legend><input id="in-legend"></legend>
+<input id="in-fieldset">
+</fieldset>
+<input id="outside">
+
+<script>
+var output = "This test ensures disabled on a fieldset reaches every descendant control's accessibility enabled state, except a control in the fieldset's first legend, which HTML exempts.\n\n";
+
+function isEnabled(id)
+{
+    return accessibilityController.accessibleElementById(id).isEnabled;
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    output += expect("isEnabled('in-fieldset')", "false");
+    output += expect("isEnabled('in-legend')", "true");
+    output += expect("isEnabled('outside')", "true");
+
+    setTimeout(async function() {
+        document.getElementById("fieldset").disabled = false;
+
+        output += "\nRemoving disabled from the fieldset re-enables the descendant.\n";
+        output += await expectAsync("isEnabled('in-fieldset')", "true");
+
+        document.getElementById("fieldset").style.display = "none";
+        document.getElementById("outside").style.display = "none";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/required-control-invalid-status-expected.txt
+++ b/LayoutTests/accessibility/mac/required-control-invalid-status-expected.txt
@@ -1,0 +1,18 @@
+This test ensures a control that fails native constraint validation reports AXInvalid true without the author setting aria-invalid, and that AXInvalid and checkValidity() agree as the control becomes valid.
+
+A required control left empty is invalid to both the DOM and accessibility.
+PASS: target.checkValidity() === false
+PASS: invalidStatus() === 'true'
+
+Satisfying the constraint clears both.
+PASS: target.checkValidity() === true
+PASS: invalidStatus() === 'false'
+
+aria-invalid is authored, so it wins over the native state.
+PASS: target.checkValidity() === true
+PASS: invalidStatus() === 'spelling'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/required-control-invalid-status.html
+++ b/LayoutTests/accessibility/mac/required-control-invalid-status.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<input id="target" required>
+
+<script>
+var output = "This test ensures a control that fails native constraint validation reports AXInvalid true without the author setting aria-invalid, and that AXInvalid and checkValidity() agree as the control becomes valid.\n\n";
+
+function invalidStatus()
+{
+    return accessibilityController.accessibleElementById("target").stringAttributeValue("AXInvalid");
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var target = document.getElementById("target");
+
+    output += "A required control left empty is invalid to both the DOM and accessibility.\n";
+    output += expect("target.checkValidity()", "false");
+    output += expect("invalidStatus()", "'true'");
+
+    setTimeout(async function() {
+        target.value = "supplied";
+
+        output += "\nSatisfying the constraint clears both.\n";
+        output += expect("target.checkValidity()", "true");
+        output += await expectAsync("invalidStatus()", "'false'");
+
+        target.setAttribute("aria-invalid", "spelling");
+
+        output += "\naria-invalid is authored, so it wins over the native state.\n";
+        output += expect("target.checkValidity()", "true");
+        output += await expectAsync("invalidStatus()", "'spelling'");
+
+        document.getElementById("target").style.display = "none";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 0491e835aaeb89231f2ee5bd0ea3396e5c9535f7
<pre>
AX: Add layout tests for form control state reaching accessibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=323356">https://bugs.webkit.org/show_bug.cgi?id=323356</a>
<a href="https://rdar.apple.com/186598685">rdar://186598685</a>

Reviewed by Chris Fleizach.

required-control-invalid-status.html:
No test called checkValidity(). Asserts AXInvalid and checkValidity() agree on the same
control, and that aria-invalid wins over the native state (a branch that was untested).

custom-validity-invalid-status.html:
No test called setCustomValidity() and verified AXInvalid changed to match.

fieldset-disabled-propagation.html:
No test both used a disabled fieldset and asserted the enabled state it propagates.
Covers HTML&apos;s first-legend exemption, the rule most likely to be lost in a refactor.

* LayoutTests/accessibility/isolated-tree/mac/custom-validity-invalid-status-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/custom-validity-invalid-status.html: Added.
* LayoutTests/accessibility/isolated-tree/mac/fieldset-disabled-propagation-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/fieldset-disabled-propagation.html: Added.
* LayoutTests/accessibility/isolated-tree/mac/required-control-invalid-status-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/required-control-invalid-status.html: Added.
* LayoutTests/accessibility/mac/custom-validity-invalid-status-expected.txt: Added.
* LayoutTests/accessibility/mac/custom-validity-invalid-status.html: Added.
* LayoutTests/accessibility/mac/fieldset-disabled-propagation-expected.txt: Added.
* LayoutTests/accessibility/mac/fieldset-disabled-propagation.html: Added.
* LayoutTests/accessibility/mac/required-control-invalid-status-expected.txt: Added.
* LayoutTests/accessibility/mac/required-control-invalid-status.html: Added.

Canonical link: <a href="https://commits.webkit.org/320468@main">https://commits.webkit.org/320468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8622730b28405800070f7a03c039bd0ae57ad49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195146 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60088 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144420 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165018 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124705 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46808 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157180 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44576 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6202 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197095 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58402 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153894 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41212 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59106 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153551 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48065 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127955 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57604 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19594 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56962 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57213 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57039 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->