### PR TITLE
Use WTF::switchOn for the BufferOrString variant in ClipboardItemBindingsDataSource

### DIFF
--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
@@ -226,12 +226,18 @@ void ClipboardItemBindingsDataSource::invokeCompletionHandler()
     PasteboardCustomData customData;
     for (auto& itemTypeLoader : itemTypeLoaders) {
         auto type = itemTypeLoader->type();
-        auto& data = itemTypeLoader->data();
-        if (std::holds_alternative<String>(data) && !!std::get<String>(data))
-            customData.writeString(type, std::get<String>(data));
-        else if (std::holds_alternative<Ref<SharedBuffer>>(data))
-            customData.writeData(type, std::get<Ref<SharedBuffer>>(data).copyRef());
-        else {
+        bool didWrite = WTF::switchOn(itemTypeLoader->data(),
+            [&](const String& string) {
+                if (!string)
+                    return false;
+                customData.writeString(type, string);
+                return true;
+            },
+            [&](const Ref<SharedBuffer>& buffer) {
+                customData.writeData(type, buffer.copyRef());
+                return true;
+            });
+        if (!didWrite) {
             completionHandler(std::nullopt);
             return;
         }
@@ -280,15 +286,13 @@ void ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::didFail(Exception
 
 String ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::dataAsString() const
 {
-    if (std::holds_alternative<Ref<SharedBuffer>>(m_data)) {
-        auto& buffer = std::get<Ref<SharedBuffer>>(m_data);
-        return String::fromUTF8(buffer->span());
-    }
-
-    if (std::holds_alternative<String>(m_data))
-        return std::get<String>(m_data);
-
-    return { };
+    return WTF::switchOn(m_data,
+        [](const String& string) {
+            return string;
+        },
+        [](const Ref<SharedBuffer>& buffer) {
+            return String::fromUTF8(buffer->span());
+        });
 }
 
 void ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::sanitizeDataIfNeeded()
@@ -328,11 +332,13 @@ void ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::sanitizeDataIfNee
     }
 
     if (m_type == "image/png"_s) {
-        RefPtr<SharedBuffer> bufferToSanitize;
-        if (std::holds_alternative<Ref<SharedBuffer>>(m_data))
-            bufferToSanitize = std::get<Ref<SharedBuffer>>(m_data).ptr();
-        else if (std::holds_alternative<String>(m_data))
-            bufferToSanitize = utf8Buffer(std::get<String>(m_data));
+        RefPtr<SharedBuffer> bufferToSanitize = WTF::switchOn(m_data,
+            [](const String& string) -> RefPtr<SharedBuffer> {
+                return utf8Buffer(string);
+            },
+            [](const Ref<SharedBuffer>& buffer) -> RefPtr<SharedBuffer> {
+                return buffer.ptr();
+            });
 
         if (!bufferToSanitize || bufferToSanitize->isEmpty())
             return;


### PR DESCRIPTION
#### dc774f0cde658499d412683a1f9e69e061b0ff97
<pre>
Use WTF::switchOn for the BufferOrString variant in ClipboardItemBindingsDataSource
<a href="https://bugs.webkit.org/show_bug.cgi?id=323363">https://bugs.webkit.org/show_bug.cgi?id=323363</a>
<a href="https://rdar.apple.com/186603909">rdar://186603909</a>

Reviewed by Chris Dumez.

ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::m_data is a
Variant&lt;String, Ref&lt;SharedBuffer&gt;&gt;, but it was hand-decoded with
std::holds_alternative + std::get pairs in three places. Besides being
verbose, the form in invokeCompletionHandler() only rejected an
unexpected alternative via a catch-all else, so an added variant
alternative could silently fall through elsewhere.

Replace the manual decoding with WTF::switchOn, which is exhaustive over
the variant&apos;s alternatives and lets the compiler enforce that every
alternative is handled. No change in behavior: invokeCompletionHandler()
still rejects on a null String, and both dataAsString() and the image/png
sanitization path resolve to the same values as before.

* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
(WebCore::ClipboardItemBindingsDataSource::invokeCompletionHandler):
(WebCore::ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::dataAsString const):
(WebCore::ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::sanitizeDataIfNeeded):

Canonical link: <a href="https://commits.webkit.org/320480@main">https://commits.webkit.org/320480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f6589fe868c2528a98b2da0f2cc83fa8534f757

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195162 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5dd10af1-707e-4544-8a24-3d075add3398) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144433 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/652dcb83-aa26-4f9d-86fc-062a9b500f18) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124718 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aa94f7e3-4036-49fe-bc56-809d88804c76) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46824 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44931 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44589 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6217 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197110 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58416 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153908 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41221 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59121 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41201 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153565 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48081 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131410 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/127972 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57618 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19607 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/56977 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57228 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57054 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->