### PR TITLE
GPU process is never reset when GraphicsContextGL creation repeatedly fails, leaving WebGL permanently broken until the browser is quit

### DIFF
--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -819,6 +819,29 @@ void GPUProcess::webProcessConnectionCountForTesting(CompletionHandler<void(uint
     completionHandler(GPUConnectionToWebProcess::objectCountForTesting());
 }
 
+void GPUProcess::setCreatesFailingWebGLContextsForTesting(bool value, CompletionHandler<void()>&& completionHandler)
+{
+    m_createsFailingWebGLContextsForTesting = value;
+    completionHandler();
+}
+
+void GPUProcess::didSucceedGraphicsContextGLCreation()
+{
+    assertIsMainRunLoop();
+    m_consecutiveGraphicsContextGLCreationFailures = 0;
+}
+
+void GPUProcess::didFailGraphicsContextGLCreation()
+{
+    assertIsMainRunLoop();
+    if (++m_consecutiveGraphicsContextGLCreationFailures < maxConsecutiveGraphicsContextGLCreationFailures)
+        return;
+
+    RELEASE_LOG_ERROR(Process, "%p - GPUProcess::didFailGraphicsContextGLCreation: GraphicsContextGL creation failed %u consecutive times, requesting GPU process termination to recover", this, m_consecutiveGraphicsContextGLCreationFailures);
+    m_consecutiveGraphicsContextGLCreationFailures = 0;
+    protect(parentProcessConnection())->send(Messages::GPUProcessProxy::TerminateForGraphicsContextGLFailures(), 0);
+}
+
 void GPUProcess::terminateWebProcess(WebCore::ProcessIdentifier identifier, IPC::MessageName invalidMessageName)
 {
     protect(parentProcessConnection())->send(Messages::GPUProcessProxy::TerminateWebProcess(identifier, invalidMessageName), 0);

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -161,6 +161,12 @@ public:
 
     void webProcessConnectionCountForTesting(CompletionHandler<void(uint64_t)>&&);
 
+    void didSucceedGraphicsContextGLCreation();
+    void didFailGraphicsContextGLCreation();
+
+    void setCreatesFailingWebGLContextsForTesting(bool, CompletionHandler<void()>&&);
+    bool createsFailingWebGLContextsForTesting() const { return m_createsFailingWebGLContextsForTesting; }
+
 #if USE(EXTENSIONKIT)
     void resolveBookmarkDataForCacheDirectory(std::span<const uint8_t> bookmarkData);
 #endif
@@ -345,6 +351,9 @@ private:
     bool m_haveEnabledSWVP9Decoder { false };
 #endif
     bool m_isNowPlayingArbiterActive { false };
+    bool m_createsFailingWebGLContextsForTesting { false };
+    unsigned m_consecutiveGraphicsContextGLCreationFailures { 0 };
+    static constexpr unsigned maxConsecutiveGraphicsContextGLCreationFailures { 3 };
 
 };
 

--- a/Source/WebKit/GPUProcess/GPUProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUProcess.messages.in
@@ -90,6 +90,7 @@ messages -> GPUProcess : AuxiliaryProcess {
     UserPreferredLanguagesChanged(Vector<String> languages)
 
     WebProcessConnectionCountForTesting() -> (uint64_t count)
+    SetCreatesFailingWebGLContextsForTesting(bool value) -> ()
 
 #if USE(EXTENSIONKIT)
     ResolveBookmarkDataForCacheDirectory(std::span<const uint8_t> bookmarkData)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
 
 #include "GPUConnectionToWebProcess.h"
+#include "GPUProcess.h"
 #include "Logging.h"
 #include "RemoteGraphicsContextGLInitializationState.h"
 #include "RemoteGraphicsContextGLMessages.h"
@@ -131,7 +132,8 @@ void RemoteGraphicsContextGL::stopListeningForIPC(Ref<RemoteGraphicsContextGL>&&
 void RemoteGraphicsContextGL::workQueueInitialize(WebCore::GraphicsContextGLAttributes&& attributes)
 {
     assertIsCurrent(workQueue());
-    platformWorkQueueInitialize(WTF::move(attributes));
+    if (!m_createsFailingContextForTesting)
+        platformWorkQueueInitialize(WTF::move(attributes));
     m_connection->open(*this, m_workQueue);
     if (RefPtr context = m_context) {
         context->setClient(this);
@@ -164,6 +166,17 @@ void RemoteGraphicsContextGL::workQueueInitialize(WebCore::GraphicsContextGLAttr
         m_connection->startReceivingMessages(*this, Messages::RemoteGraphicsContextGL::messageReceiverName(), m_identifier.toUInt64());
     } else
         send(Messages::RemoteGraphicsContextGLProxy::WasCreated(std::nullopt));
+
+    bool created = !!m_context;
+    callOnMainRunLoop([weakGPUConnectionToWebProcess = m_gpuConnectionToWebProcess, created] {
+        RefPtr gpuConnectionToWebProcess = weakGPUConnectionToWebProcess.get();
+        if (!gpuConnectionToWebProcess)
+            return;
+        if (created)
+            gpuConnectionToWebProcess->gpuProcess().didSucceedGraphicsContextGLCreation();
+        else
+            gpuConnectionToWebProcess->gpuProcess().didFailGraphicsContextGLCreation();
+    });
 }
 
 void RemoteGraphicsContextGL::workQueueUninitialize()

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -101,6 +101,8 @@ protected:
 
     void workQueueInitialize(WebCore::GraphicsContextGLAttributes&&);
     virtual void platformWorkQueueInitialize(WebCore::GraphicsContextGLAttributes&&) { };
+
+    void setCreatesFailingContextForTesting() { m_createsFailingContextForTesting = true; }
     void workQueueUninitialize();
     template<typename T>
     IPC::Error send(T&& message) const
@@ -182,6 +184,8 @@ protected:
     const RemoteGraphicsContextGLIdentifier m_identifier;
     const Ref<RemoteRenderingBackend> m_renderingBackend;
     const Ref<RemoteSharedResourceCache> m_sharedResourceCache;
+    // Set on the main thread in create() before initialize() dispatches the work-queue task.
+    bool m_createsFailingContextForTesting { false };
 #if ENABLE(VIDEO)
     const Ref<RemoteVideoFrameObjectHeap> m_videoFrameObjectHeap;
 #if PLATFORM(COCOA)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(WEBGL) && PLATFORM(COCOA)
 
 #include "GPUConnectionToWebProcess.h"
+#include "GPUProcess.h"
 #include "IPCUtilities.h"
 #include "RemoteSharedResourceCache.h"
 #include <WebCore/ProcessIdentity.h>
@@ -99,6 +100,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteGraphicsContextGLCocoa);
 Ref<RemoteGraphicsContextGL> RemoteGraphicsContextGL::create(GPUConnectionToWebProcess& gpuConnectionToWebProcess, WebCore::GraphicsContextGLAttributes&& attributes, RemoteGraphicsContextGLIdentifier graphicsContextGLIdentifier, RemoteRenderingBackend& renderingBackend, Ref<IPC::StreamServerConnection>&& streamConnection)
 {
     auto instance = adoptRef(*new RemoteGraphicsContextGLCocoa(gpuConnectionToWebProcess, graphicsContextGLIdentifier, renderingBackend, WTF::move(streamConnection)));
+    if (gpuConnectionToWebProcess.gpuProcess().createsFailingWebGLContextsForTesting())
+        instance->setCreatesFailingContextForTesting();
     instance->initialize(WTF::move(attributes));
     return instance;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -166,6 +166,7 @@ typedef NSVisualEffectView _WKPlatformVisualEffectView;
 
 - (void)_createMediaSessionCoordinatorForTesting:(id <_WKMediaSessionCoordinator>)privateCoordinator completionHandler:(void(^)(BOOL))completionHandler;
 - (void)_gpuToWebProcessConnectionCountForTesting:(void(^)(NSUInteger))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
+- (void)_setGPUProcessCreatesFailingWebGLContextsForTesting:(BOOL)value completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
 - (void)_isLayerTreeFrozenForTesting:(void (^)(BOOL frozen))completionHandler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -875,6 +875,19 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     });
 }
 
+- (void)_setGPUProcessCreatesFailingWebGLContextsForTesting:(BOOL)value completionHandler:(void(^)(void))completionHandler
+{
+    RefPtr gpuProcess = _page->configuration().processPool().gpuProcess();
+    if (!gpuProcess) {
+        completionHandler();
+        return;
+    }
+
+    gpuProcess->setCreatesFailingWebGLContextsForTesting(value, [completionHandler = makeBlockPtr(completionHandler)] {
+        completionHandler();
+    });
+}
+
 - (void)_setConnectedToHardwareConsoleForTesting:(BOOL)connected
 {
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -570,12 +570,12 @@ void GPUProcessProxy::gpuProcessExited(ProcessTerminationReason reason)
     case ProcessTerminationReason::IdleExit:
     case ProcessTerminationReason::Unresponsive:
     case ProcessTerminationReason::Crash:
+    case ProcessTerminationReason::RequestedByGPUProcess:
         RELEASE_LOG_ERROR(Process, "%p - GPUProcessProxy::gpuProcessExited: reason=%" PUBLIC_LOG_STRING, this, processTerminationReasonToString(reason).characters());
         break;
     case ProcessTerminationReason::ExceededProcessCountLimit:
     case ProcessTerminationReason::NavigationSwap:
     case ProcessTerminationReason::RequestedByNetworkProcess:
-    case ProcessTerminationReason::RequestedByGPUProcess:
     case ProcessTerminationReason::RequestedByModelProcess:
     case ProcessTerminationReason::GPUProcessCrashedTooManyTimes:
     case ProcessTerminationReason::ModelProcessCrashedTooManyTimes:
@@ -604,6 +604,13 @@ void GPUProcessProxy::processIsReadyToExit()
     gpuProcessExited(ProcessTerminationReason::IdleExit); // May cause |this| to get deleted.
 }
 
+void GPUProcessProxy::terminateForGraphicsContextGLFailures()
+{
+    RELEASE_LOG_ERROR(Process, "%p - GPUProcessProxy::terminateForGraphicsContextGLFailures: GPU process reported repeated GraphicsContextGL creation failures, terminating it so a fresh one is relaunched on next use", this);
+    terminate();
+    gpuProcessExited(ProcessTerminationReason::RequestedByGPUProcess); // May cause |this| to get deleted.
+}
+
 void GPUProcessProxy::childConnectionDidBecomeUnresponsive()
 {
     RELEASE_LOG_ERROR(Process, "%p - GPUProcessProxy::childConnectionDidBecomeUnresponsive:", this);
@@ -618,6 +625,11 @@ void GPUProcessProxy::terminateForTesting()
 void GPUProcessProxy::webProcessConnectionCountForTesting(CompletionHandler<void(uint64_t)>&& completionHandler)
 {
     sendWithAsyncReply(Messages::GPUProcess::WebProcessConnectionCountForTesting(), WTF::move(completionHandler));
+}
+
+void GPUProcessProxy::setCreatesFailingWebGLContextsForTesting(bool value, CompletionHandler<void()>&& completionHandler)
+{
+    sendWithAsyncReply(Messages::GPUProcess::SetCreatesFailingWebGLContextsForTesting(value), WTF::move(completionHandler));
 }
 
 void GPUProcessProxy::didClose(IPC::Connection&)

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -148,6 +148,7 @@ public:
 
     void terminateForTesting();
     void webProcessConnectionCountForTesting(CompletionHandler<void(uint64_t)>&&);
+    void setCreatesFailingWebGLContextsForTesting(bool, CompletionHandler<void()>&&);
 
 #if PLATFORM(COCOA)
     static void setEnableMetalDebugDeviceInNewGPUProcessesForTesting(bool enable) { s_enableMetalDebugDeviceInNewGPUProcessesForTesting = enable; }
@@ -219,6 +220,7 @@ private:
 
     void terminateWebProcess(WebCore::ProcessIdentifier, IPC::MessageName);
     void processIsReadyToExit();
+    void terminateForGraphicsContextGLFailures();
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     void didCreateContextForVisibilityPropagation(WebPageProxyIdentifier, WebCore::PageIdentifier, LayerHostingContextID);

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
@@ -46,6 +46,7 @@ messages -> GPUProcessProxy {
 #endif
 
     ProcessIsReadyToExit()
+    TerminateForGraphicsContextGLFailures()
     TerminateWebProcess(WebCore::ProcessIdentifier webProcessIdentifier, enum:uint16_t IPC::MessageName invalidMessageName)
 }
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -566,7 +566,11 @@ void WebProcessPool::gpuProcessExited(ProcessID identifier, ProcessTerminationRe
     for (Ref process : processes)
         process->gpuProcessExited(reason);
 
-    if (reason == ProcessTerminationReason::Crash || reason == ProcessTerminationReason::Unresponsive) {
+    // RequestedByGPUProcess here means the GPU process asked to be reset because
+    // GraphicsContextGL creation kept failing. Count it like a crash so that an
+    // environment where creation never succeeds (e.g. a VM with no usable GPU) does
+    // not relaunch the GPU process indefinitely; the shared backstop stops the loop.
+    if (reason == ProcessTerminationReason::Crash || reason == ProcessTerminationReason::Unresponsive || reason == ProcessTerminationReason::RequestedByGPUProcess) {
         if (++m_recentGPUProcessCrashCount > maximumGPUProcessRelaunchAttemptsBeforeKillingWebProcesses) {
             WEBPROCESSPOOL_RELEASE_LOG_ERROR(Process, "gpuProcessDidExit: GPU Process has crashed more than %u times in the last %g seconds, terminating all WebProcesses", maximumGPUProcessRelaunchAttemptsBeforeKillingWebProcesses, resetGPUProcessCrashCountDelay.seconds());
             m_resetGPUProcessCrashCountTimer.stop();

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -156,6 +156,7 @@ Tests/WebKit/WKWebView/FullscreenRemoveNodeBeforeEnter.mm @nonARC
 Tests/WebKit/WKWebView/FullscreenScrollAndResize.mm @nonARC
 Tests/WebKit/WKWebView/FullscreenVideoTextRecognition.mm @nonARC
 Tests/WebKit/WKWebView/GPUProcess.mm @nonARC
+Tests/WebKit/WKWebView/GPUProcessWebGLRecovery.mm @nonARC
 Tests/WebKit/WKWebView/Geolocation.mm @nonARC
 Tests/WebKit/WKWebView/GetComputedStyleAfterIframeRemoval.mm @nonARC
 Tests/WebKit/WKWebView/GetDisplayMedia.mm @nonARC

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GPUProcessWebGLRecovery.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GPUProcessWebGLRecovery.mm
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "Helpers/PlatformUtilities.h"
+#import "Helpers/cocoa/TestNavigationDelegate.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKPreferencesRefPrivate.h>
+#import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKString.h>
+#import <WebKit/WKWebViewConfiguration.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebViewPrivateForTesting.h>
+#import <wtf/RetainPtr.h>
+
+namespace TestWebKitAPI {
+
+// Without the fix the retry loop never gets a working context and the GPU process PID
+// never changes, so both expectations below FAIL. With the fix the GPU process is reset
+// after repeated creation failures, a fresh one serves a working context, and both PASS.
+
+static void enableWebGLInGPUProcess(WKWebViewConfiguration *configuration)
+{
+    WKPreferencesRef preferences = (__bridge WKPreferencesRef)[configuration preferences];
+    WKPreferencesSetBoolValueForKeyForTesting(preferences, true, WKStringCreateWithUTF8CString("UseGPUProcessForCanvasRenderingEnabled"));
+    WKPreferencesSetBoolValueForKeyForTesting(preferences, true, WKStringCreateWithUTF8CString("UseGPUProcessForWebGLEnabled"));
+}
+
+// Returns true if a WebGL context that actually works (not lost, no GL error) can be
+// obtained. Retries for a few seconds because recovery involves an asynchronous GPU
+// process termination + relaunch. Uses setTimeout (not requestAnimationFrame) so it
+// makes progress even in an off-window test WebView.
+static NSString *retryUntilWorkingWebGLContextJS()
+{
+    return @"const sleep = ms => new Promise(r => setTimeout(r, ms));"
+        "for (let i = 0; i < 80; ++i) {"
+        "    const c = document.createElement('canvas');"
+        "    c.width = 64; c.height = 64;"
+        "    const gl = c.getContext('webgl');"
+        "    if (gl) {"
+        "        await sleep(50);" // Let an async creation failure surface as context loss.
+        "        if (!gl.isContextLost()) {"
+        "            gl.clear(gl.COLOR_BUFFER_BIT);"
+        "            if (gl.getError() === 0 && !gl.isContextLost())"
+        "                return true;"
+        "        }"
+        "    }"
+        "    await sleep(50);"
+        "}"
+        "return false;";
+}
+
+TEST(GPUProcess, WebGLRecoversWhenContextCreationKeepsFailing)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    enableWebGLInGPUProcess(configuration.get());
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get()]);
+    [webView synchronouslyLoadHTMLString:@"<html><body></body></html>"];
+
+    // Bring up a healthy GPU process by creating one working WebGL context.
+    __block bool done = false;
+    [webView callAsyncJavaScript:@"const c = document.createElement('canvas'); c.width = 64; c.height = 64; return !!c.getContext('webgl');" arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
+        EXPECT_TRUE(!error);
+        EXPECT_TRUE([result boolValue]);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    auto *processPool = configuration.get().processPool;
+    unsigned timeout = 0;
+    while (![processPool _gpuProcessIdentifier] && timeout++ < 100)
+        TestWebKitAPI::Util::runFor(0.1_s);
+
+    auto initialGPUProcessPID = [processPool _gpuProcessIdentifier];
+    EXPECT_NE(initialGPUProcessPID, 0);
+    if (!initialGPUProcessPID)
+        return;
+
+    // Arm the GPU process so every subsequent GraphicsContextGL comes up with a null backend.
+    done = false;
+    [webView _setGPUProcessCreatesFailingWebGLContextsForTesting:YES completionHandler:^{
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    // Keep trying to obtain a working WebGL context. Without the recovery fix this never
+    // succeeds; with the fix the poisoned GPU process is reset and a fresh one serves a
+    // working context.
+    __block bool gotContext = false;
+    done = false;
+    [webView callAsyncJavaScript:retryUntilWorkingWebGLContextJS() arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
+        EXPECT_TRUE(!error);
+        gotContext = [result boolValue];
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    EXPECT_TRUE(gotContext);
+
+    // Recovery must have replaced the poisoned GPU process with a fresh one.
+    EXPECT_NE([processPool _gpuProcessIdentifier], 0);
+    EXPECT_NE([processPool _gpuProcessIdentifier], initialGPUProcessPID);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### dbcb371805938f8cfc84540f4c858691e984b38f
<pre>
GPU process is never reset when GraphicsContextGL creation repeatedly fails, leaving WebGL permanently broken until the browser is quit
<a href="https://bugs.webkit.org/show_bug.cgi?id=323385">https://bugs.webkit.org/show_bug.cgi?id=323385</a>
<a href="https://rdar.apple.com/186615404">rdar://186615404</a>

Reviewed by NOBODY (OOPS!).

When a GraphicsContextGL backend cannot be created in the GPU process,
RemoteGraphicsContextGL::workQueueInitialize sends WasCreated(std::nullopt)
and RemoteGraphicsContextGLProxy just marks that one context lost. Nothing
counts these failures or recovers the process. The only existing recovery
triggers are a GPU process crash (didClose) and IPC unresponsiveness
(didBecomeUnresponsive); a GPU process that is alive and IPC-responsive but
whose GL backend can no longer create contexts is never reset. As a result
every subsequent WebGL context is dead-on-arrival across reloads until the
browser is quit and relaunched.

Recover by tracking consecutive GraphicsContextGL creation failures in the
GPU process. workQueueInitialize now reports each outcome to GPUProcess on the
main thread; a success resets the counter and, once creation fails
maxConsecutiveGraphicsContextGLCreationFailures (3) times in a row, GPUProcess
asks the UIProcess to terminate it via
GPUProcessProxy::TerminateForGraphicsContextGLFailures(). That reuses the
existing teardown path (terminate() + gpuProcessExited(RequestedByGPUProcess)),
so a fresh GPU process is relaunched on next use. RequestedByGPUProcess is
moved out of the ASSERT_NOT_REACHED bucket in gpuProcessExited() since it is
now a legitimate exit reason.

To avoid relaunching the GPU process indefinitely in an environment where
GraphicsContextGL creation never succeeds (e.g. a VM with no usable GPU),
WebProcessPool::gpuProcessExited counts a RequestedByGPUProcess exit toward the
existing recent-crash counter, so the shared backstop
(maximumGPUProcessRelaunchAttemptsBeforeKillingWebProcesses within
resetGPUProcessCrashCountDelay) stops the loop. The per-process failure counter
resets on relaunch, so this cross-process bound is what actually terminates a
persistent failure loop.

Adds a testing-only injection hook
(-[WKWebView _setGPUProcessCreatesFailingWebGLContextsForTesting:completionHandler:])
that arms workQueueInitialize to skip creating the platform backend, so the
failing-backend condition can be reproduced deterministically, and an API test
asserting the GPU process is replaced and a working WebGL context is regained.

* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::setCreatesFailingWebGLContextsForTesting):
(WebKit::GPUProcess::didSucceedGraphicsContextGLCreation):
(WebKit::GPUProcess::didFailGraphicsContextGLCreation):
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::workQueueInitialize):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
(WebKit::RemoteGraphicsContextGL::setCreatesFailingContextForTesting):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp:
(WebKit::RemoteGraphicsContextGL::create):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _setGPUProcessCreatesFailingWebGLContextsForTesting:completionHandler:]):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::gpuProcessExited):
(WebKit::GPUProcessProxy::terminateForGraphicsContextGLFailures):
(WebKit::GPUProcessProxy::setCreatesFailingWebGLContextsForTesting):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::gpuProcessExited):
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/GPUProcessWebGLRecovery.mm: Added.
(TestWebKitAPI::enableWebGLInGPUProcess):
(TestWebKitAPI::retryUntilWorkingWebGLContextJS):
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbcb371805938f8cfc84540f4c858691e984b38f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195378 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/149966 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186908 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58691 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144606 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100323 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165198 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124892 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47011 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45084 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157380 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44768 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6433 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51626 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197328 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58630 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154098 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59341 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153755 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48256 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131632 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128271 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57828 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19787 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57191 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57441 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57265 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->