### PR TITLE
AX: Add layout tests for the text marker index space over non-Latin scripts

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-combining-marks-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-combining-marks-expected.txt
@@ -1,0 +1,18 @@
+This test ensures a combining mark occupies its own text marker index. The paragraph holds two grapheme clusters that are two code units each, so an index space counting grapheme clusters rather than code units would disagree with the string length.
+
+The accessibility text keeps the marks decomposed.
+PASS: text().length === 12
+PASS: text().codePointAt(4) === 0x301
+PASS: text().codePointAt(9) === 0x308
+PASS: text().normalize('NFC') === 'café naïve'
+
+Every code unit has its own index, and it round-trips.
+PASS: walk.containerTextLength === 12
+PASS: walk.indicesChecked === 12
+PASS: walk.worstRoundTripDrift === 0
+PASS: walk.worstLengthDifference === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-combining-marks.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-combining-marks.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/ax-text-marker-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">cafe&#x301; nai&#x308;ve</p>
+
+<script>
+var output = "This test ensures a combining mark occupies its own text marker index. The paragraph holds two grapheme clusters that are two code units each, so an index space counting grapheme clusters rather than code units would disagree with the string length.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var walk = checkRoundTripAllTextMarkerIndicesWithinContainer(target);
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    output += "The accessibility text keeps the marks decomposed.\n";
+    output += expect("text().length", "12");
+    output += expect("text().codePointAt(4)", "0x301");
+    output += expect("text().codePointAt(9)", "0x308");
+    output += expect("text().normalize('NFC')", "'café naïve'");
+
+    output += "\nEvery code unit has its own index, and it round-trips.\n";
+    output += expect("walk.containerTextLength", "12");
+    output += expect("walk.indicesChecked", "12");
+    output += expect("walk.worstRoundTripDrift", "0");
+    output += expect("walk.worstLengthDifference", "0");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-hebrew-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-hebrew-expected.txt
@@ -1,0 +1,18 @@
+This test ensures the text marker index space over right-to-left text stays logical: every index round-trips, and the string from the start of the paragraph to an index is as long as that index, even though the characters render right to left.
+
+The letters keep logical order, so index 0 is the first letter of the first word, not the rightmost glyph.
+PASS: text() === 'שלום עולם'
+PASS: text().length === 9
+PASS: text().codePointAt(0) === 0x5E9
+PASS: text().codePointAt(8) === 0x5DD
+
+Every code unit has its own index, and it round-trips.
+PASS: walk.containerTextLength === 9
+PASS: walk.indicesChecked === 9
+PASS: walk.worstRoundTripDrift === 0
+PASS: walk.worstLengthDifference === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-hebrew.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-hebrew.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/ax-text-marker-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">שלום עולם</p>
+
+<script>
+var output = "This test ensures the text marker index space over right-to-left text stays logical: every index round-trips, and the string from the start of the paragraph to an index is as long as that index, even though the characters render right to left.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var walk = checkRoundTripAllTextMarkerIndicesWithinContainer(target);
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    output += "The letters keep logical order, so index 0 is the first letter of the first word, not the rightmost glyph.\n";
+    output += expect("text()", "'שלום עולם'");
+    output += expect("text().length", "9");
+    output += expect("text().codePointAt(0)", "0x5E9");
+    output += expect("text().codePointAt(8)", "0x5DD");
+
+    output += "\nEvery code unit has its own index, and it round-trips.\n";
+    output += expect("walk.containerTextLength", "9");
+    output += expect("walk.indicesChecked", "9");
+    output += expect("walk.worstRoundTripDrift", "0");
+    output += expect("walk.worstLengthDifference", "0");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-indic-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-indic-expected.txt
@@ -1,0 +1,18 @@
+This test ensures Devanagari text, where a vowel sign renders to the left of the consonant it follows and a virama joins two consonants into a conjunct, keeps a text marker index per code unit in logical order rather than in the order the glyphs appear.
+
+The vowel sign keeps its logical position after the consonant, not its visual one before it.
+PASS: text().length === 6
+PASS: text().codePointAt(0) === 0x939
+PASS: text().codePointAt(1) === 0x93F
+PASS: text().codePointAt(3) === 0x94D
+
+Every code unit has its own index, and it round-trips.
+PASS: walk.containerTextLength === 6
+PASS: walk.indicesChecked === 6
+PASS: walk.worstRoundTripDrift === 0
+PASS: walk.worstLengthDifference === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-indic.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-indic.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/ax-text-marker-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">&#x939;&#x93F;&#x928;&#x94D;&#x926;&#x940;</p>
+
+<script>
+var output = "This test ensures Devanagari text, where a vowel sign renders to the left of the consonant it follows and a virama joins two consonants into a conjunct, keeps a text marker index per code unit in logical order rather than in the order the glyphs appear.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var walk = checkRoundTripAllTextMarkerIndicesWithinContainer(target);
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    output += "The vowel sign keeps its logical position after the consonant, not its visual one before it.\n";
+    output += expect("text().length", "6");
+    output += expect("text().codePointAt(0)", "0x939");
+    output += expect("text().codePointAt(1)", "0x93F");
+    output += expect("text().codePointAt(3)", "0x94D");
+
+    output += "\nEvery code unit has its own index, and it round-trips.\n";
+    output += expect("walk.containerTextLength", "6");
+    output += expect("walk.indicesChecked", "6");
+    output += expect("walk.worstRoundTripDrift", "0");
+    output += expect("walk.worstLengthDifference", "0");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-marker-index-combining-marks-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-index-combining-marks-expected.txt
@@ -1,0 +1,18 @@
+This test ensures a combining mark occupies its own text marker index. The paragraph holds two grapheme clusters that are two code units each, so an index space counting grapheme clusters rather than code units would disagree with the string length.
+
+The accessibility text keeps the marks decomposed.
+PASS: text().length === 12
+PASS: text().codePointAt(4) === 0x301
+PASS: text().codePointAt(9) === 0x308
+PASS: text().normalize('NFC') === 'café naïve'
+
+Every code unit has its own index, and it round-trips.
+PASS: walk.containerTextLength === 12
+PASS: walk.indicesChecked === 12
+PASS: walk.worstRoundTripDrift === 0
+PASS: walk.worstLengthDifference === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-marker-index-combining-marks.html
+++ b/LayoutTests/accessibility/mac/text-marker-index-combining-marks.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/ax-text-marker-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">cafe&#x301; nai&#x308;ve</p>
+
+<script>
+var output = "This test ensures a combining mark occupies its own text marker index. The paragraph holds two grapheme clusters that are two code units each, so an index space counting grapheme clusters rather than code units would disagree with the string length.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var walk = checkRoundTripAllTextMarkerIndicesWithinContainer(target);
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    output += "The accessibility text keeps the marks decomposed.\n";
+    output += expect("text().length", "12");
+    output += expect("text().codePointAt(4)", "0x301");
+    output += expect("text().codePointAt(9)", "0x308");
+    output += expect("text().normalize('NFC')", "'café naïve'");
+
+    output += "\nEvery code unit has its own index, and it round-trips.\n";
+    output += expect("walk.containerTextLength", "12");
+    output += expect("walk.indicesChecked", "12");
+    output += expect("walk.worstRoundTripDrift", "0");
+    output += expect("walk.worstLengthDifference", "0");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-marker-index-hebrew-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-index-hebrew-expected.txt
@@ -1,0 +1,18 @@
+This test ensures the text marker index space over right-to-left text stays logical: every index round-trips, and the string from the start of the paragraph to an index is as long as that index, even though the characters render right to left.
+
+The letters keep logical order, so index 0 is the first letter of the first word, not the rightmost glyph.
+PASS: text() === 'שלום עולם'
+PASS: text().length === 9
+PASS: text().codePointAt(0) === 0x5E9
+PASS: text().codePointAt(8) === 0x5DD
+
+Every code unit has its own index, and it round-trips.
+PASS: walk.containerTextLength === 9
+PASS: walk.indicesChecked === 9
+PASS: walk.worstRoundTripDrift === 0
+PASS: walk.worstLengthDifference === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-marker-index-hebrew.html
+++ b/LayoutTests/accessibility/mac/text-marker-index-hebrew.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/ax-text-marker-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">שלום עולם</p>
+
+<script>
+var output = "This test ensures the text marker index space over right-to-left text stays logical: every index round-trips, and the string from the start of the paragraph to an index is as long as that index, even though the characters render right to left.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var walk = checkRoundTripAllTextMarkerIndicesWithinContainer(target);
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    output += "The letters keep logical order, so index 0 is the first letter of the first word, not the rightmost glyph.\n";
+    output += expect("text()", "'שלום עולם'");
+    output += expect("text().length", "9");
+    output += expect("text().codePointAt(0)", "0x5E9");
+    output += expect("text().codePointAt(8)", "0x5DD");
+
+    output += "\nEvery code unit has its own index, and it round-trips.\n";
+    output += expect("walk.containerTextLength", "9");
+    output += expect("walk.indicesChecked", "9");
+    output += expect("walk.worstRoundTripDrift", "0");
+    output += expect("walk.worstLengthDifference", "0");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-marker-index-indic-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-index-indic-expected.txt
@@ -1,0 +1,18 @@
+This test ensures Devanagari text, where a vowel sign renders to the left of the consonant it follows and a virama joins two consonants into a conjunct, keeps a text marker index per code unit in logical order rather than in the order the glyphs appear.
+
+The vowel sign keeps its logical position after the consonant, not its visual one before it.
+PASS: text().length === 6
+PASS: text().codePointAt(0) === 0x939
+PASS: text().codePointAt(1) === 0x93F
+PASS: text().codePointAt(3) === 0x94D
+
+Every code unit has its own index, and it round-trips.
+PASS: walk.containerTextLength === 6
+PASS: walk.indicesChecked === 6
+PASS: walk.worstRoundTripDrift === 0
+PASS: walk.worstLengthDifference === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-marker-index-indic.html
+++ b/LayoutTests/accessibility/mac/text-marker-index-indic.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/ax-text-marker-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">&#x939;&#x93F;&#x928;&#x94D;&#x926;&#x940;</p>
+
+<script>
+var output = "This test ensures Devanagari text, where a vowel sign renders to the left of the consonant it follows and a virama joins two consonants into a conjunct, keeps a text marker index per code unit in logical order rather than in the order the glyphs appear.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var walk = checkRoundTripAllTextMarkerIndicesWithinContainer(target);
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    output += "The vowel sign keeps its logical position after the consonant, not its visual one before it.\n";
+    output += expect("text().length", "6");
+    output += expect("text().codePointAt(0)", "0x939");
+    output += expect("text().codePointAt(1)", "0x93F");
+    output += expect("text().codePointAt(3)", "0x94D");
+
+    output += "\nEvery code unit has its own index, and it round-trips.\n";
+    output += expect("walk.containerTextLength", "6");
+    output += expect("walk.indicesChecked", "6");
+    output += expect("walk.worstRoundTripDrift", "0");
+    output += expect("walk.worstLengthDifference", "0");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 5e2f8ed9bc169adb88ca7adabf0528f00cf22868
<pre>
AX: Add layout tests for the text marker index space over non-Latin scripts
<a href="https://bugs.webkit.org/show_bug.cgi?id=323359">https://bugs.webkit.org/show_bug.cgi?id=323359</a>
<a href="https://rdar.apple.com/186602375">rdar://186602375</a>

Reviewed by Chris Fleizach.

AXIndexForTextMarker and AXTextMarkerForIndex describe a character offset space, and
checkRoundTripAllTextMarkerIndicesWithinContainer measures two invariants over it:

  1. Every index round-trips through a marker
  2. The string from the container start to an index is as long as that index.

Existing bidi and multibyte tests assert the extracted string but use no index API, so
add tests verifying index-based roundtrips work in these cases.

text-marker-index-hebrew.html:
text-marker-bidi-element-hebrew.html already asserts that mixed Hebrew and English
comes back in logical order, across six unicode-bidi values. It reads only
stringForTextMarkerRange and boundsForRange, never the index APIs.

text-marker-index-combining-marks.html:
No accessibility test contains a combining mark at all. Two code units per grapheme
cluster is where an index counting clusters would drift from one counting code units.

text-marker-index-indic.html:
No accessibility test contains Devanagari or Tamil. A vowel sign renders left of the
consonant it follows and a virama fuses two consonants, so glyph order and code unit
order disagree, making it an interesting and novel test.

* LayoutTests/accessibility/isolated-tree/mac/text-marker-index-combining-marks-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/text-marker-index-combining-marks.html: Added.
* LayoutTests/accessibility/isolated-tree/mac/text-marker-index-hebrew-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/text-marker-index-hebrew.html: Added.
* LayoutTests/accessibility/isolated-tree/mac/text-marker-index-indic-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/text-marker-index-indic.html: Added.
* LayoutTests/accessibility/mac/text-marker-index-combining-marks-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-index-combining-marks.html: Added.
* LayoutTests/accessibility/mac/text-marker-index-hebrew-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-index-hebrew.html: Added.
* LayoutTests/accessibility/mac/text-marker-index-indic-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-index-indic.html: Added.

Canonical link: <a href="https://commits.webkit.org/320508@main">https://commits.webkit.org/320508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d61cfeb335426a225ae1e61f5b23c9decbe197a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195156 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/26ef0768-2e4b-415e-93b3-e12428ff2b22) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144429 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187777 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48096 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed layout tests; 2 new passes 4 flakes") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124714 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46820 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44926 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157192 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44582 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6212 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197105 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58411 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153904 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41241 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59116 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41194 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153561 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48076 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127965 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57613 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19600 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56972 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57223 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57049 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->