### PR TITLE
[JSC] Non-global `RegExp#replace` with an empty string should return a substring

### DIFF
--- a/JSTests/microbenchmarks/string-replace-regexp-strip-prefix.js
+++ b/JSTests/microbenchmarks/string-replace-regexp-strip-prefix.js
@@ -1,0 +1,16 @@
+function test(url)
+{
+    return url.replace(/^https?:\/\//, "");
+}
+noInline(test);
+
+const urls = [];
+for (let k = 0; k < 64; k++)
+    urls.push((k & 1 ? "https://" : "http://") + "host" + k + ".example.com/path/to/resource/" + k + "?query=" + (k * 7));
+
+let result;
+for (let i = 0; i < 2000000; ++i)
+    result = test(urls[i & 63]);
+
+if (test("https://a.example/b") !== "a.example/b")
+    throw new Error("bad result: " + test("https://a.example/b"));

--- a/JSTests/stress/string-replace-regexp-non-global-string-replacement.js
+++ b/JSTests/stress/string-replace-regexp-non-global-string-replacement.js
@@ -1,0 +1,57 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + JSON.stringify(actual) + " expected: " + JSON.stringify(expected));
+}
+
+function replaceEmpty(string, regExp) {
+    return string.replace(regExp, "");
+}
+noInline(replaceEmpty);
+
+function replaceString(string, regExp, replacement) {
+    return string.replace(regExp, replacement);
+}
+noInline(replaceString);
+
+const rope = "http://" + "example.com/" + "path".repeat(3);
+const substring = "xxhttps://example.com/index.htmlyy".slice(2, -2);
+const wide = "https://あいう.example/え";
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(replaceEmpty("https://example.com/", /^https?:\/\//), "example.com/");
+    shouldBe(replaceEmpty("example.com/", /^https?:\/\//), "example.com/");
+    shouldBe(replaceEmpty("http://", /^https?:\/\//), "");
+    shouldBe(replaceEmpty("/a/b///", /\/+$/), "/a/b");
+    shouldBe(replaceEmpty("file.tar.gz", /\.[^.]+$/), "file.tar");
+    shouldBe(replaceEmpty("abc", /b/), "ac");
+    shouldBe(replaceEmpty("ab", /b/), "a");
+    shouldBe(replaceEmpty("ba", /b/), "a");
+    shouldBe(replaceEmpty("abc", /(?:)/), "abc");
+    shouldBe(replaceEmpty(rope, /^https?:\/\//), "example.com/pathpathpath");
+    shouldBe(replaceEmpty(substring, /^https?:\/\//), "example.com/index.html");
+    shouldBe(replaceEmpty(substring, /\.html$/), "https://example.com/index");
+    shouldBe(replaceEmpty(wide, /^https?:\/\//), "あいう.example/え");
+    shouldBe(replaceEmpty(wide, /\.example/), "https://あいう/え");
+
+    shouldBe(replaceString("/api/v2/items", /\/v\d+\//, "/latest/"), "/api/latest/items");
+    shouldBe(replaceString("v2/items", /^v\d+/, "latest"), "latest/items");
+    shouldBe(replaceString("items/v2", /v\d+$/, "latest"), "items/latest");
+    shouldBe(replaceString("v2", /v\d+/, "latest"), "latest");
+    shouldBe(replaceString("abc", /(?:)/, "-"), "-abc");
+    shouldBe(replaceString(rope, /example/, "あ"), "http://あ.com/pathpathpath");
+    shouldBe(replaceString(wide, /い/, "i"), "https://あiう.example/え");
+    shouldBe(replaceString("a-b", /(\w)-(\w)/, "$2-$1"), "b-a");
+    shouldBe(replaceString("a-b", /-/, "[$&]"), "a[-]b");
+}
+
+shouldBe(replaceString("prefix:value", /:/, "="), "prefix=value");
+shouldBe(RegExp.leftContext, "prefix");
+shouldBe(RegExp.rightContext, "value");
+shouldBe(RegExp.lastMatch, ":");
+
+const result = replaceEmpty("https://example.com/", /^https?:\/\//);
+shouldBe(result.length, 12);
+shouldBe(result.charCodeAt(0), "e".charCodeAt(0));
+shouldBe(result + "!", "example.com/!");
+const map = new Map([[result, 1]]);
+shouldBe(map.get("example.com/"), 1);

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -1528,6 +1528,13 @@ ALWAYS_INLINE JSString* replaceOneWithStringUsingRegExpSearch(VM& vm, JSGlobalOb
     if (!result)
         return string;
 
+    if (replacementString.isEmpty()) {
+        if (!result.start)
+            return jsSubstringOfResolved(vm, string, result.end, source.length() - result.end);
+        if (result.end == source.length())
+            return jsSubstringOfResolved(vm, string, 0, result.start);
+    }
+
     auto before = StringView { source }.substring(0, result.start);
     auto after = StringView { source }.substring(result.end, source.length() - result.end);
 


### PR DESCRIPTION
#### 7aeed1e3bd69527b49cf85957c5d53d0044fbd7a
<pre>
[JSC] Non-global `RegExp#replace` with an empty string should return a substring
<a href="https://bugs.webkit.org/show_bug.cgi?id=323409">https://bugs.webkit.org/show_bug.cgi?id=323409</a>

Reviewed by Yusuke Suzuki.

`url.replace(/^https?:\/\//, &quot;&quot;)` and similar idioms that strip a prefix or
a suffix copied the rest of the subject into a new StringImpl, so the cost
grew with the length of the string. The string-search version of replace
already returns substring cells for this.

When the replacement is empty and the match touches either end of the
subject, return a substring of the subject. Other cases keep the flat copy,
because a rope of several pieces is slower once it is resolved.

                                             Baseline                  Patched

string-replace-regexp-trim-end           16.5122+-0.2286     ?     16.5982+-0.2722        ?
string-replace-regexp-trim-start         15.8060+-0.2518           15.5517+-0.1634          might be 1.0163x faster
string-replace-regexp-strip-prefix       56.5716+-0.4533     ^     24.6314+-0.1697        ^ definitely 2.2967x faster
string-replace-empty                      6.6183+-0.2257     ^      6.2340+-0.1388        ^ definitely 1.0616x faster

Tests: JSTests/microbenchmarks/string-replace-regexp-strip-prefix.js
       JSTests/stress/string-replace-regexp-non-global-string-replacement.js

* JSTests/microbenchmarks/string-replace-regexp-strip-prefix.js: Added.
(test):
* JSTests/stress/string-replace-regexp-non-global-string-replacement.js: Added.
(shouldBe):
(replaceEmpty):
(replaceString):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::replaceOneWithStringUsingRegExpSearch):

Canonical link: <a href="https://commits.webkit.org/321015@main">https://commits.webkit.org/321015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c00e7d3a346cc857c2ddc5108acc6840bcf5bac8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195254 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/149887 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144503 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100285 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165097 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124795 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46900 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45002 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6737 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13597 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157266 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44665 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6307 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46185 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197203 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58507 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153984 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-animations/nested-scale-animations.html (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41634 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59213 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153643 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48159 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131501 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128106 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57709 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19683 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57068 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57317 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57145 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->