### PR TITLE
AX: Add layout tests for bidirectional text and runtime text direction changes

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-children-order-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-children-order-expected.txt
@@ -1,0 +1,14 @@
+This test ensures flipping direction to right-to-left after load rearranges where the children are drawn without rearranging the order the accessibility tree reports them in.
+
+Left to right: DOM order and drawing order agree.
+PASS: childTitles() === 'One, Two, Three'
+PASS: firstIsDrawnLeftOfThird() === true
+
+Right to left: the first child is now drawn rightmost, and the reported order is unchanged.
+PASS: firstIsDrawnLeftOfThird() === false
+PASS: childTitles() === 'One, Two, Three'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-children-order.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-children-order.html
@@ -1,0 +1,50 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="target" role="group"><button id="first">One</button><button id="second">Two</button><button id="third">Three</button></div>
+
+<script>
+var output = "This test ensures flipping direction to right-to-left after load rearranges where the children are drawn without rearranging the order the accessibility tree reports them in.\n\n";
+
+function childTitles()
+{
+    var group = accessibilityController.accessibleElementById("target");
+    var titles = [];
+    for (var i = 0; i < group.childrenCount; i++)
+        titles.push(group.childAtIndex(i).title.replace("AXTitle: ", ""));
+    return titles.join(", ");
+}
+
+function firstIsDrawnLeftOfThird()
+{
+    return accessibilityController.accessibleElementById("first").pageX < accessibilityController.accessibleElementById("third").pageX;
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    output += "Left to right: DOM order and drawing order agree.\n";
+    output += expect("childTitles()", "'One, Two, Three'");
+    output += expect("firstIsDrawnLeftOfThird()", "true");
+
+    setTimeout(async function() {
+        document.getElementById("target").dir = "rtl";
+
+        output += "\nRight to left: the first child is now drawn rightmost, and the reported order is unchanged.\n";
+        output += await expectAsync("firstIsDrawnLeftOfThird()", "false");
+        output += expect("childTitles()", "'One, Two, Three'");
+
+        document.getElementById("target").style.display = "none";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-string-content-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-string-content-expected.txt
@@ -1,0 +1,13 @@
+This test ensures text extracted after direction is flipped to right-to-left comes back in logical order, not in the order the glyphs are drawn. The text is replaced at the same time so the assertion cannot pass against a value cached from before the flip.
+
+PASS: text() === 'abc אבג def'
+
+After the flip the new text is still logical: the Latin run that comes first in the DOM comes first in the string.
+PASS: text() === 'xyz אבג uvw'
+PASS: text().indexOf('xyz') === 0
+PASS: text().indexOf('uvw') === 8
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-string-content.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-string-content.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">abc אבג def</p>
+
+<script>
+var output = "This test ensures text extracted after direction is flipped to right-to-left comes back in logical order, not in the order the glyphs are drawn. The text is replaced at the same time so the assertion cannot pass against a value cached from before the flip.\n\n";
+
+function text()
+{
+    var target = accessibilityController.accessibleElementById("target");
+    return target.stringForTextMarkerRange(target.textMarkerRangeForElement(target));
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    output += expect("text()", "'abc אבג def'");
+
+    setTimeout(async function() {
+        document.getElementById("target").dir = "rtl";
+        document.getElementById("target").textContent = "xyz אבג uvw";
+
+        output += "\nAfter the flip the new text is still logical: the Latin run that comes first in the DOM comes first in the string.\n";
+        output += await expectAsync("text()", "'xyz אבג uvw'");
+        output += expect("text().indexOf('xyz')", "0");
+        output += expect("text().indexOf('uvw')", "8");
+
+        document.getElementById("target").style.display = "none";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-mixed-direction-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-mixed-direction-expected.txt
@@ -1,0 +1,17 @@
+This test ensures a paragraph holding both right-to-left and left-to-right runs, whose own direction is resolved from its content, reports its text and its index space in logical order rather than in the order the runs are drawn.
+
+The embedded left-to-right run keeps its logical position between the two right-to-left runs.
+PASS: text() === 'שלום world שלום'
+PASS: text().length === 15
+PASS: text().indexOf('world') === 5
+
+Every code unit has its own index, and it round-trips across the direction boundaries.
+PASS: walk.containerTextLength === 15
+PASS: walk.indicesChecked === 15
+PASS: walk.worstRoundTripDrift === 0
+PASS: walk.worstLengthDifference === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-mixed-direction.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-mixed-direction.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/ax-text-marker-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target" dir="auto">שלום world שלום</p>
+
+<script>
+var output = "This test ensures a paragraph holding both right-to-left and left-to-right runs, whose own direction is resolved from its content, reports its text and its index space in logical order rather than in the order the runs are drawn.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var walk = checkRoundTripAllTextMarkerIndicesWithinContainer(target);
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    output += "The embedded left-to-right run keeps its logical position between the two right-to-left runs.\n";
+    output += expect("text()", "'שלום world שלום'");
+    output += expect("text().length", "15");
+    output += expect("text().indexOf('world')", "5");
+
+    output += "\nEvery code unit has its own index, and it round-trips across the direction boundaries.\n";
+    output += expect("walk.containerTextLength", "15");
+    output += expect("walk.indicesChecked", "15");
+    output += expect("walk.worstRoundTripDrift", "0");
+    output += expect("walk.worstLengthDifference", "0");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-rtl-attribute-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-rtl-attribute-expected.txt
@@ -1,0 +1,17 @@
+This test ensures a dir=rtl paragraph of left-to-right words reports its text and index space in logical order. The words are drawn right to left while each word's letters are drawn left to right, so visual order and logical order disagree at the word level but not the letter level.
+
+The first word in the DOM is the first word in the string, though it is drawn rightmost.
+PASS: text() === 'alpha beta gamma'
+PASS: text().indexOf('alpha') === 0
+PASS: text().indexOf('gamma') === 11
+
+Every code unit has its own index, and it round-trips.
+PASS: walk.containerTextLength === 16
+PASS: walk.indicesChecked === 16
+PASS: walk.worstRoundTripDrift === 0
+PASS: walk.worstLengthDifference === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-rtl-attribute.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/text-marker-index-rtl-attribute.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/ax-text-marker-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target" dir="rtl">alpha beta gamma</p>
+
+<script>
+var output = "This test ensures a dir=rtl paragraph of left-to-right words reports its text and index space in logical order. The words are drawn right to left while each word's letters are drawn left to right, so visual order and logical order disagree at the word level but not the letter level.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var walk = checkRoundTripAllTextMarkerIndicesWithinContainer(target);
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    output += "The first word in the DOM is the first word in the string, though it is drawn rightmost.\n";
+    output += expect("text()", "'alpha beta gamma'");
+    output += expect("text().indexOf('alpha')", "0");
+    output += expect("text().indexOf('gamma')", "11");
+
+    output += "\nEvery code unit has its own index, and it round-trips.\n";
+    output += expect("walk.containerTextLength", "16");
+    output += expect("walk.indicesChecked", "16");
+    output += expect("walk.worstRoundTripDrift", "0");
+    output += expect("walk.worstLengthDifference", "0");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/dynamic-rtl-children-order-expected.txt
+++ b/LayoutTests/accessibility/mac/dynamic-rtl-children-order-expected.txt
@@ -1,0 +1,14 @@
+This test ensures flipping direction to right-to-left after load rearranges where the children are drawn without rearranging the order the accessibility tree reports them in.
+
+Left to right: DOM order and drawing order agree.
+PASS: childTitles() === 'One, Two, Three'
+PASS: firstIsDrawnLeftOfThird() === true
+
+Right to left: the first child is now drawn rightmost, and the reported order is unchanged.
+PASS: firstIsDrawnLeftOfThird() === false
+PASS: childTitles() === 'One, Two, Three'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/dynamic-rtl-children-order.html
+++ b/LayoutTests/accessibility/mac/dynamic-rtl-children-order.html
@@ -1,0 +1,50 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="target" role="group"><button id="first">One</button><button id="second">Two</button><button id="third">Three</button></div>
+
+<script>
+var output = "This test ensures flipping direction to right-to-left after load rearranges where the children are drawn without rearranging the order the accessibility tree reports them in.\n\n";
+
+function childTitles()
+{
+    var group = accessibilityController.accessibleElementById("target");
+    var titles = [];
+    for (var i = 0; i < group.childrenCount; i++)
+        titles.push(group.childAtIndex(i).title.replace("AXTitle: ", ""));
+    return titles.join(", ");
+}
+
+function firstIsDrawnLeftOfThird()
+{
+    return accessibilityController.accessibleElementById("first").pageX < accessibilityController.accessibleElementById("third").pageX;
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    output += "Left to right: DOM order and drawing order agree.\n";
+    output += expect("childTitles()", "'One, Two, Three'");
+    output += expect("firstIsDrawnLeftOfThird()", "true");
+
+    setTimeout(async function() {
+        document.getElementById("target").dir = "rtl";
+
+        output += "\nRight to left: the first child is now drawn rightmost, and the reported order is unchanged.\n";
+        output += await expectAsync("firstIsDrawnLeftOfThird()", "false");
+        output += expect("childTitles()", "'One, Two, Three'");
+
+        document.getElementById("target").style.display = "none";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/dynamic-rtl-string-content-expected.txt
+++ b/LayoutTests/accessibility/mac/dynamic-rtl-string-content-expected.txt
@@ -1,0 +1,13 @@
+This test ensures text extracted after direction is flipped to right-to-left comes back in logical order, not in the order the glyphs are drawn. The text is replaced at the same time so the assertion cannot pass against a value cached from before the flip.
+
+PASS: text() === 'abc אבג def'
+
+After the flip the new text is still logical: the Latin run that comes first in the DOM comes first in the string.
+PASS: text() === 'xyz אבג uvw'
+PASS: text().indexOf('xyz') === 0
+PASS: text().indexOf('uvw') === 8
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/dynamic-rtl-string-content.html
+++ b/LayoutTests/accessibility/mac/dynamic-rtl-string-content.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target">abc אבג def</p>
+
+<script>
+var output = "This test ensures text extracted after direction is flipped to right-to-left comes back in logical order, not in the order the glyphs are drawn. The text is replaced at the same time so the assertion cannot pass against a value cached from before the flip.\n\n";
+
+function text()
+{
+    var target = accessibilityController.accessibleElementById("target");
+    return target.stringForTextMarkerRange(target.textMarkerRangeForElement(target));
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    output += expect("text()", "'abc אבג def'");
+
+    setTimeout(async function() {
+        document.getElementById("target").dir = "rtl";
+        document.getElementById("target").textContent = "xyz אבג uvw";
+
+        output += "\nAfter the flip the new text is still logical: the Latin run that comes first in the DOM comes first in the string.\n";
+        output += await expectAsync("text()", "'xyz אבג uvw'");
+        output += expect("text().indexOf('xyz')", "0");
+        output += expect("text().indexOf('uvw')", "8");
+
+        document.getElementById("target").style.display = "none";
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-marker-index-mixed-direction-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-index-mixed-direction-expected.txt
@@ -1,0 +1,17 @@
+This test ensures a paragraph holding both right-to-left and left-to-right runs, whose own direction is resolved from its content, reports its text and its index space in logical order rather than in the order the runs are drawn.
+
+The embedded left-to-right run keeps its logical position between the two right-to-left runs.
+PASS: text() === 'שלום world שלום'
+PASS: text().length === 15
+PASS: text().indexOf('world') === 5
+
+Every code unit has its own index, and it round-trips across the direction boundaries.
+PASS: walk.containerTextLength === 15
+PASS: walk.indicesChecked === 15
+PASS: walk.worstRoundTripDrift === 0
+PASS: walk.worstLengthDifference === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-marker-index-mixed-direction.html
+++ b/LayoutTests/accessibility/mac/text-marker-index-mixed-direction.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/ax-text-marker-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target" dir="auto">שלום world שלום</p>
+
+<script>
+var output = "This test ensures a paragraph holding both right-to-left and left-to-right runs, whose own direction is resolved from its content, reports its text and its index space in logical order rather than in the order the runs are drawn.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var walk = checkRoundTripAllTextMarkerIndicesWithinContainer(target);
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    output += "The embedded left-to-right run keeps its logical position between the two right-to-left runs.\n";
+    output += expect("text()", "'שלום world שלום'");
+    output += expect("text().length", "15");
+    output += expect("text().indexOf('world')", "5");
+
+    output += "\nEvery code unit has its own index, and it round-trips across the direction boundaries.\n";
+    output += expect("walk.containerTextLength", "15");
+    output += expect("walk.indicesChecked", "15");
+    output += expect("walk.worstRoundTripDrift", "0");
+    output += expect("walk.worstLengthDifference", "0");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/text-marker-index-rtl-attribute-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-index-rtl-attribute-expected.txt
@@ -1,0 +1,17 @@
+This test ensures a dir=rtl paragraph of left-to-right words reports its text and index space in logical order. The words are drawn right to left while each word's letters are drawn left to right, so visual order and logical order disagree at the word level but not the letter level.
+
+The first word in the DOM is the first word in the string, though it is drawn rightmost.
+PASS: text() === 'alpha beta gamma'
+PASS: text().indexOf('alpha') === 0
+PASS: text().indexOf('gamma') === 11
+
+Every code unit has its own index, and it round-trips.
+PASS: walk.containerTextLength === 16
+PASS: walk.indicesChecked === 16
+PASS: walk.worstRoundTripDrift === 0
+PASS: walk.worstLengthDifference === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-marker-index-rtl-attribute.html
+++ b/LayoutTests/accessibility/mac/text-marker-index-rtl-attribute.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/ax-text-marker-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="target" dir="rtl">alpha beta gamma</p>
+
+<script>
+var output = "This test ensures a dir=rtl paragraph of left-to-right words reports its text and index space in logical order. The words are drawn right to left while each word's letters are drawn left to right, so visual order and logical order disagree at the word level but not the letter level.\n\n";
+
+if (window.accessibilityController) {
+    var target = accessibilityController.accessibleElementById("target");
+    var targetRange = target.textMarkerRangeForElement(target);
+    var walk = checkRoundTripAllTextMarkerIndicesWithinContainer(target);
+
+    function text()
+    {
+        return target.stringForTextMarkerRange(targetRange);
+    }
+
+    output += "The first word in the DOM is the first word in the string, though it is drawn rightmost.\n";
+    output += expect("text()", "'alpha beta gamma'");
+    output += expect("text().indexOf('alpha')", "0");
+    output += expect("text().indexOf('gamma')", "11");
+
+    output += "\nEvery code unit has its own index, and it round-trips.\n";
+    output += expect("walk.containerTextLength", "16");
+    output += expect("walk.indicesChecked", "16");
+    output += expect("walk.worstRoundTripDrift", "0");
+    output += expect("walk.worstLengthDifference", "0");
+
+    document.getElementById("target").style.display = "none";
+
+    debug(output);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 5eee8c0ae0310c78ad07f24b6532d9e10398bf75
<pre>
AX: Add layout tests for bidirectional text and runtime text direction changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=323362">https://bugs.webkit.org/show_bug.cgi?id=323362</a>
<a href="https://rdar.apple.com/186603868">rdar://186603868</a>

Reviewed by Chris Fleizach.

text-marker-index-mixed-direction.html:
text-marker-bidi-inline-cite.html already covers a dir=auto paragraph holding nested
dir=rtl and dir=ltr runs, and asserts the extracted string and range length. It uses no
index API, so the round trip across the direction boundaries, and the offset of the
embedded left-to-right run, are what this adds.

text-marker-index-rtl-attribute.html:
Same gap for dir=rtl. Left-to-right words in a right-to-left paragraph are a distinct
case from right-to-left characters. The words reverse while the letters inside them do
not, and an index space built from drawn order would still contain the right characters.

dynamic-rtl-children-order.html:
No accessibility test sets direction at runtime at all. Asserts the drawn order actually
reverses before re-checking the reported order, so it cannot pass against a tree that
never updated.

dynamic-rtl-string-content.html:
Likewise. The text is replaced in the same turn as the flip, so a stale isolated-tree
read cannot satisfy the assertion.

* LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-children-order-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-children-order.html: Added.
* LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-string-content-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/dynamic-rtl-string-content.html: Added.
* LayoutTests/accessibility/isolated-tree/mac/text-marker-index-mixed-direction-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/text-marker-index-mixed-direction.html: Added.
* LayoutTests/accessibility/isolated-tree/mac/text-marker-index-rtl-attribute-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/text-marker-index-rtl-attribute.html: Added.
* LayoutTests/accessibility/mac/dynamic-rtl-children-order-expected.txt: Added.
* LayoutTests/accessibility/mac/dynamic-rtl-children-order.html: Added.
* LayoutTests/accessibility/mac/dynamic-rtl-string-content-expected.txt: Added.
* LayoutTests/accessibility/mac/dynamic-rtl-string-content.html: Added.
* LayoutTests/accessibility/mac/text-marker-index-mixed-direction-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-index-mixed-direction.html: Added.
* LayoutTests/accessibility/mac/text-marker-index-rtl-attribute-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-index-rtl-attribute.html: Added.

Canonical link: <a href="https://commits.webkit.org/320507@main">https://commits.webkit.org/320507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7186a36a66f5076edcbb52aafee37e58b07e605f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195161 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d7e29ac2-f526-4934-bb54-60151bf4dda5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58474 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144432 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b33ca44c-9afc-4ce5-b5fb-205af4e0d871) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124717 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0034de1e-8c0d-4285-847f-6a373879515c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46823 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44930 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157195 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44588 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6216 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197109 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58415 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164527 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153907 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41243 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59120 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41200 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153564 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48080 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127971 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57617 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19606 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56976 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57227 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57053 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->