### PR TITLE
[Site Isolation] Taps on Sign in with Google buttons don't draw highlights

### DIFF
--- a/LayoutTests/http/tests/site-isolation/ios/tap-highlight-in-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/ios/tap-highlight-in-cross-origin-iframe-expected.txt
@@ -1,0 +1,13 @@
+Tapping a button inside a cross-origin iframe should show a tap highlight over the button.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS buttonWasClicked is true
+PASS highlightWidth is > 0
+PASS highlightHeight is > 0
+PASS highlightTop is >= iframeTop - 20
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/ios/tap-highlight-in-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/ios/tap-highlight-in-cross-origin-iframe.html
@@ -1,0 +1,52 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+description("Tapping a button inside a cross-origin iframe should show a tap highlight over the button.");
+jsTestIsAsync = true;
+
+const iframeTop = 100;
+const buttonHeight = 60;
+let highlightWidth;
+let highlightHeight;
+let highlightTop;
+let buttonWasClicked = false;
+
+async function waitForTapHighlightToAppear()
+{
+    let rect;
+    for (let i = 0; i < 100; i++) {
+        rect = await UIHelper.tapHighlightViewRect();
+        if (rect.width > 0 && rect.height > 0)
+            break;
+        await UIHelper.ensurePresentationUpdate();
+    }
+    return rect;
+}
+
+addEventListener("message", async (event) => {
+    if (event.data === "clicked") {
+        buttonWasClicked = true;
+        return;
+    }
+    if (event.data !== "ready")
+        return;
+
+    await UIHelper.ensurePresentationUpdate();
+
+    await UIHelper.activateAt(100, iframeTop + buttonHeight / 2);
+
+    const rect = await waitForTapHighlightToAppear();
+    highlightWidth = rect.width;
+    highlightHeight = rect.height;
+    highlightTop = rect.top;
+
+    shouldBeTrue("buttonWasClicked");
+    shouldBeGreaterThan("highlightWidth", "0");
+    shouldBeGreaterThan("highlightHeight", "0");
+    shouldBeGreaterThanOrEqual("highlightTop", "iframeTop - 20");
+
+    finishJSTest();
+});
+</script>
+<iframe style="position: absolute; left: 0; top: 100px; width: 400px; height: 300px; border: none;" src="http://localhost:8000/site-isolation/resources/tap-target-frame.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/ios/tap-highlight-in-transformed-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/ios/tap-highlight-in-transformed-cross-origin-iframe-expected.txt
@@ -1,0 +1,16 @@
+Tapping a button inside a cross-origin iframe that has a scale transform should show a tap highlight over the button, scaled to match it.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS buttonWasClicked is true
+PASS highlightWidth is > 0
+PASS highlightHeight is > 0
+PASS highlightTop is > iframeTop - 20
+PASS highlightWidth < expectedWidthScaled + 40 is true
+PASS highlightHeight < expectedHeightScaled + 40 is true
+PASS highlightTop < 160 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/ios/tap-highlight-in-transformed-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/ios/tap-highlight-in-transformed-cross-origin-iframe.html
@@ -1,0 +1,56 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+description("Tapping a button inside a cross-origin iframe that has a scale transform should show a tap highlight over the button, scaled to match it.");
+jsTestIsAsync = true;
+
+const iframeTop = 100;
+const expectedWidthScaled = 100;
+const expectedHeightScaled = 30;
+let highlightWidth;
+let highlightHeight;
+let highlightTop;
+let buttonWasClicked = false;
+
+async function waitForTapHighlightToAppear()
+{
+    let rect;
+    for (let i = 0; i < 100; i++) {
+        rect = await UIHelper.tapHighlightViewRect();
+        if (rect.width > 0 && rect.height > 0)
+            break;
+        await UIHelper.ensurePresentationUpdate();
+    }
+    return rect;
+}
+
+addEventListener("message", async (event) => {
+    if (event.data === "clicked") {
+        buttonWasClicked = true;
+        return;
+    }
+    if (event.data !== "ready")
+        return;
+
+    await UIHelper.ensurePresentationUpdate();
+
+    await UIHelper.activateAt(100, 115);
+
+    const rect = await waitForTapHighlightToAppear();
+    highlightWidth = rect.width;
+    highlightHeight = rect.height;
+    highlightTop = rect.top;
+
+    shouldBeTrue("buttonWasClicked");
+    shouldBeGreaterThan("highlightWidth", "0");
+    shouldBeGreaterThan("highlightHeight", "0");
+    shouldBeGreaterThan("highlightTop", "iframeTop - 20");
+    shouldBeTrue("highlightWidth < expectedWidthScaled + 40");
+    shouldBeTrue("highlightHeight < expectedHeightScaled + 40");
+    shouldBeTrue("highlightTop < 160");
+
+    finishJSTest();
+});
+</script>
+<iframe style="position: absolute; left: 50px; top: 100px; width: 400px; height: 300px; border: none; transform: scale(0.5); transform-origin: 0 0;" src="http://localhost:8000/site-isolation/resources/tap-target-frame.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/ios/tap-highlight-with-two-same-site-cross-origin-iframes-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/ios/tap-highlight-with-two-same-site-cross-origin-iframes-expected.txt
@@ -1,0 +1,14 @@
+With two same-site cross-origin iframes at different positions on the page, tapping a button in the first should show a tap highlight over that button, not at the second iframe's position.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS buttonWasClicked is true
+PASS highlightWidth is > 0
+PASS highlightHeight is > 0
+PASS highlightTop < frameBTop - 100 is true
+PASS highlightTop is >= frameATop - 20
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/ios/tap-highlight-with-two-same-site-cross-origin-iframes.html
+++ b/LayoutTests/http/tests/site-isolation/ios/tap-highlight-with-two-same-site-cross-origin-iframes.html
@@ -1,0 +1,61 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script>
+description("With two same-site cross-origin iframes at different positions on the page, tapping a button in the first should show a tap highlight over that button, not at the second iframe's position.");
+jsTestIsAsync = true;
+
+const frameATop = 20;
+const frameBTop = 400;
+let highlightTop;
+let highlightLeft;
+let highlightWidth;
+let highlightHeight;
+let buttonWasClicked = false;
+let readyCount = 0;
+
+async function waitForTapHighlightToAppear()
+{
+    let rect;
+    for (let i = 0; i < 100; i++) {
+        rect = await UIHelper.tapHighlightViewRect();
+        if (rect.width > 0 && rect.height > 0)
+            break;
+        await UIHelper.ensurePresentationUpdate();
+    }
+    return rect;
+}
+
+addEventListener("message", async (event) => {
+    if (event.data === "clicked") {
+        buttonWasClicked = true;
+        return;
+    }
+    if (event.data !== "ready")
+        return;
+
+    if (++readyCount < 2)
+        return;
+
+    await UIHelper.ensurePresentationUpdate();
+
+    const a = document.getElementById("frameA").getBoundingClientRect();
+    await UIHelper.activateAt(a.left + 100, a.top + 30);
+
+    const rect = await waitForTapHighlightToAppear();
+    highlightTop = rect.top;
+    highlightLeft = rect.left;
+    highlightWidth = rect.width;
+    highlightHeight = rect.height;
+
+    shouldBeTrue("buttonWasClicked");
+    shouldBeGreaterThan("highlightWidth", "0");
+    shouldBeGreaterThan("highlightHeight", "0");
+    shouldBeTrue("highlightTop < frameBTop - 100");
+    shouldBeGreaterThanOrEqual("highlightTop", "frameATop - 20");
+
+    finishJSTest();
+});
+</script>
+<iframe id="frameA" style="position: absolute; left: 100px; top: 20px; width: 400px; height: 300px; border: none;" src="http://localhost:8000/site-isolation/resources/tap-target-frame.html"></iframe>
+<iframe id="frameB" style="position: absolute; left: 300px; top: 400px; width: 400px; height: 300px; border: none;" src="http://localhost:8000/site-isolation/resources/tap-target-frame.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/resources/tap-target-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/tap-target-frame.html
@@ -1,0 +1,9 @@
+<body style="margin: 0; font: 20px monospace;">
+<button id="target" style="width: 200px; height: 60px;">Tap me</button>
+<script>
+document.getElementById("target").addEventListener("click", () => {
+    window.top.postMessage("clicked", "*");
+});
+window.top.postMessage("ready", "*");
+</script>
+</body>

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -597,6 +597,11 @@ FloatQuad FrameView::convertToRootViewAcrossIsolatedFrames(const FloatQuad& quad
     };
 }
 
+FloatQuad FrameView::contentsToMainFrameView(const FloatQuad& quad) const
+{
+    return convertToRootViewAcrossIsolatedFrames(contentsToView(quad));
+}
+
 FloatRect FrameView::rootViewToContentsAcrossIsolatedFrames(FloatRect rect) const
 {
     return viewToContents(convertFromRootViewAcrossIsolatedFrames(rect));

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -132,6 +132,8 @@ public:
     WEBCORE_EXPORT FloatQuad convertToRootViewAcrossIsolatedFrames(const FloatQuad&) const;
     WEBCORE_EXPORT FloatRect rootViewToContentsAcrossIsolatedFrames(FloatRect) const;
 
+    WEBCORE_EXPORT FloatQuad contentsToMainFrameView(const FloatQuad&) const;
+
     WEBCORE_EXPORT virtual LayoutRect layoutViewportRect() const = 0;
 
     // Computes the visible area of a child frame in this frame as a rectangle.

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -1036,6 +1036,16 @@ FloatRect ScrollView::contentsToView(FloatRect rect) const
     return rect;
 }
 
+FloatQuad ScrollView::contentsToView(const FloatQuad& quad) const
+{
+    FloatQuad result;
+    result.setP1(contentsToView(quad.p1()));
+    result.setP2(contentsToView(quad.p2()));
+    result.setP3(contentsToView(quad.p3()));
+    result.setP4(contentsToView(quad.p4()));
+    return result;
+}
+
 IntPoint ScrollView::contentsToContainingViewContents(const IntPoint& point) const
 {
     if (const RefPtr parentScrollView = parent()) {

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -342,6 +342,8 @@ public:
     FloatRect viewToContents(FloatRect) const;
     FloatRect contentsToView(FloatRect) const;
 
+    FloatQuad contentsToView(const FloatQuad&) const;
+
     IntPoint contentsToContainingViewContents(const IntPoint&) const;
     IntRect contentsToContainingViewContents(IntRect) const;
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -3269,7 +3269,7 @@ Awaitable<std::optional<WebCore::RemoteUserInputEventData>> WebPage::potentialTa
         send(Messages::WebPageProxy::HandleSmartMagnificationInformationForPotentialTap(requestID, absoluteBoundingRect, fitEntireRect, viewportMinimumScale, viewportMaximumScale, nodeIsRootLevel, nodeIsPluginElement));
     }
 
-    sendTapHighlightForNodeIfNecessary(requestID, m_potentialTapNode.get(), positionInRootView);
+    sendTapHighlightForNodeIfNecessary(frameID, requestID, m_potentialTapNode.get(), positionInRootView);
 #if ENABLE(TWO_PHASE_CLICKS)
     if (RefPtr potentialTapNode = m_potentialTapNode; potentialTapNode && !potentialTapNode->allowsDoubleTapGesture())
         send(Messages::WebPageProxy::DisableDoubleTapGesturesDuringTapIfNecessary(requestID));
@@ -3399,22 +3399,22 @@ void WebPage::didHandleTapAsHover()
     send(Messages::WebPageProxy::DidHandleTapAsHover());
 }
 
-void WebPage::sendTapHighlightForNodeIfNecessary(WebKit::TapIdentifier requestID, Node* node, FloatPoint point)
+void WebPage::sendTapHighlightForNodeIfNecessary(std::optional<WebCore::FrameIdentifier> frameID, WebKit::TapIdentifier requestID, Node* node, FloatPoint point)
 {
 #if ENABLE(TWO_PHASE_CLICKS)
     if (!node)
         return;
 
-    RefPtr localMainFrame = m_page->localMainFrame();
-    if (!localMainFrame)
+    RefPtr localRootFrame = this->localRootFrame(frameID);
+    if (!localRootFrame)
         return;
 
-    if (m_page->isEditable() && node == protect(localMainFrame->document())->body())
+    if (m_page->isEditable() && node == protect(localRootFrame->document())->body())
         return;
 
     if (RefPtr element = dynamicDowncast<Element>(*node)) {
         ASSERT(m_page);
-        localMainFrame->loader().prefetchDNSIfNeeded(element->absoluteLinkURL());
+        localRootFrame->loader().prefetchDNSIfNeeded(element->absoluteLinkURL());
     }
 
     RefPtr updatedNode = node;
@@ -3450,7 +3450,7 @@ void WebPage::sendTapHighlightForNodeIfNecessary(WebKit::TapIdentifier requestID
         if (!updatedNode->document().frame()->isMainFrame()) {
             RefPtr view = updatedNode->document().frame()->view();
             for (auto& quad : quads)
-                quad = view->contentsToRootView(quad);
+                quad = view->contentsToMainFrameView(quad);
         }
 
         LayoutRoundedRect::Radii borderRadii;
@@ -3462,6 +3462,7 @@ void WebPage::sendTapHighlightForNodeIfNecessary(WebKit::TapIdentifier requestID
         send(Messages::WebPageProxy::DidGetTapHighlightGeometries(requestID, highlightColor, quads, roundedIntSize(borderRadii.topLeft()), roundedIntSize(borderRadii.topRight()), roundedIntSize(borderRadii.bottomLeft()), roundedIntSize(borderRadii.bottomRight()), nodeHasBuiltInClickHandling));
     }
 #else
+    UNUSED_PARAM(frameID);
     UNUSED_PARAM(requestID);
     UNUSED_PARAM(node);
     UNUSED_PARAM(point);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1147,7 +1147,7 @@ public:
     void cancelPotentialTapInFrame(WebFrame&);
     void commitPotentialTapFailed();
     void didHandleTapAsHover();
-    void sendTapHighlightForNodeIfNecessary(WebKit::TapIdentifier, WebCore::Node*, WebCore::FloatPoint);
+    void sendTapHighlightForNodeIfNecessary(std::optional<WebCore::FrameIdentifier>, WebKit::TapIdentifier, WebCore::Node*, WebCore::FloatPoint);
     void handleSyntheticClick(std::optional<WebCore::FrameIdentifier>, WebCore::Node& nodeRespondingToClick, const WebCore::FloatPoint& location, OptionSet<WebKit::WebEventModifier>, WebCore::PointerID = WebCore::mousePointerID);
     void completeSyntheticClick(std::optional<WebCore::FrameIdentifier>, WebCore::Node& nodeRespondingToClick, const WebCore::FloatPoint& location, OptionSet<WebKit::WebEventModifier>, WebCore::SyntheticClickType, WebCore::PointerID = WebCore::mousePointerID);
     void handleDoubleTapForDoubleClickAtPoint(const WebCore::IntPoint&, OptionSet<WebKit::WebEventModifier>, TransactionID lastLayerTreeTransactionId, WebEventInputSource, WebMouseEventSyntheticClickType);

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1104,7 +1104,7 @@ void WebPage::handleTwoFingerTapAtPoint(const WebCore::IntPoint& point, OptionSe
         send(Messages::WebPageProxy::DidNotHandleTapAsClick(roundedIntPoint(adjustedPoint)));
         return;
     }
-    sendTapHighlightForNodeIfNecessary(requestID, nodeRespondingToClick, point);
+    sendTapHighlightForNodeIfNecessary(std::nullopt, requestID, nodeRespondingToClick, point);
     completeSyntheticClick(std::nullopt, *nodeRespondingToClick, adjustedPoint, modifiers, WebCore::SyntheticClickType::TwoFingerTap);
 }
 
@@ -1139,7 +1139,7 @@ void WebPage::tapHighlightAtPosition(WebKit::TapIdentifier requestID, const Floa
     if (!localMainFrame)
         return;
     FloatPoint adjustedPoint;
-    sendTapHighlightForNodeIfNecessary(requestID, localMainFrame->nodeRespondingToClickEvents(position, adjustedPoint), position);
+    sendTapHighlightForNodeIfNecessary(std::nullopt, requestID, localMainFrame->nodeRespondingToClickEvents(position, adjustedPoint), position);
 }
 
 void WebPage::inspectorNodeSearchMovedToPosition(const FloatPoint& position)


### PR DESCRIPTION
#### 318dfa2c20460bd9dbd6251ddaae0e58147ee26e
<pre>
[Site Isolation] Taps on Sign in with Google buttons don&apos;t draw highlights
<a href="https://bugs.webkit.org/show_bug.cgi?id=323255">https://bugs.webkit.org/show_bug.cgi?id=323255</a>
<a href="https://rdar.apple.com/185718733">rdar://185718733</a>

Reviewed by NOBODY (OOPS!).

When tapping on the &quot;Continue&quot; button for sign in with Google iframes, the
highlight when the button is tapped didn&apos;t render.

The tap was registering fine, but no highlight was drawn at all.

There were two problems. The code for drawing the highlight looked up the frame
it was working with using localMainFrame(), which is null in a cross-origin
subframe&apos;s process because the main frame there is a RemoteFrame. It returned
early, so the highlight geometry was never sent to the UI process. The tap is
dispatched to the process hosting the tapped frame, so that frame is available
locally even though the main frame isn&apos;t. localRootFrame finds it by taking the
frame ID the tap was dispatched with, which localMainFrame has no way to accept.

Once that was fixed, the highlight was drawn at the wrong coordinates. The code
tried to find out where to draw the highlight by walking up the frame tree using
ScrollView::contentsToRootView, which only follows widget parents and stops at
the process boundary.

In this patch, I passed the target frame ID down to
sendTapHighlightForNodeIfNecessary and used localRootFrame instead of
localMainFrame. I also added FrameView::contentsToMainFrameView for FloatQuad
and switched to it, which is aware of remote frames and site isolation (it uses
convertToRootViewAcrossIsolatedFrames, so it applies each ancestor frame&apos;s
offset, transform and scroll position without any IPC). It takes a quad rather
than a rect because a transformed ancestor frame doesn&apos;t preserve axis
alignment.

I didn&apos;t use WebPageProxy::convertRectToMainFrameCoordinates for this, since it
needs a message from the UI process to the web process (and returns the wrong
result).

Tests: http/tests/site-isolation/ios/tap-highlight-in-cross-origin-iframe.html
       http/tests/site-isolation/ios/tap-highlight-in-transformed-cross-origin-iframe.html
       http/tests/site-isolation/ios/tap-highlight-with-two-same-site-cross-origin-iframes.html

* LayoutTests/http/tests/site-isolation/ios/tap-highlight-in-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/ios/tap-highlight-in-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/ios/tap-highlight-in-transformed-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/ios/tap-highlight-in-transformed-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/ios/tap-highlight-with-two-same-site-cross-origin-iframes-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/ios/tap-highlight-with-two-same-site-cross-origin-iframes.html: Added.
* LayoutTests/http/tests/site-isolation/resources/tap-target-frame.html: Added.
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::contentsToMainFrameView const):
* Source/WebCore/page/FrameView.h:
* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::contentsToView const):
* Source/WebCore/platform/ScrollView.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::potentialTapAtPosition):
(WebKit::WebPage::sendTapHighlightForNodeIfNecessary):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::handleTwoFingerTapAtPoint):
(WebKit::WebPage::tapHighlightAtPosition):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/318dfa2c20460bd9dbd6251ddaae0e58147ee26e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195214 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/149764 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6daa4ac-c602-453c-80fa-9cf8e331aacd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186741 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144473 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100281 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5b41ca6f-891e-42ad-be52-929e7a29d7b5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124763 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1de82829-813b-4acf-8557-746ac97440d7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46866 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44966 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157235 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44631 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6269 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51462 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197163 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58467 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164570 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153957 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59173 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41238 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153610 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48126 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131461 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128039 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57669 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19649 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57028 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57279 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57105 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->