### PR TITLE
[EWS] API EWS runs the whole retry ladder for an already-known flaky failure

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -570,6 +570,13 @@ class ResultsDBReportMixin(abc.ABC):
     """
     results_db_log_name = 'results-db'
     reports_to_results_db = True
+    INCLUDED_FLAKY_VERDICTS = frozenset({
+        ResultsDatabase.CLEAN_TREE_VERDICT,
+        ResultsDatabase.DIRTY_TREE_VERDICT,
+        ResultsDatabase.BETWEEN_BUILDS_VERDICT,
+    })
+    MAX_FAILURES_TO_CHECK_RESULTS_DB = 50
+    prefix = ''
 
     # From Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/configuration.py
     RESULTS_REQUIRED_CONFIG = ['platform', 'is_simulator', 'version', 'architecture']
@@ -699,6 +706,56 @@ class ResultsDBReportMixin(abc.ABC):
         if self.flaky_failures_in_results_db:
             parts.append(f"flaky tests: {', '.join(sorted(self.flaky_failures_in_results_db))}")
         return f"Ignored {'; '.join(parts)} based on results-db"
+
+    @defer.inlineCallbacks
+    def flaky_new_failures_using_results_db(self, new_failures: set[str]) -> Generator[Any, Any, set[str]]:
+        """
+        The subset of `new_failures` whose results-database verdict is in INCLUDED_FLAKY_VERDICTS.
+        Only the first MAX_FAILURES_TO_CHECK_RESULTS_DB names, sorted, are queried; the rest are
+        absent from the result rather than reported as unexcused.
+        """
+        tests = sorted(new_failures)[:self.MAX_FAILURES_TO_CHECK_RESULTS_DB]
+        configuration = self.results_db_query_configuration()
+        yield self._addToLog(self.results_db_log_name, f'Checking Results database for flakiness of {len(tests)} new failure(s). Configuration: {configuration}\n')
+
+        flakes, flake_logs = yield ResultsDatabase.flaky_verdicts_for(
+            tests, configuration=configuration, suite=self.suite,
+            authors=self.getProperty('owners', []),
+            pr_number=self.getProperty('github.number', None),
+        )
+        if flake_logs:
+            yield self._addToLog(self.results_db_log_name, flake_logs)
+
+        flaky, unsupported, unknown, ignored, shadowed = {}, [], [], [], []
+        for test in tests:
+            flake = flakes.get(test, FlakyVerdict(request_failed=True))
+            flake_summary = 'False'
+            if flake.is_flaky:
+                flaky[test] = flake.flaky_type
+                if flake.flaky_type == ResultsDatabase.BETWEEN_BUILDS_VERDICT and not flake.intra_build_evidence:
+                    unsupported.append(test)
+                flake_summary = f'{flake.flaky_type}: {flake.evidence}'
+                if flake.flaky_type in self.INCLUDED_FLAKY_VERDICTS and test not in unsupported:
+                    ignored.append(test)
+                else:
+                    shadowed.append(test)
+            elif flake.request_failed:
+                unknown.append(test)
+                flake_summary = 'Unknown'
+
+            yield self._addToLog(self.results_db_log_name, f'\n{test}: pre-existing-flake={flake_summary}\n')
+
+        self.setProperty('results-db_' + self.prefix + 'flaky', flaky)
+        self.setProperty('results-db_' + self.prefix + 'flaky_unsupported', sorted(unsupported))
+        self.setProperty('results-db_' + self.prefix + 'flaky_unknown', sorted(unknown))
+
+        for action, acted_on in (('Ignored', ignored), ('Would have ignored', shadowed)):
+            if acted_on:
+                yield self._addToLog(
+                    self.results_db_log_name,
+                    f"\n{action} {len(acted_on)} flaky test(s): {', '.join(sorted(acted_on))}\n",
+                )
+        defer.returnValue(set(ignored))
 
 
 class Contributors(object):
@@ -5832,6 +5889,7 @@ class RunAPITests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin):
     test_failures_log_name = 'test-failures'
     results_db_log_name = 'results-db'
     suffix = 'api_first_run'
+    prefix = 'api_'
     MAX_FAILURES_TO_CHECK_RESULTS_DB = 50
     command = ['python3', 'Tools/Scripts/run-api-tests', '--timestamps', '--no-build',
                WithProperties('--%(configuration)s'), '--verbose', '--json-output={0}'.format(jsonFileName)]
@@ -5846,6 +5904,7 @@ class RunAPITests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin):
         super().__init__(logEnviron=False, timeout=20 * 60, **kwargs)
         self.failing_tests_filtered = []
         self.preexisting_failures_in_results_db = []
+        self.flaky_failures_in_results_db = {}
         self.steps_to_add = []
 
     @defer.inlineCallbacks
@@ -5925,7 +5984,7 @@ class RunAPITests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin):
             self.build.results = SUCCESS
             self.setProperty('build_summary', message)
         else:
-            self.doOnFailure()
+            yield self.doOnFailure()
 
         self.build.addStepsAfterCurrentStep(self.steps_to_add)
         defer.returnValue(rc)
@@ -6067,7 +6126,44 @@ class ReRunAPITests(RunAPITests):
             yield self.report_to_results_db(results, flaky_type='BetweenStepsDirtyTree')
         defer.returnValue(failures)
 
-    def doOnFailure(self):
+    def failures_in_both_dirty_runs(self) -> set[str]:
+        """
+        The failures AnalyzeAPITestsResults would attribute to the change, before the clean-tree run
+        subtracts its own from them.
+        """
+        first_run_failures = self.getProperty('api_first_run_failures_filtered', None)
+        if first_run_failures is None:
+            first_run_failures = self.getProperty('api_first_run_failures', [])
+        second_run_failures = self.getProperty('api_second_run_failures_filtered', None)
+        if second_run_failures is None:
+            second_run_failures = self.getProperty('api_second_run_failures', [])
+        return set(first_run_failures) & set(second_run_failures)
+
+    @defer.inlineCallbacks
+    def doOnFailure(self) -> Generator[Any, Any, None]:
+        is_main = self.getProperty('github.base.ref', DEFAULT_BRANCH) == DEFAULT_BRANCH
+        if is_main and (candidates := self.failures_in_both_dirty_runs()):
+            # parse_and_set_failures has already reported this build's BetweenStepsDirtyTree
+            # evidence, the only evidence the revert and clean-tree run would have added.
+            excused = yield self.flaky_new_failures_using_results_db(candidates)
+            if excused == candidates:
+                flaky = self.getProperty('results-db_api_flaky', {})
+                self.flaky_failures_in_results_db = {test: flaky.get(test) for test in excused}
+                message = self.results_db_ignore_message()
+                self.descriptionDone = message
+                self.build.results = SUCCESS
+                self.setProperty('force_build_success', True)
+                self.setProperty('build_summary', message)
+
+                # AnalyzeAPITestsResults never runs on this path, so nothing else reports these
+                # candidates.
+                results = self.merged_results(candidates, {
+                    'first-run': 'api_first_run_results',
+                    'second-run': 'api_second_run_results',
+                })
+                yield self.report_to_results_db(results)
+                return
+
         self.steps_to_add += [RevertAppliedChanges(), CleanWorkingDirectory(), ValidateChange(verifyBugClosed=False, addURLs=False)]
         platform = self.getProperty('platform')
         if platform == 'wpe':
@@ -6104,11 +6200,7 @@ class AnalyzeAPITestsResults(ResultsDBReportMixin, buildstep.BuildStep, AddToLog
     descriptionDone = ['analyze-api-tests-results']
     NUM_FAILURES_TO_DISPLAY = 10
     MAX_FAILURES_TO_CHECK_RESULTS_DB = 50
-    INCLUDED_FLAKY_VERDICTS = frozenset({
-        ResultsDatabase.CLEAN_TREE_VERDICT,
-        ResultsDatabase.DIRTY_TREE_VERDICT,
-        ResultsDatabase.BETWEEN_BUILDS_VERDICT,
-    })
+    prefix = 'api_'
 
     @defer.inlineCallbacks
     def run(self):
@@ -6190,55 +6282,6 @@ class AnalyzeAPITestsResults(ResultsDBReportMixin, buildstep.BuildStep, AddToLog
                 self.setProperty('build_summary', message.strip())
             self.build.buildFinished([message], SUCCESS)
             defer.returnValue(SUCCESS)
-
-    @defer.inlineCallbacks
-    def flaky_new_failures_using_results_db(self, new_failures: set[str]) -> Generator[Any, Any, set[str]]:
-        """
-        Verdicts for the failures the clean-tree run did not explain, returning the ones with a
-        verdict in INCLUDED_FLAKY_VERDICTS.
-        """
-        tests = sorted(new_failures)[:self.MAX_FAILURES_TO_CHECK_RESULTS_DB]
-        configuration = self.results_db_query_configuration()
-        yield self._addToLog(self.results_db_log_name, f'Checking Results database for flakiness of {len(tests)} new failure(s). Configuration: {configuration}\n')
-
-        flakes, flake_logs = yield ResultsDatabase.flaky_verdicts_for(
-            tests, configuration=configuration, suite=self.suite,
-            authors=self.getProperty('owners', []),
-            pr_number=self.getProperty('github.number', None),
-        )
-        if flake_logs:
-            yield self._addToLog(self.results_db_log_name, flake_logs)
-
-        flaky, unsupported, unknown, ignored, shadowed = {}, [], [], [], []
-        for test in tests:
-            flake = flakes.get(test, FlakyVerdict(request_failed=True))
-            flake_summary = 'False'
-            if flake.is_flaky:
-                flaky[test] = flake.flaky_type
-                if flake.flaky_type == ResultsDatabase.BETWEEN_BUILDS_VERDICT and not flake.intra_build_evidence:
-                    unsupported.append(test)
-                flake_summary = f'{flake.flaky_type}: {flake.evidence}'
-                if flake.flaky_type in self.INCLUDED_FLAKY_VERDICTS and test not in unsupported:
-                    ignored.append(test)
-                else:
-                    shadowed.append(test)
-            elif flake.request_failed:
-                unknown.append(test)
-                flake_summary = 'Unknown'
-
-            yield self._addToLog(self.results_db_log_name, f'\n{test}: pre-existing-flake={flake_summary}\n')
-
-        self.setProperty('results-db_api_flaky', flaky)
-        self.setProperty('results-db_api_flaky_unsupported', sorted(unsupported))
-        self.setProperty('results-db_api_flaky_unknown', sorted(unknown))
-
-        for action, acted_on in (('Ignored', ignored), ('Would have ignored', shadowed)):
-            if acted_on:
-                yield self._addToLog(
-                    self.results_db_log_name,
-                    f"\n{action} {len(acted_on)} flaky test(s): {', '.join(sorted(acted_on))}\n",
-                )
-        defer.returnValue(set(ignored))
 
     def send_email_for_flaky_failure(self, test_name):
         try:

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -4273,9 +4273,9 @@ class TestReportToResultsDB(BuildStepMixinAdditions, unittest.TestCase):
 
 
 class TestAPITestFlakinessReadUsingResultsDB(BuildStepMixinAdditions, unittest.TestCase):
-    """The read lives in AnalyzeAPITestsResults: excusing a failure in the first run's step would
-    empty its filtered failures, so the clean-tree run that produces the evidence for the verdict
-    would never be queued."""
+    """The earliest the read can happen is ReRunAPITests, which is where the build's only derivable
+    evidence, BetweenStepsDirtyTree, has just been reported. AnalyzeAPITestsResults reads again for
+    the failures the clean-tree run did not explain."""
 
     def setUp(self) -> defer.Deferred:
         self.longMessage = True
@@ -4423,6 +4423,235 @@ class TestAPITestFlakinessReadUsingResultsDB(BuildStepMixinAdditions, unittest.T
         yield step.run()
 
         self.assertEqual([(authors, pr_number) for _, _, _, authors, pr_number in queried], [(['jappleseed'], 42)])
+
+
+class TestReRunAPITestsExcusesKnownFlakes(BuildStepMixinAdditions, unittest.TestCase):
+    """The revert, the rebuild without the change, the clean-tree run and the analyze step exist to
+    decide the failures that survived both dirty runs, so a results-db verdict for every one of them
+    makes all four unnecessary."""
+
+    LADDER = [
+        RevertAppliedChanges(), CleanWorkingDirectory(), ValidateChange(verifyBugClosed=False, addURLs=False),
+        CompileWebKitWithoutChange(retry_build_on_failure=True), ValidateChange(verifyBugClosed=False, addURLs=False),
+        KillOldProcesses(), RunAPITestsWithoutChange(), AnalyzeAPITestsResults(),
+    ]
+
+    def setUp(self) -> defer.Deferred:
+        self.longMessage = True
+        return self.setup_test_build_step()
+
+    def tearDown(self) -> defer.Deferred:
+        return self.tear_down_test_build_step()
+
+    def configureStep(self, first_run: list, second_run: list, filtered: bool = True) -> ReRunAPITests:
+        self.setup_step(ReRunAPITests())
+        self.setProperty('platform', 'mac')
+        self.setProperty('configuration', 'release')
+        self.setProperty('fullPlatform', 'mac-sonoma')
+        self.setProperty('os_version', '14.6.1')
+        self.setProperty('architecture', 'arm64')
+        self.setProperty('api_first_run_failures', first_run)
+        self.setProperty('api_second_run_failures', second_run)
+        if filtered:
+            self.setProperty('api_first_run_failures_filtered', first_run)
+            self.setProperty('api_second_run_failures_filtered', second_run)
+        step = self.get_nth_step(0)
+        step._addToLog = lambda logName, message: defer.succeed(None)
+        return step
+
+    @defer.inlineCallbacks
+    def test_a_verdict_for_every_candidate_skips_the_revert_and_the_clean_tree_run(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(['suite.flaky'], ['suite.flaky'])
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', TestAPITestFlakinessReadUsingResultsDB.fake_verdicts(
+            {'suite.flaky': FlakyVerdict(flaky_type='DirtyTree')}))
+
+        yield step.doOnFailure()
+
+        self.assertEqual(step.steps_to_add, [])
+        self.assertEqual(step.build.results, SUCCESS)
+        self.assertEqual(self.getProperty('build_summary'), 'Ignored flaky tests: suite.flaky based on results-db')
+        self.assertEqual(self.getProperty('force_build_success'), True)
+        self.assertEqual(step.descriptionDone, 'Ignored flaky tests: suite.flaky based on results-db')
+
+    @defer.inlineCallbacks
+    def test_a_pull_request_against_a_branch_still_queues_the_whole_ladder(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(['suite.flaky'], ['suite.flaky'])
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', TestAPITestFlakinessReadUsingResultsDB.fake_verdicts(
+            {'suite.flaky': FlakyVerdict(flaky_type='DirtyTree')}))
+        self.setProperty('github.base.ref', 'safari-7620-branch')
+
+        yield step.doOnFailure()
+
+        self.assertEqual(step.steps_to_add, self.LADDER)
+        self.assertIsNone(self.getProperty('build_summary'))
+        self.assertIsNone(self.getProperty('force_build_success'))
+
+    @defer.inlineCallbacks
+    def test_one_candidate_without_a_verdict_queues_the_whole_ladder(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(['suite.flaky', 'suite.new'], ['suite.flaky', 'suite.new'])
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', TestAPITestFlakinessReadUsingResultsDB.fake_verdicts(
+            {'suite.flaky': FlakyVerdict(flaky_type='DirtyTree')}))
+
+        yield step.doOnFailure()
+
+        self.assertEqual(step.steps_to_add, self.LADDER)
+        self.assertIsNone(self.getProperty('build_summary'))
+        self.assertIsNone(self.getProperty('force_build_success'))
+
+    @defer.inlineCallbacks
+    def test_a_verdict_the_analyze_step_would_not_excuse_queues_the_ladder(self) -> Generator[Any, Any, None]:
+        # BetweenBuilds without intra-build evidence is the bucket the analyze step shadows rather
+        # than ignores, so the early exit must not act on it either.
+        step = self.configureStep(['suite.flaky'], ['suite.flaky'])
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', TestAPITestFlakinessReadUsingResultsDB.fake_verdicts(
+            {'suite.flaky': FlakyVerdict(flaky_type='BetweenBuilds')}))
+
+        yield step.doOnFailure()
+
+        self.assertEqual(step.steps_to_add, self.LADDER)
+        self.assertEqual(self.getProperty('results-db_api_flaky_unsupported'), ['suite.flaky'])
+
+    @defer.inlineCallbacks
+    def test_a_failed_request_queues_the_ladder(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(['suite.flaky'], ['suite.flaky'])
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', classmethod(
+            lambda cls, tests, **kwargs: defer.succeed(({test: FlakyVerdict(request_failed=True) for test in tests}, ''))))
+
+        yield step.doOnFailure()
+
+        self.assertEqual(step.steps_to_add, self.LADDER)
+        self.assertEqual(self.getProperty('results-db_api_flaky_unknown'), ['suite.flaky'])
+
+    @defer.inlineCallbacks
+    def test_only_the_failures_of_both_dirty_runs_are_candidates(self) -> Generator[Any, Any, None]:
+        queried = []
+        step = self.configureStep(['suite.both', 'suite.first_only'], ['suite.both', 'suite.second_only'])
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', TestAPITestFlakinessReadUsingResultsDB.fake_verdicts(
+            {'suite.both': FlakyVerdict(flaky_type='DirtyTree')}, queried))
+
+        yield step.doOnFailure()
+
+        self.assertEqual(queried, [(['suite.both'], {'platform': 'mac', 'style': 'release'}, 'api-tests', [], None)])
+        self.assertEqual(step.steps_to_add, [])
+
+    @defer.inlineCallbacks
+    def test_a_pre_existing_failure_filtered_out_of_a_run_is_not_a_candidate(self) -> Generator[Any, Any, None]:
+        queried = []
+        step = self.configureStep(['suite.flaky', 'suite.pre_existing'], ['suite.flaky', 'suite.pre_existing'], filtered=False)
+        self.setProperty('api_first_run_failures_filtered', ['suite.flaky'])
+        self.setProperty('api_second_run_failures_filtered', ['suite.flaky'])
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', TestAPITestFlakinessReadUsingResultsDB.fake_verdicts(
+            {'suite.flaky': FlakyVerdict(flaky_type='DirtyTree')}, queried))
+
+        yield step.doOnFailure()
+
+        self.assertEqual([tests for tests, _, _, _, _ in queried], [['suite.flaky']])
+        self.assertEqual(step.steps_to_add, [])
+
+    @defer.inlineCallbacks
+    def test_an_unparsed_run_queries_nothing_and_queues_the_ladder(self) -> Generator[Any, Any, None]:
+        queried = []
+        step = self.configureStep(['suite.flaky'], [], filtered=False)
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', TestAPITestFlakinessReadUsingResultsDB.fake_verdicts({}, queried))
+
+        yield step.doOnFailure()
+
+        self.assertEqual(queried, [])
+        self.assertEqual(step.steps_to_add, self.LADDER)
+
+    @defer.inlineCallbacks
+    def test_the_early_read_forwards_the_change_identity(self) -> Generator[Any, Any, None]:
+        queried = []
+        step = self.configureStep(['suite.flaky'], ['suite.flaky'])
+        self.setProperty('owners', ['jappleseed'])
+        self.setProperty('github.number', 42)
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', TestAPITestFlakinessReadUsingResultsDB.fake_verdicts({}, queried))
+
+        yield step.doOnFailure()
+
+        self.assertEqual([(authors, pr_number) for _, _, _, authors, pr_number in queried], [(['jappleseed'], 42)])
+
+    @defer.inlineCallbacks
+    def test_a_gtk_build_still_installs_its_dependencies_before_the_rebuild(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(['suite.new'], ['suite.new'])
+        self.setProperty('platform', 'gtk')
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', TestAPITestFlakinessReadUsingResultsDB.fake_verdicts({}))
+
+        yield step.doOnFailure()
+
+        self.assertEqual(step.steps_to_add, [
+            RevertAppliedChanges(), CleanWorkingDirectory(), ValidateChange(verifyBugClosed=False, addURLs=False), InstallGtkDependencies(),
+            CompileWebKitWithoutChange(retry_build_on_failure=True), ValidateChange(verifyBugClosed=False, addURLs=False), KillOldProcesses(), RunAPITestsWithoutChange(),
+            AnalyzeAPITestsResults(),
+        ])
+
+    @defer.inlineCallbacks
+    def test_a_whole_step_run_excuses_its_failure_and_queues_nothing(self) -> Generator[Any, Any, None]:
+        step = self.configureStep(['suite.flaky'], [], filtered=False)
+        self.setProperty('api_first_run_failures_filtered', ['suite.flaky'])
+        self.patch(ResultsDatabase, 'is_test_pre_existing_failure', classmethod(
+            lambda cls, test, **kwargs: defer.succeed({'is_existing_failure': False, 'pass_rate': 0.98, 'raw_data': '', 'logs': ''})))
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', TestAPITestFlakinessReadUsingResultsDB.fake_verdicts(
+            {'suite.flaky': FlakyVerdict(flaky_type='DirtyTree')}))
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        log_environ=False,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', f'python3 Tools/Scripts/run-api-tests --timestamps --no-build --release --verbose --json-output=api_test_results.json 2>&1 | Tools/Scripts/filter-test-logs api'],
+                        logfiles={'json': 'api_test_results.json'},
+                        timeout=20 * 60,
+                        )
+            .log('json', stdout='{"Failed":[{"name":"suite.flaky"}],"Timedout":[],"Crashed":[],"results":{"suite.flaky":{"actual":"FAIL"}}}')
+            .log('stdio', stdout='Ran 2 tests of 2 with 1 successful')
+            .exit(1),
+        )
+        self.expect_outcome(result=FAILURE, state_string='1 api test failed or timed out')
+
+        yield self.run_step()
+
+        self.assertEqual([queued for queued in step.steps_to_add if queued in self.LADDER], [])
+        self.assertEqual(self.getProperty('build_summary'), 'Ignored flaky tests: suite.flaky based on results-db')
+        self.assertEqual(self.getProperty('force_build_success'), True)
+
+    @defer.inlineCallbacks
+    def test_the_early_exit_reports_the_candidates_to_the_results_db(self) -> Generator[Any, Any, None]:
+        # AnalyzeAPITestsResults never runs on this path, so nothing else reports the intersection
+        # failures the build is about to excuse; a pre-existing BetweenStepsDirtyTree report is
+        # seeded here to prove the two stay disjoint rather than being merged or deduplicated.
+        step = self.configureStep(['suite.flaky'], ['suite.flaky'])
+        self.setProperty('api_first_run_results', {'suite.flaky': {'actual': 'FAIL'}})
+        self.setProperty('api_second_run_results', {'suite.flaky': {'actual': 'CRASH'}})
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', TestAPITestFlakinessReadUsingResultsDB.fake_verdicts(
+            {'suite.flaky': FlakyVerdict(flaky_type='DirtyTree')}))
+        between_steps_report = {'suite.betweensteps': {'actual': 'FAIL'}}
+        self.results_db_reports.append(dict(between_steps_report))
+
+        yield step.doOnFailure()
+
+        self.assertEqual(len(self.results_db_reports), 2)
+        self.assertEqual(self.results_db_reports[0], between_steps_report)
+        report = self.results_db_reports[1]
+        self.assertIsNone(report['flaky_type'])
+        self.assertEqual(report['results'], {
+            'suite.flaky': {'actual': 'FAIL CRASH', 'actual_by_run': {'first-run': 'FAIL', 'second-run': 'CRASH'}},
+        })
+
+    @defer.inlineCallbacks
+    def test_the_ladder_path_leaves_the_between_steps_report_untouched(self) -> Generator[Any, Any, None]:
+        # The ladder still hands the decision to AnalyzeAPITestsResults, so doOnFailure must not add
+        # its own report here; a pre-existing BetweenStepsDirtyTree report is seeded to prove it is
+        # left exactly as parse_and_set_failures left it, on this path too.
+        step = self.configureStep(['suite.flaky', 'suite.new'], ['suite.flaky', 'suite.new'])
+        self.setProperty('api_first_run_results', {'suite.flaky': {'actual': 'FAIL'}, 'suite.new': {'actual': 'FAIL'}})
+        self.setProperty('api_second_run_results', {'suite.flaky': {'actual': 'FAIL'}, 'suite.new': {'actual': 'FAIL'}})
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', TestAPITestFlakinessReadUsingResultsDB.fake_verdicts(
+            {'suite.flaky': FlakyVerdict(flaky_type='DirtyTree')}))
+        between_steps_report = {'suite.betweensteps': {'actual': 'FAIL'}}
+        self.results_db_reports.append(dict(between_steps_report))
+
+        yield step.doOnFailure()
+
+        self.assertEqual(step.steps_to_add, self.LADDER)
+        self.assertEqual(self.results_db_reports, [between_steps_report])
 
 
 class TestAPITestStepsReportAsTheyRun(BuildStepMixinAdditions, unittest.TestCase):


### PR DESCRIPTION
#### 9e098ca11b8f8de1ffc6bcd45ea2aabae15d7912
<pre>
[EWS] API EWS runs the whole retry ladder for an already-known flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=323311">https://bugs.webkit.org/show_bug.cgi?id=323311</a>
&lt;<a href="https://rdar.apple.com/problem/186558544">rdar://problem/186558544</a>&gt;

Reviewed by Aakash Jain.

When `run-api-tests` fails twice with the change, `ReRunAPITests.doOnFailure`
queues the revert, a rebuild and a clean-tree run, and only afterwards does
`AnalyzeAPITestsResults` ask the results database whether those failures were
flaky all along. `API-Tests-macOS-EWS` build 164902 spent 85 minutes on that
ladder before excusing a test the database records at a 98% pass rate.

Ask at the point the ladder would be queued instead. Both runs with the change
have reported their `BetweenStepsDirtyTree` evidence by then, so no evidence the
query depends on is lost. The first run still cannot ask: `run-api-tests` has no
`--treat-failing-as-flaky`, so it records one outcome per test, and a first-run
verdict would empty the failure list, pass the step, and prevent the rerun that
writes the only evidence API can produce.

Candidates are the failures both dirty runs share, taken from the same
`_filtered` properties `AnalyzeAPITestsResults` reads and falling back the same
way, so the two steps cannot disagree about what is excusable. When every
candidate has a verdict in `INCLUDED_FLAKY_VERDICTS` the build finishes green
through `force_build_success` and skips the revert, the rebuild, the clean-tree
run and the analyze step. One unexplained failure queues the ladder unchanged.

The early exit reports those candidates itself. `parse_and_set_failures` reports
only the symmetric difference of the two runs, and the intersection was reported
by `AnalyzeAPITestsResults`, which never runs on this path, so without a report
here the results-database rows for exactly the tests being excused would be
lost. The two reports remain disjoint, so nothing is written twice.

`flaky_new_failures_using_results_db` and `INCLUDED_FLAKY_VERDICTS` move to
`ResultsDBReportMixin`, which both callers now share.

* Tools/CISupport/ews-build/steps.py:
(ResultsDBReportMixin):
(ResultsDBReportMixin.flaky_new_failures_using_results_db):
(RunAPITests.__init__):
(RunAPITests.run):
(ReRunAPITests.failures_in_both_dirty_runs):
(ReRunAPITests):
(ReRunAPITests.doOnFailure):
(AnalyzeAPITestsResults):
(AnalyzeAPITestsResults.run):
(AnalyzeAPITestsResults.flaky_new_failures_using_results_db): Deleted.
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/320465@main">https://commits.webkit.org/320465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/610c32cef682b868f2eb34476a561ad4333a112b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58771 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52600 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195186 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186713 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58498 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48119 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124736 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/46843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/44612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6241 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197135 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/184254 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58440 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/164551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/153927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41206 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59145 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153584 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48100 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128002 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57642 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/19630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57001 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57252 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57078 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->