### PR TITLE
Introduce CStringWithEncoding so that a CString can remember its encoding

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1271,18 +1271,18 @@ static bool fillBufferWithContentsOfFile(const String& fileName, Vector<char>& b
         fprintf(stderr, "Error when parsing file name: %s\n", fileName.ascii().data());
         return false;
     }
-    if (stat(fileNameUTF->data(), &statBuf) == -1) {
-        fprintf(stderr, "Could not open file: %s\n", fileNameUTF->data());
+    if (FileSystem::statFile(fileNameUTF->spanIncludingNullTerminator(), statBuf) == -1) {
+        SAFE_FPRINTF(stderr, "Could not open file: %s\n", *fileNameUTF);
         return false;
     }
 
     if ((statBuf.st_mode & S_IFMT) != S_IFREG) {
-        fprintf(stderr, "Trying to open a non-file: %s\n", fileNameUTF->data());
+        SAFE_FPRINTF(stderr, "Trying to open a non-file: %s\n", *fileNameUTF);
         return false;
     }
-    auto* f = fopen(fileNameUTF->data(), "rb");
+    auto* f = fopen(fileNameUTF->characters(), "rb");
     if (!f) {
-        fprintf(stderr, "Could not open file: %s\n", fileNameUTF->data());
+        SAFE_FPRINTF(stderr, "Could not open file: %s\n", *fileNameUTF);
         return false;
     }
 
@@ -1455,7 +1455,7 @@ static bool fetchModuleFromLocalFileSystem(const URL& fileURL, Vector& buffer)
 #else
     auto pathName = fileName.utf8();
     struct stat status { };
-    if (stat(pathName.data(), &status))
+    if (FileSystem::statFile(pathName.spanIncludingNullTerminator(), status))
         return false;
     if ((status.st_mode & S_IFMT) != S_IFREG)
         return false;
@@ -1570,7 +1570,7 @@ void GlobalObject::promiseRejectionTracker(JSGlobalObject*, JSPromise*, JSPromis
 
 #endif // ENABLE(FUZZILLI)
 
-static CString toCString(JSGlobalObject* globalObject, ThrowScope& scope, std::expected<CString, UTF8ConversionError> expectedString)
+static UTF8CString toCString(JSGlobalObject* globalObject, ThrowScope& scope, std::expected<UTF8CString, UTF8ConversionError> expectedString)
 {
     if (expectedString)
         return expectedString.value();
@@ -1586,7 +1586,7 @@ static CString toCString(JSGlobalObject* globalObject, ThrowScope& scope, std::e
     return { };
 }
 
-template<typename T> static CString toCString(JSGlobalObject* globalObject, ThrowScope& scope, T& string)
+template<typename T> static UTF8CString toCString(JSGlobalObject* globalObject, ThrowScope& scope, T& string)
 {
     return toCString(globalObject, scope, string.tryGetUTF8());
 }
@@ -3787,7 +3787,7 @@ static void dumpException(GlobalObject* globalObject, JSValue exception)
         if (stackString.length()) {
             auto expectedUtf8 = stackString.tryGetUTF8();
             if (expectedUtf8)
-                printf("%s\n", expectedUtf8.value().data());
+                SAFE_PRINTF("%s\n", expectedUtf8.value());
         }
     }
 

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -532,6 +532,12 @@ bool moveFile(const String& oldPath, const String& newPath)
 }
 #endif
 
+int statFile(std::span<const char> pathIncludingNullTerminator, struct stat& result)
+{
+    RELEASE_ASSERT(!pathIncludingNullTerminator.empty() && !pathIncludingNullTerminator.back());
+    return stat(pathIncludingNullTerminator.data(), &result);
+}
+
 std::optional<uint64_t> fileSize(const String& path)
 {
     std::error_code ec;

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <span>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <time.h>
 #include <utility>
@@ -52,6 +53,10 @@
 
 #if USE(CF)
 typedef const struct __CFData* CFDataRef;
+#endif
+
+#if !OS(WINDOWS)
+struct stat;
 #endif
 
 OBJC_CLASS NSString;
@@ -137,6 +142,10 @@ WTF_EXPORT_PRIVATE CString fileSystemRepresentation(const String&);
 #if !PLATFORM(WIN)
 WTF_EXPORT_PRIVATE String stringFromFileSystemRepresentation(const char*);
 #endif
+
+// stat() needs a null-terminated path, so these take the span including the terminator and check for it.
+WTF_EXPORT_PRIVATE int statFile(std::span<const char> pathIncludingNullTerminator, struct stat&);
+inline int statFile(std::span<const char8_t> pathIncludingNullTerminator, struct stat& result) { return statFile(byteCast<char>(pathIncludingNullTerminator), result); }
 
 using Salt = std::array<uint8_t, 8>;
 WTF_EXPORT_PRIVATE std::optional<Salt> readOrMakeSalt(const String& path);

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -23,6 +23,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <wtf/Platform.h>
+#include <wtf/text/Latin1Character.h>
 
 #if defined(__has_feature)
 #if __has_feature(objc_arc)
@@ -121,6 +122,7 @@ template<typename> struct DefaultRefDerefTraits;
 
 template<typename> class Awaitable;
 template<typename> class Borrow;
+template<typename> class CStringWithEncoding;
 template<typename> class CompactPtr;
 template<typename> class CompletionHandler;
 template<typename, size_t = 0> class Deque;
@@ -169,6 +171,10 @@ template<typename T> class InlineWeakPtr;
 template<typename T> struct NoTaggingTraits;
 template<typename T> class ThreadSafeWeakPtr;
 template<typename T> class ThreadSafeWeakRef;
+
+using UTF8CString = CStringWithEncoding<char8_t>;
+using Latin1CString = CStringWithEncoding<Latin1Character>;
+using ASCIICString = CStringWithEncoding<char>;
 
 template <typename T>
 using SaSegmentedVector = SegmentedVector<T, 8, 0, SegmentedVectorGrowthPolicy::Constant, SequesteredArenaMalloc>;

--- a/Source/WTF/wtf/PrintStream.cpp
+++ b/Source/WTF/wtf/PrintStream.cpp
@@ -80,7 +80,7 @@ void printInternal(PrintStream& out, const char* string)
     out.printf("%s", string);
 }
 
-static void printExpectedCStringHelper(PrintStream& out, const char* type, std::expected<CString, UTF8ConversionError> expectedCString)
+static void printExpectedCStringHelper(PrintStream& out, const char* type, std::expected<UTF8CString, UTF8ConversionError> expectedCString)
 {
     if (!expectedCString) [[unlikely]] {
         if (expectedCString.error() == UTF8ConversionError::OutOfMemory) {

--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -109,7 +109,7 @@ std::optional<WallTime> fileCreationTime(const String& path)
 #elif OS(DARWIN) || OS(OPENBSD) || OS(NETBSD) || OS(FREEBSD) || OS(HAIKU)
     struct stat fileInfo;
 
-    if (stat(fsRep.data(), &fileInfo) == -1)
+    if (statFile(fsRep.spanIncludingNullTerminator(), fileInfo) == -1)
         return std::nullopt;
 
     return WallTime::fromRawSeconds(fileInfo.st_birthtime);
@@ -203,7 +203,7 @@ std::optional<int32_t> getFileDeviceId(const String& path)
         return std::nullopt;
 
     struct stat fileStat;
-    if (stat(fsFile.data(), &fileStat) == -1)
+    if (statFile(fsFile.spanIncludingNullTerminator(), fileStat) == -1)
         return std::nullopt;
 
     return fileStat.st_dev;

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -178,25 +178,25 @@ bool CStringHash::equal(const CString& a, const CString& b)
 enum class ASCIICase { Lower, Upper };
 
 template<ASCIICase type>
-CString convertASCIICase(std::span<const char8_t> input)
+UTF8CString convertASCIICase(std::span<const char8_t> input)
 {
     if (input.empty())
-        return CString(""_s);
+        return UTF8CString(""_s);
 
-    std::span<char> characters;
-    auto result = CString::newUninitialized(input.size(), characters);
+    std::span<char8_t> characters;
+    auto result = UTF8CString::newUninitialized(input.size(), characters);
     size_t i = 0;
     for (auto character : input)
         characters[i++] = type == ASCIICase::Lower ? toASCIILower(character) : toASCIIUpper(character);
     return result;
 }
 
-CString convertToASCIILowercase(std::span<const char8_t> string)
+UTF8CString convertToASCIILowercase(std::span<const char8_t> string)
 {
     return convertASCIICase<ASCIICase::Lower>(string);
 }
 
-CString convertToASCIIUppercase(std::span<const char8_t> string)
+UTF8CString convertToASCIIUppercase(std::span<const char8_t> string)
 {
     return convertASCIICase<ASCIICase::Upper>(string);
 }

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -25,14 +25,19 @@
 
 #pragma once
 
+#include <concepts>
 #include <span>
 #include <wtf/DebugHeap.h>
+#include <wtf/Forward.h>
 #include <wtf/HashFunctions.h>
 #include <wtf/HashTraits.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/SwiftBridging.h>
+#include <wtf/text/ASCIIFastPath.h>
+#include <wtf/text/Latin1Character.h>
+#include <wtf/unicode/UTF8Conversion.h>
 
 namespace WTF {
 
@@ -66,13 +71,16 @@ private:
 // A null-terminated, nullable, copy-on-write char array. Useful for interacting with C-style APIs.
 
 // Like const char*, CString does not know its encoding. The caller must apply the right encoding when extracting characters.
-class CString final {
+// Prefer CStringWithEncoding (UTF8CString / Latin1CString / ASCIICString) below, which carries the encoding in the type.
+class CString {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(CString);
 public:
     CString() { }
     WTF_EXPORT_PRIVATE CString(ASCIILiteral);
     WTF_EXPORT_PRIVATE CString(const char*); // Any encoding
     WTF_EXPORT_PRIVATE CString(std::span<const char>); // Any encoding
+    // FIXME: These two should be removed. They are the exact ambiguity CStringWithEncoding exists to
+    // eliminate: both encodings land in the same char buffer and become indistinguishable.
     CString(std::span<const Latin1Character>); // Latin1
     CString(std::span<const char8_t> characters) : CString(byteCast<Latin1Character>(characters)) { } // UTF-8
     CString(CStringBuffer* buffer) : m_buffer(buffer) { }
@@ -114,8 +122,8 @@ WTF_EXPORT_PRIVATE bool NODELETE operator==(const CString&, const CString&);
 WTF_EXPORT_PRIVATE bool NODELETE operator==(const CString&, ASCIILiteral);
 WTF_EXPORT_PRIVATE bool operator<(const CString&, const CString&);
 
-WTF_EXPORT_PRIVATE CString convertToASCIILowercase(std::span<const char8_t>);
-WTF_EXPORT_PRIVATE CString convertToASCIIUppercase(std::span<const char8_t>);
+WTF_EXPORT_PRIVATE UTF8CString convertToASCIILowercase(std::span<const char8_t>);
+WTF_EXPORT_PRIVATE UTF8CString convertToASCIIUppercase(std::span<const char8_t>);
 
 struct CStringHash {
     static unsigned hash(const CString& string) { return string.hash(); }
@@ -172,8 +180,131 @@ inline std::string CString::toStdString() const
 // CString is null terminated
 inline const char* safePrintfType(const CString& cstring) { return cstring.data(); }
 
+// A CString that remembers the encoding of its bytes. Converts implicitly to CString, which erases the encoding.
+// The character type carries the encoding, following WTF convention: char8_t is UTF-8, Latin1Character is
+// Latin-1, and char is ASCII, as in ASCIILiteral.
+//
+// Unlike ASCIILiteral, ASCIICString cannot enforce that its bytes really are ASCII: newUninitialized hands out
+// a mutable buffer, so there is no point at which the contents can be checked. It is therefore defined as
+// Latin-1 restricted to 0..127, and every operation treats it that way. A stray non-ASCII byte is then merely
+// a mislabeled Latin-1 byte, with no ill-defined behavior; the constructor asserts against it in debug builds.
+template<typename CharacterType> class CStringWithEncoding final : public CString {
+    // Heap allocation policy is inherited from CString.
+    static_assert(std::same_as<CharacterType, char8_t> || std::same_as<CharacterType, Latin1Character> || std::same_as<CharacterType, char>);
+public:
+    CStringWithEncoding() = default;
+
+    CStringWithEncoding(HashTableDeletedValueType)
+        : CString(HashTableDeletedValue)
+    {
+    }
+
+    // An ASCII literal is valid in every supported encoding.
+    CStringWithEncoding(ASCIILiteral literal)
+        : CString(literal)
+    {
+    }
+
+    explicit CStringWithEncoding(std::span<const CharacterType> characters)
+        : CString(byteCast<char>(characters))
+    {
+        if constexpr (std::same_as<CharacterType, char>)
+            ASSERT(charactersAreAllASCII(byteCast<Latin1Character>(characters)));
+    }
+
+    static CStringWithEncoding newUninitialized(size_t length, std::span<CharacterType>& characterBuffer)
+    {
+        std::span<char> bytes;
+        auto result = CString::newUninitialized(length, bytes);
+        characterBuffer = byteCast<CharacterType>(bytes);
+        return CStringWithEncoding { result.buffer() };
+    }
+
+    // These hide the CString versions so that the encoding survives into the pointer and span types.
+    const CharacterType* data() const LIFETIME_BOUND { return byteCast<CharacterType>(CString::data()); }
+    std::span<const CharacterType> span() const LIFETIME_BOUND { return byteCast<CharacterType>(CString::span()); }
+    std::span<const CharacterType> spanIncludingNullTerminator() const LIFETIME_BOUND { return byteCast<CharacterType>(CString::spanIncludingNullTerminator()); }
+    std::span<CharacterType> mutableSpan() LIFETIME_BOUND { return byteCast<CharacterType>(CString::mutableSpan()); }
+    std::span<CharacterType> mutableSpanIncludingNullTerminator() LIFETIME_BOUND { return byteCast<CharacterType>(CString::mutableSpanIncludingNullTerminator()); }
+
+    // This is the escape hatch for external C functions and printf-style formatting, matching ASCIILiteral::characters().
+    // Interactions with other strings should go through the span. Not offered for Latin-1: handing Latin-1 bytes to a
+    // const char* API is only meaningful when they happen to be ASCII, and such a string should have come from
+    // String::ascii(). Callers that really want the raw bytes can use byteCast<char>(span()) or slice to CString.
+    // FIXME: Should go away once callers that only need bytes have moved to span().
+    const char* characters() const LIFETIME_BOUND requires (!std::same_as<CharacterType, Latin1Character>) { return CString::data(); }
+
+private:
+    explicit CStringWithEncoding(CStringBuffer* buffer)
+        : CString(buffer)
+    {
+    }
+};
+
+// These are exact matches, so they win over the CString overloads above, which would require a derived-to-base conversion.
+template<typename CharacterType>
+bool NODELETE operator==(const CStringWithEncoding<CharacterType>& a, const CStringWithEncoding<CharacterType>& b)
+{
+    if (a.isNull() != b.isNull())
+        return false;
+    return equalSpans(a.span(), b.span());
+}
+
+template<typename CharacterType>
+bool operator<(const CStringWithEncoding<CharacterType>& a, const CStringWithEncoding<CharacterType>& b)
+{
+    if (a.isNull())
+        return !b.isNull();
+    if (b.isNull())
+        return false;
+    return is_lt(compareSpans(a.span(), b.span()));
+}
+
+// ASCII is Latin-1 restricted to 0..127, so ASCII against Latin-1 is left to the CString comparison above,
+// which compares bytes; decoding both sides would give the same answer. UTF-8 bytes cannot be compared
+// against either of the single-byte encodings, so those combinations decode to code points instead.
+// Treating ASCII as Latin-1 rather than as raw bytes is what keeps this consistent for an ASCIICString that
+// holds a non-ASCII byte: it then compares exactly like the equivalent Latin1CString, instead of matching
+// both a Latin1CString and a UTF8CString that do not match each other.
+template<typename A, typename B> concept NeedsCodePointComparison = std::same_as<A, char8_t> != std::same_as<B, char8_t>;
+
+template<typename A, typename B> requires NeedsCodePointComparison<A, B>
+bool operator==(const CStringWithEncoding<A>& a, const CStringWithEncoding<B>& b)
+{
+    if (a.isNull() != b.isNull())
+        return false;
+    if constexpr (std::same_as<A, char8_t>)
+        return Unicode::equal(byteCast<Latin1Character>(b.span()), a.span());
+    else
+        return Unicode::equal(byteCast<Latin1Character>(a.span()), b.span());
+}
+
+// Ordering has no equivalent helper, and nothing needs to order strings of different encodings. Convert explicitly.
+template<typename A, typename B> requires NeedsCodePointComparison<A, B>
+bool operator<(const CStringWithEncoding<A>&, const CStringWithEncoding<B>&) = delete;
+
+template<typename CharacterType> struct CStringWithEncodingHash {
+    static unsigned hash(const CStringWithEncoding<CharacterType>& string) { return string.hash(); }
+    static bool NODELETE equal(const CStringWithEncoding<CharacterType>& a, const CStringWithEncoding<CharacterType>& b)
+    {
+        if (a.isHashTableDeletedValue())
+            return b.isHashTableDeletedValue();
+        if (b.isHashTableDeletedValue())
+            return false;
+        return a == b;
+    }
+    static constexpr bool safeToCompareToEmptyOrDeleted = true;
+};
+
+template<typename CharacterType> struct DefaultHash<CStringWithEncoding<CharacterType>> : CStringWithEncodingHash<CharacterType> { };
+template<typename CharacterType> struct HashTraits<CStringWithEncoding<CharacterType>> : SimpleClassHashTraits<CStringWithEncoding<CharacterType>> { };
+
 } // namespace WTF
 
+using WTF::ASCIICString;
 using WTF::CString;
+using WTF::CStringWithEncoding;
+using WTF::Latin1CString;
+using WTF::UTF8CString;
 using WTF::convertToASCIILowercase;
 using WTF::convertToASCIIUppercase;

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -1578,17 +1578,17 @@ size_t NODELETE StringImpl::sizeInBytes() const
     return size + sizeof(*this);
 }
 
-std::expected<CString, UTF8ConversionError> StringImpl::utf8ForCharacters(std::span<const Latin1Character> source)
+std::expected<UTF8CString, UTF8ConversionError> StringImpl::utf8ForCharacters(std::span<const Latin1Character> source)
 {
     return tryGetUTF8ForCharacters([] (std::span<const char8_t> converted) {
-        return CString { converted };
+        return UTF8CString { converted };
     }, source);
 }
 
-std::expected<CString, UTF8ConversionError> StringImpl::utf8ForCharacters(std::span<const char16_t> characters, ConversionMode mode)
+std::expected<UTF8CString, UTF8ConversionError> StringImpl::utf8ForCharacters(std::span<const char16_t> characters, ConversionMode mode)
 {
     return tryGetUTF8ForCharacters([] (std::span<const char8_t> converted) {
-        return CString { converted };
+        return UTF8CString { converted };
     }, characters, mode);
 }
 
@@ -1630,7 +1630,7 @@ size_t StringImpl::tryConvertUTF16ToUTF8(std::span<const char16_t> source, std::
     return notFound;
 }
 
-std::expected<CString, UTF8ConversionError> StringImpl::tryGetUTF8(ConversionMode mode) const
+std::expected<UTF8CString, UTF8ConversionError> StringImpl::tryGetUTF8(ConversionMode mode) const
 {
     if (is8Bit())
         return utf8ForCharacters(span8());

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -333,8 +333,8 @@ public:
 
     bool isSubString() const { return bufferOwnership() == BufferSubstring; }
 
-    static WTF_EXPORT_PRIVATE std::expected<CString, UTF8ConversionError> utf8ForCharacters(std::span<const Latin1Character> characters);
-    static WTF_EXPORT_PRIVATE std::expected<CString, UTF8ConversionError> utf8ForCharacters(std::span<const char16_t> characters, ConversionMode = LenientConversion);
+    static WTF_EXPORT_PRIVATE std::expected<UTF8CString, UTF8ConversionError> utf8ForCharacters(std::span<const Latin1Character> characters);
+    static WTF_EXPORT_PRIVATE std::expected<UTF8CString, UTF8ConversionError> utf8ForCharacters(std::span<const char16_t> characters, ConversionMode = LenientConversion);
     static WTF_EXPORT_PRIVATE std::expected<size_t, UTF8ConversionError> utf8ForCharactersIntoBuffer(std::span<const char16_t> characters, ConversionMode, Vector<char8_t, 1024>&);
     static WTF_EXPORT_PRIVATE size_t utf8LengthFromUTF16(std::span<const char16_t> characters);
     static WTF_EXPORT_PRIVATE size_t tryConvertUTF16ToUTF8(std::span<const char16_t> source, std::span<char8_t> destination);
@@ -346,7 +346,8 @@ public:
 
     template<typename Func>
     std::expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> tryGetUTF8(NOESCAPE const Func&, ConversionMode = LenientConversion) const;
-    WTF_EXPORT_PRIVATE std::expected<CString, UTF8ConversionError> tryGetUTF8(ConversionMode = LenientConversion) const;
+    WTF_EXPORT_PRIVATE std::expected<UTF8CString, UTF8ConversionError> tryGetUTF8(ConversionMode = LenientConversion) const;
+    // FIXME: Should return a UTF8CString, like tryGetUTF8() above already does.
     WTF_EXPORT_PRIVATE CString utf8(ConversionMode = LenientConversion) const;
 
 private:

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -106,10 +106,10 @@ bool StringView::endsWithIgnoringASCIICase(StringView suffix) const
     return ::WTF::endsWithIgnoringASCIICase(*this, suffix);
 }
 
-std::expected<CString, UTF8ConversionError> StringView::tryGetUTF8(ConversionMode mode) const
+std::expected<UTF8CString, UTF8ConversionError> StringView::tryGetUTF8(ConversionMode mode) const
 {
     if (isNull())
-        return CString { ""_span };
+        return UTF8CString { u8""_span };
     if (is8Bit())
         return StringImpl::utf8ForCharacters(span8());
     return StringImpl::utf8ForCharacters(span16(), mode);

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -127,7 +127,8 @@ public:
     WTF_EXPORT_PRIVATE RetainPtr<NSString> createNSStringWithoutCopying() const;
 #endif
 
-    WTF_EXPORT_PRIVATE std::expected<CString, UTF8ConversionError> tryGetUTF8(ConversionMode = LenientConversion) const;
+    WTF_EXPORT_PRIVATE std::expected<UTF8CString, UTF8ConversionError> tryGetUTF8(ConversionMode = LenientConversion) const;
+    // FIXME: Should return a UTF8CString, like tryGetUTF8() above already does.
     WTF_EXPORT_PRIVATE CString utf8(ConversionMode = LenientConversion) const;
 
     template<typename Func>

--- a/Source/WTF/wtf/text/TextStream.h
+++ b/Source/WTF/wtf/text/TextStream.h
@@ -86,6 +86,8 @@ public:
     WTF_EXPORT_PRIVATE TextStream& operator<<(const char*);
     WTF_EXPORT_PRIVATE TextStream& operator<<(const void*);
     WTF_EXPORT_PRIVATE TextStream& operator<<(const AtomString&);
+    // FIXME: This appends the bytes as Latin-1. It should take an encoding-aware CStringWithEncoding
+    // and decode accordingly, rather than silently reinterpreting a sliced UTF8CString.
     WTF_EXPORT_PRIVATE TextStream& operator<<(const CString&);
     WTF_EXPORT_PRIVATE TextStream& operator<<(const String&);
     WTF_EXPORT_PRIVATE TextStream& operator<<(ASCIILiteral);

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -392,21 +392,21 @@ Vector<String> String::splitAllowingEmptyEntries(StringView separator) const
     return splitInternal<true>(separator);
 }
 
-CString String::ascii() const
+ASCIICString String::ascii() const
 {
     // Printable ASCII characters 32..127 and the null character are
     // preserved, characters outside of this range are converted to '?'.
 
     if (isEmpty()) {
         std::span<char> characterBuffer;
-        return CString::newUninitialized(0, characterBuffer);
+        return ASCIICString::newUninitialized(0, characterBuffer);
     }
 
     if (this->is8Bit()) {
         auto characters = this->span8();
 
         std::span<char> characterBuffer;
-        CString result = CString::newUninitialized(characters.size(), characterBuffer);
+        auto result = ASCIICString::newUninitialized(characters.size(), characterBuffer);
 
         size_t characterBufferIndex = 0;
         for (auto character : characters)
@@ -417,7 +417,7 @@ CString String::ascii() const
 
     auto characters = span16();
     std::span<char> characterBuffer;
-    CString result = CString::newUninitialized(characters.size(), characterBuffer);
+    auto result = ASCIICString::newUninitialized(characters.size(), characterBuffer);
 
     size_t characterBufferIndex = 0;
     for (auto character : characters)
@@ -426,41 +426,41 @@ CString String::ascii() const
     return result;
 }
 
-CString String::latin1() const
+Latin1CString String::latin1() const
 {
     // Basic Latin1 (ISO) encoding - Unicode characters 0..255 are
     // preserved, characters outside of this range are converted to '?'.
 
     if (isEmpty())
-        return ""_span;
+        return Latin1CString { ""_span8 };
 
     if (is8Bit())
-        return CString(this->span8());
+        return Latin1CString { this->span8() };
 
     auto characters = this->span16();
-    std::span<char> characterBuffer;
-    CString result = CString::newUninitialized(characters.size(), characterBuffer);
+    std::span<Latin1Character> characterBuffer;
+    auto result = Latin1CString::newUninitialized(characters.size(), characterBuffer);
 
     size_t characterBufferIndex = 0;
     for (auto character : characters)
-        characterBuffer[characterBufferIndex++] = !isLatin1(character) ? '?' : character;
+        characterBuffer[characterBufferIndex++] = !isLatin1(character) ? '?' : static_cast<Latin1Character>(character);
 
     return result;
 }
 
-std::expected<CString, UTF8ConversionError> String::tryGetUTF8(ConversionMode mode) const
+std::expected<UTF8CString, UTF8ConversionError> String::tryGetUTF8(ConversionMode mode) const
 {
-    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->tryGetUTF8(mode) : CString { ""_span };
+    SUPPRESS_UNCOUNTED_ARG return m_impl ? m_impl->tryGetUTF8(mode) : UTF8CString { u8""_span };
 }
 
-std::expected<CString, UTF8ConversionError> String::tryGetUTF8() const
+std::expected<UTF8CString, UTF8ConversionError> String::tryGetUTF8() const
 {
     return tryGetUTF8(LenientConversion);
 }
 
 CString String::utf8(ConversionMode mode) const
 {
-    std::expected<CString, UTF8ConversionError> expectedString = tryGetUTF8(mode);
+    auto expectedString = tryGetUTF8(mode);
     RELEASE_ASSERT(expectedString);
     return expectedString.value();
 }

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -120,15 +120,17 @@ public:
 
     unsigned sizeInBytes() const { return m_impl ? m_impl->length() * (is8Bit() ? sizeof(Latin1Character) : sizeof(char16_t)) : 0; }
 
-    WTF_EXPORT_PRIVATE CString ascii() const;
-    WTF_EXPORT_PRIVATE CString latin1() const;
+    WTF_EXPORT_PRIVATE ASCIICString ascii() const;
+    WTF_EXPORT_PRIVATE Latin1CString latin1() const;
 
+    // FIXME: Should return a UTF8CString, like tryGetUTF8() below already does. Blocked on the
+    // ~2900 call sites, most of which pass utf8().data() to a %s and would need characters().
     WTF_EXPORT_PRIVATE CString utf8(ConversionMode = LenientConversion) const;
 
     template<typename Func>
     std::expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> tryGetUTF8(NOESCAPE const Func&, ConversionMode = LenientConversion) const;
-    WTF_EXPORT_PRIVATE std::expected<CString, UTF8ConversionError> tryGetUTF8(ConversionMode) const;
-    WTF_EXPORT_PRIVATE std::expected<CString, UTF8ConversionError> tryGetUTF8() const;
+    WTF_EXPORT_PRIVATE std::expected<UTF8CString, UTF8ConversionError> tryGetUTF8(ConversionMode) const;
+    WTF_EXPORT_PRIVATE std::expected<UTF8CString, UTF8ConversionError> tryGetUTF8() const;
 
     char16_t codeUnitAt(unsigned index) const;
     char16_t operator[](unsigned index) const { return codeUnitAt(index); }

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -777,7 +777,7 @@ void SubresourceLoader::didFinishLoading(const NetworkLoadMetrics& networkLoadMe
     ASSERT(!resource->resourceToRevalidate());
     // FIXME (129394): We should cancel the load when a decode error occurs instead of continuing the load to completion.
     ASSERT(!resource->errorOccurred() || resource->status() == CachedResource::DecodeError || !resource->isLoading());
-    LOG(ResourceLoading, "Received '%s'.", resource->url().string().latin1().data());
+    LOG(ResourceLoading, "Received '%s'.", resource->url().string().utf8().data());
     logResourceLoaded(protect(frame()).get(), resource->type());
 
     m_loadTiming.markEndTime();
@@ -831,7 +831,7 @@ void SubresourceLoader::didFail(const ResourceError& error)
 
     ASSERT(!reachedTerminalState());
     RefPtr resource = m_resource;
-    LOG(ResourceLoading, "Failed to load '%s'.\n", resource->url().string().latin1().data());
+    LOG(ResourceLoading, "Failed to load '%s'.\n", resource->url().string().utf8().data());
 
     RefPtr frame = m_frame;
     if (frame && frame->document() && error.isAccessControl() && error.domain() != InspectorNetworkAgent::errorDomain() && resource->type() != CachedResource::Type::Ping)
@@ -874,7 +874,7 @@ void SubresourceLoader::willCancel(const ResourceError& error)
 
     Ref protectedThis { *this };
     RefPtr resource = m_resource;
-    LOG(ResourceLoading, "Cancelled load of '%s'.\n", resource->url().string().latin1().data());
+    LOG(ResourceLoading, "Cancelled load of '%s'.\n", resource->url().string().utf8().data());
 
 #if PLATFORM(IOS_FAMILY)
     m_state = m_state == Uninitialized ? CancelledWhileInitializing : Finishing;

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -147,7 +147,7 @@ void CachedResource::deref() const
 void CachedResource::failBeforeStarting()
 {
     // FIXME: What if resources in other frames were waiting for this revalidation?
-    LOG(ResourceLoading, "Cannot start loading '%s'", url().string().latin1().data());
+    LOG(ResourceLoading, "Cannot start loading '%s'", url().string().utf8().data());
     if (allowsCaching() && m_resourceToRevalidate)
         MemoryCache::singleton().revalidationFailed(*this);
     error(CachedResource::LoadError);

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1214,7 +1214,7 @@ ResourceErrorOr<Ref<CachedResource>> CachedResourceLoader::requestResource(Cache
         return makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, url, "URL is invalid"_s });
     }
 
-    LOG(ResourceLoading, "CachedResourceLoader::requestResource '%.255s', charset '%s', priority=%d, forPreload=%u", url.stringCenterEllipsizedToLength().latin1().data(), request.charset().latin1().data(), request.priority() ? static_cast<int>(request.priority().value()) : -1, forPreload == ForPreload::Yes);
+    LOG(ResourceLoading, "CachedResourceLoader::requestResource '%.255s', charset '%s', priority=%d, forPreload=%u", url.stringCenterEllipsizedToLength().utf8().data(), request.charset().utf8().data(), request.priority() ? static_cast<int>(request.priority().value()) : -1, forPreload == ForPreload::Yes);
 
     request.setDestinationIfNotSet(destinationForType(type, frame));
 
@@ -1552,7 +1552,7 @@ Ref<CachedResource> CachedResourceLoader::loadResource(CachedResource::Type type
     ASSERT(!request.allowsCaching() || mayAddToMemoryCache == MayAddToMemoryCache::No || !memoryCache->resourceForRequest(request.resourceRequest(), sessionID)
         || request.resourceRequest().cachePolicy() == ResourceRequestCachePolicy::DoNotUseAnyCache || request.resourceRequest().cachePolicy() == ResourceRequestCachePolicy::ReloadIgnoringCacheData || request.resourceRequest().cachePolicy() == ResourceRequestCachePolicy::RefreshAnyCacheData);
 
-    LOG(ResourceLoading, "Loading CachedResource for '%s'.", request.resourceRequest().url().stringCenterEllipsizedToLength().latin1().data());
+    LOG(ResourceLoading, "Loading CachedResource for '%s'.", request.resourceRequest().url().stringCenterEllipsizedToLength().utf8().data());
 
     auto resource = createResource(type, WTF::move(request), sessionID, &cookieJar, settings, protect(document()).get());
 

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -136,7 +136,7 @@ bool MemoryCache::add(CachedResource& resource)
     
     resourceAccessed(resource);
 
-    LOG(ResourceLoading, "MemoryCache::add Added '%.255s', resource %p\n", resource.url().string().latin1().data(), &resource);
+    LOG(ResourceLoading, "MemoryCache::add Added '%.255s', resource %p\n", resource.url().string().utf8().data(), &resource);
     return true;
 }
 
@@ -430,7 +430,7 @@ void MemoryCache::remove(CachedResource& resource)
     RELEASE_ASSERT(isMainThread());
     RefPtr protectedResource { resource };
 
-    LOG(ResourceLoading, "Evicting resource %p for '%.255s' from cache", &resource, resource.url().string().latin1().data());
+    LOG(ResourceLoading, "Evicting resource %p for '%.255s' from cache", &resource, resource.url().string().utf8().data());
     // The resource may have already been removed by someone other than our caller,
     // who needed a fresh copy for a reload. See <http://bugs.webkit.org/show_bug.cgi?id=12479#c6>.
     if (auto* resources = sessionResourceMap(resource.sessionID())) {

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -267,7 +267,7 @@ void logMemoryStatistics(LogMemoryStatisticsReason reason)
         String tagName = displayNameForVMTag(i);
         if (!tagName)
             tagName = makeString("Tag "_s, i);
-        RELEASE_LOG(MemoryPressure, "  %" PUBLIC_LOG_STRING ": %lu MB in %zu regions", tagName.latin1().data(), dirty / MB, pages[i].regionCount);
+        RELEASE_LOG(MemoryPressure, "  %" PUBLIC_LOG_STRING ": %lu MB in %zu regions", tagName.utf8().data(), dirty / MB, pages[i].regionCount);
     }
 
     bool shouldLogJavaScriptObjectCounts = os_variant_allows_internal_security_policies("com.apple.WebKit");

--- a/Source/WebCore/platform/network/curl/CurlContext.cpp
+++ b/Source/WebCore/platform/network/curl/CurlContext.cpp
@@ -406,8 +406,7 @@ void CurlHandle::setURL(const URL& url, LocalhostAlias localhostAlias)
             curlUrl.setQuery(String());
     }
 
-    // url is in ASCII so latin1() will only convert it to char* without character translation.
-    curl_easy_setopt(m_handle, CURLOPT_URL, curlUrl.string().latin1().data());
+    curl_easy_setopt(m_handle, CURLOPT_URL, curlUrl.string().utf8().data());
 
     if (url.protocolIs("https"_s))
         enableSSL();

--- a/Source/WebCore/platform/network/curl/CurlContext.h
+++ b/Source/WebCore/platform/network/curl/CurlContext.h
@@ -207,7 +207,7 @@ public:
     }
 
     void append(const char* str) { m_list = curl_slist_append(m_list, str); }
-    void append(const String& str) { append(str.latin1().data()); }
+    void append(const String& str) { append(str.utf8().data()); }
 
 private:
     struct curl_slist* m_list { nullptr };

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -193,7 +193,7 @@ bool SQLiteDatabase::open(const String& filename, OpenMode openMode, OptionSet<O
 
         auto shmFileName = makeString(filename, "-shm"_s);
         if (FileSystem::fileExists(shmFileName) && !FileSystem::isSafeToUseMemoryMapForPath(shmFileName)) {
-            RELEASE_LOG_FAULT(SQLDatabase, "Opened an SQLite database with a Class A -shm file. This may trigger a crash when the user locks the device. (%s)", shmFileName.latin1().data());
+            RELEASE_LOG_FAULT(SQLDatabase, "Opened an SQLite database with a Class A -shm file. This may trigger a crash when the user locks the device. (%s)", shmFileName.utf8().data());
             if (!FileSystem::makeSafeToUseMemoryMapForPath(shmFileName))
                 return false;
         }

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -227,7 +227,7 @@ RefPtr<FragmentedSharedBuffer> RenderThemeAdwaita::mediaControlsImageDataForIcon
 {
 #if USE(GLIB)
     auto path = makeString("/org/webkit/media-controls/"_s, iconName, '.', iconType);
-    GRefPtr data = adoptGRef(g_resources_lookup_data(path.latin1().data(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
+    GRefPtr data = adoptGRef(g_resources_lookup_data(path.utf8().data(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
     if (!data)
         return nullptr;
     return SharedBuffer::create(span(data));
@@ -246,7 +246,7 @@ String RenderThemeAdwaita::mediaControlsBase64StringForIconNameAndType(const Str
 {
 #if USE(GLIB)
     auto path = makeString("/org/webkit/media-controls/"_s, iconName, '.', iconType);
-    GRefPtr data = adoptGRef(g_resources_lookup_data(path.latin1().data(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
+    GRefPtr data = adoptGRef(g_resources_lookup_data(path.utf8().data(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
     if (!data)
         return emptyString();
     return base64EncodeToString(span(data));

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -1607,7 +1607,7 @@ xmlDocPtr xmlDocPtrForString(CachedResourceLoader& cachedResourceLoader, const S
         return nullptr;
 
     XMLDocumentParserScope scope(&cachedResourceLoader, errorFunc);
-    return xmlReadMemory(characters.data(), static_cast<int>(sizeInBytes), url.latin1().data(), encoding, XSLT_PARSE_OPTIONS);
+    return xmlReadMemory(characters.data(), static_cast<int>(sizeInBytes), url.utf8().data(), encoding, XSLT_PARSE_OPTIONS);
 }
 #endif
 

--- a/Source/WebDriver/glib/SessionHostGlib.cpp
+++ b/Source/WebDriver/glib/SessionHostGlib.cpp
@@ -149,7 +149,7 @@ void SessionHost::launchBrowser(Function<void (std::optional<String> error)>&& c
 
     m_cancellable = adoptGRef(g_cancellable_new());
     GUniquePtr<char> inspectorAddress(
-        g_strdup_printf("%s:%u", targetIp.isEmpty() ? "127.0.0.1" : targetIp.latin1().data(), targetPort > 0 ? targetPort : freePort())
+        g_strdup_printf("%s:%u", targetIp.isEmpty() ? "127.0.0.1" : targetIp.utf8().data(), targetPort > 0 ? targetPort : freePort())
     );
     if (!targetIp.isEmpty()) {
         m_isRemoteBrowser = true;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -542,7 +542,7 @@ std::unique_ptr<Entry> Cache::store(const WebCore::ResourceRequest& request, con
 {
     ASSERT(responseData);
 
-    LOG(NetworkCache, "(NetworkProcess) storing %s, partition %s", request.url().stringWithoutFragmentIdentifier().latin1().data(), makeCacheKey(request).partition().latin1().data());
+    LOG(NetworkCache, "(NetworkProcess) storing %s, partition %s", request.url().stringWithoutFragmentIdentifier().utf8().data(), makeCacheKey(request).partition().utf8().data());
 
     StoreDecision storeDecision = makeStoreDecision(request, response, responseData ? responseData->size() : 0);
     if (storeDecision != StoreDecision::Yes) {
@@ -586,7 +586,7 @@ std::unique_ptr<Entry> Cache::store(const WebCore::ResourceRequest& request, con
 
 std::unique_ptr<Entry> Cache::storeRedirect(const WebCore::ResourceRequest& request, const WebCore::ResourceResponse& response, const WebCore::ResourceRequest& redirectRequest, std::optional<Seconds> maxAgeCap)
 {
-    LOG(NetworkCache, "(NetworkProcess) storing redirect %s -> %s", request.url().string().latin1().data(), redirectRequest.url().string().latin1().data());
+    LOG(NetworkCache, "(NetworkProcess) storing redirect %s -> %s", request.url().string().utf8().data(), redirectRequest.url().string().utf8().data());
 
     StoreDecision storeDecision = makeStoreDecision(request, response, 0);
     if (storeDecision != StoreDecision::Yes) {
@@ -597,7 +597,7 @@ std::unique_ptr<Entry> Cache::storeRedirect(const WebCore::ResourceRequest& requ
     auto cacheEntry = makeRedirectEntry(request, response, redirectRequest);
 
     if (maxAgeCap) {
-        LOG(NetworkCache, "(NetworkProcess) capping max age for redirect %s -> %s", request.url().string().latin1().data(), redirectRequest.url().string().latin1().data());
+        LOG(NetworkCache, "(NetworkProcess) capping max age for redirect %s -> %s", request.url().string().utf8().data(), redirectRequest.url().string().utf8().data());
         cacheEntry->capMaxAge(maxAgeCap.value());
     }
 
@@ -610,7 +610,7 @@ std::unique_ptr<Entry> Cache::storeRedirect(const WebCore::ResourceRequest& requ
 
 std::unique_ptr<Entry> Cache::update(const WebCore::ResourceRequest& originalRequest, const Entry& existingEntry, const WebCore::ResourceResponse& validatingResponse, PrivateRelayed privateRelayed)
 {
-    LOG(NetworkCache, "(NetworkProcess) updating %s", originalRequest.url().string().latin1().data());
+    LOG(NetworkCache, "(NetworkProcess) updating %s", originalRequest.url().string().utf8().data());
 
     WebCore::ResourceResponse response = existingEntry.response();
     WebCore::updateResponseHeadersAfterRevalidation(response, validatingResponse);

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheFileSystem.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheFileSystem.cpp
@@ -64,7 +64,7 @@ FileTimes fileTimes(const String& path)
 {
 #if HAVE(STAT_BIRTHTIME)
     struct stat fileInfo;
-    if (stat(FileSystem::fileSystemRepresentation(path).data(), &fileInfo))
+    if (FileSystem::statFile(FileSystem::fileSystemRepresentation(path).spanIncludingNullTerminator(), fileInfo))
         return { };
     return { WallTime::fromRawSeconds(fileInfo.st_birthtime), WallTime::fromRawSeconds(fileInfo.st_mtime) };
 #elif USE(SOUP)

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -214,7 +214,7 @@ static RetainPtr<nw_parameters_t> createParameters(NetworkConnectionToWebProcess
         MAYBE_SOFT_LINK(nw_webtransport_options_set_initial_max_streams_uni)(options, maxStreamsUni);
         MAYBE_SOFT_LINK(nw_webtransport_options_set_initial_max_streams_bidi)(options, maxStreamsBidi);
         for (auto& header : additionalHeaders)
-            MAYBE_SOFT_LINK(nw_webtransport_options_add_connect_request_header)(options, header.key.latin1().data(), header.value.latin1().data());
+            MAYBE_SOFT_LINK(nw_webtransport_options_add_connect_request_header)(options, header.key.utf8().data(), header.value.utf8().data());
         MAYBE_SOFT_LINK(nw_webtransport_options_add_connect_request_header)(options, "wt-available-protocols", protocols.utf8().data());
     };
 

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -464,7 +464,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
     auto contentEncodingSniffingPolicy = resourceLoader.contentEncodingSniffingPolicy();
     StoredCredentialsPolicy storedCredentialsPolicy = resourceLoader.shouldUseCredentialStorage() ? StoredCredentialsPolicy::Use : StoredCredentialsPolicy::DoNotUse;
 
-    LOG(NetworkScheduling, "(WebProcess) WebLoaderStrategy::scheduleLoad, url '%s' will be scheduled with the NetworkProcess with priority %d, storedCredentialsPolicy %i", resourceLoader.url().string().latin1().data(), static_cast<int>(resourceLoader.request().priority()), (int)storedCredentialsPolicy);
+    LOG(NetworkScheduling, "(WebProcess) WebLoaderStrategy::scheduleLoad, url '%s' will be scheduled with the NetworkProcess with priority %d, storedCredentialsPolicy %i", resourceLoader.url().string().utf8().data(), static_cast<int>(resourceLoader.request().priority()), (int)storedCredentialsPolicy);
 
     NetworkResourceLoadParameters loadParameters {
         trackingParameters.webPageProxyID,

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -183,7 +183,7 @@ void WebResourceLoader::willSendRequest(ResourceRequest&& proposedRequest, IPC::
     // Make the request whole again as we do not normally encode the request's body when sending it over IPC, for performance reasons.
     proposedRequest.setHTTPBody(proposedRequestBody.takeData());
 
-    LOG(Network, "(WebProcess) WebResourceLoader::willSendRequest to '%s'", proposedRequest.url().string().latin1().data());
+    LOG(Network, "(WebProcess) WebResourceLoader::willSendRequest to '%s'", proposedRequest.url().string().utf8().data());
     WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderWillSendRequest);
     
     if (RefPtr frame = coreLoader->frame()) {
@@ -251,7 +251,7 @@ void WebResourceLoader::updateNetworkLoadMetrics(NetworkLoadMetrics& metrics)
 void WebResourceLoader::didReceiveResponse(ResourceResponse&& response, PrivateRelayed privateRelayed, bool needsContinueDidReceiveResponseMessage, std::optional<NetworkLoadMetrics>&& metrics)
 {
     RefPtr coreLoader = m_coreLoader;
-    LOG(Network, "(WebProcess) WebResourceLoader::didReceiveResponse for '%s'. Status %d.", coreLoader->url().string().latin1().data(), response.httpStatusCode());
+    LOG(Network, "(WebProcess) WebResourceLoader::didReceiveResponse for '%s'. Status %d.", coreLoader->url().string().utf8().data(), response.httpStatusCode());
     WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderDidReceiveResponse, response.httpStatusCode());
 
     Ref<WebResourceLoader> protectedThis(*this);
@@ -324,7 +324,7 @@ void WebResourceLoader::didReceiveResponse(ResourceResponse&& response, PrivateR
 void WebResourceLoader::didReceiveData(IPC::SharedBufferReference&& data, uint64_t bytesTransferredOverNetwork)
 {
     RefPtr coreLoader = m_coreLoader;
-    LOG(Network, "(WebProcess) WebResourceLoader::didReceiveData of size %zu for '%s'", data.size(), coreLoader->url().string().latin1().data());
+    LOG(Network, "(WebProcess) WebResourceLoader::didReceiveData of size %zu for '%s'", data.size(), coreLoader->url().string().utf8().data());
     ASSERT_WITH_MESSAGE(!m_isProcessingNetworkResponse, "Network process should not send data until we've validated the response");
 
     if (m_interceptController.isIntercepting(*coreLoader->identifier())) [[unlikely]] {
@@ -369,7 +369,7 @@ void WebResourceLoader::didReceiveData(IPC::SharedBufferReference&& data, uint64
 void WebResourceLoader::didFinishResourceLoad(NetworkLoadMetrics&& networkLoadMetrics)
 {
     RefPtr coreLoader = m_coreLoader;
-    LOG(Network, "(WebProcess) WebResourceLoader::didFinishResourceLoad for '%s'", coreLoader->url().string().latin1().data());
+    LOG(Network, "(WebProcess) WebResourceLoader::didFinishResourceLoad for '%s'", coreLoader->url().string().utf8().data());
     WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderDidFinishResourceLoad, static_cast<uint64_t>(m_numBytesReceived));
 
     if (m_interceptController.isIntercepting(*coreLoader->identifier())) [[unlikely]] {
@@ -436,7 +436,7 @@ void WebResourceLoader::cancelPendingStreamUpload()
 void WebResourceLoader::didFailResourceLoad(const ResourceError& error)
 {
     RefPtr coreLoader = m_coreLoader;
-    LOG(Network, "(WebProcess) WebResourceLoader::didFailResourceLoad for '%s'", coreLoader->url().string().latin1().data());
+    LOG(Network, "(WebProcess) WebResourceLoader::didFailResourceLoad for '%s'", coreLoader->url().string().utf8().data());
     WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderDidFailResourceLoad);
 
     if (m_interceptController.isIntercepting(*coreLoader->identifier())) [[unlikely]] {
@@ -455,7 +455,7 @@ void WebResourceLoader::didFailResourceLoad(const ResourceError& error)
 void WebResourceLoader::didBlockAuthenticationChallenge()
 {
     RefPtr coreLoader = m_coreLoader;
-    LOG(Network, "(WebProcess) WebResourceLoader::didBlockAuthenticationChallenge for '%s'", coreLoader->url().string().latin1().data());
+    LOG(Network, "(WebProcess) WebResourceLoader::didBlockAuthenticationChallenge for '%s'", coreLoader->url().string().utf8().data());
     WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderDidBlockAuthenticationChallenge);
 
     coreLoader->didBlockAuthenticationChallenge();
@@ -464,7 +464,7 @@ void WebResourceLoader::didBlockAuthenticationChallenge()
 void WebResourceLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied(const ResourceResponse& response)
 {
     RefPtr coreLoader = m_coreLoader;
-    LOG(Network, "(WebProcess) WebResourceLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied for '%s'", coreLoader->url().string().latin1().data());
+    LOG(Network, "(WebProcess) WebResourceLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied for '%s'", coreLoader->url().string().utf8().data());
     WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderStopLoadingAfterSecurityPolicyDenied);
 
     protect(coreLoader->documentLoader())->stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied(*coreLoader->identifier(), response);
@@ -474,7 +474,7 @@ void WebResourceLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDeni
 void WebResourceLoader::didReceiveResource(ShareableResource::Handle&& handle)
 {
     RefPtr coreLoader = m_coreLoader;
-    LOG(Network, "(WebProcess) WebResourceLoader::didReceiveResource for '%s'", coreLoader->url().string().latin1().data());
+    LOG(Network, "(WebProcess) WebResourceLoader::didReceiveResource for '%s'", coreLoader->url().string().utf8().data());
     WEBRESOURCELOADER_RELEASE_LOG(WebResourceLoaderDidReceiveResource);
 
     RefPtr<SharedBuffer> buffer = WTF::move(handle).tryWrapInSharedBuffer();

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -678,7 +678,7 @@ void WebProcess::platformSetWebsiteDataStoreParameters(WebProcessDataStoreParame
 
     if (!parameters.javaScriptConfigurationDirectory.isEmpty()) {
         auto javaScriptConfigFile = makeString(parameters.javaScriptConfigurationDirectory, "/JSC.config"_s);
-        JSC::processConfigFile(javaScriptConfigFile.latin1().data(), "com.apple.WebKit.WebContent", m_uiProcessBundleIdentifier.latin1().data());
+        JSC::processConfigFile(javaScriptConfigFile.utf8().data(), "com.apple.WebKit.WebContent", m_uiProcessBundleIdentifier.utf8().data());
     }
 }
 

--- a/Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.cpp
+++ b/Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.cpp
@@ -53,7 +53,7 @@ static Color imageBufferPixelAt(const ImageBuffer& imageBuffer, FloatPoint point
     };
     if (differs(gotRed, expectedRed) || differs(gotGreen, expectedGreen) || differs(gotBlue, expectedBlue) || differs(gotAlpha, expectedAlpha)) {
         // Use this to debug the contents in the browser.
-        // WTFLogAlways("%s", imageBuffer.toDataURL("image/png"_s).latin1().data());
+        // WTFLogAlways("%s", imageBuffer.toDataURL("image/png"_s).utf8().data());
         return ::testing::AssertionFailure() << "color is not expected at " << point << ". Got: " << got << ", expected: " << expected << " with tolerance " << tolerance << ".";
     }
     return ::testing::AssertionSuccess();

--- a/Tools/TestWebKitAPI/Tests/WTF/CString.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CString.cpp
@@ -25,8 +25,13 @@
 
 #include "config.h"
 
+#include <array>
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/text/CString.h>
+#include <wtf/text/MakeString.h>
 #include <wtf/text/StringCommon.h>
+#include <wtf/text/WTFString.h>
 
 TEST(WTF, CStringNullStringConstructor)
 {
@@ -287,4 +292,163 @@ TEST(WTF, CStringViewASCIICaseConversions)
     EXPECT_EQ(WTF::convertToASCIIUppercase(std::span<const char8_t>()), CString(""_s));
     EXPECT_EQ(WTF::convertToASCIILowercase(u8""_span), CString(""_s));
     EXPECT_EQ(WTF::convertToASCIIUppercase(u8""_span), CString(""_s));
+}
+
+// The encoding survives into the span's element type, which is what makes the rest of WTF do the right thing.
+static_assert(std::same_as<decltype(std::declval<const UTF8CString&>().span())::element_type, const char8_t>);
+static_assert(std::same_as<decltype(std::declval<const Latin1CString&>().span())::element_type, const Latin1Character>);
+static_assert(std::same_as<decltype(std::declval<UTF8CString&>().mutableSpan())::element_type, char8_t>);
+static_assert(std::same_as<decltype(std::declval<const UTF8CString&>().data()), const char8_t*>);
+static_assert(std::same_as<decltype(std::declval<const Latin1CString&>().data()), const Latin1Character*>);
+static_assert(std::same_as<decltype(std::declval<const UTF8CString&>().characters()), const char*>);
+// ASCII is spelled with char, as in ASCIILiteral, so its accessors match the untyped ones.
+static_assert(std::same_as<decltype(std::declval<const ASCIICString&>().data()), const char*>);
+static_assert(std::same_as<decltype(std::declval<const ASCIICString&>().span())::element_type, const char>);
+// Erasing the encoding gives back the untyped CString span.
+static_assert(std::same_as<decltype(std::declval<const CString&>().span())::element_type, const char>);
+// Slicing to CString is allowed, but nothing implicitly converts the other way or between encodings.
+static_assert(std::is_convertible_v<UTF8CString, CString>);
+static_assert(!std::is_convertible_v<CString, UTF8CString>);
+static_assert(!std::is_convertible_v<Latin1CString, UTF8CString>);
+// Ordering across encodings must not compile. This has to go through a concept: with concrete
+// types, selecting a deleted overload is a hard error rather than an unsatisfied requirement.
+template<typename A, typename B> concept IsEqualityComparable = requires(const A& a, const B& b)
+{
+    a == b;
+};
+template<typename A, typename B> concept IsLessThanComparable = requires(const A& a, const B& b)
+{
+    a < b;
+};
+static_assert(IsEqualityComparable<UTF8CString, UTF8CString>);
+static_assert(IsEqualityComparable<Latin1CString, Latin1CString>);
+// Latin-1 and UTF-8 are compared by code point rather than by byte.
+static_assert(IsEqualityComparable<UTF8CString, Latin1CString>);
+static_assert(IsEqualityComparable<Latin1CString, UTF8CString>);
+static_assert(!IsLessThanComparable<UTF8CString, Latin1CString>);
+// ASCII is Latin-1 restricted to 0..127: byte comparison against Latin-1, code point comparison against UTF-8.
+static_assert(IsEqualityComparable<ASCIICString, UTF8CString>);
+static_assert(IsEqualityComparable<ASCIICString, Latin1CString>);
+static_assert(!IsLessThanComparable<ASCIICString, UTF8CString>);
+static_assert(IsLessThanComparable<ASCIICString, Latin1CString>);
+// The conversions that have been migrated report their encoding in the type.
+static_assert(std::same_as<decltype(std::declval<const String&>().ascii()), ASCIICString>);
+static_assert(std::same_as<decltype(std::declval<const String&>().latin1()), Latin1CString>);
+static_assert(std::same_as<decltype(std::declval<const String&>().tryGetUTF8()), std::expected<UTF8CString, UTF8ConversionError>>);
+static_assert(std::same_as<decltype(std::declval<const StringView&>().tryGetUTF8()), std::expected<UTF8CString, UTF8ConversionError>>);
+static_assert(std::same_as<decltype(WTF::convertToASCIILowercase(u8""_span)), UTF8CString>);
+// Comparing against a plain CString stays available: it means "unknown encoding", so it is the deliberate escape hatch.
+static_assert(IsEqualityComparable<UTF8CString, CString>);
+// An ASCII literal is valid in every encoding, so this stays available too.
+static_assert(IsEqualityComparable<UTF8CString, ASCIILiteral>);
+
+TEST(WTF, CStringWithEncodingConstruction)
+{
+    UTF8CString nullString;
+    EXPECT_TRUE(nullString.isNull());
+    EXPECT_TRUE(nullString.isEmpty());
+    EXPECT_EQ(nullString.data(), static_cast<const char8_t*>(nullptr));
+    EXPECT_EQ(nullString.characters(), static_cast<const char*>(nullptr));
+    EXPECT_EQ(nullString.length(), 0UZ);
+
+    UTF8CString fromSpan { u8"Water🍉Melon"_span };
+    EXPECT_FALSE(fromSpan.isNull());
+    EXPECT_EQ(fromSpan.length(), 14UZ);
+    EXPECT_TRUE(equalSpans(fromSpan.span(), u8"Water🍉Melon"_span));
+    EXPECT_STREQ(fromSpan.characters(), "Water🍉Melon");
+
+    UTF8CString fromLiteral { "test"_s };
+    EXPECT_EQ(fromLiteral, UTF8CString { u8"test"_span });
+    EXPECT_EQ(fromLiteral, "test"_s);
+
+    constexpr auto latin1Cafe = WTF::toArray<Latin1Character>({ 'c', 'a', 'f', 0xE9 });
+    Latin1CString latin1String { std::span<const Latin1Character> { latin1Cafe } };
+    EXPECT_EQ(latin1String.length(), 4UZ);
+    EXPECT_TRUE(equalSpans(latin1String.span(), std::span<const Latin1Character> { latin1Cafe }));
+}
+
+TEST(WTF, CStringWithEncodingNewUninitialized)
+{
+    std::span<char8_t> characters;
+    auto string = UTF8CString::newUninitialized(4, characters);
+    EXPECT_EQ(characters.size(), 4UZ);
+    memcpySpan(characters, u8"test"_span);
+    EXPECT_EQ(string, UTF8CString { u8"test"_span });
+    EXPECT_EQ(string.spanIncludingNullTerminator()[4], u8'\0');
+}
+
+TEST(WTF, CStringWithEncodingComparison)
+{
+    UTF8CString a { u8"abc"_span };
+    UTF8CString b { u8"abd"_span };
+    UTF8CString nullString;
+
+    EXPECT_EQ(a, UTF8CString { u8"abc"_span });
+    EXPECT_NE(a, b);
+    EXPECT_NE(a, nullString);
+    EXPECT_EQ(nullString, UTF8CString { });
+    EXPECT_TRUE(a < b);
+    EXPECT_FALSE(b < a);
+    EXPECT_TRUE(nullString < a);
+}
+
+TEST(WTF, CStringWithEncodingCrossEncodingComparison)
+{
+    constexpr auto latin1Cafe = WTF::toArray<Latin1Character>({ 'c', 'a', 'f', 0xE9 });
+    Latin1CString latin1 { std::span<const Latin1Character> { latin1Cafe } };
+    UTF8CString utf8 { u8"café"_span };
+
+    // Same text, different bytes: 4 Latin-1 bytes against 5 UTF-8 bytes.
+    EXPECT_EQ(latin1.length(), 4UZ);
+    EXPECT_EQ(utf8.length(), 5UZ);
+    EXPECT_EQ(latin1, utf8);
+    EXPECT_EQ(utf8, latin1);
+
+    EXPECT_NE(latin1, UTF8CString { u8"cafe"_span });
+    EXPECT_NE(utf8, Latin1CString { "cafe"_s });
+
+    // Null and empty stay distinct, as they do within a single encoding.
+    EXPECT_NE(Latin1CString { }, UTF8CString { u8""_span });
+    EXPECT_EQ(Latin1CString { }, UTF8CString { });
+
+    // ASCII is a subset of both, so it matches its own bytes in either.
+    ASCIICString ascii { String("cafe"_s).ascii() };
+    EXPECT_EQ(ascii, Latin1CString { "cafe"_s });
+    EXPECT_EQ(ascii, UTF8CString { u8"cafe"_span });
+    EXPECT_NE(ascii, latin1);
+    EXPECT_NE(ascii, utf8);
+}
+
+TEST(WTF, CStringWithEncodingHashing)
+{
+    HashSet<UTF8CString> set;
+    EXPECT_TRUE(set.add(UTF8CString { u8"Water🍉Melon"_span }).isNewEntry);
+    EXPECT_FALSE(set.add(UTF8CString { u8"Water🍉Melon"_span }).isNewEntry);
+    EXPECT_TRUE(set.add(UTF8CString { u8"other"_span }).isNewEntry);
+    EXPECT_EQ(set.size(), 2U);
+    EXPECT_TRUE(set.contains(UTF8CString { u8"other"_span }));
+    EXPECT_FALSE(set.contains(UTF8CString { u8"missing"_span }));
+
+    HashMap<UTF8CString, int> map;
+    map.add(UTF8CString { u8"key"_span }, 1);
+    EXPECT_EQ(map.get(UTF8CString { u8"key"_span }), 1);
+
+    // Hashing is over the raw bytes, so an equal untyped CString agrees.
+    EXPECT_EQ(UTF8CString { u8"key"_span }.hash(), CString("key").hash());
+}
+
+TEST(WTF, CStringWithEncodingMakeString)
+{
+    // makeString picks its adapter off the span's element type, so a UTF8CString is decoded as UTF-8.
+    UTF8CString utf8String { u8"Water🍉Melon"_span };
+    EXPECT_EQ(makeString(utf8String), String::fromUTF8(u8"Water🍉Melon"_span));
+    EXPECT_EQ(makeString(utf8String).length(), 12U);
+
+    // Erasing the encoding falls back to reinterpreting the bytes as Latin-1.
+    EXPECT_EQ(makeString(static_cast<const CString&>(utf8String)).length(), 14U);
+
+    constexpr auto latin1Cafe = WTF::toArray<Latin1Character>({ 'c', 'a', 'f', 0xE9 });
+    Latin1CString latin1String { std::span<const Latin1Character> { latin1Cafe } };
+    EXPECT_EQ(makeString(latin1String), String::fromUTF8(u8"café"_span));
+    EXPECT_EQ(makeString(latin1String).length(), 4U);
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -442,7 +442,7 @@ void InjectedBundle::outputText(StringView output, IsFinalTestOutput isFinalTest
     // is done via asynchronous IPC, even if the connection is in fully synchronous mode due to a WKBundlePagePostSynchronousMessageForTesting()
     // call. Otherwise, messages logged via sync and async IPC may end up out of order and cause flakiness.
     auto messageName = isFinalTestOutput == IsFinalTestOutput::Yes ? toWK("FinalTextOutput") : toWK("TextOutput");
-    WKBundlePagePostMessageIgnoringFullySynchronousMode(page()->page(), messageName.get(), toWK(string ? string->data() : "Out of memory\n").get());
+    WKBundlePagePostMessageIgnoringFullySynchronousMode(page()->page(), messageName.get(), toWK(string ? string->characters() : "Out of memory\n").get());
 }
 
 void InjectedBundle::postNewBeforeUnloadReturnValue(bool value)


### PR DESCRIPTION
#### 5f14e32e576011c24bb941454bbd6463caf12533
<pre>
Introduce CStringWithEncoding so that a CString can remember its encoding
<a href="https://bugs.webkit.org/show_bug.cgi?id=323408">https://bugs.webkit.org/show_bug.cgi?id=323408</a>

Reviewed by Darin Adler.

CString is a ref-counted, null-terminated, copy-on-write char buffer, and as its own
header comment says, it &quot;does not know its encoding&quot;. In practice its bytes are almost
always UTF-8 (String::utf8()) or Latin-1 (String::latin1()), but the distinction is lost
at construction: CString(std::span&lt;const char8_t&gt;) and CString(std::span&lt;const
Latin1Character&gt;) both byteCast into the same char storage.

That is not just a documentation problem. StringConcatenate.h auto-adapts any class with
a span() member into a StringTypeAdapter, keyed on the span&apos;s element type: a
span&lt;const char8_t&gt; is decoded as real UTF-8 via Unicode::checkUTF8, while any other
one-byte type is reinterpreted as Latin-1. Because CString::span() returns
span&lt;const char&gt;, makeString(string.utf8()) silently mojibakes every non-ASCII string.

This adds CStringWithEncoding&lt;CharacterType&gt;, which carries the encoding in the type, and
three aliases following the existing WTF convention that the byte type is the encoding:

    using UTF8CString = CStringWithEncoding&lt;char8_t&gt;;
    using Latin1CString = CStringWithEncoding&lt;Latin1Character&gt;;
    using ASCIICString = CStringWithEncoding&lt;char&gt;;

char spells ASCII here to match ASCIILiteral, whose characters() returns const char* and
whose span() returns span&lt;const char&gt;.

CStringWithEncoding derives publicly from CString, so that adoption can be incremental:
a typed string decays implicitly to const CString&amp;, which keeps safePrintfType,
printInternal, TextStream, the IPC and persistence coders, the generated CString log
signatures in LogMessages.in, and every existing const CString&amp; parameter working
unchanged as producers are migrated one at a time. Slicing erases the encoding back to
&quot;unknown&quot;, which is a widening to CString&apos;s documented semantics rather than a loss of
correctness. The derived class is final, adds no members and has no vtable, so sizeof is
unchanged. It is built entirely on CString&apos;s public API; the only change to CString
itself is dropping the final specifier.

data(), span() and mutableSpan() are hidden with tightly typed versions so the encoding
survives into the pointer and span types. characters() is the escape hatch that returns
const char* for external C functions and printf-style formatting.

Comparing Latin-1 bytes against UTF-8 bytes is meaningless, so those combinations are
deleted. The deleted overloads are exact matches and therefore beat the CString
comparison, which would need a derived-to-base conversion. ASCII is a subset of both, so
those combinations deliberately fall through to the byte comparison on CString.
Comparison against a plain CString stays available: CString means &quot;unknown encoding&quot;, so
it is the deliberate escape hatch.

The following conversions are migrated in this patch:

    String::ascii()                     -&gt; ASCIICString
    String::latin1()                    -&gt; Latin1CString
    String::tryGetUTF8()                -&gt; std::expected&lt;UTF8CString, ...&gt;
    StringView::tryGetUTF8()            -&gt; std::expected&lt;UTF8CString, ...&gt;
    StringImpl::tryGetUTF8()            -&gt; std::expected&lt;UTF8CString, ...&gt;
    StringImpl::utf8ForCharacters()     -&gt; std::expected&lt;UTF8CString, ...&gt;
    convertToASCIILowercase/Uppercase() -&gt; UTF8CString

utf8() on String, StringView and StringImpl still returns CString and is left with a
FIXME; retyping it means touching roughly 2900 call sites, most of which pass
utf8().data() to a %s and would need characters() instead. FIXMEs are also left on
CString&apos;s span&lt;const char8_t&gt; and span&lt;const Latin1Character&gt; constructors, which are the
exact ambiguity this type exists to remove, and on TextStream::operator&lt;&lt;(const CString&amp;),
which appends bytes as Latin-1 and so will mis-render a sliced UTF8CString.

This patch is types only; there is no behavior change. Nothing in the tree feeds a
tryGetUTF8() result into makeString or StringBuilder::append, which is the only place the
new char8_t span typing would switch Latin-1 reinterpretation to real UTF-8 decoding.

Also update to call `URL::string().utf8()` instead of `URL::string().latin1()` for logging.
URLs are only guaranteed to be ASCII when they are valid. When parsing fails, URL::string()
may return an invalid URL string which may not be ASCII (or even latin1).

Test: Tools/TestWebKitAPI/Tests/WTF/CString.cpp

* Source/JavaScriptCore/jsc.cpp:
(fillBufferWithContentsOfFile):
(toCString):
(dumpException):
(fetchModuleFromLocalFileSystem):
* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/PrintStream.cpp:
(WTF::printExpectedCStringHelper):
* Source/WTF/wtf/text/CString.cpp:
(WTF::convertASCIICase):
(WTF::convertToASCIILowercase):
(WTF::convertToASCIIUppercase):
* Source/WTF/wtf/text/CString.h:
(WTF::operator==):
(WTF::operator&lt;):
(WTF::CStringWithEncodingHash::hash):
(WTF::CStringWithEncodingHash::equal):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::utf8ForCharacters):
(WTF::StringImpl::tryGetUTF8 const):
* Source/WTF/wtf/text/StringImpl.h:
* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::tryGetUTF8 const):
* Source/WTF/wtf/text/StringView.h:
* Source/WTF/wtf/text/TextStream.h:
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::ascii const):
(WTF::String::latin1 const):
(WTF::String::tryGetUTF8 const):
(WTF::String::utf8 const):
* Source/WTF/wtf/text/WTFString.h:
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::didFinishLoading):
(WebCore::SubresourceLoader::didFail):
(WebCore::SubresourceLoader::willCancel):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::failBeforeStarting):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
(WebCore::CachedResourceLoader::loadResource):
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::add):
(WebCore::MemoryCache::remove):
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::logMemoryStatistics):
* Source/WebCore/platform/network/curl/CurlContext.cpp:
(WebCore::CurlHandle::setURL):
* Source/WebCore/platform/network/curl/CurlContext.h:
(WebCore::CurlSList::append):
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::open):
* Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp:
(WebCore::RenderThemeAdwaita::mediaControlsImageDataForIconNameAndType):
(WebCore::RenderThemeAdwaita::mediaControlsBase64StringForIconNameAndType):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::xmlDocPtrForString):
* Source/WebDriver/glib/SessionHostGlib.cpp:
(WebDriver::SessionHost::launchBrowser):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::store):
(WebKit::NetworkCache::Cache::storeRedirect):
(WebKit::NetworkCache::Cache::update):
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::createParameters):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::willSendRequest):
(WebKit::WebResourceLoader::didReceiveResponse):
(WebKit::WebResourceLoader::didReceiveData):
(WebKit::WebResourceLoader::didFinishResourceLoad):
(WebKit::WebResourceLoader::didFailResourceLoad):
(WebKit::WebResourceLoader::didBlockAuthenticationChallenge):
(WebKit::WebResourceLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied):
(WebKit::WebResourceLoader::didReceiveResource):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):
* Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.cpp:
(TestWebKitAPI::imageBufferPixelIs):
* Tools/TestWebKitAPI/Tests/WTF/CString.cpp:
(requires):
(TEST(WTF, CStringWithEncodingConstruction)):
(TEST(WTF, CStringWithEncodingNewUninitialized)):
(TEST(WTF, CStringWithEncodingComparison)):
(TEST(WTF, CStringWithEncodingHashing)):
(TEST(WTF, CStringWithEncodingMakeString)):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::outputText):
* Source/WTF/wtf/FileSystem.h:
(WTF::FileSystemImpl::statFile):
* Source/WTF/wtf/posix/FileSystemPOSIX.cpp:
(WTF::FileSystemImpl::statFile):
(WTF::FileSystemImpl::fileCreationTime):
(WTF::FileSystemImpl::getFileDeviceId):
* Source/WebKit/NetworkProcess/cache/NetworkCacheFileSystem.cpp:
(WebKit::NetworkCache::fileTimes):

Canonical link: <a href="https://commits.webkit.org/320652@main">https://commits.webkit.org/320652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e7be18fde225e70ed33bf9658b7c717501a34e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150246 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59121 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144959 "Found 1 new test failure: fast/dom/lazy-image-loading-document-leak.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100495 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125251 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47359 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45417 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/7156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14040 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157726 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45108 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6857 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46739 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52050 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197754 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59058 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154473 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41365 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59767 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41713 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154122 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48602 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132115 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128998 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58245 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20130 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57617 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57860 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57684 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->