### PR TITLE
SVG property registry should not take the initial value as a non-type template parameter

### DIFF
--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
@@ -43,10 +43,10 @@ SVGComponentTransferFunctionElement::SVGComponentTransferFunctionElement(const Q
         didRegistration = true;
         PropertyRegistry::registerProperty<SVGNames::typeAttr, ComponentTransferType, &SVGComponentTransferFunctionElement::m_type>();
         PropertyRegistry::registerProperty<SVGNames::tableValuesAttr, &SVGComponentTransferFunctionElement::m_tableValues>();
-        PropertyRegistry::registerProperty<SVGNames::slopeAttr, &SVGComponentTransferFunctionElement::m_slope, initialSlopeValue>();
+        PropertyRegistry::registerProperty<SVGNames::slopeAttr, &SVGComponentTransferFunctionElement::m_slope>(initialSlopeValue);
         PropertyRegistry::registerProperty<SVGNames::interceptAttr, &SVGComponentTransferFunctionElement::m_intercept>();
-        PropertyRegistry::registerProperty<SVGNames::amplitudeAttr, &SVGComponentTransferFunctionElement::m_amplitude, initialAmplitudeValue>();
-        PropertyRegistry::registerProperty<SVGNames::exponentAttr, &SVGComponentTransferFunctionElement::m_exponent, initialExponentValue>();
+        PropertyRegistry::registerProperty<SVGNames::amplitudeAttr, &SVGComponentTransferFunctionElement::m_amplitude>(initialAmplitudeValue);
+        PropertyRegistry::registerProperty<SVGNames::exponentAttr, &SVGComponentTransferFunctionElement::m_exponent>(initialExponentValue);
         PropertyRegistry::registerProperty<SVGNames::offsetAttr, &SVGComponentTransferFunctionElement::m_offset>();
     };
 }

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -46,9 +46,9 @@ inline SVGFEConvolveMatrixElement::SVGFEConvolveMatrixElement(const QualifiedNam
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
         PropertyRegistry::registerProperty<SVGNames::inAttr, &SVGFEConvolveMatrixElement::m_in1>();
-        PropertyRegistry::registerProperty<SVGNames::orderAttr, &SVGFEConvolveMatrixElement::m_orderX, &SVGFEConvolveMatrixElement::m_orderY, initialOrderValue, initialOrderValue>();
+        PropertyRegistry::registerProperty<SVGNames::orderAttr, &SVGFEConvolveMatrixElement::m_orderX, &SVGFEConvolveMatrixElement::m_orderY>(initialOrderValue, initialOrderValue);
         PropertyRegistry::registerProperty<SVGNames::kernelMatrixAttr, &SVGFEConvolveMatrixElement::m_kernelMatrix>();
-        PropertyRegistry::registerProperty<SVGNames::divisorAttr, &SVGFEConvolveMatrixElement::m_divisor, initialDivisorValue>();
+        PropertyRegistry::registerProperty<SVGNames::divisorAttr, &SVGFEConvolveMatrixElement::m_divisor>(initialDivisorValue);
         PropertyRegistry::registerProperty<SVGNames::biasAttr, &SVGFEConvolveMatrixElement::m_bias>();
         PropertyRegistry::registerProperty<SVGNames::targetXAttr, &SVGFEConvolveMatrixElement::m_targetX>();
         PropertyRegistry::registerProperty<SVGNames::targetYAttr, &SVGFEConvolveMatrixElement::m_targetY>();

--- a/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
@@ -45,8 +45,8 @@ inline SVGFEDiffuseLightingElement::SVGFEDiffuseLightingElement(const QualifiedN
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
         PropertyRegistry::registerProperty<SVGNames::inAttr, &SVGFEDiffuseLightingElement::m_in1>();
-        PropertyRegistry::registerProperty<SVGNames::diffuseConstantAttr, &SVGFEDiffuseLightingElement::m_diffuseConstant, initialDiffuseConstantValue>();
-        PropertyRegistry::registerProperty<SVGNames::surfaceScaleAttr, &SVGFEDiffuseLightingElement::m_surfaceScale, initialSurfaceScaleValue>();
+        PropertyRegistry::registerProperty<SVGNames::diffuseConstantAttr, &SVGFEDiffuseLightingElement::m_diffuseConstant>(initialDiffuseConstantValue);
+        PropertyRegistry::registerProperty<SVGNames::surfaceScaleAttr, &SVGFEDiffuseLightingElement::m_surfaceScale>(initialSurfaceScaleValue);
         PropertyRegistry::registerProperty<SVGNames::kernelUnitLengthAttr, &SVGFEDiffuseLightingElement::m_kernelUnitLengthX, &SVGFEDiffuseLightingElement::m_kernelUnitLengthY>();
     }
 }

--- a/Source/WebCore/svg/SVGFEDropShadowElement.cpp
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.cpp
@@ -45,9 +45,9 @@ inline SVGFEDropShadowElement::SVGFEDropShadowElement(const QualifiedName& tagNa
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
         PropertyRegistry::registerProperty<SVGNames::inAttr, &SVGFEDropShadowElement::m_in1>();
-        PropertyRegistry::registerProperty<SVGNames::dxAttr, &SVGFEDropShadowElement::m_dx, initialDxValue>();
-        PropertyRegistry::registerProperty<SVGNames::dyAttr, &SVGFEDropShadowElement::m_dy, initialDyValue>();
-        PropertyRegistry::registerProperty<SVGNames::stdDeviationAttr, &SVGFEDropShadowElement::m_stdDeviationX, &SVGFEDropShadowElement::m_stdDeviationY, initialStdDeviationValue, initialStdDeviationValue>();
+        PropertyRegistry::registerProperty<SVGNames::dxAttr, &SVGFEDropShadowElement::m_dx>(initialDxValue);
+        PropertyRegistry::registerProperty<SVGNames::dyAttr, &SVGFEDropShadowElement::m_dy>(initialDyValue);
+        PropertyRegistry::registerProperty<SVGNames::stdDeviationAttr, &SVGFEDropShadowElement::m_stdDeviationX, &SVGFEDropShadowElement::m_stdDeviationY>(initialStdDeviationValue, initialStdDeviationValue);
     }
 }
 

--- a/Source/WebCore/svg/SVGFELightElement.cpp
+++ b/Source/WebCore/svg/SVGFELightElement.cpp
@@ -58,7 +58,7 @@ SVGFELightElement::SVGFELightElement(const QualifiedName& tagName, Document& doc
         PropertyRegistry::registerProperty<SVGNames::pointsAtXAttr, &SVGFELightElement::m_pointsAtX>();
         PropertyRegistry::registerProperty<SVGNames::pointsAtYAttr, &SVGFELightElement::m_pointsAtY>();
         PropertyRegistry::registerProperty<SVGNames::pointsAtZAttr, &SVGFELightElement::m_pointsAtZ>();
-        PropertyRegistry::registerProperty<SVGNames::specularExponentAttr, &SVGFELightElement::m_specularExponent, initialSpecularExponentValue>();
+        PropertyRegistry::registerProperty<SVGNames::specularExponentAttr, &SVGFELightElement::m_specularExponent>(initialSpecularExponentValue);
         PropertyRegistry::registerProperty<SVGNames::limitingConeAngleAttr, &SVGFELightElement::m_limitingConeAngle>();
     }
 }

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
@@ -47,9 +47,9 @@ inline SVGFESpecularLightingElement::SVGFESpecularLightingElement(const Qualifie
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
         PropertyRegistry::registerProperty<SVGNames::inAttr, &SVGFESpecularLightingElement::m_in1>();
-        PropertyRegistry::registerProperty<SVGNames::specularConstantAttr, &SVGFESpecularLightingElement::m_specularConstant, initialSpecularConstantValue>();
-        PropertyRegistry::registerProperty<SVGNames::specularExponentAttr, &SVGFESpecularLightingElement::m_specularExponent, initialSpecularExponentValue>();
-        PropertyRegistry::registerProperty<SVGNames::surfaceScaleAttr, &SVGFESpecularLightingElement::m_surfaceScale, initialSurfaceScaleValue>();
+        PropertyRegistry::registerProperty<SVGNames::specularConstantAttr, &SVGFESpecularLightingElement::m_specularConstant>(initialSpecularConstantValue);
+        PropertyRegistry::registerProperty<SVGNames::specularExponentAttr, &SVGFESpecularLightingElement::m_specularExponent>(initialSpecularExponentValue);
+        PropertyRegistry::registerProperty<SVGNames::surfaceScaleAttr, &SVGFESpecularLightingElement::m_surfaceScale>(initialSurfaceScaleValue);
         PropertyRegistry::registerProperty<SVGNames::kernelUnitLengthAttr, &SVGFESpecularLightingElement::m_kernelUnitLengthX, &SVGFESpecularLightingElement::m_kernelUnitLengthY>();
     }
 }

--- a/Source/WebCore/svg/SVGFETurbulenceElement.cpp
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.cpp
@@ -44,7 +44,7 @@ inline SVGFETurbulenceElement::SVGFETurbulenceElement(const QualifiedName& tagNa
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
         PropertyRegistry::registerProperty<SVGNames::baseFrequencyAttr, &SVGFETurbulenceElement::m_baseFrequencyX, &SVGFETurbulenceElement::m_baseFrequencyY>();
-        PropertyRegistry::registerProperty<SVGNames::numOctavesAttr, &SVGFETurbulenceElement::m_numOctaves, initialOctavesValue>();
+        PropertyRegistry::registerProperty<SVGNames::numOctavesAttr, &SVGFETurbulenceElement::m_numOctaves>(initialOctavesValue);
         PropertyRegistry::registerProperty<SVGNames::seedAttr, &SVGFETurbulenceElement::m_seed>();
         PropertyRegistry::registerProperty<SVGNames::stitchTilesAttr, SVGStitchOptions, &SVGFETurbulenceElement::m_stitchTiles>();
         PropertyRegistry::registerProperty<SVGNames::typeAttr, TurbulenceType, &SVGFETurbulenceElement::m_type>();

--- a/Source/WebCore/svg/properties/SVGAnimatedPrimitivePropertyAccessor.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPrimitivePropertyAccessor.h
@@ -49,11 +49,13 @@ public:
     }
 
 protected:
-    // property and initialValue have to stay template arguments: they are what gives each
-    // attribute its own singleton. As function arguments there would be one per OwnerType, and the
-    // second attribute registered would silently be handed the first one's accessor.
-    template<typename AccessorType, const Ref<AnimatedPropertyType> OwnerType::*property, ValueType initialValue>
-    static const SVGMemberAccessor<OwnerType>& singleton()
+    // property has to stay a template argument: it is what gives each attribute its own
+    // singleton. As a function argument there would be one per OwnerType, and the second
+    // attribute registered would silently be handed the first one's accessor. initialValue does
+    // not have to be one: the singleton is already unique per property, and each property is
+    // registered exactly once, so the first call is the only one.
+    template<typename AccessorType, const Ref<AnimatedPropertyType> OwnerType::*property>
+    static const SVGMemberAccessor<OwnerType>& singleton(ValueType initialValue)
     {
         static NeverDestroyed<AccessorType> propertyAccessor { property, initialValue };
         return propertyAccessor;

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyAccessorImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyAccessorImpl.h
@@ -94,8 +94,8 @@ class SVGAnimatedIntegerAccessor final : public SVGAnimatedPrimitivePropertyAcce
 public:
     using Base::Base;
     using Base::property;
-    template<auto property, int initialValue>
-    constexpr static const SVGMemberAccessor<OwnerType>& singleton() { return Base::template singleton<SVGAnimatedIntegerAccessor, property, initialValue>(); }
+    template<auto property>
+    static const SVGMemberAccessor<OwnerType>& singleton(int initialValue) { return Base::template singleton<SVGAnimatedIntegerAccessor, property>(initialValue); }
 
 private:
     RefPtr<SVGAttributeAnimator> createAnimator(OwnerType& owner, const QualifiedName& attributeName, AnimationMode animationMode, CalcMode calcMode, bool isAccumulated, bool isAdditive) const final
@@ -163,8 +163,8 @@ class SVGAnimatedNumberAccessor final : public SVGAnimatedPrimitivePropertyAcces
 public:
     using Base::Base;
     using Base::property;
-    template<auto property, float initialValue>
-    constexpr static const SVGMemberAccessor<OwnerType>& singleton() { return Base::template singleton<SVGAnimatedNumberAccessor, property, initialValue>(); }
+    template<auto property>
+    static const SVGMemberAccessor<OwnerType>& singleton(float initialValue) { return Base::template singleton<SVGAnimatedNumberAccessor, property>(initialValue); }
 
 private:
     RefPtr<SVGAttributeAnimator> createAnimator(OwnerType& owner, const QualifiedName& attributeName, AnimationMode animationMode, CalcMode calcMode, bool isAccumulated, bool isAdditive) const final

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessor.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessor.h
@@ -57,9 +57,10 @@ protected:
         return propertyAccessor;
     }
 
-    // Template arguments for the reason given in SVGAnimatedPrimitivePropertyAccessor::singleton().
-    template<typename AccessorType, auto property1, auto property2, auto initialValue1, auto initialValue2>
-    static SVGMemberAccessor<OwnerType>& singleton()
+    // The properties are template arguments for the reason given in
+    // SVGAnimatedPrimitivePropertyAccessor::singleton(); the initial values need not be.
+    template<typename AccessorType, auto property1, auto property2, typename ValueType1, typename ValueType2>
+    static SVGMemberAccessor<OwnerType>& singleton(ValueType1 initialValue1, ValueType2 initialValue2)
     {
         static NeverDestroyed<AccessorType> propertyAccessor { property1, initialValue1, property2, initialValue2 };
         return propertyAccessor;

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessorImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessorImpl.h
@@ -92,8 +92,8 @@ class SVGAnimatedIntegerPairAccessor final : public SVGAnimatedPropertyPairAcces
 
 public:
     using Base::Base;
-    template<auto property1, auto property2, int initialValue1, int initialValue2>
-    constexpr static const SVGMemberAccessor<OwnerType>& singleton() { return Base::template singleton<SVGAnimatedIntegerPairAccessor, property1, property2, initialValue1, initialValue2>(); }
+    template<auto property1, auto property2>
+    static const SVGMemberAccessor<OwnerType>& singleton(int initialValue1, int initialValue2) { return Base::template singleton<SVGAnimatedIntegerPairAccessor, property1, property2>(initialValue1, initialValue2); }
 
 private:
     std::optional<String> synchronize(const OwnerType& owner) const final
@@ -127,8 +127,8 @@ class SVGAnimatedNumberPairAccessor final : public SVGAnimatedPropertyPairAccess
 
 public:
     using Base::Base;
-    template<auto property1, auto property2, float initialValue1, float initialValue2>
-    constexpr static const SVGMemberAccessor<OwnerType>& singleton() { return Base::template singleton<SVGAnimatedNumberPairAccessor, property1, property2, initialValue1, initialValue2>(); }
+    template<auto property1, auto property2>
+    static const SVGMemberAccessor<OwnerType>& singleton(float initialValue1, float initialValue2) { return Base::template singleton<SVGAnimatedNumberPairAccessor, property1, property2>(initialValue1, initialValue2); }
 
 private:
     std::optional<String> synchronize(const OwnerType& owner) const final

--- a/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
+++ b/Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h
@@ -95,10 +95,10 @@ public:
 
     // initialValue has to agree with what the element passes to SVGAnimatedInteger::create(): that
     // is what the property is born with, and this is only the way back to it.
-    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedInteger> OwnerType::*property, int initialValue = 0>
-    static void registerProperty()
+    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedInteger> OwnerType::*property>
+    static void registerProperty(int initialValue = 0)
     {
-        registerProperty(attributeName, SVGAnimatedIntegerAccessor<OwnerType>::template singleton<property, initialValue>());
+        registerProperty(attributeName, SVGAnimatedIntegerAccessor<OwnerType>::template singleton<property>(initialValue));
     }
 
     template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedLength> OwnerType::*property>
@@ -113,10 +113,10 @@ public:
         registerProperty(attributeName, SVGAnimatedLengthListAccessor<OwnerType>::template singleton<property>());
     }
 
-    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedNumber> OwnerType::*property, float initialValue = 0.0f>
-    static void registerProperty()
+    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedNumber> OwnerType::*property>
+    static void registerProperty(float initialValue = 0)
     {
-        registerProperty(attributeName, SVGAnimatedNumberAccessor<OwnerType>::template singleton<property, initialValue>());
+        registerProperty(attributeName, SVGAnimatedNumberAccessor<OwnerType>::template singleton<property>(initialValue));
     }
 
     template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedNumberList> OwnerType::*property>
@@ -167,16 +167,16 @@ public:
         registerProperty(attributeName, SVGAnimatedTransformListAccessor<OwnerType>::template singleton<property>());
     }
 
-    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedInteger> OwnerType::*property1, const Ref<SVGAnimatedInteger> OwnerType::*property2, int initialValue1 = 0, int initialValue2 = 0>
-    static void registerProperty()
+    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedInteger> OwnerType::*property1, const Ref<SVGAnimatedInteger> OwnerType::*property2>
+    static void registerProperty(int initialValue1 = 0, int initialValue2 = 0)
     {
-        registerProperty(attributeName, SVGAnimatedIntegerPairAccessor<OwnerType>::template singleton<property1, property2, initialValue1, initialValue2>());
+        registerProperty(attributeName, SVGAnimatedIntegerPairAccessor<OwnerType>::template singleton<property1, property2>(initialValue1, initialValue2));
     }
 
-    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedNumber> OwnerType::*property1, const Ref<SVGAnimatedNumber> OwnerType::*property2, float initialValue1 = 0.0f, float initialValue2 = 0.0f>
-    static void registerProperty()
+    template<const LazyNeverDestroyed<const QualifiedName>& attributeName, const Ref<SVGAnimatedNumber> OwnerType::*property1, const Ref<SVGAnimatedNumber> OwnerType::*property2>
+    static void registerProperty(float initialValue1 = 0, float initialValue2 = 0)
     {
-        registerProperty(attributeName, SVGAnimatedNumberPairAccessor<OwnerType>::template singleton<property1, property2, initialValue1, initialValue2>());
+        registerProperty(attributeName, SVGAnimatedNumberPairAccessor<OwnerType>::template singleton<property1, property2>(initialValue1, initialValue2));
     }
 
     // Enumerate all the SVGMemberAccessors recursively. The functor will be called and will


### PR DESCRIPTION
#### a6509b7967f0b7b8d8c03b2b16cc7801b9ffa01f
<pre>
SVG property registry should not take the initial value as a non-type template parameter
<a href="https://bugs.webkit.org/show_bug.cgi?id=323357">https://bugs.webkit.org/show_bug.cgi?id=323357</a>

Reviewed by Said Abou-Hallawa.

320226@main started storing each SVGAnimatedInteger and SVGAnimatedNumber
attribute&apos;s initial value on its accessor, and passed it as a non-type template
parameter alongside the property. On the other hand initialValue does not need
to be a template parameter. The singleton is already unique per property, and a
property is registered exactly once.

This patch is a simplification of the original without changing the idea behind
the original patch. We detected this issue compiling for and older Android NDK.

No behaviour change so original tests should check if the patch is
correct.

* Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp:
(WebCore::SVGComponentTransferFunctionElement::PropertyRegistry::registerProperties):
* Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp:
(WebCore::SVGFEConvolveMatrixElement::PropertyRegistry::registerProperties):
* Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp:
(WebCore::SVGFEDiffuseLightingElement::PropertyRegistry::registerProperties):
* Source/WebCore/svg/SVGFEDropShadowElement.cpp:
(WebCore::SVGFEDropShadowElement::PropertyRegistry::registerProperties):
* Source/WebCore/svg/SVGFELightElement.cpp:
(WebCore::SVGFELightElement::PropertyRegistry::registerProperties):
* Source/WebCore/svg/SVGFESpecularLightingElement.cpp:
(WebCore::SVGFESpecularLightingElement::PropertyRegistry::registerProperties):
* Source/WebCore/svg/SVGFETurbulenceElement.cpp:
(WebCore::SVGFETurbulenceElement::PropertyRegistry::registerProperties):
* Source/WebCore/svg/properties/SVGAnimatedPrimitivePropertyAccessor.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyAccessorImpl.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessor.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessorImpl.h:
* Source/WebCore/svg/properties/SVGPropertyOwnerRegistry.h:

Canonical link: <a href="https://commits.webkit.org/320736@main">https://commits.webkit.org/320736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33a7813bdeae967c8476b577c20a5d69e42cd4e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196031 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150423 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187586 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60997 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59356 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145134 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100625 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165704 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125429 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47546 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45585 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157906 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45281 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7094 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197997 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59291 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154672 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41430 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59999 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154324 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48788 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132348 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129296 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58466 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20304 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57844 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58080 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57907 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->