### PR TITLE
[EWS] Each results-database test step carries its own copy of the shared reporting behaviour

### DIFF
--- a/Tools/CISupport/ews-build/results_db.py
+++ b/Tools/CISupport/ews-build/results_db.py
@@ -97,6 +97,7 @@ class EWSRowDetails:
 @dataclass
 class EWSRow:
     """One row the results database has recorded for one test in one configuration."""
+    test: str = ''
     uuid: int = 0
     start_time: int = 0
     # Whatever the suite that ran the test reports, which differs per suite.
@@ -105,8 +106,9 @@ class EWSRow:
     details: EWSRowDetails = field(default_factory=EWSRowDetails)
 
     @classmethod
-    def from_json(cls, data: dict) -> 'EWSRow':
+    def from_json(cls, data: dict, test: str = '') -> 'EWSRow':
         return cls(
+            test=test,
             uuid=data.get('uuid') or 0,
             start_time=data.get('start_time') or 0,
             result=data.get('result') or {},
@@ -408,24 +410,24 @@ class ResultsDatabase(object):
             bucket.setdefault(flaky_type, []).append(row)
 
         for flaky_type, dropped in sorted(same_pull_request.items()):
-            logger(f"Ignored {len(dropped)} {flaky_type} row(s) recorded by this change's own pull request (#{curr_pr})\n")
+            logger(f"{dropped[0].test}: Ignored {len(dropped)} {flaky_type} row(s) recorded by this change's own pull request (#{curr_pr})\n")
         for flaky_type, dropped in sorted(same_authors.items()):
-            logger(f"Ignored {len(dropped)} {flaky_type} row(s) recorded by this change's own author(s)\n")
+            logger(f"{dropped[0].test}: Ignored {len(dropped)} {flaky_type} row(s) recorded by this change's own author(s)\n")
         return by_type
 
     @classmethod
     def _is_intra_build_flake(cls, rows: EWSRowByType, logger: Callable[[str], None]) -> Optional[FlakyVerdict]:
         if failed_with_no_flaky_type := rows.get(cls.FAILED_ROWS, []):
-            logger(f'Ignored {len(failed_with_no_flaky_type)} flake row(s) that carried no flaky_type\n')
+            logger(f'{failed_with_no_flaky_type[0].test}: Ignored {len(failed_with_no_flaky_type)} flake row(s) that carried no flaky_type\n')
         if unrecognized := {name for name in rows if name not in cls.WITHIN_BUILD_ROWS and name != cls.FAILED_ROWS}:
-            logger(f"Ignored flakiness recorded as {', '.join(sorted(unrecognized))}\n")
+            logger(f"{rows[next(iter(unrecognized))][0].test}: Ignored flakiness recorded as {', '.join(sorted(unrecognized))}\n")
 
         if clean_tree := rows.get(cls.WITHIN_STEP_CLEAN_TREE, []):
             evidence = cls._evidence_in(clean_tree)
             if verdict := cls._convict(evidence, cls.CLEAN_TREE_VERDICT, builds_needed=cls.BUILDS_FOR_CLEAN_TREE_FLAKE):
                 return verdict
             logger(
-                f'{len(clean_tree)} clean-tree row(s) come from {len(evidence.build_urls)} build(s), '
+                f'{clean_tree[0].test}: {len(clean_tree)} clean-tree row(s) come from {len(evidence.build_urls)} build(s), '
                 f'fewer than the {cls.BUILDS_FOR_CLEAN_TREE_FLAKE} the clean-tree rule needs\n'
             )
 
@@ -450,7 +452,7 @@ class ResultsDatabase(object):
         rows_without_an_author = sum(1 for row in failed if not row.details.authors)
         if rows_without_an_author and len(evidence.authors) < cls.AUTHORS_FOR_BETWEEN_BUILD_FLAKE:
             logger(
-                f'{rows_without_an_author} row(s) record no author, so the between-builds rule saw '
+                f'{failed[0].test}: {rows_without_an_author} row(s) record no author, so the between-builds rule saw '
                 f'{len(evidence.authors)} of the {cls.AUTHORS_FOR_BETWEEN_BUILD_FLAKE} it needs '
                 f'across {len(evidence.pr_numbers)} pull request(s)\n'
             )
@@ -510,7 +512,7 @@ class ResultsDatabase(object):
                 return None
 
             for entry in entries:
-                rows = [EWSRow.from_json(row) for row in (entry.get('results') or [])]
+                rows = [EWSRow.from_json(row, test=entry['test']) for row in (entry.get('results') or [])]
                 by_test.setdefault(entry['test'], []).extend(rows)
 
         return by_test

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -576,6 +576,7 @@ class ResultsDBReportMixin(abc.ABC):
         ResultsDatabase.BETWEEN_BUILDS_VERDICT,
     })
     MAX_FAILURES_TO_CHECK_RESULTS_DB = 50
+    NUM_FAILURES_TO_DISPLAY = 10
     prefix = ''
 
     # From Tools/Scripts/libraries/resultsdbpy/resultsdbpy/controller/configuration.py
@@ -619,6 +620,17 @@ class ResultsDBReportMixin(abc.ABC):
             authors=[author for author in authors if author],
             build_url=f'{self.master.config.buildbotURL}#/builders/{self.build._builderid}/builds/{self.build.number}',
         )
+
+    @defer.inlineCallbacks
+    def resolve_identifier_for_results_db(self, configuration: dict, has_failures: bool) -> Generator[Any, Any, tuple]:
+        identifier = self.getProperty('identifier', None)
+        yield self._addToLog(self.results_db_log_name, f'Checking Results database for failing tests. Identifier: {identifier}, configuration: {configuration}\n')
+        has_commit = False
+        if has_failures and identifier:
+            has_commit = yield ResultsDatabase.has_commit(commit=identifier)
+            if not has_commit:
+                yield self._addToLog(self.results_db_log_name, f"'{identifier}' could not be found on the results database, falling back to tip-of-tree\n")
+        defer.returnValue((identifier, has_commit))
 
     def merged_results(self, test_filter, runs):
         """
@@ -701,18 +713,27 @@ class ResultsDBReportMixin(abc.ABC):
 
     def results_db_ignore_message(self) -> str:
         parts = []
-        if self.preexisting_failures_in_results_db:
-            parts.append(f"pre-existing failures: {', '.join(self.preexisting_failures_in_results_db)}")
-        if self.flaky_failures_in_results_db:
-            parts.append(f"flaky tests: {', '.join(sorted(self.flaky_failures_in_results_db))}")
-        return f"Ignored {'; '.join(parts)} based on results-db"
+        if self.pre_existing_failures_in_results_db:
+            parts.append(f"Ignored pre-existing failures: {', '.join(self.pre_existing_failures_in_results_db)}")
+        if self.pre_existing_flakes_in_results_db:
+            parts.append(f"Ignored pre-existing flakes: {', '.join(sorted(self.pre_existing_flakes_in_results_db))}")
+        return '\n'.join(parts)
+
+    def results_db_ignore_counts_message(self) -> str:
+        counts = []
+        if self.pre_existing_failures_in_results_db:
+            counts.append(f'{len(self.pre_existing_failures_in_results_db)} pre-existing')
+        if self.pre_existing_flakes_in_results_db:
+            counts.append(f'{len(self.pre_existing_flakes_in_results_db)} flaky')
+        return f"Ignored {' and '.join(counts)} failure(s)"
 
     @defer.inlineCallbacks
-    def flaky_new_failures_using_results_db(self, new_failures: set[str]) -> Generator[Any, Any, set[str]]:
+    def pre_existing_flakes_using_results_db(self, new_failures: set[str]) -> Generator[Any, Any, set[str]]:
         """
         The subset of `new_failures` whose results-database verdict is in INCLUDED_FLAKY_VERDICTS.
         Only the first MAX_FAILURES_TO_CHECK_RESULTS_DB names, sorted, are queried; the rest are
-        absent from the result rather than reported as unexcused.
+        absent from the result rather than reported as unexcused. Every verdict seen is recorded on
+        the step and in the results-db_<prefix>flaky, _flaky_unsupported and _flaky_unknown properties.
         """
         tests = sorted(new_failures)[:self.MAX_FAILURES_TO_CHECK_RESULTS_DB]
         configuration = self.results_db_query_configuration()
@@ -745,6 +766,9 @@ class ResultsDBReportMixin(abc.ABC):
 
             yield self._addToLog(self.results_db_log_name, f'\n{test}: pre-existing-flake={flake_summary}\n')
 
+        self.pre_existing_flakes_in_results_db = flaky
+        self.unsupported_flakes_in_results_db = unsupported
+        self.unknown_flakes_in_results_db = unknown
         self.setProperty('results-db_' + self.prefix + 'flaky', flaky)
         self.setProperty('results-db_' + self.prefix + 'flaky_unsupported', sorted(unsupported))
         self.setProperty('results-db_' + self.prefix + 'flaky_unknown', sorted(unknown))
@@ -3585,7 +3609,6 @@ class RunJavaScriptCoreTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, Sh
     flunkOnFailure = True
     jsonFileName = 'jsc_results.json'
     logfiles = {'json': jsonFileName}
-    results_db_log_name = 'results-db'
     command = ['perl', 'Tools/Scripts/run-javascriptcore-tests', '--no-build', '--no-fail-fast', f'--json-output={jsonFileName}', WithProperties('--%(configuration)s')]
     # We rely on run-jsc-stress-tests to weed out any flaky tests. We also cap
     # the effective timeout to avoid the dreaded "command timed out: 1200
@@ -3602,12 +3625,6 @@ class RunJavaScriptCoreTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, Sh
     results_db_stage = 'with-change'
     NUM_FAILURES_TO_DISPLAY_IN_STATUS = 5
     FAILURE_THRESHOLD = 1000
-    MAX_FAILURES_TO_CHECK_RESULTS_DB = 50
-    INCLUDED_FLAKY_VERDICTS = frozenset({
-        ResultsDatabase.CLEAN_TREE_VERDICT,
-        ResultsDatabase.DIRTY_TREE_VERDICT,
-        ResultsDatabase.BETWEEN_BUILDS_VERDICT,
-    })
 
     def __init__(self, **kwargs):
         super().__init__(logEnviron=False, sigtermTime=10, timeout=1 * 60 * 60, **kwargs)
@@ -3616,8 +3633,8 @@ class RunJavaScriptCoreTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, Sh
         self.flaky = {}
         self.stressTestFailures_filtered = []
         self.binaryFailures_filtered = []
-        self.preexisting_failures_in_results_db = []
-        self.flaky_failures_in_results_db = {}
+        self.pre_existing_failures_in_results_db = []
+        self.pre_existing_flakes_in_results_db = {}
         self.unsupported_flakes_in_results_db = []
         self.unknown_flakes_in_results_db = []
 
@@ -3705,10 +3722,7 @@ class RunJavaScriptCoreTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, Sh
             yield self.filter_failures_using_results_db(self.stressTestFailures, self.binaryFailures)
             self.setProperty(self.prefix + 'stress_test_failures_filtered', sorted(self.stressTestFailures_filtered))
             self.setProperty(self.prefix + 'binary_failures_filtered', sorted(self.binaryFailures_filtered))
-            self.setProperty('results-db_' + self.prefix + 'pre_existing', sorted(self.preexisting_failures_in_results_db))
-            self.setProperty('results-db_' + self.prefix + 'flaky', self.flaky_failures_in_results_db)
-            self.setProperty('results-db_' + self.prefix + 'flaky_unsupported', sorted(self.unsupported_flakes_in_results_db))
-            self.setProperty('results-db_' + self.prefix + 'flaky_unknown', sorted(self.unknown_flakes_in_results_db))
+            self.setProperty('results-db_' + self.prefix + 'pre_existing', sorted(self.pre_existing_failures_in_results_db))
 
     def evaluateCommand(self, cmd):
         platform = self.getProperty('platform')
@@ -3733,7 +3747,7 @@ class RunJavaScriptCoreTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, Sh
             message = 'Passed JSC tests'
             self.descriptionDone = message
             self.build.results = SUCCESS
-        elif ((self.preexisting_failures_in_results_db or self.flaky_failures_in_results_db) and not self.stressTestFailures_filtered and not self.binaryFailures_filtered):
+        elif ((self.pre_existing_failures_in_results_db or self.pre_existing_flakes_in_results_db) and not self.stressTestFailures_filtered and not self.binaryFailures_filtered):
             message = self.results_db_ignore_message()
             self.descriptionDone = message
             self.build.results = SUCCESS
@@ -3767,7 +3781,7 @@ class RunJavaScriptCoreTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, Sh
         return rc
 
     @defer.inlineCallbacks
-    def _check_for_preexisting_failures(self, tests, filtered_tests, configuration, identifier, has_commit):
+    def _check_for_pre_existing_failures(self, tests, filtered_tests, configuration, identifier, has_commit):
         for test in tests[:self.MAX_FAILURES_TO_CHECK_RESULTS_DB]:
             data = yield ResultsDatabase.is_test_pre_existing_failure(
                 test, configuration=configuration,
@@ -3776,7 +3790,7 @@ class RunJavaScriptCoreTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, Sh
             )
             yield self._addToLog(self.results_db_log_name, f"\n{test}: pass_rate: {data['pass_rate']}, pre-existing-failure={data['is_existing_failure']}\nResponse from results-db: {data['raw_data']}\n{data['logs']}")
             if data['is_existing_failure']:
-                self.preexisting_failures_in_results_db.append(test)
+                self.pre_existing_failures_in_results_db.append(test)
                 filtered_tests.remove(test)
             else:
                 yield self._addToLog(self.results_db_log_name, f'{test} is not a pre-existing failure, continuing with retry...')
@@ -3786,67 +3800,24 @@ class RunJavaScriptCoreTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, Sh
         self.stressTestFailures_filtered = stress_test_failures.copy()
         self.binaryFailures_filtered = binary_failures.copy()
 
-        identifier = self.getProperty('identifier', None)
-        platform = self.getProperty('platform', None)
-        configuration = {}
-        if platform:
-            configuration['platform'] = ResultsDatabase.platform_for_query(platform)
-        style = self.getProperty('configuration', None)
-        if style and style in ['debug', 'release']:
-            configuration['style'] = style
+        configuration = self.results_db_query_configuration()
 
-        yield self._addToLog(self.results_db_log_name, f'Checking Results database for failing JSC tests. Identifier: {identifier}, configuration: {configuration}')
-        has_commit = False
-        if (stress_test_failures or binary_failures) and identifier:
-            has_commit = yield ResultsDatabase.has_commit(commit=identifier)
-            if not has_commit:
-                yield self._addToLog(self.results_db_log_name, f"'{identifier}' could not be found on the results database, falling back to tip-of-tree\n")
+        identifier, has_commit = yield self.resolve_identifier_for_results_db(configuration, bool(stress_test_failures or binary_failures))
 
-        yield self._check_for_preexisting_failures(stress_test_failures, self.stressTestFailures_filtered, configuration, identifier, has_commit)
-        yield self._check_for_preexisting_failures(binary_failures, self.binaryFailures_filtered, configuration, identifier, has_commit)
+        yield self._check_for_pre_existing_failures(stress_test_failures, self.stressTestFailures_filtered, configuration, identifier, has_commit)
+        yield self._check_for_pre_existing_failures(binary_failures, self.binaryFailures_filtered, configuration, identifier, has_commit)
 
         # TODO: Ask for a verdict on binary failures too. AnalyzeJSCTestsResults.report_failure reports
         # only stress failures, so the database holds no binary-test row to match one against.
         checked = stress_test_failures[:self.MAX_FAILURES_TO_CHECK_RESULTS_DB]
-        unexplained = [test for test in checked if test in self.stressTestFailures_filtered]
-        flakes, flake_logs = yield ResultsDatabase.flaky_verdicts_for(
-            unexplained, configuration=configuration, suite='javascriptcore-tests',
-            authors=self.getProperty('owners', []),
-            pr_number=self.getProperty('github.number', None),
-        )
-        if flake_logs:
-            yield self._addToLog(self.results_db_log_name, flake_logs)
-
-        ignored, shadowed = [], []
-        for test in unexplained:
-            flake = flakes.get(test, FlakyVerdict(request_failed=True))
-            flake_summary = 'False'
-            if flake.is_flaky:
-                self.flaky_failures_in_results_db[test] = flake.flaky_type
-                if flake.flaky_type == ResultsDatabase.BETWEEN_BUILDS_VERDICT and not flake.intra_build_evidence:
-                    self.unsupported_flakes_in_results_db.append(test)
-                flake_summary = f'{flake.flaky_type}: {flake.evidence}'
-                if flake.flaky_type in self.INCLUDED_FLAKY_VERDICTS and test not in self.unsupported_flakes_in_results_db:
-                    ignored.append(test)
-                    if test in self.stressTestFailures_filtered:
-                        self.stressTestFailures_filtered.remove(test)
-                else:
-                    shadowed.append(test)
-            elif flake.request_failed:
-                self.unknown_flakes_in_results_db.append(test)
-                flake_summary = 'Unknown'
-
-            yield self._addToLog(self.results_db_log_name, f'\n{test}: pre-existing-flake={flake_summary}\n')
-
-        for action, acted_on in (('Ignored', ignored), ('Would have ignored', shadowed)):
-            if acted_on:
-                yield self._addToLog(
-                    self.results_db_log_name,
-                    f"\n{action} {len(acted_on)} flaky test(s): {', '.join(sorted(acted_on))}\n",
-                )
+        unexplained = {test for test in checked if test in self.stressTestFailures_filtered}
+        excused = yield self.pre_existing_flakes_using_results_db(unexplained)
+        for test in excused:
+            if test in self.stressTestFailures_filtered:
+                self.stressTestFailures_filtered.remove(test)
 
     def getResultSummary(self):
-        if self.results != SUCCESS and not self.stressTestFailures_filtered and not self.binaryFailures_filtered and (self.preexisting_failures_in_results_db or self.flaky_failures_in_results_db):
+        if self.results != SUCCESS and not self.stressTestFailures_filtered and not self.binaryFailures_filtered and (self.pre_existing_failures_in_results_db or self.pre_existing_flakes_in_results_db):
             return {'step': self.results_db_ignore_message()}
         elif self.results != SUCCESS and (self.stressTestFailures or self.binaryFailures):
             status = ''
@@ -3906,7 +3877,6 @@ class AnalyzeJSCTestsResults(ResultsDBReportMixin, buildstep.BuildStep, AddToLog
     suite = 'javascriptcore-tests'
     description = ['analyze-jsc-test-results']
     descriptionDone = ['analyze-jsc-tests-results']
-    NUM_FAILURES_TO_DISPLAY = 10
 
     @defer.inlineCallbacks
     def run(self):
@@ -4100,18 +4070,13 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
     jsonFileName = 'layout-test-results/full_results.json'
     logfiles = {'json': jsonFileName}
     test_failures_log_name = 'test-failures'
-    results_db_log_name = 'results-db'
     results_db_flavor = 'wk2'
     suite = 'layout-tests'
+    prefix = 'first_run_'
     ENABLE_GUARD_MALLOC = False
     ENABLE_ADDITIONAL_ARGUMENTS = True
     EXIT_AFTER_FAILURES = '60'
     MAX_FAILURES_TO_CHECK_RESULTS_DB = 60
-    INCLUDED_FLAKY_VERDICTS = frozenset({
-        ResultsDatabase.CLEAN_TREE_VERDICT,
-        ResultsDatabase.DIRTY_TREE_VERDICT,
-        ResultsDatabase.BETWEEN_BUILDS_VERDICT,
-    })
     STRESS_MODE = False
     command = ['python3', 'Tools/Scripts/run-webkit-tests',
                '--no-build',
@@ -4124,8 +4089,8 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
         super().__init__(logEnviron=False, timeout=5.5 * 60 * 60, **kwargs)
         self.incorrectLayoutLines = []
         self.failing_tests_filtered = []
-        self.preexisting_failures_in_results_db = []
-        self.flaky_failures_in_results_db = {}
+        self.pre_existing_failures_in_results_db = []
+        self.pre_existing_flakes_in_results_db = {}
         self.unsupported_flakes_in_results_db = []
         self.unknown_flakes_in_results_db = []
         self.layout_test_driver = None
@@ -4251,10 +4216,7 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
             if is_main and first_results.failing_tests and not first_results.did_exceed_test_failure_limit:
                 yield self.filter_failures_using_results_db(first_results.failing_tests)
                 self.setProperty('first_run_failures_filtered', sorted(self.failing_tests_filtered))
-                self.setProperty('results-db_first_run_pre_existing', sorted(self.preexisting_failures_in_results_db))
-                self.setProperty('results-db_first_run_flaky', self.flaky_failures_in_results_db)
-                self.setProperty('results-db_first_run_flaky_unsupported', sorted(self.unsupported_flakes_in_results_db))
-                self.setProperty('results-db_first_run_flaky_unknown', sorted(self.unknown_flakes_in_results_db))
+                self.setProperty('results-db_' + self.prefix + 'pre_existing', sorted(self.pre_existing_failures_in_results_db))
 
             yield self.report_to_results_db(first_results.flaky_results, flaky_type='WithinStepDirtyTree', stage='first-run')
 
@@ -4263,69 +4225,33 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
     @defer.inlineCallbacks
     def filter_failures_using_results_db(self, failing_tests):
         self.failing_tests_filtered = failing_tests.copy()
-        identifier = self.getProperty('identifier', None)
         configuration = self.results_db_query_configuration()
 
-        yield self._addToLog(self.results_db_log_name, f'Checking Results database for failing tests. Identifier: {identifier}, configuration: {configuration}\n')
-        has_commit = False
-        if failing_tests and identifier:
-            has_commit = yield ResultsDatabase.has_commit(commit=identifier)
-            if not has_commit:
-                yield self._addToLog(self.results_db_log_name, f"'{identifier}' could not be found on the results database, falling back to tip-of-tree\n")
+        identifier, has_commit = yield self.resolve_identifier_for_results_db(configuration, bool(failing_tests))
 
         tests = failing_tests[:self.MAX_FAILURES_TO_CHECK_RESULTS_DB]
-        pre_existing = {}
+        unexplained = set()
         for test in tests:
-            pre_existing[test] = yield ResultsDatabase.is_test_pre_existing_failure(
+            data = yield ResultsDatabase.is_test_pre_existing_failure(
                 test, configuration=configuration,
                 commit=identifier if has_commit else None,
             )
-
-        unexplained = [test for test in tests if not pre_existing[test]['is_existing_failure']]
-        flakes, flake_logs = yield ResultsDatabase.flaky_verdicts_for(
-            unexplained, configuration=configuration, suite=self.suite,
-            authors=self.getProperty('owners', []),
-            pr_number=self.getProperty('github.number', None),
-        )
-        if flake_logs:
-            yield self._addToLog(self.results_db_log_name, flake_logs)
-
-        ignored, shadowed = [], []
-        for test in tests:
-            data = pre_existing[test]
-            flake = flakes.get(test, FlakyVerdict(request_failed=True))
-            flake_summary = 'False'
             if data['is_existing_failure']:
-                self.preexisting_failures_in_results_db.append(test)
+                self.pre_existing_failures_in_results_db.append(test)
                 self.failing_tests_filtered.remove(test)
-            elif flake.is_flaky:
-                self.flaky_failures_in_results_db[test] = flake.flaky_type
-                if flake.flaky_type == ResultsDatabase.BETWEEN_BUILDS_VERDICT and not flake.intra_build_evidence:
-                    self.unsupported_flakes_in_results_db.append(test)
-                flake_summary = f'{flake.flaky_type}: {flake.evidence}'
-                if flake.flaky_type in self.INCLUDED_FLAKY_VERDICTS:
-                    ignored.append(test)
-                    self.failing_tests_filtered.remove(test)
-                else:
-                    shadowed.append(test)
-            elif flake.request_failed:
-                self.unknown_flakes_in_results_db.append(test)
-                flake_summary = 'Unknown'
+            else:
+                unexplained.add(test)
 
             yield self._addToLog(
                 self.results_db_log_name,
                 f"\n{test}: pass_rate: {data['pass_rate']}, pre-existing-failure={data['is_existing_failure']}\n"
                 f"Response from results-db: {data['raw_data']}\n"
                 f"{data['logs']}"
-                f"pre-existing-flake={flake_summary}\n"
             )
 
-        for action, acted_on in (('Ignored', ignored), ('Would have ignored', shadowed)):
-            if acted_on:
-                yield self._addToLog(
-                    self.results_db_log_name,
-                    f"\n{action} {len(acted_on)} flaky test(s): {', '.join(sorted(acted_on))}\n",
-                )
+        excused = yield self.pre_existing_flakes_using_results_db(unexplained)
+        for test in excused:
+            self.failing_tests_filtered.remove(test)
 
     def evaluateResult(self, cmd):
         result = SUCCESS
@@ -4378,7 +4304,7 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
             self.build.results = SUCCESS
             if RunWebKitTestsInStressMode.FAILURE_MSG_IN_STRESS_MODE not in previous_build_summary:
                 self.setProperty('build_summary', message)
-        elif ((self.preexisting_failures_in_results_db or self.flaky_failures_in_results_db) and len(self.failing_tests_filtered) == 0):
+        elif ((self.pre_existing_failures_in_results_db or self.pre_existing_flakes_in_results_db) and len(self.failing_tests_filtered) == 0):
             # All tests that failed this run were pre-existing failures or known flaky in the results database
             message = self.results_db_ignore_message()
             self.descriptionDone = message
@@ -4425,13 +4351,8 @@ class RunWebKitTests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin
         status = self.name
 
         if self.results != SUCCESS:
-            if ((self.preexisting_failures_in_results_db or self.flaky_failures_in_results_db) and len(self.failing_tests_filtered) == 0):
-                counts = []
-                if self.preexisting_failures_in_results_db:
-                    counts.append(f"{len(self.preexisting_failures_in_results_db)} pre-existing")
-                if self.flaky_failures_in_results_db:
-                    counts.append(f"{len(self.flaky_failures_in_results_db)} flaky")
-                return {'step': f"Ignored {' and '.join(counts)} failure(s) based on results-db"}
+            if ((self.pre_existing_failures_in_results_db or self.pre_existing_flakes_in_results_db) and len(self.failing_tests_filtered) == 0):
+                return {'step': self.results_db_ignore_counts_message()}
             if self.incorrectLayoutLines:
                 status = ' '.join(self.incorrectLayoutLines)
                 return {'step': status}
@@ -4540,7 +4461,7 @@ class RunWebKitTestsInSiteIsolationMode(RunWebKitTestsInStressMode):
 class ReRunWebKitTests(RunWebKitTests):
     name = 're-run-layout-tests'
     results_db_flavor = None
-    NUM_FAILURES_TO_DISPLAY = 10
+    prefix = 'second_run_'
 
     def evaluateCommand(self, cmd):
         rc = self.evaluateResult(cmd)
@@ -4584,7 +4505,7 @@ class ReRunWebKitTests(RunWebKitTests):
             if RunWebKitTestsInStressMode.FAILURE_MSG_IN_STRESS_MODE not in previous_build_summary:
                 self.setProperty('build_summary', message)
             self.build.addStepsAfterCurrentStep(steps_to_add)
-        elif ((self.preexisting_failures_in_results_db or self.flaky_failures_in_results_db) and len(self.failing_tests_filtered) == 0):
+        elif ((self.pre_existing_failures_in_results_db or self.pre_existing_flakes_in_results_db) and len(self.failing_tests_filtered) == 0):
             # All tests that failed this run were pre-existing failures or known flaky in the results database
             message = self.results_db_ignore_message()
             self.descriptionDone = message
@@ -4659,10 +4580,7 @@ class ReRunWebKitTests(RunWebKitTests):
             if is_main and second_results.failing_tests and not second_results.did_exceed_test_failure_limit:
                 yield self.filter_failures_using_results_db(second_results.failing_tests)
                 self.setProperty('second_run_failures_filtered', sorted(self.failing_tests_filtered))
-                self.setProperty('results-db_second_run_pre_existing', sorted(self.preexisting_failures_in_results_db))
-                self.setProperty('results-db_second_run_flaky', self.flaky_failures_in_results_db)
-                self.setProperty('results-db_second_run_flaky_unsupported', sorted(self.unsupported_flakes_in_results_db))
-                self.setProperty('results-db_second_run_flaky_unknown', sorted(self.unknown_flakes_in_results_db))
+                self.setProperty('results-db_' + self.prefix + 'pre_existing', sorted(self.pre_existing_failures_in_results_db))
 
             yield self.report_to_results_db(second_results.flaky_results, flaky_type='WithinStepDirtyTree', stage='second-run')
 
@@ -4825,7 +4743,6 @@ class AnalyzeLayoutTestsResults(ResultsDBReportMixin, buildstep.BuildStep, Bugzi
     suite = 'layout-tests'
     description = ['analyze-layout-test-results']
     descriptionDone = ['analyze-layout-tests-results']
-    NUM_FAILURES_TO_DISPLAY = 10
 
     @defer.inlineCallbacks
     def report_failure(self, new_failures=None, exceed_failure_limit=False, failure_message=''):
@@ -5887,10 +5804,8 @@ class RunAPITests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin):
     jsonFileName = 'api_test_results.json'
     logfiles = {'json': jsonFileName}
     test_failures_log_name = 'test-failures'
-    results_db_log_name = 'results-db'
     suffix = 'api_first_run'
     prefix = 'api_'
-    MAX_FAILURES_TO_CHECK_RESULTS_DB = 50
     command = ['python3', 'Tools/Scripts/run-api-tests', '--timestamps', '--no-build',
                WithProperties('--%(configuration)s'), '--verbose', '--json-output={0}'.format(jsonFileName)]
     failedTestsFormatString = '%d api test%s failed or timed out'
@@ -5903,8 +5818,8 @@ class RunAPITests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin):
     def __init__(self, **kwargs):
         super().__init__(logEnviron=False, timeout=20 * 60, **kwargs)
         self.failing_tests_filtered = []
-        self.preexisting_failures_in_results_db = []
-        self.flaky_failures_in_results_db = {}
+        self.pre_existing_failures_in_results_db = []
+        self.pre_existing_flakes_in_results_db = {}
         self.steps_to_add = []
 
     @defer.inlineCallbacks
@@ -5977,9 +5892,9 @@ class RunAPITests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin):
                         FilterAPITestsForPlatform(),
                         RunAPITestsParallelSafety(),
                     ]
-        elif (self.name != RunAPITestsWithoutChange.name and self.preexisting_failures_in_results_db and len(self.failing_tests_filtered) == 0):
+        elif (self.name != RunAPITestsWithoutChange.name and self.pre_existing_failures_in_results_db and len(self.failing_tests_filtered) == 0):
             # This means all the tests which failed in this run were also failing or flaky in results database
-            message = f"Ignored pre-existing failure: {', '.join(self.preexisting_failures_in_results_db)}"
+            message = self.results_db_ignore_message()
             self.descriptionDone = message
             self.build.results = SUCCESS
             self.setProperty('build_summary', message)
@@ -6037,7 +5952,7 @@ class RunAPITests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin):
             yield self._addToLog(self.test_failures_log_name, '\n'.join(failures))
             yield self.filter_api_test_failures_using_results_db(failures)
             self.setProperty(f'{self.suffix}_failures_filtered', sorted(self.failing_tests_filtered))
-            self.setProperty(f'results-db_{self.suffix}_pre_existing', sorted(self.preexisting_failures_in_results_db))
+            self.setProperty(f'results-db_{self.suffix}_pre_existing', sorted(self.pre_existing_failures_in_results_db))
 
     def doOnFailure(self):
         self.steps_to_add += [
@@ -6081,21 +5996,9 @@ class RunAPITests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin):
     @defer.inlineCallbacks
     def filter_api_test_failures_using_results_db(self, failing_tests):
         self.failing_tests_filtered = failing_tests.copy()
-        identifier = self.getProperty('identifier', None)
-        platform = self.getProperty('platform', None)
-        configuration = {}
-        if platform:
-            configuration['platform'] = ResultsDatabase.platform_for_query(platform)
-        style = self.getProperty('configuration', None)
-        if style and style in ['debug', 'release']:
-            configuration['style'] = style
+        configuration = self.results_db_query_configuration()
 
-        yield self._addToLog(self.results_db_log_name, f'Checking Results database for failing tests. Identifier: {identifier}, configuration: {configuration}')
-        has_commit = False
-        if failing_tests and identifier:
-            has_commit = yield ResultsDatabase.has_commit(commit=identifier)
-            if not has_commit:
-                yield self._addToLog(self.results_db_log_name, f"'{identifier}' could not be found on the results database, falling back to tip-of-tree\n")
+        identifier, has_commit = yield self.resolve_identifier_for_results_db(configuration, bool(failing_tests))
 
         for test in failing_tests[:self.MAX_FAILURES_TO_CHECK_RESULTS_DB]:
             data = yield ResultsDatabase.is_test_pre_existing_failure(
@@ -6105,7 +6008,7 @@ class RunAPITests(shell.Test, ResultsDBReportMixin, AddToLogMixin, ShellMixin):
             )
             yield self._addToLog(self.results_db_log_name, f"\n{test}: pass_rate: {data['pass_rate']}, pre-existing-failure={data['is_existing_failure']}\nResponse from results-db: {data['raw_data']}\n{data['logs']}")
             if data['is_existing_failure']:
-                self.preexisting_failures_in_results_db.append(test)
+                self.pre_existing_failures_in_results_db.append(test)
                 self.failing_tests_filtered.remove(test)
 
 
@@ -6145,10 +6048,10 @@ class ReRunAPITests(RunAPITests):
         if is_main and (candidates := self.failures_in_both_dirty_runs()):
             # parse_and_set_failures has already reported this build's BetweenStepsDirtyTree
             # evidence, the only evidence the revert and clean-tree run would have added.
-            excused = yield self.flaky_new_failures_using_results_db(candidates)
+            excused = yield self.pre_existing_flakes_using_results_db(candidates)
             if excused == candidates:
                 flaky = self.getProperty('results-db_api_flaky', {})
-                self.flaky_failures_in_results_db = {test: flaky.get(test) for test in excused}
+                self.pre_existing_flakes_in_results_db = {test: flaky.get(test) for test in excused}
                 message = self.results_db_ignore_message()
                 self.descriptionDone = message
                 self.build.results = SUCCESS
@@ -6198,8 +6101,6 @@ class AnalyzeAPITestsResults(ResultsDBReportMixin, buildstep.BuildStep, AddToLog
     suite = 'api-tests'
     description = ['analyze-api-test-results']
     descriptionDone = ['analyze-api-tests-results']
-    NUM_FAILURES_TO_DISPLAY = 10
-    MAX_FAILURES_TO_CHECK_RESULTS_DB = 50
     prefix = 'api_'
 
     @defer.inlineCallbacks
@@ -6235,7 +6136,7 @@ class AnalyzeAPITestsResults(ResultsDBReportMixin, buildstep.BuildStep, AddToLog
         new_failures = failures_with_patch - clean_tree_failures
         ignored_flaky_failures = set()
         if new_failures:
-            ignored_flaky_failures = yield self.flaky_new_failures_using_results_db(new_failures)
+            ignored_flaky_failures = yield self.pre_existing_flakes_using_results_db(new_failures)
             results = self.merged_results(new_failures, {
                 'first-run': 'api_first_run_results',
                 'second-run': 'api_second_run_results',
@@ -6278,7 +6179,7 @@ class AnalyzeAPITestsResults(ResultsDBReportMixin, buildstep.BuildStep, AddToLog
                 for flaky_failure in flaky_failures:
                     self.send_email_for_flaky_failure(flaky_failure)
             if ignored_flaky_failures:
-                message += f" Ignored flaky tests: {', '.join(sorted(ignored_flaky_failures))} based on results-db"
+                message += f" Ignored pre-existing flakes: {', '.join(sorted(ignored_flaky_failures))}"
                 self.setProperty('build_summary', message.strip())
             self.build.buildFinished([message], SUCCESS)
             defer.returnValue(SUCCESS)
@@ -8275,7 +8176,7 @@ class FindModifiedSaferCPPExpectations(shell.ShellCommand, AddToLogMixin):
             return {'step': f'Unable to find modified expectations'}
 
 
-class FindUnexpectedStaticAnalyzerResults(shell.ShellCommand, AnalyzeChange, AddToLogMixin):
+class FindUnexpectedStaticAnalyzerResults(shell.ShellCommand, ResultsDBReportMixin, AnalyzeChange, AddToLogMixin):
     name = 'find-unexpected-static-analyzer-results'
     description = ['finding unexpected static analyzer results']
     descriptionDone = ['found unexpected static analyzer results']
@@ -8410,13 +8311,7 @@ class FindUnexpectedStaticAnalyzerResults(shell.ShellCommand, AnalyzeChange, Add
     def filter_results_using_results_db(self, results_json):
         self.unexpected_results_filtered = results_json
         identifier = self.getProperty('identifier', None) or self.getProperty('got_revision', None)
-        platform = self.getProperty('platform', None)
-        configuration = {}
-        if platform:
-            configuration['platform'] = ResultsDatabase.platform_for_query(platform)
-        style = self.getProperty('configuration', None)
-        if style and style in ['debug', 'release']:
-            configuration['style'] = style
+        configuration = self.results_db_query_configuration()
 
         yield self._addToLog(self.results_db_log_name, f'Checking Results database for unexpected results. Identifier: {identifier}, configuration: {configuration}\n')
         has_commit = False

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -1845,39 +1845,39 @@ class TestRunJavaScriptCoreTestsResultsDBIgnoreBranch(BuildStepMixinAdditions, u
         step = self._configure()
         step.stressTestFailures_filtered = []
         step.binaryFailures_filtered = []
-        step.flaky_failures_in_results_db = {'stress/flaky.js': 'CleanTree'}
+        step.pre_existing_flakes_in_results_db = {'stress/flaky.js': 'CleanTree'}
 
         rc = step.evaluateCommand(self._FailedCmd())
 
         self.assertEqual(rc, WARNINGS)
-        self.assertEqual(self.getProperty('build_summary'), 'Ignored flaky tests: stress/flaky.js based on results-db')
+        self.assertEqual(self.getProperty('build_summary'), 'Ignored pre-existing flakes: stress/flaky.js')
         self.assertEqual(self.build.results, SUCCESS)
         self.assertEqual(self.steps_added, [])
 
     def test_pre_existing_failure_still_takes_the_ignore_branch(self) -> None:
         # Regression guard: the message used to be hand-built here ("Ignored pre-existing failure: ...")
         # and now comes from the shared results_db_ignore_message() helper, which pluralizes
-        # "failures" and appends "based on results-db".
+        # "failures".
         step = self._configure()
         step.stressTestFailures_filtered = []
         step.binaryFailures_filtered = []
-        step.preexisting_failures_in_results_db = ['stress/pre-existing.js']
+        step.pre_existing_failures_in_results_db = ['stress/pre-existing.js']
 
         rc = step.evaluateCommand(self._FailedCmd())
 
         self.assertEqual(rc, WARNINGS)
-        self.assertEqual(self.getProperty('build_summary'), 'Ignored pre-existing failures: stress/pre-existing.js based on results-db')
+        self.assertEqual(self.getProperty('build_summary'), 'Ignored pre-existing failures: stress/pre-existing.js')
         self.assertEqual(self.build.results, SUCCESS)
         self.assertEqual(self.steps_added, [])
 
     def test_unexcused_flaky_verdict_takes_the_normal_failure_path(self) -> None:
         # A flaky verdict outside INCLUDED_FLAKY_VERDICTS leaves stressTestFailures_filtered
-        # non-empty, so the ignore branch must not fire even though flaky_failures_in_results_db
+        # non-empty, so the ignore branch must not fire even though pre_existing_flakes_in_results_db
         # is populated.
         step = self._configure()
         step.stressTestFailures_filtered = ['stress/flaky.js']
         step.binaryFailures_filtered = []
-        step.flaky_failures_in_results_db = {'stress/flaky.js': 'BetweenBuilds'}
+        step.pre_existing_flakes_in_results_db = {'stress/flaky.js': 'BetweenBuilds'}
 
         rc = step.evaluateCommand(self._FailedCmd())
 
@@ -1894,11 +1894,11 @@ class TestRunJavaScriptCoreTestsResultsDBIgnoreBranch(BuildStepMixinAdditions, u
         step.stressTestFailures_filtered = []
         step.binaryFailures = []
         step.binaryFailures_filtered = []
-        step.flaky_failures_in_results_db = {'stress/flaky.js': 'CleanTree'}
+        step.pre_existing_flakes_in_results_db = {'stress/flaky.js': 'CleanTree'}
 
         summary = step.getResultSummary()
 
-        self.assertEqual(summary, {'step': 'Ignored flaky tests: stress/flaky.js based on results-db'})
+        self.assertEqual(summary, {'step': 'Ignored pre-existing flakes: stress/flaky.js'})
 
     def test_getResultSummary_still_reports_raw_failures_when_not_excused(self) -> None:
         step = self._configure()
@@ -2012,7 +2012,7 @@ class TestRunJSCTestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase):
         yield step.filter_failures_using_results_db(['stress/flaky.js'], [])
 
         self.assertEqual(step.stressTestFailures_filtered, ['stress/flaky.js'])
-        self.assertEqual(step.flaky_failures_in_results_db, {'stress/flaky.js': 'CleanTree'})
+        self.assertEqual(step.pre_existing_flakes_in_results_db, {'stress/flaky.js': 'CleanTree'})
 
 
 class TestAnalyzeJSCTestsResults(BuildStepMixinAdditions, unittest.TestCase):
@@ -2205,7 +2205,7 @@ class TestFilterJSCTestFailuresUsingResultsDB(BuildStepMixinAdditions, unittest.
         )
         self.assertEqual(step.stressTestFailures_filtered, ['stress/force-error.js.bytecode-cache'])
         self.assertEqual(step.binaryFailures_filtered, ['testdfg'])
-        self.assertEqual(sorted(step.preexisting_failures_in_results_db), ['stress/dfg-osr-entry-hoisted-clobber.js.default', 'testapi'])
+        self.assertEqual(sorted(step.pre_existing_failures_in_results_db), ['stress/dfg-osr-entry-hoisted-clobber.js.default', 'testapi'])
 
     @defer.inlineCallbacks
     def test_caps_the_number_of_results_db_queries(self) -> None:
@@ -2227,8 +2227,8 @@ class TestFilterJSCTestFailuresUsingResultsDB(BuildStepMixinAdditions, unittest.
 
         self.assertEqual(step.stressTestFailures_filtered, [])
         self.assertEqual(step.binaryFailures_filtered, ['testapi'])
-        self.assertEqual(step.flaky_failures_in_results_db, {'stress/force-error.js.bytecode-cache': 'CleanTree'})
-        self.assertEqual(step.preexisting_failures_in_results_db, [])
+        self.assertEqual(step.pre_existing_flakes_in_results_db, {'stress/force-error.js.bytecode-cache': 'CleanTree'})
+        self.assertEqual(step.pre_existing_failures_in_results_db, [])
         self.assertIn("\nstress/force-error.js.bytecode-cache: pre-existing-flake=CleanTree: {'pr_numbers': [12345]}\n", logs)
         self.assertIn('\nIgnored 1 flaky test(s): stress/force-error.js.bytecode-cache\n', logs)
         self.assertNotIn('\nWould have ignored 1 flaky test(s): stress/force-error.js.bytecode-cache\n', logs)
@@ -2245,8 +2245,8 @@ class TestFilterJSCTestFailuresUsingResultsDB(BuildStepMixinAdditions, unittest.
 
         self.assertEqual(step.stressTestFailures_filtered, ['stress/force-error.js.bytecode-cache'])
         self.assertEqual(step.binaryFailures_filtered, ['testapi'])
-        self.assertEqual(step.flaky_failures_in_results_db, {'stress/force-error.js.bytecode-cache': 'BetweenBuilds'})
-        self.assertEqual(step.preexisting_failures_in_results_db, [])
+        self.assertEqual(step.pre_existing_flakes_in_results_db, {'stress/force-error.js.bytecode-cache': 'BetweenBuilds'})
+        self.assertEqual(step.pre_existing_failures_in_results_db, [])
         self.assertIn("\nstress/force-error.js.bytecode-cache: pre-existing-flake=BetweenBuilds: {'pr_numbers': [12345]}\n", logs)
         self.assertIn('\nWould have ignored 1 flaky test(s): stress/force-error.js.bytecode-cache\n', logs)
         self.assertNotIn('\nIgnored 1 flaky test(s): stress/force-error.js.bytecode-cache\n', logs)
@@ -2262,7 +2262,7 @@ class TestFilterJSCTestFailuresUsingResultsDB(BuildStepMixinAdditions, unittest.
 
         self.assertEqual(step.stressTestFailures_filtered, ['stress/force-error.js.bytecode-cache'])
         self.assertEqual(step.binaryFailures_filtered, ['testapi'])
-        self.assertEqual(step.flaky_failures_in_results_db, {'stress/force-error.js.bytecode-cache': 'BetweenBuilds'})
+        self.assertEqual(step.pre_existing_flakes_in_results_db, {'stress/force-error.js.bytecode-cache': 'BetweenBuilds'})
         self.assertEqual(step.unsupported_flakes_in_results_db, ['stress/force-error.js.bytecode-cache'])
         self.assertIn("\nstress/force-error.js.bytecode-cache: pre-existing-flake=BetweenBuilds: {'pr_numbers': [12345]}\n", logs)
         self.assertIn('\nWould have ignored 1 flaky test(s): stress/force-error.js.bytecode-cache\n', logs)
@@ -2294,9 +2294,9 @@ class TestFilterJSCTestFailuresUsingResultsDB(BuildStepMixinAdditions, unittest.
         ])
         self.assertEqual(len(self.flake_queries), 1)
         tests, kwargs = self.flake_queries[0]
-        self.assertEqual(tests, [
+        self.assertEqual(tests, sorted([
             'stress/force-error.js.bytecode-cache', 'stress/dfg-osr-entry-hoisted-clobber.js.default',
-        ])
+        ]))
         self.assertEqual(kwargs, {
             'configuration': {'platform': 'mac', 'style': 'release'}, 'suite': 'javascriptcore-tests',
             'authors': [], 'pr_number': None,
@@ -2324,7 +2324,7 @@ class TestFilterJSCTestFailuresUsingResultsDB(BuildStepMixinAdditions, unittest.
 
         self.assertEqual(len(self.flake_queries), 1)
         tests, _ = self.flake_queries[0]
-        self.assertEqual(tests, stress_test_failures[:cap])
+        self.assertEqual(tests, sorted(stress_test_failures[:cap]))
 
     @defer.inlineCallbacks
     def test_a_failed_verdict_query_is_recorded_as_unknown(self) -> Generator[Any, Any, None]:
@@ -2334,7 +2334,7 @@ class TestFilterJSCTestFailuresUsingResultsDB(BuildStepMixinAdditions, unittest.
         yield step.filter_failures_using_results_db(['stress/force-error.js.bytecode-cache'], ['testapi'])
 
         self.assertEqual(step.unknown_flakes_in_results_db, ['stress/force-error.js.bytecode-cache'])
-        self.assertEqual(step.flaky_failures_in_results_db, {})
+        self.assertEqual(step.pre_existing_flakes_in_results_db, {})
         self.assertEqual(step.stressTestFailures_filtered, ['stress/force-error.js.bytecode-cache'])
         self.assertEqual(step.binaryFailures_filtered, ['testapi'])
 
@@ -3763,7 +3763,7 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
         step = self._configure(pre_existing)
         yield step.filter_failures_using_results_db(failing_tests)
         self.assertEqual(step.failing_tests_filtered, ['real.html'])
-        self.assertEqual(sorted(step.preexisting_failures_in_results_db), ['flaky1.html', 'flaky2.html'])
+        self.assertEqual(sorted(step.pre_existing_failures_in_results_db), ['flaky1.html', 'flaky2.html'])
 
     def test_pre_existing_after_real_failure_still_stripped(self):
         # Regression guard: a pre-existing failure listed after a non-pre-existing one must still be
@@ -3794,9 +3794,9 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
         yield step.filter_failures_using_results_db(['real.html', 'flaky.html'])
 
         self.assertEqual(step.failing_tests_filtered, ['real.html'])
-        self.assertEqual(step.flaky_failures_in_results_db, {'flaky.html': 'DirtyTree'})
-        self.assertEqual(step.preexisting_failures_in_results_db, [])
-        self.assertEqual(step.results_db_ignore_message(), 'Ignored flaky tests: flaky.html based on results-db')
+        self.assertEqual(step.pre_existing_flakes_in_results_db, {'flaky.html': 'DirtyTree'})
+        self.assertEqual(step.pre_existing_failures_in_results_db, [])
+        self.assertEqual(step.results_db_ignore_message(), 'Ignored pre-existing flakes: flaky.html')
 
     @defer.inlineCallbacks
     def test_a_verdict_outside_the_included_set_is_recorded_without_ignoring_the_failure(self) -> Generator[Any, Any, None]:
@@ -3813,7 +3813,24 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
         yield step.filter_failures_using_results_db(['real.html', 'flaky.html'])
 
         self.assertEqual(step.failing_tests_filtered, ['real.html', 'flaky.html'])
-        self.assertEqual(step.flaky_failures_in_results_db, {'flaky.html': 'BetweenBuilds'})
+        self.assertEqual(step.pre_existing_flakes_in_results_db, {'flaky.html': 'BetweenBuilds'})
+
+    @defer.inlineCallbacks
+    def test_a_between_builds_verdict_with_no_intra_build_evidence_is_not_excused(self) -> Generator[Any, Any, None]:
+        step = self._configure(set())
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', classmethod(
+            lambda cls, tests, **kwargs: defer.succeed(({
+                test: (
+                    FlakyVerdict(flaky_type='BetweenBuilds')
+                    if test == 'flaky.html' else FlakyVerdict()
+                ) for test in tests
+            }, ''))))
+
+        yield step.filter_failures_using_results_db(['real.html', 'flaky.html'])
+
+        self.assertEqual(step.failing_tests_filtered, ['real.html', 'flaky.html'])
+        self.assertEqual(step.pre_existing_flakes_in_results_db, {'flaky.html': 'BetweenBuilds'})
+        self.assertEqual(step.unsupported_flakes_in_results_db, ['flaky.html'])
 
     @defer.inlineCallbacks
     def test_a_test_with_no_verdict_is_not_treated_as_sound(self):
@@ -3826,7 +3843,7 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
         yield step.filter_failures_using_results_db(['real.html'])
 
         self.assertEqual(step.failing_tests_filtered, ['real.html'])
-        self.assertEqual(step.flaky_failures_in_results_db, {})
+        self.assertEqual(step.pre_existing_flakes_in_results_db, {})
 
     @defer.inlineCallbacks
     def test_the_ignore_message_covers_both_categories(self):
@@ -3844,7 +3861,7 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
         self.assertEqual(step.failing_tests_filtered, [])
         self.assertEqual(
             step.results_db_ignore_message(),
-            'Ignored pre-existing failures: pre-existing.html; flaky tests: flaky.html based on results-db',
+            'Ignored pre-existing failures: pre-existing.html\nIgnored pre-existing flakes: flaky.html',
         )
 
     @defer.inlineCallbacks
@@ -3852,7 +3869,7 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
         # buildbot overwrites build.results after the step that ignored the failures, so the verdict
         # has to be restored here. Driven by a property rather than the summary's wording.
         self.setup_step(SetBuildSummary())
-        self.setProperty('build_summary', 'Ignored flaky tests: flaky.html based on results-db')
+        self.setProperty('build_summary', 'Ignored pre-existing flakes: flaky.html')
         self.setProperty('force_build_success', True)
         self.build.results = FAILURE
         self.expect_outcome(result=SUCCESS)
@@ -3869,8 +3886,8 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
         step._addToLog = lambda logName, message: defer.succeed(None)
         step.incorrectLayoutLines = []
         step.failing_tests_filtered = []
-        step.preexisting_failures_in_results_db = ['pre-existing.html']
-        step.flaky_failures_in_results_db = ['flaky.html']
+        step.pre_existing_failures_in_results_db = ['pre-existing.html']
+        step.pre_existing_flakes_in_results_db = ['flaky.html']
         self.patch(self.build, 'addStepsAfterCurrentStep', lambda steps: None)
 
         self.assertEqual(step.evaluateCommand(Cmd()), WARNINGS)
@@ -4349,8 +4366,8 @@ class TestAPITestFlakinessReadUsingResultsDB(BuildStepMixinAdditions, unittest.T
         result = yield step.run()
 
         self.assertEqual(result, SUCCESS)
-        self.assertEqual(self.getProperty('build_summary'), 'Ignored flaky tests: suite.flaky based on results-db')
-        self.assertIn('Ignored flaky tests: suite.flaky based on results-db', self.build.text[0])
+        self.assertEqual(self.getProperty('build_summary'), 'Ignored pre-existing flakes: suite.flaky')
+        self.assertIn('Ignored pre-existing flakes: suite.flaky', self.build.text[0])
 
     @defer.inlineCallbacks
     def test_a_clean_tree_only_build_sets_no_build_summary(self) -> Generator[Any, Any, None]:
@@ -4469,9 +4486,9 @@ class TestReRunAPITestsExcusesKnownFlakes(BuildStepMixinAdditions, unittest.Test
 
         self.assertEqual(step.steps_to_add, [])
         self.assertEqual(step.build.results, SUCCESS)
-        self.assertEqual(self.getProperty('build_summary'), 'Ignored flaky tests: suite.flaky based on results-db')
+        self.assertEqual(self.getProperty('build_summary'), 'Ignored pre-existing flakes: suite.flaky')
         self.assertEqual(self.getProperty('force_build_success'), True)
-        self.assertEqual(step.descriptionDone, 'Ignored flaky tests: suite.flaky based on results-db')
+        self.assertEqual(step.descriptionDone, 'Ignored pre-existing flakes: suite.flaky')
 
     @defer.inlineCallbacks
     def test_a_pull_request_against_a_branch_still_queues_the_whole_ladder(self) -> Generator[Any, Any, None]:
@@ -4609,7 +4626,7 @@ class TestReRunAPITestsExcusesKnownFlakes(BuildStepMixinAdditions, unittest.Test
         yield self.run_step()
 
         self.assertEqual([queued for queued in step.steps_to_add if queued in self.LADDER], [])
-        self.assertEqual(self.getProperty('build_summary'), 'Ignored flaky tests: suite.flaky based on results-db')
+        self.assertEqual(self.getProperty('build_summary'), 'Ignored pre-existing flakes: suite.flaky')
         self.assertEqual(self.getProperty('force_build_success'), True)
 
     @defer.inlineCallbacks
@@ -4761,7 +4778,7 @@ class TestJSCTestStepsReportAsTheyRun(BuildStepMixinAdditions, unittest.TestCase
         def fake_filter(stress_test_failures, binary_failures):
             step.stressTestFailures_filtered = list(stress_test_failures)
             step.binaryFailures_filtered = list(binary_failures)
-            step.preexisting_failures_in_results_db = []
+            step.pre_existing_failures_in_results_db = []
             return defer.succeed(None)
 
         step.filter_failures_using_results_db = fake_filter
@@ -4825,6 +4842,7 @@ class TestLayoutTestStepsReportAsTheyRun(BuildStepMixinAdditions, unittest.TestC
     FLAKY = '{"tests":{"fast":{"flaky.html":{"report":"FLAKY","expected":"PASS","actual":"TIMEOUT PASS"}}},"num_regressions":0,"interrupted":false,"num_flaky":1,"version":4}'
     FLAKY_AND_REGRESSED = '{"tests":{"fast":{"flaky.html":{"report":"FLAKY","expected":"PASS","actual":"TIMEOUT PASS"},"b.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"both.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}}},"num_regressions":2,"interrupted":false,"num_flaky":1,"version":4}'
     TRUNCATED = '{"tests":{"fast":{"flaky.html":{"report":"FLAKY","expected":"PASS","actual":"TIMEOUT PASS"},"b.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"both.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}}},"num_regressions":2,"interrupted":true,"num_flaky":1,"version":4}'
+    THREE_REGRESSIONS = '{"tests":{"fast":{"flaky.html":{"report":"FLAKY","expected":"PASS","actual":"TIMEOUT PASS"},"b.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"both.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"},"c.html":{"report":"REGRESSION","expected":"PASS","actual":"TEXT"}}},"num_regressions":3,"interrupted":false,"num_flaky":1,"version":4}'
 
     class FakeLogObserver(object):
         def __init__(self, stdout=''):
@@ -4864,7 +4882,7 @@ class TestLayoutTestStepsReportAsTheyRun(BuildStepMixinAdditions, unittest.TestC
 
         def fake_filter(failing_tests):
             step.failing_tests_filtered = list(failing_tests)
-            step.preexisting_failures_in_results_db = []
+            step.pre_existing_failures_in_results_db = []
             return defer.succeed(None)
 
         step.filter_failures_using_results_db = fake_filter
@@ -4898,24 +4916,55 @@ class TestLayoutTestStepsReportAsTheyRun(BuildStepMixinAdditions, unittest.TestC
         )
 
     @defer.inlineCallbacks
-    def test_the_first_run_exports_the_verdicts_it_relied_on(self):
-        step = self.configureStep(RunWebKitTests, self.FLAKY_AND_REGRESSED)
+    def test_the_first_run_exports_the_verdicts_it_relied_on(self) -> Generator[Any, Any, None]:
+        # A dashboard outside this tree ingests these four names literally, so a real run of the
+        # filter has to write every one of them under the first-run prefix.
+        step = self.configureStep(RunWebKitTests, self.THREE_REGRESSIONS)
+        del step.filter_failures_using_results_db
+        self.patch(ResultsDatabase, 'has_commit', classmethod(lambda cls, commit=None: defer.succeed(False)))
+        self.patch(ResultsDatabase, 'is_test_pre_existing_failure', classmethod(
+            lambda cls, test, **kwargs: defer.succeed({
+                'is_existing_failure': test == 'fast/b.html',
+                'pass_rate': 0 if test == 'fast/b.html' else 100,
+                'raw_data': {}, 'logs': '', 'request_failed': False,
+            })))
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', classmethod(lambda cls, tests, **kwargs: defer.succeed((
+            {
+                'fast/both.html': FlakyVerdict(flaky_type='BetweenBuilds'),
+                'fast/c.html': FlakyVerdict(request_failed=True),
+            }, ''))))
 
-        def fake_filter(failing_tests):
-            step.failing_tests_filtered = list(failing_tests)
-            step.preexisting_failures_in_results_db = ['fast/b.html']
-            step.flaky_failures_in_results_db = {'fast/both.html': 'CleanTree'}
-            step.unsupported_flakes_in_results_db = ['fast/both.html']
-            step.unknown_flakes_in_results_db = ['fast/a.html']
-            return defer.succeed(None)
-
-        step.filter_failures_using_results_db = fake_filter
         yield step.runCommand(['run-webkit-tests'])
 
-        self.assertEqual(self.getProperty('results-db_first_run_flaky'), {'fast/both.html': 'CleanTree'})
         self.assertEqual(self.getProperty('results-db_first_run_pre_existing'), ['fast/b.html'])
+        self.assertEqual(self.getProperty('results-db_first_run_flaky'), {'fast/both.html': 'BetweenBuilds'})
         self.assertEqual(self.getProperty('results-db_first_run_flaky_unsupported'), ['fast/both.html'])
-        self.assertEqual(self.getProperty('results-db_first_run_flaky_unknown'), ['fast/a.html'])
+        self.assertEqual(self.getProperty('results-db_first_run_flaky_unknown'), ['fast/c.html'])
+
+    @defer.inlineCallbacks
+    def test_the_rerun_exports_the_verdicts_it_relied_on_under_its_own_prefix(self) -> Generator[Any, Any, None]:
+        # The same four names the dashboard ingests, written by the re-run under second_run_.
+        step = self.configureStep(ReRunWebKitTests, self.THREE_REGRESSIONS)
+        del step.filter_failures_using_results_db
+        self.patch(ResultsDatabase, 'has_commit', classmethod(lambda cls, commit=None: defer.succeed(False)))
+        self.patch(ResultsDatabase, 'is_test_pre_existing_failure', classmethod(
+            lambda cls, test, **kwargs: defer.succeed({
+                'is_existing_failure': test == 'fast/b.html',
+                'pass_rate': 0 if test == 'fast/b.html' else 100,
+                'raw_data': {}, 'logs': '', 'request_failed': False,
+            })))
+        self.patch(ResultsDatabase, 'flaky_verdicts_for', classmethod(lambda cls, tests, **kwargs: defer.succeed((
+            {
+                'fast/both.html': FlakyVerdict(flaky_type='BetweenBuilds'),
+                'fast/c.html': FlakyVerdict(request_failed=True),
+            }, ''))))
+
+        yield step.runCommand(['run-webkit-tests'])
+
+        self.assertEqual(self.getProperty('results-db_second_run_pre_existing'), ['fast/b.html'])
+        self.assertEqual(self.getProperty('results-db_second_run_flaky'), {'fast/both.html': 'BetweenBuilds'})
+        self.assertEqual(self.getProperty('results-db_second_run_flaky_unsupported'), ['fast/both.html'])
+        self.assertEqual(self.getProperty('results-db_second_run_flaky_unknown'), ['fast/c.html'])
 
     @defer.inlineCallbacks
     def test_the_rerun_reports_its_flakes_and_what_differed_from_the_first_run(self):
@@ -7879,7 +7928,7 @@ class TestFilterAPITestFailuresUsingResultsDB(BuildStepMixinAdditions, unittest.
         step = self._configure(pre_existing)
         yield step.filter_api_test_failures_using_results_db(failing_tests)
         self.assertEqual(step.failing_tests_filtered, ['suite.real_failure'])
-        self.assertEqual(sorted(step.preexisting_failures_in_results_db), ['suite.AlsoFlaky', 'suite.MultipleAccounts'])
+        self.assertEqual(sorted(step.pre_existing_failures_in_results_db), ['suite.AlsoFlaky', 'suite.MultipleAccounts'])
 
     def test_pre_existing_after_real_failure_still_stripped(self):
         # Regression guard: a pre-existing failure listed after a non-pre-existing one must still be
@@ -7899,6 +7948,19 @@ class TestFilterAPITestFailuresUsingResultsDB(BuildStepMixinAdditions, unittest.
         return self._check_order(
             ['suite.AlsoFlaky', 'suite.MultipleAccounts', 'suite.real_failure'],
             {'suite.MultipleAccounts', 'suite.AlsoFlaky'},
+        )
+
+    @defer.inlineCallbacks
+    def test_the_ignore_message_names_the_pre_existing_failures(self) -> Generator[Any, Any, None]:
+        # The step used to hand-build this sentence in the singular; the shared helper pluralizes
+        # "failures".
+        step = self._configure({'suite.MultipleAccounts'})
+
+        yield step.filter_api_test_failures_using_results_db(['suite.MultipleAccounts'])
+
+        self.assertEqual(
+            step.results_db_ignore_message(),
+            'Ignored pre-existing failures: suite.MultipleAccounts',
         )
 
     @defer.inlineCallbacks
@@ -13652,7 +13714,7 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
         rows = [self._flaky_row('WithinStepCleanTree', 153004, 72787, [self.SUBMITTER])]
         verdicts, logs = yield self._verdicts_for(rows)
         self.assertFalse(verdicts[self.TEST].is_flaky)
-        self.assertIn('1 clean-tree row(s) come from 1 build(s), fewer than the 2 the clean-tree rule needs', logs)
+        self.assertIn('layout/test.html: 1 clean-tree row(s) come from 1 build(s), fewer than the 2 the clean-tree rule needs', logs)
         self.assertNotIn("recorded by this change's own author(s)", logs)
 
     @defer.inlineCallbacks
@@ -13688,7 +13750,7 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
         ]
         verdicts, logs = yield self._verdicts_for(rows, authors=())
         self.assertFalse(verdicts[self.TEST].is_flaky)
-        self.assertIn('3 clean-tree row(s) come from 1 build(s), fewer than the 2 the clean-tree rule needs', logs)
+        self.assertIn('layout/test.html: 3 clean-tree row(s) come from 1 build(s), fewer than the 2 the clean-tree rule needs', logs)
 
     @defer.inlineCallbacks
     def test_a_single_build_of_clean_tree_evidence_falls_through_to_the_dirty_tree_rule(self) -> Generator[Any, Any, None]:
@@ -13701,7 +13763,7 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
         result = verdicts[self.TEST]
         self.assertEqual(result.flaky_type, 'DirtyTree')
         self.assertEqual(result.pr_numbers, {72701, 72650})
-        self.assertIn('1 clean-tree row(s) come from 1 build(s), fewer than the 2 the clean-tree rule needs', logs)
+        self.assertIn('layout/test.html: 1 clean-tree row(s) come from 1 build(s), fewer than the 2 the clean-tree rule needs', logs)
 
     @defer.inlineCallbacks
     def test_clean_tree_evidence_below_its_threshold_does_not_fill_the_dirty_tree_quota(self) -> Generator[Any, Any, None]:
@@ -13720,7 +13782,7 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
         ]
         verdicts, logs = yield self._verdicts_for(rows)
         self.assertFalse(verdicts[self.TEST].is_flaky)
-        self.assertIn("Ignored 1 WithinStepDirtyTree row(s) recorded by this change's own author(s)", logs)
+        self.assertIn("layout/test.html: Ignored 1 WithinStepDirtyTree row(s) recorded by this change's own author(s)", logs)
 
     @defer.inlineCallbacks
     def test_the_dirty_tree_rule_does_not_count_the_change_s_own_pull_request(self) -> Generator[Any, Any, None]:
@@ -13730,7 +13792,7 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
         ]
         verdicts, logs = yield self._verdicts_for(rows, pr_number=72787)
         self.assertFalse(verdicts[self.TEST].is_flaky)
-        self.assertIn("Ignored 1 WithinStepDirtyTree row(s) recorded by this change's own pull request (#72787)", logs)
+        self.assertIn("layout/test.html: Ignored 1 WithinStepDirtyTree row(s) recorded by this change's own pull request (#72787)", logs)
 
     @defer.inlineCallbacks
     def test_the_dirty_tree_rule_convicts_when_the_submitter_wrote_none_of_the_rows(self) -> Generator[Any, Any, None]:
@@ -13754,7 +13816,7 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
         verdicts, logs = yield self._verdicts_for(rows)
         self.assertEqual(verdicts[self.TEST], FlakyVerdict())
         self.assertIsNone(verdicts[self.TEST].flaky_type)
-        self.assertIn("Ignored 2 WithinStepDirtyTree row(s) recorded by this change's own author(s)", logs)
+        self.assertIn("layout/test.html: Ignored 2 WithinStepDirtyTree row(s) recorded by this change's own author(s)", logs)
 
     @defer.inlineCallbacks
     def test_two_dirty_tree_pull_requests_is_flaky(self):
@@ -13836,7 +13898,7 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
         verdicts, logs = yield self._verdicts_for(rows, authors=())
 
         self.assertFalse(verdicts[self.TEST].is_flaky)
-        self.assertIn('Ignored 1 flake row(s) that carried no flaky_type', logs)
+        self.assertIn('layout/test.html: Ignored 1 flake row(s) that carried no flaky_type', logs)
         self.assertNotIn('Ignored flakiness recorded as Failed', logs)
 
     @defer.inlineCallbacks
@@ -13956,7 +14018,7 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
         ]
         verdicts, logs = yield self._verdicts_for(failed_rows=rows, pr_number=72787)
         self.assertFalse(verdicts[self.TEST].is_flaky)
-        self.assertIn("Ignored 1 Failed row(s) recorded by this change's own pull request (#72787)", logs)
+        self.assertIn("layout/test.html: Ignored 1 Failed row(s) recorded by this change's own pull request (#72787)", logs)
 
     @defer.inlineCallbacks
     def test_the_change_s_own_pull_request_does_not_fill_the_between_builds_quota(self) -> Generator[Any, Any, None]:
@@ -13969,7 +14031,7 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
         verdicts, logs = yield self._verdicts_for(failed_rows=rows, pr_number=72787)
         result = verdicts[self.TEST]
         self.assertFalse(result.is_flaky)
-        self.assertIn("Ignored 2 Failed row(s) recorded by this change's own pull request (#72787)", logs)
+        self.assertIn("layout/test.html: Ignored 2 Failed row(s) recorded by this change's own pull request (#72787)", logs)
 
     @defer.inlineCallbacks
     def test_the_two_rejection_reasons_are_reported_separately(self) -> Generator[Any, Any, None]:
@@ -13980,8 +14042,8 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
         ]
         verdicts, logs = yield self._verdicts_for(failed_rows=rows, pr_number=72787)
         self.assertFalse(verdicts[self.TEST].is_flaky)
-        self.assertIn("Ignored 1 Failed row(s) recorded by this change's own pull request (#72787)", logs)
-        self.assertIn("Ignored 1 Failed row(s) recorded by this change's own author(s)", logs)
+        self.assertIn("layout/test.html: Ignored 1 Failed row(s) recorded by this change's own pull request (#72787)", logs)
+        self.assertIn("layout/test.html: Ignored 1 Failed row(s) recorded by this change's own author(s)", logs)
 
     @defer.inlineCallbacks
     def test_between_builds_does_not_count_the_change_s_own_author(self) -> Generator[Any, Any, None]:
@@ -13993,7 +14055,7 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
         ]
         verdicts, logs = yield self._verdicts_for(failed_rows=rows)
         self.assertFalse(verdicts[self.TEST].is_flaky)
-        self.assertIn("Ignored 1 Failed row(s) recorded by this change's own author(s)", logs)
+        self.assertIn("layout/test.html: Ignored 1 Failed row(s) recorded by this change's own author(s)", logs)
 
     @defer.inlineCallbacks
     def test_between_builds_convicts_when_the_submitter_wrote_none_of_the_rows(self) -> Generator[Any, Any, None]:
@@ -14017,7 +14079,7 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
         ]
         verdicts, logs = yield self._verdicts_for(failed_rows=rows)
         self.assertFalse(verdicts[self.TEST].is_flaky)
-        self.assertIn('3 row(s) record no author, so the between-builds rule saw 0 of the 2 it needs', logs)
+        self.assertIn('layout/test.html: 3 row(s) record no author, so the between-builds rule saw 0 of the 2 it needs', logs)
         self.assertIn('across 3 pull request(s)', logs)
         self.assertNotIn("recorded by this change's own author(s)", logs)
 
@@ -14030,7 +14092,7 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
         verdicts, logs = yield self._verdicts_for(failed_rows=rows)
         self.assertEqual(verdicts[self.TEST], FlakyVerdict())
         self.assertIsNone(verdicts[self.TEST].flaky_type)
-        self.assertIn("Ignored 2 Failed row(s) recorded by this change's own author(s)", logs)
+        self.assertIn("layout/test.html: Ignored 2 Failed row(s) recorded by this change's own author(s)", logs)
 
     @defer.inlineCallbacks
     def test_between_builds_counts_a_row_the_submitter_co_authored(self) -> Generator[Any, Any, None]:
@@ -14045,7 +14107,7 @@ class TestIsTestFlakyClassifier(unittest.TestCase):
         self.assertEqual(result.flaky_type, 'BetweenBuilds')
         self.assertEqual(result.pr_numbers, {72787, 72701, 72650})
         self.assertEqual(result.authors, {'aperturedev', 'issacroy', 'jsmith-webkit', 'dpettifer'})
-        self.assertIn("Ignored 1 Failed row(s) recorded by this change's own author(s)", logs)
+        self.assertIn("layout/test.html: Ignored 1 Failed row(s) recorded by this change's own author(s)", logs)
 
     @defer.inlineCallbacks
     def test_no_history_not_flaky(self):


### PR DESCRIPTION
#### ab9b56ad6cc1a19caccdfb252dc3408030f237c6
<pre>
[EWS] Each results-database test step carries its own copy of the shared reporting behaviour
<a href="https://bugs.webkit.org/show_bug.cgi?id=323387">https://bugs.webkit.org/show_bug.cgi?id=323387</a>
<a href="https://rdar.apple.com/186616569">rdar://186616569</a>

Reviewed by Aakash Jain.

The layout, API and JSC test steps all report to the results database
through `ResultsDBReportMixin`, but each carried its own log name, its
own copy of the query constants, its own copy of the configuration a
query is built from, its own copy of the lookup deciding which commit to
ask about, and its own copy of the classifier deciding which new
failures the database already knew were flaky. A change to any of it had
to be made three times, and a step that drifted from the others drew no
complaint. Hoist the lookup as `resolve_identifier_for_results_db`, the
classifier as `pre_existing_flakes_using_results_db`, the two sentences
naming ignored evidence as `results_db_ignore_message` and
`results_db_ignore_counts_message`, and `NUM_FAILURES_TO_DISPLAY`, and
drop the duplicate constants. `RunWebKitTests` keeps its own
`MAX_FAILURES_TO_CHECK_RESULTS_DB`, since it asks about 60 failures
rather than the shared 50.

The classifier names the properties it writes from `prefix`, so layout
gains `prefix = &apos;first_run_&apos;` on `RunWebKitTests` and `&apos;second_run_&apos;` on
`ReRunWebKitTests` in place of the names it spelled out. Every
`results-db_` property keeps the name it had, which matters because
builds are ingested by keying on those strings, so a rename loses data
rather than failing. The `pre_existing` property stays written at each
call site, since the API steps build that one name from `suffix` and
folding it in would rename four of them.

Layout excused a `BetweenBuilds` verdict that carried no
`intra_build_evidence`, and the shared classifier does not, so layout is
tightened to agree with API and JSC. A test failing only in that shape
is now blamed on the change rather than ignored.

Some text a reader sees changes with the sharing. The JSC log line gains
the trailing newline it was missing and reads &quot;failing tests&quot; like the
others rather than &quot;failing JSC tests&quot;. The API step&apos;s ignored-evidence
line reads &quot;Ignored pre-existing failures&quot; rather than &quot;Ignored
pre-existing failure&quot;, and can now name ignored flakes as well.

The two ignored-evidence sentences change shape as well. A `; ` joined the
two halves under one leading &quot;Ignored&quot;, so the flaky half read as a
continuation of the failure half; each half now carries its own &quot;Ignored&quot;
and they are joined by a newline, which means `build_summary` and
`descriptionDone` can hold two lines where they held one. &quot;flaky tests&quot;
becomes &quot;pre-existing flakes&quot;, the name the attribute and the property
already use, and the trailing &quot;based on results-db&quot; goes from all three
sentences — a reader who cares which database answered is already reading
the results-db log.

`preexisting_failures_in_results_db` and `flaky_failures_in_results_db`
become `pre_existing_failures_in_results_db` and
`pre_existing_flakes_in_results_db`. A flake found this way is
pre-existing in the sense the failures are, and `pre_existing` with the
underscore is the spelling `is_test_pre_existing_failure` and the
property names already use.

`FindUnexpectedStaticAnalyzerResults` already declared
`results_db_log_name` and `suite` but not the mixin that defines them,
which is why it could not reach the shared query configuration until it
listed the mixin among its bases.

A row the results database returns did not know which test it described,
so the lines saying which evidence was ignored — whether a row was
recorded by the change&apos;s own pull request, carried no `flaky_type`, or
fell below the clean-tree bar — named no test at all. A build with
several failing tests therefore produced a log whose lines could not be
attributed to any of them. Carry the test name on `EWSRow` and print it
on each of those lines.

* Tools/CISupport/ews-build/results_db.py:
(EWSRow):
(EWSRow.from_json):
(ResultsDatabase):
(ResultsDatabase._is_intra_build_flake):
(ResultsDatabase._is_inter_build_flake):
* Tools/CISupport/ews-build/steps.py:
(ResultsDBReportMixin):
(ResultsDBReportMixin.resolve_identifier_for_results_db):
(RunJavaScriptCoreTests):
(RunJavaScriptCoreTests.filter_failures_using_results_db):
(RunWebKitTests):
(RunWebKitTests.filter_failures_using_results_db):
(RunAPITests):
(RunAPITests.filter_api_test_failures_using_results_db):
(AnalyzeAPITestsResults):
(ResultsDBReportMixin.results_db_ignore_message):
(ResultsDBReportMixin.results_db_ignore_counts_message):
(ResultsDBReportMixin.pre_existing_flakes_using_results_db):
(RunJavaScriptCoreTests.__init__):
(RunJavaScriptCoreTests.runCommand):
(RunJavaScriptCoreTests.evaluateCommand):
(RunJavaScriptCoreTests._check_for_pre_existing_failures):
(RunJavaScriptCoreTests.getResultSummary):
(AnalyzeJSCTestsResults):
(RunWebKitTests.__init__):
(RunWebKitTests.runCommand):
(RunWebKitTests.evaluateCommand):
(RunWebKitTests.getResultSummary):
(ReRunWebKitTests):
(ReRunWebKitTests.evaluateCommand):
(ReRunWebKitTests.runCommand):
(AnalyzeLayoutTestsResults):
(RunAPITests.__init__):
(RunAPITests.run):
(RunAPITests.analyze_failures_using_results_db):
(ReRunAPITests.doOnFailure):
(AnalyzeAPITestsResults.run):
(FindUnexpectedStaticAnalyzerResults):
(FindUnexpectedStaticAnalyzerResults.filter_results_using_results_db):
(ResultsDBReportMixin.flaky_new_failures_using_results_db): Deleted.
(RunJavaScriptCoreTests._check_for_preexisting_failures): Deleted.
* Tools/CISupport/ews-build/steps_unittest.py:
(TestFilterLayoutTestFailuresUsingResultsDB._check_order):
(TestFilterLayoutTestFailuresUsingResultsDB.test_a_verdict_in_the_included_set_removes_the_failure):
(TestFilterLayoutTestFailuresUsingResultsDB.test_a_verdict_outside_the_included_set_is_recorded_without_ignoring_the_failure):
(TestFilterLayoutTestFailuresUsingResultsDB):
(TestFilterLayoutTestFailuresUsingResultsDB.test_a_between_builds_verdict_with_no_intra_build_evidence_is_not_excused):
(TestFilterLayoutTestFailuresUsingResultsDB.test_a_test_with_no_verdict_is_not_treated_as_sound):
(TestFilterLayoutTestFailuresUsingResultsDB.test_ignoring_every_failure_sets_the_property_set_build_summary_reads):
(TestJSCTestStepsReportAsTheyRun.configureRunStep.fake_filter):
(TestLayoutTestStepsReportAsTheyRun):
(TestLayoutTestStepsReportAsTheyRun.configureStep.fake_filter):
(TestLayoutTestStepsReportAsTheyRun.test_the_first_run_exports_the_verdicts_it_relied_on):
(TestLayoutTestStepsReportAsTheyRun.test_the_rerun_exports_the_verdicts_it_relied_on_under_its_own_prefix):
(TestLayoutTestStepsReportAsTheyRun.test_the_first_run_exports_the_verdicts_it_relied_on.fake_filter): Deleted.

Canonical link: <a href="https://commits.webkit.org/320501@main">https://commits.webkit.org/320501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0038c0252e8d9346016f204509a78de25d94be8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195226 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58538 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144480 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124772 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46875 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157242 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44640 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6279 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197175 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/184294 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58479 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153961 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59185 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153620 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28098 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48133 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128058 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57681 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19658 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57040 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57289 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57117 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->