### PR TITLE
[GTK][WPE] Build and run the IPC API tests on Linux

### DIFF
--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -599,7 +599,7 @@ if (ENABLE_WEBKIT)
 
     WEBKIT_EXECUTABLE_DECLARE(TestWebKit)
 
-    if (APPLE)
+    if (APPLE OR PORT STREQUAL "GTK" OR PORT STREQUAL "WPE")
         # TestIPC definitions
         set(TestIPC_SOURCES
             Helpers/Utilities.cpp
@@ -645,6 +645,71 @@ if (ENABLE_WEBKIT)
         set(TestIPC_FRAMEWORKS
             WebKit
         )
+
+        if (NOT APPLE)
+            # TestIPC compiles the IPC implementation directly rather than linking WebKit.
+            list(APPEND TestIPC_SOURCES
+                generic/main.cpp
+
+                ${WEBKIT_DIR}/Platform/IPC/ArgumentCoders.cpp
+                ${WEBKIT_DIR}/Platform/IPC/Connection.cpp
+                ${WEBKIT_DIR}/Platform/IPC/Decoder.cpp
+                ${WEBKIT_DIR}/Platform/IPC/Encoder.cpp
+                ${WEBKIT_DIR}/Platform/IPC/IPCUtilities.cpp
+                ${WEBKIT_DIR}/Platform/IPC/MessageLog.cpp
+                ${WEBKIT_DIR}/Platform/IPC/MessageReceiveQueueMap.cpp
+                ${WEBKIT_DIR}/Platform/IPC/MessageReceiverMap.cpp
+                ${WEBKIT_DIR}/Platform/IPC/MessageSender.cpp
+                ${WEBKIT_DIR}/Platform/IPC/SharedBufferReference.cpp
+                ${WEBKIT_DIR}/Platform/IPC/SharedFileHandle.cpp
+                ${WEBKIT_DIR}/Platform/IPC/StreamClientConnection.cpp
+                ${WEBKIT_DIR}/Platform/IPC/StreamConnectionBuffer.cpp
+                ${WEBKIT_DIR}/Platform/IPC/StreamConnectionWorkQueue.cpp
+                ${WEBKIT_DIR}/Platform/IPC/StreamServerConnection.cpp
+                ${WEBKIT_DIR}/Platform/IPC/TransferString.cpp
+                ${WEBKIT_DIR}/Platform/IPC/glib/ConnectionGLib.cpp
+                ${WEBKIT_DIR}/Platform/IPC/unix/ArgumentCodersUnix.cpp
+                ${WEBKIT_DIR}/Platform/IPC/unix/IPCSemaphoreUnix.cpp
+                ${WEBKIT_DIR}/Platform/IPC/unix/IPCUtilitiesUnix.cpp
+
+                ${WEBCORE_DIR}/platform/SharedMemory.cpp
+                ${WEBCORE_DIR}/platform/unix/SharedMemoryUnix.cpp
+                ${WEBKIT_DIR}/Platform/EditingRangeClamping.cpp
+                ${WEBKIT_DIR}/Platform/Logging.cpp
+                ${WEBKIT_DIR}/Shared/WebFoundTextRange.cpp
+                ${WebKit_DERIVED_SOURCES_DIR}/MessageNames.cpp
+                ${WebKit_DERIVED_SOURCES_DIR}/WebKitPlatformGeneratedSerializers.cpp
+            )
+
+            list(APPEND TestIPC_PRIVATE_INCLUDE_DIRECTORIES
+                ${CMAKE_SOURCE_DIR}/Source
+                ${WEBCORE_DIR}
+                ${WEBCORE_DIR}/platform
+                ${WEBCORE_DIR}/platform/graphics
+                ${WEBCORE_DIR}/platform/graphics/gstreamer
+                ${WEBCORE_DIR}/platform/network
+                ${WEBCORE_DIR}/platform/text
+                ${GSTREAMER_INCLUDE_DIRS}
+                ${GSTREAMER_AUDIO_INCLUDE_DIRS}
+                ${GSTREAMER_PBUTILS_INCLUDE_DIRS}
+                ${GSTREAMER_VIDEO_INCLUDE_DIRS}
+                ${WEBKIT_DIR}
+                ${WEBKIT_DIR}/Platform
+                ${WEBKIT_DIR}/Platform/IPC
+                ${WEBKIT_DIR}/Platform/IPC/glib
+                ${WEBKIT_DIR}/Platform/IPC/unix
+                ${WEBKIT_DIR}/Shared
+                ${WEBKIT_DIR}/Shared/glib
+                ${WebKit_DERIVED_SOURCES_DIR}
+            )
+
+            list(APPEND TestIPC_LIBRARIES
+                WebKit::WTF
+                WebKit::WebCore
+                ${GLIB_LIBRARIES}
+            )
+
+        endif ()
 
         WEBKIT_EXECUTABLE_DECLARE(TestIPC)
         target_compile_definitions(TestIPC PRIVATE BUILDING_TEST_IPC)
@@ -745,7 +810,7 @@ if (ENABLE_WEBKIT)
         WEBKIT_COMPUTE_SOURCES(TestWebKit)
     endif ()
     WEBKIT_TEST(TestWebKit)
-    if (APPLE)
+    if (APPLE OR PORT STREQUAL "GTK" OR PORT STREQUAL "WPE")
         WEBKIT_TEST(TestIPC)
     endif ()
 endif ()

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -244,6 +244,11 @@ TEST_P(ConnectionTestABBA, AAndBInvalidateDoesNotDeliverDidClose)
     EXPECT_FALSE(bClient().waitForDidClose(kWaitForAbsenceTimeout));
 }
 
+#if PLATFORM(COCOA)
+
+// Invalidating an unopened connection closes its socket, so a peer using Unix domain sockets sees
+// the end of file and reports didClose. A Mach based peer is never told.
+
 TEST_P(ConnectionTestABBA, UnopenedAAndInvalidateDoesNotDeliverBDidClose)
 {
     ASSERT_TRUE(openB());
@@ -251,6 +256,8 @@ TEST_P(ConnectionTestABBA, UnopenedAAndInvalidateDoesNotDeliverBDidClose)
     deleteA();
     EXPECT_FALSE(bClient().waitForDidClose(kWaitForAbsenceTimeout));
 }
+
+#endif // PLATFORM(COCOA)
 
 TEST_P(ConnectionTestABBA, IncomingMessageThrottlingWorks)
 {

--- a/Tools/TestWebKitAPI/Tests/IPC/EventTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/EventTests.cpp
@@ -104,6 +104,12 @@ TEST_P(EventTestABBA, SerializeAndSignal)
     pair->event.wait();
 }
 
+#if PLATFORM(COCOA)
+
+// Destroying the Signal interrupts the wait only where the pair is a Mach send and receive right.
+// The non-Cocoa implementation is a plain semaphore pair, so this would wait forever rather than
+// fail (see the FIXME in IPCEvent.h, and the matching guard in IPCEventTests.cpp).
+
 TEST_P(EventTestABBA, InterruptOnDestruct)
 {
     ASSERT_TRUE(openA());
@@ -128,6 +134,8 @@ TEST_P(EventTestABBA, InterruptOnDestruct)
 
     pair->event.wait();
 }
+
+#endif // PLATFORM(COCOA)
 
 #undef RUN_LOOP_NAME
 #undef LOCAL_STRINGIFY

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCEventTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCEventTests.cpp
@@ -93,16 +93,22 @@ TEST(IPCEventTests, SignalDoesNotBlockWhenNotWaitedFor)
     auto pair = IPC::createEventSignalPair();
     ASSERT_TRUE(pair.has_value());
     // Signalling must not block when the previous signal has not been waited for, the same as
-    // Semaphore::signal(). The Event holds one signal, so the rest are dropped.
+    // Semaphore::signal().
     auto start = MonotonicTime::now();
     for (int i = 0; i < 100; ++i)
         pair->signal.signal();
     EXPECT_LT(MonotonicTime::now() - start, shortTimeout);
 
     EXPECT_TRUE(pair->event.waitFor(longTimeout));
+#if PLATFORM(COCOA)
+    // A Mach notification port coalesces, so the Event holds one signal and the rest were
+    // dropped. The non-Cocoa implementation is a counting semaphore pair, which keeps them all.
     EXPECT_FALSE(pair->event.waitFor(shortTimeout));
+#else
+    while (pair->event.waitFor(shortTimeout)) { }
+#endif
 
-    // Dropping those signals did not break the pair.
+    // Consuming those signals did not break the pair.
     pair->signal.signal();
     EXPECT_TRUE(pair->event.waitFor(longTimeout));
 }


### PR DESCRIPTION
#### 9f7bc0710176d1924e73f6d1c2ed00262b6f81be
<pre>
[GTK][WPE] Build and run the IPC API tests on Linux
<a href="https://bugs.webkit.org/show_bug.cgi?id=323435">https://bugs.webkit.org/show_bug.cgi?id=323435</a>

Reviewed by Carlos Garcia Campos.

Tools/TestWebKitAPI/Tests/IPC has 244 tests covering Connection,
StreamClientConnection, StreamServerConnection, StreamConnectionWorkQueue,
StreamConnectionBuffer and IPC::Event/Signal, and none of them are built on any
Linux port. A change to the IPC layer can only be validated through layout
tests, we are trying to check the semaphore implementation for the
GPUProcess, we need more validation activating these tests.

Three tests assert Cocoa specific semantics and are guarded, each where the
behavior actually differs rather than at the file level:

- IPCEventTests.SignalDoesNotBlockWhenNotWaitedFor expects the Event to hold one
  signal and drop the rest. A Mach notification port coalesces; the non-Cocoa
  implementation is a counting semaphore pair, so it keeps them. Only that one
  assertion is Cocoa only, and the remaining signals are drained so the rest of
  the test still means something.
- EventTestABBA.InterruptOnDestruct expects destroying the Signal to interrupt a
  wait. That is a property of the Mach send and receive right pair, and
  IPCEvent.h already carries a FIXME saying the non-Cocoa implementation does
  not have it. IPCEventTests.cpp already guards the equivalent tests; this one
  was missed because it could not be run. Without the guard it waits forever
  rather than failing.
- ConnectionTestABBA.UnopenedAAndInvalidateDoesNotDeliverBDidClose expects a
  peer not to be told when an unopened connection is invalidated. Invalidating
  it closes the socket, so a peer on Unix domain sockets sees the end of file
  and reports didClose, where a Mach based peer is never told.

The result is 244 tests passing on WPE. Nothing changes for the Apple ports:
every guarded test stays inside its #if PLATFORM(COCOA), and no non-test code is
touched.

* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/PlatformWPE.cmake:
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
* Tools/TestWebKitAPI/Tests/IPC/EventTests.cpp:
* Tools/TestWebKitAPI/Tests/IPC/IPCEventTests.cpp:

Canonical link: <a href="https://commits.webkit.org/320519@main">https://commits.webkit.org/320519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/357cfadba903104e2f481ff1f340138ef507f6e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/184955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195290 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58602 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144531 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165132 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124819 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46932 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157301 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44698 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6342 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197238 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58543 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154014 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41255 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59251 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153671 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48185 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128171 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57745 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19714 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57104 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57353 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->