### PR TITLE
[Canvas] parseColor() constructs CSSParserContext(HTMLStandardMode) twice

### DIFF
--- a/Source/WebCore/html/canvas/CanvasStyle.cpp
+++ b/Source/WebCore/html/canvas/CanvasStyle.cpp
@@ -117,7 +117,8 @@ Color parseColor(const String& colorString, ScriptExecutionContext& scriptExecut
     // FIXME: Add constructor for CSSParserContext that takes a ScriptExecutionContext to allow preferences to be
     //        checked correctly.
     using namespace CSSPropertyParserHelpers;
-    auto color = parseColorRawSimple(colorString, CSSParserContext(HTMLStandardMode));
+    CSSParserContext cssParserContext(HTMLStandardMode);
+    auto color = parseColorRawSimple(colorString, cssParserContext);
     if (color.isValid())
         return color;
     CSSColorParsingOptions options {
@@ -126,7 +127,7 @@ Color parseColor(const String& colorString, ScriptExecutionContext& scriptExecut
     CSS::PlatformColorResolutionState state {
         .resolvedCurrentColor = Color::black
     };
-    return parseColorRawGeneral(colorString, CSSParserContext(HTMLStandardMode), scriptExecutionContext, options, state);
+    return parseColorRawGeneral(colorString, cssParserContext, scriptExecutionContext, options, state);
 }
 
 }


### PR DESCRIPTION
#### 1bf94f1c0c462bef841fca9877c167bf4bc769b3
<pre>
[Canvas] parseColor() constructs CSSParserContext(HTMLStandardMode) twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=323404">https://bugs.webkit.org/show_bug.cgi?id=323404</a>
<a href="https://rdar.apple.com/186639923">rdar://186639923</a>

Reviewed by Tim Nguyen.

The ScriptExecutionContext overload of parseColor() constructed an
identical CSSParserContext(HTMLStandardMode) twice: once for the
parseColorRawSimple() fast path, and again for parseColorRawGeneral()
on the fall-through slow path. CSSParserContext is a heavy struct, so
this was a redundant build whenever the simple parse failed.

Hoist it into a single local reused by both calls, matching the sibling
CanvasBase overload which already binds the context once.

* Source/WebCore/html/canvas/CanvasStyle.cpp:
(WebCore::parseColor):

Canonical link: <a href="https://commits.webkit.org/320512@main">https://commits.webkit.org/320512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66bf610df3d1c8d15da5c21d4374159f65f8b7c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52661 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195248 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ea6de856-6a33-4250-9549-9414166d0053) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144501 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb24a6f9-49af-489b-a04c-13e21c12aed3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124793 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/54a4cac6-0ae6-4555-a0a5-ad6335549a56) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46898 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44998 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157264 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44661 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6301 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51496 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197197 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58501 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153976 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41248 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59207 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153635 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48156 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131495 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128100 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57703 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19679 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57062 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57311 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57139 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->