### PR TITLE
CanvasNoiseInjection misclassifies the bottom-left pixel due to an off-by-one in the bottom-row check

### DIFF
--- a/Source/WebCore/html/CanvasNoiseInjection.cpp
+++ b/Source/WebCore/html/CanvasNoiseInjection.cpp
@@ -96,7 +96,7 @@ static std::pair<std::array<int, 4>, std::array<int, 4>> boundingNeighbors(int i
     auto bufferSize = bytes.size_bytes();
     auto pixelIndex = index / bytesPerPixel;
     bool isInTopRow = pixelIndex < static_cast<size_t>(size.width());
-    bool isInBottomRow = pixelIndex > static_cast<size_t>((size.height() - 1) * size.width());
+    bool isInBottomRow = pixelIndex >= static_cast<size_t>((size.height() - 1) * size.width());
     bool isInLeftColumn = !(pixelIndex % size.width());
     bool isInRightColumn = (pixelIndex % size.width()) == static_cast<unsigned>(size.width()) - 1;
     bool isInTopLeftCorner = isInTopRow && isInLeftColumn;


### PR DESCRIPTION
#### 3c0232a5d33e17eeec3db8c24e5f7bf171cf8742
<pre>
CanvasNoiseInjection misclassifies the bottom-left pixel due to an off-by-one in the bottom-row check
<a href="https://bugs.webkit.org/show_bug.cgi?id=323405">https://bugs.webkit.org/show_bug.cgi?id=323405</a>
<a href="https://rdar.apple.com/186640624">rdar://186640624</a>

Reviewed by Gerald Squelart.

boundingNeighbors() classifies the bottom row with

    pixelIndex &gt; (size.height() - 1) * size.width()

but the last row spans indices [(H-1)*W, H*W-1], so the test should be
&quot;&gt;=&quot;. With &quot;&gt;&quot;, the bottom-left pixel (pixelIndex == (H-1)*W) is not
recognized as being in the bottom row, and consequently not recognized
as the bottom-left corner. The top-row check on the line above already
uses the correct &quot;&lt;&quot; form; this makes the bottom-row check symmetric.

This has no observable effect on output: the misclassified pixel falls
into the left-column branch, whose below-neighbor is out of bounds, so
areColorsRelated() returns false and the bounding colors stay at their
defaults -- identical to what the corner early-return produces. It also
does not trip the isIndexInBounds() assertion, because the out-of-bounds
below-index equals bufferSize exactly and the &quot;+ 3&quot; probe is
short-circuited. This is a correctness/clarity fix; no test is added
because the pixel output is byte-for-byte unchanged and any test would
pass without the fix.

* Source/WebCore/html/CanvasNoiseInjection.cpp:
(WebCore::boundingNeighbors):

Canonical link: <a href="https://commits.webkit.org/320510@main">https://commits.webkit.org/320510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/287d0eed2f75b0e8238849b7cb5217ad9b3efb13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195250 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186777 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144497 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48171 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124789 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46896 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/44999 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44664 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6303 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46181 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51498 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197199 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58503 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153979 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41249 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59209 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41267 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153638 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48153 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131497 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128102 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57705 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19682 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57064 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57313 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57141 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->