### PR TITLE
[Text Extraction] Stale node UID resolution heuristic should surface failure in the case where the resolved node is stale

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -3423,6 +3423,7 @@ InteractionDescription interactionDescription(const Interaction& interaction, Lo
         }
     }
 
+    bool didAppendElementString = false;
     auto appendElementString = [&]<typename... T>(T&&... args) {
         auto elementString = textDescription(std::forward<T>(args)...);
         if (elementString.isEmpty())
@@ -3450,6 +3451,7 @@ InteractionDescription interactionDescription(const Interaction& interaction, Lo
         }();
 
         description.append(makeString(WTF::move(elementPrefix), WTF::move(elementString)));
+        didAppendElementString = true;
     };
 
     if (auto location = interaction.locationInRootView) {
@@ -3476,7 +3478,9 @@ InteractionDescription interactionDescription(const Interaction& interaction, Lo
         didFindTargetNode = node && node->isConnected();
     }
 
-    return { description.toString(), WTF::move(stringsToValidate), didFindTargetNode };
+    bool targetsSpecificElement = interaction.locationInRootView || interaction.nodeIdentifier || interaction.targetNodeHandleIdentifier || (usesSearchText && !interaction.text.isEmpty());
+
+    return { description.toString(), WTF::move(stringsToValidate), didFindTargetNode, didAppendElementString || !targetsSpecificElement };
 }
 
 std::optional<FrameIdentifier> contentFrameIdentifierForNode(NodeIdentifier identifier)

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -79,6 +79,7 @@ struct InteractionDescription {
     String description;
     Vector<String> stringsToValidate;
     bool didFindTargetNode { true };
+    bool describesInteractionTarget { true };
 };
 
 enum class EventListenerCategory : uint8_t {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4938,6 +4938,7 @@ header: <WebCore/TextExtractionTypes.h>
     String description;
     Vector<String> stringsToValidate;
     bool didFindTargetNode;
+    bool describesInteractionTarget;
 };
 
 header: <WebCore/TextExtractionTypes.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm
@@ -69,6 +69,59 @@
 
 constexpr Seconds defaultInteractionPresentationUpdateTimeout = 100_ms;
 
+constexpr auto staleNodeIdentifierGuidance = " The page changed since this uid was last observed; re-extract the page and retry with a current uid."_s;
+
+#if USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
+
+namespace WebKit {
+
+struct ConnectedRemapCandidate {
+    Ref<WebKit::WebFrameProxy> frame;
+    WebCore::NodeIdentifier nodeIdentifier;
+};
+
+} // namespace WebKit
+
+static String noteForRemappedStaleNode(const String& requestedIdentifier)
+{
+    return makeString("Note: the targeted node (uid="_s, requestedIdentifier, ") was stale from an earlier page state and was automatically re-resolved to the current matching element."_s);
+}
+
+static void findFirstConnectedRemapCandidate(WebKit::WebPageProxy& page, const Vector<String>& candidateIdentifiers, CompletionHandler<void(std::optional<WebKit::ConnectedRemapCandidate>&&)>&& completion)
+{
+    RefPtr<WebKit::WebFrameProxy> frameToQuery;
+    Vector<WebCore::NodeIdentifier> nodeIdentifiers;
+    for (auto& candidateIdentifier : candidateIdentifiers) {
+        auto candidate = WebKit::parseExtractedNodeInfo(candidateIdentifier);
+        if (!candidate)
+            continue;
+
+        RefPtr candidateFrame = WebKit::WebFrameProxy::webFrame(candidate->frameIdentifier) ?: page.mainFrame();
+        if (!candidateFrame)
+            continue;
+
+        if (!frameToQuery)
+            frameToQuery = candidateFrame;
+        else if (frameToQuery != candidateFrame)
+            continue;
+
+        nodeIdentifiers.append(candidate->nodeIdentifier);
+    }
+
+    if (!frameToQuery || nodeIdentifiers.isEmpty())
+        return completion({ });
+
+    Ref frame = frameToQuery.releaseNonNull();
+    frame->findFirstConnectedNode(WTF::move(nodeIdentifiers), [frame, completion = WTF::move(completion)](auto nodeIdentifier) mutable {
+        if (!nodeIdentifier)
+            return completion({ });
+
+        completion(WebKit::ConnectedRemapCandidate { WTF::move(frame), *nodeIdentifier });
+    });
+}
+
+#endif // USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
+
 #if PLATFORM(IOS_FAMILY)
 namespace ForcedDisplayRefreshProperties {
 constexpr Seconds refreshInterval = 100_ms;
@@ -167,7 +220,9 @@ static std::optional<WebCore::NodeIdentifier> activeContextMenuTargetNodeIdentif
 @end
 
 @interface WKWebView (WKTextExtractionInternal)
-- (void)_describeInteraction:(WebCore::TextExtraction::Interaction)interaction inFrame:(RefPtr<WebKit::WebFrameProxy>)targetFrame nodeIdentifier:(const String&)nodeIdentifier staleNodeNote:(const String&)staleNodeNote shouldResolveStaleNodeIdentifier:(BOOL)shouldResolveStaleNodeIdentifier completionHandler:(void (^)(NSString *, NSError *))completionHandler;
+- (void)_describeInteraction:(WebCore::TextExtraction::Interaction)interaction inFrame:(RefPtr<WebKit::WebFrameProxy>)targetFrame staleNodeResolution:(const WebKit::StaleNodeResolutionState&)staleNodeResolution completionHandler:(void (^)(NSString *, NSError *))completionHandler;
+- (void)_retryInteractionWithConnectedRemapCandidate:(WebCore::TextExtraction::Interaction)interaction actionType:(_WKTextExtractionAction)actionType requestedNodeIdentifier:(const String&)requestedIdentifier remapCandidates:(const Vector<String>&)remapCandidates failureDescription:(const String&)failureDescription completionHandler:(void(^)(_WKTextExtractionInteractionResult *))completionHandler;
+- (void)_retryDescribingInteractionWithConnectedRemapCandidate:(WebCore::TextExtraction::Interaction)interaction requestedNodeIdentifier:(const String&)requestedIdentifier remapCandidates:(const Vector<String>&)remapCandidates completionHandler:(void (^)(NSString *, NSError *))completionHandler;
 - (Vector<String>)_activeNativeMenuItemTitles;
 #if PLATFORM(MAC)
 - (RetainPtr<NSPopUpButtonCell>)_activePopupButtonCell;
@@ -523,7 +578,7 @@ static WebKit::TextExtractionOutputFormat textExtractionOutputFormat(_WKTextExtr
     };
 }
 
-- (void)_performInteraction:(WebCore::TextExtraction::Interaction)interaction inFrame:(RefPtr<WebKit::WebFrameProxy>)targetFrame actionType:(_WKTextExtractionAction)actionType nodeIdentifier:(const String&)attemptedIdentifier staleNodeNote:(const String&)staleNodeNote shouldResolveStaleNodeIdentifier:(BOOL)shouldResolveStaleNodeIdentifier completionHandler:(void(^)(_WKTextExtractionInteractionResult *))completionHandler
+- (void)_performInteraction:(WebCore::TextExtraction::Interaction)interaction inFrame:(RefPtr<WebKit::WebFrameProxy>)targetFrame actionType:(_WKTextExtractionAction)actionType staleNodeResolution:(const WebKit::StaleNodeResolutionState&)staleNodeResolution completionHandler:(void(^)(_WKTextExtractionInteractionResult *))completionHandler
 {
 #if USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
     RefPtr page = _page;
@@ -547,9 +602,7 @@ static WebKit::TextExtractionOutputFormat textExtractionOutputFormat(_WKTextExtr
         weakPage = WeakPtr { *page },
         assertionScope = WTF::move(assertionScope),
         actionType,
-        attemptedIdentifier,
-        staleNodeNote,
-        shouldResolveStaleNodeIdentifier,
+        staleNodeResolution,
         interaction = WTF::move(interactionForRetry),
         presentationUpdateTimeout,
         completionHandler = makeBlockPtr(WTF::move(completionHandler))
@@ -557,23 +610,15 @@ static WebKit::TextExtractionOutputFormat textExtractionOutputFormat(_WKTextExtr
         RetainPtr strongSelf = weakSelf.get();
         RefPtr strongPage = weakPage.get();
 
-        if (!success && shouldResolveStaleNodeIdentifier && strongSelf && strongPage && !attemptedIdentifier.isEmpty()) {
-            auto resolved = strongPage->textExtractionCache().resolve(attemptedIdentifier);
+        if (!success && strongSelf && strongPage && !staleNodeResolution.requestedIdentifier.isEmpty() && !staleNodeResolution.didRemap()) {
+            auto resolved = strongPage->textExtractionCache().resolve(staleNodeResolution.requestedIdentifier);
             if (resolved.resolution == WebKit::TextExtractionCache::NodeResolution::Remapped) {
-                RELEASE_LOG(TextExtraction, "<%@: %p> Interaction failed; re-resolved stale node %" PUBLIC_LOG_STRING " to %" PUBLIC_LOG_STRING " and retrying", [strongSelf class], strongSelf.get(), attemptedIdentifier.utf8().data(), resolved.identifier.utf8().data());
-                auto note = makeString("Note: the targeted node (uid="_s, attemptedIdentifier, ") was stale from an earlier page state and was automatically re-resolved to the current matching element."_s);
-                RefPtr<WebKit::WebFrameProxy> retryFrame;
-                if (auto identifiers = WebKit::parseExtractedNodeInfo(resolved.identifier)) {
-                    interaction.nodeIdentifier = { WTF::move(identifiers->nodeIdentifier) };
-                    retryFrame = WebKit::WebFrameProxy::webFrame(WTF::move(identifiers->frameIdentifier));
-                }
-                if (!retryFrame)
-                    retryFrame = strongPage->mainFrame();
-                [strongSelf _performInteraction:WTF::move(interaction) inFrame:WTF::move(retryFrame) actionType:actionType nodeIdentifier:resolved.identifier staleNodeNote:note shouldResolveStaleNodeIdentifier:NO completionHandler:completionHandler.get()];
+                [strongSelf _retryInteractionWithConnectedRemapCandidate:WTF::move(interaction) actionType:actionType requestedNodeIdentifier:staleNodeResolution.requestedIdentifier remapCandidates:resolved.identifiers failureDescription:description completionHandler:completionHandler.get()];
                 return;
             }
-            if (resolved.resolution == WebKit::TextExtractionCache::NodeResolution::Stale || resolved.resolution == WebKit::TextExtractionCache::NodeResolution::Ambiguous)
-                description = makeString(description, " The page changed since this uid was last observed; re-extract the page and retry with a current uid."_s);
+
+            if (resolved.resolution != WebKit::TextExtractionCache::NodeResolution::Current && resolved.resolution != WebKit::TextExtractionCache::NodeResolution::Unknown)
+                description = makeString(description, staleNodeIdentifierGuidance);
         }
 
         RetainPtr<NSString> errorDescription;
@@ -584,8 +629,8 @@ static WebKit::TextExtractionOutputFormat textExtractionOutputFormat(_WKTextExtr
                 replacedDescription = applyReplacementsToDescription(description, stringsToValidate, strongSelf->_lastTextExtractionReplacementStrings);
 
             summary = replacedDescription.createNSString();
-            if (!staleNodeNote.isEmpty())
-                summary = adoptNS([[NSString alloc] initWithFormat:@"%@ %@", summary.get(), staleNodeNote.createNSString().get()]);
+            if (staleNodeResolution.didRemap())
+                summary = adoptNS([[NSString alloc] initWithFormat:@"%@ %@", summary.get(), staleNodeResolution.noteForCurrentAttempt.createNSString().get()]);
         } else
             errorDescription = description.createNSString();
 
@@ -621,6 +666,42 @@ static WebKit::TextExtractionOutputFormat textExtractionOutputFormat(_WKTextExtr
         RunLoop::mainSingleton().dispatchAfter(presentationUpdateTimeout, [aggregator] {
             aggregator.get()();
         });
+    });
+#endif // USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
+}
+
+- (void)_retryInteractionWithConnectedRemapCandidate:(WebCore::TextExtraction::Interaction)interaction actionType:(_WKTextExtractionAction)actionType requestedNodeIdentifier:(const String&)requestedIdentifier remapCandidates:(const Vector<String>&)remapCandidates failureDescription:(const String&)failureDescription completionHandler:(void(^)(_WKTextExtractionInteractionResult *))completionHandler
+{
+#if USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
+    auto reportStaleNode = [failureDescription, completionHandler = makeBlockPtr(completionHandler)] {
+        RetainPtr errorDescription = makeString(failureDescription, staleNodeIdentifierGuidance).createNSString();
+        completionHandler(adoptNS([[_WKTextExtractionInteractionResult alloc] initWithErrorDescription:errorDescription.get() summary:nil interactedElementBounds:CGRectNull]).get());
+    };
+
+    RefPtr page = _page;
+    if (!page)
+        return reportStaleNode();
+
+    findFirstConnectedRemapCandidate(*page, remapCandidates, [
+        weakSelf = WeakObjCPtr<WKWebView>(self),
+        actionType,
+        requestedIdentifier,
+        interaction = WTF::move(interaction),
+        reportStaleNode = WTF::move(reportStaleNode),
+        completionHandler = makeBlockPtr(completionHandler)
+    ](std::optional<WebKit::ConnectedRemapCandidate>&& candidate) mutable {
+        RetainPtr strongSelf = weakSelf.get();
+        if (!strongSelf || !candidate) {
+            RELEASE_LOG_ERROR(TextExtraction, "<%@: %p> Interaction failed; every node that uid=%" PUBLIC_LOG_STRING " could be re-resolved to is also stale", [strongSelf class], strongSelf.get(), requestedIdentifier.utf8().data());
+            return reportStaleNode();
+        }
+
+        RELEASE_LOG(TextExtraction, "<%@: %p> Interaction failed; re-resolved stale node %" PUBLIC_LOG_STRING " to a connected node and retrying", [strongSelf class], strongSelf.get(), requestedIdentifier.utf8().data());
+        interaction.nodeIdentifier = candidate->nodeIdentifier;
+        [strongSelf _performInteraction:WTF::move(interaction) inFrame:RefPtr { candidate->frame.ptr() } actionType:actionType staleNodeResolution:WebKit::StaleNodeResolutionState {
+            .requestedIdentifier = requestedIdentifier,
+            .noteForCurrentAttempt = noteForRemappedStaleNode(requestedIdentifier)
+        } completionHandler:completionHandler.get()];
     });
 #endif // USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
 }
@@ -985,11 +1066,11 @@ static OptionSet<WebCore::DataDetectorType> NODELETE coreDataDetectorTypes(_WKTe
         return completionHandler([NSString stringWithFormat:@"Select popup menu item labeled '%s'", interaction.text.utf8().data()], nil);
 #endif
 
-    [self _describeInteraction:WTF::move(interaction) inFrame:targetFrame nodeIdentifier:nodeIdentifierString staleNodeNote:emptyString() shouldResolveStaleNodeIdentifier:YES completionHandler:completionHandler];
+    [self _describeInteraction:WTF::move(interaction) inFrame:targetFrame staleNodeResolution:WebKit::StaleNodeResolutionState { .requestedIdentifier = nodeIdentifierString } completionHandler:completionHandler];
 #endif // USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
 }
 
-- (void)_describeInteraction:(WebCore::TextExtraction::Interaction)interaction inFrame:(RefPtr<WebKit::WebFrameProxy>)targetFrame nodeIdentifier:(const String&)attemptedIdentifier staleNodeNote:(const String&)staleNodeNote shouldResolveStaleNodeIdentifier:(BOOL)shouldResolveStaleNodeIdentifier completionHandler:(void (^)(NSString *, NSError *))completionHandler
+- (void)_describeInteraction:(WebCore::TextExtraction::Interaction)interaction inFrame:(RefPtr<WebKit::WebFrameProxy>)targetFrame staleNodeResolution:(const WebKit::StaleNodeResolutionState&)staleNodeResolution completionHandler:(void (^)(NSString *, NSError *))completionHandler
 {
 #if USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
     RefPtr page = _page;
@@ -1000,36 +1081,37 @@ static OptionSet<WebCore::DataDetectorType> NODELETE coreDataDetectorTypes(_WKTe
     targetFrame->describeTextExtractionInteraction(WTF::move(interaction), [
         weakSelf = WeakObjCPtr<WKWebView>(self),
         weakPage = WeakPtr { *page },
-        attemptedIdentifier,
-        staleNodeNote,
-        shouldResolveStaleNodeIdentifier,
+        staleNodeResolution,
         interaction = WTF::move(interactionForRetry),
         completionHandler = makeBlockPtr(WTF::move(completionHandler))
     ](auto&& result) mutable {
         RetainPtr strongSelf = weakSelf.get();
         RefPtr strongPage = weakPage.get();
 
-        if (!result.didFindTargetNode && shouldResolveStaleNodeIdentifier && strongSelf && strongPage && !attemptedIdentifier.isEmpty()) {
-            auto resolved = strongPage->textExtractionCache().resolve(attemptedIdentifier);
+        bool resolutionIsStale = false;
+        if (!result.didFindTargetNode && strongSelf && strongPage && !staleNodeResolution.requestedIdentifier.isEmpty() && !staleNodeResolution.didRemap()) {
+            auto resolved = strongPage->textExtractionCache().resolve(staleNodeResolution.requestedIdentifier);
             if (resolved.resolution == WebKit::TextExtractionCache::NodeResolution::Remapped) {
-                RELEASE_LOG(TextExtraction, "<%@: %p> Describe target missing; re-resolved stale node %" PUBLIC_LOG_STRING " to %" PUBLIC_LOG_STRING " and retrying", [strongSelf class], strongSelf.get(), attemptedIdentifier.utf8().data(), resolved.identifier.utf8().data());
-                auto note = makeString("Note: the targeted node (uid="_s, attemptedIdentifier, ") was stale from an earlier page state and was automatically re-resolved to the current matching element."_s);
-                RefPtr<WebKit::WebFrameProxy> retryFrame;
-                if (auto identifiers = WebKit::parseExtractedNodeInfo(resolved.identifier)) {
-                    interaction.nodeIdentifier = { WTF::move(identifiers->nodeIdentifier) };
-                    retryFrame = WebKit::WebFrameProxy::webFrame(WTF::move(identifiers->frameIdentifier));
-                }
-                if (!retryFrame)
-                    retryFrame = strongPage->mainFrame();
-                [strongSelf _describeInteraction:WTF::move(interaction) inFrame:WTF::move(retryFrame) nodeIdentifier:resolved.identifier staleNodeNote:note shouldResolveStaleNodeIdentifier:NO completionHandler:completionHandler.get()];
+                [strongSelf _retryDescribingInteractionWithConnectedRemapCandidate:WTF::move(interaction) requestedNodeIdentifier:staleNodeResolution.requestedIdentifier remapCandidates:resolved.identifiers completionHandler:completionHandler.get()];
                 return;
             }
+
+            resolutionIsStale = resolved.resolution != WebKit::TextExtractionCache::NodeResolution::Current && resolved.resolution != WebKit::TextExtractionCache::NodeResolution::Unknown;
+        }
+
+        if (!result.describesInteractionTarget) {
+            RELEASE_LOG_ERROR(TextExtraction, "<%@: %p> Unable to describe the target of an interaction with node %" PUBLIC_LOG_STRING, [strongSelf class], strongSelf.get(), staleNodeResolution.requestedIdentifier.utf8().data());
+            auto errorDescription = makeString("Unable to describe the target of the interaction."_s, resolutionIsStale ? staleNodeIdentifierGuidance : ""_s);
+            completionHandler(nil, [NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{
+                NSDebugDescriptionErrorKey: errorDescription.createNSString()
+            }]);
+            return;
         }
 
         auto description = WTF::move(result.description);
         auto stringsToValidate = WTF::move(result.stringsToValidate);
         auto valid = Box<bool>::create(true);
-        Ref aggregator = MainRunLoopCallbackAggregator::create([completionHandler = WTF::move(completionHandler), description, valid, staleNodeNote, weakSelf, stringsToValidate] {
+        Ref aggregator = MainRunLoopCallbackAggregator::create([completionHandler = WTF::move(completionHandler), description, valid, staleNodeResolution, weakSelf, stringsToValidate] {
             if (!valid.get()) {
                 completionHandler(nil, [NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{
                     NSDebugDescriptionErrorKey: @"One or more strings failed validation."
@@ -1042,8 +1124,8 @@ static OptionSet<WebCore::DataDetectorType> NODELETE coreDataDetectorTypes(_WKTe
                 replacedDescription = applyReplacementsToDescription(description, stringsToValidate, strongSelf->_lastTextExtractionReplacementStrings);
 
             RetainPtr summary = replacedDescription.createNSString();
-            if (!staleNodeNote.isEmpty())
-                summary = adoptNS([[NSString alloc] initWithFormat:@"%@ %@", summary.get(), staleNodeNote.createNSString().get()]);
+            if (staleNodeResolution.didRemap())
+                summary = adoptNS([[NSString alloc] initWithFormat:@"%@ %@", summary.get(), staleNodeResolution.noteForCurrentAttempt.createNSString().get()]);
             completionHandler(summary, nil);
         });
 
@@ -1058,6 +1140,43 @@ static OptionSet<WebCore::DataDetectorType> NODELETE coreDataDetectorTypes(_WKTe
             });
         }
 #endif // ENABLE(TEXT_EXTRACTION_FILTER)
+    });
+#endif // USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
+}
+
+- (void)_retryDescribingInteractionWithConnectedRemapCandidate:(WebCore::TextExtraction::Interaction)interaction requestedNodeIdentifier:(const String&)requestedIdentifier remapCandidates:(const Vector<String>&)remapCandidates completionHandler:(void (^)(NSString *, NSError *))completionHandler
+{
+#if USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
+    auto reportStaleNode = [completionHandler = makeBlockPtr(completionHandler)] {
+        RetainPtr errorDescription = makeString("Unable to describe the target of the interaction."_s, staleNodeIdentifierGuidance).createNSString();
+        completionHandler(nil, [NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{
+            NSDebugDescriptionErrorKey: errorDescription
+        }]);
+    };
+
+    RefPtr page = _page;
+    if (!page)
+        return reportStaleNode();
+
+    findFirstConnectedRemapCandidate(*page, remapCandidates, [
+        weakSelf = WeakObjCPtr<WKWebView>(self),
+        requestedIdentifier,
+        interaction = WTF::move(interaction),
+        reportStaleNode = WTF::move(reportStaleNode),
+        completionHandler = makeBlockPtr(completionHandler)
+    ](std::optional<WebKit::ConnectedRemapCandidate>&& candidate) mutable {
+        RetainPtr strongSelf = weakSelf.get();
+        if (!strongSelf || !candidate) {
+            RELEASE_LOG_ERROR(TextExtraction, "<%@: %p> Describe target missing; every node that uid=%" PUBLIC_LOG_STRING " could be re-resolved to is also stale", [strongSelf class], strongSelf.get(), requestedIdentifier.utf8().data());
+            return reportStaleNode();
+        }
+
+        RELEASE_LOG(TextExtraction, "<%@: %p> Describe target missing; re-resolved stale node %" PUBLIC_LOG_STRING " to a connected node and retrying", [strongSelf class], strongSelf.get(), requestedIdentifier.utf8().data());
+        interaction.nodeIdentifier = candidate->nodeIdentifier;
+        [strongSelf _describeInteraction:WTF::move(interaction) inFrame:RefPtr { candidate->frame.ptr() } staleNodeResolution:WebKit::StaleNodeResolutionState {
+            .requestedIdentifier = requestedIdentifier,
+            .noteForCurrentAttempt = noteForRemappedStaleNode(requestedIdentifier)
+        } completionHandler:completionHandler.get()];
     });
 #endif // USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -67,6 +67,7 @@
 #import "SafeBrowsingUtilities.h"
 #import "SessionStateCoding.h"
 #import "TextExtractionAssertionScope.h"
+#import "TextExtractionCache.h"
 #import "TextExtractionFilter.h"
 #import "TextExtractionURLCache.h"
 #import "UIDelegate.h"
@@ -7358,7 +7359,7 @@ static Vector<Ref<API::TargetedElementInfo>> elementsFromWKElements(NSArray<_WKT
     }
 #endif // PLATFORM(MAC)
 
-    [self _performInteraction:WTF::move(interaction) inFrame:targetFrame actionType:actionType nodeIdentifier:nodeIdentifierString staleNodeNote:emptyString() shouldResolveStaleNodeIdentifier:YES completionHandler:completionHandler];
+    [self _performInteraction:WTF::move(interaction) inFrame:targetFrame actionType:actionType staleNodeResolution:WebKit::StaleNodeResolutionState { .requestedIdentifier = nodeIdentifierString } completionHandler:completionHandler];
 #endif // USE(APPLE_INTERNAL_SDK) || (!PLATFORM(WATCHOS) && !PLATFORM(APPLETV))
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -167,6 +167,7 @@ class ViewSnapshot;
 class WebFrameProxy;
 class WebPageProxy;
 struct PrintInfo;
+struct StaleNodeResolutionState;
 #if PLATFORM(MAC)
 class WebViewImpl;
 #endif
@@ -808,7 +809,7 @@ struct LiveResizeSnapshotState {
 - (void)_extractDebugTextWithConfigurationWithoutUpdatingFilterRules:(_WKTextExtractionConfiguration *)configuration assertionScope:(UniqueRef<WebKit::TextExtractionAssertionScope>&&)assertionScope completionHandler:(void(^)(_WKTextExtractionResult *))completionHandler;
 - (void)_filterExtractedStringWithoutUpdatingFilterRules:(NSString *)string options:(_WKTextExtractionFilterOptions)options completionHandler:(void(^)(NSString *))completionHandler;
 - (std::expected<std::pair<RefPtr<WebKit::WebFrameProxy>, WebCore::TextExtraction::Interaction>, RetainPtr<NSString>>)_convertToWebCoreInteraction:(_WKTextExtractionInteraction *)wkInteraction nodeIdentifier:(const String&)nodeIdentifierString;
-- (void)_performInteraction:(WebCore::TextExtraction::Interaction)interaction inFrame:(RefPtr<WebKit::WebFrameProxy>)targetFrame actionType:(_WKTextExtractionAction)actionType nodeIdentifier:(const String&)nodeIdentifier staleNodeNote:(const String&)staleNodeNote shouldResolveStaleNodeIdentifier:(BOOL)shouldResolveStaleNodeIdentifier completionHandler:(void(^)(_WKTextExtractionInteractionResult *))completionHandler;
+- (void)_performInteraction:(WebCore::TextExtraction::Interaction)interaction inFrame:(RefPtr<WebKit::WebFrameProxy>)targetFrame actionType:(_WKTextExtractionAction)actionType staleNodeResolution:(const WebKit::StaleNodeResolutionState&)staleNodeResolution completionHandler:(void(^)(_WKTextExtractionInteractionResult *))completionHandler;
 
 #if ENABLE(TEXT_EXTRACTION_FILTER)
 - (void)_validateText:(const String&)text inFrame:(std::optional<WebCore::FrameIdentifier>&&)frameIdentifier inNode:(std::optional<WebCore::NodeIdentifier>&&)nodeIdentifier completionHandler:(CompletionHandler<void(const String&)>&&)completionHandler;

--- a/Source/WebKit/UIProcess/TextExtractionCache.cpp
+++ b/Source/WebKit/UIProcess/TextExtractionCache.cpp
@@ -85,11 +85,11 @@ Vector<String> TextExtractionCache::contextWindowAfter(const Vector<TextExtracti
 auto TextExtractionCache::resolve(const String& identifier) const -> ResolvedNode
 {
     if (m_entries.isEmpty())
-        return { identifier, NodeResolution::Unknown };
+        return { { identifier }, NodeResolution::Unknown };
 
     size_t newestIndex = m_entries.size() - 1;
     if (m_entries[newestIndex].lineIndexForUID.contains(identifier))
-        return { identifier, NodeResolution::Current };
+        return { { identifier }, NodeResolution::Current };
 
     Vector<size_t, maxEntries> sourceEntryIndices;
     for (size_t index = 0; index < newestIndex; ++index) {
@@ -98,8 +98,9 @@ auto TextExtractionCache::resolve(const String& identifier) const -> ResolvedNod
     }
 
     if (sourceEntryIndices.isEmpty())
-        return { identifier, NodeResolution::Unknown };
+        return { { identifier }, NodeResolution::Unknown };
 
+    Vector<String> candidates;
     auto& newestURL = m_entries[newestIndex].url;
     for (size_t targetIndex = newestIndex; targetIndex > sourceEntryIndices.first(); --targetIndex) {
         auto& target = m_entries[targetIndex];
@@ -134,13 +135,24 @@ auto TextExtractionCache::resolve(const String& identifier) const -> ResolvedNod
         if (remappedIdentifiers.isEmpty())
             continue;
 
-        if (remappedIdentifiers.size() > 1)
-            return { { }, NodeResolution::Ambiguous };
+        if (remappedIdentifiers.size() > 1) {
+            if (candidates.isEmpty())
+                return { { }, NodeResolution::Ambiguous };
+            break;
+        }
 
-        return { *remappedIdentifiers.begin(), NodeResolution::Remapped };
+        auto& remapped = *remappedIdentifiers.begin();
+        if (!candidates.contains(remapped))
+            candidates.append(remapped);
+
+        if (candidates.size() >= maxRemapCandidates)
+            break;
     }
 
-    return { { }, NodeResolution::Stale };
+    if (candidates.isEmpty())
+        return { { }, NodeResolution::Stale };
+
+    return { WTF::move(candidates), NodeResolution::Remapped };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/TextExtractionCache.h
+++ b/Source/WebKit/UIProcess/TextExtractionCache.h
@@ -36,6 +36,7 @@ class TextExtractionCache {
 public:
     static constexpr auto maxEntries = 20;
     static constexpr auto contextLineCount = 3;
+    static constexpr auto maxRemapCandidates = 4;
 
     enum class NodeResolution : uint8_t {
         Current,
@@ -46,7 +47,7 @@ public:
     };
 
     struct ResolvedNode {
-        String identifier;
+        Vector<String> identifiers;
         NodeResolution resolution { NodeResolution::Unknown };
     };
 
@@ -65,6 +66,13 @@ private:
     static Vector<String> contextWindowAfter(const Vector<TextExtractionLineContent>&, unsigned targetIndex);
 
     Vector<Entry> m_entries;
+};
+
+struct StaleNodeResolutionState {
+    String requestedIdentifier;
+    String noteForCurrentAttempt;
+
+    bool didRemap() const { return !noteForCurrentAttempt.isEmpty(); }
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -1269,6 +1269,14 @@ void WebFrameProxy::requestContentFrameIdentifierForNode(NodeIdentifier nodeIden
     sendWithAsyncReply(Messages::WebFrame::RequestContentFrameIdentifierForNode(nodeIdentifier), WTF::move(completion));
 }
 
+void WebFrameProxy::findFirstConnectedNode(Vector<NodeIdentifier>&& candidates, CompletionHandler<void(std::optional<NodeIdentifier>)>&& completion)
+{
+    if (RefPtr page = m_page.get(); !page || !page->hasRunningProcess())
+        return completion({ });
+
+    sendWithAsyncReply(Messages::WebFrame::FindFirstConnectedNode(WTF::move(candidates)), WTF::move(completion));
+}
+
 void WebFrameProxy::getSelectorPathsForNode(JSHandleInfo&& handle, CompletionHandler<void(Vector<HashSet<String>>&&)>&& completion)
 {
     if (RefPtr page = m_page.get(); !page || !page->hasRunningProcess())

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -335,6 +335,7 @@ public:
     void requestContainerJSHandleForExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
     void requestContainerJSHandleForSearchTexts(Vector<String>&&, std::optional<WebCore::NodeIdentifier>&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
     void requestContentFrameIdentifierForNode(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>&&)>&&);
+    void findFirstConnectedNode(Vector<WebCore::NodeIdentifier>&&, CompletionHandler<void(std::optional<WebCore::NodeIdentifier>)>&&);
 
     void getSelectorPathsForNode(JSHandleInfo&&, CompletionHandler<void(Vector<HashSet<String>>&&)>&&);
     void getNodeForSelectorPaths(Vector<HashSet<String>>&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -2001,7 +2001,7 @@ void WebFrame::describeTextExtractionInteraction(TextExtraction::Interaction&& i
 {
     RefPtr frame = coreLocalFrame();
     if (!frame)
-        return completion({ { }, { }, false });
+        return completion({ { }, { }, false, false });
 
     auto resolvedInteraction = interactionWithResolvedTargetNode(WTF::move(interaction));
     completion(TextExtraction::interactionDescription(resolvedInteraction, *frame));
@@ -2077,6 +2077,17 @@ void WebFrame::requestContainerJSHandleForSearchTexts(Vector<String>&& searchTex
 void WebFrame::requestContentFrameIdentifierForNode(NodeIdentifier nodeIdentifier, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>&&)>&& completion)
 {
     completion(TextExtraction::contentFrameIdentifierForNode(nodeIdentifier));
+}
+
+void WebFrame::findFirstConnectedNode(Vector<NodeIdentifier>&& candidates, CompletionHandler<void(std::optional<NodeIdentifier>)>&& completion)
+{
+    for (auto& candidate : candidates) {
+        RefPtr node = Node::fromIdentifier(candidate);
+        if (node && node->isConnected())
+            return completion(candidate);
+    }
+
+    completion({ });
 }
 
 void WebFrame::getSelectorPathsForNode(JSHandleInfo&& handle, CompletionHandler<void(Vector<HashSet<String>>&&)>&& completion)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -309,6 +309,7 @@ public:
     void requestContainerJSHandleForExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
     void requestContainerJSHandleForSearchTexts(Vector<String>&&, std::optional<WebCore::NodeIdentifier>&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
     void requestContentFrameIdentifierForNode(WebCore::NodeIdentifier, CompletionHandler<void(std::optional<WebCore::FrameIdentifier>&&)>&&);
+    void findFirstConnectedNode(Vector<WebCore::NodeIdentifier>&&, CompletionHandler<void(std::optional<WebCore::NodeIdentifier>)>&&);
 
     void getSelectorPathsForNode(JSHandleInfo&&, CompletionHandler<void(Vector<HashSet<String>>&&)>&&);
     void getNodeForSelectorPaths(Vector<HashSet<String>>&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
@@ -46,6 +46,7 @@ messages -> WebFrame {
     RequestContainerJSHandleForExtractedText(struct WebCore::TextExtraction::ExtractedText text) -> (struct std::optional<WebKit::JSHandleInfo> handle)
     RequestContainerJSHandleForSearchTexts(Vector<String> texts, std::optional<WebCore::NodeIdentifier> fallbackNodeIdentifier) -> (struct std::optional<WebKit::JSHandleInfo> handle)
     RequestContentFrameIdentifierForNode(WebCore::NodeIdentifier nodeIdentifier) -> (std::optional<WebCore::FrameIdentifier> frameIdentifier)
+    FindFirstConnectedNode(Vector<WebCore::NodeIdentifier> candidates) -> (std::optional<WebCore::NodeIdentifier> nodeIdentifier)
 
     # Element targeting support
     GetSelectorPathsForNode(struct WebKit::JSHandleInfo handle) -> (Vector<HashSet<String>> selectors)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -447,7 +447,7 @@ TEST(TextExtractionTests, InteractionDescriptionAndSearchTextForLabellessIcons)
         "<div class='row-bravo'><span>Bravo Label</span><button onclick=''></button></div>"];
 
     RetainPtr debugText = [webView synchronouslyGetDebugText:nil];
-    auto clickDescription = [&](NSString *className, NSString *searchText) -> NSString * {
+    auto makeClickInteraction = [&](NSString *className, NSString *searchText) {
         RetainPtr identifier = extractNodeIdentifier(debugText, className);
         EXPECT_NOT_NULL(identifier);
 
@@ -456,10 +456,20 @@ TEST(TextExtractionTests, InteractionDescriptionAndSearchTextForLabellessIcons)
         if (searchText)
             [interaction setText:searchText];
 
+        return interaction;
+    };
+
+    auto clickDescription = [&](NSString *className, NSString *searchText) -> NSString * {
         NSError *error = nil;
-        NSString *description = [interaction debugDescriptionInWebView:webView error:&error];
+        NSString *description = [makeClickInteraction(className, searchText) debugDescriptionInWebView:webView error:&error];
         EXPECT_NULL(error);
         return description;
+    };
+
+    auto cannotDescribeClick = [&](NSString *className, NSString *searchText) -> bool {
+        NSError *error = nil;
+        NSString *description = [makeClickInteraction(className, searchText) debugDescriptionInWebView:webView error:&error];
+        return !description && error;
     };
 
     EXPECT_WK_STREQ("Click on i with class “chevron-one” before rendered text “Notifications”", clickDescription(@"chevron-one", nil));
@@ -469,8 +479,8 @@ TEST(TextExtractionTests, InteractionDescriptionAndSearchTextForLabellessIcons)
     EXPECT_WK_STREQ("Click on button after rendered text “Bravo Label” under div with class “row-bravo”", clickDescription(@"button", nil));
 
     EXPECT_WK_STREQ("Click on “Security” in child node of span under div with class “head-two”, with rendered text “Security”", clickDescription(@"chevron-two", @"Security"));
-    EXPECT_WK_STREQ("Click", clickDescription(@"chevron-two", @"Notifications"));
-    EXPECT_WK_STREQ("Click", clickDescription(@"chevron-two", @"Nonexistent"));
+    EXPECT_TRUE(cannotDescribeClick(@"chevron-two", @"Notifications"));
+    EXPECT_TRUE(cannotDescribeClick(@"chevron-two", @"Nonexistent"));
 }
 
 TEST(TextExtractionTests, InteractionDescriptionIncludesAssociatedLabelText)
@@ -604,6 +614,37 @@ TEST(TextExtractionTests, InteractionDebugDescriptionWithStaleNodeIdentifier)
     [interaction setText:@"Test"];
 
     EXPECT_NOT_NULL([interaction debugDescriptionInWebView:webView error:&error]);
+}
+
+TEST(TextExtractionTests, InteractionDebugDescriptionWithUnresolvableNodeIdentifier)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration preferences] _setTextExtractionEnabled:YES];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    [webView synchronouslyLoadTestPageNamed:@"debug-text-extraction"];
+
+    NSError *error = nil;
+    RetainPtr interaction = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionClick]);
+    [interaction setNodeIdentifier:@"999999999"];
+
+    EXPECT_NULL([interaction debugDescriptionInWebView:webView error:&error]);
+    EXPECT_NOT_NULL(error);
+}
+
+TEST(TextExtractionTests, InteractionDebugDescriptionWithoutTargetElement)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration preferences] _setTextExtractionEnabled:YES];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    [webView synchronouslyLoadTestPageNamed:@"debug-text-extraction"];
+
+    NSError *error = nil;
+    RetainPtr interaction = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionScroll]);
+
+    EXPECT_WK_STREQ("Scroll to next page", [interaction debugDescriptionInWebView:webView error:&error]);
+    EXPECT_NULL(error);
 }
 
 TEST(TextExtractionTests, InteractionResultSummary)
@@ -796,6 +837,58 @@ TEST(TextExtractionTests, InteractionRemapsStaleNodeIdentifierWithURL)
     EXPECT_TRUE([summary containsString:@"stale"]);
     EXPECT_TRUE([summary containsString:@"re-resolved"]);
     EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.accountTabClicked"] boolValue]);
+}
+
+TEST(TextExtractionTests, InteractionReportsStaleNodeWhenRemapCandidateIsAlsoStale)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration preferences] _setTextExtractionEnabled:YES];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+
+    auto makeDebugTextConfiguration = [] {
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setFilterOptions:_WKTextExtractionFilterNone];
+        return configuration;
+    };
+
+    RetainPtr verificationURL = [NSURL URLWithString:@"https://example.com/verify"];
+    RetainPtr chooseMethodMarkup = @"<div>"
+        "<p>Keeping your account safe</p>"
+        "<p>Choose one to continue</p>"
+        "<label><input type='radio' name='method' aria-label='Email verification'>Email</label>"
+        "<label><input type='radio' name='method' aria-label='Text verification'>Text</label>"
+        "<button id='continue'>Continue</button>"
+        "</div>";
+
+    RetainPtr enterCodeMarkup = @"<div>"
+        "<p>Enter verification code</p>"
+        "<p>It may take a few minutes to arrive</p>"
+        "<input type='text' aria-label='Verification code'>"
+        "<button id='verify'>Verify</button>"
+        "</div>";
+
+    [webView synchronouslyLoadHTMLString:chooseMethodMarkup baseURL:verificationURL];
+    RetainPtr staleIdentifier = extractNodeIdentifier([webView synchronouslyGetDebugText:makeDebugTextConfiguration()], @"Email verification");
+    EXPECT_NOT_NULL(staleIdentifier);
+
+    [webView synchronouslyLoadHTMLString:chooseMethodMarkup baseURL:verificationURL];
+    RetainPtr supersededIdentifier = extractNodeIdentifier([webView synchronouslyGetDebugText:makeDebugTextConfiguration()], @"Email verification");
+    EXPECT_NOT_NULL(supersededIdentifier);
+    EXPECT_FALSE([staleIdentifier isEqualToString:supersededIdentifier]);
+
+    [webView synchronouslyLoadHTMLString:enterCodeMarkup baseURL:verificationURL];
+    RetainPtr latestDebugText = [webView synchronouslyGetDebugText:makeDebugTextConfiguration()];
+    EXPECT_FALSE([latestDebugText containsString:@"Email verification"]);
+
+    RetainPtr interaction = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionClick]);
+    [interaction setNodeIdentifier:staleIdentifier];
+
+    RetainPtr result = [webView synchronouslyPerformInteraction:interaction];
+    EXPECT_NULL([result summary]);
+    RetainPtr<NSString> errorDescription = [[result error] userInfo][NSDebugDescriptionErrorKey];
+    EXPECT_TRUE([errorDescription containsString:@"re-extract the page"]);
+    EXPECT_FALSE([errorDescription containsString:@"re-resolved"]);
 }
 
 TEST(TextExtractionTests, TargetNodeAndClientAttributes)


### PR DESCRIPTION
#### 1207e682053fff75cd104d5ae8a02f138c50f72a
<pre>
[Text Extraction] Stale node UID resolution heuristic should surface failure in the case where the resolved node is stale
<a href="https://bugs.webkit.org/show_bug.cgi?id=323397">https://bugs.webkit.org/show_bug.cgi?id=323397</a>
<a href="https://rdar.apple.com/186483543">rdar://186483543</a>

Reviewed by Abrar Rahman Protyasha.

The stale node resolution heuristic (for Safari MCP, Automatically Fix Passwords, etc.) currently
allows agents to interact with stale node `uid`s, as long as the stale node `uid` can be mapped to a
node in the DOM that appeared in a later extraction with matching self-and-surrounding context. This
is achieved by maintaining a sliding window of recent text extraction results on the web view, such
that we&apos;re able to both:

1.  Detect when the agent tries to interact with a stale `uid` that no longer corresponds to
    anything in the current page.

2.  Check if anything in the later text extraction looks (nearly) identical to the old context
    (ignoring differences in `uid` and some other transient attributes), and instead of failing,
    handle the interaction as if the agent tried to interact with that newer node `uid`.

This is especially crucial to keep weaker models from consistently failing to issue valid tool calls
when reasoning about long-horizon tasks, if it tries to interact with stale nodes. However, this
mechanism currently doesn&apos;t check that this newer resolved node isn&apos;t (itself) stale; as a result,
the interaction result and description can end up confusing agents even further (&quot;node uid `X` was
stale, so we resolved it to `Y`&quot;, followed by &quot;Failed to interact with `Y` because `Y` was stale&quot;).

To fix this, we add one final sanity check to ensure that the node we end up resolving the stale uid
to isn&apos;t also stale. `resolve()` now returns the remapping candidates in order of preference, and we
ask the web process for the first one that&apos;s still connected before committing to it. If none of
them are, we report the original failure as a stale uid and tell the agent to re-extract the page
rather than interacting with a node we already know is gone.

Test:   TextExtractionTests.InteractionDebugDescriptionWithUnresolvableNodeIdentifier
        TextExtractionTests.InteractionDebugDescriptionWithoutTargetElement
        TextExtractionTests.InteractionReportsStaleNodeWhenRemapCandidateIsAlsoStale

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::interactionDescription):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView+TextExtraction.mm:
(noteForRemappedStaleNode):
(findFirstConnectedRemapCandidate):
(-[WKWebView _performInteraction:inFrame:actionType:staleNodeResolution:completionHandler:]):
(-[WKWebView _retryInteractionWithConnectedRemapCandidate:actionType:requestedNodeIdentifier:remapCandidates:failureDescription:completionHandler:]):
(-[WKWebView _describeInteraction:completionHandler:]):
(-[WKWebView _describeInteraction:inFrame:staleNodeResolution:completionHandler:]):
(-[WKWebView _retryDescribingInteractionWithConnectedRemapCandidate:requestedNodeIdentifier:remapCandidates:completionHandler:]):
(-[WKWebView _performInteraction:inFrame:actionType:nodeIdentifier:staleNodeNote:shouldResolveStaleNodeIdentifier:completionHandler:]): Deleted.
(-[WKWebView _describeInteraction:inFrame:nodeIdentifier:staleNodeNote:shouldResolveStaleNodeIdentifier:completionHandler:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _performInteraction:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/TextExtractionCache.cpp:
(WebKit::TextExtractionCache::resolve const):
* Source/WebKit/UIProcess/TextExtractionCache.h:
(WebKit::StaleNodeResolutionState::didRemap const):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::findFirstConnectedNode):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::describeTextExtractionInteraction):
(WebKit::WebFrame::findFirstConnectedNode):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.messages.in:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, InteractionDebugDescriptionWithStaleNodeIdentifier)):
(TestWebKitAPI::TEST(TextExtractionTests, InteractionDebugDescriptionWithoutTargetElement)):
(TestWebKitAPI::TEST(TextExtractionTests, InteractionReportsStaleNodeWhenRemapCandidateIsAlsoStale)):

Canonical link: <a href="https://commits.webkit.org/320523@main">https://commits.webkit.org/320523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3cefd454c42900ca27a9c091dff78a559d0f362

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195320 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/03c4981e-3f75-4edc-aaff-28b28df2e564) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58632 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144559 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c98655a0-5d4b-42a3-92d5-2deb3f6eeeb5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165156 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124846 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e01a75a3-d398-4a64-917c-237cd533b3e5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46958 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157327 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44723 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6372 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51567 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49403 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197268 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58572 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154040 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41261 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59282 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153697 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48212 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131572 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128206 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57774 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19741 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57134 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57383 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57210 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->