### PR TITLE
[WebGPU] ~CommandBuffer can run on Metal completion thread, racing non-atomic CommandEncoder refcount and Device::m_commandEncoderMap

### DIFF
--- a/LayoutTests/ipc/webgpu-command-encoder-cross-thread-destruction-race-expected.txt
+++ b/LayoutTests/ipc/webgpu-command-encoder-cross-thread-destruction-race-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/webgpu-command-encoder-cross-thread-destruction-race.html
+++ b/LayoutTests/ipc/webgpu-command-encoder-cross-thread-destruction-race.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<body>
+<p>This test passes if it does not crash.</p>
+<script>
+window.testRunner?.dumpAsText();
+window.testRunner?.waitUntilDone();
+
+(async () => {
+    if (!window.IPC) {
+        window.testRunner?.notifyDone();
+        return;
+    }
+
+    const TIMEOUT = 1000;
+    let nextId = (Math.floor(Math.random() * 100000) + 1) * 100000;
+    const freshId = () => ++nextId;
+
+    const M = IPC.messages;
+    const MSG_CreateRenderingBackend = M.GPUConnectionToWebProcess_CreateRenderingBackend.name;
+    const MSG_CreateGPU = M.GPUConnectionToWebProcess_CreateGPU.name;
+    const MSG_WasCreated = M.RemoteGPUProxy_WasCreated.name;
+    const MSG_RequestAdapter = M.RemoteGPU_RequestAdapter.name;
+    const MSG_RequestDevice = M.RemoteAdapter_RequestDevice.name;
+    const MSG_CreateCommandEncoder = M.RemoteDevice_CreateCommandEncoder.name;
+    const MSG_Finish = M.RemoteCommandEncoder_Finish.name;
+    const MSG_Submit = M.RemoteQueue_Submit.name;
+    const MSG_CB_Destruct = M.RemoteCommandBuffer_Destruct.name;
+    const MSG_CE_Destruct = M.RemoteCommandEncoder_Destruct.name;
+    const MSG_ReleaseGPU = M.GPUConnectionToWebProcess_ReleaseGPU.name;
+
+    const [rbSC, rbHandle] = IPC.createStreamClientConnection(14, TIMEOUT);
+    rbSC.open();
+    const backendID = freshId();
+    IPC.sendMessage("GPU", 0, MSG_CreateRenderingBackend,
+        [{ type: "uint64_t", value: backendID }, { type: "StreamServerConnectionHandle", value: rbHandle }]);
+
+    async function iteration(NA, NB) {
+        const [gpuSC, gpuHandle] = IPC.createStreamClientConnection(18, TIMEOUT);
+        gpuSC.open();
+        const gpuID = freshId();
+        IPC.sendMessage("GPU", 0, MSG_CreateGPU,
+            [{ type: "uint64_t", value: gpuID }, { type: "uint64_t", value: backendID }, { type: "StreamServerConnectionHandle", value: gpuHandle }]);
+        const wasCreated = gpuSC.waitForMessage(gpuID, MSG_WasCreated);
+        if (!wasCreated || !wasCreated[0].value)
+            return false;
+
+        const adapterID = freshId();
+        gpuSC.sendSyncMessage(gpuID, MSG_RequestAdapter,
+            [{ type: "bool", value: 0 }, { type: "bool", value: 0 }, { type: "bool", value: 0 }, { type: "uint64_t", value: adapterID }]);
+        const deviceID = freshId(), queueID = freshId();
+        gpuSC.sendSyncMessage(adapterID, MSG_RequestDevice,
+            [{ type: "String", value: "" }, { type: "Vector", value: [] }, { type: "Vector", value: [] },
+             { type: "uint64_t", value: deviceID }, { type: "uint64_t", value: queueID }]);
+
+        const encA = [], cbA = [];
+        for (let i = 0; i < NA; i++) {
+            const eId = freshId(), cbId = freshId();
+            encA.push(eId); cbA.push(cbId);
+            gpuSC.sendMessage(deviceID, MSG_CreateCommandEncoder,
+                [{ type: "bool", value: 1 }, { type: "String", value: "" }, { type: "uint64_t", value: eId }]);
+            gpuSC.sendMessage(eId, MSG_Finish,
+                [{ type: "String", value: "" }, { type: "uint64_t", value: cbId }]);
+        }
+        for (let j = 0; j < NB; j++) {
+            gpuSC.sendMessage(deviceID, MSG_CreateCommandEncoder,
+                [{ type: "bool", value: 1 }, { type: "String", value: "" }, { type: "uint64_t", value: freshId() }]);
+        }
+
+        const cbVec = cbA.map(id => ({ type: "uint64_t", value: id }));
+        gpuSC.sendMessage(queueID, MSG_Submit, [{ type: "Vector", value: cbVec }]);
+        for (let i = 0; i < NA; i++) {
+            gpuSC.sendMessage(cbA[i], MSG_CB_Destruct, []);
+            gpuSC.sendMessage(encA[i], MSG_CE_Destruct, []);
+        }
+
+        IPC.sendMessage("GPU", 0, MSG_ReleaseGPU,
+            [{ type: "uint64_t", value: gpuID }]);
+        gpuSC.invalidate();
+        return true;
+    }
+
+    const ITERS = 200, NA = 50, NB = 150;
+    for (let it = 0; it < ITERS; it++) {
+        try {
+            if (!await iteration(NA, NB))
+                break;
+        } catch (e) { }
+        if (!(it % 10))
+            await new Promise(r => setTimeout(r, 0));
+    }
+    window.testRunner?.notifyDone();
+})();
+</script>
+</body>

--- a/LayoutTests/ipc/webgpu-instance-cross-thread-destruction-race-expected.txt
+++ b/LayoutTests/ipc/webgpu-instance-cross-thread-destruction-race-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/webgpu-instance-cross-thread-destruction-race.html
+++ b/LayoutTests/ipc/webgpu-instance-cross-thread-destruction-race.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<body>
+<p>This test passes if it does not crash.</p>
+<script>
+window.testRunner?.dumpAsText();
+window.testRunner?.waitUntilDone();
+
+(async () => {
+    if (!window.IPC) {
+        window.testRunner?.notifyDone();
+        return;
+    }
+
+    const TIMEOUT = 1000;
+    let nextId = (Math.floor(Math.random() * 100000) + 1) * 100000;
+    const freshId = () => ++nextId;
+
+    const M = IPC.messages;
+    const MSG_CreateRenderingBackend = M.GPUConnectionToWebProcess_CreateRenderingBackend.name;
+    const MSG_CreateGPU = M.GPUConnectionToWebProcess_CreateGPU.name;
+    const MSG_WasCreated = M.RemoteGPUProxy_WasCreated.name;
+    const MSG_RequestAdapter = M.RemoteGPU_RequestAdapter.name;
+    const MSG_RequestDevice = M.RemoteAdapter_RequestDevice.name;
+    const MSG_CreateCommandEncoder = M.RemoteDevice_CreateCommandEncoder.name;
+    const MSG_Finish = M.RemoteCommandEncoder_Finish.name;
+    const MSG_Submit = M.RemoteQueue_Submit.name;
+    const MSG_ReleaseGPU = M.GPUConnectionToWebProcess_ReleaseGPU.name;
+
+    const [rbSC, rbHandle] = IPC.createStreamClientConnection(14, TIMEOUT);
+    rbSC.open();
+    const backendID = freshId();
+    IPC.sendMessage("GPU", 0, MSG_CreateRenderingBackend,
+        [{ type: "uint64_t", value: backendID }, { type: "StreamServerConnectionHandle", value: rbHandle }]);
+
+    async function iteration(NA) {
+        const [gpuSC, gpuHandle] = IPC.createStreamClientConnection(18, TIMEOUT);
+        gpuSC.open();
+        const gpuID = freshId();
+        IPC.sendMessage("GPU", 0, MSG_CreateGPU,
+            [{ type: "uint64_t", value: gpuID }, { type: "uint64_t", value: backendID }, { type: "StreamServerConnectionHandle", value: gpuHandle }]);
+        const wasCreated = gpuSC.waitForMessage(gpuID, MSG_WasCreated);
+        if (!wasCreated || !wasCreated[0].value)
+            return false;
+
+        const adapterID = freshId();
+        gpuSC.sendSyncMessage(gpuID, MSG_RequestAdapter,
+            [{ type: "bool", value: 0 }, { type: "bool", value: 0 }, { type: "bool", value: 0 }, { type: "uint64_t", value: adapterID }]);
+        const deviceID = freshId(), queueID = freshId();
+        gpuSC.sendSyncMessage(adapterID, MSG_RequestDevice,
+            [{ type: "String", value: "" }, { type: "Vector", value: [] }, { type: "Vector", value: [] },
+             { type: "uint64_t", value: deviceID }, { type: "uint64_t", value: queueID }]);
+
+        const cbIds = [];
+        for (let i = 0; i < NA; i++) {
+            const eId = freshId(), cbId = freshId();
+            cbIds.push(cbId);
+            gpuSC.sendMessage(deviceID, MSG_CreateCommandEncoder,
+                [{ type: "bool", value: 1 }, { type: "String", value: "" }, { type: "uint64_t", value: eId }]);
+            gpuSC.sendMessage(eId, MSG_Finish,
+                [{ type: "String", value: "" }, { type: "uint64_t", value: cbId }]);
+        }
+
+        const cbVec = cbIds.map(id => ({ type: "uint64_t", value: id }));
+        gpuSC.sendMessage(queueID, MSG_Submit, [{ type: "Vector", value: cbVec }]);
+
+        IPC.sendMessage("GPU", 0, MSG_ReleaseGPU,
+            [{ type: "uint64_t", value: gpuID }]);
+        gpuSC.invalidate();
+        return true;
+    }
+
+    const ITERS = 300, NA = 200;
+    for (let it = 0; it < ITERS; it++) {
+        try {
+            if (!await iteration(NA))
+                break;
+        } catch (e) { }
+        if (!(it % 10))
+            await new Promise(r => setTimeout(r, 0));
+    }
+    window.testRunner?.notifyDone();
+})();
+</script>
+</body>

--- a/Source/WebGPU/WebGPU/CommandBuffer.mm
+++ b/Source/WebGPU/WebGPU/CommandBuffer.mm
@@ -27,6 +27,7 @@
 #import "CommandBuffer.h"
 
 #import "APIConversions.h"
+#import "Instance.h"
 #import <wtf/TZoneMallocInlines.h>
 
 namespace WebGPU {
@@ -117,12 +118,17 @@ void CommandBuffer::makeInvalidDueToCommit(NSString* lastError)
         [m_commandBuffer encodeSignalEvent:m_sharedEvent value:m_sharedEventSignalValue];
 
     m_cachedCommandBuffer = m_commandBuffer;
+    if (RefPtr instance = m_device->instance())
+        instance->retainCommandBuffer(*this, m_commandBuffer);
     [m_commandBuffer addCompletedHandler:[protectedThis = protect(*this)](id<MTLCommandBuffer> completedCommandBuffer) {
         double kernelStartTime = completedCommandBuffer.kernelStartTime;
         double kernelEndTime = completedCommandBuffer.kernelEndTime;
         protectedThis->m_gpuExecutionDurationSeconds.store(kernelEndTime - kernelStartTime, std::memory_order_relaxed);
         protectedThis->m_commandBufferComplete.signal();
-        protectedThis->m_device->getQueue()->scheduleWork([protectedThis, kernelStartTime, kernelEndTime]() mutable {
+        protectedThis->m_device->getQueue()->scheduleWork([weakThis = ThreadSafeWeakPtr { protectedThis.get() }, kernelStartTime, kernelEndTime]() mutable {
+            RefPtr protectedThis { weakThis.get() };
+            if (!protectedThis)
+                return;
             protectedThis->m_cachedCommandBuffer = nil;
             if (RefPtr commandEncoder = protectedThis->m_commandEncoder) {
                 commandEncoder->recordGPUExecutionWindowOnCanvasTextures(kernelStartTime, kernelEndTime);

--- a/Source/WebGPU/WebGPU/Instance.h
+++ b/Source/WebGPU/WebGPU/Instance.h
@@ -51,6 +51,7 @@ class MachSendRight;
 namespace WebGPU {
 
 class Adapter;
+class CommandBuffer;
 class Device;
 class PresentationContext;
 class Texture;
@@ -73,6 +74,8 @@ public:
 
     bool isValid() const { return m_isValid; }
     void retainDevice(Device&, id<MTLCommandBuffer>);
+    void retainCommandBuffer(CommandBuffer&, id<MTLCommandBuffer>);
+    void waitForCommandBufferCompletions();
 
     // This can be called on a background thread.
     using WorkItem = Function<void()>;
@@ -90,7 +93,8 @@ private:
     // This can be used on a background thread.
     Deque<WGPUWorkItem> m_pendingWork WTF_GUARDED_BY_LOCK(m_lock);
     using CommandBufferContainer = Vector<WeakObjCPtr<id<MTLCommandBuffer>>>;
-    HashMap<Ref<Device>, CommandBufferContainer> retainedDeviceInstances WTF_GUARDED_BY_LOCK(m_lock);
+    HashMap<Ref<Device>, CommandBufferContainer> retainedDeviceInstances;
+    Vector<std::pair<Ref<CommandBuffer>, WeakObjCPtr<id<MTLCommandBuffer>>>> m_retainedCommandBufferInstances;
     const std::optional<const MachSendRight> m_webProcessID;
     const WGPUScheduleWorkBlock m_scheduleWorkBlock;
     Lock m_lock;

--- a/Source/WebGPU/WebGPU/Instance.mm
+++ b/Source/WebGPU/WebGPU/Instance.mm
@@ -28,6 +28,7 @@
 
 #import "APIConversions.h"
 #import "Adapter.h"
+#import "CommandBuffer.h"
 #import "HardwareCapabilities.h"
 #import "PresentationContext.h"
 #import <cstring>
@@ -73,6 +74,22 @@ Instance::Instance()
 }
 
 Instance::~Instance() = default;
+
+void Instance::waitForCommandBufferCompletions()
+{
+    auto retainedCommandBuffers { std::exchange(m_retainedCommandBufferInstances, { }) };
+    auto retainedDevices { std::exchange(retainedDeviceInstances, { }) };
+    for (const auto& [_, weakCommandBuffer] : retainedCommandBuffers) {
+        if (id<MTLCommandBuffer> commandBuffer = weakCommandBuffer.get().get(); commandBuffer.status >= MTLCommandBufferStatusCommitted)
+            [commandBuffer waitUntilCompleted];
+    }
+    for (const auto& container : retainedDevices.values()) {
+        for (const auto& weakCommandBuffer : container) {
+            if (id<MTLCommandBuffer> commandBuffer = weakCommandBuffer.get().get(); commandBuffer.status >= MTLCommandBufferStatusCommitted)
+                [commandBuffer waitUntilCompleted];
+        }
+    }
+}
 
 Ref<PresentationContext> Instance::createSurface(const WGPUSurfaceDescriptor& descriptor)
 {
@@ -194,7 +211,6 @@ void Instance::requestAdapter(const WGPURequestAdapterOptions& options, Completi
 
 void Instance::retainDevice(Device& device, id<MTLCommandBuffer> commandBuffer)
 {
-    Locker locker(m_lock);
     auto& container = retainedDeviceInstances.ensure(device, [] {
         return CommandBufferContainer { };
     }).iterator->value;
@@ -209,6 +225,14 @@ void Instance::retainDevice(Device& device, id<MTLCommandBuffer> commandBuffer)
     retainedDeviceInstances.removeIf([&](auto& pair) {
         return !pair.value.size();
     });
+}
+
+void Instance::retainCommandBuffer(CommandBuffer& commandBuffer, id<MTLCommandBuffer> mtlCommandBuffer)
+{
+    m_retainedCommandBufferInstances.removeAllMatching([](auto& pair) {
+        return !pair.second;
+    });
+    m_retainedCommandBufferInstances.append({ commandBuffer, mtlCommandBuffer });
 }
 
 id<MTLDevice> Instance::device() const
@@ -227,6 +251,7 @@ void NODELETE wgpuInstanceReference(WGPUInstance instance)
 
 void wgpuInstanceRelease(WGPUInstance instance)
 {
+    protect(WebGPU::fromAPI(instance))->waitForCommandBufferCompletions();
     WebGPU::fromAPI(instance).deref();
 }
 


### PR DESCRIPTION
#### 70e05bc9fbbf66f5dbf746ee1706b0158c994ed1
<pre>
[WebGPU] ~CommandBuffer can run on Metal completion thread, racing non-atomic CommandEncoder refcount and Device::m_commandEncoderMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=315794">https://bugs.webkit.org/show_bug.cgi?id=315794</a>
<a href="https://rdar.apple.com/176483048">rdar://176483048</a>

Reviewed by Mike Wyrzykowski.

CommandBuffer::makeInvalidDueToCommit registers an addCompletedHandler block whose body
bounces cleanup work to the WebGPU work queue via Queue::scheduleWork. The inner lambda
captures a strong Ref&lt;CommandBuffer&gt;. During RemoteGPU teardown, StreamConnectionWorkQueue::dispatch
silently drops the lambda when m_shouldQuit is set; the dropped lambda&apos;s Ref&lt;CommandBuffer&gt;
is destroyed on com.Metal.CompletionQueueDispatch. If that is the last ref, ~CommandBuffer
runs on the Metal thread and (a) non-atomically derefs m_commandEncoder (CommandEncoder is
RefCountedAndCanMakeWeakPtr), racing the work-queue thread&apos;s deref via ObjectHeap::clear()
-&gt; torn refcount -&gt; UAF; and (b) ~CommandEncoder mutates the unlocked Device::m_commandEncoderMap,
racing the work-queue thread&apos;s concurrent removeCommandEncoder.

Additionally, every WebGPU addCompletedHandler/addScheduledHandler that calls
Queue::scheduleWork creates a temporary RefPtr&lt;Instance&gt; via m_instance.get() on the Metal
thread; if that temp outlives the work-queue&apos;s wgpuInstanceRelease deref, ~Instance runs on
the Metal thread and destroys whatever Ref&lt;Device&gt;/Ref&lt;CommandBuffer&gt; Instance owns there.

Fix:

1. Anchor each committed CommandBuffer in Instance::m_retainedCommandBufferInstances so the
   Metal-thread block&apos;s deref is never the last. The anchor is keyed by a
   WeakObjCPtr&lt;id&lt;MTLCommandBuffer&gt;&gt; and lazily pruned when that pointer goes nil; nil
   implies MTLCommandBuffer dealloc, which only happens after Metal&apos;s
   didCompleteWithStartTime: has Block_release()d every completion handler, so the outer
   block&apos;s Ref&lt;CommandBuffer&gt; is already gone by the time the anchor is dropped.

2. Drain all retained MTLCommandBuffers (waitUntilCompleted) in wgpuInstanceRelease before
   deref(), so the C-API ref is alive while completion handlers run -&gt; no Metal-thread
   RefPtr&lt;Instance&gt; temporary can be the last -&gt; ~Instance and the anchors are released on
   the work-queue thread.

3. Change the inner lambda to capture ThreadSafeWeakPtr&lt;CommandBuffer&gt;. This is load-bearing,
   not just defense-in-depth: Instance::scheduleWork wraps the inner lambda in an ObjC block
   via makeBlockPtr().get(), and that wrapper is autoreleased on the Metal thread. Its pool
   drains at _dispatch_last_resort_autorelease_pool_pop, which is after waitUntilCompleted
   returns (after _completedCallbacksDone). With a strong inner capture, the autoreleased
   block copy holds a Ref&lt;CommandBuffer&gt; past the anchor&apos;s lifetime, and ~CommandBuffer runs
   on the Metal thread when the pool drains. With a weak capture, the autoreleased copy
   holds nothing that destructs cross-thread.

retainCommandBuffer, retainDevice, and waitForCommandBufferCompletions all run on the
single per-Instance StreamConnectionWorkQueue thread (Instance is per-RemoteGPU, not
per-process), so the m_lock acquire around the retention containers is unnecessary; drop it
along with the WTF_GUARDED_BY_LOCK annotations. m_lock continues to guard m_pendingWork for
the unused defaultScheduleWork/processEvents fallback.

Regressed in 288538@main.

Tests: ipc/webgpu-command-encoder-cross-thread-destruction-race.html
       ipc/webgpu-instance-cross-thread-destruction-race.html

* LayoutTests/ipc/webgpu-command-encoder-cross-thread-destruction-race-expected.txt: Added.
* LayoutTests/ipc/webgpu-command-encoder-cross-thread-destruction-race.html: Added.
* LayoutTests/ipc/webgpu-instance-cross-thread-destruction-race-expected.txt: Added.
* LayoutTests/ipc/webgpu-instance-cross-thread-destruction-race.html: Added.
* Source/WebGPU/WebGPU/CommandBuffer.mm:
(WebGPU::CommandBuffer::makeInvalidDueToCommit):
* Source/WebGPU/WebGPU/Instance.h:
* Source/WebGPU/WebGPU/Instance.mm:
(WebGPU::Instance::waitForCommandBufferCompletions):
(WebGPU::Instance::retainDevice):
(WebGPU::Instance::retainCommandBuffer):
(wgpuInstanceRelease):

Originally-landed-as: c1b3074a6202. <a href="https://rdar.apple.com/185367024">rdar://185367024</a>
Canonical link: <a href="https://commits.webkit.org/320662@main">https://commits.webkit.org/320662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bdcc366ec9f92b5799e2b09a69eb2741244dc9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195420 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/149990 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58732 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144634 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100336 "Exiting early after 60 failures. 60 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124926 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47037 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45109 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44793 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6476 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51664 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197372 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164729 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154129 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41372 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59378 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153784 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48283 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131673 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128310 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57861 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19812 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57228 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57474 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57298 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->