### PR TITLE
[JSC] Add "dc zva" zero-fill loop for sanitizeStackForVM

### DIFF
--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -1984,16 +1984,35 @@ if not C_LOOP
             # Because of ARM64 calling convention, stack-pointer is already 16-byte aligned.
             # Let's check address is aligned or not to use 16-byte zero-fill.
             assert(macro (ok)  btpz a0, (PtrSize * 2 - 1), ok end)
-            btpz address, (PtrSize * 2 - 1), .zeroFillLoop
+            btpz address, (PtrSize * 2 - 1), .zeroFillAligned
             # If it is not aligned, then store pointer-size and increment.
             emit "str xzr, [x1], #8" # address is a1, thus x1
             bpbeq a0, address, .zeroFillDone
+        .zeroFillAligned:
             assert(macro (ok)  btpz address, (PtrSize * 2 - 1), ok end)
+            # dc zva clears a whole zero block per instruction without reading memory, roughly
+            # twice the throughput of a store-pair loop. It is only usable when that block is one
+            # 64-byte cache line (DCZID_EL0.BS == 4) and unprivileged use is permitted
+            # (DCZID_EL0.DZP == 0); every other bit of the register is RES0, so both conditions
+            # hold exactly when it reads 4.
+            emit "mrs x2, dczid_el0" # scratch is a2, thus x2
+            bpneq scratch, 4, .zeroFillLoop
+        .zeroFillToBlock:
+            btpz address, 63, .zeroFillBlocks
+            emit "stp xzr, xzr, [x1], #16" # address is a1, thus x1
+            bpa a0, address, .zeroFillToBlock
+            jmp .zeroFillDone
+        .zeroFillBlocks:
+            emit "and x2, x0, #-64" # scratch = the last block boundary at or below the end
+            bpbeq scratch, address, .zeroFillLoop
+        .zeroFillBlockLoop:
+            emit "dc zva, x1" # address is a1, thus x1
+            addp 64, address
+            bpa scratch, address, .zeroFillBlockLoop
+            bpbeq a0, address, .zeroFillDone
         .zeroFillLoop:
-            # Use non-temporal store-pair (stnp) since these stack values are meaningless to the execution.
-            # Avoid polluting CPU cache by using stnp.
-            emit "stnp xzr, xzr, [x1]" # address is a1, thus x1
-            addp PtrSize * 2, address
+            # stp, not stnp: for regions this small the non-temporal hint measures slower.
+            emit "stp xzr, xzr, [x1], #16" # address is a1, thus x1
             bpa a0, address, .zeroFillLoop
         else
             move 0, scratch


### PR DESCRIPTION
#### a0042af348458a9d9de2ec3f1636424c20163818
<pre>
[JSC] Add &quot;dc zva&quot; zero-fill loop for sanitizeStackForVM
<a href="https://bugs.webkit.org/show_bug.cgi?id=323368">https://bugs.webkit.org/show_bug.cgi?id=323368</a>
<a href="https://rdar.apple.com/186606262">rdar://186606262</a>

Reviewed by Marcus Plutowski.

This patch adds &quot;dc zva&quot; zero-fill code for sanitizeStackForVM.
Clearing stack can be dramatically large, and &quot;dc zva&quot; loop can be
faster to zero-fill these region. Currently we only allow it when
dczid_el0 is configured to be 4 in OS.
Also, for smaller size, stp is faster than stnp, so now &quot;dc zva&quot; handles
large region and stp will fill the gap.

We may apply the same to zero-filling locals at the top of interpreter,
and potentially using it in JIT as well as a subsequent change.

* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:

Canonical link: <a href="https://commits.webkit.org/320475@main">https://commits.webkit.org/320475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb89ea54ed8a5d356887b1e8e0771cfe1c70678a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58821 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52649 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195236 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aa7eb9ea-03a0-41aa-b25e-74a614884e89) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58548 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4189ce14-1672-4bd2-a2de-fbaba26bc77f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187856 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/48160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/124778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/531b7b03-b6c2-4cf6-b1bd-e67dfdb02400) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/46885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/6716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/13581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/44649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6289 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46167 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51484 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197185 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58489 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/164588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/153967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59195 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153626 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28091 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/48141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131483 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128073 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57691 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/19667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57050 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57299 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57127 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->