### PR TITLE
Resync `cookies` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/WEB_FEATURES.yml
@@ -1,8 +1,3 @@
-features:
-- name: cookie-enabled
-  files:
-  - cookie-enabled-noncookie-frame.html
-- name: cookies
-  files:
-  - "*"
-  - "!cookie-enabled-noncookie-frame.html"
+rules:
+- cookie-enabled-noncookie-frame.html: [cookie-enabled]
+- "*": [cookies]

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/WEB_FEATURES.yml
@@ -1,3 +1,2 @@
-features:
-- name: cookies
-  files: "**"
+rules:
+- "**": [cookies]

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/httponly-overwrite.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/httponly-overwrite.https.window-expected.txt
@@ -1,0 +1,10 @@
+
+PASS A cookie set without HttpOnly is not http-only
+PASS A cookie set with HttpOnly is http-only
+PASS Adding HttpOnly to a cookie with an unchanged value makes it http-only
+PASS Removing HttpOnly from a cookie with an unchanged value makes it not http-only
+PASS Adding HttpOnly through a second Set-Cookie in the same response
+PASS Removing HttpOnly through a second Set-Cookie in the same response
+FAIL Adding HttpOnly to a cookie with an unchanged value hides it from document.cookie assert_equals: The cookie is no longer exposed to document.cookie expected (object) null but got (string) "1"
+PASS Removing HttpOnly from a cookie with an unchanged value exposes it to document.cookie
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/httponly-overwrite.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/httponly-overwrite.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/httponly-overwrite.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/httponly-overwrite.https.window.js
@@ -1,0 +1,136 @@
+// META: title=Overwriting a cookie's HttpOnly attribute while its value stays the same
+
+'use strict';
+
+// https://httpwg.org/http-extensions/draft-ietf-httpbis-layered-cookies.html#store-a-cookie
+// https://github.com/httpwg/http-extensions/issues/3501
+
+async function setCookieViaHTTP(cookie) {
+  const set = encodeURIComponent(JSON.stringify(cookie));
+  const response = await fetch(`/cookies/resources/cookie.py?set=${set}`);
+  assert_true(response.ok, 'Setting the cookie via HTTP succeeded');
+}
+
+// The raw Cookie request header, which unlike document.cookie also observes
+// HttpOnly cookies.
+async function getCookieHeader() {
+  const response = await fetch('/cookiestore/resources/cookie_helper.py',
+                               {credentials: 'include'});
+  assert_true(response.ok, 'Reading the Cookie header succeeded');
+  const text = await response.text();
+  return decodeURIComponent(text.replace(/^cookie=/, ''));
+}
+
+function cookieValue(cookieString, name) {
+  for (const pair of cookieString.split('; ')) {
+    const index = pair.indexOf('=');
+    if (index !== -1 && pair.substring(0, index) === name) {
+      return pair.substring(index + 1);
+    }
+  }
+  return null;
+}
+
+// Whether a cookie's http-only is true, observed without reading
+// document.cookie: a cookie can only be overwritten through a non-HTTP API if
+// its http-only is false, so if a write from script does not land the cookie's
+// http-only is true.
+async function isHttpOnly(name) {
+  document.cookie = `${name}=overwritten; Path=/`;
+  return cookieValue(await getCookieHeader(), name) !== 'overwritten';
+}
+
+function cookieTest(description, suffix, body) {
+  const name = `httponly-overwrite-${suffix}`;
+  promise_test(async t => {
+    t.add_cleanup(() => setCookieViaHTTP(`${name}=; Path=/; Max-Age=0`));
+    t.add_cleanup(
+        () => setCookieViaHTTP(`${name}=; Path=/; Max-Age=0; HttpOnly`));
+    await body(t, name);
+  }, description);
+}
+
+// These two establish that isHttpOnly() reports what it claims to.
+cookieTest('A cookie set without HttpOnly is not http-only', 'control1',
+           async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=/`);
+  assert_false(await isHttpOnly(name));
+});
+
+cookieTest('A cookie set with HttpOnly is http-only', 'control2',
+           async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=/; HttpOnly`);
+  assert_true(await isHttpOnly(name));
+});
+
+// A cookie's http-only has to be updated even when nothing else about the cookie
+// changes. Failing to do so leaves the cookie writable by the non-HTTP APIs the
+// server just asked to have it protected from.
+cookieTest('Adding HttpOnly to a cookie with an unchanged value makes it http-only',
+           'test1', async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=/`);
+  assert_false(await isHttpOnly(name), 'The cookie starts out not http-only');
+
+  await setCookieViaHTTP(`${name}=1; Path=/; HttpOnly`);
+  assert_equals(cookieValue(await getCookieHeader(), name), '1',
+                'The cookie is still in the cookie store with its value');
+  assert_true(await isHttpOnly(name), 'The cookie is now http-only');
+});
+
+cookieTest('Removing HttpOnly from a cookie with an unchanged value makes it not http-only',
+           'test2', async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=/; HttpOnly`);
+  assert_true(await isHttpOnly(name), 'The cookie starts out http-only');
+
+  await setCookieViaHTTP(`${name}=1; Path=/`);
+  assert_equals(cookieValue(await getCookieHeader(), name), '1',
+                'The cookie is still in the cookie store with its value');
+  assert_false(await isHttpOnly(name), 'The cookie is no longer http-only');
+});
+
+// As above, but with both cookies in a single response, so that they also have
+// an identical creation time.
+cookieTest('Adding HttpOnly through a second Set-Cookie in the same response',
+           'test3', async (t, name) => {
+  await setCookieViaHTTP([`${name}=1; Path=/`, `${name}=1; Path=/; HttpOnly`]);
+  assert_equals(cookieValue(await getCookieHeader(), name), '1',
+                'The cookie is in the cookie store with its value');
+  assert_true(await isHttpOnly(name), 'The cookie is http-only');
+});
+
+cookieTest('Removing HttpOnly through a second Set-Cookie in the same response',
+           'test4', async (t, name) => {
+  await setCookieViaHTTP([`${name}=1; Path=/; HttpOnly`, `${name}=1; Path=/`]);
+  assert_equals(cookieValue(await getCookieHeader(), name), '1',
+                'The cookie is in the cookie store with its value');
+  assert_false(await isHttpOnly(name), 'The cookie is not http-only');
+});
+
+// An http-only cookie also has to stop being exposed to non-HTTP APIs. This is
+// separate from the tests above so that a user agent that protects the cookie
+// from being overwritten but keeps exposing its value fails only here.
+cookieTest('Adding HttpOnly to a cookie with an unchanged value hides it from document.cookie',
+           'test5', async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=/`);
+  assert_equals(cookieValue(document.cookie, name), '1',
+                'The cookie is exposed to document.cookie');
+
+  await setCookieViaHTTP(`${name}=1; Path=/; HttpOnly`);
+  assert_equals(cookieValue(await getCookieHeader(), name), '1',
+                'The cookie is still in the cookie store with its value');
+  assert_equals(cookieValue(document.cookie, name), null,
+                'The cookie is no longer exposed to document.cookie');
+});
+
+cookieTest('Removing HttpOnly from a cookie with an unchanged value exposes it to document.cookie',
+           'test6', async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=/; HttpOnly`);
+  assert_equals(cookieValue(document.cookie, name), null,
+                'The cookie is not exposed to document.cookie');
+
+  await setCookieViaHTTP(`${name}=1; Path=/`);
+  assert_equals(cookieValue(await getCookieHeader(), name), '1',
+                'The cookie is still in the cookie store with its value');
+  assert_equals(cookieValue(document.cookie, name), '1',
+                'The cookie is now exposed to document.cookie');
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/resources/path/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/resources/path/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/resources/path/one.html

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/resources/pathfakeout/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/resources/pathfakeout/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/resources/pathfakeout/one.html

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/resources/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/resources/domain-child.sub.html

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/w3c-import.log
@@ -10,14 +10,13 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/attributes-ctl.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/domain.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/expires.html
+/LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/httponly-overwrite.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/invalid.html
 /LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/max-age.html
 /LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/path-redirect.html

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/domain/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/domain/WEB_FEATURES.yml
@@ -1,3 +1,2 @@
-features:
-- name: cookies
-  files: "**"
+rules:
+- "**": [cookies]

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/domain/support/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/domain/support/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/domain/support/idn-child.sub.https.html

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/domain/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/domain/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/domain/WEB_FEATURES.yml

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/encoding/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/encoding/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/encoding/charset.html

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/name/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/name/WEB_FEATURES.yml
@@ -1,3 +1,2 @@
-features:
-- name: cookies
-  files: "**"
+rules:
+- "**": [cookies]

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/name/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/name/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/name/WEB_FEATURES.yml

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/ordering/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/ordering/resources/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/ordering/resources/ordering-child.sub.html

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/ordering/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/ordering/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/ordering/ordering.sub.html

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/origin-bound-cookies/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/origin-bound-cookies/resources/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/origin-bound-cookies/resources/scheme-bound-cookies-window.html

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/origin-bound-cookies/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/origin-bound-cookies/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/origin-bound-cookies/port-bound-cookies.html

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/WEB_FEATURES.yml
@@ -1,3 +1,2 @@
-features:
-- name: partitioned-cookies
-  files: "**"
+rules:
+- "**": [partitioned-cookies]

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https-expected.txt
@@ -1,6 +1,4 @@
 
 
-PASS Setting Partitioned cookie on top-level site and embedding a cross-site iframe
-PASS Embed same-site embed in cross-site
-FAIL Same-site embed with a cross-site parent partitioned cookie access assert_false: expected false got true
+FAIL Setting Partitioned cookie on top-level site and embedding a cross-site iframe assert_false: Partitioned cookie set on the top-level site must not be accessible to a same-site embed that has a cross-site ancestor expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https.html
@@ -27,16 +27,30 @@
 
     assert_true(document.cookie.includes(partitionedCookie));
 
-    const iframe = document.createElement("iframe");
-    const url = new URL(
-      "/cookies/partitioned-cookies/resources/" +
-          "ancestor-chain-cross-site-embed.html",
-          get_host_info().HTTPS_NOTSAMESITE_ORIGIN + self.location.pathname);
+    // Listen for the grandchild frame's result before creating the iframe so we
+    // never miss it. The A1->B->A2 tree reports through a single postMessage to
+    // the top, avoiding the cross-process fetch_tests_from_window() races.
+    const result = await new Promise(resolve => {
+      window.addEventListener("message", function handler(event) {
+        if (event.data && event.data.type === "ancestor-chain-result") {
+          window.removeEventListener("message", handler);
+          resolve(event.data);
+        }
+      });
 
-    iframe.src = url.href;
-    document.body.appendChild(iframe);
+      const iframe = document.createElement("iframe");
+      const url = new URL(
+        "/cookies/partitioned-cookies/resources/" +
+            "ancestor-chain-cross-site-embed.html",
+            get_host_info().HTTPS_NOTSAMESITE_ORIGIN + self.location.pathname);
+      iframe.src = url.href;
+      document.body.appendChild(iframe);
+    });
 
-    await fetch_tests_from_window(iframe.contentWindow);
+    assert_false(result.cookieVisible,
+        "Partitioned cookie set on the top-level site must not be accessible " +
+        "to a same-site embed that has a cross-site ancestor");
+
     erase_cookie_from_js("ancestor", "Secure; Path=/; SameSite=None; Partitioned");
   }, "Setting Partitioned cookie on top-level site and embedding a cross-site iframe");
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-cross-site-embed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-cross-site-embed.html
@@ -1,31 +1,19 @@
 <!doctype html>
 <head>
 <meta charset="utf-8"/>
-<meta name="timeout" content="long">
-<script src="/resources/testharness.js"></script>
-<script src="/cookies/resources/testharness-helpers.js"></script>
 <script src="/common/get-host-info.sub.js"></script>
-<script src="/cookies/resources/cookie-helper.sub.js"></script>
 <title>Test partitioned cookies ancestor chain: cross site embed</title>
 </head>
 <body>
 <script>
-
-promise_test(async () => {
-  assert_false(document.cookie.includes("ancestor=chain"));
-
+  // Cross-site middle frame: it only embeds a same-site (to the top-level page)
+  // grandchild frame so that the grandchild has a cross-site ancestor. The
+  // grandchild reports its result straight to window.top.
   const iframe = document.createElement("iframe");
-    const url = new URL(
+  const url = new URL(
     "./ancestor-chain-same-site-embed.html",
     get_host_info().ORIGIN + self.location.pathname);
-
   iframe.src = url.href;
   document.body.appendChild(iframe);
-  await new Promise(r => iframe.onload = r);
-
- await fetch_tests_from_window(iframe.contentWindow);
-
-}, "Embed same-site embed in cross-site");
-
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-same-site-embed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-same-site-embed.html
@@ -1,19 +1,19 @@
 <!doctype html>
 <head>
 <meta charset="utf-8"/>
-<meta name="timeout" content="long">
-<script src="/resources/testharness.js"></script>
-<script src="/cookies/resources/testharness-helpers.js"></script>
 <title>Test partitioned cookies ancestor chain: same site embed</title>
 </head>
 <body>
 <script>
-
-test(() => {
-  // The cookie set on the top-level site has no cross-site ancestor in and this embed has a
-  // cross-site ancestor. So the partitioned cookie should not be accessible.
-  assert_false(document.cookie.includes("ancestor=chain"));
-}, "Same-site embed with a cross-site parent partitioned cookie access");
-
+  // This frame is same-site with the top-level page but has a cross-site
+  // ancestor. The top-level page's partitioned cookie has no cross-site
+  // ancestor in its key, so it must not be accessible here. Report the result
+  // directly to the top-level page via a single postMessage rather than
+  // forwarding through nested fetch_tests_from_window(), whose multi-message
+  // catch-up protocol races across process boundaries under Fission.
+  window.top.postMessage({
+    type: "ancestor-chain-result",
+    cookieVisible: document.cookie.includes("ancestor=chain"),
+  }, "*");
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-cross-site-embed.html

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/WEB_FEATURES.yml

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/path/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/path/WEB_FEATURES.yml
@@ -1,3 +1,2 @@
-features:
-- name: cookies
-  files: "**"
+rules:
+- "**": [cookies]

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-percent-encoded.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-percent-encoded.https.window-expected.txt
@@ -1,0 +1,12 @@
+
+PASS CONTROL a cookie for the probed path is visible in it
+PASS CONTROL a cookie for a prefix of the probed path is visible in it
+FAIL A Path attribute where a literal space does not match a percent-encoded space assert_equals: expected (object) null but got (string) "1"
+PASS A Path attribute where a percent-encoded space matches a percent-encoded space
+PASS A Path attribute where a non-ASCII byte is not reachable at the percent-encoding of that byte
+FAIL A Path attribute where a non-ASCII byte is not reachable at the percent-encoding of its isomorphic decoding assert_equals: expected (object) null but got (string) "1"
+PASS A Path attribute where a multi-byte non-ASCII sequence is not reachable at the percent-encoding of those bytes
+FAIL A Path attribute where a multi-byte non-ASCII sequence is not reachable at the percent-encoding of its isomorphic decoding assert_equals: expected (object) null but got (string) "1"
+PASS A Path attribute where an already percent-encoded non-ASCII byte matches, being ASCII itself
+PASS cleanup: unregister the service worker
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-percent-encoded.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-percent-encoded.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-percent-encoded.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-percent-encoded.https.window.js
@@ -1,0 +1,184 @@
+// META: title=Cookie Path attribute matching against percent-encoded URL paths
+
+'use strict';
+
+// A cookie's path is compared against the request URL's path, whose segments are
+// percent-encoded. So a byte written literally in a Path attribute does not match
+// its percent-encoded form in a URL, and a non-ASCII byte, which makes the cookie
+// fail to parse, is not reachable at any encoding of it.
+//
+// Observing this needs paths with no file behind them, so a service worker
+// synthesizes a document at whichever path is probed. The document reads
+// document.cookie, because a service worker cannot see a request's Cookie header.
+//
+// https://github.com/whatwg/url/issues/814
+
+const PROBE_DIR = '/cookies/path/resources/probe';
+const NAME_PREFIX = 'match-percent-encoded-';
+
+// Sets a Set-Cookie header, replacing "ZZ" in `cookie` with the raw bytes given
+// as percent-escapes. wptserve percent-decodes the query into bytes and cookie.py
+// passes those bytes to the header unchanged, which is how a byte that a URL path
+// would percent-encode reaches the Path attribute as itself.
+async function setCookieViaHTTP(cookie, rawEscape) {
+  let query = encodeURIComponent(JSON.stringify([cookie]));
+  if (rawEscape !== undefined) {
+    query = query.replace('ZZ', rawEscape);
+  }
+  const response = await fetch(`/cookies/resources/cookie.py?set=${query}`);
+  assert_true(response.ok, 'Setting the cookie via HTTP succeeded');
+}
+
+function cookieValue(cookieString, name) {
+  for (const pair of cookieString.split('; ')) {
+    const index = pair.indexOf('=');
+    if (index !== -1 && pair.substring(0, index) === name) {
+      return pair.substring(index + 1);
+    }
+  }
+  return null;
+}
+
+// Loads a synthesized document at `path` and returns what it reported.
+function probeAtPath(path) {
+  return new Promise(resolve => {
+    const iframe = document.createElement('iframe');
+    iframe.style = 'display: none';
+    const onMessage = event => {
+      if (event.source !== iframe.contentWindow) {
+        return;
+      }
+      window.removeEventListener('message', onMessage);
+      iframe.remove();
+      resolve(event.data);
+    };
+    window.addEventListener('message', onMessage);
+    iframe.src = path;
+    document.body.appendChild(iframe);
+  });
+}
+
+let registration;
+
+promise_setup(async () => {
+  registration = await navigator.serviceWorker.register(
+      'resources/probe/sw.js', {scope: `${PROBE_DIR}/`});
+  // navigator.serviceWorker.ready is not usable here: it waits for a worker
+  // controlling this document, and this document is outside the scope the probe
+  // paths need. Wait on the registration's own worker instead.
+  const worker =
+      registration.installing || registration.waiting || registration.active;
+  if (worker.state !== 'activated') {
+    await new Promise(resolve => {
+      worker.addEventListener('statechange', () => {
+        if (worker.state === 'activated') {
+          resolve();
+        }
+      });
+    });
+  }
+});
+
+// Sets the cookie under test, then expires it again through the same Path, which
+// is what removes it.
+function cookieTest(description, {suffix, pathSegment, raw}, body) {
+  const name = NAME_PREFIX + suffix;
+  promise_test(async t => {
+    t.add_cleanup(() => setCookieViaHTTP(
+        `${name}=; Max-Age=0; Path=${PROBE_DIR}/${pathSegment}`, raw));
+
+    await setCookieViaHTTP(`${name}=1; Path=${PROBE_DIR}/${pathSegment}`, raw);
+    await body(t, name);
+  }, description);
+}
+
+// Controls: the service worker synthesizes a document at the probed path and
+// cookies for that path are visible in it, so the apparatus reports what it
+// claims to.
+cookieTest('CONTROL a cookie for the probed path is visible in it',
+           {suffix: 'control', pathSegment: 'zzx'}, async (t, name) => {
+  const result = await probeAtPath(`${PROBE_DIR}/zzx/probe.html`);
+  assert_equals(result.path, `${PROBE_DIR}/zzx/probe.html`,
+                'The document was synthesized at the probed path');
+  assert_equals(cookieValue(result.cookie, name), '1');
+});
+
+cookieTest('CONTROL a cookie for a prefix of the probed path is visible in it',
+           {suffix: 'prefix', pathSegment: ''}, async (t, name) => {
+  const result = await probeAtPath(`${PROBE_DIR}/zzx/probe.html`);
+  assert_equals(cookieValue(result.cookie, name), '1');
+});
+
+// Each case sets one cookie whose Path ends in `pathSegment`, with "ZZ" replaced
+// by the raw bytes `raw` when given, then probes the URL path segment
+// `probeSegment`.
+const CASES = [
+  // A byte that is ASCII but that a URL path percent-encodes. The cookie is
+  // stored, but its path does not match the encoded segment.
+  {
+    name: 'a literal space does not match a percent-encoded space',
+    pathSegment: 'zzZZa',
+    raw: '%20',
+    probeSegment: 'zz%20a',
+    sent: false,
+  },
+  {
+    name: 'a percent-encoded space matches a percent-encoded space',
+    pathSegment: 'zz%20a',
+    probeSegment: 'zz%20a',
+    sent: true,
+  },
+
+  // A non-ASCII byte cannot be a URL path segment, so the cookie fails to parse
+  // and is reachable nowhere: neither at the percent-encoding of the byte, nor at
+  // the percent-encoding of its isomorphic decoding.
+  {
+    name: 'a non-ASCII byte is not reachable at the percent-encoding of that byte',
+    pathSegment: 'zzZZ',
+    raw: '%B8',
+    probeSegment: 'zz%B8',
+    sent: false,
+  },
+  {
+    name: 'a non-ASCII byte is not reachable at the percent-encoding of its isomorphic decoding',
+    pathSegment: 'zzZZ',
+    raw: '%B8',
+    probeSegment: 'zz%C2%B8',
+    sent: false,
+  },
+  {
+    name: 'a multi-byte non-ASCII sequence is not reachable at the percent-encoding of those bytes',
+    pathSegment: 'zzZZ',
+    raw: '%E4%B8%AD',
+    probeSegment: 'zz%E4%B8%AD',
+    sent: false,
+  },
+  {
+    name: 'a multi-byte non-ASCII sequence is not reachable at the percent-encoding of its isomorphic decoding',
+    pathSegment: 'zzZZ',
+    raw: '%E4%B8%AD',
+    probeSegment: 'zz%C3%A4%C2%B8%C2%AD',
+    sent: false,
+  },
+  {
+    name: 'an already percent-encoded non-ASCII byte matches, being ASCII itself',
+    pathSegment: 'zz%C2%B8',
+    probeSegment: 'zz%C2%B8',
+    sent: true,
+  },
+];
+
+for (const [index, testCase] of CASES.entries()) {
+  cookieTest(`A Path attribute where ${testCase.name}`,
+             {suffix: `case${index}`, pathSegment: testCase.pathSegment,
+              raw: testCase.raw},
+             async (t, name) => {
+    const result =
+        await probeAtPath(`${PROBE_DIR}/${testCase.probeSegment}/probe.html`);
+    assert_equals(cookieValue(result.cookie, name), testCase.sent ? '1' : null);
+  });
+}
+
+promise_test(async t => {
+  await registration.unregister();
+}, 'cleanup: unregister the service worker');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-segment-boundaries.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-segment-boundaries.https.window-expected.txt
@@ -1,0 +1,8 @@
+
+PASS A Path equal to the request path matches
+PASS A Path that is a prefix ending at a segment boundary matches
+PASS A Path that is a prefix ending in a slash matches
+PASS A Path that is a prefix not ending at a segment boundary does not match
+PASS A Path that is the request path followed by a slash does not match
+PASS A Path that is the request path followed by a segment does not match
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-segment-boundaries.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-segment-boundaries.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-segment-boundaries.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-segment-boundaries.https.window.js
@@ -1,0 +1,97 @@
+// META: title=Cookie Path attribute matching only at path segment boundaries
+
+'use strict';
+
+// A cookie is only sent when its path is the request URL's path, or a prefix of
+// it that ends at a path segment boundary. In particular a cookie path that is
+// longer than the request URL's path never matches, even when the request URL's
+// path is a prefix of it.
+//
+// https://httpwg.org/http-extensions/draft-ietf-httpbis-layered-cookies.html#store-a-cookie
+
+const DIR = '/cookies/path/resources';
+const TARGET = `${DIR}/echo.py`;
+const NAME_PREFIX = 'segment-boundaries-';
+
+async function setCookieViaHTTP(cookie) {
+  const set = encodeURIComponent(JSON.stringify([cookie]));
+  const response = await fetch(`/cookies/resources/cookie.py?set=${set}`);
+  assert_true(response.ok, 'Setting the cookie via HTTP succeeded');
+}
+
+// The Cookie header the server receives for a request to TARGET.
+async function cookieHeaderAtTarget() {
+  const response = await fetch(TARGET, {credentials: 'include'});
+  assert_true(response.ok, 'Reading the Cookie header succeeded');
+  return (await response.text()).trim();
+}
+
+function cookieValue(cookieString, name) {
+  for (const pair of cookieString.split('; ')) {
+    const index = pair.indexOf('=');
+    if (index !== -1 && pair.substring(0, index) === name) {
+      return pair.substring(index + 1);
+    }
+  }
+  return null;
+}
+
+// Sets the cookie under test, then expires it again through the same Path, which
+// is what removes it.
+function pathTest({name, suffix, path, sent}) {
+  const cookieName = NAME_PREFIX + suffix;
+  promise_test(async t => {
+    t.add_cleanup(
+        () => setCookieViaHTTP(`${cookieName}=; Path=${path}; Max-Age=0`));
+
+    await setCookieViaHTTP(`${cookieName}=1; Path=${path}`);
+    assert_equals(cookieValue(await cookieHeaderAtTarget(), cookieName),
+                  sent ? '1' : null);
+  }, name);
+}
+
+pathTest({
+  name: 'A Path equal to the request path matches',
+  suffix: 'exact',
+  path: TARGET,
+  sent: true,
+});
+
+pathTest({
+  name: 'A Path that is a prefix ending at a segment boundary matches',
+  suffix: 'prefix',
+  path: DIR,
+  sent: true,
+});
+
+pathTest({
+  name: 'A Path that is a prefix ending in a slash matches',
+  suffix: 'trailingslash',
+  path: `${DIR}/`,
+  sent: true,
+});
+
+// The request path continues with ".py" rather than a "/", so the cookie path is
+// not a prefix ending at a segment boundary.
+pathTest({
+  name: 'A Path that is a prefix not ending at a segment boundary does not match',
+  suffix: 'midsegment',
+  path: `${DIR}/echo`,
+  sent: false,
+});
+
+// The request path is a prefix of the cookie path rather than the other way
+// around. A cookie path longer than the request path can never match.
+pathTest({
+  name: 'A Path that is the request path followed by a slash does not match',
+  suffix: 'longerslash',
+  path: `${TARGET}/`,
+  sent: false,
+});
+
+pathTest({
+  name: 'A Path that is the request path followed by a segment does not match',
+  suffix: 'longersegment',
+  path: `${TARGET}/sub`,
+  sent: false,
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/path/non-ascii-path-attribute.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/path/non-ascii-path-attribute.https.window-expected.txt
@@ -1,0 +1,9 @@
+
+PASS A later Path attribute overrides an earlier one
+PASS A non-ASCII byte in the value is not a parse failure
+PASS A non-ASCII Path attribute followed by a valid one is not a parse failure
+PASS A non-ASCII byte in the winning Path attribute is a parse failure
+PASS A Path attribute with non-ASCII bytes appended does not match that path
+PASS A non-ASCII Path attribute does not fall back to the default path
+PASS A lone non-ASCII byte in the winning Path attribute is a parse failure
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/path/non-ascii-path-attribute.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/path/non-ascii-path-attribute.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/path/non-ascii-path-attribute.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/path/non-ascii-path-attribute.https.window.js
@@ -1,0 +1,125 @@
+// META: title=A non-ASCII byte in the winning Path attribute makes the cookie fail to parse
+
+'use strict';
+
+// A cookie's path is a URL path, whose segments are ASCII strings, so a Path
+// attribute holding a non-ASCII byte cannot be represented and the cookie fails
+// to parse. The check applies to the Path attribute that wins, not to every Path
+// attribute seen, matching how the rest of a cookie is validated once parsing
+// has settled on its final values.
+//
+// https://github.com/whatwg/url/issues/814
+
+const DIR = '/cookies/path/resources';
+const TARGET = `${DIR}/echo.py`;
+// The default path for a cookie set through /cookies/resources/cookie.py.
+const DEFAULT_PATH_TARGET = '/cookies/resources/list.py';
+const NAME_PREFIX = 'non-ascii-path-';
+
+// Sets a Set-Cookie header, replacing "ZZ" in `cookie` with the raw bytes given
+// as percent-escapes. wptserve percent-decodes the query into bytes and
+// cookie.py passes those bytes to the header unchanged, which is how a raw
+// non-ASCII byte reaches the Path attribute.
+async function setCookieViaHTTP(cookie, rawEscape) {
+  let query = encodeURIComponent(JSON.stringify([cookie]));
+  if (rawEscape !== undefined) {
+    query = query.replace('ZZ', rawEscape);
+  }
+  const response = await fetch(`/cookies/resources/cookie.py?set=${query}`);
+  assert_true(response.ok, 'Setting the cookie via HTTP succeeded');
+}
+
+// The value of `name` in the Cookie header the server receives for a request to
+// TARGET, or null if it is not there.
+async function cookieValueAtTarget(name) {
+  const response = await fetch(TARGET, {credentials: 'include'});
+  assert_true(response.ok, 'Reading the Cookie header succeeded');
+  for (const pair of (await response.text()).trim().split('; ')) {
+    const index = pair.indexOf('=');
+    if (index !== -1 && pair.substring(0, index) === name) {
+      return pair.substring(index + 1);
+    }
+  }
+  return null;
+}
+
+// The same for a request to the default path, which answers with JSON.
+async function cookieValueAtDefaultPath(name) {
+  const response = await fetch(DEFAULT_PATH_TARGET, {credentials: 'include'});
+  assert_true(response.ok, 'Reading the cookies succeeded');
+  const cookies = await response.json();
+  return name in cookies ? cookies[name] : null;
+}
+
+// Cookies are expired through every Path they could have been stored under,
+// since only a matching Path removes them.
+function cookieTest(description, suffix, paths, body) {
+  const name = NAME_PREFIX + suffix;
+  promise_test(async t => {
+    for (const path of paths) {
+      t.add_cleanup(
+          () => setCookieViaHTTP(`${name}=; Path=${path}; Max-Age=0`));
+    }
+    await body(t, name);
+  }, description);
+}
+
+// Control: a later Path attribute overrides an earlier one, which the tests
+// below depend on.
+cookieTest('A later Path attribute overrides an earlier one', 'later',
+           [DIR, `${DIR}/nomatch`], async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=${DIR}/nomatch; Path=${DIR}`);
+  assert_equals(await cookieValueAtTarget(name), '1');
+});
+
+// Control: a non-ASCII byte outside the Path attribute is not a parse failure,
+// so it is specifically the path that cannot hold one.
+cookieTest('A non-ASCII byte in the value is not a parse failure', 'value',
+           [DIR], async (t, name) => {
+  await setCookieViaHTTP(`${name}=ZZ; Path=${DIR}`, '%E4%B8%AD');
+  assert_not_equals(await cookieValueAtTarget(name), null,
+                    'The cookie was stored and sent');
+});
+
+// A non-ASCII byte in a Path attribute that loses to a later one does not matter,
+// because only the winning Path attribute is validated.
+cookieTest('A non-ASCII Path attribute followed by a valid one is not a parse failure',
+           'losing', [DIR], async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=${DIR}/zzZZ; Path=${DIR}`,
+                         '%E4%B8%AD');
+  assert_equals(await cookieValueAtTarget(name), '1');
+});
+
+// When the non-ASCII Path attribute is the one that wins, the cookie fails to
+// parse and nothing is stored.
+cookieTest('A non-ASCII byte in the winning Path attribute is a parse failure',
+           'winning', [DIR], async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=${DIR}; Path=${DIR}/zzZZ`,
+                         '%E4%B8%AD');
+  assert_equals(await cookieValueAtTarget(name), null);
+});
+
+// The cookie must not be sent for a path the non-ASCII bytes were appended to.
+// A user agent that truncated the Path at the first non-ASCII byte, or dropped
+// the attribute so that the path became "/", would send it here.
+cookieTest('A Path attribute with non-ASCII bytes appended does not match that path',
+           'appended', [DIR, '/'], async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=${DIR}ZZ`, '%E4%B8%AD');
+  assert_equals(await cookieValueAtTarget(name), null);
+});
+
+// Nor may it fall back to the default path, which is what an ignored Path
+// attribute would produce.
+cookieTest('A non-ASCII Path attribute does not fall back to the default path',
+           'fallback', ['/cookies/resources'], async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=${DIR}/zzZZ`, '%E4%B8%AD');
+  assert_equals(await cookieValueAtDefaultPath(name), null);
+});
+
+// A lone non-ASCII byte is not valid UTF-8 on its own, and is equally rejected.
+cookieTest('A lone non-ASCII byte in the winning Path attribute is a parse failure',
+           'lone', [DIR, '/cookies/resources'], async (t, name) => {
+  await setCookieViaHTTP(`${name}=1; Path=${DIR}/zzZZ`, '%B8');
+  assert_equals(await cookieValueAtTarget(name), null);
+  assert_equals(await cookieValueAtDefaultPath(name), null);
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/path/resources/echo.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/path/resources/echo.py
@@ -1,0 +1,5 @@
+def main(request, response):
+    headers = [(b"Content-Type", b"text/plain"),
+               (b"Cache-Control", b"no-store"),
+               (b"Access-Control-Allow-Origin", b"*")]
+    return headers, request.headers.get(b"cookie", b"")

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/path/resources/probe/sw.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/path/resources/probe/sw.js
@@ -1,0 +1,22 @@
+// Synthesizes a document at any path under this scope ending in "/probe.html",
+// so that a test can observe which cookies match a path that has no
+// corresponding file. Anything else is left to the network.
+//
+// Note a service worker cannot inspect the Cookie header of a request, as it is
+// a forbidden header name and cookies are attached after the fetch event, so the
+// synthesized document reads document.cookie instead.
+self.addEventListener('install', event => event.waitUntil(self.skipWaiting()));
+self.addEventListener('activate', event => event.waitUntil(self.clients.claim()));
+
+self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+  if (!url.pathname.endsWith('/probe.html')) {
+    return;
+  }
+  event.respondWith(new Response(
+      `<!doctype html><meta charset=utf-8><script>
+         parent.postMessage(
+             {path: location.pathname, cookie: document.cookie}, "*");
+       </script>`,
+      {headers: {'Content-Type': 'text/html; charset=utf-8'}}));
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/path/resources/probe/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/path/resources/probe/w3c-import.log
@@ -1,0 +1,15 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/cookies/path/resources/probe/sw.js

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/path/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/path/resources/w3c-import.log
@@ -1,0 +1,15 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/cookies/path/resources/echo.py

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/path/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/path/w3c-import.log
@@ -10,10 +10,11 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/path/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/cookies/path/default.html
+/LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-percent-encoded.https.window.js
+/LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-segment-boundaries.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/cookies/path/match.html
+/LayoutTests/imported/w3c/web-platform-tests/cookies/path/non-ascii-path-attribute.https.window.js

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/WEB_FEATURES.yml
@@ -1,3 +1,2 @@
-features:
-- name: cookies
-  files: "**"
+rules:
+- "**": [cookies]

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.explicit-path.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.explicit-path.https.window-expected.txt
@@ -1,0 +1,7 @@
+
+PASS CONTROL a cookie set without a Path attribute here has a path of "/"
+PASS CONTROL "__Host-" with an explicit Path of "/" is set
+FAIL "__Host-" without a Path attribute is not set assert_equals: expected (object) null but got (string) "1"
+FAIL "__Host-" with an empty Path attribute is not set assert_equals: expected (object) null but got (string) "1"
+FAIL "__Host-" with a valueless Path attribute is not set assert_equals: expected (object) null but got (string) "1"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.explicit-path.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.explicit-path.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.explicit-path.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.explicit-path.https.window.js
@@ -1,0 +1,118 @@
+// META: title=The "__Host-" prefix requires an explicit Path attribute of "/"
+// META: timeout=long
+
+'use strict';
+
+// A "__Host-" prefixed cookie has to have been set with a Path attribute whose
+// value is "/". That is not the same as ending up with a path of "/": a cookie
+// set without a Path attribute from a URL whose path has a single segment gets a
+// default path of "/" as well, and has to be rejected all the same.
+//
+// Reaching that case needs a document whose URL has a single path segment, so
+// that its default cookie path is "/". "/" itself is the only such URL that
+// wptserve does not redirect, and a document there is same-origin, so cookies can
+// be set and read through it. HTTP is not covered for want of a handler at that
+// depth.
+//
+// https://httpwg.org/http-extensions/draft-ietf-httpbis-layered-cookies.html#sane-set-cookie
+
+const NAME_PREFIX = 'explicit-path-';
+
+// A document whose default cookie path is "/".
+function loadRootDocument() {
+  return new Promise(resolve => {
+    const iframe = document.createElement('iframe');
+    iframe.style = 'display: none';
+    iframe.addEventListener('load', () => resolve(iframe), {once: true});
+    iframe.src = '/';
+    document.body.appendChild(iframe);
+  });
+}
+
+function cookieValue(cookieString, name) {
+  for (const pair of cookieString.split('; ')) {
+    const index = pair.indexOf('=');
+    if (index !== -1 && pair.substring(0, index) === name) {
+      return pair.substring(index + 1);
+    }
+  }
+  return null;
+}
+
+// A "__Host-" prefixed cookie can only be expired by a Set-Cookie that satisfies
+// the prefix itself, so the cleanup below carries Secure and Path=/ too.
+function rootDocumentTest({name, suffix, attributes, stored}) {
+  const cookieName = `__Host-${NAME_PREFIX}${suffix}`;
+  promise_test(async t => {
+    t.add_cleanup(() => {
+      document.cookie = `${cookieName}=; Secure; Path=/; Max-Age=0`;
+    });
+
+    const iframe = await loadRootDocument();
+    t.add_cleanup(() => iframe.remove());
+    const doc = iframe.contentWindow.document;
+    assert_equals(iframe.contentWindow.location.pathname, '/',
+                  'The document has a single path segment');
+
+    doc.cookie = `${cookieName}=1; ${attributes}`;
+    assert_equals(cookieValue(doc.cookie, cookieName), stored ? '1' : null);
+  }, name);
+}
+
+// Establishes the premise: a cookie set from this document without a Path
+// attribute has a default path of "/", so it reaches a path outside this test's
+// own directory.
+promise_test(async t => {
+  const cookieName = `${NAME_PREFIX}defaultpath`;
+  t.add_cleanup(() => {
+    document.cookie = `${cookieName}=; Path=/; Max-Age=0`;
+  });
+
+  const root = await loadRootDocument();
+  t.add_cleanup(() => root.remove());
+  root.contentWindow.document.cookie = `${cookieName}=1`;
+
+  const elsewhere = await new Promise(resolve => {
+    const iframe = document.createElement('iframe');
+    iframe.style = 'display: none';
+    iframe.addEventListener('load', () => resolve(iframe), {once: true});
+    iframe.src = '/common/blank.html';
+    document.body.appendChild(iframe);
+  });
+  t.add_cleanup(() => elsewhere.remove());
+
+  assert_equals(
+      cookieValue(elsewhere.contentWindow.document.cookie, cookieName), '1',
+      'The cookie reaches /common/blank.html, so its path is "/"');
+}, 'CONTROL a cookie set without a Path attribute here has a path of "/"');
+
+// Control: the prefix is honoured when the Path attribute is there.
+rootDocumentTest({
+  name: 'CONTROL "__Host-" with an explicit Path of "/" is set',
+  suffix: 'withpath',
+  attributes: 'Secure; Path=/',
+  stored: true,
+});
+
+// The cases under test. Each of these ends up with a path of "/" through the
+// default path, without a Path attribute that says so.
+rootDocumentTest({
+  name: '"__Host-" without a Path attribute is not set',
+  suffix: 'nopath',
+  attributes: 'Secure',
+  stored: false,
+});
+
+rootDocumentTest({
+  name: '"__Host-" with an empty Path attribute is not set',
+  suffix: 'emptypath',
+  attributes: 'Secure; Path=',
+  stored: false,
+});
+
+rootDocumentTest({
+  name: '"__Host-" with a valueless Path attribute is not set',
+  suffix: 'barepath',
+  attributes: 'Secure; Path',
+  stored: false,
+});

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/WEB_FEATURES.yml
@@ -19,6 +17,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__Http.https.html
 /LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.document-cookie.html
 /LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.document-cookie.https.html
+/LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.explicit-path.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.header.html
 /LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.header.https.html
 /LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__secure.document-cookie.html

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/resources/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/resources/__init__.py

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/samesite-none-secure/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/samesite-none-secure/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/samesite-none-secure/cookies-without-samesite-must-be-secure.https.html

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/samesite/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/samesite/WEB_FEATURES.yml
@@ -1,3 +1,2 @@
-features:
-- name: cookies
-  files: "**"
+rules:
+- "**": [cookies]

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/samesite/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/samesite/resources/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/samesite/resources/cross-site-frame-with-sandboxed-embed.html

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/samesite/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/samesite/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/samesite/WEB_FEATURES.yml

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/schemeful-same-site/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/schemeful-same-site/WEB_FEATURES.yml
@@ -1,3 +1,2 @@
-features:
-- name: cookies
-  files: "**"
+rules:
+- "**": [cookies]

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/schemeful-same-site/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/schemeful-same-site/resources/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/schemeful-same-site/resources/navigateToInsecurePostToParent.html

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/schemeful-same-site/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/schemeful-same-site/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/schemeful-same-site/WEB_FEATURES.yml

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/secure/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/secure/WEB_FEATURES.yml
@@ -1,3 +1,2 @@
-features:
-- name: cookies
-  files: "**"
+rules:
+- "**": [cookies]

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/secure/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/secure/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/secure/WEB_FEATURES.yml

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/size/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/size/WEB_FEATURES.yml
@@ -1,3 +1,2 @@
-features:
-- name: cookies
-  files: "**"
+rules:
+- "**": [cookies]

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/size/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/size/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/size/WEB_FEATURES.yml

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/third-party-cookies/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/third-party-cookies/WEB_FEATURES.yml
@@ -1,3 +1,2 @@
-features:
-- name: cookies
-  files: "**"
+rules:
+- "**": [cookies]

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/third-party-cookies/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/third-party-cookies/resources/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/third-party-cookies/resources/test-helpers.js

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/third-party-cookies/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/third-party-cookies/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/third-party-cookies/WEB_FEATURES.yml

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/value/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/value/WEB_FEATURES.yml
@@ -1,3 +1,2 @@
-features:
-- name: cookies
-  files: "**"
+rules:
+- "**": [cookies]

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/value/value-overwrite.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/value/value-overwrite.https.window-expected.txt
@@ -1,0 +1,27 @@
+
+PASS Overwrite value via separate responses with 'Path=/'
+PASS Overwrite value via a single response with 'Path=/'
+PASS Overwrite value via separate responses with 'Path=/; Secure'
+PASS Overwrite value via a single response with 'Path=/; Secure'
+PASS Overwrite value via separate responses with 'Path=/; HttpOnly'
+PASS Overwrite value via a single response with 'Path=/; HttpOnly'
+PASS Overwrite value via separate responses with 'Path=/; SameSite=Strict'
+PASS Overwrite value via a single response with 'Path=/; SameSite=Strict'
+PASS Overwrite value via separate responses with 'Path=/; SameSite=Lax'
+PASS Overwrite value via a single response with 'Path=/; SameSite=Lax'
+PASS Overwrite value via separate responses with 'Path=/; SameSite=None; Secure'
+PASS Overwrite value via a single response with 'Path=/; SameSite=None; Secure'
+PASS Overwrite value via separate responses with 'Path=/; Expires=Fri, 01 Jan 2100 00:00:00 GMT'
+PASS Overwrite value via a single response with 'Path=/; Expires=Fri, 01 Jan 2100 00:00:00 GMT'
+PASS Overwrite value via separate responses with 'Path=/; Secure; HttpOnly; SameSite=Strict; Expires=Fri, 01 Jan 2100 00:00:00 GMT'
+PASS Overwrite value via a single response with 'Path=/; Secure; HttpOnly; SameSite=Strict; Expires=Fri, 01 Jan 2100 00:00:00 GMT'
+PASS Overwrite value via a single response with 'Path=/; Max-Age=1000'
+PASS Overwrite value with the empty value
+PASS Overwrite the empty value with a value
+PASS Overwrite value via document.cookie with 'Path=/'
+PASS Overwrite value via document.cookie with 'Path=/; Secure'
+PASS Overwrite value via document.cookie with 'Path=/; SameSite=Strict'
+PASS Overwrite value via document.cookie with 'Path=/; SameSite=Lax'
+PASS Overwrite value via document.cookie with 'Path=/; SameSite=None; Secure'
+PASS Overwrite value via document.cookie with 'Path=/; Expires=Fri, 01 Jan 2100 00:00:00 GMT'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/value/value-overwrite.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/value/value-overwrite.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/value/value-overwrite.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/value/value-overwrite.https.window.js
@@ -1,0 +1,124 @@
+// META: title=Overwriting a cookie's value while its attributes stay the same
+// META: timeout=long
+
+'use strict';
+
+// https://httpwg.org/http-extensions/draft-ietf-httpbis-layered-cookies.html#store-a-cookie
+// https://github.com/httpwg/http-extensions/issues/3501
+
+// A fixed expiry date, so that a cookie and the cookie overwriting it have an
+// identical expiry time no matter when they are set.
+const EXPIRES = 'Expires=Fri, 01 Jan 2100 00:00:00 GMT';
+
+const COOKIE_NAME = 'value-overwrite';
+
+async function setCookiesViaHTTP(cookies) {
+  const set = encodeURIComponent(JSON.stringify(cookies));
+  const response = await fetch(`/cookies/resources/cookie.py?set=${set}`);
+  assert_true(response.ok, 'Setting cookies via HTTP succeeded');
+}
+
+// Reads the cookie store from the server's point of view, which unlike
+// document.cookie also observes HttpOnly cookies.
+async function getCookiesViaHTTP() {
+  const response = await fetch('/cookies/resources/list.py');
+  assert_true(response.ok, 'Reading cookies via HTTP succeeded');
+  return response.json();
+}
+
+function cookieValue(cookieString, name) {
+  for (const pair of cookieString.split('; ')) {
+    const index = pair.indexOf('=');
+    if (index !== -1 && pair.substring(0, index) === name) {
+      return pair.substring(index + 1);
+    }
+  }
+  return null;
+}
+
+// Sets each cookie of `cookies` in order and then asserts that the server
+// observes the cookie with `expected` as its value.
+//
+// `separateResponses` controls whether each cookie is sent in a response of its
+// own, as opposed to all of them being sent in a single response.
+function overwriteTest({cookies, expected, name, separateResponses = true}) {
+  promise_test(async t => {
+    t.add_cleanup(() => setCookiesViaHTTP([`${COOKIE_NAME}=; Path=/; Max-Age=0`]));
+
+    if (separateResponses) {
+      for (const cookie of cookies) {
+        await setCookiesViaHTTP([cookie]);
+      }
+    } else {
+      await setCookiesViaHTTP(cookies);
+    }
+
+    assert_equals((await getCookiesViaHTTP())[COOKIE_NAME], expected);
+  }, name);
+}
+
+// Each of these attribute strings results in a cookie whose secure, same-site,
+// expiry-time, and http-only are identical to those of the cookie it overwrites,
+// leaving the value as the only difference.
+const attributeSets = [
+  'Path=/',
+  'Path=/; Secure',
+  'Path=/; HttpOnly',
+  'Path=/; SameSite=Strict',
+  'Path=/; SameSite=Lax',
+  'Path=/; SameSite=None; Secure',
+  `Path=/; ${EXPIRES}`,
+  `Path=/; Secure; HttpOnly; SameSite=Strict; ${EXPIRES}`,
+];
+
+for (const attributes of attributeSets) {
+  overwriteTest({
+    cookies: [`${COOKIE_NAME}=1; ${attributes}`, `${COOKIE_NAME}=2; ${attributes}`],
+    expected: '2',
+    name: `Overwrite value via separate responses with '${attributes}'`,
+  });
+
+  overwriteTest({
+    cookies: [`${COOKIE_NAME}=1; ${attributes}`, `${COOKIE_NAME}=2; ${attributes}`],
+    expected: '2',
+    name: `Overwrite value via a single response with '${attributes}'`,
+    separateResponses: false,
+  });
+}
+
+// Max-Age is relative to when the cookie is received, so only cookies received
+// in the same response are guaranteed an identical expiry time.
+overwriteTest({
+  cookies: [`${COOKIE_NAME}=1; Path=/; Max-Age=1000`,
+            `${COOKIE_NAME}=2; Path=/; Max-Age=1000`],
+  expected: '2',
+  name: "Overwrite value via a single response with 'Path=/; Max-Age=1000'",
+  separateResponses: false,
+});
+
+// Overwriting a value with the empty value is a change as well.
+overwriteTest({
+  cookies: [`${COOKIE_NAME}=1; Path=/`, `${COOKIE_NAME}=; Path=/`],
+  expected: '',
+  name: 'Overwrite value with the empty value',
+});
+
+// And so is overwriting the empty value with a value.
+overwriteTest({
+  cookies: [`${COOKIE_NAME}=; Path=/`, `${COOKIE_NAME}=1; Path=/`],
+  expected: '1',
+  name: 'Overwrite the empty value with a value',
+});
+
+// The equivalent of the above via a non-HTTP API. HttpOnly is excluded as it
+// cannot be set through document.cookie.
+for (const attributes of attributeSets.filter(a => !a.includes('HttpOnly'))) {
+  promise_test(async t => {
+    t.add_cleanup(() => setCookiesViaHTTP([`${COOKIE_NAME}=; Path=/; Max-Age=0`]));
+
+    document.cookie = `${COOKIE_NAME}=1; ${attributes}`;
+    document.cookie = `${COOKIE_NAME}=2; ${attributes}`;
+
+    assert_equals(cookieValue(document.cookie, COOKIE_NAME), '2');
+  }, `Overwrite value via document.cookie with '${attributes}'`);
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/value/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/value/w3c-import.log
@@ -10,10 +10,9 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/value/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/cookies/value/value-ctl.html
+/LayoutTests/imported/w3c/web-platform-tests/cookies/value/value-overwrite.https.window.js
 /LayoutTests/imported/w3c/web-platform-tests/cookies/value/value.html

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/w3c-import.log
@@ -10,8 +10,6 @@ Do NOT modify or remove this file.
 ------------------------------------------------------------------------
 Properties requiring vendor prefixes:
 None
-Property values requiring vendor prefixes:
-None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/cookies/META.yml

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/cookies/path/match-percent-encoded.https.window-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/cookies/path/match-percent-encoded.https.window-expected.txt
@@ -1,0 +1,12 @@
+
+PASS CONTROL a cookie for the probed path is visible in it
+PASS CONTROL a cookie for a prefix of the probed path is visible in it
+PASS A Path attribute where a literal space does not match a percent-encoded space
+PASS A Path attribute where a percent-encoded space matches a percent-encoded space
+PASS A Path attribute where a non-ASCII byte is not reachable at the percent-encoding of that byte
+PASS A Path attribute where a non-ASCII byte is not reachable at the percent-encoding of its isomorphic decoding
+PASS A Path attribute where a multi-byte non-ASCII sequence is not reachable at the percent-encoding of those bytes
+PASS A Path attribute where a multi-byte non-ASCII sequence is not reachable at the percent-encoding of its isomorphic decoding
+PASS A Path attribute where an already percent-encoded non-ASCII byte matches, being ASCII itself
+PASS cleanup: unregister the service worker
+


### PR DESCRIPTION
#### 7f4b74c9b84081d0a733e471f506d2480c43b89f
<pre>
Resync `cookies` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=323366">https://bugs.webkit.org/show_bug.cgi?id=323366</a>
<a href="https://rdar.apple.com/186604627">rdar://186604627</a>

Reviewed by Rupin Mittal.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/a1e944e7a879854494e1a041a8ad1e4a8ae28ab1">https://github.com/web-platform-tests/wpt/commit/a1e944e7a879854494e1a041a8ad1e4a8ae28ab1</a>

* LayoutTests/imported/w3c/web-platform-tests/cookies/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/httponly-overwrite.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/httponly-overwrite.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/httponly-overwrite.https.window.js: Added.
(async setCookieViaHTTP.const.set encodeURIComponent):
(async getCookieHeader):
(async isHttpOnly):
(cookieTest):
(async cookieTest):
* LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/resources/path/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/resources/pathfakeout/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/attributes/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/domain/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/cookies/domain/support/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/domain/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/encoding/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/name/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/cookies/name/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/ordering/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/ordering/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/origin-bound-cookies/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/origin-bound-cookies/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies-a-b-a-embed.tentative.https.html:
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-cross-site-embed.html:
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/ancestor-chain-same-site-embed.html:
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/path/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-percent-encoded.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-percent-encoded.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-percent-encoded.https.window.js: Added.
(cookieValue):
(probeAtPath):
(set assert_true):
(async setCookieViaHTTP):
* LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-segment-boundaries.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-segment-boundaries.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/path/match-segment-boundaries.https.window.js: Added.
(async setCookieViaHTTP.const.set encodeURIComponent):
(async cookieHeaderAtTarget):
(cookieValue):
(pathTest):
(async setCookieViaHTTP.set assert_true):
(async setCookieViaHTTP):
(async pathTest):
* LayoutTests/imported/w3c/web-platform-tests/cookies/path/non-ascii-path-attribute.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/path/non-ascii-path-attribute.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/path/non-ascii-path-attribute.https.window.js: Added.
(async cookieValueAtTarget):
(async cookieValueAtDefaultPath):
(cookieTest):
(async cookieTest):
(set assert_true):
(async setCookieViaHTTP):
* LayoutTests/imported/w3c/web-platform-tests/cookies/path/resources/echo.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/cookies/path/resources/probe/sw.js: Added.
(event.url.pathname.endsWith):
* LayoutTests/imported/w3c/web-platform-tests/cookies/path/resources/probe/w3c-import.log: Copied from LayoutTests/imported/w3c/web-platform-tests/cookies/encoding/w3c-import.log.
* LayoutTests/imported/w3c/web-platform-tests/cookies/path/resources/w3c-import.log: Copied from LayoutTests/imported/w3c/web-platform-tests/cookies/encoding/w3c-import.log.
* LayoutTests/imported/w3c/web-platform-tests/cookies/path/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.explicit-path.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.explicit-path.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/__host.explicit-path.https.window.js: Added.
(loadRootDocument):
(rootDocumentTest):
* LayoutTests/imported/w3c/web-platform-tests/cookies/prefix/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/samesite-none-secure/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/samesite/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/cookies/samesite/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/samesite/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/schemeful-same-site/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/cookies/schemeful-same-site/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/schemeful-same-site/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/secure/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/cookies/secure/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/size/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/cookies/size/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/third-party-cookies/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/cookies/third-party-cookies/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/third-party-cookies/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/value/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/cookies/value/value-overwrite.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/value/value-overwrite.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/cookies/value/value-overwrite.https.window.js: Added.
(async setCookiesViaHTTP.const.set encodeURIComponent):
(async getCookiesViaHTTP):
(cookieValue):
(overwriteTest):
(async setCookiesViaHTTP.set assert_true):
(async setCookiesViaHTTP):
(async const):
(const.attributes.of.attributeSets.filter.a.a.includes):
* LayoutTests/imported/w3c/web-platform-tests/cookies/value/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/cookies/w3c-import.log:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/cookies/path/match-percent-encoded.https.window-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/320486@main">https://commits.webkit.org/320486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61389118478564758a3ee6c167910b1c62f03622

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195234 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144485 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48157 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124777 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46882 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157248 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44648 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6287 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197183 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58487 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153966 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41226 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59193 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153625 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48140 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128071 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57689 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19666 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57048 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57297 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57125 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->