### PR TITLE
[macOS] "Copy" option is enabled in edit menu after selecting text in PDF with copying disallowed

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -2982,8 +2982,11 @@ bool UnifiedPDFPlugin::isEditingCommandEnabled(const String& commandName)
     if (equalLettersIgnoringASCIICase(commandName, "selectall"_s))
         return true;
 
-    if (equalLettersIgnoringASCIICase(commandName, "copy"_s) || equalLettersIgnoringASCIICase(commandName, "takefindstringfromselection"_s))
+    if (equalLettersIgnoringASCIICase(commandName, "takefindstringfromselection"_s))
         return hasSelection();
+
+    if (equalLettersIgnoringASCIICase(commandName, "copy"_s))
+        return hasSelection() && [m_pdfDocument allowsCopying];
 
     return false;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewEditActions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewEditActions.mm
@@ -28,6 +28,7 @@
 #import "ClassMethodSwizzler.h"
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/cocoa/TestWKWebView.h"
+#import "PDFTestHelpers.h"
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 
@@ -400,12 +401,15 @@ TEST(WebKit, CanInvokeTranslateWithTextSelection)
 
 #else
 
-TEST(WKWebViewEditActions, CopyMenuItemDisabledWithNoSelection)
+static void validateCopyMenuItem(WKWebViewConfiguration *webViewConfiguration, void (^prepareContent)(TestWKWebView *webView), bool copyAllowed)
 {
-    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
-    [webView synchronouslyLoadHTMLString:@"<p>Hello, WebKit</p>"];
-    [webView becomeFirstResponder];
-    [webView waitForNextPresentationUpdate];
+    NSRect frame = NSMakeRect(0, 0, 400, 400);
+    RetainPtr<TestWKWebView> webView;
+    if (webViewConfiguration)
+        webView = adoptNS([[TestWKWebView alloc] initWithFrame:frame configuration:webViewConfiguration]);
+    else
+        webView = adoptNS([[TestWKWebView alloc] initWithFrame:frame]);
+    prepareContent(webView);
 
     auto validateCopyItem = [&] -> BOOL {
         RetainPtr menu = adoptNS([NSMenu new]);
@@ -418,14 +422,33 @@ TEST(WKWebViewEditActions, CopyMenuItemDisabledWithNoSelection)
         return [item isEnabled];
     };
 
-    // With no selection the Copy menu item must be disabled.
     [webView stringByEvaluatingJavaScript:@"getSelection().removeAllRanges()"];
     EXPECT_FALSE(validateCopyItem());
 
-    // With a range selection the Copy menu item must be enabled.
     [webView selectAll:nil];
     [webView waitForNextPresentationUpdate];
-    EXPECT_TRUE(validateCopyItem());
+    EXPECT_EQ(validateCopyItem(), copyAllowed);
+}
+
+TEST(WKWebViewEditActions, CopyMenuItemDisabledWithNoSelection)
+{
+    validateCopyMenuItem(nil, ^(TestWKWebView *webView) {
+        [webView synchronouslyLoadHTMLString:@"<p>Hello, WebKit</p>"];
+        [webView becomeFirstResponder];
+        [webView waitForNextPresentationUpdate];
+    }, true);
+}
+
+TEST(WKWebViewEditActions, CopyMenuItemDisabledInCopyDisallowedPDF)
+{
+    validateCopyMenuItem(configurationForWebViewTestingUnifiedPDF(), ^(TestWKWebView *webView) {
+        RetainPtr request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"copying-disabled" withExtension:@"pdf"]];
+        [webView waitForNextPresentationUpdate];
+        [[webView window] makeFirstResponder:webView];
+        [[webView window] makeKeyAndOrderFront:nil];
+        [[webView window] orderFrontRegardless];
+        [webView sendClickAtPoint:NSMakePoint(100, 100)];
+    }, false);
 }
 
 TEST(WKWebViewEditActions, ModifyTextWritingDirection)


### PR DESCRIPTION
#### 054171fd6f8625e6cabc883518caa42c025a6d2e
<pre>
[macOS] &quot;Copy&quot; option is enabled in edit menu after selecting text in PDF with copying disallowed
<a href="https://bugs.webkit.org/show_bug.cgi?id=323418">https://bugs.webkit.org/show_bug.cgi?id=323418</a>
<a href="https://rdar.apple.com/186648332">rdar://186648332</a>

Reviewed by Aditya Keerthi.

AppKit consults -validateUserInterfaceItem: when constructing its edit
menu. When inquired about @selector(copy:), isEditingCommandEnabled()
says yes if there is an active selection in the PDF. However, this is
only necessary and not sufficient for a copy operation, since the
underlying document itself must allow copying. In this patch, we teach
our editing command validity check in the plugin to respect that
attribute of the PDF document.

For test coverage, we retrofit the existing edit action validity check
performed by CopyMenuItemDisabledWithNoSelection.

Test: WKWebViewEditActions.CopyMenuItemDisabledInCopyDisallowedPDF

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::isEditingCommandEnabled):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewEditActions.mm:
(TestWebKitAPI::validateCopyMenuItem):
(TestWebKitAPI::TEST(WKWebViewEditActions, CopyMenuItemDisabledWithNoSelection)):
(TestWebKitAPI::TEST(WKWebViewEditActions, CopyMenuItemDisabledInCopyDisallowedPDF)):

Canonical link: <a href="https://commits.webkit.org/320534@main">https://commits.webkit.org/320534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6aa7c868aade74b4f0f75784a32079c1ffe7ca1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195264 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e23d4aa-5c0f-4b87-bee4-f1e1c5921765) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144511 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/804c63db-6a4e-440b-90e3-e9c95a636ea8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165115 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124803 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f5d31a4-a549-4037-ab73-1a004e4d2b7a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46911 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45011 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157286 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44678 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6317 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197213 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58517 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/153992 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59223 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41281 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153652 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28103 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48166 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131511 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128126 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57719 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19696 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57078 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57327 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57155 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->