### PR TITLE
[Skia] Use SkSurface image snapshot and temporary image in ImageBufferSkiaUnacceleratedBackend for NativeImage getters

### DIFF
--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -326,38 +326,7 @@ void ImageBufferSkiaAcceleratedBackend::getPixelBuffer(const IntRect& srcRect, P
     // CPU needs to read pixels now, replay the recording.
     replayCanvasRecordingContextIfNeeded();
 
-    const IntRect backendRect { { }, size() };
-    const auto sourceRectClipped = intersection(backendRect, srcRect);
-    IntRect destinationRect { IntPoint::zero(), sourceRectClipped.size() };
-
-    if (srcRect.x() < 0)
-        destinationRect.setX(destinationRect.x() - srcRect.x());
-    if (srcRect.y() < 0)
-        destinationRect.setY(destinationRect.y() - srcRect.y());
-
-    if (destination.size() != sourceRectClipped.size())
-        destination.zeroFill();
-
-    const auto destinationColorType = (destination.format().pixelFormat == PixelFormat::RGBA8)
-        ? SkColorType::kRGBA_8888_SkColorType : SkColorType::kBGRA_8888_SkColorType;
-
-    const auto destinationAlphaType = (destination.format().alphaFormat == AlphaPremultiplication::Premultiplied)
-        ? SkAlphaType::kPremul_SkAlphaType : SkAlphaType::kUnpremul_SkAlphaType;
-
-    auto destinationInfo = SkImageInfo::Make(destination.size().width(), destination.size().height(),
-        destinationColorType, destinationAlphaType, destination.format().colorSpace.platformColorSpace());
-    SkPixmap pixmap(destinationInfo, destination.bytes().data(), destination.size().width() * 4);
-
-    SkPixmap dstPixmap;
-    if (!pixmap.extractSubset(&dstPixmap, destinationRect)) [[unlikely]]
-        return;
-
-    m_surface->readPixels(dstPixmap, sourceRectClipped.x(), sourceRectClipped.y());
-}
-
-static std::span<uint8_t> mutableSpan(SkData* data)
-{
-    return unsafeMakeSpan(static_cast<uint8_t*>(data->writable_data()), data->size());
+    ImageBufferSkiaSurfaceBackend::getPixelBuffer(srcRect, destination);
 }
 
 void ImageBufferSkiaAcceleratedBackend::putPixelBuffer(const PixelBufferSourceView& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
@@ -368,56 +337,7 @@ void ImageBufferSkiaAcceleratedBackend::putPixelBuffer(const PixelBufferSourceVi
     // CPU needs to write pixels now, replay the recording.
     replayCanvasRecordingContextIfNeeded();
 
-    UNUSED_PARAM(destFormat);
-
-    ASSERT(IntRect({ 0, 0 }, pixelBuffer.size()).contains(srcRect));
-    ASSERT(pixelBuffer.format().pixelFormat == PixelFormat::RGBA8 || pixelBuffer.format().pixelFormat == PixelFormat::BGRA8);
-    ASSERT(pixelBuffer.format().alphaFormat == AlphaPremultiplication::Premultiplied || pixelBuffer.format().alphaFormat == AlphaPremultiplication::Unpremultiplied);
-
-    const auto colorType = (pixelBuffer.format().pixelFormat == PixelFormat::RGBA8)
-        ? SkColorType::kRGBA_8888_SkColorType : SkColorType::kBGRA_8888_SkColorType;
-
-    const auto alphaType = (pixelBuffer.format().alphaFormat == AlphaPremultiplication::Premultiplied)
-        ? SkAlphaType::kPremul_SkAlphaType : SkAlphaType::kUnpremul_SkAlphaType;
-
-    const IntRect backendRect { { }, size() };
-    auto sourceRectClipped = intersection({ IntPoint::zero(), pixelBuffer.size() }, srcRect);
-    auto destinationRect = sourceRectClipped;
-    destinationRect.moveBy(destPoint);
-
-    if (srcRect.x() < 0)
-        destinationRect.setX(destinationRect.x() - srcRect.x());
-    if (srcRect.y() < 0)
-        destinationRect.setY(destinationRect.y() - srcRect.y());
-
-    destinationRect.intersect(backendRect);
-    sourceRectClipped.setSize(destinationRect.size());
-
-    auto pixelBufferInfo = SkImageInfo::Make(pixelBuffer.size().width(), pixelBuffer.size().height(),
-        colorType, alphaType, pixelBuffer.format().colorSpace.platformColorSpace());
-    SkPixmap pixmap(pixelBufferInfo, pixelBuffer.bytes().data(), pixelBuffer.size().width() * 4);
-
-    SkPixmap srcPixmap;
-    if (!pixmap.extractSubset(&srcPixmap, sourceRectClipped)) [[unlikely]]
-        return;
-
-    const auto destAlphaType = (destFormat == AlphaPremultiplication::Premultiplied)
-        ? SkAlphaType::kPremul_SkAlphaType : SkAlphaType::kUnpremul_SkAlphaType;
-
-    // If all the pixels in the source rectangle are opaque, it does not matter which kind
-    // of alpha is involved: the destination pixels will be replaced by the source ones.
-    if (m_surface->imageInfo().alphaType() == destAlphaType || srcPixmap.computeIsOpaque()) {
-        m_surface->writePixels(srcPixmap, destinationRect.x(), destinationRect.y());
-        return;
-    }
-
-    // Fall back to converting, but only the part covered by sourceRectClipped/srcPixmap.
-    auto data = SkData::MakeUninitialized(srcPixmap.computeByteSize());
-    ImageBufferBackend::putPixelBuffer(pixelBuffer, sourceRectClipped, IntPoint::zero(), destFormat, mutableSpan(data.get()));
-    auto convertedSrcInfo = SkImageInfo::Make(srcPixmap.dimensions(), SkColorType::kBGRA_8888_SkColorType,
-        SkAlphaType::kPremul_SkAlphaType, colorSpace().platformColorSpace());
-    SkPixmap convertedSrcPixmap(convertedSrcInfo, data->writable_data(), convertedSrcInfo.minRowBytes64());
-    m_surface->writePixels(convertedSrcPixmap, destinationRect.x(), destinationRect.y());
+    ImageBufferSkiaSurfaceBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat);
 }
 
 #if USE(COORDINATED_GRAPHICS)

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp
@@ -27,6 +27,9 @@
 #include "ImageBufferSkiaSurfaceBackend.h"
 
 #if USE(SKIA)
+#include "IntRect.h"
+#include "PixelBuffer.h"
+#include "SkiaSpanExtras.h"
 
 namespace WebCore {
 
@@ -76,6 +79,89 @@ unsigned ImageBufferSkiaSurfaceBackend::bytesPerRow() const
 bool ImageBufferSkiaSurfaceBackend::canMapBackingStore() const
 {
     return true;
+}
+
+void ImageBufferSkiaSurfaceBackend::getPixelBuffer(const IntRect& srcRect, PixelBuffer& destination)
+{
+    const IntRect backendRect { { }, size() };
+    const auto sourceRectClipped = intersection(backendRect, srcRect);
+    IntRect destinationRect { IntPoint::zero(), sourceRectClipped.size() };
+
+    if (srcRect.x() < 0)
+        destinationRect.setX(destinationRect.x() - srcRect.x());
+    if (srcRect.y() < 0)
+        destinationRect.setY(destinationRect.y() - srcRect.y());
+
+    if (destination.size() != sourceRectClipped.size())
+        destination.zeroFill();
+
+    const auto destinationColorType = (destination.format().pixelFormat == PixelFormat::RGBA8)
+        ? SkColorType::kRGBA_8888_SkColorType : SkColorType::kBGRA_8888_SkColorType;
+
+    const auto destinationAlphaType = (destination.format().alphaFormat == AlphaPremultiplication::Premultiplied)
+        ? SkAlphaType::kPremul_SkAlphaType : SkAlphaType::kUnpremul_SkAlphaType;
+
+    auto destinationInfo = SkImageInfo::Make(destination.size().width(), destination.size().height(),
+        destinationColorType, destinationAlphaType, destination.format().colorSpace.platformColorSpace());
+    SkPixmap pixmap(destinationInfo, destination.bytes().data(), destination.size().width() * 4);
+
+    SkPixmap dstPixmap;
+    if (!pixmap.extractSubset(&dstPixmap, destinationRect)) [[unlikely]]
+        return;
+
+    m_surface->readPixels(dstPixmap, sourceRectClipped.x(), sourceRectClipped.y());
+}
+
+void ImageBufferSkiaSurfaceBackend::putPixelBuffer(const PixelBufferSourceView& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
+{
+    ASSERT(IntRect({ 0, 0 }, pixelBuffer.size()).contains(srcRect));
+    ASSERT(pixelBuffer.format().pixelFormat == PixelFormat::RGBA8 || pixelBuffer.format().pixelFormat == PixelFormat::BGRA8);
+    ASSERT(pixelBuffer.format().alphaFormat == AlphaPremultiplication::Premultiplied || pixelBuffer.format().alphaFormat == AlphaPremultiplication::Unpremultiplied);
+
+    const auto colorType = (pixelBuffer.format().pixelFormat == PixelFormat::RGBA8)
+        ? SkColorType::kRGBA_8888_SkColorType : SkColorType::kBGRA_8888_SkColorType;
+
+    const auto alphaType = (pixelBuffer.format().alphaFormat == AlphaPremultiplication::Premultiplied)
+        ? SkAlphaType::kPremul_SkAlphaType : SkAlphaType::kUnpremul_SkAlphaType;
+
+    const IntRect backendRect { { }, size() };
+    auto sourceRectClipped = intersection({ IntPoint::zero(), pixelBuffer.size() }, srcRect);
+    auto destinationRect = sourceRectClipped;
+    destinationRect.moveBy(destPoint);
+
+    if (srcRect.x() < 0)
+        destinationRect.setX(destinationRect.x() - srcRect.x());
+    if (srcRect.y() < 0)
+        destinationRect.setY(destinationRect.y() - srcRect.y());
+
+    destinationRect.intersect(backendRect);
+    sourceRectClipped.setSize(destinationRect.size());
+
+    auto pixelBufferInfo = SkImageInfo::Make(pixelBuffer.size().width(), pixelBuffer.size().height(),
+        colorType, alphaType, pixelBuffer.format().colorSpace.platformColorSpace());
+    SkPixmap pixmap(pixelBufferInfo, pixelBuffer.bytes().data(), pixelBuffer.size().width() * 4);
+
+    SkPixmap srcPixmap;
+    if (!pixmap.extractSubset(&srcPixmap, sourceRectClipped)) [[unlikely]]
+        return;
+
+    const auto destAlphaType = (destFormat == AlphaPremultiplication::Premultiplied)
+        ? SkAlphaType::kPremul_SkAlphaType : SkAlphaType::kUnpremul_SkAlphaType;
+
+    // If all the pixels in the source rectangle are opaque, it does not matter which kind
+    // of alpha is involved: the destination pixels will be replaced by the source ones.
+    if (m_surface->imageInfo().alphaType() == destAlphaType || srcPixmap.computeIsOpaque()) {
+        m_surface->writePixels(srcPixmap, destinationRect.x(), destinationRect.y());
+        return;
+    }
+
+    // Fall back to converting, but only the part covered by sourceRectClipped/srcPixmap.
+    auto data = SkData::MakeUninitialized(srcPixmap.computeByteSize());
+    ImageBufferBackend::putPixelBuffer(pixelBuffer, sourceRectClipped, IntPoint::zero(), destFormat, mutableSpan(data.get()));
+    auto convertedSrcInfo = SkImageInfo::Make(srcPixmap.dimensions(), SkColorType::kBGRA_8888_SkColorType,
+        SkAlphaType::kPremul_SkAlphaType, colorSpace().platformColorSpace());
+    SkPixmap convertedSrcPixmap(convertedSrcInfo, data->writable_data(), convertedSrcInfo.minRowBytes64());
+    m_surface->writePixels(convertedSrcPixmap, destinationRect.x(), destinationRect.y());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h
@@ -54,6 +54,9 @@ protected:
     unsigned bytesPerRow() const final;
     bool canMapBackingStore() const final;
 
+    void getPixelBuffer(const IntRect&, PixelBuffer&) override;
+    void putPixelBuffer(const PixelBufferSourceView&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat) override;
+
     sk_sp<SkSurface> m_surface;
     GraphicsContextSkia m_context;
 };

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
@@ -28,11 +28,8 @@
 
 #if USE(SKIA)
 #include "FontRenderOptions.h"
-#include "IntRect.h"
+#include "IntSize.h"
 #include "NativeImage.h"
-#include "PixelBuffer.h"
-#include "SkiaSpanExtras.h"
-#include <skia/core/SkPixmap.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -63,35 +60,12 @@ ImageBufferSkiaUnacceleratedBackend::~ImageBufferSkiaUnacceleratedBackend() = de
 
 RefPtr<NativeImage> ImageBufferSkiaUnacceleratedBackend::copyNativeImage()
 {
-    SkPixmap pixmap;
-    if (m_surface->peekPixels(&pixmap))
-        return NativeImage::create(SkImages::RasterFromPixmapCopy(pixmap));
-    return nullptr;
+    return NativeImage::create(m_surface->makeImageSnapshot());
 }
 
 RefPtr<NativeImage> ImageBufferSkiaUnacceleratedBackend::createNativeImageReference()
 {
-    SkPixmap pixmap;
-    if (m_surface->peekPixels(&pixmap)) {
-        return NativeImage::create(SkImages::RasterFromPixmap(pixmap, [](const void*, void* context) {
-            static_cast<SkSurface*>(context)->unref();
-        }, SkSafeRef(m_surface.get())));
-    }
-    return nullptr;
-}
-
-void ImageBufferSkiaUnacceleratedBackend::getPixelBuffer(const IntRect& srcRect, PixelBuffer& destination)
-{
-    SkPixmap pixmap;
-    if (m_surface->peekPixels(&pixmap))
-        ImageBufferBackend::getPixelBuffer(srcRect, span(pixmap), destination);
-}
-
-void ImageBufferSkiaUnacceleratedBackend::putPixelBuffer(const PixelBufferSourceView& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
-{
-    SkPixmap pixmap;
-    if (m_surface->peekPixels(&pixmap))
-        ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, mutableSpan(pixmap));
+    return NativeImage::create(m_surface->makeTemporaryImage());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.h
@@ -45,9 +45,6 @@ private:
 
     RefPtr<NativeImage> copyNativeImage() final;
     RefPtr<NativeImage> createNativeImageReference() final;
-
-    void getPixelBuffer(const IntRect&, PixelBuffer&) final;
-    void putPixelBuffer(const PixelBufferSourceView&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat) final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/SkiaSpanExtras.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaSpanExtras.h
@@ -45,6 +45,11 @@ inline std::span<const uint8_t> span(const sk_sp<SkData>& data)
     return span(data.get());
 }
 
+inline std::span<uint8_t> mutableSpan(SkData* data)
+{
+    return unsafeMakeSpan(static_cast<uint8_t*>(data->writable_data()), data->size());
+}
+
 inline std::span<const uint8_t> span(const SkPixmap& pixmap)
 {
     return unsafeMakeSpan(static_cast<const uint8_t*>(pixmap.addr()), pixmap.computeByteSize());


### PR DESCRIPTION
#### 210feffe55bb33afeb29a638963f8e7fd42af6eb
<pre>
[Skia] Use SkSurface image snapshot and temporary image in ImageBufferSkiaUnacceleratedBackend for NativeImage getters
<a href="https://bugs.webkit.org/show_bug.cgi?id=323417">https://bugs.webkit.org/show_bug.cgi?id=323417</a>

Reviewed by Nikolas Zimmermann.

It&apos;s not only simpler, but more efficient, especially in the case of
copyNativeImage() because we can even avoid the copy if the image is
used and released before the surface is written. For copy on write to
properly work we can&apos;t modify the surface pixels wihtout using the Skia
API, so this patch also moves the ImageBufferSkiaAcceleratedBackend
implementation of getPixelBuffer and putPixelBuffer to the base class
ImageBufferSkiaSurfaceBackend to be used by both accelerated and
unaccelerated classes.

* Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp:
(WebCore::ImageBufferSkiaUnacceleratedBackend::copyNativeImage):
(WebCore::ImageBufferSkiaUnacceleratedBackend::createNativeImageReference):
(WebCore::ImageBufferSkiaUnacceleratedBackend::putPixelBuffer):
(WebCore::ImageBufferSkiaUnacceleratedBackend::getPixelBuffer): Deleted.
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::getPixelBuffer):
(WebCore::ImageBufferSkiaAcceleratedBackend::putPixelBuffer):
(WebCore::mutableSpan): Deleted.
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp:
(WebCore::ImageBufferSkiaSurfaceBackend::getPixelBuffer):
(WebCore::ImageBufferSkiaSurfaceBackend::putPixelBuffer):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.h:
* Source/WebCore/platform/graphics/skia/SkiaSpanExtras.h:
(WebCore::mutableSpan):

Canonical link: <a href="https://commits.webkit.org/320615@main">https://commits.webkit.org/320615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cbce8e2825bfae372160bd2b20f8c3ad45a6ed1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195672 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58987 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144845 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165433 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125138 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47254 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45313 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157621 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45004 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6725 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51916 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49697 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197621 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58924 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154356 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59633 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154007 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28138 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48496 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131955 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128783 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58111 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20026 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57483 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57726 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57550 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->