### PR TITLE
AX: Add layout tests for the text marker index space over emoji and invisible characters

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-regional-indicators-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-regional-indicators-expected.txt
@@ -1,0 +1,17 @@
+This test ensures a regional indicator pair, which is one flag to a reader but four code units and two code points, keeps a text marker index per code unit that still round-trips.
+
+Both regional indicators survive into the accessibility text.
+PASS: text().length === 13
+PASS: text().codePointAt(5) === 0x1F1EF
+PASS: text().codePointAt(7) === 0x1F1F5
+
+Every code unit has its own index, and it round-trips.
+PASS: walk.containerTextLength === 13
+PASS: walk.indicesChecked === 13
+PASS: walk.worstRoundTripDrift === 0
+PASS: walk.worstLengthDifference === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-regional-indicators.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-regional-indicators.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/ax-text-marker-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">Flag &#x1F1EF;&#x1F1F5; end</p>
+
+<script>
+var output = "This test ensures a regional indicator pair, which is one flag to a reader but four code units and two code points, keeps a text marker index per code unit that still round-trips.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var walk = checkRoundTripAllTextMarkerIndicesWithinContainer(target);
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    output += "Both regional indicators survive into the accessibility text.\n";
+    output += expect("text().length", "13");
+    output += expect("text().codePointAt(5)", "0x1F1EF");
+    output += expect("text().codePointAt(7)", "0x1F1F5");
+
+    output += "\nEvery code unit has its own index, and it round-trips.\n";
+    output += expect("walk.containerTextLength", "13");
+    output += expect("walk.indicesChecked", "13");
+    output += expect("walk.worstRoundTripDrift", "0");
+    output += expect("walk.worstLengthDifference", "0");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-variation-selector-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-variation-selector-expected.txt
@@ -1,0 +1,17 @@
+This test ensures a variation selector, which changes how the preceding character is drawn but is itself invisible, still occupies its own text marker index and reaches the accessibility text.
+
+The selector is preserved rather than folded into the character it modifies.
+PASS: text().length === 12
+PASS: text().codePointAt(6) === 0x2764
+PASS: text().codePointAt(7) === 0xFE0F
+
+Every code unit has its own index, and it round-trips.
+PASS: walk.containerTextLength === 12
+PASS: walk.indicesChecked === 12
+PASS: walk.worstRoundTripDrift === 0
+PASS: walk.worstLengthDifference === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-variation-selector.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-variation-selector.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/ax-text-marker-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">Heart &#x2764;&#xFE0F; end</p>
+
+<script>
+var output = "This test ensures a variation selector, which changes how the preceding character is drawn but is itself invisible, still occupies its own text marker index and reaches the accessibility text.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var walk = checkRoundTripAllTextMarkerIndicesWithinContainer(target);
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    output += "The selector is preserved rather than folded into the character it modifies.\n";
+    output += expect("text().length", "12");
+    output += expect("text().codePointAt(6)", "0x2764");
+    output += expect("text().codePointAt(7)", "0xFE0F");
+
+    output += "\nEvery code unit has its own index, and it round-trips.\n";
+    output += expect("walk.containerTextLength", "12");
+    output += expect("walk.indicesChecked", "12");
+    output += expect("walk.worstRoundTripDrift", "0");
+    output += expect("walk.worstLengthDifference", "0");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-zwj-sequence-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-zwj-sequence-expected.txt
@@ -1,0 +1,18 @@
+This test ensures a zero width joiner emoji sequence, which is one glyph to a reader but five code units, keeps the joiner and both halves in the accessibility text and a text marker index per code unit.
+
+The joiner is not dropped, so the sequence can be reconstructed.
+PASS: text().length === 15
+PASS: text().codePointAt(6) === 0x1F469
+PASS: text().codePointAt(8) === 0x200D
+PASS: text().codePointAt(9) === 0x1F4BB
+
+Every code unit has its own index, and it round-trips.
+PASS: walk.containerTextLength === 15
+PASS: walk.indicesChecked === 15
+PASS: walk.worstRoundTripDrift === 0
+PASS: walk.worstLengthDifference === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-zwj-sequence.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-zwj-sequence.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/ax-text-marker-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">Emoji &#x1F469;&#x200D;&#x1F4BB; end</p>
+
+<script>
+var output = "This test ensures a zero width joiner emoji sequence, which is one glyph to a reader but five code units, keeps the joiner and both halves in the accessibility text and a text marker index per code unit.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var walk = checkRoundTripAllTextMarkerIndicesWithinContainer(target);
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    output += "The joiner is not dropped, so the sequence can be reconstructed.\n";
+    output += expect("text().length", "15");
+    output += expect("text().codePointAt(6)", "0x1F469");
+    output += expect("text().codePointAt(8)", "0x200D");
+    output += expect("text().codePointAt(9)", "0x1F4BB");
+
+    output += "\nEvery code unit has its own index, and it round-trips.\n";
+    output += expect("walk.containerTextLength", "15");
+    output += expect("walk.indicesChecked", "15");
+    output += expect("walk.worstRoundTripDrift", "0");
+    output += expect("walk.worstLengthDifference", "0");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-marker-index-regional-indicators-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-index-regional-indicators-expected.txt
@@ -1,0 +1,17 @@
+This test ensures a regional indicator pair, which is one flag to a reader but four code units and two code points, keeps a text marker index per code unit that still round-trips.
+
+Both regional indicators survive into the accessibility text.
+PASS: text().length === 13
+PASS: text().codePointAt(5) === 0x1F1EF
+PASS: text().codePointAt(7) === 0x1F1F5
+
+Every code unit has its own index, and it round-trips.
+PASS: walk.containerTextLength === 13
+PASS: walk.indicesChecked === 13
+PASS: walk.worstRoundTripDrift === 0
+PASS: walk.worstLengthDifference === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-marker-index-regional-indicators.html
+++ b/LayoutTests/accessibility/mac/text-marker-index-regional-indicators.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/ax-text-marker-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">Flag &#x1F1EF;&#x1F1F5; end</p>
+
+<script>
+var output = "This test ensures a regional indicator pair, which is one flag to a reader but four code units and two code points, keeps a text marker index per code unit that still round-trips.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var walk = checkRoundTripAllTextMarkerIndicesWithinContainer(target);
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    output += "Both regional indicators survive into the accessibility text.\n";
+    output += expect("text().length", "13");
+    output += expect("text().codePointAt(5)", "0x1F1EF");
+    output += expect("text().codePointAt(7)", "0x1F1F5");
+
+    output += "\nEvery code unit has its own index, and it round-trips.\n";
+    output += expect("walk.containerTextLength", "13");
+    output += expect("walk.indicesChecked", "13");
+    output += expect("walk.worstRoundTripDrift", "0");
+    output += expect("walk.worstLengthDifference", "0");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-marker-index-variation-selector-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-index-variation-selector-expected.txt
@@ -1,0 +1,17 @@
+This test ensures a variation selector, which changes how the preceding character is drawn but is itself invisible, still occupies its own text marker index and reaches the accessibility text.
+
+The selector is preserved rather than folded into the character it modifies.
+PASS: text().length === 12
+PASS: text().codePointAt(6) === 0x2764
+PASS: text().codePointAt(7) === 0xFE0F
+
+Every code unit has its own index, and it round-trips.
+PASS: walk.containerTextLength === 12
+PASS: walk.indicesChecked === 12
+PASS: walk.worstRoundTripDrift === 0
+PASS: walk.worstLengthDifference === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-marker-index-variation-selector.html
+++ b/LayoutTests/accessibility/mac/text-marker-index-variation-selector.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/ax-text-marker-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">Heart &#x2764;&#xFE0F; end</p>
+
+<script>
+var output = "This test ensures a variation selector, which changes how the preceding character is drawn but is itself invisible, still occupies its own text marker index and reaches the accessibility text.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var walk = checkRoundTripAllTextMarkerIndicesWithinContainer(target);
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    output += "The selector is preserved rather than folded into the character it modifies.\n";
+    output += expect("text().length", "12");
+    output += expect("text().codePointAt(6)", "0x2764");
+    output += expect("text().codePointAt(7)", "0xFE0F");
+
+    output += "\nEvery code unit has its own index, and it round-trips.\n";
+    output += expect("walk.containerTextLength", "12");
+    output += expect("walk.indicesChecked", "12");
+    output += expect("walk.worstRoundTripDrift", "0");
+    output += expect("walk.worstLengthDifference", "0");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-marker-index-zwj-sequence-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-index-zwj-sequence-expected.txt
@@ -1,0 +1,18 @@
+This test ensures a zero width joiner emoji sequence, which is one glyph to a reader but five code units, keeps the joiner and both halves in the accessibility text and a text marker index per code unit.
+
+The joiner is not dropped, so the sequence can be reconstructed.
+PASS: text().length === 15
+PASS: text().codePointAt(6) === 0x1F469
+PASS: text().codePointAt(8) === 0x200D
+PASS: text().codePointAt(9) === 0x1F4BB
+
+Every code unit has its own index, and it round-trips.
+PASS: walk.containerTextLength === 15
+PASS: walk.indicesChecked === 15
+PASS: walk.worstRoundTripDrift === 0
+PASS: walk.worstLengthDifference === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-marker-index-zwj-sequence.html
+++ b/LayoutTests/accessibility/mac/text-marker-index-zwj-sequence.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/ax-text-marker-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">Emoji &#x1F469;&#x200D;&#x1F4BB; end</p>
+
+<script>
+var output = "This test ensures a zero width joiner emoji sequence, which is one glyph to a reader but five code units, keeps the joiner and both halves in the accessibility text and a text marker index per code unit.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var walk = checkRoundTripAllTextMarkerIndicesWithinContainer(target);
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    output += "The joiner is not dropped, so the sequence can be reconstructed.\n";
+    output += expect("text().length", "15");
+    output += expect("text().codePointAt(6)", "0x1F469");
+    output += expect("text().codePointAt(8)", "0x200D");
+    output += expect("text().codePointAt(9)", "0x1F4BB");
+
+    output += "\nEvery code unit has its own index, and it round-trips.\n";
+    output += expect("walk.containerTextLength", "15");
+    output += expect("walk.indicesChecked", "15");
+    output += expect("walk.worstRoundTripDrift", "0");
+    output += expect("walk.worstLengthDifference", "0");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 9977e3c2b4c81fbf2aecf8b7762cb9bea1322b9c
<pre>
AX: Add layout tests for the text marker index space over emoji and invisible characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=323360">https://bugs.webkit.org/show_bug.cgi?id=323360</a>
<a href="https://rdar.apple.com/186603195">rdar://186603195</a>

Reviewed by Chris Fleizach.

bounds-for-range-multibyte-glyphs.html already captures the code unit span of a joined
emoji and a variation-selector emoji, by asserting the rect boundsForRange returns for
each. It never reads the string and never uses the index APIs, so what is new below is
the index round trip and the presence of the invisible characters themselves.

text-marker-index-regional-indicators.html:
No accessibility test contains a regional indicator. A flag is four code units and two
code points in one glyph, stressing surrogate pairs and cluster boundaries together.

text-marker-index-zwj-sequence.html:
Asserts the zero width joiner survives into the accessibility text at its own index.
The bounds test shows an eleven code unit span is treated as one glyph but cannot show
the joiner is still in the string. Without it, an assistive technology reconstructing
the sequence from character offsets gets two unrelated emoji.

text-marker-index-variation-selector.html:
Same for a variation selector, which is invisible and only changes how the preceding
character is drawn. Asserting its code point is the only way to tell it was preserved
rather than folded into the character it modifies.

* LayoutTests/accessibility/isolated-tree/mac/text-marker-index-regional-indicators-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/text-marker-index-regional-indicators.html: Added.
* LayoutTests/accessibility/isolated-tree/mac/text-marker-index-variation-selector-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/text-marker-index-variation-selector.html: Added.
* LayoutTests/accessibility/isolated-tree/mac/text-marker-index-zwj-sequence-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/text-marker-index-zwj-sequence.html: Added.
* LayoutTests/accessibility/mac/text-marker-index-regional-indicators-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-index-regional-indicators.html: Added.
* LayoutTests/accessibility/mac/text-marker-index-variation-selector-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-index-variation-selector.html: Added.
* LayoutTests/accessibility/mac/text-marker-index-zwj-sequence-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-index-zwj-sequence.html: Added.

Canonical link: <a href="https://commits.webkit.org/320506@main">https://commits.webkit.org/320506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b5d72c51c54f3ceb637357fe3564556607d1559

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58745 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195160 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d4b7c9b-a827-40c5-931c-731c091b8f83) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144430 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9abab8e2-9a23-4070-989f-63d8e9b287c1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165027 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124716 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ece44411-be11-4553-96c7-5bcca73d6508) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46822 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44929 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157194 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44585 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6215 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197108 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164524 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153906 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41242 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59119 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41197 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153563 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48079 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127970 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57616 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19603 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56975 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57226 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57052 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->