### PR TITLE
[DRAFT] Validate Untrusted Frame Identifiers

### DIFF
--- a/Source/WebKit/UIProcess/FrameOwnershipAuthority.h
+++ b/Source/WebKit/UIProcess/FrameOwnershipAuthority.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Untrusted.h"
+#include "WebFrameProxy.h"
+#include "WebPageProxy.h"
+#include "WebProcessProxy.h"
+#include <WebCore/FrameIdentifier.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebKit {
+
+// Vouches for a frame identifier a web content process named: the frame exists, it belongs to the
+// page the message was addressed to, and the process that sent the message hosts it.
+//
+// This is the procedure for the frame a message acts on. A message that acts on a frame's parent -
+// because the attribute it carries lives on the owner element rather than on the frame - is the
+// parent's to speak for, and needs a procedure of its own.
+class FrameHostedBySenderAuthority : public IPC::CanValidateUntrusted<FrameHostedBySenderAuthority> {
+public:
+    FrameHostedBySenderAuthority(const WebProcessProxy& sender, const WebPageProxy& page)
+        : m_sender(sender)
+        , m_page(page)
+    {
+    }
+
+    std::optional<IPC::ValidationFailure> checkUntrusted(const WebCore::FrameIdentifier& frameID) const
+    {
+        RefPtr sender = m_sender.get();
+        RefPtr page = m_page.get();
+        if (!sender || !page)
+            return IPC::ValidationFailure::Ignore;
+
+        // Either the frame was destroyed while this message was in flight, or the sender named a
+        // frame that has never existed. Both leave nothing to act on, and the first is routine, so
+        // this is not by itself evidence of the second.
+        RefPtr frame = WebFrameProxy::webFrame(frameID);
+        if (!frame)
+            return IPC::ValidationFailure::Ignore;
+
+        // A frame outlives its page only while the page is being torn down.
+        RefPtr framePage = frame->page();
+        if (!framePage)
+            return IPC::ValidationFailure::Ignore;
+
+        // A frame never moves between pages, so naming a frame of some other page is not something
+        // a race can produce. WebPageProxy::focusedFrameChanged already terminates for this.
+        if (framePage.get() != page.get())
+            return IPC::ValidationFailure::Terminate;
+
+        // With site isolation the process hosting a frame changes as that frame navigates, and a
+        // message the previous process sent before the swap is still legitimately in flight. So a
+        // mismatch here is a lost race rather than a claim the sender could not have made honestly;
+        // didSameDocumentNavigationForFrameViaJS already reaches that conclusion by hand.
+        if (&frame->process() != sender.get())
+            return IPC::ValidationFailure::Ignore;
+
+        return std::nullopt;
+    }
+
+private:
+    // Weak, so that constructing a validator cannot extend the life of a process or a page, and a
+    // validator that outlives either drops the message rather than crashing.
+    WeakPtr<const WebProcessProxy> m_sender;
+    WeakPtr<const WebPageProxy> m_page;
+};
+
+} // namespace WebKit
+
+namespace IPC {
+
+template<> struct IsValidationProcedureFor<WebKit::FrameHostedBySenderAuthority, WebCore::FrameIdentifier> : std::true_type { };
+
+} // namespace IPC

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7990,16 +7990,20 @@ void WebPageProxy::preferencesDidChange()
     protect(websiteDataStore())->propagateSettingUpdates();
 }
 
-void WebPageProxy::didCreateSubframe(FrameIdentifier parentID, FrameIdentifier newFrameID, String&& frameName, SandboxFlags sandboxFlags, ReferrerPolicy referrerPolicy, ScrollbarMode scrollingMode)
+void WebPageProxy::didCreateSubframe(IPC::Untrusted<FrameIdentifier>&& untrustedParentID, FrameIdentifier newFrameID, String&& frameName, SandboxFlags sandboxFlags, ReferrerPolicy referrerPolicy, ScrollbarMode scrollingMode)
 {
+    auto parentID = WTF::move(untrustedParentID).unsafeExtractWithoutValidation(IPC::UnvalidatedReason::NeedsReview);
+
     RefPtr parent = WebFrameProxy::webFrame(parentID);
     if (!parent)
         return;
     parent->didCreateSubframe(newFrameID, WTF::move(frameName), sandboxFlags, referrerPolicy, scrollingMode);
 }
 
-void WebPageProxy::didDestroyFrame(IPC::Connection& connection, FrameIdentifier frameID)
+void WebPageProxy::didDestroyFrame(IPC::Connection& connection, IPC::Untrusted<FrameIdentifier>&& untrustedFrameID)
 {
+    auto frameID = WTF::move(untrustedFrameID).unsafeExtractWithoutValidation(IPC::UnvalidatedReason::NeedsReview);
+
 #if ENABLE(WEB_AUTHN)
     protect(protect(websiteDataStore())->authenticatorManager())->cancelRequest(webPageIDInMainFrameProcess(), frameID);
 #endif
@@ -8300,8 +8304,10 @@ void WebPageProxy::updateSandboxFlags(IPC::Connection& connection, WebCore::Fram
     }
 }
 
-void WebPageProxy::updateOpener(IPC::Connection& connection, WebCore::FrameIdentifier frameID, std::optional<WebCore::FrameIdentifier> newOpener)
+void WebPageProxy::updateOpener(IPC::Connection& connection, IPC::Untrusted<WebCore::FrameIdentifier>&& untrustedFrameID, std::optional<WebCore::FrameIdentifier> newOpener)
 {
+    auto frameID = WTF::move(untrustedFrameID).unsafeExtractWithoutValidation(IPC::UnvalidatedReason::NeedsReview);
+
     if (RefPtr frame = WebFrameProxy::webFrame(frameID))
         frame->updateOpener(newOpener);
     forEachWebContentProcess([&](auto& webProcess, auto pageID) {
@@ -8457,8 +8463,10 @@ void WebPageProxy::didStartProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& 
 #endif
 }
 
-void WebPageProxy::didExplicitOpenForFrame(IPC::Connection& connection, FrameIdentifier frameID, URL&& url, String&& mimeType)
+void WebPageProxy::didExplicitOpenForFrame(IPC::Connection& connection, IPC::Untrusted<FrameIdentifier>&& untrustedFrameID, URL&& url, String&& mimeType)
 {
+    auto frameID = WTF::move(untrustedFrameID).unsafeExtractWithoutValidation(IPC::UnvalidatedReason::NeedsReview);
+
     RefPtr frame = WebFrameProxy::webFrame(frameID);
     if (!frame)
         return;
@@ -9478,8 +9486,10 @@ void WebPageProxy::didFailLoadForFrame(IPC::Connection& connection, FrameIdentif
     }
 }
 
-void WebPageProxy::didSameDocumentNavigationForFrame(IPC::Connection& connection, FrameIdentifier frameID, std::optional<WebCore::NavigationIdentifier> navigationID, SameDocumentNavigationType navigationType, URL&& url, const UserData& userData)
+void WebPageProxy::didSameDocumentNavigationForFrame(IPC::Connection& connection, IPC::Untrusted<FrameIdentifier>&& untrustedFrameID, std::optional<WebCore::NavigationIdentifier> navigationID, SameDocumentNavigationType navigationType, URL&& url, const UserData& userData)
 {
+    auto frameID = WTF::move(untrustedFrameID).unsafeExtractWithoutValidation(IPC::UnvalidatedReason::NeedsReview);
+
     RefPtr protectedPageClient { pageClient() };
 
     RefPtr frame = WebFrameProxy::webFrame(frameID);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -87,6 +87,7 @@
 #include "FocusedElementInformation.h"
 #include "FormDataReference.h"
 #include "FrameInfoData.h"
+#include "FrameOwnershipAuthority.h"
 #include "FrameProcess.h"
 #include "FrameTreeCreationParameters.h"
 #include "FrameTreeNodeData.h"
@@ -9488,7 +9489,8 @@ void WebPageProxy::didFailLoadForFrame(IPC::Connection& connection, FrameIdentif
 
 void WebPageProxy::didSameDocumentNavigationForFrame(IPC::Connection& connection, IPC::Untrusted<FrameIdentifier>&& untrustedFrameID, std::optional<WebCore::NavigationIdentifier> navigationID, SameDocumentNavigationType navigationType, URL&& url, const UserData& userData)
 {
-    auto frameID = WTF::move(untrustedFrameID).unsafeExtractWithoutValidation(IPC::UnvalidatedReason::NeedsReview);
+    Ref process = WebProcessProxy::fromConnection(connection);
+    EXTRACT_WITH_MESSAGE_CHECK(process, frameID, untrustedFrameID, FrameHostedBySenderAuthority { process, *this });
 
     RefPtr protectedPageClient { pageClient() };
 
@@ -9496,7 +9498,7 @@ void WebPageProxy::didSameDocumentNavigationForFrame(IPC::Connection& connection
     if (!frame)
         return;
 
-    MESSAGE_CHECK_URL(protect(m_legacyMainFrameProcess), url);
+    MESSAGE_CHECK_URL(process, url);
 
     WEBPAGEPROXY_RELEASE_LOG(Loading, "didSameDocumentNavigationForFrame: frameID=%" PRIu64 ", isMainFrame=%d, type=%u", frameID.toUInt64(), frame->isMainFrame(), std::to_underlying(navigationType));
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7991,9 +7991,10 @@ void WebPageProxy::preferencesDidChange()
     protect(websiteDataStore())->propagateSettingUpdates();
 }
 
-void WebPageProxy::didCreateSubframe(IPC::Untrusted<FrameIdentifier>&& untrustedParentID, FrameIdentifier newFrameID, String&& frameName, SandboxFlags sandboxFlags, ReferrerPolicy referrerPolicy, ScrollbarMode scrollingMode)
+void WebPageProxy::didCreateSubframe(IPC::Connection& connection, IPC::Untrusted<FrameIdentifier>&& untrustedParentID, FrameIdentifier newFrameID, String&& frameName, SandboxFlags sandboxFlags, ReferrerPolicy referrerPolicy, ScrollbarMode scrollingMode)
 {
-    auto parentID = WTF::move(untrustedParentID).unsafeExtractWithoutValidation(IPC::UnvalidatedReason::NeedsReview);
+    Ref process = WebProcessProxy::fromConnection(connection);
+    EXTRACT_WITH_MESSAGE_CHECK(process, parentID, untrustedParentID, FrameHostedBySenderAuthority { process, *this });
 
     RefPtr parent = WebFrameProxy::webFrame(parentID);
     if (!parent)
@@ -8003,6 +8004,11 @@ void WebPageProxy::didCreateSubframe(IPC::Untrusted<FrameIdentifier>&& untrusted
 
 void WebPageProxy::didDestroyFrame(IPC::Connection& connection, IPC::Untrusted<FrameIdentifier>&& untrustedFrameID)
 {
+    // FIXME: This wants FrameHostedBySenderAuthority too, but validating it changes teardown as
+    // well as rejecting forgeries. A process running a provisional load holds a frame with the
+    // committed frame's identifier, so when that load is abandoned this arrives from a process that
+    // does not host the frame, and treating it as a lost race would stop disconnecting a frame that
+    // is disconnected today. That needs its own change, with tests.
     auto frameID = WTF::move(untrustedFrameID).unsafeExtractWithoutValidation(IPC::UnvalidatedReason::NeedsReview);
 
 #if ENABLE(WEB_AUTHN)
@@ -8307,7 +8313,8 @@ void WebPageProxy::updateSandboxFlags(IPC::Connection& connection, WebCore::Fram
 
 void WebPageProxy::updateOpener(IPC::Connection& connection, IPC::Untrusted<WebCore::FrameIdentifier>&& untrustedFrameID, std::optional<WebCore::FrameIdentifier> newOpener)
 {
-    auto frameID = WTF::move(untrustedFrameID).unsafeExtractWithoutValidation(IPC::UnvalidatedReason::NeedsReview);
+    Ref process = WebProcessProxy::fromConnection(connection);
+    EXTRACT_WITH_MESSAGE_CHECK(process, frameID, untrustedFrameID, FrameHostedBySenderAuthority { process, *this });
 
     if (RefPtr frame = WebFrameProxy::webFrame(frameID))
         frame->updateOpener(newOpener);
@@ -8466,13 +8473,13 @@ void WebPageProxy::didStartProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& 
 
 void WebPageProxy::didExplicitOpenForFrame(IPC::Connection& connection, IPC::Untrusted<FrameIdentifier>&& untrustedFrameID, URL&& url, String&& mimeType)
 {
-    auto frameID = WTF::move(untrustedFrameID).unsafeExtractWithoutValidation(IPC::UnvalidatedReason::NeedsReview);
+    Ref process = WebProcessProxy::fromConnection(connection);
+    EXTRACT_WITH_MESSAGE_CHECK(process, frameID, untrustedFrameID, FrameHostedBySenderAuthority { process, *this });
 
     RefPtr frame = WebFrameProxy::webFrame(frameID);
     if (!frame)
         return;
 
-    Ref process = WebProcessProxy::fromConnection(connection);
     if (!checkURLReceivedFromCurrentOrPreviousWebProcess(process, url)) {
         WEBPAGEPROXY_RELEASE_LOG_ERROR(Process, "Ignoring WebPageProxy::DidExplicitOpenForFrame() IPC from the WebContent process because the file URL is outside the sandbox");
         return;

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2770,7 +2770,7 @@ public:
 
     void generateTestReport(const String& message, const String& group);
 
-    void didDestroyFrame(IPC::Connection&, WebCore::FrameIdentifier);
+    void didDestroyFrame(IPC::Connection&, IPC::Untrusted<WebCore::FrameIdentifier>&&);
     void disconnectFramesFromPage();
 
     void didCommitLoadForFrame(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, std::optional<WebCore::NavigationIdentifier>, String&& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType, bool hasCertificateInfo, bool usedLegacyTLS, bool wasPrivateRelayed, String&& proxyName, const WebCore::ResourceResponseSource, bool containsPluginDocument, WebCore::HasInsecureContent, WebCore::MouseEventPolicy, WebCore::DocumentSecurityPolicy&&, IPC::Untrusted<HashSet<WebCore::SecurityOriginData>>&& cspOriginsThatUpgradeInsecureNavigations, const UserData&, WebCore::RestoredFromBackForwardCache, RefPtr<FrameState>&& redirectReplaceFrameState);
@@ -3143,7 +3143,7 @@ private:
     static bool hasMouseDevice();
 #endif
 
-    void didCreateSubframe(WebCore::FrameIdentifier parent, WebCore::FrameIdentifier newFrameID, String&& frameName, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode);
+    void didCreateSubframe(IPC::Untrusted<WebCore::FrameIdentifier>&& parent, WebCore::FrameIdentifier newFrameID, String&& frameName, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode);
 
     void didStartProvisionalLoadForFrame(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, std::optional<WebCore::NavigationIdentifier>, URL&&, URL&& unreachableURL, const UserData&, WallTime);
     void didReceiveServerRedirectForProvisionalLoadForFrame(IPC::Connection&, WebCore::FrameIdentifier, std::optional<WebCore::NavigationIdentifier>, WebCore::ResourceRequest&&, const UserData&);
@@ -3154,10 +3154,10 @@ private:
     void didFinishDocumentLoadForFrame(IPC::Connection&, WebCore::FrameIdentifier, std::optional<WebCore::NavigationIdentifier>, const UserData&, WallTime);
     void didFinishLoadForFrame(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, std::optional<WebCore::NavigationIdentifier>, const UserData&, WallTime);
     void didFailLoadForFrame(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, std::optional<WebCore::NavigationIdentifier>, const WebCore::ResourceError&, const UserData&);
-    void didSameDocumentNavigationForFrame(IPC::Connection&, WebCore::FrameIdentifier, std::optional<WebCore::NavigationIdentifier>, SameDocumentNavigationType, URL&&, const UserData&);
+    void didSameDocumentNavigationForFrame(IPC::Connection&, IPC::Untrusted<WebCore::FrameIdentifier>&&, std::optional<WebCore::NavigationIdentifier>, SameDocumentNavigationType, URL&&, const UserData&);
     void didSameDocumentNavigationForFrameViaJS(IPC::Connection&, SameDocumentNavigationType, URL&&, NavigationActionData&&, const UserData&);
     void didChangeMainDocument(IPC::Connection&, WebCore::FrameIdentifier, std::optional<WebCore::NavigationIdentifier>);
-    void didExplicitOpenForFrame(IPC::Connection&, WebCore::FrameIdentifier, URL&&, String&& mimeType);
+    void didExplicitOpenForFrame(IPC::Connection&, IPC::Untrusted<WebCore::FrameIdentifier>&&, URL&&, String&& mimeType);
 
     void didReceiveTitleForFrame(IPC::Connection&, WebCore::FrameIdentifier, String&&, const UserData&);
     void NODELETE didFirstLayoutForFrame(WebCore::FrameIdentifier, const UserData&);
@@ -3186,7 +3186,7 @@ private:
 #endif
     void updateSandboxFlags(IPC::Connection&, WebCore::FrameIdentifier, WebCore::SandboxFlags);
     void updateReferrerPolicy(IPC::Connection&, WebCore::FrameIdentifier, WebCore::ReferrerPolicy);
-    void updateOpener(IPC::Connection&, WebCore::FrameIdentifier, std::optional<WebCore::FrameIdentifier>);
+    void updateOpener(IPC::Connection&, IPC::Untrusted<WebCore::FrameIdentifier>&&, std::optional<WebCore::FrameIdentifier>);
     void updateScrollingMode(IPC::Connection&, WebCore::FrameIdentifier, WebCore::ScrollbarMode);
     void setFramePrinting(IPC::Connection&, WebCore::FrameIdentifier, bool printing, const WebCore::FloatSize& pageSize, const WebCore::FloatSize& originalPageSize, float maximumShrinkRatio, WebCore::AdjustViewSize shouldAdjustViewSize);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3143,7 +3143,7 @@ private:
     static bool hasMouseDevice();
 #endif
 
-    void didCreateSubframe(IPC::Untrusted<WebCore::FrameIdentifier>&& parent, WebCore::FrameIdentifier newFrameID, String&& frameName, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode);
+    void didCreateSubframe(IPC::Connection&, IPC::Untrusted<WebCore::FrameIdentifier>&& parent, WebCore::FrameIdentifier newFrameID, String&& frameName, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode);
 
     void didStartProvisionalLoadForFrame(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, std::optional<WebCore::NavigationIdentifier>, URL&&, URL&& unreachableURL, const UserData&, WallTime);
     void didReceiveServerRedirectForProvisionalLoadForFrame(IPC::Connection&, WebCore::FrameIdentifier, std::optional<WebCore::NavigationIdentifier>, WebCore::ResourceRequest&&, const UserData&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -140,8 +140,8 @@ messages -> WebPageProxy {
     EndNetworkRequestsForPageLoadTiming(WebCore::FrameIdentifier frameID, WallTime timestamp)
 
     # Frame lifetime messages
-    DidCreateSubframe(WebCore::FrameIdentifier parent, WebCore::FrameIdentifier newFrameID, String frameName, WebCore::SandboxFlags sandboxFlags, WebCore::ReferrerPolicy referrerPolicy, enum:uint8_t WebCore::ScrollbarMode scrollingMode) CanDispatchOutOfOrder
-    DidDestroyFrame(WebCore::FrameIdentifier frameID)
+    DidCreateSubframe(IPC::Untrusted<WebCore::FrameIdentifier> parent, WebCore::FrameIdentifier newFrameID, String frameName, WebCore::SandboxFlags sandboxFlags, WebCore::ReferrerPolicy referrerPolicy, enum:uint8_t WebCore::ScrollbarMode scrollingMode) CanDispatchOutOfOrder
+    DidDestroyFrame(IPC::Untrusted<WebCore::FrameIdentifier> frameID)
 
     # Frame load messages
     DidStartProvisionalLoadForFrame(WebCore::FrameIdentifier frameID, struct WebKit::FrameInfoData frameInfo, WebCore::ResourceRequest request, std::optional<WebCore::NavigationIdentifier> navigationID, URL url, URL unreachableURL, WebKit::UserData userData, WallTime timestamp)
@@ -158,14 +158,14 @@ messages -> WebPageProxy {
     DidFirstVisuallyNonEmptyLayoutForFrame(WebCore::FrameIdentifier frameID, WebKit::UserData userData, WallTime timestamp)
     DidReachLayoutMilestone(OptionSet<WebCore::LayoutMilestone> layoutMilestones, WallTime timestamp)
     DidReceiveTitleForFrame(WebCore::FrameIdentifier frameID, String title, WebKit::UserData userData)
-    DidSameDocumentNavigationForFrame(WebCore::FrameIdentifier frameID, std::optional<WebCore::NavigationIdentifier> navigationID, enum:uint8_t WebKit::SameDocumentNavigationType type, URL url, WebKit::UserData userData)
+    DidSameDocumentNavigationForFrame(IPC::Untrusted<WebCore::FrameIdentifier> frameID, std::optional<WebCore::NavigationIdentifier> navigationID, enum:uint8_t WebKit::SameDocumentNavigationType type, URL url, WebKit::UserData userData)
     DidSameDocumentNavigationForFrameViaJS(enum:uint8_t WebKit::SameDocumentNavigationType type, URL url, struct WebKit::NavigationActionData navigationActionData, WebKit::UserData userData);
     DidChangeMainDocument(WebCore::FrameIdentifier frameID, std::optional<WebCore::NavigationIdentifier> navigationID)
-    DidExplicitOpenForFrame(WebCore::FrameIdentifier frameID, URL url, String mimeType)
+    DidExplicitOpenForFrame(IPC::Untrusted<WebCore::FrameIdentifier> frameID, URL url, String mimeType)
     DidDestroyNavigation(WebCore::NavigationIdentifier navigationID)
     UpdateSandboxFlags(WebCore::FrameIdentifier frameID, WebCore::SandboxFlags sandboxFlags)
     UpdateReferrerPolicy(WebCore::FrameIdentifier frameID, WebCore::ReferrerPolicy referrerPolicy)
-    UpdateOpener(WebCore::FrameIdentifier frameID, std::optional<WebCore::FrameIdentifier> newOpener)
+    UpdateOpener(IPC::Untrusted<WebCore::FrameIdentifier> frameID, std::optional<WebCore::FrameIdentifier> newOpener)
     [EnabledBy=SiteIsolationEnabled] UpdateScrollingMode(WebCore::FrameIdentifier frameID, enum:uint8_t WebCore::ScrollbarMode scrollingMode)
     [EnabledBy=SiteIsolationEnabled] SetFramePrinting(WebCore::FrameIdentifier frameID, bool printing, WebCore::FloatSize pageSize, WebCore::FloatSize originalPageSize, float maximumShrinkRatio, enum:bool WebCore::AdjustViewSize shouldAdjustViewSize);
     ResolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier frameID, WebCore::IntPoint point) -> (String result)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -482,6 +482,7 @@
 		1AE00D4D182D6EB000087DD7 /* WKBrowsingContextHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AE00D4B182D6EB000087DD7 /* WKBrowsingContextHandle.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1AE00D4F182D6F5000087DD7 /* WKBrowsingContextHandleInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AE00D4E182D6F5000087DD7 /* WKBrowsingContextHandleInternal.h */; };
 		1AE00D611831792100087DD7 /* FrameLoadState.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AE00D5F1831792100087DD7 /* FrameLoadState.h */; };
+		A5F2D1F12FE1C0A100B7E402 /* FrameOwnershipAuthority.h in Headers */ = {isa = PBXBuildFile; fileRef = A5F2D1F02FE1C0A100B7E402 /* FrameOwnershipAuthority.h */; };
 		1AE286781C7E76510069AC4F /* _WKWebsiteDataSize.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AE286761C7E76510069AC4F /* _WKWebsiteDataSize.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1AE2867A1C7F7BA60069AC4F /* WKWebsiteDataStorePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AE286791C7F7BA60069AC4F /* WKWebsiteDataStorePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1AE286801C7F92C00069AC4F /* _WKWebsiteDataSizeInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AE2867F1C7F92BF0069AC4F /* _WKWebsiteDataSizeInternal.h */; };
@@ -4144,6 +4145,7 @@
 		1AE00D4E182D6F5000087DD7 /* WKBrowsingContextHandleInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKBrowsingContextHandleInternal.h; sourceTree = "<group>"; };
 		1AE00D5E1831792100087DD7 /* FrameLoadState.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FrameLoadState.cpp; sourceTree = "<group>"; };
 		1AE00D5F1831792100087DD7 /* FrameLoadState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FrameLoadState.h; sourceTree = "<group>"; };
+		A5F2D1F02FE1C0A100B7E402 /* FrameOwnershipAuthority.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameOwnershipAuthority.h; sourceTree = "<group>"; };
 		1AE117F511DBB30900981615 /* ProcessLauncher.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProcessLauncher.cpp; sourceTree = "<group>"; };
 		1AE286751C7E76510069AC4F /* _WKWebsiteDataSize.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebsiteDataSize.mm; sourceTree = "<group>"; };
 		1AE286761C7E76510069AC4F /* _WKWebsiteDataSize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebsiteDataSize.h; sourceTree = "<group>"; };
@@ -16227,6 +16229,7 @@
 				D6C27CBA2EC2757B00AA941F /* FindTextMatchesCallbackAggregator.h */,
 				1AE00D5E1831792100087DD7 /* FrameLoadState.cpp */,
 				1AE00D5F1831792100087DD7 /* FrameLoadState.h */,
+				A5F2D1F02FE1C0A100B7E402 /* FrameOwnershipAuthority.h */,
 				FA6757052B815C8300C1566A /* FrameProcess.cpp */,
 				FA6757062B815C8300C1566A /* FrameProcess.h */,
 				9EC532A22447FBAD00215216 /* GeolocationIdentifier.h */,
@@ -18496,6 +18499,7 @@
 				F30EE4742E72227500935B60 /* FrameInspectorTargetProxy.h in Headers */,
 				1AE00D611831792100087DD7 /* FrameLoadState.h in Headers */,
 				A1B2C3D4E5F60718DEADBEEF /* FrameNetworkAgentProxy.h in Headers */,
+				A5F2D1F12FE1C0A100B7E402 /* FrameOwnershipAuthority.h in Headers */,
 				5C121E842410208D00486F9B /* FrameTreeNodeData.h in Headers */,
 				2D4AF0892044C3C4006C8817 /* FrontBoardServicesSPI.h in Headers */,
 				CD78E1151DB7D7ED0014A2DE /* FullscreenClient.h in Headers */,


### PR DESCRIPTION
#### d0cc9091add6c2a7708b3bc991e67aaf2007fc01
<pre>
[Site Isolation] Validate the frame identifiers in the frame tree and explicit open handlers
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

Three more of the handlers that resolve a web-content-supplied FrameIdentifier
against the process-global frame map now require FrameHostedBySenderAuthority to
have vouched for it first:

- didCreateSubframe grafted a subframe onto any frame in any page. It did not
  take the sending connection at all, so no check was possible: the generated
  dispatch passes one when the handler asks for it, and it never did. Adding
  IPC::Connection&amp; is the whole structural fix; the authority is then applied to
  the parent, because the parent&apos;s document is what creates the child, so the
  parent&apos;s host is who may say so.

  WebFrameProxy::didCreateSubframe&apos;s existing test - that the new child&apos;s
  identifier encodes the parent&apos;s process - is left alone. It reads a process
  identifier off the wire, so it was never a sender check, and the reported
  attack was to enumerate process identifiers until one matched; but it also
  drops stale subframe creation after a cross-site navigation, which the
  authority does not, so it still earns its place.

- updateOpener reassigned any frame&apos;s opener and then broadcast the new opener
  to every other web content process in the browsing context group.

- didExplicitOpenForFrame rewrote any frame&apos;s URL and MIME type. The sending
  process was already resolved here, only for the file-URL sandbox check, so
  this is the authority using a fact the handler already had.

didDestroyFrame is deliberately not converted. Its identifier is declared
IPC::Untrusted and it keeps a NeedsReview bypass with a comment: validating it
is not purely a rejection, because a process running a provisional load holds a
frame carrying the committed frame&apos;s identifier, so abandoning that load
produces this message from a process that does not host the frame. Treating that
as a lost race would stop disconnecting a frame that is disconnected today,
which is a teardown change that needs its own tests.

Tests: http/tests/site-isolation, fast/history and fast/frames, comparing this
branch against main built and run the same way. Both produce the same 15
unexpected crashes, all of them the pre-existing WebCore accessibility assertion
children[i]-&gt;indexInParent() == i, plus a rotating handful of flaky inspector
and media-controls text failures that differ run to run in both directions. No
run of either produced a message check failure, so nothing here rejects traffic
the tests generate.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCreateSubframe):
(WebKit::WebPageProxy::didDestroyFrame):
(WebKit::WebPageProxy::updateOpener):
(WebKit::WebPageProxy::didExplicitOpenForFrame):
* Source/WebKit/UIProcess/WebPageProxy.h:
</pre>
----------------------------------------------------------------------
#### c288e6cc072137b4271cd1e9b7880e33b5224ed0
<pre>
[Site Isolation] Validate the frame identifier in DidSameDocumentNavigationForFrame
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

WebPageProxy::didSameDocumentNavigationForFrame resolved the FrameIdentifier the
web content process sent against the process-global frame map and then mutated
PageLoadState, the frame&apos;s load state and the navigation client, without
establishing that the sending process hosts that frame or that the frame belongs
to this page. Since FrameIdentifiers are sequential, a compromised web content
process can name the main frame of a page it has nothing to do with and drive
the URL its own tab displays, which is a phishing primitive.

Its sibling didSameDocumentNavigationForFrameViaJS has had the process half of
this check since site isolation landed; this is the same relation stated once,
as a type, so the next handler cannot be written without it.

FrameHostedBySenderAuthority is the first validation procedure for frame
identifiers. It answers one question - may this sender speak for this frame on
this page - and its three outcomes are chosen to match what the surrounding
handlers already do:

- No such frame: Ignore. The frame may have been destroyed while the message was
  in flight, which is routine, and an invented identifier is indistinguishable
  from that. Either way there is nothing to act on.

- The frame belongs to a different page: Terminate. A frame never moves between
  pages, so no race produces this; the sender named something it could not
  honestly have named. The page being gone entirely is a different matter, and
  is Ignore, because that happens during teardown.

- The frame is hosted by a different process: Ignore. Under site isolation the
  process hosting a frame changes as the frame navigates, and the previous
  process&apos;s messages are still in flight across the swap. Terminating here would
  kill web content processes during ordinary navigation.
  didSameDocumentNavigationForFrameViaJS already reaches this conclusion by
  hand, with an ASSERT that site isolation is on.

Only the frame the message acts on is covered. Handlers whose payload belongs to
the frame&apos;s owner element - updateScrollingMode, updateReferrerPolicy,
updateSandboxFlags - are the parent frame&apos;s to speak for and need a separate
procedure; they are unchanged here and keep their hand-written checks.

EXTRACT_WITH_MESSAGE_CHECK is what keeps the Ignore/Terminate distinction from
collapsing at the point of use: a handler asserts valueMayBeLegitimate rather
than the validation result, so only an impossible claim marks the message
invalid, while a lost race just returns.

Drive-by, because the check now has the sending process to hand:
MESSAGE_CHECK_URL was testing the URL against m_legacyMainFrameProcess rather
than against the process the message actually came from. Under site isolation
those are different processes, so the file-URL sandbox check was being made
against the wrong one.

* Source/WebKit/Platform/IPC/Untrusted.h:
* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/FrameOwnershipAuthorities.cpp: Added.
(WebKit::FrameHostedBySenderAuthority::FrameHostedBySenderAuthority):
(WebKit::FrameHostedBySenderAuthority::checkUntrusted const):
* Source/WebKit/UIProcess/FrameOwnershipAuthorities.h: Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didSameDocumentNavigationForFrame):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
</pre>
----------------------------------------------------------------------
#### 2052d7a8cb11e42239d7b5f8989842d45a49d9cf
<pre>
[IPC] Declare the frame identifiers WebPageProxy looks up as IPC::Untrusted
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

WebFrameProxy::webFrame() resolves a FrameIdentifier against allFrames(), a
process-global static HashMap holding every frame of every page in every web
content process. A FrameIdentifier is a sequential ObjectIdentifier, so a
compromised web content process does not have to guess one, it counts. Nothing
about the lookup requires the caller to establish that the sending process hosts
the frame it named, and the handlers that do establish it do so by hand, which
means the ones nobody thought about do not.

This applies IPC::Untrusted&lt;T&gt; (<a href="https://commits.webkit.org/320234@main">320234@main</a>), which was introduced for origins
and URLs, to that identifier. It changes no behaviour: every handler here
immediately calls unsafeExtractWithoutValidation(NeedsReview). The point is only
to move these parameters into a type whose value cannot be reached without
saying, in a form grep can count, that it was not checked. Later commits in this
series replace the NeedsReview bypasses with validation procedures.

The five messages declared here are the ones named by the two radars that have a
single receiver and no non-IPC callers, so the wrapper can sit on the handler
itself. DidStartProvisionalLoadForFrame and DidCommitLoadForFrame are also named
by the same reports and are not in this commit: both are received by
ProvisionalPageProxy as well, and didCommitLoadForFrame is additionally called
from WebFrameProxy::commitProvisionalFrame and from the back/forward path, so
they first need the didStartProvisionalLoadForFrameShared treatment - an IPC
entry point that unwraps, and a shared implementation that takes the bare
identifier. That split is worth its own change.
DidSameDocumentNavigationForFrameViaJS carries its identifier inside
NavigationActionData rather than as a parameter, so it needs a way to declare a
struct member untrusted; it is not here either.

Notes on the generator:

- IPC::Untrusted&lt;T&gt; is a receive-side-only wrapper. The decoder produces it and
  the handler must accept it, but the sender, the message class&apos;s constructor,
  its members and its encode() all deal in the bare T. sender_type() unwraps for
  those, so no send site changes and the wire format is identical. The Arguments
  tuple is the one place the wrapper survives, which is what makes decode
  produce it.

- Forward declarations unwrap too, but still pull in the wrapper&apos;s header, so
  WebCore::FrameIdentifier keeps being forward declared in the generated
  Messages.h rather than dragging in FrameIdentifier.h.

- <a href="https://commits.webkit.org/320234@main">320234@main</a> added Platform/IPC/Untrusted.h without adding it to the Xcode
  project, because at that point the only thing including it was JSIPCBinding.h
  under ENABLE(IPC_TESTING_API). WebKit resolves quoted includes through
  Xcode&apos;s headermap, which is built from project membership, so the header has
  to be in project.pbxproj before anything in a normal build can include it.

Drive-by: TestWithMultipleDispatchedFrom was in messages_unittest.py&apos;s receiver
list but not in the tests Makefile&apos;s TESTS, so regenerating the expectations
dropped it from MessageNames and broke the test. Added it to TESTS.

* Source/WebKit/Scripts/webkit/messages.py:
(sender_type):
(function_parameter_type):
(function_parameter_requires_suppress_forward_decl):
(arguments_constructor_name):
* Source/WebKit/Scripts/webkit/tests/Makefile:
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
* Source/WebKit/Scripts/webkit/tests/MessageNames.cpp:
* Source/WebKit/Scripts/webkit/tests/MessageNames.h:
* Source/WebKit/Scripts/webkit/tests/TestWithDispatchedFromAndTo.messages.in:
* Source/WebKit/Scripts/webkit/tests/TestWithDispatchedFromAndToMessageReceiver.cpp:
* Source/WebKit/Scripts/webkit/tests/TestWithDispatchedFromAndToMessages.h:
* Source/WebKit/Scripts/webkit/untrusted.py: Added.
(unwrap_untrusted):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCreateSubframe):
(WebKit::WebPageProxy::didDestroyFrame):
(WebKit::WebPageProxy::updateOpener):
(WebKit::WebPageProxy::didExplicitOpenForFrame):
(WebKit::WebPageProxy::didSameDocumentNavigationForFrame):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7656c832a4ff547ce0bdb1812a3833f9558abdd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195318 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/149931 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2f835a44-63dc-4e59-a778-06922e9d95eb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144557 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100310 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cfea27a4-f70b-48a4-8c1a-62aef9692e28) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48233 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165153 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.IframeOpener (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124844 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/281efd6f-ab65-420e-ac91-d4851f03773e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46960 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45047 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.IframeOpener (failure)") | | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157329 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.IframeOpener (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44720 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6370 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197266 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58570 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154039 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59280 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153701 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48207 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131570 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128204 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57772 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19738 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57132 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57381 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57208 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->