### PR TITLE
[JSC] Fill the result array of `Object.values` directly instead of via `MarkedArgumentBuffer`

### DIFF
--- a/JSTests/microbenchmarks/object-values-row.js
+++ b/JSTests/microbenchmarks/object-values-row.js
@@ -1,0 +1,16 @@
+var rows = [];
+for (var i = 0; i < 16; ++i) {
+    var row = {};
+    for (var j = 0; j < 12; ++j)
+        row["field" + j] = i * 100 + j;
+    rows.push(row);
+}
+
+function test(row)
+{
+    return Object.values(row);
+}
+noInline(test);
+
+for (var i = 0; i < 1e5; ++i)
+    test(rows[i & 15]);

--- a/JSTests/stress/object-values-indexed-properties.js
+++ b/JSTests/stress/object-values-indexed-properties.js
@@ -1,0 +1,68 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+function reference(object) {
+    var result = [];
+    for (var key of Object.keys(object))
+        result.push(object[key]);
+    return result;
+}
+
+function check(object) {
+    shouldBe(JSON.stringify(Object.values(object)), JSON.stringify(reference(object)));
+}
+
+check({ 0: "a", 1: "b", 2: "c" });
+check({ 0: "a", 1: "b", 2: "c", x: 1, y: 2 });
+check({ 0: 10, 1: 20, z: 3 });
+check({ 0: 1.5, 1: 2.5, w: "q" });
+
+{
+    var object = {};
+    object[0] = "a";
+    object[2] = "c";
+    object.n = "named";
+    check(object);
+}
+
+{
+    var object = {};
+    object[100000] = "big";
+    object[5] = "small";
+    object[50000] = "mid";
+    object.k = "named";
+    check(object);
+    shouldBe(JSON.stringify(Object.values(object)), '["small","mid","big","named"]');
+}
+
+{
+    var object = {};
+    object[10] = "sparse";
+    Object.defineProperty(object, 20, { value: "hidden", enumerable: false });
+    object.k = "named";
+    shouldBe(JSON.stringify(Object.values(object)), '["sparse","named"]');
+}
+
+{
+    var object = {};
+    for (var i = 0; i < 10000; ++i)
+        object[i] = i;
+    object.tail = "end";
+    var values = Object.values(object);
+    shouldBe(values.length, 10001);
+    shouldBe(values[0], 0);
+    shouldBe(values[9999], 9999);
+    shouldBe(values[10000], "end");
+}
+
+for (var i = 0; i < testLoopCount; ++i) {
+    var object = { 0: i, 1: i + 1, a: i, b: i + 2 };
+    var values = Object.values(object);
+    shouldBe(values.length, 4);
+    shouldBe(values[0], i);
+    shouldBe(values[1], i + 1);
+    shouldBe(values[2], i);
+    shouldBe(values[3], i + 2);
+}

--- a/JSTests/stress/object-values-many-properties.js
+++ b/JSTests/stress/object-values-many-properties.js
@@ -1,0 +1,85 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+function makeObject(count) {
+    var object = {};
+    for (var i = 0; i < count; ++i)
+        object["p" + i] = i;
+    return object;
+}
+
+function reference(object) {
+    var result = [];
+    for (var key of Object.keys(object))
+        result.push(object[key]);
+    return result;
+}
+
+function check(object) {
+    shouldBe(JSON.stringify(Object.values(object)), JSON.stringify(reference(object)));
+}
+
+for (var count of [0, 1, 8, 9, 10, 16, 17, 32, 33, 100, 1000])
+    check(makeObject(count));
+
+{
+    var object = makeObject(12);
+    Object.defineProperty(object, "hidden", { value: 42, enumerable: false });
+    object[Symbol("symbol")] = 43;
+    check(object);
+}
+
+{
+    var object = makeObject(12);
+    object[3] = "three";
+    object[1] = "one";
+    object[100] = "hundred";
+    check(object);
+}
+
+{
+    var object = makeObject(12);
+    delete object.p5;
+    check(object);
+    object.p5 = "again";
+    check(object);
+}
+
+{
+    var object = makeObject(12);
+    Object.defineProperty(object, "getter", { get() { return "getter"; }, enumerable: true });
+    check(object);
+}
+
+{
+    var object = makeObject(12);
+    Object.freeze(object);
+    check(object);
+}
+
+{
+    var object = makeObject(20);
+    for (var i = 0; i < 20; ++i)
+        object["p" + i] = { index: i };
+    var results = [];
+    for (var i = 0; i < testLoopCount; ++i)
+        results.push(Object.values(object));
+    gc();
+    for (var result of results) {
+        shouldBe(result.length, 20);
+        for (var i = 0; i < 20; ++i)
+            shouldBe(result[i].index, i);
+    }
+}
+
+{
+    var object = makeObject(9);
+    var first = Object.values(object);
+    var second = Object.values(object);
+    first[0] = "changed";
+    shouldBe(second[0], 0);
+    first.push("pushed");
+    shouldBe(first.length, 10);
+}

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -577,9 +577,9 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorValues, (JSGlobalObject* globalObject,
     }
 
     {
-        MarkedArgumentBuffer namedPropertyValues;
         bool canUseFastPath = false;
-        if (!target->canHaveExistingOwnIndexedGetterSetterProperties() && !target->hasNonReifiedStaticProperties()) {
+        unsigned namedPropertyCount = 0;
+        if (!target->canHaveExistingOwnIndexedGetterSetterProperties() && !target->hasNonReifiedStaticProperties() && !globalObject->isHavingABadTime()) {
             Structure* targetStructure = target->structure();
             if (targetStructure->canPerformFastPropertyEnumerationCommon()) {
                 canUseFastPath = true;
@@ -590,36 +590,50 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorValues, (JSGlobalObject* globalObject,
                     if (entry.key()->isSymbol())
                         return true;
 
-                    namedPropertyValues.appendWithCrashOnOverflow(target->getDirect(entry.offset()));
+                    ++namedPropertyCount;
                     return true;
                 });
             }
         }
 
         if (canUseFastPath) {
-            Structure* arrayStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous);
-            MarkedArgumentBuffer indexedPropertyValues;
+            unsigned indexedPropertyCount = 0;
             if (target->canHaveExistingOwnIndexedProperties()) {
-                target->forEachOwnIndexedProperty<JSObject::SortMode::Ascending>(globalObject, [&](unsigned, JSValue value) {
-                    indexedPropertyValues.appendWithCrashOnOverflow(value);
+                target->forEachOwnIndexedProperty<JSObject::SortMode::Ascending>(globalObject, [&](unsigned, JSValue) {
+                    ++indexedPropertyCount;
                     return IterationStatus::Continue;
                 });
             }
             RETURN_IF_EXCEPTION(scope, { });
 
-            {
-                ObjectInitializationScope initializationScope(vm);
-                JSArray* result = nullptr;
-                if ((result = JSArray::tryCreateUninitializedRestricted(initializationScope, nullptr, arrayStructure, indexedPropertyValues.size() + namedPropertyValues.size()))) [[likely]] {
-                    for (unsigned i = 0; i < indexedPropertyValues.size(); ++i)
-                        result->initializeIndex(initializationScope, i, indexedPropertyValues.at(i));
-                    for (unsigned i = 0; i < namedPropertyValues.size(); ++i)
-                        result->initializeIndex(initializationScope, indexedPropertyValues.size() + i, namedPropertyValues.at(i));
-                    return JSValue::encode(result);
-                }
+            JSArray* result = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous), indexedPropertyCount + namedPropertyCount);
+            if (!result) [[unlikely]] {
+                throwOutOfMemoryError(globalObject, scope);
+                return { };
             }
-            throwOutOfMemoryError(globalObject, scope);
-            return { };
+
+            auto values = result->butterfly()->contiguous();
+            unsigned index = 0;
+            if (indexedPropertyCount) {
+                target->forEachOwnIndexedProperty<JSObject::SortMode::Ascending>(globalObject, [&](unsigned, JSValue value) {
+                    values.at(result, index++).setWithoutWriteBarrier(value);
+                    return IterationStatus::Continue;
+                });
+                RETURN_IF_EXCEPTION(scope, { });
+            }
+            target->structure()->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
+                if (entry.attributes() & PropertyAttribute::DontEnum)
+                    return true;
+
+                if (entry.key()->isSymbol())
+                    return true;
+
+                values.at(result, index++).setWithoutWriteBarrier(target->getDirect(entry.offset()));
+                return true;
+            });
+            ASSERT(index == result->length());
+            vm.writeBarrier(result);
+            return JSValue::encode(result);
         }
     }
 


### PR DESCRIPTION
#### f37e63364972e1422369384acae46239389122eb
<pre>
[JSC] Fill the result array of `Object.values` directly instead of via `MarkedArgumentBuffer`
<a href="https://bugs.webkit.org/show_bug.cgi?id=323406">https://bugs.webkit.org/show_bug.cgi?id=323406</a>

Reviewed by Yusuke Suzuki.

Object.values on a plain object with N enumerable properties currently
collects the N values into a MarkedArgumentBuffer and then copies them into
the result array. MarkedArgumentBuffer has 8 inline slots, so from the 9th
property every call pays a fastMalloc/fastFree pair plus an add/remove on
Heap::markListSet for the spilled buffer. Object.values on a 12 field object
is 2.3x slower than V8 on our benchmark, and 1.5x slower than the same call
on an 8 field object.

This patch counts the indexed properties and the enumerable string
properties first, allocates the result array at that size, and then writes
each value straight into the array&apos;s contiguous storage. The array is
created fully initialized (holes), so the second walk may safely
re-materialize the property table after a GC. The having-a-bad-time case now
takes the generic path instead, since the fast path fills contiguous storage
directly.

                                        Baseline                  Patched

object-values                        5.0333+-0.1520     ^      1.5819+-0.0352        ^ definitely 3.1818x faster
object-entries                      18.3643+-0.1810     ?     18.4215+-0.1904        ?
object-values-row                    6.7000+-0.1198     ^      2.9258+-0.0584        ^ definitely 2.2900x faster
object-keys-map-values              14.1839+-0.1945           13.9498+-0.1343          might be 1.0168x faster
proxy-ownkeys-via-object-keys       54.2542+-0.3351     ?     54.5607+-0.2671        ?
object-keys                          6.8686+-0.0807            6.8571+-0.0720

Tests: JSTests/microbenchmarks/object-values-row.js
       JSTests/stress/object-values-many-properties.js

* JSTests/microbenchmarks/object-values-row.js: Added.
(test):
* JSTests/stress/object-values-indexed-properties.js: Added.
(shouldBe):
(check):
* JSTests/stress/object-values-many-properties.js: Added.
(shouldBe):
(reference):
(check):
(1000.check.makeObject):
(check.get check):
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/320603@main">https://commits.webkit.org/320603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e958919bbed43480a980c57637c964dc78428f20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195621 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58934 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165392 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125091 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47213 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45276 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/7004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13894 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157580 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44962 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6675 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46553 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51863 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197570 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58871 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154309 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41323 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59580 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41566 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153960 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48456 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131898 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128707 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58058 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19982 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57430 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57673 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57497 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->