### PR TITLE
Cache.delete() and Cache.keys() swallow exceptions thrown while constructing a Request from a URL string

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-delete.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-delete.https.any-expected.txt
@@ -7,4 +7,5 @@ PASS Cache.delete supports ignoreVary
 PASS Cache.delete with a non-existent entry
 PASS Cache.delete with ignoreSearch option (request with search parameters)
 PASS Cache.delete with ignoreSearch option (when it is specified as false)
+PASS Cache.delete with a string that cannot construct a Request
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-delete.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-delete.https.any.js
@@ -161,4 +161,13 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
   },
   'Cache.delete with ignoreSearch option (when it is specified as false)');
 
+cache_test(function(cache, test) {
+    return promise_rejects_js(
+      test,
+      TypeError,
+      cache.delete('https://user:password@example.com/'),
+      'Cache.delete should reject with the exception thrown when constructing ' +
+      'a Request from the given URL string fails.');
+  }, 'Cache.delete with a string that cannot construct a Request');
+
 done();

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-delete.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-delete.https.any.serviceworker-expected.txt
@@ -7,4 +7,5 @@ PASS Cache.delete supports ignoreVary
 PASS Cache.delete with a non-existent entry
 PASS Cache.delete with ignoreSearch option (request with search parameters)
 PASS Cache.delete with ignoreSearch option (when it is specified as false)
+PASS Cache.delete with a string that cannot construct a Request
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-delete.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-delete.https.any.sharedworker-expected.txt
@@ -7,4 +7,5 @@ PASS Cache.delete supports ignoreVary
 PASS Cache.delete with a non-existent entry
 PASS Cache.delete with ignoreSearch option (request with search parameters)
 PASS Cache.delete with ignoreSearch option (when it is specified as false)
+PASS Cache.delete with a string that cannot construct a Request
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-delete.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-delete.https.any.worker-expected.txt
@@ -7,4 +7,5 @@ PASS Cache.delete supports ignoreVary
 PASS Cache.delete with a non-existent entry
 PASS Cache.delete with ignoreSearch option (request with search parameters)
 PASS Cache.delete with ignoreSearch option (when it is specified as false)
+PASS Cache.delete with a string that cannot construct a Request
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-keys.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-keys.https.any-expected.txt
@@ -15,4 +15,5 @@ PASS Cache.keys with explicitly undefined request
 PASS Cache.keys with explicitly undefined request and empty options
 PASS Cache.keys without parameters and VARY entries
 PASS Cache.keys with a HEAD Request
+PASS Cache.keys with a string that cannot construct a Request
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-keys.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-keys.https.any.js
@@ -209,4 +209,13 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
         });
   }, 'Cache.keys with a HEAD Request');
 
+cache_test(function(cache, test) {
+    return promise_rejects_js(
+      test,
+      TypeError,
+      cache.keys('https://user:password@example.com/'),
+      'Cache.keys should reject with the exception thrown when constructing ' +
+      'a Request from the given URL string fails.');
+  }, 'Cache.keys with a string that cannot construct a Request');
+
 done();

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-keys.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-keys.https.any.serviceworker-expected.txt
@@ -15,4 +15,5 @@ PASS Cache.keys with explicitly undefined request
 PASS Cache.keys with explicitly undefined request and empty options
 PASS Cache.keys without parameters and VARY entries
 PASS Cache.keys with a HEAD Request
+PASS Cache.keys with a string that cannot construct a Request
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-keys.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-keys.https.any.sharedworker-expected.txt
@@ -15,4 +15,5 @@ PASS Cache.keys with explicitly undefined request
 PASS Cache.keys with explicitly undefined request and empty options
 PASS Cache.keys without parameters and VARY entries
 PASS Cache.keys with a HEAD Request
+PASS Cache.keys with a string that cannot construct a Request
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-keys.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-keys.https.any.worker-expected.txt
@@ -15,4 +15,5 @@ PASS Cache.keys with explicitly undefined request
 PASS Cache.keys with explicitly undefined request and empty options
 PASS Cache.keys without parameters and VARY entries
 PASS Cache.keys with a HEAD Request
+PASS Cache.keys with a string that cannot construct a Request
 

--- a/Source/WebCore/Modules/cache/DOMCache.cpp
+++ b/Source/WebCore/Modules/cache/DOMCache.cpp
@@ -456,9 +456,13 @@ void DOMCache::remove(RequestInfo&& info, CacheQueryOptions&& options, DOMPromis
     if (!scriptExecutionContext()) [[unlikely]]
         return;
 
-    auto requestOrException = requestFromInfo(WTF::move(info), options.ignoreMethod);
+    bool requestValidationFailed = false;
+    auto requestOrException = requestFromInfo(WTF::move(info), options.ignoreMethod, &requestValidationFailed);
     if (requestOrException.hasException()) {
-        promise.resolve(false);
+        if (requestValidationFailed)
+            promise.resolve(false);
+        else
+            promise.reject(requestOrException.releaseException());
         return;
     }
 
@@ -482,9 +486,13 @@ void DOMCache::keys(std::optional<RequestInfo>&& info, CacheQueryOptions&& optio
 
     ResourceRequest resourceRequest;
     if (info) {
-        auto requestOrException = requestFromInfo(WTF::move(info.value()), options.ignoreMethod);
+        bool requestValidationFailed = false;
+        auto requestOrException = requestFromInfo(WTF::move(info.value()), options.ignoreMethod, &requestValidationFailed);
         if (requestOrException.hasException()) {
-            promise.resolve(Vector<Ref<FetchRequest>> { });
+            if (requestValidationFailed)
+                promise.resolve(Vector<Ref<FetchRequest>> { });
+            else
+                promise.reject(requestOrException.releaseException());
             return;
         }
         resourceRequest = requestOrException.releaseReturnValue()->resourceRequest();


### PR DESCRIPTION
#### 946a6c01843cc7da0b446fffbae6c9b1c152a303
<pre>
Cache.delete() and Cache.keys() swallow exceptions thrown while constructing a Request from a URL string
<a href="https://bugs.webkit.org/show_bug.cgi?id=323401">https://bugs.webkit.org/show_bug.cgi?id=323401</a>
<a href="https://rdar.apple.com/186636105">rdar://186636105</a>

Reviewed by Youenn Fablet.

DOMCache::remove() and DOMCache::keys() called requestFromInfo() without the
requestValidationFailed out-parameter and resolved the promise with an empty
result (false / an empty array) on any exception. As a result a genuine
TypeError thrown while constructing the Request from a string — e.g. a URL
that is invalid or contains credentials — was silently turned into an empty
resolve instead of rejecting the promise.

The Cache specification requires the exception to propagate. For
Cache.delete() [1]:

    &quot;Else if request is a string, then:
     Set r to the associated request of the result of invoking the initial
     value of Request as constructor with request as its argument. If this
     throws an exception, return a promise rejected with that exception.&quot;

and identically for Cache.keys() [2]:

    &quot;Else if request is a string, then:
     Set r to the associated request of the result of invoking the initial
     value of Request as constructor with request as its argument. If this
     throws an exception, return a promise rejected with that exception.&quot;

Only a Request object whose method is not `GET` (without ignoreMethod) resolves
with an empty result. doMatch() and matchAll() already distinguish these two
cases via the requestValidationFailed bool; make remove() and keys() do the
same. Chrome and Firefox already reject in this case.

[1] <a href="https://w3c.github.io/ServiceWorker/#cache-delete">https://w3c.github.io/ServiceWorker/#cache-delete</a>
[2] <a href="https://w3c.github.io/ServiceWorker/#cache-keys">https://w3c.github.io/ServiceWorker/#cache-keys</a>

* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-delete.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-delete.https.any.js:
(cache_test):
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-delete.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-delete.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-delete.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-keys.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-keys.https.any.js:
(cache_test):
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-keys.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-keys.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/cache-storage/cache-keys.https.any.worker-expected.txt:
* Source/WebCore/Modules/cache/DOMCache.cpp:
(WebCore::DOMCache::remove):
(WebCore::DOMCache::keys):

Canonical link: <a href="https://commits.webkit.org/320524@main">https://commits.webkit.org/320524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38bc6e043f76e49ede03bfea289e9cdf68eb55ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195241 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/325b380d-2785-465c-85a5-dbcdbe4a832b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144490 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/284e8542-4dc0-486a-bad5-0aae8557dcdb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124782 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bbc937ed-edda-430f-9eaf-9fcb1efd0098) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46890 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44993 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157256 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44654 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6294 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51489 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197190 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58494 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153971 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41264 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59200 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153630 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48146 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131488 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128083 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57696 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19672 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57055 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57304 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57132 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->