### PR TITLE
Update fetch/compression-dictionary from WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/compressed-large-resources-001.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/compressed-large-resources-001.tentative.https.html
@@ -18,8 +18,9 @@
   const image_dictionary = "image-001.png";
   const image_compressed = `self-compressed-image-001.png.${format}`;
   compression_dictionary_promise_test(async t => {
+    const test_id = token();
     // Load the non-compressed image to register it as a dictionary for itself.
-    await fetchStaticResourceWithUseAsDictionaryHeader(image_dictionary, image_compressed, "image");
+    await fetchStaticResourceWithUseAsDictionaryHeader(`${image_dictionary}?id=${test_id}`, `${image_compressed}?id=${test_id}`, "image");
 
     // Wait for another dictionary to register to give a chance for the
     // previous registration to complete. That registration was not done via
@@ -32,7 +33,7 @@
 
     // Append the compressed image.
     const img = document.createElement("img");
-    img.src = `./resources/static/${image_compressed}`;
+    img.src = `./resources/static/${image_compressed}?id=${test_id}`;
     t.add_cleanup(_ => img.remove());
     await new Promise((resolve, reject) => {
       img.onload = resolve;
@@ -49,8 +50,9 @@
   const script_dictionary = "script-001.js";
   const script_compressed = `self-compressed-script-001.js.${format}`;
   compression_dictionary_promise_test(async t => {
+    const test_id = token();
     // Load the non-compressed script to register it as a dictionary for itself.
-    await fetchStaticResourceWithUseAsDictionaryHeader(script_dictionary, script_compressed, "script");
+    await fetchStaticResourceWithUseAsDictionaryHeader(`${script_dictionary}?id=${test_id}`, `${script_compressed}?id=${test_id}`, "script");
 
     // Wait for another dictionary to register to give a chance for the
     // previous registration to complete. See comment above about why we can't
@@ -59,7 +61,7 @@
 
     // Append the compressed script.
     const script = document.createElement("script");
-    script.src = `./resources/static/${script_compressed}`;
+    script.src = `./resources/static/${script_compressed}?id=${test_id}`;
     window.compressionDictionaryScriptLoaded = false;
     t.add_cleanup(_ => {
       script.remove();
@@ -78,8 +80,9 @@
   const style_dictionary = "style-001.css";
   const style_compressed = `self-compressed-style-001.css.${format}`;
   compression_dictionary_promise_test(async t => {
+    const test_id = token();
     // Load the non-compressed style to register it as a dictionary for itself.
-    await fetchStaticResourceWithUseAsDictionaryHeader(style_dictionary, style_compressed, "style");
+    await fetchStaticResourceWithUseAsDictionaryHeader(`${style_dictionary}?id=${test_id}`, `${style_compressed}?id=${test_id}`, "style");
 
     // Wait for another dictionary to register to give a chance for the
     // previous registration to complete. See comment above about why we can't
@@ -89,7 +92,7 @@
     // Append the compressed style and test div.
     const link = document.createElement("link");
     link.rel = "stylesheet";
-    link.href = `./resources/static/${style_compressed}`;
+    link.href = `./resources/static/${style_compressed}?id=${test_id}`;
     const div = document.createElement("div");
     div.className = "green_square";
     t.add_cleanup(_ => {

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/compressed-large-resources-002.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/compressed-large-resources-002.tentative.https.html
@@ -21,8 +21,9 @@
     {subframe_dictionary: "script-001.js", subframe_compressed: `subframe-001-compressed-by-script-001.html.${format}`},
   ].forEach(config => {
     compression_dictionary_promise_test(async t => {
+      const test_id = token();
       // Load the non-compressed style to register it as a dictionary for itself.
-      await fetchStaticResourceWithUseAsDictionaryHeader(config.subframe_dictionary, config.subframe_compressed, "iframe");
+      await fetchStaticResourceWithUseAsDictionaryHeader(`${config.subframe_dictionary}?id=${test_id}`, `${config.subframe_compressed}?id=${test_id}`, "iframe");
 
       // Wait for another dictionary to register to give a chance for the
       // previous registration to complete. See comment in the 001 file about
@@ -31,7 +32,7 @@
 
       // Append the compressed subframe.
       const iframe = document.createElement("iframe");
-      iframe.src = `./resources/static/${config.subframe_compressed}`;
+      iframe.src = `./resources/static/${config.subframe_compressed}?id=${test_id}`;
       const waitMessageFromIframe = new Promise(resolve => {
         function iframeListener(event) { resolve(event.data === "ready"); }
         window.addEventListener("message", iframeListener, {once: true});

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-no-cors.tentative.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-no-cors.tentative.https.html
@@ -11,35 +11,47 @@
 <body>
 <script>
 
-function getHeadersCrossorigin() {
+function getHeaders(isCrossOrigin) {
   function headersCallback(r) {
     return (x) => {
       r(x);
     }
   }
+  // Default fetch mode for script (without a crossorigin attribute) is no-cors.
   let script = document.createElement("script");
   return new Promise((resolve, reject) => {
-    getHeadersCrossorigin['callback'] = headersCallback(resolve);
+    getHeaders['callback'] = headersCallback(resolve);
     script.src =
-      `${CROSS_ORIGIN_RESOURCES_URL}/echo-headers.py?callback=getHeadersCrossorigin.callback`;
+      `${isCrossOrigin ? CROSS_ORIGIN_RESOURCES_URL : SAME_ORIGIN_RESOURCES_URL}/echo-headers.py?callback=getHeaders.callback`;
     document.head.appendChild(script);
   });
 }
 
 compression_dictionary_promise_test(async (t) => {
   // Register the dictionary
-  const dict = await (await fetch(kRegisterDictionaryPath)).text();
+  const dictionary_id = `no-cors_cross-origin_${token()}`;
+  const dict = await (await fetch(`${kRegisterDictionaryPath}?id=${dictionary_id}`)).text();
   assert_equals(dict, kDefaultDictionaryContent);
-  assert_equals(
-      await waitUntilAvailableDictionaryHeader(t, {}),
-      kDefaultDictionaryHashBase64);
+  await waitUntilHeader(t, "dictionary-id", {expected_header: `"${dictionary_id}"`});
   // Test a no-cors crossorigin fetch
-  const headers = await getHeadersCrossorigin();
+  const headers = await getHeaders(true /* cross-origin */);
   assert_false("available-dictionary" in headers);
 }, 'Fetch cross-origin no-cors request does not include Available-Dictionary header');
 
 compression_dictionary_promise_test(async (t) => {
-  const dictionary_url = `${CROSS_ORIGIN_RESOURCES_URL}/register-dictionary.py`;
+  // Register the dictionary
+  const dictionary_id = `no-cors_same-origin_${token()}`;
+  const dict = await (await fetch(`${kRegisterDictionaryPath}?id=${dictionary_id}`)).text();
+  assert_equals(dict, kDefaultDictionaryContent);
+  await waitUntilHeader(t, "dictionary-id", {expected_header: `"${dictionary_id}"`});
+  // Test a no-cors same-origin fetch
+  const headers = await getHeaders(false /* cross-origin */);
+  assert_true("available-dictionary" in headers);
+}, 'Fetch same-origin no-cors request includes Available-Dictionary header');
+
+compression_dictionary_promise_test(async (t) => {
+  const dictionary_id = `redirect_${token()}`;
+  const dictionary_url = `${CROSS_ORIGIN_RESOURCES_URL}/register-dictionary.py?id=${dictionary_id}`;
   const redirect_url = `/common/redirect.py?location=${encodeURIComponent(dictionary_url)}`;
   try {
     await fetch(redirect_url, {mode: 'no-cors'});


### PR DESCRIPTION
#### 1f0200061b2d1e0f908f60be104bd45f53cf4570
<pre>
Update fetch/compression-dictionary from WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=323414">https://bugs.webkit.org/show_bug.cgi?id=323414</a>

Reviewed by Patrick Griffis.

Import the following changes:
<a href="https://github.com/web-platform-tests/wpt/pull/62427">https://github.com/web-platform-tests/wpt/pull/62427</a>
<a href="https://github.com/web-platform-tests/wpt/pull/62428">https://github.com/web-platform-tests/wpt/pull/62428</a>

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/4a01b83e3b93b3e394f9f4f503b3152cf54098b8">https://github.com/web-platform-tests/wpt/commit/4a01b83e3b93b3e394f9f4f503b3152cf54098b8</a>

* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/compressed-large-resources-001.tentative.https.html:
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/compressed-large-resources-002.tentative.https.html:
* LayoutTests/imported/w3c/web-platform-tests/fetch/compression-dictionary/dictionary-fetch-no-cors.tentative.https.html:

Canonical link: <a href="https://commits.webkit.org/320611@main">https://commits.webkit.org/320611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/575d7b9b3fa84f478e048dab72304f5c933adc52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195656 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144832 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125126 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47243 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45302 "Passed tests") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44992 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6709 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49686 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197605 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58908 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164928 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154342 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41331 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59617 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41597 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153993 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48485 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128755 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58095 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20014 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57467 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57710 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57534 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->