### PR TITLE
[Site Isolation] Change coordinate space for cross-process frame geometry

### DIFF
--- a/LayoutTests/http/tests/site-isolation/ios/exposed-content-rect-3d-transformed-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/ios/exposed-content-rect-3d-transformed-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS exposedContentRect of a 3D transformed cross-origin iframe, and of a frame nested inside it
+

--- a/LayoutTests/http/tests/site-isolation/ios/exposed-content-rect-3d-transformed.html
+++ b/LayoutTests/http/tests/site-isolation/ios/exposed-content-rect-3d-transformed.html
@@ -1,0 +1,60 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>exposedContentRect of a 3D transformed cross-origin iframe and a frame nested inside it</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script src="../resources/frame-geometry-test.js"></script>
+<style>
+body { margin: 0 }
+#child {
+    position: absolute;
+    left: 200px;
+    top: 100px;
+    width: 200px;
+    height: 150px;
+    border: 0;
+    transform: perspective(700px) rotateY(40deg);
+    transform-origin: 0 0;
+}
+#spacer { height: 2000px }
+</style>
+<body>
+<iframe id="child" src="http://localhost:8000/site-isolation/resources/frame-geometry-frame-with-same-site-child.html?label=child"></iframe>
+<div id="spacer"></div>
+<script>
+
+// Frame hierarchy, where F1 has a perspective and rotateY transform:
+// - child F1 in this document at (200, 100) with content box 200x150 (cross-site to main frame)
+// - grandchild F2 inside F1 at (20, 20) with content box 100x100 (same-site to F1)
+
+async function scrollAndSettle(y)
+{
+    window.scrollTo(0, y);
+    await UIHelper.ensureVisibleContentRectAndStablePresentationUpdate();
+}
+
+promise_test(async t => {
+    await assertExposedRect("child", "0,0 200x150", "the whole child frame should have tiled backing");
+    await assertExposedRect("grandchild", "0,0 100x100", "the whole grandchild frame should too");
+
+    await scrollAndSettle(175);
+    const childRect = await waitForExposedRect("child", rect => rect.height > 0 && rect.y > 0);
+    assert_equals(childRect.x, 0, "the left edge of the child frame still needs backing");
+    assert_equals(childRect.width, 200, "the child frame is clipped at the top, not at the sides");
+    assert_equals(childRect.bottom, 150, "the bottom edge of the child frame still needs backing");
+    assert_approx_equals(childRect.y, 75, 1, "the top 75 rows of the child frame no longer need it");
+    const rect = await waitForExposedRect("grandchild", rect => rect.height > 0 && rect.y > 0);
+    assert_equals(rect.x, 0, "the grandchild is not clipped horizontally");
+    assert_equals(rect.width, 100, "the grandchild is not clipped horizontally");
+    assert_equals(rect.bottom, 100, "the bottom of the grandchild still needs backing");
+    assert_approx_equals(rect.y, 55, 1, "the grandchild is clipped where the child frame is clipped");
+
+    await scrollAndSettle(400);
+    await assertExposedRect("child", "0,0 0x0", "the child frame is scrolled out entirely");
+    await assertExposedRect("grandchild", "0,0 0x0", "the grandchild frame is scrolled out entirely");
+}, "exposedContentRect of a 3D transformed cross-origin iframe, and of a frame nested inside it");
+
+</script>
+</body>

--- a/LayoutTests/http/tests/site-isolation/ios/exposed-content-rect-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/ios/exposed-content-rect-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS A frame's exposedContentRect does not depend on whether it is in another process
+

--- a/LayoutTests/http/tests/site-isolation/ios/exposed-content-rect-nested-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/ios/exposed-content-rect-nested-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS exposedContentRect is mapped down a frame tree whose levels are in different processes
+

--- a/LayoutTests/http/tests/site-isolation/ios/exposed-content-rect-nested.html
+++ b/LayoutTests/http/tests/site-isolation/ios/exposed-content-rect-nested.html
@@ -1,0 +1,54 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>exposedContentRect mapped down a frame tree whose levels are in different processes</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script src="../resources/frame-geometry-test.js"></script>
+<style>
+body { margin: 0 }
+#child {
+    position: absolute;
+    left: 200px;
+    top: 100px;
+    width: 300px;
+    height: 250px;
+    border: 0;
+}
+#spacer { height: 2000px }
+</style>
+<body>
+<iframe id="child" src="http://localhost:8000/site-isolation/resources/frame-geometry-child-cross-site.html?label=child"></iframe>
+<div id="spacer"></div>
+<script>
+
+// Frame hierarchy:
+// - child F1 in this document at (200, 100) with content box 300x250 (cross-site to main frame)
+// - grandchild F2 inside F1 at (30, 50) with content box 200x150 (same-site to main frame)
+// - great-grandchild F3 inside F2 at (10, 25) with content box 120x100 (cross-site to main frame)
+
+async function scrollAndSettle(y)
+{
+    window.scrollTo(0, y);
+    await UIHelper.ensureVisibleContentRectAndStablePresentationUpdate();
+}
+
+promise_test(async t => {
+    await assertExposedRect("child", "0,0 300x250", "whole child frame should have tiled backing");
+    await assertExposedRect("grandchild", "0,0 200x150", "whole grandchild frame should have tiled backing");
+    await assertExposedRect("greatGrandchild", "0,0 120x100", "whole great-grandchild frame should have tiled backing");
+
+    await scrollAndSettle(225);
+    await assertExposedRect("child", "0,125 300x125", "half the child frame should have tiled backing");
+    await assertExposedRect("grandchild", "0,75 200x75", "half the grandchild frame should have tiled backing");
+    await assertExposedRect("greatGrandchild", "0,50 120x50", "half the great-grandchild frame should have tiled backing");
+
+    await scrollAndSettle(500);
+    await assertExposedRect("child", "0,0 0x0", "none of the child frame has tiled backing");
+    await assertExposedRect("grandchild", "0,0 0x0", "none of the grandchild frame has tiled backing");
+    await assertExposedRect("greatGrandchild", "0,0 0x0", "none of the great-grandchild frame has tiled backing");
+}, "exposedContentRect is mapped down a frame tree whose levels are in different processes");
+
+</script>
+</body>

--- a/LayoutTests/http/tests/site-isolation/ios/exposed-content-rect.html
+++ b/LayoutTests/http/tests/site-isolation/ios/exposed-content-rect.html
@@ -1,0 +1,83 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>exposedContentRect is the same whether or not the frame is in another process</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script src="../resources/frame-geometry-test.js"></script>
+<style>
+body { margin: 0 }
+.bordered { position: absolute; top: 100px; width: 200px; height: 150px; border: 5px solid black; padding: 10px }
+#borderSameSite { left: 0 }
+#borderCrossSite { left: 300px }
+.zoomWrapper { position: absolute; top: 1100px }
+#zoomSameSiteWrapper { left: 0 }
+#zoomCrossSiteWrapper { left: 400px }
+.zoomed { display: block; zoom: 2; width: 150px; height: 100px; border: 5px solid black }
+#spacer { height: 2500px }
+</style>
+<body>
+
+<iframe class="bordered" id="borderSameSite"
+    src="http://127.0.0.1:8000/site-isolation/resources/frame-geometry-frame.html?label=borderSameSite"></iframe>
+<iframe class="bordered" id="borderCrossSite"
+    src="http://localhost:8000/site-isolation/resources/frame-geometry-frame.html?label=borderCrossSite"></iframe>
+
+<div class="zoomWrapper" id="zoomSameSiteWrapper">
+    <iframe class="zoomed" scrolling="no"
+        src="http://127.0.0.1:8000/site-isolation/resources/frame-geometry-frame.html?label=zoomSameSite"></iframe>
+</div>
+<div class="zoomWrapper" id="zoomCrossSiteWrapper">
+    <iframe class="zoomed" scrolling="no"
+        src="http://localhost:8000/site-isolation/resources/frame-geometry-frame.html?label=zoomCrossSite"></iframe>
+</div>
+
+<div id="spacer"></div>
+<script>
+
+const CONFIGURATIONS = [
+    {
+        name: "an owner element with a border and padding",
+        sameSite: "borderSameSite",
+        crossSite: "borderCrossSite",
+        // These are nodes at y=100 with a border box of size 230x180 and a content box of size 200x150.
+        expected: {
+            0: "0,0 200x150",    // For scrollY=0, the entire content box should be tiled.
+            190: "0,75 200x75",  // For scrollY=190, half the content box should be tiled.
+            400: "0,0 0x0",      // For scrollY=400, none of the content box should be tiled.
+        },
+    },
+    {
+        name: "an owner element with a used zoom",
+        sameSite: "zoomSameSite",
+        crossSite: "zoomCrossSite",
+        // These are nodes at y=1100 with a border box of size 320x220 and a content box of size 300x200.
+        expected: {
+            1100: "0,0 300x200",    // For scrollY=1100, the entire content box should be tiled.
+            1210: "0,100 300x100",  // For scrollY=1210, half the content box should be tiled.
+            1500: "0,0 0x0",        // For scrollY=1500, none of the content box should be tiled.
+        },
+    },
+];
+
+const ALL_LABELS = CONFIGURATIONS.flatMap(configuration => [configuration.sameSite, configuration.crossSite]);
+
+promise_test(async t => {
+    assert_true(await waitForFirstReports(ALL_LABELS), "every frame reported at least once");
+
+    for (const configuration of CONFIGURATIONS) {
+        for (const [offset, expected] of Object.entries(configuration.expected)) {
+            window.scrollTo(0, Number(offset));
+            await UIHelper.ensureVisibleContentRectAndStablePresentationUpdate();
+
+            await assertExposedRect(configuration.sameSite, expected,
+                `${configuration.name}, same site, at scrollY=${offset}`);
+            await assertExposedRect(configuration.crossSite, expected,
+                `${configuration.name}, cross site, at scrollY=${offset}`);
+        }
+    }
+}, "A frame's exposedContentRect does not depend on whether it is in another process");
+
+</script>
+</body>

--- a/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-scrolled-out-3d-transformed-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-scrolled-out-3d-transformed-cross-origin-iframe-expected.txt
@@ -1,0 +1,16 @@
+Tests that requestAnimationFrame and DOM timers are throttled in an out-of-process subframe with a 3D transform scrolled outside the viewport
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+The frame is inside the viewport, so it should not be throttled.
+PASS throttlingState became "requestAnimationFrame=false,timers=false"
+Scrolling the frame above the viewport.
+PASS throttlingState became "requestAnimationFrame=true,timers=true"
+Scrolling the frame back into the viewport.
+PASS throttlingState became "requestAnimationFrame=false,timers=false"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-scrolled-out-3d-transformed-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-scrolled-out-3d-transformed-cross-origin-iframe.html
@@ -1,0 +1,48 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that requestAnimationFrame and DOM timers are throttled in an out-of-process subframe with a 3D transform scrolled outside the viewport");
+
+var jsTestIsAsync = true;
+var throttlingState = "";
+var testFrame;
+
+window.addEventListener("message", function(event) {
+    throttlingState = event.data;
+}, false);
+
+function runTest()
+{
+    testFrame = document.getElementById("testFrame");
+
+    setInterval(function() {
+        testFrame.contentWindow.postMessage("report-throttling-reasons", "*");
+    }, 50);
+
+    debug("The frame is inside the viewport, so it should not be throttled.");
+    shouldBecomeEqualToString("throttlingState", "requestAnimationFrame=false,timers=false", scrollFrameOutOfViewport);
+}
+
+function scrollFrameOutOfViewport()
+{
+    debug("Scrolling the frame above the viewport.");
+    window.scrollTo(0, 3000);
+    shouldBecomeEqualToString("throttlingState", "requestAnimationFrame=true,timers=true", scrollFrameBackIntoViewport);
+}
+
+function scrollFrameBackIntoViewport()
+{
+    debug("Scrolling the frame back into the viewport.");
+    window.scrollTo(0, 0);
+    shouldBecomeEqualToString("throttlingState", "requestAnimationFrame=false,timers=false", finishJSTest);
+}
+</script>
+<iframe id="testFrame" src="http://localhost:8000/site-isolation/resources/request-animation-frame-throttling-frame.html" onload="runTest()"
+    style="width: 200px; height: 150px; border: 0; transform: perspective(700px) rotateY(40deg); transform-origin: 0 0;"></iframe>
+<div style="width: 100px; height: 4000px;"></div>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-scrolled-out-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-scrolled-out-cross-origin-iframe-expected.txt
@@ -1,0 +1,16 @@
+Tests that requestAnimationFrame and DOM timers are throttled in an out-of-process subframe scrolled outside the viewport
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+The frame is inside the viewport, so it should not be throttled.
+PASS throttlingState became "requestAnimationFrame=false,timers=false"
+Scrolling the frame above the viewport.
+PASS throttlingState became "requestAnimationFrame=true,timers=true"
+Scrolling the frame back into the viewport.
+PASS throttlingState became "requestAnimationFrame=false,timers=false"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-scrolled-out-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-scrolled-out-cross-origin-iframe.html
@@ -1,0 +1,47 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that requestAnimationFrame and DOM timers are throttled in an out-of-process subframe scrolled outside the viewport");
+
+var jsTestIsAsync = true;
+var throttlingState = "";
+var testFrame;
+
+window.addEventListener("message", function(event) {
+    throttlingState = event.data;
+}, false);
+
+function runTest()
+{
+    testFrame = document.getElementById("testFrame");
+
+    setInterval(function() {
+        testFrame.contentWindow.postMessage("report-throttling-reasons", "*");
+    }, 50);
+
+    debug("The frame is inside the viewport, so it should not be throttled.");
+    shouldBecomeEqualToString("throttlingState", "requestAnimationFrame=false,timers=false", scrollFrameOutOfViewport);
+}
+
+function scrollFrameOutOfViewport()
+{
+    debug("Scrolling the frame above the viewport.");
+    window.scrollTo(0, 3000);
+    shouldBecomeEqualToString("throttlingState", "requestAnimationFrame=true,timers=true", scrollFrameBackIntoViewport);
+}
+
+function scrollFrameBackIntoViewport()
+{
+    debug("Scrolling the frame back into the viewport.");
+    window.scrollTo(0, 0);
+    shouldBecomeEqualToString("throttlingState", "requestAnimationFrame=false,timers=false", finishJSTest);
+}
+</script>
+<iframe id="testFrame" src="http://localhost:8000/site-isolation/resources/request-animation-frame-throttling-frame.html" onload="runTest()" style="width: 200px; height: 150px;"></iframe>
+<div style="width: 100px; height: 4000px;"></div>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/frame-geometry-child-cross-site.html
+++ b/LayoutTests/http/tests/site-isolation/resources/frame-geometry-child-cross-site.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>frame geometry for cross-site child holding a same-site grandchild</title>
+<style>
+body { margin: 0 }
+iframe { position: absolute; left: 30px; top: 50px; width: 200px; height: 150px; border: 0 }
+</style>
+<script src="frame-geometry-reporter.js"></script>
+<body>
+<iframe src="http://127.0.0.1:8000/site-isolation/resources/frame-geometry-grandchild-same-site.html?label=grandchild"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/frame-geometry-frame-with-same-site-child.html
+++ b/LayoutTests/http/tests/site-isolation/resources/frame-geometry-frame-with-same-site-child.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>windowClipRect reporter, with a same-site child</title>
+<style>
+body { margin: 0 }
+iframe { position: absolute; left: 20px; top: 20px; width: 100px; height: 100px; border: 0 }
+</style>
+<script src="frame-geometry-reporter.js"></script>
+<body>
+<iframe src="frame-geometry-frame.html?label=grandchild"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/frame-geometry-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/frame-geometry-frame.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>windowClipRect reporter, no children</title>
+<script src="frame-geometry-reporter.js"></script>

--- a/LayoutTests/http/tests/site-isolation/resources/frame-geometry-grandchild-same-site.html
+++ b/LayoutTests/http/tests/site-isolation/resources/frame-geometry-grandchild-same-site.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>frame geometry for same-site grandchild holding a cross-site great-grandchild</title>
+<style>
+body { margin: 0 }
+iframe { position: absolute; left: 10px; top: 25px; width: 120px; height: 100px; border: 0 }
+</style>
+<script src="frame-geometry-reporter.js"></script>
+<body>
+<iframe src="http://localhost:8000/site-isolation/resources/frame-geometry-frame.html?label=greatGrandchild"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/frame-geometry-reporter.js
+++ b/LayoutTests/http/tests/site-isolation/resources/frame-geometry-reporter.js
@@ -1,0 +1,33 @@
+(function () {
+    var label = new URLSearchParams(location.search).get("label");
+
+    function toArray(rect)
+    {
+        return [rect.x, rect.y, rect.width, rect.height];
+    }
+
+    function report()
+    {
+        if (!window.internals) {
+            top.postMessage({ label: label }, "*");
+            return;
+        }
+
+        top.postMessage({
+            label: label,
+            windowClipRect: toArray(internals.windowClipRect()),
+            exposedContentRect: toArray(internals.exposedContentRect())
+        }, "*");
+    }
+
+    window.addEventListener("message", function (event) {
+        if (event.data !== "report-frame-geometry")
+            return;
+
+        report();
+
+        // Forward the request to this frame's children.
+        for (var i = 0; i < window.length; i++)
+            window[i].postMessage(event.data, "*");
+    }, false);
+})();

--- a/LayoutTests/http/tests/site-isolation/resources/frame-geometry-test.js
+++ b/LayoutTests/http/tests/site-isolation/resources/frame-geometry-test.js
@@ -1,0 +1,79 @@
+// Loaded by the main frame of the frame geometry tests. We pass every iframe in the test pages a
+// "label" query parameter, which is used to track the frame geometry of each of the iframes.
+
+// Need to poll since frame geometry arrives at cross-site frames asynchronously.
+const POLL_INTERVAL_MS = 25;
+const POLL_TIMEOUT_MS = 4000;
+
+// The last frame geometry report for each frame.
+const reports = { };
+
+window.addEventListener("message", function (event) {
+    if (event.data && event.data.label)
+        reports[event.data.label] = event.data;
+}, false);
+
+function requestReports()
+{
+    for (let i = 0; i < window.length; i++)
+        window[i].postMessage("report-frame-geometry", "*");
+}
+
+function geometryRect(report, field)
+{
+    if (!report || !report[field])
+        return null;
+
+    const [x, y, width, height] = report[field];
+    return {
+        x, y, width, height,
+        right: x + width,
+        bottom: y + height,
+        isEmpty: width <= 0 && height <= 0,
+        toString() { return `${x},${y} ${width}x${height}`; }
+    };
+}
+
+// Polls until the predicate returns true or a timeout occurs.
+async function waitForRect(label, field, predicate)
+{
+    const deadline = performance.now() + POLL_TIMEOUT_MS;
+
+    while (true) {
+        requestReports();
+        await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+
+        const rect = geometryRect(reports[label], field);
+        if (rect && predicate(rect))
+            return rect;
+
+        if (performance.now() > deadline)
+            return rect;
+    }
+}
+
+async function assertRect(label, field, expected, description)
+{
+    const rect = await waitForRect(label, field, rect => rect.toString() === expected);
+    assert_equals(rect ? rect.toString() : `no report from "${label}"`, expected, description);
+}
+
+const waitForClipRect = (label, predicate) => waitForRect(label, "windowClipRect", predicate);
+const waitForExposedRect = (label, predicate) => waitForRect(label, "exposedContentRect", predicate);
+const assertClipRect = (label, expected, description) => assertRect(label, "windowClipRect", expected, description);
+const assertExposedRect = (label, expected, description) => assertRect(label, "exposedContentRect", expected, description);
+
+// Waits for each frame to report frame geometry once.
+async function waitForFirstReports(labels)
+{
+    const deadline = performance.now() + POLL_TIMEOUT_MS;
+
+    while (labels.some(label => !reports[label])) {
+        requestReports();
+        await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+
+        if (performance.now() > deadline)
+            return false;
+    }
+    return true;
+}

--- a/LayoutTests/http/tests/site-isolation/resources/request-animation-frame-throttling-frame.html
+++ b/LayoutTests/http/tests/site-isolation/resources/request-animation-frame-throttling-frame.html
@@ -4,8 +4,8 @@
 <script>
 
 if (window.internals) {
-    // The OutsideViewport override is per-Page, and this frame has its own Page in its own process, so it
-    // has to be enabled here as well as in the embedder.
+    // FIXME: out-of-viewport throttling is on by default, but Internals::resetToConsistentState()
+    // turns it off in layout tests. We may want to modify the test runner to not do that.
     internals.setOutsideViewportThrottlingEnabled(true);
 }
 
@@ -17,13 +17,11 @@ function step()
 requestAnimationFrame(step);
 
 window.addEventListener("message", function() {
-    // Report only the viewport reason. A cross-origin frame that has had no user interaction also carries
-    // NonInteractedCrossOriginFrame, which is not what these tests are about.
+    // Report only OutsideViewport. A cross-origin frame that has no user interaction can also be
+    // throttled due to NonInteractedCrossOriginFrame, but that's not what we're testing here.
     var reasons = window.internals ? internals.requestAnimationFrameThrottlingReasons() : "no internals";
     var throttlesAnimationFrames = reasons.includes("OutsideViewport");
 
-    // The DOM timer half of the same throttle. Unlike the reason above, it does not depend on the
-    // OutsideViewport override, so it also covers the configuration that ships.
     var throttlesTimers = window.internals ? internals.areTimersThrottled() : false;
 
     parent.postMessage("requestAnimationFrame=" + throttlesAnimationFrames + ",timers=" + throttlesTimers, "*");

--- a/LayoutTests/http/tests/site-isolation/window-clip-rect-3d-transformed-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/window-clip-rect-3d-transformed-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS windowClipRect of a 3D transformed cross-origin iframe, and of a frame nested inside it
+

--- a/LayoutTests/http/tests/site-isolation/window-clip-rect-3d-transformed.html
+++ b/LayoutTests/http/tests/site-isolation/window-clip-rect-3d-transformed.html
@@ -1,0 +1,53 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>windowClipRect of a 3D transformed cross-origin iframe and a frame nested inside it</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/frame-geometry-test.js"></script>
+<style>
+body { margin: 0 }
+#child {
+    position: absolute;
+    left: 200px;
+    top: 100px;
+    width: 200px;
+    height: 150px;
+    border: 0;
+    transform: perspective(700px) rotateY(40deg);
+    transform-origin: 0 0;
+}
+#spacer { height: 2000px }
+</style>
+<body>
+<iframe id="child" src="http://localhost:8000/site-isolation/resources/frame-geometry-frame-with-same-site-child.html?label=child"></iframe>
+<div id="spacer"></div>
+<script>
+
+// Frame hierarchy, where F1 has a perspective and rotateY transform:
+// - child F1 in this document at (200, 100) with content box 200x150 (cross-site to main frame)
+// - grandchild F2 inside F1 at (20, 20) with content box 100x100 (same-site to F1)
+
+promise_test(async t => {
+    await assertClipRect("child", "0,0 200x150", "the whole child frame is on screen");
+    await assertClipRect("grandchild", "20,20 100x100", "the whole grandchild frame is on screen");
+
+    window.scrollTo(0, 175);
+    const childRect = await waitForClipRect("child", rect => rect.height > 0 && rect.y > 0);
+    assert_equals(childRect.x, 0, "the left edge of the child frame is on screen");
+    assert_equals(childRect.width, 200, "the child frame is clipped at the top, not at the sides");
+    assert_equals(childRect.bottom, 150, "the bottom edge of the child frame is on screen");
+    assert_approx_equals(childRect.y, 75, 1, "the top 75 rows of the child frame are scrolled out");
+    const rect = await waitForClipRect("grandchild", rect => rect.height > 0 && rect.y > 20);
+    assert_equals(rect.x, 20, "the grandchild is not clipped horizontally");
+    assert_equals(rect.width, 100, "the grandchild is not clipped horizontally");
+    assert_equals(rect.bottom, 120, "the bottom of the grandchild is above the clip");
+    assert_approx_equals(rect.y, 75, 1, "the grandchild is clipped where the child frame is clipped");
+
+    window.scrollTo(0, 400);
+    await assertClipRect("child", "0,0 0x0", "the child frame is scrolled out entirely");
+    await assertClipRect("grandchild", "0,0 0x0", "the grandchild frame is scrolled out entirely");
+}, "windowClipRect of a 3D transformed cross-origin iframe, and of a frame nested inside it");
+
+</script>
+</body>

--- a/LayoutTests/http/tests/site-isolation/window-clip-rect-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/window-clip-rect-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS A frame's windowClipRect does not depend on whether it is in another process
+

--- a/LayoutTests/http/tests/site-isolation/window-clip-rect-nested-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/window-clip-rect-nested-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS windowClipRect is computed down a frame tree that changes process at every level
+

--- a/LayoutTests/http/tests/site-isolation/window-clip-rect-nested.html
+++ b/LayoutTests/http/tests/site-isolation/window-clip-rect-nested.html
@@ -1,0 +1,47 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>windowClipRect down a frame tree that alternates between two sites</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/frame-geometry-test.js"></script>
+<style>
+body { margin: 0 }
+#child {
+    position: absolute;
+    left: 200px;
+    top: 100px;
+    width: 300px;
+    height: 250px;
+    border: 0;
+}
+#spacer { height: 2000px }
+</style>
+<body>
+<iframe id="child" src="http://localhost:8000/site-isolation/resources/frame-geometry-child-cross-site.html?label=child"></iframe>
+<div id="spacer"></div>
+<script>
+
+// Frame hierarchy:
+// - child F1 in this document at (200, 100) with content box 300x250 (cross-site to main frame)
+// - grandchild F2 inside F1 at (30, 50) with content box 200x150 (same-site to main frame)
+// - great-grandchild F3 inside F2 at (10, 25) with content box 120x100 (cross-site to main frame)
+
+promise_test(async t => {
+    await assertClipRect("child", "0,0 300x250", "the whole child frame is on screen");
+    await assertClipRect("grandchild", "0,0 200x150", "the whole grandchild frame is on screen");
+    await assertClipRect("greatGrandchild", "0,0 120x100", "the whole great-grandchild frame is on screen");
+
+    window.scrollTo(0, 225);
+    await assertClipRect("child", "0,125 300x125", "half of the child frame is on screen");
+    await assertClipRect("grandchild", "0,75 200x75", "the grandchild is clipped by the child's clip");
+    await assertClipRect("greatGrandchild", "0,50 120x50", "the great-grandchild is clipped by the grandchild's clip");
+
+    window.scrollTo(0, 500);
+    await assertClipRect("child", "0,0 0x0", "the child frame is scrolled out entirely");
+    await assertClipRect("grandchild", "0,0 0x0", "the grandchild frame is scrolled out entirely");
+    await assertClipRect("greatGrandchild", "0,0 0x0", "the great-grandchild frame is scrolled out entirely");
+}, "windowClipRect is computed down a frame tree that changes process at every level");
+
+</script>
+</body>

--- a/LayoutTests/http/tests/site-isolation/window-clip-rect.html
+++ b/LayoutTests/http/tests/site-isolation/window-clip-rect.html
@@ -1,0 +1,139 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>windowClipRect is the same whether or not the frame is in another process</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+<script src="resources/frame-geometry-test.js"></script>
+<style>
+body { margin: 0 }
+.bordered { position: absolute; top: 100px; width: 200px; height: 150px; border: 5px solid black; padding: 10px }
+#borderSameSite { left: 0 }
+#borderCrossSite { left: 300px }
+.zoomWrapper { position: absolute; top: 1100px }
+#zoomSameSiteWrapper { left: 0 }
+#zoomCrossSiteWrapper { left: 400px }
+.zoomed { display: block; zoom: 2; width: 150px; height: 100px; border: 5px solid black }
+.clipper { position: absolute; top: 1700px; overflow: hidden; width: 300px; height: 200px }
+#clippedSameSiteClipper { left: 0 }
+#clippedCrossSiteClipper { left: 400px }
+.clipped { position: absolute; left: 0; top: -40px; display: block; width: 200px; height: 150px; border: 0 }
+#spacer { height: 3000px }
+</style>
+<body>
+<iframe class="bordered" id="borderSameSite"
+    src="http://127.0.0.1:8000/site-isolation/resources/frame-geometry-frame.html?label=borderSameSite"></iframe>
+<iframe class="bordered" id="borderCrossSite"
+    src="http://localhost:8000/site-isolation/resources/frame-geometry-frame.html?label=borderCrossSite"></iframe>
+
+<div class="zoomWrapper" id="zoomSameSiteWrapper">
+    <iframe class="zoomed" scrolling="no"
+        src="http://127.0.0.1:8000/site-isolation/resources/frame-geometry-frame.html?label=zoomSameSite"></iframe>
+</div>
+<div class="zoomWrapper" id="zoomCrossSiteWrapper">
+    <iframe class="zoomed" scrolling="no"
+        src="http://localhost:8000/site-isolation/resources/frame-geometry-frame.html?label=zoomCrossSite"></iframe>
+</div>
+
+<div class="clipper" id="clippedSameSiteClipper">
+    <iframe class="clipped"
+        src="http://127.0.0.1:8000/site-isolation/resources/frame-geometry-frame.html?label=clippedSameSite"></iframe>
+</div>
+<div class="clipper" id="clippedCrossSiteClipper">
+    <iframe class="clipped"
+        src="http://localhost:8000/site-isolation/resources/frame-geometry-frame.html?label=clippedCrossSite"></iframe>
+</div>
+
+<div id="spacer"></div>
+<script>
+
+// The expected windowClipRect values differ for same-site and cross-site iframes here, because
+// windowClipRect is in window coordinates, and the origin for window coordinates is based on the
+// local root's view coordinates.
+//
+// - For a same-site iframe the local root frame is the main frame. So for an unclipped iframe,
+//   the windowClipRect's origin is the iframe's position in the main frame's view.
+// - For a cross-site iframe the iframe is its own local root frame. So for an unclipped root iframe
+//   in that process, the windowClipRect's origin is (0, 0).
+
+const CONFIGURATIONS = [
+    {
+        name: "an owner element with a border and padding",
+        sameSite: "borderSameSite",
+        crossSite: "borderCrossSite",
+        // These are nodes at y=100 with a border box of size 230x180 and a content box of size
+        // 200x150. The content box runs from y=115 to y=265.
+        steps: [
+            { scrollY: 0, sameSite: "15,115 200x150", crossSite: "0,0 200x150",
+              what: "the entire content box is on screen" },
+            { scrollY: 190, sameSite: "15,190 200x75", crossSite: "0,75 200x75",
+              what: "half the content box is on screen" },
+            { scrollY: 400, sameSite: "0,0 0x0", crossSite: "0,0 0x0",
+              what: "none of the content box is on screen" },
+        ],
+    },
+    {
+        name: "an owner element with a used zoom",
+        sameSite: "zoomSameSite",
+        crossSite: "zoomCrossSite",
+        // These are nodes at y=1100 with a border box of size 320x220 and a content box of size
+        // 300x200. The content box runs from y=1110 to y=1310.
+        steps: [
+            { scrollY: 1100, sameSite: "10,1110 300x200", crossSite: "0,0 300x200",
+              what: "the entire content box is on screen" },
+            { scrollY: 1210, sameSite: "10,1210 300x100", crossSite: "0,100 300x100",
+              what: "half the content box is on screen" },
+            { scrollY: 1500, sameSite: "0,0 0x0", crossSite: "0,0 0x0",
+              what: "none of the content box is on screen" },
+        ],
+    },
+    {
+        name: "an owner element clipped by an ancestor",
+        sameSite: "clippedSameSite",
+        crossSite: "clippedCrossSite",
+        // These nodes are at y=1660 with a border and content box of size 200x150. The top 40 px
+        // of the box are clipped by an ancestor node.
+        steps: [
+            { scrollY: 1400, sameSite: "0,1700 200x110", crossSite: "0,40 200x110",
+              what: "the ancestor clips the top of the content box" },
+            { scrollY: 1755, sameSite: "0,1755 200x55", crossSite: "0,95 200x55",
+              what: "the ancestor and the viewport both clip it" },
+            { scrollY: 1900, sameSite: "0,0 0x0", crossSite: "0,0 0x0",
+              what: "none of the content box is on screen" },
+        ],
+    },
+];
+
+const ALL_LABELS = CONFIGURATIONS.flatMap(configuration => [configuration.sameSite, configuration.crossSite]);
+
+function inDocumentCoordinates(rect, scrollY)
+{
+    if (rect.isEmpty)
+        return "0,0 0x0";
+
+    const scrollTakenOut = internals.delegatesScrollingToNativeView() ? 0 : scrollY;
+    return `${rect.x},${rect.y + scrollTakenOut} ${rect.width}x${rect.height}`;
+}
+
+promise_test(async t => {
+    assert_true(await waitForFirstReports(ALL_LABELS), "every frame reported at least once");
+
+    for (const configuration of CONFIGURATIONS) {
+        for (const step of configuration.steps) {
+            window.scrollTo(0, step.scrollY);
+            await UIHelper.ensureVisibleContentRectAndStablePresentationUpdate();
+
+            await assertClipRect(configuration.crossSite, step.crossSite,
+                `${configuration.name}, cross site: ${step.what}`);
+
+            const sameSiteRect = await waitForClipRect(configuration.sameSite,
+                rect => inDocumentCoordinates(rect, step.scrollY) === step.sameSite);
+            assert_equals(inDocumentCoordinates(sameSiteRect, step.scrollY), step.sameSite,
+                `${configuration.name}, same site: ${step.what}`);
+        }
+    }
+}, "A frame's windowClipRect does not depend on whether it is in another process");
+
+</script>
+</body>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -43,6 +43,10 @@ http/tests/site-isolation/select-in-cross-origin-iframe.html [ Pass ]
 http/tests/site-isolation/autofill-credentials-in-cross-origin-iframe.html [ Pass ]
 http/tests/site-isolation/open-panel-in-cross-origin-iframe.html [ Pass ]
 http/tests/site-isolation/focus-navigation-cross-origin-iframe.html [ Pass ]
+http/tests/site-isolation/ios/exposed-content-rect.html [ Pass ]
+http/tests/site-isolation/ios/exposed-content-rect-nested.html [ Pass ]
+http/tests/site-isolation/ios/exposed-content-rect-3d-transformed.html [ Pass ]
+
 fast/forms/switch [ Pass ]
 fast/snapshot [ Skip ]
 

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -88,7 +88,7 @@ public:
     WEBCORE_EXPORT Frame& NODELETE top() const;
     unsigned NODELETE depth() const;
 
-    bool hasRemoteFrameDescendant() const;
+    WEBCORE_EXPORT bool hasRemoteFrameDescendant() const;
 
     WEBCORE_EXPORT RefPtr<Frame> scopedChild(unsigned index) const;
     WEBCORE_EXPORT RefPtr<Frame> scopedChildByUniqueName(const AtomString&) const;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2214,6 +2214,20 @@ TransformationMatrix LocalFrameView::absoluteToChildFrameOwnerLocalTransform(con
     return valueOrDefault(matrix->inverse());
 }
 
+FloatRect LocalFrameView::mapAbsoluteToChildFrameViewRect(const FloatRect& rect, const Frame& child) const
+{
+    return mapAbsoluteToChildFrameViewRect(rect, absoluteToChildFrameOwnerLocalTransform(child),
+        childFrameOwnerContentBoxLocation(child));
+}
+
+FloatRect LocalFrameView::mapAbsoluteToChildFrameViewRect(const FloatRect& rect, const TransformationMatrix& absoluteToChildFrameOwnerLocalTransform, FloatPoint childFrameOwnerContentBoxLocation)
+{
+    // Use projectQuad() instead of mapRect() here to handle 3D rotations.
+    auto childFrameViewRect = absoluteToChildFrameOwnerLocalTransform.projectQuad(rect).boundingBox();
+    childFrameViewRect.moveBy(-childFrameOwnerContentBoxLocation);
+    return childFrameViewRect;
+}
+
 LayoutRect LocalFrameView::rectForFixedPositionLayout() const
 {
     if (m_frame->settings().visualViewportEnabled())

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -268,7 +268,7 @@ public:
 
     FloatSize sizeForCSSDynamicViewportUnits() const;
 
-    IntRect windowClipRect() const final;
+    WEBCORE_EXPORT IntRect windowClipRect() const final;
     WEBCORE_EXPORT IntRect windowClipRectForFrameOwner(const HTMLFrameOwnerElement*, bool clipToLayerContents) const;
 
     WEBCORE_EXPORT void scrollToEdgeWithOptions(WebCore::RectEdges<bool>, const ScrollPositionChangeOptions&);
@@ -330,6 +330,9 @@ public:
     LayoutPoint childFrameOwnerContentBoxLocation(const Frame&) const final;
     TransformationMatrix childFrameOwnerToRootContentTransform(const Frame&) const final;
     TransformationMatrix absoluteToChildFrameOwnerLocalTransform(const Frame&) const final;
+
+    FloatRect mapAbsoluteToChildFrameViewRect(const FloatRect&, const Frame& child) const;
+    static FloatRect mapAbsoluteToChildFrameViewRect(const FloatRect& rectInAbsolute, const TransformationMatrix& absoluteToChildFrameOwnerLocalTransform, FloatPoint childFrameOwnerContentBoxLocation);
 
     static LayoutRect visibleDocumentRect(const FloatRect& visibleContentRect, float headerHeight, float footerHeight, const FloatSize& totalContentsSize, float pageScaleFactor);
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2287,30 +2287,57 @@ void Page::syncLocalFrameInfoToRemote()
 #endif
 
         for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
+            auto absoluteToChildFrameOwnerLocalTransform = frameView->absoluteToChildFrameOwnerLocalTransform(*child);
+            auto contentBoxLocation = frameView->childFrameOwnerContentBoxLocation(*child);
+
+            // We could use the mapAbsoluteToChildFrameViewRect member function here, but use the
+            // static version instead to reuse absoluteToChildFrameOwnerLocalTransform across
+            // multiple calls.
+            auto mapParentAbsoluteToChildFrameViewRect = [&] (const LayoutRect& rect) {
+                return LocalFrameView::mapAbsoluteToChildFrameViewRect(FloatRect { rect }, absoluteToChildFrameOwnerLocalTransform, contentBoxLocation);
+            };
+
             auto visibleRectInParent = frameView->visibleRectOfChild(*child.get());
 
+            auto onScreenRectInChildView = [&] {
+                if (!visibleRectInParent)
+                    return IntRect { };
+
+                auto onScreenRectInParent = *visibleRectInParent;
+                onScreenRectInParent.intersect(windowClipRectInContentCoordinates());
+                if (onScreenRectInParent.isEmpty())
+                    return IntRect { };
+
+                return enclosingIntRect(mapParentAbsoluteToChildFrameViewRect(onScreenRectInParent));
+            }();
+
 #if PLATFORM(IOS_FAMILY)
-            // Clamp the child's visible rect to the portion of the page actually on-screen, so an offscreen
-            // iframe commits ~0 tiles — matching the single-tiled-backing coverage decision the page makes
-            // with site isolation off. visibleRectOfChild() clips through the compositor tree but not the
-            // top-level viewport, so a fully-below-fold iframe can still return a non-empty box; intersect
-            // it here with the parent's exposed viewport.
-            auto exposedContentRectInParent = visibleRectInParent;
-            if (exposedContentRectInParent)
-                exposedContentRectInParent->intersect(exposedContentRect());
+            auto exposedContentRectInChildView = [&]() -> FloatRect {
+                auto exposedContentRectInParent = visibleRectInParent;
+                if (exposedContentRectInParent)
+                    exposedContentRectInParent->intersect(exposedContentRect());
+                if (!exposedContentRectInParent || exposedContentRectInParent->isEmpty())
+                    return FloatRect { };
+
+                auto rectInChildView = mapParentAbsoluteToChildFrameViewRect(*exposedContentRectInParent);
+                if (rectInChildView.isEmpty())
+                    return FloatRect { };
+
+                return rectInChildView;
+            }();
 #endif
 
             childrenFrameLayoutInfo.add(child->frameID(), RemoteFrameLayoutInfo::create(
-                windowClipRectInContentCoordinates(),
                 visibleRectInParent,
+                onScreenRectInChildView,
 #if PLATFORM(IOS_FAMILY)
-                exposedContentRectInParent,
+                exposedContentRectInChildView,
 #endif
                 !!child->ownerRenderer(),
                 frameView->childFrameOwnerToRootContentTransform(*child),
-                frameView->absoluteToChildFrameOwnerLocalTransform(*child),
+                WTF::move(absoluteToChildFrameOwnerLocalTransform),
                 frame.usedZoomForChild(*child),
-                frameView->childFrameOwnerContentBoxLocation(*child),
+                contentBoxLocation,
                 frameView->appearanceOfOwnerElementOfChildFrame(*child)
             ));
         }

--- a/Source/WebCore/page/RemoteFrameLayoutInfo.cpp
+++ b/Source/WebCore/page/RemoteFrameLayoutInfo.cpp
@@ -35,10 +35,10 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteFrameLayoutInfo);
 
 RemoteFrameLayoutInfo::RemoteFrameLayoutInfo(
-    LayoutRect windowClipRectInParent,
     std::optional<LayoutRect> visibleRectInParent,
+    IntRect onScreenRectInChildView,
 #if PLATFORM(IOS_FAMILY)
-    std::optional<LayoutRect> exposedContentRectInParent,
+    FloatRect exposedContentRectInChildView,
 #endif
     bool ownerHasRenderer,
     TransformationMatrix childFrameOwnerToRootContentTransform,
@@ -47,10 +47,10 @@ RemoteFrameLayoutInfo::RemoteFrameLayoutInfo(
     LayoutPoint contentBoxLocation,
     OptionSet<FrameOwnerElementAppearance> ownerElementAppearance
 )
-    : m_windowClipRectInParent(windowClipRectInParent)
-    , m_visibleRectInParent(visibleRectInParent)
+    : m_visibleRectInParent(visibleRectInParent)
+    , m_onScreenRectInChildView(onScreenRectInChildView)
 #if PLATFORM(IOS_FAMILY)
-    , m_exposedContentRectInParent(exposedContentRectInParent)
+    , m_exposedContentRectInChildView(exposedContentRectInChildView)
 #endif
     , m_ownerHasRenderer(ownerHasRenderer)
     , m_childFrameOwnerToRootContentTransform(WTF::move(childFrameOwnerToRootContentTransform))
@@ -59,24 +59,6 @@ RemoteFrameLayoutInfo::RemoteFrameLayoutInfo(
     , m_contentBoxLocation(contentBoxLocation)
     , m_ownerElementAppearance(ownerElementAppearance)
 {
-}
-
-std::optional<FloatRect> RemoteFrameLayoutInfo::mapParentContentsToChildWindow(const LayoutRect& rectInParent) const
-{
-    // A non-affine owner transform (a 3D transform, say) has no meaningful rect inverse, so report
-    // that the rect is unknown.
-    if (!m_absoluteToChildFrameOwnerLocalTransform.isAffine())
-        return std::nullopt;
-
-    // Inverse of LocalFrameView::visibleRectOfChild(): visibleRectInParent is in the parent document's
-    // coordinates. Map it into the iframe owner element's local space, subtract the owner content-box
-    // offset so the rect is relative to the iframe content origin, and undo the owner's used CSS zoom so
-    // the result is in the child frame's unzoomed root-content coordinates (its RenderView space).
-    auto ownerLocal = m_absoluteToChildFrameOwnerLocalTransform.mapRect(FloatRect { rectInParent });
-    ownerLocal.moveBy(-FloatPoint { m_contentBoxLocation });
-    if (m_usedZoom > 0)
-        ownerLocal.scale(1.0f / m_usedZoom);
-    return ownerLocal;
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, FrameOwnerElementAppearance appearance)
@@ -96,10 +78,10 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const RemoteFrameLayoutInfo& in
 {
     WTF::TextStream::GroupScope scope(ts);
     ts << "RemoteFrameLayoutInfo"_s;
-    ts.dumpProperty("windowClipRectInParent"_s, info.windowClipRectInParent());
     ts.dumpProperty("visibleRectInParent"_s, info.visibleRectInParent());
+    ts.dumpProperty("onScreenRectInChildView"_s, info.onScreenRectInChildView());
 #if PLATFORM(IOS_FAMILY)
-    ts.dumpProperty("exposedContentRectInParent"_s, info.exposedContentRectInParent());
+    ts.dumpProperty("exposedContentRectInChildView"_s, info.exposedContentRectInChildView());
 #endif
     ts.dumpProperty("ownerHasRenderer"_s, info.ownerHasRenderer());
     ts.dumpProperty("childFrameOwnerToRootContentTransform"_s, info.childFrameOwnerToRootContentTransform());

--- a/Source/WebCore/page/RemoteFrameLayoutInfo.h
+++ b/Source/WebCore/page/RemoteFrameLayoutInfo.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <WebCore/FloatRect.h>
+#include <WebCore/IntRect.h>
 #include <WebCore/LayoutRect.h>
 #include <WebCore/TransformationMatrix.h>
 #include <wtf/RefCounted.h>
@@ -50,10 +52,10 @@ class RemoteFrameLayoutInfo : public RefCounted<RemoteFrameLayoutInfo> {
 public:
     template<typename... Args> static Ref<RemoteFrameLayoutInfo> create(Args&&... args) { return adoptRef(*new RemoteFrameLayoutInfo(std::forward<Args>(args)...)); }
 
-    LayoutRect windowClipRectInParent() const { return m_windowClipRectInParent; }
     std::optional<LayoutRect> visibleRectInParent() const { return m_visibleRectInParent; }
+    IntRect onScreenRectInChildView() const { return m_onScreenRectInChildView; }
 #if PLATFORM(IOS_FAMILY)
-    std::optional<LayoutRect> exposedContentRectInParent() const { return m_exposedContentRectInParent; }
+    FloatRect exposedContentRectInChildView() const { return m_exposedContentRectInChildView; }
 #endif
     bool ownerHasRenderer() const { return m_ownerHasRenderer; }
     const TransformationMatrix& childFrameOwnerToRootContentTransform() const { return m_childFrameOwnerToRootContentTransform; }
@@ -62,16 +64,12 @@ public:
     LayoutPoint contentBoxLocation() const { return m_contentBoxLocation; }
     OptionSet<FrameOwnerElementAppearance> ownerElementAppearance() const { return m_ownerElementAppearance; }
 
-    // This maps a rect from the parent frame's content coordinate space into this frame's
-    // window space. This may fail and return std::nullopt for non-affine transforms.
-    WEBCORE_EXPORT std::optional<FloatRect> mapParentContentsToChildWindow(const LayoutRect&) const;
-
 private:
     WEBCORE_EXPORT RemoteFrameLayoutInfo(
-        LayoutRect windowClipRectInParent,
         std::optional<LayoutRect> visibleRectInParent,
+        IntRect onScreenRectInChildView,
 #if PLATFORM(IOS_FAMILY)
-        std::optional<LayoutRect> exposedContentRectInParent,
+        FloatRect exposedContentRectInChildView,
 #endif
         bool ownerHasRenderer,
         TransformationMatrix childFrameOwnerToRootContentTransform,
@@ -81,20 +79,19 @@ private:
         OptionSet<FrameOwnerElementAppearance>
     );
 
-    // The parent frame's windowClipRect in the parent's content coordinate space.
-    LayoutRect m_windowClipRectInParent;
-
     // The visible portion of this frame in the parent frame's content coordinate space. This is
     // clipped by the compositor tree but not by the viewport, because IntersectionObserver applies
     // its own viewport clip (layoutViewportRect) at each recursion step.
-    //
-    // To get the part of this frame that is on screen, intersect with windowClipRectInParent.
     std::optional<LayoutRect> m_visibleRectInParent;
 
+    // The portion of this frame that is on screen, in the frame's own view space (i.e.
+    // visibleRectOfChild intersected with windowClipRect mapped to the frame's view space).
+    IntRect m_onScreenRectInChildView;
+
 #if PLATFORM(IOS_FAMILY)
-    // Rectangle of the visible portion of the frame in its parent frame,
-    // in the coordinate space of the document of the parent frame.
-    std::optional<LayoutRect> m_exposedContentRectInParent;
+    // The portion of this frame that should be tiled, in the frame's own view space. Empty means
+    // tile nothing.
+    FloatRect m_exposedContentRectInChildView;
 #endif
 
     // Whether the frame's owner element has a renderer (e.g. not display:none).

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -2499,6 +2499,30 @@ ExceptionOr<Ref<DOMRect>> Internals::visualViewportRect()
     return DOMRect::create(frameView.visualViewportRect());
 }
 
+ExceptionOr<Ref<DOMRect>> Internals::windowClipRect()
+{
+    Document* document = contextDocument();
+    if (!document || !document->view())
+        return Exception { ExceptionCode::InvalidAccessError };
+
+    document->updateLayout(LayoutOptions::IgnorePendingStylesheets);
+
+    auto& frameView = *document->view();
+    return DOMRect::create(frameView.windowClipRect());
+}
+
+ExceptionOr<Ref<DOMRect>> Internals::exposedContentRect()
+{
+    Document* document = contextDocument();
+    if (!document || !document->view())
+        return Exception { ExceptionCode::InvalidAccessError };
+
+    document->updateLayout(LayoutOptions::IgnorePendingStylesheets);
+
+    auto& frameView = *document->view();
+    return DOMRect::create(frameView.exposedContentRect());
+}
+
 ExceptionOr<void> Internals::setViewIsTransparent(bool transparent)
 {
     Document* document = contextDocument();
@@ -2874,6 +2898,15 @@ ExceptionOr<void> Internals::setDelegatesScrolling(bool enabled)
 
     document->view()->setDelegatedScrollingMode(enabled ? DelegatedScrollingMode::DelegatedToNativeScrollView : DelegatedScrollingMode::NotDelegated);
     return { };
+}
+
+ExceptionOr<bool> Internals::delegatesScrollingToNativeView()
+{
+    Document* document = contextDocument();
+    if (!document || !document->view() || !document->page() || &document->page()->mainFrame() != document->frame())
+        return Exception { ExceptionCode::InvalidAccessError };
+
+    return document->view()->delegatesScrollingToNativeView();
 }
 
 ExceptionOr<uint64_t> Internals::lastSpellCheckRequestSequence()

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -412,6 +412,8 @@ public:
 
     ExceptionOr<Ref<DOMRect>> layoutViewportRect();
     ExceptionOr<Ref<DOMRect>> visualViewportRect();
+    ExceptionOr<Ref<DOMRect>> windowClipRect();
+    ExceptionOr<Ref<DOMRect>> exposedContentRect();
 
     ExceptionOr<void> setViewIsTransparent(bool);
 
@@ -472,6 +474,7 @@ public:
     String textFragmentDirectiveForRange(const Range&);
 
     ExceptionOr<void> setDelegatesScrolling(bool enabled);
+    ExceptionOr<bool> delegatesScrollingToNativeView();
 
     ExceptionOr<uint64_t> lastSpellCheckRequestSequence();
     ExceptionOr<uint64_t> lastSpellCheckProcessedSequence();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -639,6 +639,8 @@ enum ContentsFormat {
 
     DOMRect layoutViewportRect();
     DOMRect visualViewportRect();
+    DOMRect windowClipRect();
+    DOMRect exposedContentRect();
 
     undefined setViewIsTransparent(boolean trnasparent);
 
@@ -701,6 +703,7 @@ enum ContentsFormat {
     DOMString textFragmentDirectiveForRange(Range range);
 
     undefined setDelegatesScrolling(boolean enabled);
+    boolean delegatesScrollingToNativeView();
 
     unsigned long long lastSpellCheckRequestSequence();
     unsigned long long lastSpellCheckProcessedSequence();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1340,10 +1340,10 @@ class WebCore::LayoutRect {
 using WebCore::ScrollPosition = WebCore::IntPoint;
 
 [RefCounted] class WebCore::RemoteFrameLayoutInfo {
-    WebCore::LayoutRect windowClipRectInParent();
     std::optional<WebCore::LayoutRect> visibleRectInParent();
+    WebCore::IntRect onScreenRectInChildView();
 #if PLATFORM(IOS_FAMILY)
-    std::optional<WebCore::LayoutRect> exposedContentRectInParent();
+    WebCore::FloatRect exposedContentRectInChildView();
 #endif
     bool ownerHasRenderer();
     WebCore::TransformationMatrix childFrameOwnerToRootContentTransform();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1525,32 +1525,19 @@ void WebPage::updateChildFrameVisibleRectsFromParent(WebCore::Frame& parentCoreF
             needsViewportContentsChanged = true;
         }
 
-        auto visibleRectFromParentFrameProcess = [&]() -> std::optional<IntRect> {
-            // This is the portion of the child frame that is on screen in the parent's content
-            // coordinate space.
-            auto onScreenRectInParent = layoutInfo->visibleRectInParent();
-            if (!onScreenRectInParent) {
-                // Either the owner element has no renderer, or this frame is entirely clipped by an
-                // ancestor in the parent frame process.
-                return IntRect { };
-            }
-            onScreenRectInParent->intersect(layoutInfo->windowClipRectInParent());
-
-            auto onScreenRectInChild = layoutInfo->mapParentContentsToChildWindow(*onScreenRectInParent);
-            if (onScreenRectInChild) {
-                onScreenRectInChild->intersect(FloatRect { { }, childView->size() });
-                return enclosingIntRect(*onScreenRectInChild);
-            }
-
-            // We couldn't map the rect into the child's coordinate space (e.g. non-affine
-            // transform). Return std::nullopt, which will cause LocalFrameView::windowClipRect
-            // to make the conservative assumption that the visibleContentRect is unclipped.
-            return std::nullopt;
-        }();
+        auto visibleRectFromParentFrameProcess = layoutInfo->onScreenRectInChildView();
+        visibleRectFromParentFrameProcess.intersect(IntRect { { }, childView->size() });
 
         if (childView->visibleRectFromParentFrameProcess() != visibleRectFromParentFrameProcess) {
             childView->setVisibleRectFromParentFrameProcess(visibleRectFromParentFrameProcess);
             needsViewportContentsChanged = true;
+
+            // FIXME: if this frame has a remote descendant, then we have to propagate this frame's
+            // windowClipRect to it via Page::syncLocalFrameInfoToRemote(), and that currently only
+            // happens in updateRendering. We should see if we can figure out a more efficient way
+            // of doing this.
+            if (!needsRenderingUpdate && localChild->tree().hasRemoteFrameDescendant())
+                needsRenderingUpdate = true;
         }
 
         if (needsViewportContentsChanged)
@@ -1560,15 +1547,10 @@ void WebPage::updateChildFrameVisibleRectsFromParent(WebCore::Frame& parentCoreF
         // FIXME (320601): this only affects tile coverage on iOS by setting exposedContentRect on
         // this child frame based on the exposedContentRect from the parent frame process. We need
         // to do something similar on macOS (see visibleRectForLayerFlushing).
-        auto exposedContentRectInParent = layoutInfo->exposedContentRectInParent();
-        bool exposedContentRectInParentIsEmpty = !exposedContentRectInParent || exposedContentRectInParent->isEmpty();
-        auto projected = exposedContentRectInParentIsEmpty ? FloatRect { } : layoutInfo->mapParentContentsToChildWindow(*exposedContentRectInParent).value_or(FloatRect { });
-        projected.intersect(FloatRect { { }, childView->size() });
-
-        // The parent frame process thinks this frame is visible, but we think it isn't. Err on the
-        // side of tiling the full view until we get updated geometry from the parent frame process.
-        if (!exposedContentRectInParentIsEmpty && projected.isEmpty())
-            projected = FloatRect { { }, childView->size() };
+        auto fullChildViewRect = FloatRect { { }, childView->size() };
+        auto exposedContentRectInChildView = layoutInfo->exposedContentRectInChildView();
+        auto projected = exposedContentRectInChildView;
+        projected.intersect(fullChildViewRect);
 
         if (childView->exposedContentRect() != projected) {
             childView->setExposedContentRect(projected);


### PR DESCRIPTION
#### bd7861b451f226a255358c8310321eae3e6c88f8
<pre>
[Site Isolation] Change coordinate space for cross-process frame geometry
<a href="https://bugs.webkit.org/show_bug.cgi?id=323375">https://bugs.webkit.org/show_bug.cgi?id=323375</a>
<a href="https://rdar.apple.com/problem/186609673">rdar://problem/186609673</a>

Reviewed by Alex Christensen.

In 318269@main and 319536@main, we introduced new fields in RemoteFrameLayoutInfo in order to fix
the way exposedContentRect (which controls tile coverage) and windowClipRect (which controls various
visibility-based heuristics like hidden frame throttling) work in remote frames.

There are two problems with these fields:

1. windowClipRectInParent is the viewport in the parent frame&apos;s content coordinate space, so it
   changes on every frame when the parent frame scrolls. We don&apos;t want these values to change on
   every frame. Instead, they should only change when necessary (like when the remote frame
   intersects the edges of the viewport). This allows us to make future perf optimizations to avoid
   sending a FrameGeometry IPC if it matches a previously sent value.

2. On the receiver side, we bailed out of mapping the rects into the remote frame&apos;s view space for
   any non-affine transform, causing us to fall back to non-optimal fallback behavior for remote
   frames with 3D transforms (e.g. tiling the entire frame and never throttling it).

To address this, this patch makes it so that on the sender side, Page::syncLocalFrameInfoToRemote
now sends rects in the child frame&apos;s view coordinate space instead of the parent frame&apos;s content
coordinate space. This is accomplished via a new mapAbsoluteToChildFrameViewRect function in
LocalFrameView, which uses projectQuad rather than mapRect so that the non-affine case works.

On the receiver side, we no longer need to map the rect into our own view coordinate space, so we
can just intersect the rects with the frame&apos;s size and use them directly as inputs into the
exposedContentRect and windowClipRect computations.

Most of these paths had very little testing, so I added tests for both exposedContentRect and
windowClipRect which check that these values are correct for both same-site and cross-site iframes.
This needed new internals accessors for both rects, plus delegatesScrollingToNativeView, since
whether a clip rect in window coordinates has had the scroll position taken out of it differs
between macOS and iOS.

Tests: http/tests/site-isolation/ios/exposed-content-rect-3d-transformed.html
       http/tests/site-isolation/ios/exposed-content-rect-nested.html
       http/tests/site-isolation/ios/exposed-content-rect.html
       http/tests/site-isolation/request-animation-frame-throttling-scrolled-out-3d-transformed-cross-origin-iframe.html
       http/tests/site-isolation/request-animation-frame-throttling-scrolled-out-cross-origin-iframe.html
       http/tests/site-isolation/window-clip-rect-3d-transformed.html
       http/tests/site-isolation/window-clip-rect-nested.html
       http/tests/site-isolation/window-clip-rect.html

* LayoutTests/http/tests/site-isolation/ios/exposed-content-rect-3d-transformed-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/ios/exposed-content-rect-3d-transformed.html: Added.
* LayoutTests/http/tests/site-isolation/ios/exposed-content-rect-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/ios/exposed-content-rect-nested-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/ios/exposed-content-rect-nested.html: Added.
* LayoutTests/http/tests/site-isolation/ios/exposed-content-rect.html: Added.
* LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-scrolled-out-3d-transformed-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-scrolled-out-3d-transformed-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-scrolled-out-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/request-animation-frame-throttling-scrolled-out-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/frame-geometry-child-cross-site.html: Added.
* LayoutTests/http/tests/site-isolation/resources/frame-geometry-frame-with-same-site-child.html: Added.
* LayoutTests/http/tests/site-isolation/resources/frame-geometry-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/frame-geometry-grandchild-same-site.html: Added.
* LayoutTests/http/tests/site-isolation/resources/frame-geometry-reporter.js: Added.
* LayoutTests/http/tests/site-isolation/resources/frame-geometry-test.js: Added.
* LayoutTests/http/tests/site-isolation/resources/request-animation-frame-throttling-frame.html:
* LayoutTests/http/tests/site-isolation/window-clip-rect-3d-transformed-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/window-clip-rect-3d-transformed.html: Added.
* LayoutTests/http/tests/site-isolation/window-clip-rect-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/window-clip-rect-nested-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/window-clip-rect-nested.html: Added.
* LayoutTests/http/tests/site-isolation/window-clip-rect.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/page/FrameTree.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::mapAbsoluteToChildFrameViewRect const):
(WebCore::LocalFrameView::mapAbsoluteToChildFrameViewRect):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::syncLocalFrameInfoToRemote):
* Source/WebCore/page/RemoteFrameLayoutInfo.cpp:
(WebCore::RemoteFrameLayoutInfo::RemoteFrameLayoutInfo):
(WebCore::operator&lt;&lt;):
(WebCore::RemoteFrameLayoutInfo::mapParentContentsToChildWindow const): Deleted.
* Source/WebCore/page/RemoteFrameLayoutInfo.h:
(WebCore::RemoteFrameLayoutInfo::onScreenRectInChildView const):
(WebCore::RemoteFrameLayoutInfo::exposedContentRectInChildView const):
(WebCore::RemoteFrameLayoutInfo::windowClipRectInParent const): Deleted.
(WebCore::RemoteFrameLayoutInfo::exposedContentRectInParent const): Deleted.
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::windowClipRect):
(WebCore::Internals::exposedContentRect):
(WebCore::Internals::delegatesScrollingToNativeView):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updateChildFrameVisibleRectsFromParent):

Canonical link: <a href="https://commits.webkit.org/320528@main">https://commits.webkit.org/320528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79cc4bf9b7f3c990c320183b224a254aa13f8e71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185015 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195350 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf7c24fc-9aa8-41df-82e9-8125eaedfd56) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186877 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58661 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ba688970-8e18-4f79-802b-04fcb90315dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187970 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/48264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/124876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a7ab7ebf-32d9-4c81-88ac-9358d43ed2de) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/46991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/44747 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6402 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51596 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197297 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58601 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164683 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154071 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41262 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59311 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41351 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/153728 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48236 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131601 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128241 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57803 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19766 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57163 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57412 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57239 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->