### PR TITLE
SkiaCompositingLayer: Take the last animation value after animation ended

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -383,7 +383,7 @@ void SkiaCompositingLayer::setDebugIndicators(Color&& debugBorderColor, std::opt
 
 const TransformationMatrix& SkiaCompositingLayer::localTransform() const
 {
-    if (!m_animationsState || !m_animationsState->isRunning)
+    if (!m_animationsState)
         return m_transform;
 
     return m_animationsState->transform ? m_animationsState->transform.value() : m_transform;
@@ -391,7 +391,7 @@ const TransformationMatrix& SkiaCompositingLayer::localTransform() const
 
 const TransformationMatrix& SkiaCompositingLayer::futureLocalTransform() const
 {
-    if (!m_animationsState || !m_animationsState->isRunning)
+    if (!m_animationsState)
         return m_transform;
 
     return m_animationsState->futureTransform ? m_animationsState->futureTransform.value() : localTransform();
@@ -399,7 +399,7 @@ const TransformationMatrix& SkiaCompositingLayer::futureLocalTransform() const
 
 float SkiaCompositingLayer::opacityForAnimationsState(const AnimationsState* animationsState) const
 {
-    if (!animationsState || !animationsState->isRunning)
+    if (!animationsState)
         return m_opacity;
 
     return animationsState->opacity.value_or(m_opacity);
@@ -412,7 +412,7 @@ float SkiaCompositingLayer::opacity() const
 
 const std::optional<SkiaCompositingLayer::Filter> SkiaCompositingLayer::filter() const
 {
-    if (!m_animationsState || !m_animationsState->isRunning)
+    if (!m_animationsState)
         return m_filter;
 
     return m_animationsState->filter ? m_animationsState->filter : m_filter;


### PR DESCRIPTION
#### 4af7b773e279f8908b804e342c74ffe11139c1f1
<pre>
SkiaCompositingLayer: Take the last animation value after animation ended
<a href="https://bugs.webkit.org/show_bug.cgi?id=321993">https://bugs.webkit.org/show_bug.cgi?id=321993</a>

Reviewed by Carlos Garcia Campos.

Take the last animation value after animation ended as well as
TextureMapperLayer does. This has no effect for web, but only for &quot;flush
repaint&quot; feature of WebInspector.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::localTransform const):
(WebCore::SkiaCompositingLayer::futureLocalTransform const):
(WebCore::SkiaCompositingLayer::opacityForAnimationsState const):
(WebCore::SkiaCompositingLayer::filter const):

Canonical link: <a href="https://commits.webkit.org/320494@main">https://commits.webkit.org/320494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a20c2a6d9a8347533f2c753dbe40bdb07d00fa0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195207 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58519 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144468 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165063 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124757 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46864 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/44963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157234 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44626 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6262 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197156 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58460 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153945 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59166 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41233 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153604 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28095 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48122 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131454 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128028 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57662 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19644 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57021 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57272 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57098 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->