### PR TITLE
[EWS] results-db log contains a JSON dump of everything reported to results.webkit.org

### DIFF
--- a/Tools/CISupport/ews-build/results_db.py
+++ b/Tools/CISupport/ews-build/results_db.py
@@ -23,7 +23,6 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
-import json
 import os
 import sys
 import time
@@ -325,16 +324,12 @@ class ResultsDatabase(object):
         url = f'{cls.HOSTNAME}/api/upload/ews'
         label = f'{payload.flaky_type} flaky tests' if payload.flaky_type else 'failed tests'
         logger(f"Reporting {label} to {url}: {', '.join(sorted(payload.results))}\n")
-        # FIXME: Remove the request and response dumps once reporting has been validated against a
-        # deployed results database.
-        logger(f'Request:\n{json.dumps(document, indent=2, sort_keys=True)}\n')
 
         response = yield TwistedAdditions.request(url, type=b'POST', json=body, logger=logger)
         if not response:
             logger(f'No response from {url}, so {label} were not reported\n')
             return False
 
-        logger(f'Response from {url} ({response.status_code}):\n{response.content}\n')
         if response.status_code != 200:
             logger(f'Failed to report {label} (status {response.status_code})\n{response.content}\n')
             return False

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -13495,11 +13495,8 @@ class TestResultsDatabaseFailureHandling(unittest.TestCase):
                 'status': 'ok', 'tests': ['fast/a.html', 'fast/b.html'],
             }))
         self.assertTrue(reported)
-        self.assertIn('Request:\n{', logs)
         self.assertNotIn('api_key', logs)
         self.assertNotIn('super-secret', logs)
-        self.assertIn('"suite": "layout-tests"', logs)
-        self.assertIn('(200):', logs)
 
     @defer.inlineCallbacks
     def test_report_ews_logs_the_tests_the_server_stored(self):


### PR DESCRIPTION
#### 772a91ace41a493b5eaa051c702a4ddfcee122c0
<pre>
[EWS] results-db log contains a JSON dump of everything reported to results.webkit.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=323304">https://bugs.webkit.org/show_bug.cgi?id=323304</a>
<a href="https://rdar.apple.com/186553847">rdar://186553847</a>

Reviewed by Aakash Jain.

Every successful report dumps the whole upload payload into the
results-db log as pretty-printed JSON, then the whole response body
after it, burying the one line saying which tests were reported under
hundreds. Remove both, as the FIXME above them asked once reporting had
been validated against the deployed database. A failed report still logs
the response body.

* Tools/CISupport/ews-build/results_db.py:
(ResultsDatabase.report_ews):
* Tools/CISupport/ews-build/steps_unittest.py:
(TestResultsDatabaseFailureHandling.test_report_ews_logs_the_request_without_the_api_key):

Canonical link: <a href="https://commits.webkit.org/320500@main">https://commits.webkit.org/320500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c439203057a1f21edab5ccbf91b84c8e2717023

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184894 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195229 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186756 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58541 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144481 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48154 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165076 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124773 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46879 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44974 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157245 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44644 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6282 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197178 "Built successfully") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/184297 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58482 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153962 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59188 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41247 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153621 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28097 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48136 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128061 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57684 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19662 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57043 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57292 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57120 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->