### PR TITLE
[JSC][Wasm] Inline OMG array.new_data

### DIFF
--- a/JSTests/wasm/stress/array-new-data-inline.js
+++ b/JSTests/wasm/stress/array-new-data-inline.js
@@ -1,0 +1,69 @@
+//@ requireOptions("--useConcurrentJIT=0", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0")
+//@ $skipModes << "wasm-no-jit".to_sym
+//@ $skipModes << "wasm-no-wasm-jit".to_sym
+import { instantiate } from "../gc/wast-wrapper.js"
+import * as assert from "../assert.js"
+
+function test() {
+    const instance = instantiate(`
+      (module
+        (type $i8 (array (mut i8)))
+        (type $i32 (array (mut i32)))
+        (data $d "\\00\\01\\02\\03\\04\\05\\06\\07")
+        (func (export "newI8") (param i32 i32) (result (ref $i8))
+          (array.new_data $i8 $d (local.get 0) (local.get 1)))
+        (func (export "newI32") (param i32 i32) (result (ref $i32))
+          (array.new_data $i32 $d (local.get 0) (local.get 1)))
+        (func (export "getI8") (param (ref $i8) i32) (result i32)
+          (array.get_u $i8 (local.get 0) (local.get 1)))
+        (func (export "getI32") (param (ref $i32) i32) (result i32)
+          (array.get $i32 (local.get 0) (local.get 1)))
+        (func (export "drop")
+          (data.drop $d)))
+    `);
+    const { newI8, newI32, getI8, getI32, drop } = instance.exports;
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        const bytes = newI8(8, 0);
+        for (let j = 0; j < 8; j++)
+            assert.eq(getI8(bytes, j), j);
+
+        const slice = newI8(3, 2);
+        assert.eq(getI8(slice, 0), 2);
+        assert.eq(getI8(slice, 1), 3);
+        assert.eq(getI8(slice, 2), 4);
+
+        newI8(0, 0);
+        newI8(0, 8);
+
+        assert.throws(() => newI8(1, 8), WebAssembly.RuntimeError, "Out of bounds or failed to allocate in array.new_data");
+        assert.throws(() => newI8(9, 0), WebAssembly.RuntimeError, "Out of bounds or failed to allocate in array.new_data");
+        assert.throws(() => newI8(1, 0xffffffff), WebAssembly.RuntimeError, "Out of bounds or failed to allocate in array.new_data");
+
+        const words = newI32(2, 0);
+        assert.eq(getI32(words, 0), 0x03020100);
+        assert.eq(getI32(words, 1), 0x07060504);
+        assert.throws(() => newI32(3, 0), WebAssembly.RuntimeError, "Out of bounds or failed to allocate in array.new_data");
+        assert.throws(() => newI32(2, 1), WebAssembly.RuntimeError, "Out of bounds or failed to allocate in array.new_data");
+    }
+
+    drop();
+    newI8(0, 0);
+    assert.throws(() => newI8(0, 1), WebAssembly.RuntimeError, "Out of bounds or failed to allocate in array.new_data");
+    assert.throws(() => newI8(1, 0), WebAssembly.RuntimeError, "Out of bounds or failed to allocate in array.new_data");
+
+    const active = instantiate(`
+      (module
+        (memory 1)
+        (type $i8 (array (mut i8)))
+        (data (i32.const 0) "xy")
+        (func (export "new") (param i32 i32) (result (ref $i8))
+          (array.new_data $i8 0 (local.get 0) (local.get 1))))
+    `);
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        active.exports.new(0, 0);
+        assert.throws(() => active.exports.new(1, 0), WebAssembly.RuntimeError, "Out of bounds or failed to allocate in array.new_data");
+    }
+}
+
+test();

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -3815,8 +3815,91 @@ auto OMGIRGenerator::addArrayNewDefault(TypeSignatureIndex typeIndex, Expression
 
 auto OMGIRGenerator::addArrayNewData(TypeSignatureIndex typeIndex, uint32_t dataIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result) -> PartialResult
 {
-    result = pushArrayNewFromSegment(operationWasmArrayNewData, typeIndex, dataIndex, arraySize, offset, ExceptionType::BadArrayNewInitData);
+    Value* sizeValue = get(arraySize);
+    Value* srcOffsetValue = get(offset);
 
+    auto emitCCall = [&]() -> Value* {
+        Value* resultValue = callWasmOperation(m_currentBlock, toB3Type(Types::Arrayref), operationWasmArrayNewData,
+            instanceValue(), constant(Int32, typeIndex.rawIndex()),
+            constant(Int32, dataIndex),
+            sizeValue, srcOffsetValue);
+        emitNullCheck(resultValue, ExceptionType::BadArrayNewInitData);
+        return resultValue;
+    };
+
+    if (dataIndex >= BitVector::maxInlineBitCount()) {
+        result = push(emitCCall());
+        return { };
+    }
+
+    auto* bits = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, pointerType(), origin(), instanceValue(), safeCast<int32_t>(JSWebAssemblyInstance::offsetOfPassiveDataSegments()));
+    auto* isInline = m_currentBlock->appendNew<Value>(m_proc, BitAnd, origin(), bits, constant(pointerType(), BitVector::inlineBitMask()));
+
+    auto* inlinePath = m_proc.addBlock();
+    auto* slowPath = m_proc.addBlock();
+    auto* continuation = m_proc.addBlock();
+    auto* phi = continuation->appendNew<Value>(m_proc, Phi, wasmRefType(), origin());
+
+    m_currentBlock->appendNewControlValue(m_proc, B3::Branch, origin(), isInline,
+        FrequentedBlock(inlinePath), FrequentedBlock(slowPath, FrequencyClass::Rare));
+    inlinePath->addPredecessor(m_currentBlock);
+    slowPath->addPredecessor(m_currentBlock);
+
+    m_currentBlock = inlinePath;
+    StorageType elementType;
+    getArrayElementType(typeIndex, elementType);
+    size_t elementSize = elementType.elementSize();
+    ASSERT(!isRefType(elementType.unpacked()));
+
+    auto* srcOffsetPtr = pointerOfInt32(srcOffsetValue);
+    auto* byteCount = m_currentBlock->appendNew<Value>(m_proc, Mul, origin(), pointerOfInt32(sizeValue),
+        m_currentBlock->appendNew<ConstPtrValue>(m_proc, origin(), elementSize));
+    auto* srcSum = m_currentBlock->appendNew<Value>(m_proc, Add, origin(), srcOffsetPtr, byteCount);
+    auto* dropped = m_currentBlock->appendNew<Value>(m_proc, Equal, origin(),
+        m_currentBlock->appendNew<Value>(m_proc, BitAnd, origin(), bits, constant(pointerType(), static_cast<uintptr_t>(1) << dataIndex)),
+        constant(pointerType(), 0));
+    auto* segmentSize = m_currentBlock->appendNew<Value>(m_proc, B3::Select, origin(), dropped,
+        constant(pointerType(), 0),
+        constant(pointerType(), m_info.data[dataIndex]->sizeInBytes()));
+    Value* outOfBounds = m_currentBlock->appendNew<Value>(m_proc, BitOr, origin(),
+        m_currentBlock->appendNew<Value>(m_proc, Below, origin(), srcSum, srcOffsetPtr),
+        m_currentBlock->appendNew<Value>(m_proc, Above, origin(), srcSum, segmentSize));
+    if (elementSize > 1) {
+        outOfBounds = m_currentBlock->appendNew<Value>(m_proc, BitOr, origin(),
+            m_currentBlock->appendNew<Value>(m_proc, Above, origin(), pointerOfInt32(sizeValue),
+                constant(pointerType(), static_cast<uintptr_t>(-1) / elementSize)),
+            outOfBounds);
+    }
+    CheckValue* check = m_currentBlock->appendNew<CheckValue>(m_proc, Check, origin(), outOfBounds);
+    check->setGenerator([=, this, origin = this->origin()] (CCallHelpers& jit, const B3::StackmapGenerationParams&) {
+        this->emitExceptionCheck(jit, origin, ExceptionType::BadArrayNewInitData);
+    });
+
+    auto* structureID = loadGCObjectStructureID(typeIndex);
+    Ref<const RTT> rtt = m_info.rtt(typeIndex);
+    int32_t allocatorsBaseOffset = safeCast<int32_t>(JSWebAssemblyInstance::offsetOfAllocatorForGCObject(m_info, 0));
+    m_proc.setUsesWasmGCArrayAllocations();
+    auto* array = m_currentBlock->appendNew<WasmArrayNewValue>(m_proc, origin(), wasmRefType(), Ref { rtt }, typeIndex.rawIndex(), allocatorsBaseOffset, instanceValue(), structureID, sizeValue);
+    m_heaps.decorateWasmArrayNew(&m_heaps.VM_heapState, array);
+
+    m_currentBlock->appendNew<BulkMemoryValue>(m_proc, MemoryCopy, origin(),
+        emitArrayElementAddress(elementType, array, constant(Int32, 0)),
+        m_currentBlock->appendNew<Value>(m_proc, Add, origin(),
+            constant(pointerType(), std::bit_cast<uintptr_t>(m_info.data[dataIndex]->span().data())),
+            srcOffsetPtr),
+        byteCount);
+    mutatorFence();
+    m_currentBlock->appendNew<UpsilonValue>(m_proc, origin(), array, phi);
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = slowPath;
+    m_currentBlock->appendNew<UpsilonValue>(m_proc, origin(), emitCCall(), phi);
+    m_currentBlock->appendNewControlValue(m_proc, Jump, origin(), continuation);
+    continuation->addPredecessor(m_currentBlock);
+
+    m_currentBlock = continuation;
+    result = push(phi);
     return { };
 }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -331,6 +331,7 @@ public:
 #endif
     static constexpr ptrdiff_t offsetOfMemoryIsMemory64Bits() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_memoryIsMemory64Bits); }
     static constexpr ptrdiff_t offsetOfCachedMemory0Size() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_cachedMemory0Size); }
+    static constexpr ptrdiff_t offsetOfPassiveDataSegments() { return OBJECT_OFFSETOF(JSWebAssemblyInstance, m_passiveDataSegments); }
 
     // Tail accessors.
     static_assert(sizeof(WasmMemoryBaseAndSize) == WTF::roundUpToMultipleOf<sizeof(uint64_t)>(sizeof(WasmMemoryBaseAndSize)), "We rely on this for the alignment to be correct");

--- a/Source/WTF/wtf/BitVector.h
+++ b/Source/WTF/wtf/BitVector.h
@@ -396,7 +396,10 @@ public:
         return byteCount(bitCount);
     }
     unsigned outOfLineMemoryUse() const { return outOfLineMemoryUse(size()); }
-        
+
+    static constexpr unsigned maxInlineBitCount() { return maxInlineBits(); }
+    static constexpr uintptr_t inlineBitMask() { return static_cast<uintptr_t>(1) << maxInlineBitCount(); }
+
     WTF_EXPORT_PRIVATE void shiftRightByMultipleOf64(size_t);
 
 private:


### PR DESCRIPTION
#### 1d6bc274aa0a951c9c45f40ff80636d421b01a37
<pre>
[JSC][Wasm] Inline OMG array.new_data
<a href="https://bugs.webkit.org/show_bug.cgi?id=323371">https://bugs.webkit.org/show_bug.cgi?id=323371</a>

Reviewed by NOBODY (OOPS!).

OMG array.new_data called operationWasmArrayNewData. When the passive
data BitVector is still inline it now bounds-checks the data segment,
allocates with WasmArrayNewValue, and copies with the existing memcpy
helper. Otherwise it uses the runtime operation. BBQ and IPInt stay
on the operation.

* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/WTF/wtf/BitVector.h:
* JSTests/wasm/stress/array-new-data-inline.js: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d6bc274aa0a951c9c45f40ff80636d421b01a37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196051 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150441 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145153 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100641 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48836 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165720 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125448 "Found 1 new API test failure: TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/42949672974097MallocReadOnly (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47562 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45600 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7343 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14229 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45297 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7114 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46991 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52279 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50012 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198017 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59311 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154691 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60019 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154343 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48807 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132370 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129330 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58486 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20320 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57864 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58100 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57927 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->