### PR TITLE
WorkerThreadableLoader can start a resource load after its owning Document enters the back/forward cache

### DIFF
--- a/LayoutTests/http/tests/navigation/page-cache-worker-in-subframe-fetch-after-pagehide-expected.txt
+++ b/LayoutTests/http/tests/navigation/page-cache-worker-in-subframe-fetch-after-pagehide-expected.txt
@@ -1,0 +1,14 @@
+Tests that a load started by a dedicated worker in a subframe while its owning document is in the page cache is cancelled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+pageshow - not from cache
+pagehide - entering cache
+pageshow - from cache
+PASS Page did enter and was restored from the page cache
+PASS The load the worker started while the document was in the page cache was cancelled
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/navigation/page-cache-worker-in-subframe-fetch-after-pagehide.html
+++ b/LayoutTests/http/tests/navigation/page-cache-worker-in-subframe-fetch-after-pagehide.html
@@ -1,0 +1,54 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description('Tests that a load started by a dedicated worker in a subframe while its owning document is in the page cache is cancelled.');
+window.jsTestIsAsync = true;
+
+window.addEventListener("pageshow", async function(event) {
+    debug("pageshow - " + (event.persisted ? "" : "not ") + "from cache");
+
+    if (!event.persisted)
+        return;
+
+    testPassed("Page did enter and was restored from the page cache");
+
+    var result = await frames[0].workerLoadResult;
+    if (result === "rejected")
+        testPassed("The load the worker started while the document was in the page cache was cancelled");
+    else
+        testFailed("The load the worker started while the document was in the page cache was not cancelled: " + result);
+
+    setTimeout(finishJSTest, 0);
+}, false);
+
+window.addEventListener("pagehide", function(event) {
+    debug("pagehide - " + (event.persisted ? "" : "not ") + "entering cache");
+    if (!event.persisted) {
+        testFailed("Page did not enter the page cache.");
+        finishJSTest();
+        return;
+    }
+
+    frames[0].startFetch();
+}, false);
+
+window.addEventListener("message", function(event) {
+    if (event.data !== "ready")
+        return;
+    setTimeout(function() {
+        window.location.href = "resources/page-cache-helper.html";
+    }, 0);
+}, false);
+
+window.addEventListener('load', function() {
+    var iframe = document.createElement("iframe");
+    iframe.src = "resources/page-cache-worker-in-subframe-fetch-after-pagehide-frame.html";
+    document.body.appendChild(iframe);
+}, false);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/navigation/resources/page-cache-worker-in-subframe-fetch-after-pagehide-frame.html
+++ b/LayoutTests/http/tests/navigation/resources/page-cache-worker-in-subframe-fetch-after-pagehide-frame.html
@@ -1,0 +1,17 @@
+<script>
+var worker = new Worker("page-cache-worker-in-subframe-fetch-after-pagehide-worker.js");
+var workerLoadResult = new Promise(function(resolve) {
+    worker.onmessage = function(event) {
+        if (event.data === "ready") {
+            parent.postMessage("ready", "*");
+            return;
+        }
+        resolve(event.data);
+    };
+});
+
+function startFetch()
+{
+    worker.postMessage("fetch");
+}
+</script>

--- a/LayoutTests/http/tests/navigation/resources/page-cache-worker-in-subframe-fetch-after-pagehide-worker.js
+++ b/LayoutTests/http/tests/navigation/resources/page-cache-worker-in-subframe-fetch-after-pagehide-worker.js
@@ -1,0 +1,7 @@
+onmessage = function() {
+    fetch("/resources/square100.png?page-cache-worker-in-subframe-fetch-after-pagehide", { cache: "no-store" }).then(
+        function() { postMessage("resolved"); },
+        function() { postMessage("rejected"); });
+};
+
+postMessage("ready");

--- a/Source/WebCore/loader/WorkerThreadableLoader.cpp
+++ b/Source/WebCore/loader/WorkerThreadableLoader.cpp
@@ -183,6 +183,11 @@ WorkerThreadableLoader::MainThreadBridge::MainThreadBridge(ThreadableLoaderClien
         ASSERT(isMainThread());
         Ref document = downcast<Document>(context);
 
+        if (document->backForwardCacheState() == Document::InBackForwardCache) {
+            didFail(document->identifier(), ResourceError { ResourceError::Type::Cancellation });
+            return;
+        }
+
         // FIXME: If the site requests a local resource, then this will return a non-zero value but the sync path will return a 0 value.
         // Either this should return 0 or the other code path should call a failure callback.
         m_mainThreadLoader = DocumentThreadableLoader::create(document, *this, WTF::move(request), options->options, WTF::move(options->origin), WTF::move(contentSecurityPolicyIsolatedCopy), WTF::move(crossOriginEmbedderPolicyCopy), WTF::move(options->referrer), DocumentThreadableLoader::ShouldLogError::No);


### PR DESCRIPTION
#### ff7b63149c89b951a7d29b384a0a6047f9a966c5
<pre>
WorkerThreadableLoader can start a resource load after its owning Document enters the back/forward cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=323432">https://bugs.webkit.org/show_bug.cgi?id=323432</a>

Reviewed by NOBODY (OOPS!).

The WPE layout-test bots hit sometimes the assetion in
WebCore::DocumentLoader::addSubresourceLoader(). It is reported in wrong tests
because it fails while destroying the previous test run, so the noise of
the crash is problematic.

The assertion indicates that a new SubresourceLoader was being added to a
DocumentLoader whose document was already in Document::InBackForwardCache.

The crash stack shows the load originated from
WorkerThreadableLoader::MainThreadBridge. Worker resource loads are initiated
on a worker thread and posted asynchronously to the owning document main thread.

Multiple tests are causing this failures randomly in the bots.

This is not an exploratory patch anymore because we added a test to validate
this situation: a page with an iframe that owns a worker navigates away into
the back/forward cache, and the parent pagehide handler tells that worker to
fetch(), the load arrives on the main thread after the subframe&apos;s document is
already cached, then the test passes only if that fetch is rejected. For WPE
bots use release asserts so it is going to crash if we don&apos;t have this patch.

* Source/WebCore/loader/WorkerThreadableLoader.cpp:
(WebCore::WorkerThreadableLoader::MainThreadBridge::MainThreadBridge):
* LayoutTests/http/tests/navigation/page-cache-worker-in-subframe-fetch-after-pagehide-expected.txt: Added.
* LayoutTests/http/tests/navigation/page-cache-worker-in-subframe-fetch-after-pagehide.html: Added.
* LayoutTests/http/tests/navigation/resources/page-cache-worker-in-subframe-fetch-after-pagehide-frame.html: Added.
* LayoutTests/http/tests/navigation/resources/page-cache-worker-in-subframe-fetch-after-pagehide-worker.js: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff7b63149c89b951a7d29b384a0a6047f9a966c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196125 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150501 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187682 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59450 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145209 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100675 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165773 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125512 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47621 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45648 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45353 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7190 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198093 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165289 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154764 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60094 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154408 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48864 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132442 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129432 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58559 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20376 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57937 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58172 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58002 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->