### PR TITLE
REGRESSION (Safari 27): line-height quirk not applied inside inline-block

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/br-line-height-inherited-quirks-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/br-line-height-inherited-quirks-expected.html
@@ -1,0 +1,28 @@
+<!-- Quirks mode (no doctype) -->
+<html>
+<head>
+  <title>CSS Test Reference: the line-height a BR inherits does not stretch the line box in quirks mode</title>
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+  <style>
+  body {
+      margin: 0;
+  }
+  .outer {
+      font: 20px/100px Ahem;
+  }
+  .box {
+      display: inline-block;
+      background: green;
+  }
+  .first {
+      line-height: 20px;
+  }
+  .second {
+      line-height: 40px;
+  }
+  </style>
+</head>
+<body>
+  <div class="outer"><div class="box"><div class="first">X</div><div class="second">X</div></div></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/br-line-height-inherited-quirks-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/br-line-height-inherited-quirks-ref.html
@@ -1,0 +1,28 @@
+<!-- Quirks mode (no doctype) -->
+<html>
+<head>
+  <title>CSS Test Reference: the line-height a BR inherits does not stretch the line box in quirks mode</title>
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+  <style>
+  body {
+      margin: 0;
+  }
+  .outer {
+      font: 20px/100px Ahem;
+  }
+  .box {
+      display: inline-block;
+      background: green;
+  }
+  .first {
+      line-height: 20px;
+  }
+  .second {
+      line-height: 40px;
+  }
+  </style>
+</head>
+<body>
+  <div class="outer"><div class="box"><div class="first">X</div><div class="second">X</div></div></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/br-line-height-inherited-quirks.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-inline/br-line-height-inherited-quirks.html
@@ -1,0 +1,30 @@
+<!-- Quirks mode (no doctype) -->
+<html>
+<head>
+  <title>CSS Test: the line-height a BR inherits does not stretch the line box in quirks mode</title>
+  <link rel="help" href="https://quirks.spec.whatwg.org/#the-line-height-calculation-quirk">
+  <link rel="match" href="br-line-height-inherited-quirks-ref.html">
+  <link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+  <style>
+  body {
+      margin: 0;
+  }
+  .outer {
+      font: 20px/100px Ahem;
+  }
+  .box {
+      display: inline-block;
+      background: green;
+  }
+  .first {
+      line-height: 20px;
+  }
+  .second {
+      line-height: 40px;
+  }
+  </style>
+</head>
+<body>
+  <div class="outer"><div class="box"><span class="first">X</span><br><span class="second">X</span></div></div>
+</body>
+</html>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -101,7 +101,7 @@ InlineLayoutUnit InlineFormattingUtils::logicalTopForNextLine(const LineLayoutRe
     return ceil(nextafter(lineLogicalRect.bottom(), std::numeric_limits<float>::max()));
 }
 
-bool InlineFormattingUtils::inlineLevelBoxAffectsLineBox(const InlineLevelBox& inlineLevelBox) const
+bool InlineFormattingUtils::inlineLevelBoxAffectsLineBox(const InlineLevelBox& inlineLevelBox, const LineBox& lineBox) const
 {
     if (!inlineLevelBox.mayStretchLineBox())
         return false;
@@ -109,7 +109,9 @@ bool InlineFormattingUtils::inlineLevelBoxAffectsLineBox(const InlineLevelBox& i
     if (inlineLevelBox.isLineBreakBox()) {
         // A line break box affects the line box when it has a non-default
         // line-height (e.g. br { line-height: 200px }).
-        return !inlineLevelBox.isPreferredLineHeightFontMetricsBased();
+        if (inlineLevelBox.isPreferredLineHeightFontMetricsBased())
+            return false;
+        return formattingContext().layoutState().inStandardsMode() ? true : InlineQuirks::lineBreakBoxIsOnlyContentOnLine(lineBox);
     }
     if (inlineLevelBox.isListMarker()) {
         // This does not match other browser engines. see webkit.org/b/256390.

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h
@@ -36,6 +36,7 @@ namespace Layout {
 class FloatingContext;
 class InlineFormattingContext;
 class InlineLevelBox;
+class LineBox;
 
 class InlineFormattingUtils {
 public:
@@ -47,7 +48,7 @@ public:
     enum class PreviousLineEndsParagraph : bool { No, Yes };
     InlineLayoutUnit computedTextIndent(IsIntrinsicWidthMode, IsFirstFormattedLine, std::optional<PreviousLineEndsParagraph>, InlineLayoutUnit availableWidth) const;
 
-    bool inlineLevelBoxAffectsLineBox(const InlineLevelBox&) const;
+    bool inlineLevelBoxAffectsLineBox(const InlineLevelBox&, const LineBox&) const;
 
     InlineLayoutUnit initialLineHeight(bool isFirstLine) const;
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.cpp
@@ -211,7 +211,7 @@ LineBoxVerticalAligner::LineBoxAlignmentContent LineBoxVerticalAligner::computeL
 
     auto minimumLogicalTop = std::optional<InlineLayoutUnit> { };
     auto maximumLogicalBottom = std::optional<InlineLayoutUnit> { };
-    if (formattingUtils.inlineLevelBoxAffectsLineBox(rootInlineBox)) {
+    if (formattingUtils.inlineLevelBoxAffectsLineBox(rootInlineBox, lineBox)) {
         minimumLogicalTop = InlineLayoutUnit { };
         maximumLogicalBottom = rootInlineBox.layoutBounds().height();
         inlineLevelBoxAbsoluteTopAndBottomMap.add(&rootInlineBox, AbsoluteTopAndBottom { *minimumLogicalTop, *maximumLogicalBottom });
@@ -237,7 +237,7 @@ LineBoxVerticalAligner::LineBoxAlignmentContent LineBoxVerticalAligner::computeL
         auto absoluteLogicalBottom = absoluteLogicalTop + inlineLevelBox.layoutBounds().height();
         inlineLevelBoxAbsoluteTopAndBottomMap.add(&inlineLevelBox, AbsoluteTopAndBottom { absoluteLogicalTop, absoluteLogicalBottom });
         // Stretch the min/max absolute values if applicable.
-        if (formattingUtils.inlineLevelBoxAffectsLineBox(inlineLevelBox)) {
+        if (formattingUtils.inlineLevelBoxAffectsLineBox(inlineLevelBox, lineBox)) {
             minimumLogicalTop = std::min(minimumLogicalTop.value_or(absoluteLogicalTop), absoluteLogicalTop);
             maximumLogicalBottom = std::max(maximumLogicalBottom.value_or(absoluteLogicalBottom), absoluteLogicalBottom);
         }
@@ -249,7 +249,7 @@ LineBoxVerticalAligner::LineBoxAlignmentContent LineBoxVerticalAligner::computeL
     auto topAlignedBoxesMaximumHeight = std::optional<InlineLayoutUnit> { };
     auto bottomAlignedBoxesMaximumHeight = std::optional<InlineLayoutUnit> { };
     for (auto* lineBoxRelativeInlineLevelBox : lineBoxRelativeInlineLevelBoxes) {
-        if (!formattingUtils.inlineLevelBoxAffectsLineBox(*lineBoxRelativeInlineLevelBox))
+        if (!formattingUtils.inlineLevelBoxAffectsLineBox(*lineBoxRelativeInlineLevelBox, lineBox))
             continue;
         // This line box relative aligned inline level box stretches the line box.
         auto inlineLevelBoxHeight = lineBoxRelativeInlineLevelBox->layoutBounds().height();
@@ -276,11 +276,11 @@ void LineBoxVerticalAligner::computeRootInlineBoxVerticalPosition(LineBox& lineB
     inlineLevelBoxAbsoluteBaselineOffsetMap.add(&rootInlineBox, InlineLayoutUnit { });
 
     auto maximumTopOffsetFromRootInlineBoxBaseline = std::optional<InlineLayoutUnit> { };
-    if (formattingUtils.inlineLevelBoxAffectsLineBox(rootInlineBox))
+    if (formattingUtils.inlineLevelBoxAffectsLineBox(rootInlineBox, lineBox))
         maximumTopOffsetFromRootInlineBoxBaseline = rootInlineBox.layoutBounds().ascent;
 
     auto affectsRootInlineBoxVerticalPosition = [&](auto& inlineLevelBox) {
-        return formattingUtils.inlineLevelBoxAffectsLineBox(inlineLevelBox);
+        return formattingUtils.inlineLevelBoxAffectsLineBox(inlineLevelBox, lineBox);
     };
 
     for (auto& inlineLevelBox : lineBox.nonRootInlineLevelBoxes()) {
@@ -342,7 +342,7 @@ void LineBoxVerticalAligner::computeRootInlineBoxVerticalPosition(LineBox& lineB
     rootInlineBox.setLogicalTop(rootInlineBoxLogicalTop);
 }
 
-std::optional<InlineLevelBox::AscentAndDescent> LineBoxVerticalAligner::layoutBoundsForInlineBoxSubtree(const LineBox::InlineLevelBoxList& nonRootInlineLevelBoxes, size_t inlineBoxIndex) const
+std::optional<InlineLevelBox::AscentAndDescent> LineBoxVerticalAligner::layoutBoundsForInlineBoxSubtree(const LineBox& lineBox, size_t inlineBoxIndex) const
 {
     // https://w3c.github.io/csswg-drafts/css2/#propdef-vertical-align
     //
@@ -352,6 +352,7 @@ std::optional<InlineLevelBox::AscentAndDescent> LineBoxVerticalAligner::layoutBo
     // The aligned subtree of an inline element contains that element and the aligned subtrees of all children
     // inline elements whose computed vertical-align value is not top or bottom.
     // The top of the aligned subtree is the highest of the tops of the boxes in the subtree, and the bottom is analogous.
+    auto& nonRootInlineLevelBoxes = lineBox.nonRootInlineLevelBoxes();
     ASSERT(nonRootInlineLevelBoxes[inlineBoxIndex].isInlineBox());
     auto& formattingUtils = this->formattingUtils();
     auto maximumAscent = std::optional<InlineLayoutUnit> { };
@@ -364,7 +365,7 @@ std::optional<InlineLevelBox::AscentAndDescent> LineBoxVerticalAligner::layoutBo
             // We are at the end of the descendant list.
             break;
         }
-        if (!formattingUtils.inlineLevelBoxAffectsLineBox(descendantInlineLevelBox) || descendantInlineLevelBox.hasLineBoxRelativeAlignment())
+        if (!formattingUtils.inlineLevelBoxAffectsLineBox(descendantInlineLevelBox, lineBox) || descendantInlineLevelBox.hasLineBoxRelativeAlignment())
             continue;
 
         // ascent/descent here really mean enclosing geometry adjusted by vertical alignemnt, which is in case of baseline alignment is simply layout bounds but
@@ -404,7 +405,7 @@ void LineBoxVerticalAligner::alignInlineLevelBoxes(LineBox& lineBox, InlineLayou
             [&](const CSS::Keyword::Top&) {
                 auto ascent = inlineLevelBox.layoutBounds().ascent;
                 if (inlineLevelBox.isInlineBox()) {
-                    if (auto descendantsEnclosingGeometry = layoutBoundsForInlineBoxSubtree(nonRootInlineLevelBoxes, index))
+                    if (auto descendantsEnclosingGeometry = layoutBoundsForInlineBoxSubtree(lineBox, index))
                         ascent = !inlineLevelBox.hasContent() ? descendantsEnclosingGeometry->ascent : std::max(descendantsEnclosingGeometry->ascent, ascent);
                 }
                 // Note that this logical top is not relative to the parent inline box.
@@ -413,7 +414,7 @@ void LineBoxVerticalAligner::alignInlineLevelBoxes(LineBox& lineBox, InlineLayou
             [&](const CSS::Keyword::Bottom&) {
                 auto descent = inlineLevelBox.layoutBounds().descent;
                 if (inlineLevelBox.isInlineBox()) {
-                    if (auto descendantsEnclosingGeometry = layoutBoundsForInlineBoxSubtree(nonRootInlineLevelBoxes, index))
+                    if (auto descendantsEnclosingGeometry = layoutBoundsForInlineBoxSubtree(lineBox, index))
                         descent = !inlineLevelBox.hasContent() ? descendantsEnclosingGeometry->descent : std::max(descendantsEnclosingGeometry->descent, descent);
                 }
                 // Note that this logical top is not relative to the parent inline box.

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.h
@@ -55,7 +55,7 @@ private:
     void computeRootInlineBoxVerticalPosition(LineBox&, const LineBoxAlignmentContent&) const;
     void alignInlineLevelBoxes(LineBox&, InlineLayoutUnit lineBoxLogicalHeight) const;
     InlineLayoutUnit adjustForAnnotationIfNeeded(LineBox&, InlineLayoutUnit lineBoxHeight) const;
-    std::optional<InlineLevelBox::AscentAndDescent> layoutBoundsForInlineBoxSubtree(const LineBox::InlineLevelBoxList& nonRootInlineLevelBoxes, size_t inlineBoxIndex) const;
+    std::optional<InlineLevelBox::AscentAndDescent> layoutBoundsForInlineBoxSubtree(const LineBox&, size_t inlineBoxIndex) const;
     enum class IsInlineLevelBoxAlignment : bool { No, Yes };
     InlineLayoutUnit logicalTopOffsetFromParentBaseline(const InlineLevelBox&, const InlineLevelBox& parentInlineBox, IsInlineLevelBoxAlignment = IsInlineLevelBoxAlignment::No) const;
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
@@ -56,7 +56,7 @@ InlineLayoutUnit InlineQuirks::initialLineHeight() const
     return 0.f;
 }
 
-bool InlineQuirks::lineBreakBoxAffectsParentInlineBox(const LineBox& lineBox)
+bool InlineQuirks::lineBreakBoxIsOnlyContentOnLine(const LineBox& lineBox)
 {
     // In quirks mode linebreak boxes (<br>) stop affecting the line box when (assume <br> is nested e.g. <span style="font-size: 100px"><br></span>)
     // 1. the root inline box has content <div>content<br>/div>
@@ -67,6 +67,18 @@ bool InlineQuirks::lineBreakBoxAffectsParentInlineBox(const LineBox& lineBox)
     if (lineBox.hasAtomicInlineBox())
         return false;
     // At this point we either have only the <br> on the line or inline boxes with or without content.
+    for (auto& inlineLevelBox : lineBox.nonRootInlineLevelBoxes()) {
+        // Filter out empty inline boxes e.g. <div><span></span><span></span><br></div>
+        if (inlineLevelBox.isInlineBox() && inlineLevelBox.hasContent())
+            return false;
+    }
+    return true;
+}
+
+bool InlineQuirks::lineBreakBoxAffectsParentInlineBox(const LineBox& lineBox)
+{
+    if (!lineBreakBoxIsOnlyContentOnLine(lineBox))
+        return false;
     auto& inlineLevelBoxes = lineBox.nonRootInlineLevelBoxes();
     ASSERT(!inlineLevelBoxes.isEmpty());
     if (inlineLevelBoxes.size() == 1) {
@@ -74,11 +86,6 @@ bool InlineQuirks::lineBreakBoxAffectsParentInlineBox(const LineBox& lineBox)
         // the BR's own layout bounds will drive the line height directly.
         auto& lineBreakBox = inlineLevelBoxes.first();
         return lineBreakBox.isLineBreakBox() && lineBreakBox.isPreferredLineHeightFontMetricsBased();
-    }
-    for (auto& inlineLevelBox : lineBox.nonRootInlineLevelBoxes()) {
-        // Filter out empty inline boxes e.g. <div><span></span><span></span><br></div>
-        if (inlineLevelBox.isInlineBox() && inlineLevelBox.hasContent())
-            return false;
     }
     return true;
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.h
@@ -40,6 +40,7 @@ public:
     bool NODELETE trailingNonBreakingSpaceNeedsAdjustment(bool isInIntrinsicWidthMode, bool lineHasOverflow) const;
     InlineLayoutUnit NODELETE initialLineHeight() const;
     bool inlineBoxAffectsLineBox(const InlineLevelBox&) const;
+    static bool NODELETE lineBreakBoxIsOnlyContentOnLine(const LineBox&);
     static bool NODELETE lineBreakBoxAffectsParentInlineBox(const LineBox&);
     std::optional<LayoutUnit> initialLetterAlignmentOffset(const Box& floatBox, const Style::ComputedStyle& lineBoxStyle) const;
     std::optional<InlineRect> adjustedRectForLineGridLineAlign(const InlineRect&) const;


### PR DESCRIPTION
#### 5204a1a34fa4baaf679a4f39ae0895f393fae67a
<pre>
REGRESSION (Safari 27): line-height quirk not applied inside inline-block
<a href="https://bugs.webkit.org/show_bug.cgi?id=323287">https://bugs.webkit.org/show_bug.cgi?id=323287</a>
&lt;<a href="https://rdar.apple.com/problem/186614663">rdar://problem/186614663</a>&gt;

Reviewed by Antti Koivisto.

In quirks mode the line-height quirk applies to line break boxes too, since a &lt;br&gt; has no text content.
310839@main made a &lt;br&gt; with a non-normal line-height stretch the line box unconditionally, so a line-height
inherited from an ancestor started stretching lines that have other content on them. Now the &lt;br&gt; only
stretches the line box when there&apos;s nothing else on the line to do it.

* LayoutTests/imported/w3c/web-platform-tests/css/css-inline/br-line-height-inherited-quirks-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-inline/br-line-height-inherited-quirks-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-inline/br-line-height-inherited-quirks.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::InlineFormattingUtils::inlineLevelBoxAffectsLineBox const):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.cpp:
(WebCore::Layout::LineBoxVerticalAligner::computeLineBoxLogicalHeight const):
(WebCore::Layout::LineBoxVerticalAligner::computeRootInlineBoxVerticalPosition const):
(WebCore::Layout::LineBoxVerticalAligner::layoutBoundsForInlineBoxSubtree const):
(WebCore::Layout::LineBoxVerticalAligner::alignInlineLevelBoxes const):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.h:
* Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp:
(WebCore::Layout::InlineQuirks::lineBreakBoxIsOnlyContentOnLine):
(WebCore::Layout::InlineQuirks::lineBreakBoxAffectsParentInlineBox):
* Source/WebCore/layout/formattingContexts/inline/InlineQuirks.h:

Canonical link: <a href="https://commits.webkit.org/320514@main">https://commits.webkit.org/320514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a14bee94c74904e87f2efefba770a5112f2bf71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195222 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4069ee05-fa9a-43f5-9b1b-263b512a9d0d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58534 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144479 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c607de40-a593-439c-ab2d-607a68c89f22) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124770 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2350f470-6357-48c6-9474-1f37783d476e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46874 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44972 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157241 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44641 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6277 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197171 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164580 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153958 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41251 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59181 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41245 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153618 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48135 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131469 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128053 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57677 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19659 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57036 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57287 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57113 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->