### PR TITLE
[YARR] Keep the terms of lookbehinds in match order in YarrPattern

### DIFF
--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -2690,15 +2690,7 @@ public:
 
                     bool sameDirection = term.matchDirection() == matchDirection;
                     PatternDisjunction* disjunction = term.parentheses.disjunction;
-                    unsigned origin = term.inputPosition;
-                    if (term.matchDirection() == Backward || matchDirection == Backward) {
-                        origin = 0;
-                        disjunction = m_pattern.copyDisjunctionInMatchOrder(disjunction, origin, [&] {
-                            return isSafeToRecurse();
-                        });
-                        if (!disjunction)
-                            return ErrorCode::TooManyDisjunctions;
-                    }
+                    unsigned origin = (term.matchDirection() == Forward && matchDirection == Forward) ? term.inputPosition : 0;
 
                     unsigned alreadyChecked = std::min<unsigned>(sameDirection ? positiveInputOffset.value() : term.inputPosition, disjunction->m_minimumSize);
                     unsigned uncheckAmount = sameDirection ? positiveInputOffset.value() - alreadyChecked : positiveInputOffset.value() + alreadyChecked;

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -5775,15 +5775,6 @@ class YarrGenerator final : public YarrJITInfo {
 
         PatternDisjunction* disjunction = term->parentheses.disjunction;
         bool isBackward = term->matchDirection() == Backward || m_direction == Backward;
-        if (isBackward) {
-            disjunction = m_pattern.copyDisjunctionInMatchOrder(disjunction, 0, [&] {
-                return isSafeToRecurse();
-            });
-            if (!disjunction) {
-                m_failureReason = JITFailureReason::ParenthesisNestedTooDeep;
-                return;
-            }
-        }
 
         auto originalCheckedOffset = checkedOffset;
         size_t parenBegin = m_ops.size();

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1674,6 +1674,26 @@ public:
 
         if (shouldTryConvertingForwardReferencesToBackreferences && parenthesisMatchDirection() == Forward)
             tryConvertingForwardReferencesToBackreferences();
+
+        if (lastTerm.matchDirection() == Backward && parenthesisMatchDirection() == Forward)
+            putTermsInMatchOrder(lastTerm.parentheses.disjunction);
+    }
+
+    void putTermsInMatchOrder(PatternDisjunction* disjunction)
+    {
+        if (!isSafeToRecurse()) [[unlikely]] {
+            m_error = ErrorCode::TooManyDisjunctions;
+            return;
+        }
+
+        for (auto& alternative : disjunction->m_alternatives) {
+            ASSERT(alternative->matchDirection() == Backward);
+            alternative->m_terms.reverse();
+            for (auto& term : alternative->m_terms) {
+                if ((term.type == PatternTerm::Type::ParenthesesSubpattern || term.type == PatternTerm::Type::ParentheticalAssertion) && term.matchDirection() == Backward)
+                    putTermsInMatchOrder(term.parentheses.disjunction);
+            }
+        }
     }
 
     void atomBackReference(unsigned subpatternId)
@@ -2079,7 +2099,7 @@ public:
                 break;
 
             case PatternTerm::Type::ParentheticalAssertion: {
-                unsigned disjunctionInitialInputPosition = (term.matchDirection() == Forward) ? currentInputPosition.value() : 0;
+                unsigned disjunctionInitialInputPosition = (term.matchDirection() == Forward && alternative->matchDirection() == Forward) ? currentInputPosition.value() : 0;
                 term.inputPosition = currentInputPosition;
                 term.frameLocation = currentCallFrameSize;
                 currentCallFrameSize += YarrStackSpaceForBackTrackInfoParentheticalAssertion;
@@ -3203,88 +3223,6 @@ YarrPattern::YarrPattern(StringView pattern, OptionSet<Flags> flags, ErrorCode& 
 {
     ASSERT(m_flags != Flags::DeletedValue);
     error = compile(pattern);
-}
-
-PatternDisjunction* YarrPattern::copyDisjunctionInMatchOrder(PatternDisjunction* disjunction, unsigned origin, const ScopedLambda<bool()>& isSafeToRecurse)
-{
-    if (!isSafeToRecurse()) [[unlikely]]
-        return nullptr;
-
-    auto copiedDisjunction = makeUnique<PatternDisjunction>();
-    copiedDisjunction->m_minimumSize = disjunction->m_minimumSize;
-    copiedDisjunction->m_callFrameSize = disjunction->m_callFrameSize;
-    copiedDisjunction->m_hasFixedSize = disjunction->m_hasFixedSize;
-
-    for (auto& alternative : disjunction->m_alternatives) {
-        MatchDirection direction = alternative->matchDirection();
-        PatternAlternative* copiedAlternative = copiedDisjunction->addNewAlternative(alternative->m_firstSubpatternId, direction);
-        copiedAlternative->m_lastSubpatternId = alternative->m_lastSubpatternId;
-        copiedAlternative->m_minimumSize = alternative->m_minimumSize;
-        copiedAlternative->m_hasFixedSize = alternative->m_hasFixedSize;
-        copiedAlternative->m_isLastAlternative = alternative->m_isLastAlternative;
-        size_t termCount = alternative->m_terms.size();
-        copiedAlternative->m_terms.reserveInitialCapacity(termCount);
-        unsigned inputPosition = origin;
-        for (size_t i = 0; i < termCount; ++i) {
-            PatternTerm term = alternative->m_terms[direction == Backward ? termCount - 1 - i : i];
-            switch (term.type) {
-            case PatternTerm::Type::AssertionBOL:
-            case PatternTerm::Type::AssertionEOL:
-            case PatternTerm::Type::AssertionBOI:
-            case PatternTerm::Type::AssertionEOI:
-            case PatternTerm::Type::AssertionWordBoundary:
-            case PatternTerm::Type::NumberedBackReference:
-            case PatternTerm::Type::NamedBackReference:
-                term.inputPosition = inputPosition;
-                break;
-
-            case PatternTerm::Type::NumberedForwardReference:
-            case PatternTerm::Type::NamedForwardReference:
-                break;
-
-            case PatternTerm::Type::PatternCharacter:
-                term.inputPosition = inputPosition;
-                if (term.quantityType == QuantifierType::FixedCount)
-                    inputPosition += term.quantityMaxCount.value() * (eitherUnicode() ? U16_LENGTH(term.patternCharacter) : 1);
-                break;
-
-            case PatternTerm::Type::CharacterClass:
-                term.inputPosition = inputPosition;
-                if (term.quantityType == QuantifierType::FixedCount)
-                    inputPosition += term.quantityMaxCount.value() * (eitherUnicode() && term.isFixedWidthCharacterClass() && term.characterClass->hasNonBMPCharacters() ? 2 : 1);
-                break;
-
-            case PatternTerm::Type::ParenthesesSubpattern: {
-                ASSERT(!term.parentheses.isStringList && !term.parentheses.isTerminal);
-                term.parentheses.disjunction = copyDisjunctionInMatchOrder(term.parentheses.disjunction, inputPosition, isSafeToRecurse);
-                if (!term.parentheses.disjunction)
-                    return nullptr;
-                if (term.quantityMaxCount == 1 && !term.parentheses.isCopy && term.quantityType == QuantifierType::FixedCount)
-                    inputPosition += term.parentheses.disjunction->m_minimumSize;
-                term.inputPosition = inputPosition;
-                break;
-            }
-
-            case PatternTerm::Type::ParentheticalAssertion:
-                if (direction == Forward && term.matchDirection() == Forward) {
-                    term.parentheses.disjunction = copyDisjunctionInMatchOrder(term.parentheses.disjunction, inputPosition, isSafeToRecurse);
-                    if (!term.parentheses.disjunction)
-                        return nullptr;
-                }
-                term.inputPosition = inputPosition;
-                break;
-
-            case PatternTerm::Type::DotStarEnclosure:
-                RELEASE_ASSERT_NOT_REACHED();
-            }
-            copiedAlternative->m_terms.append(term);
-        }
-        ASSERT(inputPosition - origin == alternative->m_minimumSize);
-    }
-
-    PatternDisjunction* result = copiedDisjunction.get();
-    m_disjunctions.append(WTF::move(copiedDisjunction));
-    return result;
 }
 
 void indentForNestingLevel(PrintStream& out, unsigned nestingDepth)

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -37,7 +37,6 @@
 #include <wtf/HashMap.h>
 #include <wtf/OptionSet.h>
 #include <wtf/PrintStream.h>
-#include <wtf/ScopedLambda.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/StringHash.h>
@@ -749,11 +748,6 @@ struct YarrPattern {
         return nonwordUnicodeIgnoreCasecharCached;
     }
     CharacterClass* unicodeCharacterClassFor(BuiltInCharacterClassID, bool ignoreCase, bool invert);
-
-    // The parser numbers terms in pattern order. Lookbehinds, and lookaheads inside them, are
-    // compiled from a copy whose terms are in the order they are matched (reversed for backward
-    // alternatives) with inputPosition counted from origin in that order.
-    PatternDisjunction* copyDisjunctionInMatchOrder(PatternDisjunction*, unsigned origin, const ScopedLambda<bool()>& isSafeToRecurse);
 
     unsigned offsetVectorBaseForNamedCaptures() const
     {


### PR DESCRIPTION
#### 549955d9979c99de1d9fa22a9d281629cedca59d
<pre>
[YARR] Keep the terms of lookbehinds in match order in YarrPattern
<a href="https://bugs.webkit.org/show_bug.cgi?id=323421">https://bugs.webkit.org/show_bug.cgi?id=323421</a>

Reviewed by Daniel Liu.

This is the last step of the plan in 319067@main.

Since 319067@main and 320492@main, the JIT and the interpreter match a
lookbehind from a copy of its disjunction in which the terms of each backward
alternative are reversed and inputPosition is counted in that order. The copy
was needed because YarrPatternConstructor kept the terms in pattern order.

YarrPatternConstructor now reverses the terms of the backward alternatives
when a lookbehind is closed, right after its forward references are resolved,
and setupAlternativeOffsets() counts the disjunction of a lookahead inside a
lookbehind from 0, as the copy did. Both tiers use the pattern as it is, and
copyDisjunctionInMatchOrder() is removed. The bytecode and the JIT ops are the
same as before, except that frame slots are now also numbered in match order.

* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::ByteCompiler::emitDisjunction):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::atomParenthesesEnd):
(JSC::Yarr::YarrPatternConstructor::putTermsInMatchOrder):
(JSC::Yarr::YarrPatternConstructor::setupAlternativeOffsets):
(JSC::Yarr::YarrPattern::copyDisjunctionInMatchOrder): Deleted.
* Source/JavaScriptCore/yarr/YarrPattern.h:

Canonical link: <a href="https://commits.webkit.org/320558@main">https://commits.webkit.org/320558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18f8e7c58e29ae2ed11df76b89399e725e5e48cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195263 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144513 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124805 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46912 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45012 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6746 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13617 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157287 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44677 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6316 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46194 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49355 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197212 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58516 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153994 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41285 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59222 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41280 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153654 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48169 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131510 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128125 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57718 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19695 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57077 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57326 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57154 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->