### PR TITLE
WebDriver reports "stale element reference" for a node reference from a different browsing context

### DIFF
--- a/Source/WebDriver/CommandResult.cpp
+++ b/Source/WebDriver/CommandResult.cpp
@@ -97,6 +97,8 @@ CommandResult::CommandResult(RefPtr<JSON::Value>&& result, std::optional<ErrorCo
         else if (errorName == "JavaScriptTimeout"_s)
             m_errorCode = ErrorCode::ScriptTimeout;
         else if (errorName == "NodeNotFound"_s)
+            m_errorCode = ErrorCode::NoSuchElement;
+        else if (errorName == "StaleNode"_s)
             m_errorCode = ErrorCode::StaleElementReference;
         else if (errorName == "InvalidNodeIdentifier"_s)
             m_errorCode = ErrorCode::NoSuchElement;

--- a/Source/WebKit/UIProcess/Automation/Automation.json
+++ b/Source/WebKit/UIProcess/Automation/Automation.json
@@ -72,6 +72,7 @@
                 "WindowNotFound",
                 "FrameNotFound",
                 "NodeNotFound",
+                "StaleNode",
                 "InvalidNodeIdentifier",
                 "InvalidElementState",
                 "NoJavaScriptDialog",

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -250,6 +250,8 @@ static JSValueRef evaluateJavaScriptCallback(JSContextRef context, JSObjectRef f
             errorType = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::JavaScriptTimeout);
         else if (exceptionName == "NodeNotFound"_s)
             errorType = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::NodeNotFound);
+        else if (exceptionName == "StaleNode"_s)
+            errorType = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::StaleNode);
         else if (exceptionName == "InvalidNodeIdentifier"_s)
             errorType = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::InvalidNodeIdentifier);
         else if (exceptionName == "InvalidElementState"_s)

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.js
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.js
@@ -35,6 +35,7 @@ let AutomationSessionProxy = class AutomationSessionProxy
     {
         this._nodeToIdMap = new Map;
         this._idToNodeMap = new Map;
+        this._staleIdentifiers = new Set;
     }
 
     // Public
@@ -300,6 +301,11 @@ let AutomationSessionProxy = class AutomationSessionProxy
         let node = this._idToNodeMap.get(identifier);
         if (node)
             return node;
+
+        // A node this frame knew about and then evicted is stale. One it never knew about
+        // belongs to a different browsing context, which callers must distinguish.
+        if (this._staleIdentifiers.has(identifier))
+            throw {name: "StaleNode", message: "Node with identifier '" + identifier + "' is stale"};
         throw {name: "NodeNotFound", message: "Node with identifier '" + identifier + "' was not found"};
     }
 
@@ -324,6 +330,7 @@ let AutomationSessionProxy = class AutomationSessionProxy
             if (rootNode !== document) {
                 this._nodeToIdMap.delete(node);
                 this._idToNodeMap.delete(identifier);
+                this._staleIdentifiers.add(identifier);
             }
         }
     }


### PR DESCRIPTION
#### f56eb24b31957067cad7f5fec90ee8f8f486f090
<pre>
WebDriver reports &quot;stale element reference&quot; for a node reference from a different browsing context
<a href="https://bugs.webkit.org/show_bug.cgi?id=323386">https://bugs.webkit.org/show_bug.cgi?id=323386</a>
<a href="https://rdar.apple.com/186615759">rdar://186615759</a>

Reviewed by Tim Nguyen.

Each frame&apos;s injected WebAutomationSessionProxy.js keeps its own map of node handles.
_nodeForIdentifier() throws NodeNotFound whenever a handle is absent from that map, which
conflates two different situations:
(1) the node was in this frame and has since been detached (a stale handle)
(2) the node was never in this frame, because it belongs to a different frame or window

CommandResult.cpp maps NodeNotFound to StaleElementReference, so both report stale element
reference. Per the spec, the second case is no such element (or no such shadow root for a
shadow root reference).

_clearStaleNodes() already knows the difference: it evicts only those handles whose node
is no longer rooted in this document. Recording what it evicts lets _nodeForIdentifier()
throw a distinct StaleNode error for the detached case and keep NodeNotFound for the
foreign one.

Tests: webdriver/tests/classic/execute_script/arguments.py
       webdriver/tests/classic/execute_async_script/arguments.py

* Source/WebDriver/CommandResult.cpp:
(WebDriver::CommandResult::CommandResult):
* Source/WebKit/UIProcess/Automation/Automation.json:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::evaluateJavaScriptCallback):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.js:
(let.AutomationSessionProxy):
(let.AutomationSessionProxy.prototype._nodeForIdentifier):
(let.AutomationSessionProxy.prototype._clearStaleNodes):

Canonical link: <a href="https://commits.webkit.org/320518@main">https://commits.webkit.org/320518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24c8a9db4f661cee481977f1fed31608b2d2cf31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184863 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52612 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195198 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1b4f94de-a712-49e5-9050-19f59246b5c0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58510 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144462 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48132 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165059 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124750 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0926de3c-0937-4941-aaea-c7456fcc1df2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46857 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44956 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157227 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44621 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6253 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197147 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58452 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153938 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41254 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59157 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153595 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48117 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131445 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128019 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57654 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19639 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57013 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57264 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57090 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->