### PR TITLE
[Flex Wrap Balance] Add parsing support for flex-line-count

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -146,6 +146,7 @@ PASS fit-tolerance
 PASS flex-basis
 PASS flex-direction
 PASS flex-grow
+PASS flex-line-count
 PASS flex-shrink
 PASS flex-wrap
 PASS float

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/balance/flex-line-count-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/balance/flex-line-count-computed-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Property flex-line-count value '1' assert_true: flex-line-count doesn't seem to be supported in the computed style expected true got false
-FAIL Property flex-line-count value '2' assert_true: flex-line-count doesn't seem to be supported in the computed style expected true got false
-FAIL Property flex-line-count value 'round(up, calc(7/2))' assert_true: flex-line-count doesn't seem to be supported in the computed style expected true got false
-FAIL Property flex-line-count value 'calc(NaN)' assert_true: flex-line-count doesn't seem to be supported in the computed style expected true got false
+PASS Property flex-line-count value '1'
+PASS Property flex-line-count value '2'
+PASS Property flex-line-count value 'round(up, calc(7/2))'
+PASS Property flex-line-count value 'calc(NaN)'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/balance/flex-line-count-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/balance/flex-line-count-valid-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL e.style['flex-line-count'] = "1" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['flex-line-count'] = "2" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['flex-line-count'] = "1" should set the property value
+PASS e.style['flex-line-count'] = "2" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
@@ -1,9 +1,9 @@
 
 
-FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 456
-FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 456
-FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 456
-FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 457
+FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 457
+FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 457
+FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 457
+FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 458
 PASS <select></select> has a shadow tree with slot
 PASS <select multiple=""></select> has a shadow tree with slot
 PASS <select size="4"></select> has a shadow tree with slot

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -146,6 +146,7 @@ PASS fit-tolerance
 PASS flex-basis
 PASS flex-direction
 PASS flex-grow
+PASS flex-line-count
 PASS flex-shrink
 PASS flex-wrap
 PASS float

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
@@ -1,9 +1,9 @@
 
 
-FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 442
-FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 442
-FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 442
-FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 443
+FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 443
+FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 443
+FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 443
+FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 444
 PASS <select></select> has a shadow tree with slot
 PASS <select multiple=""></select> has a shadow tree with slot
 PASS <select size="4"></select> has a shadow tree with slot

--- a/LayoutTests/platform/ios-26/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-26/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -143,6 +143,7 @@ PASS filter
 PASS flex-basis
 PASS flex-direction
 PASS flex-grow
+PASS flex-line-count
 PASS flex-shrink
 PASS flex-wrap
 PASS float

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -127,6 +127,7 @@ PASS filter
 PASS flex-basis
 PASS flex-direction
 PASS flex-grow
+PASS flex-line-count
 PASS flex-shrink
 PASS flex-wrap
 PASS float

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/shadow-dom-expected.txt
@@ -1,9 +1,9 @@
 
 
-FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 445
-FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 445
-FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 445
-FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 446
+FAIL <video controls=""></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 446
+FAIL <video></video> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 446
+FAIL <audio></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 446
+FAIL <audio controls=""></audio> has a shadow tree with no slots assert_equals: child should be outside the flat tree expected 0 but got 447
 PASS <select></select> has a shadow tree with slot
 PASS <select multiple=""></select> has a shadow tree with slot
 PASS <select size="4"></select> has a shadow tree with slot

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -133,6 +133,7 @@ PASS filter
 PASS flex-basis
 PASS flex-direction
 PASS flex-grow
+PASS flex-line-count
 PASS flex-shrink
 PASS flex-wrap
 PASS float

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3342,6 +3342,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     style/values/flexbox/StyleFlexBasis.h
     style/values/flexbox/StyleFlexGrow.h
+    style/values/flexbox/StyleFlexLineCount.h
     style/values/flexbox/StyleFlexShrink.h
     style/values/flexbox/StyleFlexWrap.h
     style/values/flexbox/StyleWebKitBoxFlex.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -5416,6 +5416,7 @@
 		BC675B6C2DEE8BB700AD4D79 /* StyleMaximumSize.h in Headers */ = {isa = PBXBuildFile; fileRef = BC675B672DEE8B7100AD4D79 /* StyleMaximumSize.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC675B6D2DEE8BB700AD4D79 /* StyleFlexBasis.h in Headers */ = {isa = PBXBuildFile; fileRef = BC675B692DEE8B8200AD4D79 /* StyleFlexBasis.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7A4C91D920FE3B4100C1E5A2 /* StyleFlexWrap.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A4C91D820FE3B4100C1E5A2 /* StyleFlexWrap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B6885C5F0B6BD0CFDBE1DB17 /* StyleFlexLineCount.h in Headers */ = {isa = PBXBuildFile; fileRef = 17E2804C741600AE026FD7D4 /* StyleFlexLineCount.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7A4C91E120FE3B4100C1E5A2 /* CSSFlexWrap.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A4C91E020FE3B4100C1E5A2 /* CSSFlexWrap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC675B6E2DEE8BB700AD4D79 /* StylePreferredSize.h in Headers */ = {isa = PBXBuildFile; fileRef = BC675B642DEE883300AD4D79 /* StylePreferredSize.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC6932740D7E293900AE44D1 /* JSDOMWindowBase.h in Headers */ = {isa = PBXBuildFile; fileRef = BC6932720D7E293900AE44D1 /* JSDOMWindowBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -19953,6 +19954,7 @@
 		BC675B692DEE8B8200AD4D79 /* StyleFlexBasis.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleFlexBasis.h; sourceTree = "<group>"; };
 		BC675B722DEEB1A600AD4D79 /* StyleFlexBasis.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleFlexBasis.cpp; sourceTree = "<group>"; };
 		7A4C91D820FE3B4100C1E5A2 /* StyleFlexWrap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleFlexWrap.h; sourceTree = "<group>"; };
+		17E2804C741600AE026FD7D4 /* StyleFlexLineCount.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleFlexLineCount.h; sourceTree = "<group>"; };
 		BC6768342CE5116A0087ED47 /* CSSValueTypes.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSValueTypes.cpp; sourceTree = "<group>"; };
 		BC6932710D7E293900AE44D1 /* JSDOMWindowBase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSDOMWindowBase.cpp; sourceTree = "<group>"; };
 		BC6932720D7E293900AE44D1 /* JSDOMWindowBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSDOMWindowBase.h; sourceTree = "<group>"; };
@@ -38407,6 +38409,7 @@
 				BC675B722DEEB1A600AD4D79 /* StyleFlexBasis.cpp */,
 				BC675B692DEE8B8200AD4D79 /* StyleFlexBasis.h */,
 				BC34D2EA2E3D22D3001EAD95 /* StyleFlexGrow.h */,
+				17E2804C741600AE026FD7D4 /* StyleFlexLineCount.h */,
 				BC34D2EC2E3D2370001EAD95 /* StyleFlexShrink.h */,
 				7A4C91D820FE3B4100C1E5A2 /* StyleFlexWrap.h */,
 				BC731F282E68B37100A6584F /* StyleWebKitBoxFlex.h */,
@@ -49218,6 +49221,7 @@
 				BC675B6D2DEE8BB700AD4D79 /* StyleFlexBasis.h in Headers */,
 				BC34D2EB2E3D22D3001EAD95 /* StyleFlexGrow.h in Headers */,
 				BC63AD372F084C2F007B62C4 /* StyleFlexibleBoxData.h in Headers */,
+				B6885C5F0B6BD0CFDBE1DB17 /* StyleFlexLineCount.h in Headers */,
 				BC34D2ED2E3D2370001EAD95 /* StyleFlexShrink.h in Headers */,
 				7A4C91D920FE3B4100C1E5A2 /* StyleFlexWrap.h in Headers */,
 				BC63AD332F084C2F007B62C4 /* StyleFontData.h in Headers */,

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -10690,6 +10690,22 @@
                 "url": "https://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow"
             }
         },
+        "flex-line-count": {
+            "animation-type": "by computed value",
+            "initial": "1",
+            "codegen-properties": {
+                "settings-flag": "cssFlexWrapBalanceEnabled",
+                "computed-style-initial-constexpr": true,
+                "computed-style-storage-path": ["m_nonInheritedData", "miscData", "flexibleBox"],
+                "computed-style-storage-kind": "value",
+                "computed-style-type": "Style::FlexLineCount",
+                "parser-grammar": "<integer [1,inf]>"
+            },
+            "specification": {
+                "category": "css-flexbox-2",
+                "url": "https://drafts.csswg.org/css-flexbox-2/#flex-line-count-property"
+            }
+        },
         "flex-shrink": {
             "animation-type": "by computed value",
             "initial": "1",

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -422,6 +422,7 @@ using BackgroundLayers = CoordinatedValueList<BackgroundLayer>;
 using BorderRadiusValue = MinimallySerializingSpaceSeparatedSize<LengthPercentage<CSS::Nonnegative>>;
 using BoxShadows = Shadows<BoxShadow>;
 using FlexGrow = Number<CSS::Nonnegative, float>;
+using FlexLineCount = Integer<CSS::Positive>;
 using FlexShrink = Number<CSS::Nonnegative, float>;
 using InsetBox = MinimallySerializingSpaceSeparatedRectEdges<InsetEdge>;
 using LineWidthBox = MinimallySerializingSpaceSeparatedRectEdges<LineWidth>;

--- a/Source/WebCore/style/computed/data/StyleFlexibleBoxData.cpp
+++ b/Source/WebCore/style/computed/data/StyleFlexibleBoxData.cpp
@@ -41,6 +41,7 @@ FlexibleBoxData::FlexibleBoxData()
     : flexGrow(ComputedStyle::initialFlexGrow())
     , flexShrink(ComputedStyle::initialFlexShrink())
     , flexBasis(ComputedStyle::initialFlexBasis())
+    , flexLineCount(ComputedStyle::initialFlexLineCount())
     , flexDirection(static_cast<unsigned>(ComputedStyle::initialFlexDirection()))
     , flexWrap(ComputedStyle::initialFlexWrap().toRaw())
 {
@@ -51,6 +52,7 @@ inline FlexibleBoxData::FlexibleBoxData(const FlexibleBoxData& other)
     , flexGrow(other.flexGrow)
     , flexShrink(other.flexShrink)
     , flexBasis(other.flexBasis)
+    , flexLineCount(other.flexLineCount)
     , flexDirection(other.flexDirection)
     , flexWrap(other.flexWrap)
 {
@@ -66,6 +68,7 @@ bool FlexibleBoxData::operator==(const FlexibleBoxData& other) const
     return flexGrow == other.flexGrow
         && flexShrink == other.flexShrink
         && flexBasis == other.flexBasis
+        && flexLineCount == other.flexLineCount
         && flexDirection == other.flexDirection
         && flexWrap == other.flexWrap;
 }
@@ -76,6 +79,7 @@ void FlexibleBoxData::dumpDifferences(TextStream& ts, const FlexibleBoxData& oth
     LOG_IF_DIFFERENT(flexGrow);
     LOG_IF_DIFFERENT(flexShrink);
     LOG_IF_DIFFERENT(flexBasis);
+    LOG_IF_DIFFERENT(flexLineCount);
 
     LOG_IF_DIFFERENT_WITH_CAST(FlexDirection, flexDirection);
     LOG_IF_DIFFERENT_WITH_FROM_RAW(FlexWrap, flexWrap);

--- a/Source/WebCore/style/computed/data/StyleFlexibleBoxData.h
+++ b/Source/WebCore/style/computed/data/StyleFlexibleBoxData.h
@@ -29,6 +29,7 @@
 #include <WebCore/RenderStyleConstants.h>
 #include <WebCore/StyleFlexBasis.h>
 #include <WebCore/StyleFlexGrow.h>
+#include <WebCore/StyleFlexLineCount.h>
 #include <WebCore/StyleFlexShrink.h>
 #include <WebCore/StyleFlexWrap.h>
 #include <wtf/Ref.h>
@@ -53,6 +54,7 @@ public:
     FlexGrow flexGrow;
     FlexShrink flexShrink;
     FlexBasis flexBasis;
+    FlexLineCount flexLineCount;
 
     PREFERRED_TYPE(FlexDirection) unsigned flexDirection : 2;
     PREFERRED_TYPE(FlexWrapType) unsigned flexWrap : 3;

--- a/Source/WebCore/style/values/flexbox/StyleFlexLineCount.h
+++ b/Source/WebCore/style/values/flexbox/StyleFlexLineCount.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StylePrimitiveNumeric.h>
+
+namespace WebCore {
+namespace Style {
+
+// <'flex-line-count'> = <integer [1,∞]>
+// https://drafts.csswg.org/css-flexbox-2/#flex-line-count-property
+using FlexLineCount = Integer<CSS::Positive>;
+
+} // namespace Style
+} // namespace WebCore


### PR DESCRIPTION
#### 1be505b36f434138574ce6db35417577c7c44146
<pre>
[Flex Wrap Balance] Add parsing support for flex-line-count
<a href="https://bugs.webkit.org/show_bug.cgi?id=323392">https://bugs.webkit.org/show_bug.cgi?id=323392</a>
<a href="https://rdar.apple.com/186619043">rdar://186619043</a>

Reviewed by Tim Nguyen and Sam Weinig.

Adds flex-line-count as &lt;integer [1,∞]&gt;, initial value 1, per css-flexbox-2
§6.1. Storage, parsing and computed-style serialization only; the value does not
affect layout yet, which is bug 323240.

The property is gated on the existing CSSFlexWrapBalanceEnabled setting rather
than a new one, because it only has an effect on a balanced container — see
balance-min-line-count-007 and -008, which assert it changes nothing under
flex-wrap: wrap and nowrap. That setting is already status: testable, so the WPT
syntax tests run with it enabled and stay byte-identical to upstream.

Style::FlexLineCount is Integer&lt;CSS::Positive&gt;, and CSS::Positive is Range { 1,
Range::infinity }, which is exactly the grammar&apos;s range. It is a value member of
FlexibleBoxData next to flexBasis, not a bitfield, so calc() results wider than
a few bits round-trip.

* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/balance/flex-line-count-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/balance/flex-line-count-valid-expected.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/computed/data/StyleFlexibleBoxData.cpp:
* Source/WebCore/style/computed/data/StyleFlexibleBoxData.h:
* Source/WebCore/style/values/flexbox/StyleFlexLineCount.h: Added.

Canonical link: <a href="https://commits.webkit.org/320530@main">https://commits.webkit.org/320530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78a0fe3bd73c89d4b9249de2cd322e04e0168528

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58937 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52766 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195353 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58664 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187973 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/48267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/124878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/46994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/44751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6405 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51599 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197300 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58604 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/164687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154074 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41263 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59314 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/153731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48239 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131604 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128246 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57806 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/19770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57166 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57415 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57242 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->