### PR TITLE
[iOS] Wireless playback causes a RemoteMediaSessionHelperProxy to be created too eagerly

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/route-activates-before-session-is-now-playing-eligible-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/route-activates-before-session-is-now-playing-eligible-expected.txt
@@ -1,0 +1,12 @@
+Test that a MediaDeviceRoute which activates while no session is eligible to be the Now Playing session is applied to a session that becomes eligible later.
+
+
+EVENT(canplaythrough)
+RUN(video.play())
+EVENT(playing)
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.muted = false)
+EVENT(webkitcurrentplaybacktargetiswirelesschanged)
+EXPECTED (video.webkitCurrentPlaybackTargetIsWireless == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/route-activates-before-session-is-now-playing-eligible.html
+++ b/LayoutTests/media/wireless-playback-media-player/route-activates-before-session-is-now-playing-eligible.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                video = document.createElement('video');
+                video.muted = true;
+                video.src = findMediaFile('video', '../content/test');
+                document.body.appendChild(video);
+
+                await waitFor(video, 'canplaythrough');
+
+                run(`video.play()`);
+                await waitFor(video, 'playing');
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                run(`video.muted = false`);
+                await waitFor(video, 'webkitcurrentplaybacktargetiswirelesschanged');
+
+                testExpected('video.webkitCurrentPlaybackTargetIsWireless', true);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <p>Test that a MediaDeviceRoute which activates while no session is eligible to be the Now Playing
+        session is applied to a session that becomes eligible later.</p>
+    </body>
+</html>

--- a/LayoutTests/platform/ios/media/media-element-does-not-eagerly-create-media-session-helper-expected.txt
+++ b/LayoutTests/platform/ios/media/media-element-does-not-eagerly-create-media-session-helper-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A media element creates the GPU process MediaSessionHelper when it can produce audio, not when it is created
+

--- a/LayoutTests/platform/ios/media/media-element-does-not-eagerly-create-media-session-helper.html
+++ b/LayoutTests/platform/ios/media/media-element-does-not-eagerly-create-media-session-helper.html
@@ -1,0 +1,47 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true UseGPUProcessForMediaEnabled=true ] -->
+<!DOCTYPE html>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../media/media-file.js"></script>
+<body>
+<script>
+
+let ensureMediaSessionHelperCount = 0;
+
+if (window.IPC) {
+    IPC.addOutgoingMessageListener("GPU", message => {
+        if (message.description === "GPUConnectionToWebProcess_EnsureMediaSessionHelper")
+            ensureMediaSessionHelperCount++;
+    });
+}
+
+async function settle()
+{
+    await new Promise(resolve => requestAnimationFrame(resolve));
+    await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+promise_test(async () => {
+    if (!window.IPC)
+        return;
+
+    const video = document.createElement("video");
+    document.body.appendChild(video);
+    await settle();
+
+    assert_equals(ensureMediaSessionHelperCount, 0,
+        "a media element that cannot produce audio should not create the GPU process MediaSessionHelper");
+
+    const loadedMetadata = new Promise(resolve => video.addEventListener("loadedmetadata", resolve, { once: true }));
+    video.src = findMediaFile("video", "../../../media/content/test");
+    await loadedMetadata;
+    await settle();
+
+    assert_equals(ensureMediaSessionHelperCount, 1,
+        "a media element that can produce audio should create the GPU process MediaSessionHelper");
+
+    video.remove();
+}, "A media element creates the GPU process MediaSessionHelper when it can produce audio, not when it is created");
+
+</script>
+</body>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -10862,6 +10862,13 @@ void HTMLMediaElement::canProduceAudioChanged()
     m_cachedCanProduceAudio.store(computeCanProduceAudio(), std::memory_order_relaxed);
     protect(mediaSession())->canProduceAudioChanged();
     updateSleepDisabling();
+
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+    if (canProduceAudio()) {
+        if (RefPtr manager = sessionManager())
+            manager->ensureMediaDeviceRouteControllerMonitoring();
+    }
+#endif
 }
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -199,10 +199,6 @@ MediaElementSession::MediaElementSession(HTMLMediaElement& element)
     , m_mainContentCheckTimer(*this, &MediaElementSession::mainContentCheckTimerFired)
     , m_clientDataBufferingTimer(*this, &MediaElementSession::clientDataBufferingTimerFired)
 {
-#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
-    if (RefPtr manager = sessionManager())
-        manager->ensureMediaDeviceRouteControllerMonitoring();
-#endif
 }
 
 MediaElementSession::~MediaElementSession()

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -82,6 +82,7 @@ protected:
     void setNowPlayingUpdateInterval(double) final;
     double nowPlayingUpdateInterval() final;
     void updateActiveNowPlayingSession(RefPtr<PlatformMediaSessionInterface>);
+    virtual void activeNowPlayingSessionChanged(PlatformMediaSessionInterface*);
     bool shouldUpdateNowPlaying(const NowPlayingInfo&);
 
     void removeSession(PlatformMediaSessionInterface&) override;

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -518,10 +518,15 @@ void MediaSessionManagerCocoa::updateActiveNowPlayingSession(RefPtr<PlatformMedi
     });
 
     if (activeSessionChanged) {
-        client().hasActiveNowPlayingSessionChanged(activeNowPlayingSession.get());
+        activeNowPlayingSessionChanged(activeNowPlayingSession.get());
 
         adjustNowPlayingUpdateInterval();
     }
+}
+
+void MediaSessionManagerCocoa::activeNowPlayingSessionChanged(PlatformMediaSessionInterface* session)
+{
+    client().hasActiveNowPlayingSessionChanged(session);
 }
 
 bool MediaSessionManagerCocoa::shouldUpdateNowPlaying(const NowPlayingInfo& nowPlayingInfo)

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -73,6 +73,8 @@ protected:
     void sessionDidCompleteAdmission(PlatformMediaSessionInterface&) override;
 
 private:
+    void applyActiveVideoRouteToSession(PlatformMediaSessionInterface&);
+    void activeNowPlayingSessionChanged(PlatformMediaSessionInterface*) final;
     void configureWirelessTargetMonitoring() final;
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
     void ensureMediaDeviceRouteControllerMonitoring() final;

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -31,7 +31,9 @@
 #import "Logging.h"
 #import "MediaPlaybackTargetCocoa.h"
 #import "MediaPlayer.h"
+#import "MediaStrategy.h"
 #import "PlatformMediaSession.h"
+#import "PlatformStrategies.h"
 #import "SystemMemory.h"
 #import "WebCoreThreadRun.h"
 #import <wtf/MainThread.h>
@@ -102,10 +104,6 @@ bool MediaSessionManageriOS::isMonitoringWirelessTargets() const
 
 void MediaSessionManageriOS::configureWirelessTargetMonitoring()
 {
-#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
-    ensureMediaDeviceRouteControllerMonitoring();
-#endif
-
 #if !PLATFORM(WATCHOS)
     bool requiresMonitoring = anyOfSessions([] (auto& session) {
         return session.requiresPlaybackTargetRouteMonitoring();
@@ -128,19 +126,35 @@ void MediaSessionManageriOS::configureWirelessTargetMonitoring()
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
 void MediaSessionManageriOS::ensureMediaDeviceRouteControllerMonitoring()
 {
+    if (!hasPlatformStrategies() || !platformStrategies()->mediaStrategy()->wirelessPlaybackMediaPlayerEnabled())
+        return;
+
     protect(MediaSessionHelper::sharedHelper())->ensureMediaDeviceRouteControllerMonitoring();
 }
 #endif
 
-void MediaSessionManageriOS::sessionDidCompleteAdmission(PlatformMediaSessionInterface& session)
+void MediaSessionManageriOS::applyActiveVideoRouteToSession(PlatformMediaSessionInterface& session)
 {
-    MediaSessionManagerCocoa::sessionDidCompleteAdmission(session);
-
     auto playbackTargetSupportsAirPlayVideo = MediaSessionHelper::sharedHelper().activeVideoRouteSupportsAirPlayVideo();
     ALWAYS_LOG(LOGIDENTIFIER, "Playback Target Supports AirPlay Video = ", playbackTargetSupportsAirPlayVideo);
     if (RefPtr target = MediaSessionHelper::sharedHelper().playbackTarget(); target && playbackTargetSupportsAirPlayVideo)
         session.setPlaybackTarget(*target);
     session.setShouldPlayToPlaybackTarget(playbackTargetSupportsAirPlayVideo);
+}
+
+void MediaSessionManageriOS::sessionDidCompleteAdmission(PlatformMediaSessionInterface& session)
+{
+    MediaSessionManagerCocoa::sessionDidCompleteAdmission(session);
+
+    applyActiveVideoRouteToSession(session);
+}
+
+void MediaSessionManageriOS::activeNowPlayingSessionChanged(PlatformMediaSessionInterface* session)
+{
+    MediaSessionManagerCocoa::activeNowPlayingSessionChanged(session);
+
+    if (session)
+        applyActiveVideoRouteToSession(*session);
 }
 
 void MediaSessionManageriOS::sessionWillEndPlayback(PlatformMediaSessionInterface& session, DelayCallingUpdateNowPlaying delayCallingUpdateNowPlaying)


### PR DESCRIPTION
#### d6d0989dd597c8d1aa6efac8f774e1354797425b
<pre>
[iOS] Wireless playback causes a RemoteMediaSessionHelperProxy to be created too eagerly
<a href="https://bugs.webkit.org/show_bug.cgi?id=323389">https://bugs.webkit.org/show_bug.cgi?id=323389</a>
<a href="https://rdar.apple.com/184536781">rdar://184536781</a>

Reviewed by Jer Noble.

317764@main made it so a RemoteMediaSessionHelperProxy is created as soon as the first
MediaElementSession is instantiated, but this was too eager, since it unnecessarily creates a
MediaSessionHelper in cases where a media element never loads a resource or never plays audibly.
This is unnecessary since wireless playback is not possible prior to the element playing audibly.

Fixed by moving the ensureMediaDeviceRouteControllerMonitoring call to
HTMLMediaElement::canProduceAudioChanged, but this exposed a bug where the lazy creation of
MediaSessionHelper may cause a wireless route to be delivered after
MediaSessionManager::sessionDidCompleteAdmission is called. If that happens the media element is
never notified of the route and playback continues locally.

Resolved this second issue by moving the route delivery code in
MediaSessionManageriOS::sessionDidCompleteAdmission to a new function
(applyActiveVideoRouteToSession) and calling that in
MediaSessionManagerCocoa::updateActiveNowPlayingSession when the Now Playing session changes.

Test: platform/ios/media/media-element-does-not-eagerly-create-media-session-helper.html

* LayoutTests/media/wireless-playback-media-player/route-activates-before-session-is-now-playing-eligible-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/route-activates-before-session-is-now-playing-eligible.html: Added.
* LayoutTests/platform/ios/media/media-element-does-not-eagerly-create-media-session-helper-expected.txt: Added.
* LayoutTests/platform/ios/media/media-element-does-not-eagerly-create-media-session-helper.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::canProduceAudioChanged):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::MediaElementSession):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateActiveNowPlayingSession):
(WebCore::MediaSessionManagerCocoa::activeNowPlayingSessionChanged):
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm:
(WebCore::MediaSessionManageriOS::configureWirelessTargetMonitoring):
(WebCore::MediaSessionManageriOS::ensureMediaDeviceRouteControllerMonitoring):
(WebCore::MediaSessionManageriOS::applyActiveVideoRouteToSession):
(WebCore::MediaSessionManageriOS::sessionDidCompleteAdmission):
(WebCore::MediaSessionManageriOS::activeNowPlayingSessionChanged):

Canonical link: <a href="https://commits.webkit.org/320748@main">https://commits.webkit.org/320748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1a245088ad19462c6722b52679b911f09ab201a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196115 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/86548042-ce83-4c9d-a083-3fbd81d332f9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187672 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59441 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145201 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/38790b5d-0b6f-4a03-84bb-09fcac08bc77) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125502 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8593f8ba-9e21-4170-89bb-cba128be4103) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47613 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157973 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45343 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7180 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52344 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198083 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59375 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165279 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154755 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41436 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60084 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154399 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48855 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129422 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58550 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20366 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57928 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58163 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57993 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->