### PR TITLE
JSON displayed with wrong encoding when loaded in a frame (browser default instead of UTF-8)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/encoding/json-document-utf8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/encoding/json-document-utf8-expected.txt
@@ -1,0 +1,6 @@
+
+PASS application/json with no charset is decoded as UTF-8 under a windows-1251 parent frame
+PASS application/json;charset=utf-8 is decoded as UTF-8
+PASS text/json with no charset is decoded as UTF-8
+PASS application/json;charset=windows-1251 honors the explicit charset
+

--- a/LayoutTests/imported/w3c/web-platform-tests/encoding/json-document-utf8.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/encoding/json-document-utf8.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<meta charset="windows-1251">
+<title>JSON documents are decoded as UTF-8 by default</title>
+<link rel="help" href="https://datatracker.ietf.org/doc/html/rfc8259#section-8.1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+const utf8 = '{"text":"\u2603\u00e9"}';
+
+function loadJSON(query) {
+  return new Promise((resolve, reject) => {
+    const frame = document.createElement("iframe");
+    frame.onload = () => {
+      const text = frame.contentDocument.body.textContent;
+      frame.remove();
+      resolve(text);
+    };
+    frame.onerror = () => { frame.remove(); reject(new Error("load failed")); };
+    frame.src = "resources/json-charset.py" + query;
+    document.body.appendChild(frame);
+  });
+}
+
+promise_test(async () => {
+  assert_equals(await loadJSON(""), utf8);
+}, "application/json with no charset is decoded as UTF-8 under a windows-1251 parent frame");
+
+promise_test(async () => {
+  assert_equals(await loadJSON("?charset=utf-8"), utf8);
+}, "application/json;charset=utf-8 is decoded as UTF-8");
+
+promise_test(async () => {
+  assert_equals(await loadJSON("?type=text/json"), utf8);
+}, "text/json with no charset is decoded as UTF-8");
+
+promise_test(async () => {
+  assert_not_equals(await loadJSON("?charset=windows-1251"), utf8);
+}, "application/json;charset=windows-1251 honors the explicit charset");
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/encoding/resources/json-charset.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/encoding/resources/json-charset.py
@@ -1,0 +1,8 @@
+def main(request, response):
+    content_type = request.GET.first(b"type", b"application/json")
+    charset = request.GET.first(b"charset", None)
+    if charset is not None:
+        content_type += b";charset=" + charset
+    response.headers.set(b"Content-Type", content_type)
+    response.headers.set(b"X-Content-Type-Options", b"nosniff")
+    response.content = '{"text":"☃é"}'.encode("utf-8")

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -287,7 +287,8 @@ TextResourceDecoder& DocumentWriter::decoder()
         if (canReferToParentFrameEncoding(frame.ptr(), parentFrame))
             decoder->setHintEncoding(parentFrame->document()->decoder());
         if (m_encoding.isEmpty()) {
-            if (canReferToParentFrameEncoding(frame.ptr(), parentFrame))
+            // Don't let a non-UTF-8 parent frame override JSON's UTF-8 default (RFC 8259).
+            if (canReferToParentFrameEncoding(frame.ptr(), parentFrame) && decoder->contentType() != TextResourceDecoder::JSON)
                 decoder->setEncoding(protect(parentFrame->document())->textEncoding(), TextResourceDecoder::EncodingFromParentFrame);
         } else {
             decoder->setEncoding(m_encoding,

--- a/Source/WebCore/loader/TextResourceDecoder.cpp
+++ b/Source/WebCore/loader/TextResourceDecoder.cpp
@@ -246,14 +246,19 @@ TextResourceDecoder::ContentType TextResourceDecoder::determineContentType(const
         return HTML;
     if (MIMETypeRegistry::isXMLMIMEType(mimeType) || mimeType == "text/xsl"_s)
         return XML;
+    if (MIMETypeRegistry::isSupportedJSONMIMEType(mimeType))
+        return JSON;
     return PlainText;
 }
 
 const PAL::TextEncoding& TextResourceDecoder::defaultEncoding(ContentType contentType, const PAL::TextEncoding& specifiedDefaultEncoding)
 {
-    // Despite 8.5 "Text/xml with Omitted Charset" of RFC 3023, we assume UTF-8 instead of US-ASCII 
+    // Despite 8.5 "Text/xml with Omitted Charset" of RFC 3023, we assume UTF-8 instead of US-ASCII
     // for text/xml. This matches Firefox.
     if (contentType == XML)
+        return PAL::UTF8Encoding();
+    // Per RFC 8259, JSON is UTF-8 by default; a BOM or explicit charset still overrides this.
+    if (contentType == JSON)
         return PAL::UTF8Encoding();
     if (!specifiedDefaultEncoding.isValid())
         return PAL::Latin1Encoding();

--- a/Source/WebCore/loader/TextResourceDecoder.h
+++ b/Source/WebCore/loader/TextResourceDecoder.h
@@ -45,7 +45,7 @@ public:
         EncodingFromParentFrame
     };
 
-    enum ContentType { PlainText, HTML, XML, CSS }; // PlainText only checks for BOM.
+    enum ContentType { PlainText, HTML, XML, CSS, JSON }; // PlainText and JSON only check for BOM.
 
     WEBCORE_EXPORT static Ref<TextResourceDecoder> create(const String& mimeType, const PAL::TextEncoding& defaultEncoding = { }, bool usesEncodingDetector = false);
     WEBCORE_EXPORT static Ref<TextResourceDecoder> create(ContentType, const PAL::TextEncoding&, bool usesEncodingDetector);


### PR DESCRIPTION
#### 70cd4be688bb80e05c128e6de6a7bcad7d62183a
<pre>
JSON displayed with wrong encoding when loaded in a frame (browser default instead of UTF-8)
<a href="https://bugs.webkit.org/show_bug.cgi?id=197369">https://bugs.webkit.org/show_bug.cgi?id=197369</a>
<a href="https://rdar.apple.com/71522231">rdar://71522231</a>

Reviewed by Chris Dumez.

The patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When an &quot;application/json&quot; response with no charset parameter was loaded into a
frame, WebCore rendered it as a text/plain document and decoded it using the
locale/default text encoding (or the parent frame&apos;s encoding), producing
mojibake for non-ASCII UTF-8 content. text/xml already defaulted to UTF-8, and
the XMLHttpRequest path already forced UTF-8, but the frame-display path did not.

Per RFC 8259 &quot;The JavaScript Object Notation (JSON) Data Interchange Format&quot;,
section 8.1 &quot;Character Encoding&quot;
(<a href="https://www.rfc-editor.org/rfc/rfc8259#section-8.1)">https://www.rfc-editor.org/rfc/rfc8259#section-8.1)</a>:

    &quot;JSON text exchanged between systems that are not part of a closed
     ecosystem MUST be encoded using UTF-8 [RFC3629].&quot;

RFC 7159 section 8.1 states the default explicitly (&quot;The default encoding is
UTF-8 ...&quot;), and the &quot;application/json&quot; media type registration defines no
&quot;charset&quot; parameter.

Default JSON documents to UTF-8, matching the existing text/xml handling, while
still letting a BOM (for UTF-16) or an explicit charset parameter override it,
and stop JSON subframes from inheriting a non-UTF-8 same-origin parent frame&apos;s
encoding.

* Source/WebCore/loader/TextResourceDecoder.h:
Add JSON to the ContentType enum.

* Source/WebCore/loader/TextResourceDecoder.cpp:
(WebCore::TextResourceDecoder::determineContentType): Classify JSON MIME types
as JSON.
(WebCore::TextResourceDecoder::defaultEncoding): Default the JSON content type
to UTF-8, matching XML.

* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::decoder): Don&apos;t override a JSON document&apos;s UTF-8
default with a non-UTF-8 parent frame encoding.

* LayoutTests/imported/w3c/web-platform-tests/encoding/json-document-utf8.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/encoding/json-document-utf8-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/encoding/resources/json-charset.py: Added.

Canonical link: <a href="https://commits.webkit.org/320596@main">https://commits.webkit.org/320596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/780b8624c16fb395424b5d46d2fb572c4e46ac32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184910 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58830 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195245 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/149782 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58557 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144493 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100283 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165090 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124785 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46892 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44994 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157258 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44658 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6298 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197194 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58498 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164597 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153975 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41315 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59204 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41261 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153634 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48150 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131492 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128092 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57700 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19676 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57059 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57308 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57136 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->