### PR TITLE
Simplify UnifiedWebPreferences.yaml's defaultValue

### DIFF
--- a/Source/WTF/Scripts/GeneratePreferences.rb
+++ b/Source/WTF/Scripts/GeneratePreferences.rb
@@ -55,6 +55,103 @@ end
 
 FileUtils.mkdir_p(options[:outputDirectory])
 
+# The frontends a preference can carry a default value for, in the order they
+# have to be listed in. A preference is in all of them unless "excludeFrom" says
+# otherwise.
+FRONTENDS = %w{ WebKitLegacy WebKit WebCore }
+
+def frontendsFor(opts)
+  FRONTENDS - (opts["excludeFrom"] || [])
+end
+
+# "defaultValue" is the value shared by every frontend the preference is in,
+# either directly or as a map of build conditions ending in "default". A frontend
+# is listed under it only where its value differs.
+def defaultValueFor(opts, frontend)
+  # JSC feature-flag options carry no JavaScriptCore default of their own; their
+  # default is the WebKit default.
+  frontend = "WebKit" if frontend == "JavaScriptCore"
+
+  specification = opts["defaultValue"]
+  return { "default" => specification } if !specification.is_a?(Hash)
+
+  value = specification.fetch(frontend, specification.reject { |key, _| FRONTENDS.include?(key) })
+  value.is_a?(Hash) ? value : { "default" => value }
+end
+
+def validate(path, parsed)
+  failed = false
+  reject = Proc.new do |name, msg|
+    STDERR.puts "error: #{path}: #{name}: #{msg}"
+    failed = true
+  end
+
+  parsed.each do |name, opts|
+    excluded = opts["excludeFrom"]
+    if excluded
+      if !excluded.is_a?(Array) || excluded.empty? || !(excluded - FRONTENDS).empty?
+        reject.call name, "\"excludeFrom\" must be a non-empty list of #{FRONTENDS.join(", ")}."
+        next
+      end
+      reject.call name, "\"excludeFrom\" must be listed in the order #{FRONTENDS.join(", ")}." if excluded != FRONTENDS & excluded
+      reject.call name, "\"excludeFrom\" excludes every frontend, so the preference would not exist anywhere." if excluded == FRONTENDS
+    end
+
+    exposed = opts["exposed"]
+    if exposed
+      if !exposed.is_a?(Array) || exposed.empty? || !(exposed - FRONTENDS).empty?
+        reject.call name, "\"exposed\" must be a non-empty list of #{FRONTENDS.join(", ")}."
+        next
+      end
+      reject.call name, "\"exposed\" must be listed in the order #{FRONTENDS.join(", ")}." if exposed != FRONTENDS & exposed
+    end
+
+    specification = opts["defaultValue"]
+    if specification.nil?
+      reject.call name, "\"defaultValue\" is required and cannot be empty."
+      next
+    end
+    next if !specification.is_a?(Hash)
+
+    if !specification.key?("default")
+      reject.call name, "\"defaultValue\" needs a \"default\", the value the frontends share."
+      next
+    end
+
+    keys = specification.keys
+    conditions = keys[0...keys.index("default")]
+    overrides = keys[(keys.index("default") + 1)..-1]
+    if conditions.any? { |key| FRONTENDS.include?(key) } || !(overrides - FRONTENDS).empty?
+      reject.call name, "\"defaultValue\" must list build conditions before \"default\" and frontends after it."
+      next
+    end
+    reject.call name, "\"defaultValue\" must list frontends in the order #{FRONTENDS.join(", ")}." if overrides != FRONTENDS & overrides
+
+    base = specification.reject { |key, _| FRONTENDS.include?(key) }
+    # An empty value would generate an empty DEFAULT_VALUE_FOR_ macro rather than
+    # fail here, so the derived sources would be what complains.
+    empty = base.select { |_, value| value.nil? }
+    empty.each_key { |key| reject.call name, "\"defaultValue\" has no value for \"#{key}\"." }
+    reject.call name, "\"defaultValue\" is only a \"default\", so it should be written as \"defaultValue: #{base["default"]}\"." if base.size == 1 && overrides.empty? && empty.empty?
+
+    overrides.each do |frontend|
+      reject.call name, "#{frontend} is excluded, so it cannot have a default value of its own." if !frontendsFor(opts).include?(frontend)
+      value = specification[frontend]
+      if value.is_a?(Hash)
+        reject.call name, "#{frontend} must not list frontends under itself." if value.keys.any? { |key| FRONTENDS.include?(key) }
+        reject.call name, "#{frontend}'s build conditions must end in \"default\"." if value.keys.last != "default"
+        reject.call name, "#{frontend} is only a \"default\", so it should be written as \"#{frontend}: #{value["default"]}\"." if value.size == 1 && !value["default"].nil?
+      else
+        value = { "default" => value }
+      end
+      value.each { |key, leaf| reject.call name, "#{frontend} has no value for \"#{key}\"." if leaf.nil? }
+      reject.call name, "#{frontend}'s value is the shared default, so it should be left out." if value.to_a == base.to_a
+    end
+  end
+
+  exit 1 if failed
+end
+
 def load(path)
   parsed = begin
     YAML.load_file(path)
@@ -71,6 +168,7 @@ def load(path)
       end
       previousName = name
     end
+    validate(path, parsed)
   end
   parsed
 end
@@ -117,9 +215,7 @@ class Preference
     @webcoreName = opts["webcoreName"]
     @condition = opts["condition"]
     @hidden = opts["hidden"] || false
-    @defaultValues = opts["defaultValue"][frontend]
-    # JSC feature-flag options carry no JavaScriptCore default group; their default is the WebKit default.
-    @defaultValues ||= opts["defaultValue"]["WebKit"] if opts["jscOptionName"]
+    @defaultValues = defaultValueFor(opts, frontend)
     @exposed = !opts["exposed"] || opts["exposed"].include?(frontend)
     @sharedPreferenceForWebProcess = opts["sharedPreferenceForWebProcess"] || false
     @richJavaScript = opts["richJavaScript"] || false
@@ -289,12 +385,12 @@ class Preferences
 
     if parsedPreferences
       parsedPreferences.each do |name, options|
-        webcoreSettingOnly = !options["webcoreBinding"] && options["defaultValue"].keys == ["WebCore"]
+        webcoreSettingOnly = !options["webcoreBinding"] && frontendsFor(options) == ["WebCore"]
         status = options["status"]
 
         if options["jscOptionName"]
           reject.call "Preference #{name} has jscOptionName, so it must set sharedPreferenceForWebProcess: true." if !options["sharedPreferenceForWebProcess"]
-          reject.call "Preference #{name} has jscOptionName, so it must specify a WebKit default value." if !options["defaultValue"]["WebKit"]
+          reject.call "Preference #{name} has jscOptionName, so it must not be excluded from WebKit." if !frontendsFor(options).include?("WebKit")
           next if failed
         end
 
@@ -318,8 +414,8 @@ class Preferences
 
         # The JavaScriptCore "frontend" is the set of preferences that back a
         # JSC::Options feature flag, identified by jscOptionName; every other frontend
-        # selects on the presence of its own default group.
-        includedInFrontend = @frontend == "JavaScriptCore" ? !options["jscOptionName"].nil? : options["defaultValue"].include?(@frontend)
+        # selects on not being excluded from itself.
+        includedInFrontend = @frontend == "JavaScriptCore" ? !options["jscOptionName"].nil? : frontendsFor(options).include?(@frontend)
         if includedInFrontend
           preference = Preference.new(name, options, @frontend)
           @preferences << preference

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -65,6 +65,32 @@
 #  When features are declared with "defaultsOverridable: true", platform user
 #  defaults may override a default value at runtime, using the preference
 #  name prefixed with "WebKitDebug".
+#
+# == Default Values ==
+#  A preference is in WebKitLegacy, WebKit and WebCore unless "excludeFrom"
+#  names the ones it is not in, in that order. That is about whether a frontend
+#  has the preference at all, not about whether it is part of that frontend's
+#  API, which is what "exposed" controls.
+#
+#  "defaultValue" is the value every frontend it is in gets:
+#
+#    defaultValue: false
+#
+#  It can instead map build conditions to values, in which case the last entry
+#  has to be "default", the value to fall back on:
+#
+#    defaultValue:
+#      PLATFORM(COCOA): true
+#      default: false
+#
+#  A frontend whose default differs is listed after "default", in the order
+#  WebKitLegacy, WebKit, WebCore, and takes either shape. Listing a frontend
+#  whose value matches the shared default is an error.
+#
+#    defaultValue:
+#      PLATFORM(COCOA): true
+#      default: false
+#      WebKitLegacy: false
 
 ARIAActionsSupportEnabled:
   type: bool
@@ -72,13 +98,7 @@ ARIAActionsSupportEnabled:
   category: dom
   humanReadableName: "aria-actions"
   humanReadableDescription: "Enable support for aria-actions"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 AVExperienceControllerFullscreenEnabled:
   type: bool
@@ -91,12 +111,8 @@ AVExperienceControllerFullscreenEnabled:
   humanReadableDescription: "Enable fullscreen video via AVExperienceController"
   condition: HAVE(AVEXPERIENCECONTROLLER)
   defaultValue:
-    WebCore:
-      default: false
-    WebKit:
-      default: true
-    WebKitLegacy:
-      default: false
+    default: false
+    WebKit: true
 
 AVFoundationEnabled:
   type: bool
@@ -106,12 +122,11 @@ AVFoundationEnabled:
   humanReadableDescription: "Enable AVFoundation"
   webcoreBinding: DeprecatedGlobalSettings
   condition: USE(AVFOUNDATION)
+  excludeFrom: [ WebCore ]
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      "PLATFORM(WATCHOS)": false
-      default: true
+    "PLATFORM(WATCHOS)": false
+    default: true
+    WebKitLegacy: true
 
 AXCustomColorModeEnabled:
   type: bool
@@ -120,38 +135,21 @@ AXCustomColorModeEnabled:
   webcoreName: axCustomColorModeEnabled
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
   condition: ENABLE(AX_CUSTOM_COLOR_MODE)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 AcceleratedCompositingEnabled:
   type: bool
   status: embedder
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 AcceleratedCompositingForFixedPositionEnabled:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      PLATFORM(IOS_FAMILY): true
-      default: false
-    WebCore:
-      PLATFORM(IOS_FAMILY): true
-      default: false
+    PLATFORM(IOS_FAMILY): true
+    default: false
+    WebKitLegacy: true
 
 AcceleratedDrawingEnabled:
   type: bool
@@ -160,13 +158,11 @@ AcceleratedDrawingEnabled:
   humanReadableName: "GraphicsLayer accelerated drawing"
   humanReadableDescription: "Enable GraphicsLayer accelerated drawing"
   defaultValue:
+    default: true
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY) && !PLATFORM(IOS_FAMILY_SIMULATOR)": true
       default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    WebCore: false
 
 AcceleratedFiltersEnabled:
   type: bool
@@ -175,13 +171,7 @@ AcceleratedFiltersEnabled:
   humanReadableName: "Accelerated Filter Rendering"
   humanReadableDescription: "Accelerated CSS and SVG filter rendering"
   condition: USE(CORE_IMAGE)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 AccentColorEnabled:
   type: bool
@@ -190,14 +180,10 @@ AccentColorEnabled:
   humanReadableName: "CSS Accent Color"
   humanReadableDescription: "Enable accent-color CSS property"
   defaultValue:
+    "PLATFORM(COCOA) || USE(THEME_ADWAITA)": true
+    default: false
     WebKitLegacy:
       "PLATFORM(COCOA)" : true
-      default: false
-    WebKit:
-      "PLATFORM(COCOA) || USE(THEME_ADWAITA)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA) || USE(THEME_ADWAITA)": true
       default: false
 
 AccessHandleEnabled:
@@ -207,16 +193,10 @@ AccessHandleEnabled:
   humanReadableName: "AccessHandle API"
   humanReadableDescription: "Enable AccessHandle API"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(COCOA)" : true
-      "PLATFORM(GTK) || PLATFORM(WPE)" : true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)" : true
-      "PLATFORM(GTK) || PLATFORM(WPE)" : true
-      default: false
+    "PLATFORM(COCOA)" : true
+    "PLATFORM(GTK) || PLATFORM(WPE)" : true
+    default: false
+    WebKitLegacy: false
 
 AccessibilityTextStitchingEnabled:
   type: bool
@@ -225,15 +205,8 @@ AccessibilityTextStitchingEnabled:
   humanReadableDescription: "Stitch adjacent text elements into one in the accessibility tree"
   webcoreBinding: DeprecatedGlobalSettings
   defaultValue:
-    WebKitLegacy:
-      "ENABLE(ACCESSIBILITY_TEXT_STITCHING)": true
-      default: false
-    WebKit:
-      "ENABLE(ACCESSIBILITY_TEXT_STITCHING)": true
-      default: false
-    WebCore:
-      "ENABLE(ACCESSIBILITY_TEXT_STITCHING)": true
-      default: false
+    "ENABLE(ACCESSIBILITY_TEXT_STITCHING)": true
+    default: false
 
 AccessibilityThreadHitTestingEnabled:
   type: bool
@@ -242,47 +215,28 @@ AccessibilityThreadHitTestingEnabled:
   humanReadableName: "Off Main-Thread Accessibility Hit Testing"
   humanReadableDescription: "Serve accessibility hit tests off the main-thread"
   webcoreBinding: DeprecatedGlobalSettings
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 AggressiveTileRetentionEnabled:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 AllowContentSecurityPolicySourceStarToMatchAnyProtocol:
   type: bool
   status: embedder
   defaultValue:
+    default: false
     WebKitLegacy:
       PLATFORM(IOS_FAMILY): WebKit::defaultAllowContentSecurityPolicySourceStarToMatchAnyProtocol()
-      default: false
-    WebKit:
-      default: false
-    WebCore:
       default: false
 
 AllowFileAccessFromFileURLs:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: false
-    WebCore:
-      default: true
+    default: true
+    WebKit: false
 
 AllowMediaContentTypesRequiringHardwareSupportAsFallback:
   type: bool
@@ -290,25 +244,16 @@ AllowMediaContentTypesRequiringHardwareSupportAsFallback:
   humanReadableName: "Allow Media Content Types Requirining Hardware As Fallback"
   humanReadableDescription: "Allow Media Content Types Requirining Hardware As Fallback"
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
-      default: false
+    "PLATFORM(COCOA)": true
+    default: false
+    WebKitLegacy: true
+    WebCore: false
 
 AllowMultiElementImplicitSubmission:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: WebKitAllowMultiElementImplicitFormSubmissionPreferenceKey
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 AllowMultipleCommitLayerTreePending:
   type: bool
@@ -317,28 +262,15 @@ AllowMultipleCommitLayerTreePending:
   humanReadableName: "Allow requesting CommitLayerTree before the previous has completed"
   humanReadableDescription: "Allow requesting CommitLayerTree before the previous has completed"
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
-    WebKit:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
-    WebCore:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
+    "PLATFORM(IOS_FAMILY)": false
+    default: true
 
 AllowPrivacySensitiveOperationsInNonPersistentDataStores:
   type: bool
   status: embedder
   humanReadableName: "Allow Privacy-Sensitive Operations in Non-Persistent Data Stores"
   humanReadableDescription: "Allow Privacy-Sensitive Operations in Non-Persistent Data Stores"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 AllowTestOnlyIPC:
@@ -346,9 +278,8 @@ AllowTestOnlyIPC:
   status: embedder
   exposed: [ WebKit ]
   webcoreBinding: none
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 AllowTestOnlyMockContentFilterIPC:
@@ -356,9 +287,8 @@ AllowTestOnlyMockContentFilterIPC:
   status: embedder
   exposed: [ WebKit ]
   webcoreBinding: none
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 AllowTestOnlyOriginAccessAllowListIPC:
@@ -366,9 +296,8 @@ AllowTestOnlyOriginAccessAllowListIPC:
   status: embedder
   exposed: [ WebKit ]
   webcoreBinding: none
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 AllowTopNavigationToDataURLs:
@@ -376,12 +305,8 @@ AllowTopNavigationToDataURLs:
   humanReadableName: "Allow top navigation to data: URLs"
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+    default: false
+    WebKitLegacy: true
 
 AllowUniversalAccessFromFileURLs:
   type: bool
@@ -389,12 +314,8 @@ AllowUniversalAccessFromFileURLs:
   status: developer
   category: security
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: false
-    WebCore:
-      default: true
+    default: true
+    WebKit: false
 
 # FIXME: This is not relevant for WebKitLegacy, so it should be excluded from WebKitLegacy entirely.
 AllowViewportShrinkToFitContent:
@@ -404,12 +325,8 @@ AllowViewportShrinkToFitContent:
   humanReadableDescription: "Allow the viewport shrink to fit content heuristic when appropriate"
   condition: PLATFORM(IOS_FAMILY)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 AllowWebGLInWorkers:
   type: bool
@@ -418,68 +335,48 @@ AllowWebGLInWorkers:
   humanReadableName: "Allow WebGL in Web Workers"
   condition: ENABLE(WEBGL)
   defaultValue:
-    WebKitLegacy:
-      "ENABLE(WEBGL_IN_WORKERS)": true
-      default: false
-    WebKit:
-      "ENABLE(WEBGL_IN_WORKERS)": true
-      default: false
-    WebCore:
-      "ENABLE(WEBGL_IN_WORKERS)": true
-      default: false
+    "ENABLE(WEBGL_IN_WORKERS)": true
+    default: false
 
 AllowsAirPlayForMediaPlayback:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: WebKitMediaPlaybackAllowsAirPlay
   condition: ENABLE(WIRELESS_PLAYBACK_TARGET)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 AllowsInlineMediaPlayback:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: WebKitMediaPlaybackAllowsInline
   defaultValue:
+    "PLATFORM(IOS_FAMILY)": false
+    default: true
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": WebKit::defaultAllowsInlineMediaPlayback()
-      default: true
-    WebKit:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
-    WebCore:
-      "PLATFORM(IOS_FAMILY)": false
       default: true
 
 AllowsInlineMediaPlaybackAfterFullscreen:
   type: bool
   status: embedder
   defaultValue:
+    "PLATFORM(IOS_FAMILY)": true
+    default: false
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": WebKit::defaultAllowsInlineMediaPlaybackAfterFullscreen()
       default: false
-    WebKit:
-      "PLATFORM(IOS_FAMILY)": true
-      default: false
-    WebCore:
-      default: true
+    WebCore: true
 
 AllowsPictureInPictureMediaPlayback:
   type: bool
   status: embedder
   defaultValue:
+    "PLATFORM(VISION)": false
+    "PLATFORM(IOS_FAMILY)": true
+    default: false
     WebKitLegacy:
       "PLATFORM(VISION)": false
       "PLATFORM(IOS_FAMILY)": WebKit::defaultAllowsPictureInPictureMediaPlayback()
-      default: false
-    WebKit:
-      "PLATFORM(VISION)": false
-      "PLATFORM(IOS_FAMILY)": true
       default: false
     WebCore:
       "PLATFORM(VISION)": false
@@ -491,12 +388,9 @@ AlternateFullScreenControlDesignEnabled:
   status: embedder
   condition: PLATFORM(IOS_FAMILY)
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(VISION)": true
-      default: false
-    WebCore:
       default: false
 
 AltitudeAngleEnabled:
@@ -506,14 +400,9 @@ AltitudeAngleEnabled:
   humanReadableName: "altitudeAngle PointerEvent Property"
   humanReadableDescription: "Enable the `altitudeAngle` property of the PointerEvents API"
   defaultValue:
-    WebKitLegacy:
-     default: false
-    WebKit:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)": true
-      default: false
+    "PLATFORM(COCOA)": true
+    default: false
+    WebKitLegacy: false
 
 AlwaysAllowLocalWebarchive:
   type: bool
@@ -522,13 +411,7 @@ AlwaysAllowLocalWebarchive:
   humanReadableName: "Always allow loading local Web Archive"
   humanReadableDescription: "Enable always allowing loading local Web Archive"
   condition: ENABLE(WEB_ARCHIVE)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 AlwaysUseTouchEventRegions:
   type: bool
@@ -537,12 +420,9 @@ AlwaysUseTouchEventRegions:
   humanReadableDescription: "Use touch event regions regardless of site isolation enablement"
   condition: ENABLE(TOUCH_EVENT_REGIONS)
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "ENABLE(COORDINATED_TOUCH_EVENTS)" : true
-      default: false
-    WebCore:
       default: false
 
 AlwaysZoomOnDoubleTap:
@@ -553,20 +433,13 @@ AlwaysZoomOnDoubleTap:
   webcoreBinding: none
   condition: PLATFORM(IOS_FAMILY)
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 AnimatedImageAsyncDecodingEnabled:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 AnimationTriggersEnabled:
   type: bool
@@ -574,13 +447,7 @@ AnimationTriggersEnabled:
   category: animation
   humanReadableName: "Animation Triggers"
   humanReadableDescription: "Support for the timeline-trigger, animation-trigger and event-trigger CSS properties"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 AnonymousBlockGenerationDisabled:
   type: bool
@@ -588,13 +455,7 @@ AnonymousBlockGenerationDisabled:
   category: css
   humanReadableName: "Disable anonymous block generation"
   humanReadableDescription: "Disable anonymous block generation for mixed blocks"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 AppBadgeEnabled:
   type: bool
@@ -602,13 +463,7 @@ AppBadgeEnabled:
   category: dom
   humanReadableName: "App Badge"
   humanReadableDescription: "Enable App Badge"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
@@ -619,24 +474,15 @@ AppHighlightsEnabled:
   humanReadableName: "App Highlights"
   humanReadableDescription: "Enable App Highlights"
   condition: ENABLE(APP_HIGHLIGHTS)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 AppleMailPaginationQuirkEnabled:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       PLATFORM(MAC): WebKit::defaultAppleMailPaginationQuirkEnabled()
-      default: false
-    WebCore:
       default: false
 
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
@@ -644,13 +490,7 @@ ApplePayCapabilityDisclosureAllowed:
   type: bool
   status: embedder
   condition: ENABLE(APPLE_PAY)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 ApplePayEnabled:
@@ -658,15 +498,8 @@ ApplePayEnabled:
   status: embedder
   condition: ENABLE(APPLE_PAY)
   defaultValue:
-    WebKitLegacy:
-      "ENABLE(APPLE_PAY_REMOTE_UI)": true
-      default: false
-    WebKit:
-      "ENABLE(APPLE_PAY_REMOTE_UI)": true
-      default: false
-    WebCore:
-      "ENABLE(APPLE_PAY_REMOTE_UI)": true
-      default: false
+    "ENABLE(APPLE_PAY_REMOTE_UI)": true
+    default: false
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
@@ -676,13 +509,7 @@ AsyncAudioSessionActivationEnabled:
   category: media
   humanReadableName: "Async Audio Session Activation"
   humanReadableDescription: "Use async IPC for audio session activation"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   sharedPreferenceForWebProcess: true
 
 # FIXME: This is on by default in WebKit2 PLATFORM(COCOA). Perhaps we should consider turning it on for WebKitLegacy as well.
@@ -692,12 +519,9 @@ AsyncClipboardAPIEnabled:
   humanReadableName: "Async clipboard API"
   humanReadableDescription: "Enable the async clipboard API"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)" : true
-      default: false
-    WebCore:
       default: false
 
 AsyncClipboardRichContentEnabled:
@@ -706,12 +530,9 @@ AsyncClipboardRichContentEnabled:
   humanReadableName: "Async clipboard rich content"
   humanReadableDescription: "Enable rich content types in the async clipboard API"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
       default: false
 
 AsyncFrameScrollingEnabled:
@@ -722,13 +543,10 @@ AsyncFrameScrollingEnabled:
   humanReadableDescription: "Perform frame scrolling off the main thread"
   exposed: [ WebKit ]
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "USE(COORDINATED_GRAPHICS)": true
       "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
       default: false
 
 AsyncOverflowScrollingEnabled:
@@ -739,13 +557,10 @@ AsyncOverflowScrollingEnabled:
   humanReadableDescription: "Perform overflow scrolling off the main thread"
   exposed: [ WebKit ]
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "USE(COORDINATED_GRAPHICS)": true
       "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
       default: false
 
 AsyncStackTraceEnabled:
@@ -757,20 +572,13 @@ AsyncStackTraceEnabled:
   webcoreBinding: none
   jscOptionName: useAsyncStackTrace
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 AsynchronousSpellCheckingEnabled:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 AttachmentElementEnabled:
   type: bool
@@ -779,11 +587,10 @@ AttachmentElementEnabled:
   humanReadableDescription: "Allow the insertion of attachment elements"
   webcoreBinding: DeprecatedGlobalSettings
   condition: ENABLE(ATTACHMENT_ELEMENT)
+  excludeFrom: [ WebCore ]
   defaultValue:
-    WebKitLegacy:
-      default: WebKit::defaultAttachmentElementEnabled()
-    WebKit:
-      default: false
+    default: false
+    WebKitLegacy: WebKit::defaultAttachmentElementEnabled()
   sharedPreferenceForWebProcess: true
 
 AttachmentWideLayoutEnabled:
@@ -792,31 +599,16 @@ AttachmentWideLayoutEnabled:
   humanReadableName: "Attachment wide-layout styling"
   humanReadableDescription: "Use horizontal wide-layout attachment style, requires Attachment Element"
   condition: ENABLE(ATTACHMENT_ELEMENT)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 AudioControlsScaleWithPageZoom:
   type: bool
   status: embedder
   category: media
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(VISION)": true
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
-    WebKit:
-      "PLATFORM(VISION)": true
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
-    WebCore:
-      "PLATFORM(VISION)": true
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
+    "PLATFORM(VISION)": true
+    "PLATFORM(IOS_FAMILY)": false
+    default: true
 
 AudioDescriptionsEnabled:
   type: bool
@@ -825,11 +617,8 @@ AudioDescriptionsEnabled:
   condition: ENABLE(VIDEO)
   humanReadableName: "Audio descriptions for video - Standard"
   humanReadableDescription: "Enable standard audio descriptions for video"
-  defaultValue:
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  excludeFrom: [ WebKitLegacy ]
+  defaultValue: true
 
 AuthorAndUserStylesEnabled:
   type: bool
@@ -837,13 +626,7 @@ AuthorAndUserStylesEnabled:
   webKitLegacyPreferenceKey: WebKitAuthorAndUserStylesEnabledPreferenceKey
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
   inspectorOverride: true
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 AutomaticLiveResizeEnabled:
   type: bool
@@ -853,9 +636,8 @@ AutomaticLiveResizeEnabled:
   webcoreBinding: none
   exposed: [ WebKit ]
   condition: PLATFORM(IOS_FAMILY)
-  defaultValue:
-    WebKit:
-      default: WebKit::defaultAutomaticLiveResizeEnabled()
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: WebKit::defaultAutomaticLiveResizeEnabled()
 
 AutomaticallyAdjustsViewScaleUsingMinimumEffectiveDeviceWidth:
   type: bool
@@ -863,24 +645,15 @@ AutomaticallyAdjustsViewScaleUsingMinimumEffectiveDeviceWidth:
   humanReadableName: "Automatically Adjust View Scale"
   humanReadableDescription: "Automatically Adjust View Scale to Fit Min. Effective Device Width"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "ENABLE(FLEXIBLE_VIEW_SCALE_FACTOR)": true
-      default: false
-    WebCore:
       default: false
 
 AutomaticallyForceEnableScrollingIfNeededToRevealUI:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 AzimuthAngleEnabled:
   type: bool
@@ -889,14 +662,9 @@ AzimuthAngleEnabled:
   humanReadableName: "azimuthAngle PointerEvent Property"
   humanReadableDescription: "Enable the `azimuthAngle` property of the PointerEvents API"
   defaultValue:
-    WebKitLegacy:
-     default: false
-    WebKit:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)": true
-      default: false
+    "PLATFORM(COCOA)": true
+    default: false
+    WebKitLegacy: false
 
 BackForwardCacheWithMediaEnabled:
   type: bool
@@ -905,13 +673,7 @@ BackForwardCacheWithMediaEnabled:
   humanReadableName: "Back/Forward Cache with Media"
   humanReadableDescription: "Enable back/forward cache for pages with media"
   condition: PLATFORM(WPE)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 BackgroundFetchAPIEnabled:
   type: bool
@@ -920,11 +682,8 @@ BackgroundFetchAPIEnabled:
   humanReadableName: "Enable background-fetch API"
   humanReadableDescription: "Enable background-fetch API"
   exposed: [ WebKit ]
-  defaultValue:
-    WebCore:
-      default: false
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy ]
+  defaultValue: false
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
@@ -937,25 +696,16 @@ BackgroundWebContentRunningBoardThrottlingEnabled:
   exposed: [ WebKit ]
   condition: PLATFORM(MAC) && USE(RUNNINGBOARD)
   defaultValue:
-    WebCore:
-      default: false
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultRunningBoardThrottlingEnabled()
+    default: false
+    WebKit: WebKit::defaultRunningBoardThrottlingEnabled()
 
 BackspaceKeyNavigationEnabled:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
-    WebKit:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
-    WebCore:
-      default: true
+    "PLATFORM(IOS_FAMILY)": false
+    default: true
+    WebCore: true
 
 # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
 BeaconAPIEnabled:
@@ -964,12 +714,8 @@ BeaconAPIEnabled:
   humanReadableName: "Beacon API"
   humanReadableDescription: "Beacon API"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 BidiContentAwarePasteEnabled:
   type: bool
@@ -977,12 +723,9 @@ BidiContentAwarePasteEnabled:
   humanReadableName: "Bidi Content Aware Paste"
   humanReadableDescription: "Bidi content aware paste"
   defaultValue:
+    default: false
     WebKit:
       "PLATFORM(IOS_FAMILY)": WebKit::defaultBidiContentAwarePasteEnabled()
-      default: false
-    WebKitLegacy:
-      default: false
-    WebCore:
       default: false
 
 BigIntMathMethodsEnabled:
@@ -994,9 +737,8 @@ BigIntMathMethodsEnabled:
   webcoreBinding: none
   jscOptionName: useBigIntMathMethods
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 BlobFileAccessEnforcementEnabled:
   type: bool
@@ -1006,15 +748,8 @@ BlobFileAccessEnforcementEnabled:
   humanReadableDescription: "Validate file backed blobs were created by the correct web process"
   sharedPreferenceForWebProcess: true
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebKit:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)": true
-      default: false
+    "PLATFORM(COCOA)": true
+    default: false
 
 BlockMediaLayerRehostingInWebContentProcess:
   type: bool
@@ -1024,12 +759,8 @@ BlockMediaLayerRehostingInWebContentProcess:
   humanReadableDescription: "GPU Process: Block Media Layer Re-hosting in WebContent process"
   condition: ENABLE(GPU_PROCESS)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 # We would have to partition BroadcastChannel based on PageGroups if we wanted to enable this for WebKitLegacy.
 BroadcastChannelEnabled:
@@ -1039,12 +770,8 @@ BroadcastChannelEnabled:
   humanReadableName: "BroadcastChannel API"
   humanReadableDescription: "BroadcastChannel API"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
@@ -1056,11 +783,10 @@ BuiltInNotificationsEnabled:
   humanReadableDescription: "Enable built-in WebKit managed notifications"
   webcoreBinding: DeprecatedGlobalSettings
   condition: ENABLE(WEB_PUSH_NOTIFICATIONS)
+  excludeFrom: [ WebKitLegacy ]
   defaultValue:
-    WebCore:
-      default: false
-    WebKit:
-      default: defaultBuiltInNotificationsEnabled()
+    default: defaultBuiltInNotificationsEnabled()
+    WebCore: false
   sharedPreferenceForWebProcess: true
 
 CSS3DTransformBackfaceVisibilityInteroperabilityEnabled:
@@ -1069,13 +795,7 @@ CSS3DTransformBackfaceVisibilityInteroperabilityEnabled:
   category: css
   humanReadableName: "CSS 3D Transform Interoperability for backface-visibility"
   humanReadableDescription: "Enable 3D transform behavior for backface-visibility that is specification-compliant but backwards incompatible"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSAppearanceBaseEnabled:
   type: bool
@@ -1083,13 +803,7 @@ CSSAppearanceBaseEnabled:
   category: css
   humanReadableName: "CSS appearance: base"
   humanReadableDescription: "Enable base value for CSS appearance"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSAttrSubstitutionFunctionEnabled:
   type: bool
@@ -1097,13 +811,7 @@ CSSAttrSubstitutionFunctionEnabled:
   status: stable
   humanReadableName: "CSS attr() substitution function"
   humanReadableDescription: "Enable CSS Values 5 attr() arbitrary substitution function"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSAxisRelativePositionKeywordsEnabled:
   type: bool
@@ -1111,13 +819,7 @@ CSSAxisRelativePositionKeywordsEnabled:
   status: stable
   humanReadableName: "CSS axis relative keywords in <position>"
   humanReadableDescription: "Enable support for CSS Values and Units Module Level 5 axis relative keywords in <position>"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSBaselineSourceEnabled:
   type: bool
@@ -1125,13 +827,7 @@ CSSBaselineSourceEnabled:
   category: css
   humanReadableName: "CSS baseline-source"
   humanReadableDescription: "Enable CSS baseline-source"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSCalcMixEnabled:
   type: bool
@@ -1139,13 +835,7 @@ CSSCalcMixEnabled:
   status: stable
   humanReadableName: "CSS calc-mix()"
   humanReadableDescription: "Enable support for CSS calc-mix()"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSColorLayersEnabled:
   type: bool
@@ -1153,13 +843,7 @@ CSSColorLayersEnabled:
   status: preview
   humanReadableName: "CSS color-layers()"
   humanReadableDescription: "Enable support for CSS color-layers()"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSConstrainedDynamicRangeLimitEnabled:
   type: bool
@@ -1167,13 +851,7 @@ CSSConstrainedDynamicRangeLimitEnabled:
   status: testable
   humanReadableName: "CSS dynamic-range-limit: constrained"
   humanReadableDescription: "Enable support for CSS dynamic-range-limit value constrained"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSCornerShapeEnabled:
   type: bool
@@ -1181,13 +859,7 @@ CSSCornerShapeEnabled:
   status: stable
   humanReadableName: "CSS corner-shape property"
   humanReadableDescription: "Enable support for CSS corner-shape property"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSCounterStyleAtRuleImageSymbolsEnabled:
   type: bool
@@ -1195,13 +867,7 @@ CSSCounterStyleAtRuleImageSymbolsEnabled:
   category: css
   humanReadableName: "CSS @counter-style <image> symbols"
   humanReadableDescription: "Enable support for <image> symbols in CSS @counter-style rules"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSDPropertyEnabled:
   type: bool
@@ -1209,13 +875,7 @@ CSSDPropertyEnabled:
   category: css
   humanReadableName: "CSS d property"
   humanReadableDescription: "Enable support for the CSS d property and SVG d presentation attribute"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSDynamicRangeLimitMixEnabled:
   type: bool
@@ -1223,13 +883,7 @@ CSSDynamicRangeLimitMixEnabled:
   status: testable
   humanReadableName: "CSS dynamic-range-limit-mix()"
   humanReadableDescription: "Enable support for CSS dynamic-range-limit-mix(), but animation stays unsupported"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSFieldSizingEnabled:
   type: bool
@@ -1237,13 +891,7 @@ CSSFieldSizingEnabled:
   category: css
   humanReadableName: "CSS field-sizing property"
   humanReadableDescription: "Enable field-sizing CSS property"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSFlexWrapBalanceEnabled:
   type: bool
@@ -1251,13 +899,7 @@ CSSFlexWrapBalanceEnabled:
   category: css
   humanReadableName: "CSS flex-wrap: balance"
   humanReadableDescription: "Enable the balance value for flex-wrap"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSFontFaceMetricOverrideDescriptorsEnabled:
   type: bool
@@ -1265,13 +907,7 @@ CSSFontFaceMetricOverrideDescriptorsEnabled:
   category: css
   humanReadableName: "CSS @font-face metric override descriptors"
   humanReadableDescription: "Enable CSS @font-face metric override descriptors"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSFontSynthesisStyleObliqueOnlyEnabled:
   type: bool
@@ -1279,13 +915,7 @@ CSSFontSynthesisStyleObliqueOnlyEnabled:
   category: css
   humanReadableName: "CSS font-synthesis-style: oblique-only"
   humanReadableDescription: "Enable the oblique-only value for the font-synthesis-style CSS property"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSFontVariantEmojiEnabled:
   type: bool
@@ -1294,12 +924,9 @@ CSSFontVariantEmojiEnabled:
   humanReadableName: "CSS font-variant-emoji property"
   humanReadableDescription: "Enable the font-variant-emoji CSS property"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
       default: false
 
 CSSFunctionAtRuleEnabled:
@@ -1308,13 +935,7 @@ CSSFunctionAtRuleEnabled:
   category: css
   humanReadableName: "CSS @function"
   humanReadableDescription: "Enable CSS @function rule"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSIdentFunctionEnabled:
   type: bool
@@ -1322,13 +943,7 @@ CSSIdentFunctionEnabled:
   category: css
   humanReadableName: "CSS ident() function"
   humanReadableDescription: "Enable the CSS Values 5 ident() function"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSIfFunctionEnabled:
   type: bool
@@ -1336,13 +951,7 @@ CSSIfFunctionEnabled:
   status: stable
   humanReadableName: "CSS if() function"
   humanReadableDescription: "Enable CSS Values 5 if() conditional substitution function"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSInheritFunctionEnabled:
   type: bool
@@ -1350,13 +959,7 @@ CSSInheritFunctionEnabled:
   category: css
   humanReadableName: "CSS inherit() function"
   humanReadableDescription: "Enable the CSS Values 5 inherit() function"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSInputSecurityEnabled:
   type: bool
@@ -1364,13 +967,7 @@ CSSInputSecurityEnabled:
   category: css
   humanReadableName: "CSS Input Security"
   humanReadableDescription: "Enable input-security CSS property"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSInternalAutoBaseParsingEnabled:
   type: bool
@@ -1378,13 +975,7 @@ CSSInternalAutoBaseParsingEnabled:
   category: css
   humanReadableName: "CSS -internal-auto-base() in author sheet"
   humanReadableDescription: "Enable parsing -internal-auto-base() in author sheet"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSLineClampEnabled:
   type: bool
@@ -1392,13 +983,7 @@ CSSLineClampEnabled:
   category: css
   humanReadableName: "CSS line-clamp"
   humanReadableDescription: "Enable CSS line-clamp"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSLineFitEdgeEnabled:
   type: bool
@@ -1406,13 +991,7 @@ CSSLineFitEdgeEnabled:
   category: css
   humanReadableName: "CSS line-fit-edge"
   humanReadableDescription: "Enable CSS line-fit-edge"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSLinkParametersEnabled:
   type: bool
@@ -1420,13 +999,7 @@ CSSLinkParametersEnabled:
   category: css
   humanReadableName: "CSS Linked Parameters"
   humanReadableDescription: "Enable passing CSS link parameters to linked resources"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSMarkerContentEnabled:
   type: bool
@@ -1434,13 +1007,7 @@ CSSMarkerContentEnabled:
   category: css
   humanReadableName: "CSS content on ::marker"
   humanReadableDescription: "Enable the content property on the ::marker pseudo-element"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSMathDepthEnabled:
   type: bool
@@ -1448,27 +1015,14 @@ CSSMathDepthEnabled:
   category: css
   humanReadableName: "CSS math-depth"
   humanReadableDescription: "Enable support for math-depth from MathML Core."
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-      
+  defaultValue: true
 CSSObjectViewBoxEnabled:
   type: bool
   status: stable
   category: css
   humanReadableName: "CSS object-view-box property"
   humanReadableDescription: "Enable support for CSS object-view-box property"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSOverflowClipMarginEnabled:
   type: bool
@@ -1476,13 +1030,7 @@ CSSOverflowClipMarginEnabled:
   category: css
   humanReadableName: "CSS overflow-clip-margin"
   humanReadableDescription: "Enable CSS overflow-clip-margin"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSPaintingAPIEnabled:
   type: bool
@@ -1491,12 +1039,9 @@ CSSPaintingAPIEnabled:
   humanReadableName: "CSS Painting API"
   humanReadableDescription: "Enable the CSS Painting API"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "ENABLE(EXPERIMENTAL_FEATURES)": true
-      default: false
-    WebCore:
       default: false
 
 CSSPickerPseudoElementEnabled:
@@ -1506,15 +1051,8 @@ CSSPickerPseudoElementEnabled:
   humanReadableName: "CSS ::picker() pseudo-element"
   humanReadableDescription: "Enable the CSS ::picker() pseudo-element"
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(WATCHOS)": false
-      default: true
-    WebKit:
-      "PLATFORM(WATCHOS)": false
-      default: true
-    WebCore:
-      "PLATFORM(WATCHOS)": false
-      default: true
+    "PLATFORM(WATCHOS)": false
+    default: true
 
 CSSRandomFunctionEnabled:
   type: bool
@@ -1522,13 +1060,7 @@ CSSRandomFunctionEnabled:
   status: stable
   humanReadableName: "CSS random()"
   humanReadableDescription: "Enable support for CSS Values and Units Module Level 5 random()"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSRandomItemFunctionEnabled:
   type: bool
@@ -1536,13 +1068,7 @@ CSSRandomItemFunctionEnabled:
   status: stable
   humanReadableName: "CSS random-item()"
   humanReadableDescription: "Enable support for CSS Values and Units Module Level 5 random-item()"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSRhythmicSizingEnabled:
   type: bool
@@ -1550,13 +1076,7 @@ CSSRhythmicSizingEnabled:
   category: css
   humanReadableName: "CSS Rhythmic Sizing"
   humanReadableDescription: "Enable CSS Rhythmic Sizing properties"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSRubyDisplayTypesInAuthorStylesEnabled:
   type: bool
@@ -1564,13 +1084,7 @@ CSSRubyDisplayTypesInAuthorStylesEnabled:
   category: css
   humanReadableName: "CSS Ruby Display Types in Author Styles"
   humanReadableDescription: "Enable CSS Ruby Display types in author styles"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSScrollAnchoringEnabled:
   type: bool
@@ -1578,13 +1092,7 @@ CSSScrollAnchoringEnabled:
   category: css
   humanReadableName: "CSS Scroll Anchoring"
   humanReadableDescription: "Enable CSS Scroll Anchoring"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSScrollStateContainerQueriesEnabled:
   type: bool
@@ -1592,13 +1100,7 @@ CSSScrollStateContainerQueriesEnabled:
   category: css
   humanReadableName: "CSS Scroll State Container Queries"
   humanReadableDescription: "Enable scroll-state value for container-type CSS property"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSScrollbarColorEnabled:
   type: bool
@@ -1607,12 +1109,8 @@ CSSScrollbarColorEnabled:
   humanReadableName: "CSS scrollbar-color property"
   humanReadableDescription: "Enable scrollbar-color CSS property"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: defaultScrollbarColorEnabled()
-    WebCore:
-      default: false
+    default: false
+    WebKit: defaultScrollbarColorEnabled()
 
 CSSScrollbarGutterEnabled:
   type: bool
@@ -1621,12 +1119,8 @@ CSSScrollbarGutterEnabled:
   humanReadableName: "CSS scrollbar-gutter property"
   humanReadableDescription: "Enable scrollbar-gutter CSS property"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 CSSScrollbarWidthEnabled:
   type: bool
@@ -1635,12 +1129,8 @@ CSSScrollbarWidthEnabled:
   humanReadableName: "CSS scrollbar-width property"
   humanReadableDescription: "Enable scrollbar-width CSS property"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 CSSSelectorJITCompilerEnabled:
   type: bool
@@ -1649,13 +1139,7 @@ CSSSelectorJITCompilerEnabled:
   humanReadableName: "CSS Selector JIT Compiler"
   humanReadableDescription: "Enable the JIT compiler for CSS selectors"
   condition: ENABLE(CSS_SELECTOR_JIT)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSSizeShorthandEnabled:
   type: bool
@@ -1663,13 +1147,7 @@ CSSSizeShorthandEnabled:
   category: css
   humanReadableName: "CSS size shorthand"
   humanReadableDescription: "Enable the size shorthand for the width and height properties"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSTextDecorationInsetEnabled:
   type: bool
@@ -1678,13 +1156,7 @@ CSSTextDecorationInsetEnabled:
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
   humanReadableName: "CSS text-decoration-inset property"
   humanReadableDescription: "Enable the text-decoration-inset property, defined in CSS Text Decoration 4"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSTextDecorationLineErrorValues:
   type: bool
@@ -1692,13 +1164,7 @@ CSSTextDecorationLineErrorValues:
   category: css
   humanReadableName: "CSS text-decoration-line: spelling-error/grammar-error"
   humanReadableDescription: "Enable support for spelling-error and grammar-error values on text-decoration-line"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSTextGroupAlignEnabled:
   type: bool
@@ -1706,13 +1172,7 @@ CSSTextGroupAlignEnabled:
   category: css
   humanReadableName: "CSS text-group-align property"
   humanReadableDescription: "Enable text-group-align CSS property"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSTextJustifyEnabled:
   type: bool
@@ -1720,13 +1180,7 @@ CSSTextJustifyEnabled:
   category: css
   humanReadableName: "CSS text-justify property"
   humanReadableDescription: "Enable the property text-justify, defined in CSS Text 3"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSTextSpacingTrimEnabled:
   type: bool
@@ -1734,13 +1188,7 @@ CSSTextSpacingTrimEnabled:
   category: css
   humanReadableName: "CSS text-spacing-trim property"
   humanReadableDescription: "Enable the property text-spacing-trim, defined in CSS Text 4"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSTextTransformMathAutoEnabled:
   type: bool
@@ -1749,27 +1197,18 @@ CSSTextTransformMathAutoEnabled:
   humanReadableName: "CSS text-transform: math-auto"
   humanReadableDescription: "Enable the math-auto text transform."
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
-    WebCore:
-      default: false
 
 CSSTextWrapPrettyEnabled:
-   type: bool
-   status: stable
-   category: css
-   humanReadableName: "CSS text-wrap: pretty"
-   humanReadableDescription: "Enable the pretty value for text-wrap-style"
-   defaultValue:
-     WebKitLegacy:
-       default: true
-     WebKit:
-       default: true
-     WebCore:
-       default: true
+  type: bool
+  status: stable
+  category: css
+  humanReadableName: "CSS text-wrap: pretty"
+  humanReadableDescription: "Enable the pretty value for text-wrap-style"
+  defaultValue: true
 
 CSSToggleFunctionEnabled:
   type: bool
@@ -1777,13 +1216,7 @@ CSSToggleFunctionEnabled:
   category: css
   humanReadableName: "CSS toggle() function"
   humanReadableDescription: "Enable CSS Values 5 toggle() function"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSTransformStyleSeparatedEnabled:
   type: bool
@@ -1792,13 +1225,7 @@ CSSTransformStyleSeparatedEnabled:
   humanReadableName: "CSS transform-style: separated"
   humanReadableDescription: "Enable transform-style: separated property to access the separated graphics layer"
   condition: HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSTreeCountingFunctionsEnabled:
   type: bool
@@ -1806,13 +1233,7 @@ CSSTreeCountingFunctionsEnabled:
   status: stable
   humanReadableName: "CSS Tree Counting Functions"
   humanReadableDescription: "Enable support for CSS Values and Units Module Level 5 tree counting functions sibling-count() and sibling-index()"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSTypedOMColorEnabled:
   type: bool
@@ -1820,13 +1241,7 @@ CSSTypedOMColorEnabled:
   category: css
   humanReadableName: "CSS Typed OM: Color Support"
   humanReadableDescription: "Enable the CSS Typed OM Color support"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSURLIntegrityModifierEnabled:
   type: bool
@@ -1834,13 +1249,7 @@ CSSURLIntegrityModifierEnabled:
   category: css
   humanReadableName: "CSS URL Modifiers: integrity()"
   humanReadableDescription: "Enable support for CSS Values and Units Module Level 5 URL integrity() modifier"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSURLModifiersEnabled:
   type: bool
@@ -1848,13 +1257,7 @@ CSSURLModifiersEnabled:
   category: css
   humanReadableName: "CSS URL Modifiers"
   humanReadableDescription: "Enable support for CSS Values and Units Module Level 5 URL modifiers"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSUnprefixedBackdropFilterEnabled:
   type: bool
@@ -1863,14 +1266,9 @@ CSSUnprefixedBackdropFilterEnabled:
   humanReadableName: "CSS Unprefixed Backdrop Filter"
   humanReadableDescription: "Enable unprefixed backdrop-filter CSS property"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "ENABLE(UNPREFIXED_BACKDROP_FILTER)": true
-      default: false
-    WebCore:
-      "ENABLE(UNPREFIXED_BACKDROP_FILTER)": true
-      default: false
+    "ENABLE(UNPREFIXED_BACKDROP_FILTER)": true
+    default: false
+    WebKitLegacy: false
 
 CSSUserSelectEnabled:
   type: bool
@@ -1878,13 +1276,7 @@ CSSUserSelectEnabled:
   category: css
   humanReadableName: "CSS Unprefixed User Select"
   humanReadableDescription: "Enable the unprefixed user-select CSS property"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSWhiteSpaceTrimEnabled:
   type: bool
@@ -1893,13 +1285,7 @@ CSSWhiteSpaceTrimEnabled:
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
   humanReadableName: "CSS white-space-trim property"
   humanReadableDescription: "Enable the property white-space-trim, defined in CSS Text 4"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CSSWordBreakAutoPhraseEnabled:
   type: bool
@@ -1908,13 +1294,7 @@ CSSWordBreakAutoPhraseEnabled:
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
   humanReadableName: "word-break: auto-phrase enabled"
   humanReadableDescription: "Enables the auto-phrase value of the word-break CSS property"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CSSWrapInsideEnabled:
   type: bool
@@ -1923,13 +1303,7 @@ CSSWrapInsideEnabled:
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
   humanReadableName: "CSS wrap-inside property"
   humanReadableDescription: "Enable the wrap-inside property, defined in CSS Text 4"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 # FIXME: This is not relevant for WebKitLegacy, so it should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 CacheAPIEnabled:
@@ -1938,12 +1312,8 @@ CacheAPIEnabled:
   humanReadableName: "Cache API"
   humanReadableDescription: "Cache API"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
   disableInLockdownMode: true
   richJavaScript: true
 
@@ -1954,14 +1324,9 @@ CanvasColorSpaceEnabled:
   humanReadableName: "Canvas Color Spaces"
   humanReadableDescription: "Enable use of predefined canvas color spaces"
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebKit:
-      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
-      default: false
+    "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
+    default: false
+    WebCore: false
 
 CanvasColorTypeEnabled:
   type: bool
@@ -1969,13 +1334,7 @@ CanvasColorTypeEnabled:
   category: dom
   humanReadableName: "Canvas Color Types and ImageData Pixel Formats"
   humanReadableDescription: "Allow different color types and pixel formats in 2D canvas"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
 
@@ -1986,13 +1345,7 @@ CanvasFiltersEnabled:
   webcoreOnChange: setNeedsRelayoutAllFrames
   humanReadableName: "Canvas Filters"
   humanReadableDescription: "Canvas Filters"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CanvasFingerprintingQuirkEnabled:
   type: bool
@@ -2000,12 +1353,8 @@ CanvasFingerprintingQuirkEnabled:
   category: dom
   humanReadableName: "Enable Canvas fingerprinting-related quirk"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 CanvasLayersEnabled:
   type: bool
@@ -2013,13 +1362,7 @@ CanvasLayersEnabled:
   category: dom
   humanReadableName: "Canvas Layers"
   humanReadableDescription: "Enable Canvas Layers"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CanvasUsesAcceleratedDrawing:
   type: bool
@@ -2027,13 +1370,11 @@ CanvasUsesAcceleratedDrawing:
   humanReadableName: "Canvas uses accelerated drawing"
   condition: USE(CA) || USE(SKIA)
   defaultValue:
+    default: true
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY) && !PLATFORM(IOS_FAMILY_SIMULATOR)": true
       default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    WebCore: false
 
 CaptionDisplaySettingsEnabled:
   type: bool
@@ -2044,12 +1385,8 @@ CaptionDisplaySettingsEnabled:
   humanReadableDescription: "Enable Caption Display Settings API"
   condition: ENABLE(VIDEO)
   defaultValue:
-    WebKit:
-      default: WebKit::defaultCaptionDisplaySettingsEnabled()
-    WebKitLegacy:
-      default: false
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultCaptionDisplaySettingsEnabled()
 
 CaptureAudioInGPUProcessEnabled:
   type: bool
@@ -2060,9 +1397,8 @@ CaptureAudioInGPUProcessEnabled:
   webcoreBinding: none
   condition: ENABLE(MEDIA_STREAM)
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: WebKit::defaultCaptureAudioInGPUProcessEnabled()
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: WebKit::defaultCaptureAudioInGPUProcessEnabled()
 
 CaptureVideoInGPUProcessEnabled:
   type: bool
@@ -2073,21 +1409,15 @@ CaptureVideoInGPUProcessEnabled:
   webcoreBinding: none
   condition: ENABLE(MEDIA_STREAM)
   exposed: [ WebKit ]
+  excludeFrom: [ WebKitLegacy, WebCore ]
   defaultValue:
-    WebKit:
-      "ENABLE(GPU_PROCESS_BY_DEFAULT)": true
-      default: false
+    "ENABLE(GPU_PROCESS_BY_DEFAULT)": true
+    default: false
 
 CaretBrowsingEnabled:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CaretPositionFromPointEnabled:
   type: bool
@@ -2095,13 +1425,7 @@ CaretPositionFromPointEnabled:
   category: dom
   humanReadableName: "document.caretPositionFromPoint() API"
   humanReadableDescription: "Enable document.caretPositionFromPoint() API"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 ChildProcessDebuggabilityEnabled:
   comment: Disables GPU process IPC timeouts
@@ -2110,13 +1434,7 @@ ChildProcessDebuggabilityEnabled:
   humanReadableName: "Child Process Debuggability"
   humanReadableDescription: "Enable stopping child processes with a debugger"
   exposed: [ WebKit ]
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ClearSiteDataExecutionContextsSupportEnabled:
   type: bool
@@ -2124,13 +1442,7 @@ ClearSiteDataExecutionContextsSupportEnabled:
   category: networking
   humanReadableName: "Clear-Site-Data: 'executionContexts' support"
   humanReadableDescription: "Enable Clear-Site-Data: 'executionContexts' support"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ClearSiteDataHTTPHeaderEnabled:
   type: bool
@@ -2139,12 +1451,8 @@ ClearSiteDataHTTPHeaderEnabled:
   humanReadableName: "Clear-Site-Data HTTP Header"
   humanReadableDescription: "Enable Clear-Site-Data HTTP Header support"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 CloseWatcherEnabled:
   type: bool
@@ -2152,25 +1460,13 @@ CloseWatcherEnabled:
   category: html
   humanReadableName: "Close Watcher API"
   humanReadableDescription: "Enable Close Watcher API including dialog closedby attribute"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 ColorFilterEnabled:
   type: bool
   status: embedder
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CommandAttributesEnabled:
   type: bool
@@ -2178,13 +1474,7 @@ CommandAttributesEnabled:
   category: html
   humanReadableName: "HTML command & commandfor attributes"
   humanReadableDescription: "Enable HTML command & commandfor attribute support"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 # FIXME: WebKit has an alternate name for this called 'ShowDebugBorders'. We should standardize on one name.
 CompositingBordersVisible:
@@ -2196,13 +1486,7 @@ CompositingBordersVisible:
   webcoreName: showDebugBorders
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
   inspectorOverride: true
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 # FIXME: WebKit has an alternate name for this called 'ShowRepaintCounter'. We should standardize on one name.
 CompositingRepaintCountersVisible:
@@ -2214,13 +1498,7 @@ CompositingRepaintCountersVisible:
   webcoreName: showRepaintCounter
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
   inspectorOverride: true
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CompressionDictionaryEnabled:
   type: bool
@@ -2228,13 +1506,7 @@ CompressionDictionaryEnabled:
   category: networking
   humanReadableName: "Compression Dictionary Transport"
   humanReadableDescription: "Enable compression dictionary transport"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 CompressionStreamEnabled:
@@ -2244,12 +1516,8 @@ CompressionStreamEnabled:
   humanReadableName: "Compression Stream API"
   humanReadableDescription: "Enable Compression Stream API"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 ConsistentQueryParameterFilteringInternalQuirkEnabled:
   type: bool
@@ -2257,13 +1525,7 @@ ConsistentQueryParameterFilteringInternalQuirkEnabled:
   category: dom
   humanReadableName: "Consistent Query Parameter Filtering Internal"
   humanReadableDescription: "Enable internal consistent query parameter filtering"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ConsistentQueryParameterFilteringQuirkEnabled:
   type: bool
@@ -2271,13 +1533,7 @@ ConsistentQueryParameterFilteringQuirkEnabled:
   category: dom
   humanReadableName: "Consistent Query Parameter Filtering"
   humanReadableDescription: "Enable consistent query parameter filtering"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 ContactPickerAPIEnabled:
   type: bool
@@ -2285,13 +1541,7 @@ ContactPickerAPIEnabled:
   category: dom
   humanReadableName: "Contact Picker API"
   humanReadableDescription: "Enable the Contact Picker API"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
@@ -2300,12 +1550,9 @@ ContentChangeObserverEnabled:
   status: embedder
   condition: ENABLE(CONTENT_CHANGE_OBSERVER)
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: defaultContentChangeObserverEnabled()
-    WebCore:
-      default: false
+    default: defaultContentChangeObserverEnabled()
+    WebKitLegacy: true
+    WebCore: false
 
 ContentDispositionAttachmentSandboxEnabled:
   comment: 'Some ports (e.g. iOS) might choose to display attachments inline, regardless
@@ -2316,13 +1563,10 @@ ContentDispositionAttachmentSandboxEnabled:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      PLATFORM(COCOA): true
-      default: false
-    WebCore:
-      default: false
+    PLATFORM(COCOA): true
+    default: false
+    WebKitLegacy: true
+    WebCore: false
 
 ContentInsetBackgroundFillEnabled:
   type: bool
@@ -2330,24 +1574,14 @@ ContentInsetBackgroundFillEnabled:
   humanReadableName: "Content Inset Background Fill"
   humanReadableDescription: "Fill content insets with background colors"
   defaultValue:
-    WebKit:
-      default: WebKit::defaultContentInsetBackgroundFillEnabled()
-    WebKitLegacy:
-      default: false
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultContentInsetBackgroundFillEnabled()
 
 ContextMenuQRCodeDetectionEnabled:
   type: bool
   status: embedder
   condition: ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 # FIXME: This is handled via WebView SPI rather than WebPreferences for WebKitLegacy. We should change the SPI to lookup the WebPreferences value instead.
 CookieEnabled:
@@ -2355,13 +1589,7 @@ CookieEnabled:
   status: embedder
   humanReadableName: "Cookies Enabled"
   webKitLegacyBinding: custom
-  defaultValue:
-    WebKit:
-      default: true
-    WebKitLegacy:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 CookieStoreAPIEnabled:
   type: bool
@@ -2370,12 +1598,9 @@ CookieStoreAPIEnabled:
   humanReadableName: "Cookie Store API"
   humanReadableDescription: "Enable Cookie Store API"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: defaultCookieStoreAPIEnabled()
-    WebCore:
-      default: true
+    default: defaultCookieStoreAPIEnabled()
+    WebKitLegacy: false
+    WebCore: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
@@ -2385,13 +1610,7 @@ CookieStoreManagerEnabled:
   status: testable
   humanReadableName: "Cookie Store API CookieStoreManager"
   humanReadableDescription: "Enable Cookie Store API CookieStoreManager which controls cookie change subscriptions for Service Workers"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
@@ -2401,13 +1620,7 @@ CoreMathMLDeprecateLegacyMathvariant:
   category: dom
   humanReadableName: "Deprecate legacy mathvariant"
   humanReadableDescription: "Align the mathvariant attribute with MathML Core, disabling all variants except italic."
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 CoreMathMLEnabled:
   type: bool
@@ -2417,12 +1630,9 @@ CoreMathMLEnabled:
   humanReadableName: "MathML Core"
   humanReadableDescription: "Disable features removed from the MathML Core spec."
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
       default: false
 
 CrossOriginEmbedderPolicyEnabled:
@@ -2432,12 +1642,8 @@ CrossOriginEmbedderPolicyEnabled:
   humanReadableName: "Cross-Origin-Embedder-Policy (COEP) header"
   humanReadableDescription: "Support for Cross-Origin-Embedder-Policy (COEP) header"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 CrossOriginOpenerPolicyEnabled:
   type: bool
@@ -2446,12 +1652,8 @@ CrossOriginOpenerPolicyEnabled:
   humanReadableName: "Cross-Origin-Opener-Policy (COOP) header"
   humanReadableDescription: "Support for Cross-Origin-Opener-Policy (COOP) header"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 CursiveFontFamily:
   type: String
@@ -2459,15 +1661,13 @@ CursiveFontFamily:
   webKitLegacyPreferenceKey: WebKitCursiveFont
   webcoreImplementation: custom
   defaultValue:
+    "PLATFORM(COCOA) && PLATFORM(IOS_FAMILY)": '"Snell Roundhand"_str'
+    "PLATFORM(COCOA) && !PLATFORM(IOS_FAMILY)": '"Apple Chancery"_str'
+    default: '"Comic Sans MS"_str'
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": '"Snell Roundhand"_str'
       default: '"Apple Chancery"_str'
-    WebKit:
-      "PLATFORM(COCOA) && PLATFORM(IOS_FAMILY)": '"Snell Roundhand"_str'
-      "PLATFORM(COCOA) && !PLATFORM(IOS_FAMILY)": '"Apple Chancery"_str'
-      default: '"Comic Sans MS"_str'
-    WebCore:
-      default: '""_str'
+    WebCore: '""_str'
 
 CustomPasteboardDataEnabled:
   type: bool
@@ -2475,12 +1675,11 @@ CustomPasteboardDataEnabled:
   humanReadableName: "Custom pasteboard data"
   humanReadableDescription: "Enable custom clipboard types and better security model for clipboard API."
   webcoreBinding: DeprecatedGlobalSettings
+  excludeFrom: [ WebCore ]
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)": true
-      default: false
+    "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)": true
+    default: false
+    WebKitLegacy: false
 
 DOMAudioSessionEnabled:
   type: bool
@@ -2490,12 +1689,8 @@ DOMAudioSessionEnabled:
   humanReadableDescription: "Enable AudioSession API"
   condition: ENABLE(DOM_AUDIO_SESSION)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 DOMAudioSessionFullEnabled:
   type: bool
@@ -2504,13 +1699,7 @@ DOMAudioSessionFullEnabled:
   humanReadableName: "AudioSession full API"
   humanReadableDescription: "Enable AudioSession full API"
   condition: ENABLE(DOM_AUDIO_SESSION)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 DOMPasteAccessRequestsEnabled:
   type: bool
@@ -2519,25 +1708,16 @@ DOMPasteAccessRequestsEnabled:
   humanReadableName: "DOM Paste Access Requests"
   humanReadableDescription: "Enable DOM Paste Access Requests"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(IOS) || PLATFORM(MAC) || PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN) || PLATFORM(VISION)": true
-      default: false
-    WebCore:
       default: false
 
 DOMPasteAllowed:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: WebKitDOMPasteAllowedPreferenceKey
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 DOMTestingAPIsEnabled:
   type: bool
@@ -2545,26 +1725,14 @@ DOMTestingAPIsEnabled:
   category: dom
   humanReadableName: "Additional Testing APIs for DOM Objects"
   humanReadableDescription: "Enable additional testing APIs for DOM objects"
-  defaultValue:
-    WebCore:
-      default: false
-    WebKit:
-      default: false
-    WebKitLegacy:
-      default: false
+  defaultValue: false
 
 DOMTimersThrottlingEnabled:
   type: bool
   status: embedder
   humanReadableName: "DOM timer throttling enabled"
   webKitLegacyPreferenceKey: WebKitDOMTimersThrottlingEnabledPreferenceKey
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 DamageRectangleThreshold:
   type: uint32_t
@@ -2573,26 +1741,14 @@ DamageRectangleThreshold:
   humanReadableName: "Damage Rectangle Threshold"
   humanReadableDescription: "Maximum number of damage rectangles to track before damaged regions are unified into their bounding box"
   condition: ENABLE(DAMAGE_TRACKING)
-  defaultValue:
-    WebKitLegacy:
-      default: 4
-    WebKit:
-      default: 4
-    WebCore:
-      default: 4
+  defaultValue: 4
 
 DataDetectorTypes:
   type: uint32_t
   refinedType: WebCore::DataDetectorType
   status: embedder
   condition: ENABLE(DATA_DETECTION)
-  defaultValue:
-    WebKitLegacy:
-      default: static_cast<DataDetectorType>(0)
-    WebKit:
-      default: static_cast<DataDetectorType>(0)
-    WebCore:
-      default: static_cast<DataDetectorType>(0)
+  defaultValue: static_cast<DataDetectorType>(0)
 
 # FIXME: This is on by default in WebKit2 (for everything but WatchOS). Perhaps we should consider turning it on for WebKitLegacy as well.
 DataListElementEnabled:
@@ -2601,14 +1757,9 @@ DataListElementEnabled:
   humanReadableName: "DataList Element"
   humanReadableDescription: "Enable datalist elements"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "(PLATFORM(COCOA) && !PLATFORM(WATCHOS)) || PLATFORM(GTK)": true
-      default: false
-    WebCore:
-      "(PLATFORM(COCOA) && !PLATFORM(WATCHOS)) || PLATFORM(GTK)": true
-      default: false
+    "(PLATFORM(COCOA) && !PLATFORM(WATCHOS)) || PLATFORM(GTK)": true
+    default: false
+    WebKitLegacy: false
   sharedPreferenceForWebProcess: true
 
 DataTransferItemsEnabled:
@@ -2617,24 +1768,18 @@ DataTransferItemsEnabled:
   humanReadableName: "Data Transfer Items"
   humanReadableDescription: "Enables DataTransferItem in the clipboard API"
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)": true
-      default: false
-    WebCore:
-      default: false
+    "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)": true
+    default: false
+    WebKitLegacy: true
+    WebCore: false
 
 DatabasesEnabled:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: WebKitDatabasesEnabledPreferenceKey
   webcoreBinding: custom
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
+  excludeFrom: [ WebCore ]
+  defaultValue: true
 
 # FIXME: This is on by default in WebKit2 (for macOS at least). Perhaps we should consider turning it on for WebKitLegacy as well.
 DateTimeInputsEditableComponentsEnabled:
@@ -2643,12 +1788,9 @@ DateTimeInputsEditableComponentsEnabled:
   humanReadableName: "Date/Time inputs have editable components"
   humanReadableDescription: "Enable multiple editable components in date/time inputs"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(MAC) || PLATFORM(GTK)": true
-      default: false
-    WebCore:
       default: false
 
 DeclarativeWebPush:
@@ -2660,47 +1802,28 @@ DeclarativeWebPush:
   humanReadableName: "Declarative Web Push"
   humanReadableDescription: "Enable Declarative Web Push"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 DefaultFixedFontSize:
   type: double
   status: embedder
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
-  defaultValue:
-    WebKitLegacy:
-      default: 13
-    WebKit:
-      default: 13
-    WebCore:
-      default: 13
+  defaultValue: 13
 
 DefaultFontSize:
   type: double
   status: embedder
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
-  defaultValue:
-    WebKitLegacy:
-      default: 16
-    WebKit:
-      default: 16
-    WebCore:
-      default: 16
+  defaultValue: 16
 
 DefaultTextEncodingName:
   type: String
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: '"ISO-8859-1"_str'
-    WebKit:
-      default: PAL::defaultTextEncodingNameForSystemLanguage()
-    WebCore:
-      default: '{ }'
+    default: PAL::defaultTextEncodingNameForSystemLanguage()
+    WebKitLegacy: '"ISO-8859-1"_str'
+    WebCore: '{ }'
 
 DeprecationReportingEnabled:
   type: bool
@@ -2708,13 +1831,7 @@ DeprecationReportingEnabled:
   category: dom
   humanReadableName: "Deprecation Reporting"
   humanReadableDescription: "Enable Deprecation Reporting"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 DetachableMediaSourceEnabled:
   type: bool
@@ -2723,13 +1840,7 @@ DetachableMediaSourceEnabled:
   humanReadableName: "Detachable Media Source"
   humanReadableDescription: "Detachable Media Source API"
   condition: ENABLE(MEDIA_SOURCE)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 DetailsAutoExpandEnabled:
   type: bool
@@ -2737,13 +1848,7 @@ DetailsAutoExpandEnabled:
   category: html
   humanReadableName: "HTML auto-expanding <details>"
   humanReadableDescription: "Enable HTML auto-expanding <details>"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 DeveloperExtrasEnabled:
   type: bool
@@ -2751,36 +1856,18 @@ DeveloperExtrasEnabled:
   defaultsOverridable: true
   webKitLegacyPreferenceKey: WebKitDeveloperExtrasEnabledPreferenceKey
   webKitLegacyBinding: custom
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 DeviceHeight:
   type: uint32_t
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: 0
-    WebKit:
-      default: 0
-    WebCore:
-      default: 0
+  defaultValue: 0
 
 DeviceOrientationEventEnabled:
   type: bool
   status: embedder
   condition: ENABLE(DEVICE_ORIENTATION)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
@@ -2790,37 +1877,21 @@ DeviceOrientationPermissionAPIEnabled:
   status: embedder
   condition: ENABLE(DEVICE_ORIENTATION)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: defaultDeviceOrientationPermissionAPIEnabled()
-    WebCore:
-      default: false
+    default: false
+    WebKit: defaultDeviceOrientationPermissionAPIEnabled()
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
 DeviceWidth:
   type: uint32_t
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: 0
-    WebKit:
-      default: 0
-    WebCore:
-      default: 0
+  defaultValue: 0
 
 DiagnosticLoggingEnabled:
   type: bool
   status: embedder
   humanReadableName: "Diagnostic logging enabled"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 DigitalCredentialsEnabled:
   type: bool
@@ -2830,12 +1901,8 @@ DigitalCredentialsEnabled:
   humanReadableDescription: "Enable the Digital Credentials API"
   condition: ENABLE(WEB_AUTHN)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultDigitalCredentialsEnabled()
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultDigitalCredentialsEnabled()
   sharedPreferenceForWebProcess: true
   disableInLockdownMode: true
   richJavaScript: true
@@ -2847,13 +1914,7 @@ DigitalCredentialsOpenID4VPEnabled:
   humanReadableName: "OpenID4VP for Digital Credentials API"
   humanReadableDescription: "Enable the OpenID4VP presentation protocols for the Digital Credentials API"
   condition: ENABLE(WEB_AUTHN)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   disableInLockdownMode: true
 
 DirectoryUploadEnabled:
@@ -2862,12 +1923,9 @@ DirectoryUploadEnabled:
   humanReadableName: "Directory Upload"
   humanReadableDescription: "input.webkitdirectory / dataTransferItem.webkitGetAsEntry()"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
       default: false
 
 # FIXME: Starting the preference name with "Disable" is inconsistent with most other preferences and should be changed.
@@ -2878,24 +1936,15 @@ DisableScreenSizeOverride:
   humanReadableName: "Disable screen size override"
   webcoreBinding: DeprecatedGlobalSettings
   condition: PLATFORM(IOS_FAMILY)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 DisabledAdaptationsMetaTagEnabled:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(WATCHOS)": true
-      default: false
-    WebCore:
       default: false
 
 # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
@@ -2903,12 +1952,8 @@ DownloadAttributeEnabled:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 DynamicSiteInterventionsEnabled:
   type: bool
@@ -2916,38 +1961,23 @@ DynamicSiteInterventionsEnabled:
   category: none
   humanReadableName: "Dynamic Site Interventions"
   humanReadableDescription: "Enable dynamic site interventions for broken websites"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 EditableLinkBehavior:
   type: uint32_t
   refinedType: WebCore::EditableLinkBehavior
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: WebKitEditableLinkDefaultBehavior
-    WebKit:
-      default: WebCore::EditableLinkBehavior::NeverLive
-    WebCore:
-      default: EditableLinkBehavior::Default
+    default: WebCore::EditableLinkBehavior::NeverLive
+    WebKitLegacy: WebKitEditableLinkDefaultBehavior
+    WebCore: EditableLinkBehavior::Default
 
 EmbedElementEnabled:
   type: bool
   status: mature
   humanReadableName: "Embed Element"
   humanReadableDescription: "Embed Element"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   disableInLockdownMode: true
 
 EnableAccessibilityOnDemand:
@@ -2959,10 +1989,10 @@ EnableAccessibilityOnDemand:
   webcoreBinding: none
   condition: PLATFORM(MAC)
   exposed: [ WebKit ]
+  excludeFrom: [ WebKitLegacy, WebCore ]
   defaultValue:
-    WebKit:
-      "ENABLE(INITIALIZE_ACCESSIBILITY_ON_DEMAND)": true
-      default: false
+    "ENABLE(INITIALIZE_ACCESSIBILITY_ON_DEMAND)": true
+    default: false
 
 EnableDebuggingFeaturesInSandbox:
   type: bool
@@ -2974,9 +2004,8 @@ EnableDebuggingFeaturesInSandbox:
   defaultsOverridable: true
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 EnableElementCurrentCSSZoom:
   type: bool
@@ -2985,26 +2014,13 @@ EnableElementCurrentCSSZoom:
   humanReadableName: "Enable Element.currentCSSZoom"
   humanReadableDescription: "Enable Element.currentCSSZoom"
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebKit:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)": true
-      default: false
+    "PLATFORM(COCOA)": true
+    default: false
 
 EnableInheritURIQueryComponent:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 EnableOpaqueLoadingForMedia:
   type: bool
@@ -3013,25 +2029,18 @@ EnableOpaqueLoadingForMedia:
   humanReadableName: "Opaque loading for media"
   humanReadableDescription: "Enable opaque loading for media"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 EncryptedMediaAPIEnabled:
   type: bool
   status: embedder
   condition: ENABLE(ENCRYPTED_MEDIA)
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(GTK) || PLATFORM(WPE)": false
       default: true
-    WebCore:
-      default: false
   sharedPreferenceForWebProcess: true
   mediaPlaybackRelated: true
 
@@ -3042,13 +2051,7 @@ EnhancedSecurityForceDisabled:
   defaultsOverridable: true
   humanReadableName: "Force disable Enhanced Security"
   humanReadableDescription: "Disables Enhanced Security for all navigations"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 EnhancedSecurityHeuristicsEnabled:
   type: bool
@@ -3058,15 +2061,8 @@ EnhancedSecurityHeuristicsEnabled:
   humanReadableName: "Enable EnhancedSecurity Heuristics"
   humanReadableDescription: "Triggers EnhancedSecurity when insecure HTTP loads occur"
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebKit:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)": true
-      default: false
+    "PLATFORM(COCOA)": true
+    default: false
 
 EnhancedSecurityLinksEnabled:
   type: bool
@@ -3077,15 +2073,8 @@ EnhancedSecurityLinksEnabled:
   humanReadableName: "Enhanced Security for links"
   humanReadableDescription: "Enables additional Enhanced Security support for certain links"
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebKit:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)": true
-      default: false
+    "PLATFORM(COCOA)": true
+    default: false
 
 EnterKeyHintEnabled:
   type: bool
@@ -3094,12 +2083,9 @@ EnterKeyHintEnabled:
   humanReadableName: "Enter Key Hint"
   humanReadableDescription: "Enable the enterKeyHint HTML attribute"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
       default: false
 
 EnumeratedARIAAttributeReflectionEnabled:
@@ -3108,13 +2094,7 @@ EnumeratedARIAAttributeReflectionEnabled:
   category: javascript
   humanReadableName: "Enumerated ARIA Attribute Reflection"
   humanReadableDescription: "Enable enumerated ARIA attributes"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 EnumeratingAllNetworkInterfacesEnabled:
   type: bool
@@ -3122,9 +2102,8 @@ EnumeratingAllNetworkInterfacesEnabled:
   humanReadableName: "Enable Enumerating All Network Interfaces"
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 EnumeratingVisibleNetworkInterfacesEnabled:
   type: bool
@@ -3132,9 +2111,8 @@ EnumeratingVisibleNetworkInterfacesEnabled:
   humanReadableName: "Enable Enumerating Visible Network Interfaces"
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 EventHandlerDrivenSmoothKeyboardScrollingEnabled:
   type: bool
@@ -3143,12 +2121,9 @@ EventHandlerDrivenSmoothKeyboardScrollingEnabled:
   humanReadableName: "EventHandler driven smooth keyboard scrolling"
   humanReadableDescription: "Enable EventHandler driven smooth keyboard scrolling"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(MAC)": WebKit::defaultScrollAnimatorEnabled()
-      default: false
-    WebCore:
       default: false
 
 EventTimingEnabled:
@@ -3158,12 +2133,8 @@ EventTimingEnabled:
   humanReadableName: "Event Timing API"
   humanReadableDescription: "Enable the Event Timing API and supporting instrumentation"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 ExperimentalSandboxEnabled:
   type: bool
@@ -3174,9 +2145,8 @@ ExperimentalSandboxEnabled:
   condition: HAVE(MACH_BOOTSTRAP_EXTENSION) || HAVE(SANDBOX_STATE_FLAGS)
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 ExplicitResourceManagementEnabled:
   type: bool
@@ -3187,9 +2157,8 @@ ExplicitResourceManagementEnabled:
   webcoreBinding: none
   jscOptionName: useExplicitResourceManagement
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 ExposeCaptureDevicesAfterCaptureEnabled:
   type: bool
@@ -3198,11 +2167,10 @@ ExposeCaptureDevicesAfterCaptureEnabled:
   humanReadableName: "Expose all capture devices when one is used"
   humanReadableDescription: "Expose all capture devices when one is used"
   condition: ENABLE(MEDIA_STREAM)
+  excludeFrom: [ WebKitLegacy ]
   defaultValue:
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: true
+    WebCore: false
 
 ExposeDefaultSpeakerAsSpecificDeviceEnabled:
   type: bool
@@ -3211,11 +2179,8 @@ ExposeDefaultSpeakerAsSpecificDeviceEnabled:
   humanReadableName: "Expose the system default speaker as a specific device"
   humanReadableDescription: "Expose the system default speaker as a specific device"
   condition: ENABLE(MEDIA_STREAM)
-  defaultValue:
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  excludeFrom: [ WebKitLegacy ]
+  defaultValue: true
 
 ExposeRollAngleAsTwistEnabled:
   type: bool
@@ -3224,13 +2189,7 @@ ExposeRollAngleAsTwistEnabled:
   humanReadableName: "Expose Apple Pencil rotation for twist PointerEvent Property"
   humanReadableDescription: "Expose Apple Pencil rotation for the `twist` PointerEvent Property"
   condition: HAVE(UITOUCH_ROLLANGLE)
-  defaultValue:
-    WebKitLegacy:
-     default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ExposeSpeakersEnabled:
   type: bool
@@ -3239,12 +2198,11 @@ ExposeSpeakersEnabled:
   humanReadableName: "Allow speaker device selection"
   humanReadableDescription: "Allow speaker device selection"
   condition: ENABLE(MEDIA_STREAM)
+  excludeFrom: [ WebKitLegacy ]
   defaultValue:
-    WebKit:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
-      default: false
+    "PLATFORM(COCOA)": true
+    default: false
+    WebCore: false
 
 ExposeSpeakersWithoutMicrophoneEnabled:
   type: bool
@@ -3253,12 +2211,11 @@ ExposeSpeakersWithoutMicrophoneEnabled:
   humanReadableName: "Allow selection of speaker device without related microphone"
   humanReadableDescription: "Allow selection of speaker device without related microphone"
   condition: ENABLE(MEDIA_STREAM)
+  excludeFrom: [ WebKitLegacy ]
   defaultValue:
-    WebKit:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
-      default: false
+    "PLATFORM(COCOA)": true
+    default: false
+    WebCore: false
 
 ExtendedAudioDescriptionsEnabled:
   type: bool
@@ -3267,11 +2224,8 @@ ExtendedAudioDescriptionsEnabled:
   condition: ENABLE(VIDEO)
   humanReadableName: "Audio descriptions for video - Extended"
   humanReadableDescription: "Enable extended audio descriptions for video"
-  defaultValue:
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  excludeFrom: [ WebKitLegacy ]
+  defaultValue: true
 
 ExtendedProofreadingEnabled:
   type: bool
@@ -3280,12 +2234,8 @@ ExtendedProofreadingEnabled:
   humanReadableDescription: "Enable Extended Proofreading"
   condition: PLATFORM(COCOA)
   defaultValue:
-    WebCore:
-      default: false
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultExtendedProofreadingEnabled()
+    default: false
+    WebKit: WebKit::defaultExtendedProofreadingEnabled()
   sharedPreferenceForWebProcess: true
 
 ExtensibleSSOEnabled:
@@ -3295,9 +2245,8 @@ ExtensibleSSOEnabled:
   webcoreBinding: none
   condition: HAVE(APP_SSO)
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 FTPEnabled:
   type: bool
@@ -3305,13 +2254,7 @@ FTPEnabled:
   category: networking
   humanReadableName: "FTP support enabled"
   humanReadableDescription: "FTP support enabled"
-  defaultValue:
-    WebCore:
-      default: false
-    WebKit:
-      default: false
-    WebKitLegacy:
-      default: false
+  defaultValue: false
 
 FacebookLiveRecordingQuirkEnabled:
   type: bool
@@ -3319,12 +2262,8 @@ FacebookLiveRecordingQuirkEnabled:
   humanReadableName: "Facebook Live Recording Quirk"
   humanReadableDescription: "Enable Facebook Live Recording Quirk"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultFacebookLiveRecordingQuirkEnabled()
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultFacebookLiveRecordingQuirkEnabled()
 
 FantasyFontFamily:
   type: String
@@ -3332,13 +2271,10 @@ FantasyFontFamily:
   webKitLegacyPreferenceKey: WebKitFantasyFont
   webcoreImplementation: custom
   defaultValue:
-    WebKitLegacy:
-      default: '"Papyrus"_str'
-    WebKit:
-      "PLATFORM(COCOA)": '"Papyrus"_str'
-      default: '"Impact"_str'
-    WebCore:
-      default: '""_str'
+    "PLATFORM(COCOA)": '"Papyrus"_str'
+    default: '"Impact"_str'
+    WebKitLegacy: '"Papyrus"_str'
+    WebCore: '""_str'
 
 FasterClicksEnabled:
   type: bool
@@ -3349,9 +2285,8 @@ FasterClicksEnabled:
   webcoreBinding: none
   condition: PLATFORM(IOS_FAMILY)
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 FetchUploadStreamsEnabled:
   type: bool
@@ -3361,25 +2296,15 @@ FetchUploadStreamsEnabled:
   humanReadableDescription: "Enable ReadableStream request bodies for fetch(). HTTP/2 (or later) required."
   exposed: [ WebKit ]
   defaultValue:
-    WebCore:
-      default: true
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 FileReaderAPIEnabled:
   type: bool
   status: embedder
   humanReadableName: "FileReader API"
   humanReadableDescription: "FileReader API"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   disableInLockdownMode: true
 
 FileSystemEnabled:
@@ -3389,16 +2314,10 @@ FileSystemEnabled:
   humanReadableName: "File System API"
   humanReadableDescription: "Enable File System API"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(COCOA)" : true
-      "PLATFORM(GTK) || PLATFORM(WPE)" : true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)" : true
-      "PLATFORM(GTK) || PLATFORM(WPE)" : true
-      default: false
+    "PLATFORM(COCOA)" : true
+    "PLATFORM(GTK) || PLATFORM(WPE)" : true
+    default: false
+    WebKitLegacy: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
 
@@ -3409,14 +2328,9 @@ FileSystemHandleSerializationEnabled:
   humanReadableName: "File System Handle Serialization"
   humanReadableDescription: "Enable FileSystemHandle for postMessage() and structuredClone()"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(COCOA)" : true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)" : true
-      default: false
+    "PLATFORM(COCOA)" : true
+    default: false
+    WebKitLegacy: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
 
@@ -3427,16 +2341,10 @@ FileSystemWritableStreamEnabled:
   humanReadableName: "File System WritableStream"
   humanReadableDescription: "Enable File System WritableStream API"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(COCOA)" : true
-      "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)" : true
-      "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
+    "PLATFORM(COCOA)" : true
+    "PLATFORM(GTK) || PLATFORM(WPE)": true
+    default: false
+    WebKitLegacy: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
 
@@ -3446,13 +2354,7 @@ FilterLinkDecorationByDefaultEnabled:
   category: networking
   humanReadableName: "Filter Link Decoration"
   humanReadableDescription: "Enable Filtering Link Decoration"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 FindInVideoEnabled:
   type: bool
@@ -3461,13 +2363,7 @@ FindInVideoEnabled:
   humanReadableName: "Find in Video"
   humanReadableDescription: "Include video subtitle/caption cues in Find-in-Page results"
   condition: ENABLE(VIDEO)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 FixedFontFamily:
   type: String
@@ -3475,13 +2371,10 @@ FixedFontFamily:
   webKitLegacyPreferenceKey: WebKitFixedFont
   webcoreImplementation: custom
   defaultValue:
-    WebKitLegacy:
-      default: '"Courier"_str'
-    WebKit:
-      "PLATFORM(COCOA)": '"Courier"_str'
-      default: '"Courier New"_str'
-    WebCore:
-      default: '""_str'
+    "PLATFORM(COCOA)": '"Courier"_str'
+    default: '"Courier New"_str'
+    WebKitLegacy: '"Courier"_str'
+    WebCore: '""_str'
 
 FontFaceSetConstructorEnabled:
   type: bool
@@ -3490,12 +2383,8 @@ FontFaceSetConstructorEnabled:
   humanReadableName: "Legacy FontFaceSet Constructor API"
   humanReadableDescription: "Legacy FontFaceSet Constructor API"
   defaultValue:
-    WebKitLegacy:
-      default: WebKit::defaultFontFaceSetConstructorEnabled()
-    WebKit:
-      default: WebKit::defaultFontFaceSetConstructorEnabled()
-    WebCore:
-      default: false
+    default: WebKit::defaultFontFaceSetConstructorEnabled()
+    WebCore: false
 
 ForceAlwaysUserScalable:
   type: bool
@@ -3505,18 +2394,16 @@ ForceAlwaysUserScalable:
   webcoreBinding: none
   condition: PLATFORM(IOS_FAMILY)
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 ForceCompositingMode:
   type: bool
   status: embedder
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 ForceEnhancedSecurity:
   type: bool
@@ -3526,13 +2413,7 @@ ForceEnhancedSecurity:
   humanReadableDescription: "Force all navigations to use Enhanced Security"
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ForceLockdownFontParserEnabled:
   type: bool
@@ -3541,25 +2422,15 @@ ForceLockdownFontParserEnabled:
   humanReadableDescription: "Forcing the Lockdown Mode Safe Font Parser independently from Lockdown Mode state"
   exposed: [ WebKit ]
   category: security
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 ForceWebGLUsesLowPower:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+    default: false
+    WebKitLegacy: true
 
 FormControlRefreshEnabled:
   type: bool
@@ -3568,12 +2439,8 @@ FormControlRefreshEnabled:
   humanReadableDescription: "Enable form control refresh for Cocoa platforms"
   condition: ENABLE(FORM_CONTROL_REFRESH)
   defaultValue:
-    WebKit:
-      default: true
-    WebKitLegacy:
-      default: true
-    WebCore:
-      default: false
+    default: true
+    WebCore: false
 
 FullScreenEnabled:
   type: bool
@@ -3584,14 +2451,9 @@ FullScreenEnabled:
   hidden: EXPERIMENTAL_FULLSCREEN_API_HIDDEN
   inspectorOverride: true
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
-      "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
+    "PLATFORM(GTK) || PLATFORM(WPE)": true
+    default: false
+    WebKitLegacy: false
   sharedPreferenceForWebProcess: true
 
 FullScreenKeyboardLock:
@@ -3601,26 +2463,14 @@ FullScreenKeyboardLock:
   humanReadableName: "Fullscreen API based Keyboard Lock"
   humanReadableDescription: "Fullscreen API based Keyboard Lock"
   condition: ENABLE(FULLSCREEN_API)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 FullscreenRequirementForScreenOrientationLockingEnabled:
   type: bool
   status: embedder
   humanReadableName: "Require being in Fullscreen to lock screen orientation"
   humanReadableDescription: "Require being in Fullscreen to lock screen orientation"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 FullscreenSceneAspectRatioLockingEnabled:
   type: bool
@@ -3628,13 +2478,7 @@ FullscreenSceneAspectRatioLockingEnabled:
   humanReadableName: "Fullscreen scene aspect ratio locking"
   humanReadableDescription: "Enable scene aspect ratio locking in Fullscreen"
   condition: PLATFORM(VISION)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 FullscreenSceneDimmingEnabled:
   type: bool
@@ -3642,13 +2486,7 @@ FullscreenSceneDimmingEnabled:
   humanReadableName: "Fullscreen scene dimming"
   humanReadableDescription: "Enable scene dimming in Fullscreen"
   condition: PLATFORM(VISION)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 GStreamerEnabled:
   type: bool
@@ -3657,9 +2495,8 @@ GStreamerEnabled:
   webcoreBinding: DeprecatedGlobalSettings
   condition: USE(GSTREAMER)
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 GamepadTriggerRumbleEnabled:
   type: bool
@@ -3668,13 +2505,7 @@ GamepadTriggerRumbleEnabled:
   humanReadableName: "Gamepad trigger vibration support"
   humanReadableDescription: "Support for Gamepad trigger vibration"
   condition: ENABLE(GAMEPAD)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 GamepadVibrationActuatorEnabled:
   type: bool
@@ -3684,12 +2515,8 @@ GamepadVibrationActuatorEnabled:
   humanReadableDescription: "Support for Gamepad.vibrationActuator"
   condition: ENABLE(GAMEPAD)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: defaultGamepadVibrationActuatorEnabled()
-    WebCore:
-      default: false
+    default: false
+    WebKit: defaultGamepadVibrationActuatorEnabled()
 
 GamepadsEnabled:
   type: bool
@@ -3698,12 +2525,8 @@ GamepadsEnabled:
   humanReadableDescription: "Web Gamepad API support"
   condition: ENABLE(GAMEPAD)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -3716,25 +2539,15 @@ GenericCueAPIEnabled:
   humanReadableName: "Generic Text Track Cue API"
   humanReadableDescription: "Enable Generic Text Track Cue API"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 GeolocationAPIEnabled:
   type: bool
   status: embedder
   humanReadableName: "Geolocation API"
   humanReadableDescription: "Enable Geolocation API"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
@@ -3745,13 +2558,10 @@ GetBoundingClientRectZoomedEnabled:
   humanReadableName: "Get(Bounding)ClientRect API zoomed"
   humanReadableDescription: "Get(Bounding)ClientRect API return a zoomed rect"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(IOS_FAMILY)": WebKit::defaultGetBoundingClientRectZoomedEnabled()
-      default: true
-    WebCore:
-      default: true
+    "PLATFORM(IOS_FAMILY)": WebKit::defaultGetBoundingClientRectZoomedEnabled()
+    default: true
+    WebKitLegacy: false
+    WebCore: true
 
 GetUserMediaRequiresFocus:
   type: bool
@@ -3760,51 +2570,32 @@ GetUserMediaRequiresFocus:
   humanReadableName: "Require focus to start getUserMedia"
   humanReadableDescription: "Require focus to start getUserMedia"
   condition: ENABLE(MEDIA_STREAM)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 GlobalPrivacyControlEnabled:
   type: "std::optional<bool>"
   status: embedder
   humanReadableName: "Global Privacy Control"
   humanReadableDescription: "Enable Global Privacy Control (GPC) signal"
-  defaultValue:
-    WebCore:
-      default: std::nullopt
+  excludeFrom: [ WebKitLegacy, WebKit ]
+  defaultValue: std::nullopt
 
 GoogleAntiFlickerOptimizationQuirkEnabled:
   type: bool
   status: mature
   humanReadableName: "Quirk to prevent delayed initial painting on sites using Google's Anti-Flicker optimization"
   humanReadableDescription: "Quirk to prevent delayed initial painting on sites using Google's Anti-Flicker optimization"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 GraphicsContextFiltersEnabled:
-   type: bool
-   status: stable
-   category: media
-   webcoreOnChange: setNeedsRelayoutAllFrames
-   humanReadableName: "GraphicsContext Filter Rendering"
-   humanReadableDescription: "GraphicsContext Filter Rendering"
-   condition: USE(GRAPHICS_CONTEXT_FILTERS)
-   defaultValue:
-     WebKitLegacy:
-       default: true
-     WebKit:
-       default: true
-     WebCore:
-       default: true
+  type: bool
+  status: stable
+  category: media
+  webcoreOnChange: setNeedsRelayoutAllFrames
+  humanReadableName: "GraphicsContext Filter Rendering"
+  humanReadableDescription: "GraphicsContext Filter Rendering"
+  condition: USE(GRAPHICS_CONTEXT_FILTERS)
+  defaultValue: true
 
 GridFormattingContextIntegrationEnabled:
   type: bool
@@ -3812,13 +2603,7 @@ GridFormattingContextIntegrationEnabled:
   category: dom
   humanReadableName: "Next-generation grid layout integration (GFC)"
   humanReadableDescription: "Enable next-generation grid layout integration (GFC)"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 GridLanesEnabled:
   type: bool
@@ -3826,13 +2611,7 @@ GridLanesEnabled:
   category: css
   humanReadableName: "CSS display: grid-lanes"
   humanReadableDescription: "Enable CSS display: grid-lanes"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 HDRAcceleratedApplyGainMapEnabled:
   type: bool
@@ -3841,41 +2620,23 @@ HDRAcceleratedApplyGainMapEnabled:
   webcoreOnChange: setNeedsRelayoutAllFrames
   humanReadableName: "HDR Accelerated Apply GainMap"
   humanReadableDescription: "Enable HDR Accelerated Apply GainMap"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 HTMLEnhancedSelectEnabled:
-   type: bool
-   status: stable
-   category: dom
-   humanReadableName: "Enhanced HTML select element"
-   humanReadableDescription: "Enable enhanced HTML select element"
-   defaultValue:
-     WebKitLegacy:
-       default: true
-     WebKit:
-       default: true
-     WebCore:
-       default: true
+  type: bool
+  status: stable
+  category: dom
+  humanReadableName: "Enhanced HTML select element"
+  humanReadableDescription: "Enable enhanced HTML select element"
+  defaultValue: true
 
 HTMLEnhancedSelectParsingEnabled:
-   type: bool
-   status: stable
-   category: dom
-   humanReadableName: "Enhanced HTML select element parsing"
-   humanReadableDescription: "Enable enhanced HTML select element parsing"
-   defaultValue:
-     WebKitLegacy:
-       default: true
-     WebKit:
-       default: true
-     WebCore:
-       default: true
+  type: bool
+  status: stable
+  category: dom
+  humanReadableName: "Enhanced HTML select element parsing"
+  humanReadableDescription: "Enable enhanced HTML select element parsing"
+  defaultValue: true
 
 HTMLEnhancedSelectParsingQuirkEnabled:
   type: bool
@@ -3884,12 +2645,9 @@ HTMLEnhancedSelectParsingQuirkEnabled:
   humanReadableName: "Enhanced HTML select element parsing quirk"
   humanReadableDescription: "Enable enhanced HTML select element parsing quirk for specific applications"
   defaultValue:
+    default: false
     WebKitLegacy:
       PLATFORM(MAC): WebKit::defaultHTMLEnhancedSelectParsingQuirkEnabled()
-      default: false
-    WebKit:
-      default: false
-    WebCore:
       default: false
 
 HTMLInCanvasEnabled:
@@ -3899,13 +2657,7 @@ HTMLInCanvasEnabled:
   webcoreOnChange: setNeedsRelayoutAllFrames
   humanReadableName: "HTML-in-Canvas"
   humanReadableDescription: "Enable HTML-in-Canvas"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 HTTPEquivEnabled:
   type: bool
@@ -3913,13 +2665,7 @@ HTTPEquivEnabled:
   humanReadableName: "http-equiv"
   humanReadableDescription: "Enable http-equiv attribute"
   webcoreName: httpEquivEnabled
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 HTTPSByDefaultEnabled:
   type: bool
@@ -3928,13 +2674,7 @@ HTTPSByDefaultEnabled:
   humanReadableName: "HTTPS-by-default (HTTPS-First)"
   humanReadableDescription: "Enable HTTPS-by-default (HTTPS-First)"
   webcoreName: httpsByDefault
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 HardwareAccelerationEnabled:
   type: bool
@@ -3942,13 +2682,7 @@ HardwareAccelerationEnabled:
   humanReadableName: "Hardware acceleration"
   humanReadableDescription: "Enable hardware acceleration"
   condition: PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 HeadingOffsetEnabled:
   type: bool
@@ -3956,39 +2690,24 @@ HeadingOffsetEnabled:
   category: html
   humanReadableName: "HTML headingoffset & headingreset attributes"
   humanReadableDescription: "Enable HTML headingoffset & headingreset attribute support"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 HiddenPageCSSAnimationSuspensionEnabled:
   type: bool
   status: embedder
   webcoreOnChange: hiddenPageCSSAnimationSuspensionEnabledChanged
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      "PLATFORM(COCOA) || PLATFORM(GTK)": true
-      default: false
-    WebCore:
-      default: false
+    "PLATFORM(COCOA) || PLATFORM(GTK)": true
+    default: false
+    WebKitLegacy: true
+    WebCore: false
 
 HiddenPageDOMTimerThrottlingAutoIncreases:
   type: bool
   status: embedder
   humanReadableName: "Hidden page DOM timer throttling auto-increases"
   webcoreOnChange: hiddenPageDOMTimerThrottlingStateChanged
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 HiddenPageDOMTimerThrottlingEnabled:
   type: bool
@@ -3997,41 +2716,26 @@ HiddenPageDOMTimerThrottlingEnabled:
   humanReadableDescription: "Enable hidden page DOM timer throttling"
   webcoreOnChange: hiddenPageDOMTimerThrottlingStateChanged
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(COCOA) || PLATFORM(GTK)": true
       default: false
-    WebCore:
-      default: false
 
 HiddenUntilFoundEnabled:
-   type: bool
-   status: stable
-   category: html
-   humanReadableName: "hidden=until-found"
-   humanReadableDescription: "Enable support for hidden=until-found"
-   defaultValue:
-     WebKitLegacy:
-       default: true
-     WebKit:
-       default: true
-     WebCore:
-       default: true
+  type: bool
+  status: stable
+  category: html
+  humanReadableName: "hidden=until-found"
+  humanReadableDescription: "Enable support for hidden=until-found"
+  defaultValue: true
 
 HighlightsFromPointEnabled:
-   type: bool
-   status: stable
-   category: css
-   humanReadableName: "CSS Custom Highlight API: highlightsFromPoint()"
-   humanReadableDescription: "Enable the CSS Custom Highlight API highlightsFromPoint() method"
-   defaultValue:
-     WebKitLegacy:
-       default: true
-     WebKit:
-       default: true
-     WebCore:
-       default: true
+  type: bool
+  status: stable
+  category: css
+  humanReadableName: "CSS Custom Highlight API: highlightsFromPoint()"
+  humanReadableDescription: "Enable the CSS Custom Highlight API highlightsFromPoint() method"
+  defaultValue: true
 
 HorizontalBannerViewOverlaysEnabled:
   type: bool
@@ -4040,12 +2744,8 @@ HorizontalBannerViewOverlaysEnabled:
   humanReadableName: "Horizontal Banner View Overlays"
   humanReadableDescription: "Horizontal Banner View Overlays"
   defaultValue:
-    WebKit:
-      default: WebKit::defaultHorizontalBannerViewOverlaysEnabled()
-    WebKitLegacy:
-      default: false
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultHorizontalBannerViewOverlaysEnabled()
 
 HostedBlurMaterialInMediaControlsEnabled:
   type: bool
@@ -4054,12 +2754,8 @@ HostedBlurMaterialInMediaControlsEnabled:
   humanReadableDescription: "Enable hosted blur material in media controls"
   condition: HAVE(MATERIAL_HOSTING)
   defaultValue:
-    WebKit:
-      default: defaultHostedBlurMaterialInMediaControlsEnabled()
-    WebKitLegacy:
-      default: false
-    WebCore:
-      default: false
+    default: false
+    WebKit: defaultHostedBlurMaterialInMediaControlsEnabled()
 
 ICECandidateFilteringEnabled:
   type: bool
@@ -4069,13 +2765,7 @@ ICECandidateFilteringEnabled:
   inspectorOverride: true
   humanReadableName: "Enable ICE Candidate Filtering"
   humanReadableDescription: "Enable ICE Candidate Filtering"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 IFrameResourceMonitorNetworkUsageThresholdForTesting:
   type: uint32_t
@@ -4085,13 +2775,7 @@ IFrameResourceMonitorNetworkUsageThresholdForTesting:
   defaultsOverridable: true
   humanReadableName: "Frame Resource Monitor Network Usage Threshold For Testing"
   humanReadableDescription: "Test override for the iframe resource monitor network usage threshold in bytes (0 means use production default)"
-  defaultValue:
-    WebKitLegacy:
-      default: 0
-    WebKit:
-      default: 0
-    WebCore:
-      default: 0
+  defaultValue: 0
 
 IFrameResourceMonitorNetworkUsageThresholdRandomnessForTesting:
   type: double
@@ -4100,13 +2784,7 @@ IFrameResourceMonitorNetworkUsageThresholdRandomnessForTesting:
   condition: ENABLE(CONTENT_EXTENSIONS)
   humanReadableName: "Frame Resource Monitor Network Usage Threshold Randomness For Testing"
   humanReadableDescription: "Test override for the iframe resource monitor network usage threshold randomness factor (only applied when the threshold-for-testing preference is set)"
-  defaultValue:
-    WebKitLegacy:
-      default: 0
-    WebKit:
-      default: 0
-    WebCore:
-      default: 0
+  defaultValue: 0
 
 IFrameResourceMonitoringEnabled:
   type: bool
@@ -4116,13 +2794,7 @@ IFrameResourceMonitoringEnabled:
   defaultsOverridable: true
   humanReadableName: "Frame Resource Monitoring Support"
   humanReadableDescription: "Enable Usage Monitoring of Frame Resource Support"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 IFrameResourceMonitoringTestingSettingsEnabled:
   type: bool
@@ -4132,13 +2804,7 @@ IFrameResourceMonitoringTestingSettingsEnabled:
   defaultsOverridable: true
   humanReadableName: "Frame Resource Monitoring Settings For Testing"
   humanReadableDescription: "Use Resource Monitoring Settings for testing"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 IOSurfaceLosslessCompressionEnabled:
   type: bool
@@ -4146,12 +2812,9 @@ IOSurfaceLosslessCompressionEnabled:
   humanReadableName: "IOSurface Lossless Compression"
   humanReadableDescription: "Use losslessly compressed IOSurfaces"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "HAVE(LOSSLESS_COMPRESSED_IOSURFACE_CG_SUPPORT)": defaultIOSurfaceLosslessCompressionEnabled()
-      default: false
-    WebCore:
       default: false
 
 IPAddressAndLocalhostMixedContentUpgradeTestingEnabled:
@@ -4160,13 +2823,7 @@ IPAddressAndLocalhostMixedContentUpgradeTestingEnabled:
   category: security
   humanReadableName: "Upgrade IP addresses and localhost in mixed content"
   humanReadableDescription: "Enable Upgrading IP addresses and localhost in mixed content"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 IPCTestingAPIEnabled:
   type: bool
@@ -4177,9 +2834,8 @@ IPCTestingAPIEnabled:
   webcoreBinding: none
   condition: ENABLE(IPC_TESTING_API)
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 IgnoreIframeEmbeddingProtectionsEnabled:
   type: bool
@@ -4187,13 +2843,7 @@ IgnoreIframeEmbeddingProtectionsEnabled:
   category: security
   humanReadableName: "Ignore iframe Embedding Protections"
   humanReadableDescription: "Ignores X-Frame-Options and CSP ancestors"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 IgnoreInvalidMessageWhenIPCTestingAPIEnabled:
@@ -4205,9 +2855,8 @@ IgnoreInvalidMessageWhenIPCTestingAPIEnabled:
   webcoreBinding: none
   condition: ENABLE(IPC_TESTING_API)
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 ImageAnalysisDuringFindInPageEnabled:
   type: bool
@@ -4215,13 +2864,7 @@ ImageAnalysisDuringFindInPageEnabled:
   humanReadableName: "Image Analysis for Find-in-Page"
   humanReadableDescription: "Trigger image analysis when performing Find-in-Page"
   condition: ENABLE(IMAGE_ANALYSIS)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ImageCaptureEnabled:
   type: bool
@@ -4230,13 +2873,10 @@ ImageCaptureEnabled:
   humanReadableName: "Image Capture API"
   humanReadableDescription: "Enable Image Capture API"
   condition: ENABLE(MEDIA_STREAM)
+  excludeFrom: [ WebKitLegacy ]
   defaultValue:
-    WebKit:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)": true
-      default: false
+    "PLATFORM(COCOA)": true
+    default: false
 
 ImageControlsEnabled:
   type: bool
@@ -4245,13 +2885,7 @@ ImageControlsEnabled:
   humanReadableName: "Image Controls"
   humanReadableDescription: "Enable image controls"
   condition: ENABLE(SERVICE_CONTROLS)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ImportDeferEnabled:
   type: bool
@@ -4262,9 +2896,8 @@ ImportDeferEnabled:
   webcoreBinding: none
   jscOptionName: useImportDefer
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 ImportTextEnabled:
   type: bool
@@ -4275,9 +2908,8 @@ ImportTextEnabled:
   webcoreBinding: none
   jscOptionName: useImportText
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 InactiveMediaCaptureStreamRepromptIntervalInMinutes:
   type: double
@@ -4285,9 +2917,8 @@ InactiveMediaCaptureStreamRepromptIntervalInMinutes:
   condition: ENABLE(MEDIA_STREAM)
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: 10
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: 10
 
 InactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes:
   type: double
@@ -4295,9 +2926,8 @@ InactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes:
   condition: ENABLE(MEDIA_STREAM)
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: defaultInactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes()
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: defaultInactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes()
 
 IncludeIgnoredInCoreAXTree:
   type: bool
@@ -4305,65 +2935,34 @@ IncludeIgnoredInCoreAXTree:
   condition: ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
   humanReadableName: "Include ignored elements in core accessibility tree"
   humanReadableDescription: "When true, accessibility-is-ignored is not used to build the core, platform-agnostic accessibility tree, and instead is expected to be applied at any platform-exposed layer."
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 IncompleteImageBorderEnabled:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 IncrementalPDFLoadingEnabled:
   type: bool
   status: embedder
   condition: HAVE(INCREMENTAL_PDF_APIS)
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(MAC)": true
-      default: false
-    WebKit:
-      "PLATFORM(MAC)": true
-      default: false
-    WebCore:
-      "PLATFORM(MAC)": true
-      default: false
+    "PLATFORM(MAC)": true
+    default: false
 
 IncrementalRenderingSuppressionTimeout:
   type: double
   status: embedder
   webKitLegacyPreferenceKey: WebKitIncrementalRenderingSuppressionTimeoutInSeconds
   webcoreName: incrementalRenderingSuppressionTimeoutInSeconds
-  defaultValue:
-    WebKitLegacy:
-      default: 5
-    WebKit:
-      default: 5
-    WebCore:
-      default: 5
+  defaultValue: 5
 
 IndexedDBAPIEnabled:
   type: bool
   status: embedder
   humanReadableName: "IndexedDB API"
   humanReadableDescription: "IndexedDB API"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -4374,13 +2973,7 @@ IndexedDBGetAllRecordsAndGetAllOptionsEnabled:
   status: stable
   humanReadableName: "IndexedDB getAllRecords() API and IDBGetAllOptions"
   humanReadableDescription: "Enable the getAllRecords() API on IDBObjectStore/IDBIndex and enable getAll()/getAllKeys() to accept IDBGetAllOptions and support direction"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 IndexedDBSQLiteMemoryBackingStoreEnabled:
   type: bool
@@ -4388,25 +2981,16 @@ IndexedDBSQLiteMemoryBackingStoreEnabled:
   category: dom
   humanReadableName: "IndexedDB SQLite Memory Backing Store"
   humanReadableDescription: "Use SQLite in-memory database for ephemeral IndexedDB instead of MemoryIDBBackingStore"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   sharedPreferenceForWebProcess: true
 
 InlineMediaPlaybackRequiresPlaysInlineAttribute:
   type: bool
   status: embedder
   defaultValue:
+    default: false
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": WebKit::defaultInlineMediaPlaybackRequiresPlaysInlineAttribute()
-      default: false
-    WebKit:
-      default: false
-    WebCore:
       default: false
 
 InputMethodUsesCorrectKeyEventOrder:
@@ -4415,13 +2999,7 @@ InputMethodUsesCorrectKeyEventOrder:
   category: dom
   humanReadableName: "Correct key event ordering with composition events"
   condition: PLATFORM(MAC)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 InputTypeColorEnabled:
@@ -4430,13 +3008,10 @@ InputTypeColorEnabled:
   humanReadableName: "Color Inputs"
   humanReadableDescription: "Enable input elements of type color"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(COCOA) && !PLATFORM(WATCHOS)": true
       "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
       default: false
   sharedPreferenceForWebProcess: true
 
@@ -4447,16 +3022,10 @@ InputTypeColorEnhancementsEnabled:
   humanReadableName: "HTML alpha and colorspace attribute support for color inputs"
   humanReadableDescription: "Enable HTML alpha and colorspace attribute support for input elements of type color"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(COCOA) && !PLATFORM(WATCHOS)": true
-      "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA) && !PLATFORM(WATCHOS)": true
-      "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
+    "PLATFORM(COCOA) && !PLATFORM(WATCHOS)": true
+    "PLATFORM(GTK) || PLATFORM(WPE)": true
+    default: false
+    WebKitLegacy: false
   sharedPreferenceForWebProcess: true
 
 InputTypeDateEnabled:
@@ -4465,14 +3034,12 @@ InputTypeDateEnabled:
   humanReadableName: "Date Input"
   humanReadableDescription: "Enable input elements of type date"
   defaultValue:
+    "PLATFORM(COCOA) || PLATFORM(GTK)": true
+    default: false
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": true
       default: false
-    WebKit:
-      "PLATFORM(COCOA) || PLATFORM(GTK)": true
-      default: false
-    WebCore:
-      default: false
+    WebCore: false
   sharedPreferenceForWebProcess: true
 
 InputTypeDateTimeLocalEnabled:
@@ -4481,14 +3048,12 @@ InputTypeDateTimeLocalEnabled:
   humanReadableName: "datetime-local Inputs"
   humanReadableDescription: "Enable input elements of type datetime-local"
   defaultValue:
+    "PLATFORM(COCOA) || PLATFORM(GTK)": true
+    default: false
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": true
       default: false
-    WebKit:
-      "PLATFORM(COCOA) || PLATFORM(GTK)": true
-      default: false
-    WebCore:
-      default: false
+    WebCore: false
   sharedPreferenceForWebProcess: true
 
 InputTypeMonthEnabled:
@@ -4498,14 +3063,12 @@ InputTypeMonthEnabled:
   humanReadableDescription: "Enable input elements of type month"
   inspectorOverride: true
   defaultValue:
+    "PLATFORM(IOS_FAMILY) || PLATFORM(GTK)": true
+    default: false
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": true
       default: false
-    WebKit:
-      "PLATFORM(IOS_FAMILY) || PLATFORM(GTK)": true
-      default: false
-    WebCore:
-      default: false
+    WebCore: false
   sharedPreferenceForWebProcess: true
 
 InputTypeTimeEnabled:
@@ -4514,14 +3077,12 @@ InputTypeTimeEnabled:
   humanReadableName: "Time Input"
   humanReadableDescription: "Enable input elements of type time"
   defaultValue:
+    "PLATFORM(COCOA) || PLATFORM(GTK)": true
+    default: false
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": true
       default: false
-    WebKit:
-      "PLATFORM(COCOA) || PLATFORM(GTK)": true
-      default: false
-    WebCore:
-      default: false
+    WebCore: false
   sharedPreferenceForWebProcess: true
 
 InputTypeWeekEnabled:
@@ -4531,12 +3092,9 @@ InputTypeWeekEnabled:
   humanReadableDescription: "Enable input elements of type week"
   inspectorOverride: true
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(IOS_FAMILY) && !PLATFORM(APPLETV) || PLATFORM(GTK)": true
-      default: false
-    WebCore:
       default: false
   sharedPreferenceForWebProcess: true
 
@@ -4545,93 +3103,66 @@ InspectorAttachedHeight:
   status: embedder
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: 500
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: 500
 
 InspectorAttachedWidth:
   type: uint32_t
   status: embedder
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: 750
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: 750
 
 InspectorAttachmentSide:
   type: uint32_t
   status: embedder
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: 0
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: 0
 
 InspectorMaximumResourcesContentSize:
   type: uint32_t
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: 200
-    WebKit:
-      "PLATFORM(WPE)": 50
-      default: 200
-    WebCore:
-      "PLATFORM(WPE)": 50
-      default: 200
+    "PLATFORM(WPE)": 50
+    default: 200
+    WebKitLegacy: 200
 
 InspectorStartsAttached:
   type: bool
   status: embedder
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 InspectorSupportsShowingCertificate:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(COCOA) || PLATFORM(WIN)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA) || PLATFORM(WIN)": true
-      default: false
+    "PLATFORM(COCOA) || PLATFORM(WIN)": true
+    default: false
+    WebKitLegacy: false
 
 InspectorWindowFrame:
   type: String
   status: embedder
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: '""_str'
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: '""_str'
 
 InteractionRegionInlinePadding:
   type: double
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: 4
-    WebKit:
-      default: 4
-    WebCore:
-      default: 4
+  defaultValue: 4
 
 InteractionRegionMinimumCornerRadius:
   type: double
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: 8
-    WebKit:
-      default: 8
-    WebCore:
-      default: 8
+  defaultValue: 8
 
 InteractionRegionsEnabled:
   type: bool
@@ -4641,12 +3172,8 @@ InteractionRegionsEnabled:
   humanReadableDescription: "Generate and visualize interaction regions"
   condition: ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
   defaultValue:
-    WebKit:
-      default: true
-    WebKitLegacy:
-      default: false
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 # FIXME: This is handled via WebView SPI rather than WebPreferences for WebKitLegacy. We should change the SPI to lookup the WebPreferences value instead.
 InteractiveFormValidationEnabled:
@@ -4656,12 +3183,8 @@ InteractiveFormValidationEnabled:
   humanReadableDescription: "HTML interactive form validation"
   webKitLegacyBinding: custom
   defaultValue:
-    WebKit:
-      default: true
-    WebKitLegacy:
-      default: false
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 InterruptAudioOnPageVisibilityChangeEnabled:
@@ -4669,12 +3192,9 @@ InterruptAudioOnPageVisibilityChangeEnabled:
   status: embedder
   condition: ENABLE(MEDIA_STREAM)
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(IOS_FAMILY)": true
-      default: false
-    WebCore:
       default: false
 
 InterruptVideoOnPageVisibilityChangeEnabled:
@@ -4682,26 +3202,18 @@ InterruptVideoOnPageVisibilityChangeEnabled:
   status: embedder
   condition: ENABLE(MEDIA_STREAM)
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(IOS_FAMILY)": true
-      default: false
-    WebKit:
-      "PLATFORM(IOS_FAMILY)": true
-      default: false
-    WebCore:
-      default: false
+    "PLATFORM(IOS_FAMILY)": true
+    default: false
+    WebCore: false
 
 InvisibleAutoplayNotPermitted:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: InvisibleAutoplayNotPermitted
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(IOS_FAMILY)": true
-      default: false
-    WebCore:
       default: false
 
 IsARIANotifyEnabled:
@@ -4710,15 +3222,8 @@ IsARIANotifyEnabled:
   humanReadableName: "ariaNotify()"
   humanReadableDescription: "Enable ariaNotify support"
   defaultValue:
-    WebKitLegacy:
-      "ENABLE(ARIA_NOTIFY)": true
-      default: false
-    WebKit:
-      "ENABLE(ARIA_NOTIFY)": true
-      default: false
-    WebCore:
-      "ENABLE(ARIA_NOTIFY)": true
-      default: false
+    "ENABLE(ARIA_NOTIFY)": true
+    default: false
 
 IsAccessibilityIsolatedTreeEnabled:
   type: bool
@@ -4728,12 +3233,9 @@ IsAccessibilityIsolatedTreeEnabled:
   webcoreBinding: DeprecatedGlobalSettings
   condition: ENABLE(ACCESSIBILITY_ISOLATED_TREE)
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "USE(ATSPI)": true
-      default: false
-    WebCore:
       default: false
 
 IsAriaLiveRegionManagementEnabled:
@@ -4742,15 +3244,8 @@ IsAriaLiveRegionManagementEnabled:
   humanReadableName: "ARIA Live Regions in WebKit"
   humanReadableDescription: "Turn on ARIA live-region management within WebKit"
   defaultValue:
-    WebKitLegacy:
-      "ENABLE(WEBKIT_MANAGED_LIVE_REGIONS)": true
-      default: false
-    WebKit:
-      "ENABLE(WEBKIT_MANAGED_LIVE_REGIONS)": true
-      default: false
-    WebCore:
-      "ENABLE(WEBKIT_MANAGED_LIVE_REGIONS)": true
-      default: false
+    "ENABLE(WEBKIT_MANAGED_LIVE_REGIONS)": true
+    default: false
 
 # FIXME: The 'Is' prefix is inconsistent with most other preferences and should be removed.
 IsFirstPartyWebsiteDataRemovalDisabled:
@@ -4759,13 +3254,7 @@ IsFirstPartyWebsiteDataRemovalDisabled:
   category: privacy
   humanReadableName: "Disable Removal of Non-Cookie Data After 7 Days of No User Interaction (ITP)"
   humanReadableDescription: "Disable removal of all non-cookie website data after seven days of no user interaction when Intelligent Tracking Prevention is enabled"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 # FIXME: This is not relevant for WebKitLegacy, so it should be excluded from WebKitLegacy entirely.
 IsFirstPartyWebsiteDataRemovalLiveOnTestingEnabled:
@@ -4774,13 +3263,7 @@ IsFirstPartyWebsiteDataRemovalLiveOnTestingEnabled:
   category: privacy
   humanReadableName: "[ITP Live-On] 1 Hour Timeout For Non-Cookie Data Removal"
   humanReadableDescription: "Remove all non-cookie website data after just one hour of no user interaction when Intelligent Tracking Prevention is enabled"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 # FIXME: This is not relevant for WebKitLegacy, so it should be excluded from WebKitLegacy entirely.
 IsFirstPartyWebsiteDataRemovalReproTestingEnabled:
@@ -4789,13 +3272,7 @@ IsFirstPartyWebsiteDataRemovalReproTestingEnabled:
   category: privacy
   humanReadableName: "[ITP Repro] 30 Second Timeout For Non-Cookie Data Removal"
   humanReadableDescription: "Remove all non-cookie website data after just 30 seconds of no user interaction when Intelligent Tracking Prevention is enabled"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 # FIXME: The 'Is' prefix is inconsistent with most other preferences and should be removed.
 IsSameSiteStrictEnforcementEnabled:
@@ -4804,13 +3281,7 @@ IsSameSiteStrictEnforcementEnabled:
   category: privacy
   humanReadableName: "SameSite strict enforcement (ITP)"
   humanReadableDescription: "Enable SameSite strict enforcement to mitigate bounce tracking"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 # FIXME: The 'Is' prefix is inconsistent with most other preferences and should be removed.
 IsThirdPartyCookieBlockingDisabled:
@@ -4819,13 +3290,7 @@ IsThirdPartyCookieBlockingDisabled:
   category: privacy
   humanReadableName: "Disable Full 3rd-Party Cookie Blocking (ITP)"
   humanReadableDescription: "Disable full third-party cookie blocking when Intelligent Tracking Prevention is enabled"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 IteratorChunkingEnabled:
   type: bool
@@ -4836,9 +3301,8 @@ IteratorChunkingEnabled:
   webcoreBinding: none
   jscOptionName: useIteratorChunking
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 IteratorIncludesEnabled:
   type: bool
@@ -4849,9 +3313,8 @@ IteratorIncludesEnabled:
   webcoreBinding: none
   jscOptionName: useIteratorIncludes
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 IteratorJoinEnabled:
   type: bool
@@ -4862,9 +3325,8 @@ IteratorJoinEnabled:
   webcoreBinding: none
   jscOptionName: useIteratorJoin
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 IteratorSequencingEnabled:
   type: bool
@@ -4875,9 +3337,8 @@ IteratorSequencingEnabled:
   webcoreBinding: none
   jscOptionName: useIteratorSequencing
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 # FIXME: This is not relevant for WebKitLegacy, so it should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 ItpDebugModeEnabled:
@@ -4886,13 +3347,7 @@ ItpDebugModeEnabled:
   category: privacy
   humanReadableName: "ITP Debug Mode"
   humanReadableDescription: "Intelligent Tracking Prevention Debug Mode"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 JSONSourceTextAccessEnabled:
   type: bool
@@ -4903,9 +3358,8 @@ JSONSourceTextAccessEnabled:
   webcoreBinding: none
   jscOptionName: useJSONSourceTextAccess
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 JSPIEnabled:
   type: bool
@@ -4916,33 +3370,24 @@ JSPIEnabled:
   webcoreBinding: none
   jscOptionName: useJSPI
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 JavaScriptCanAccessClipboard:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 JavaScriptCanOpenWindowsAutomatically:
   type: bool
   status: embedder
   defaultValue:
+    "PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)": false
+    default: true
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": false
       default: true
-    WebKit:
-      "PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)": false
-      default: true
-    WebCore:
-      default: false
+    WebCore: false
 
 JavaScriptEnabled:
   type: bool
@@ -4953,25 +3398,15 @@ JavaScriptEnabled:
   webcoreGetter: isScriptEnabled
   webcoreName: scriptEnabled
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: true
+    WebCore: false
 
 # NOTE: Clients should use per-navigation "allowsContentJavaScript" policies instead
 JavaScriptMarkupEnabled:
   type: bool
   status: embedder
   webcoreName: scriptMarkupEnabled
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 JavaScriptRuntimeFlags:
   type: uint32_t
@@ -4979,12 +3414,8 @@ JavaScriptRuntimeFlags:
   status: embedder
   webKitLegacyPreferenceKey: WebKitJavaScriptRuntimeFlagsPreferenceKey
   defaultValue:
-    WebKitLegacy:
-      default: 0
-    WebKit:
-      default: 0
-    WebCore:
-      default: '{ }'
+    default: 0
+    WebCore: '{ }'
 
 JointIterationEnabled:
   type: bool
@@ -4995,9 +3426,8 @@ JointIterationEnabled:
   webcoreBinding: none
   jscOptionName: useJointIteration
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 KeyboardDismissalGestureEnabled:
   type: bool
@@ -5006,21 +3436,15 @@ KeyboardDismissalGestureEnabled:
   condition: PLATFORM(IOS_FAMILY)
   humanReadableName: "Keyboard Dismissal Gesture"
   humanReadableDescription: "Enable the keyboard dismissal gesture"
+  excludeFrom: [ WebKitLegacy, WebCore ]
   defaultValue:
-    WebKit:
-      "PLATFORM(APPLETV)" : true
-      default: false
+    "PLATFORM(APPLETV)" : true
+    default: false
 
 LargeImageAsyncDecodingEnabled:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 
 LargestContentfulPaintEnabled:
@@ -5029,13 +3453,7 @@ LargestContentfulPaintEnabled:
   category: dom
   humanReadableName: "Largest Contentful Paint"
   humanReadableDescription: "Enable Largest Contentful Paint performance entries"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 
 LayerBasedSVGEngineEnabled:
@@ -5044,49 +3462,28 @@ LayerBasedSVGEngineEnabled:
   humanReadableName: "Layer-based SVG Engine (LBSE)"
   humanReadableDescription: "Enable next-generation layer-based SVG Engine (LBSE)"
   webcoreOnChange: layerBasedSVGEngineEnabledChanged
-  defaultValue:
-    WebCore:
-      default: false
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
+  defaultValue: false
 
 LayerBasedSVGEngineForceLayerCreationEnabled:
   type: bool
   status: internal
   humanReadableName: "LBSE: Force layer creation for all SVG renderers"
   humanReadableDescription: "Force the layer-based SVG Engine (LBSE) to create a RenderLayer for every SVG renderer (debugging only)"
-  defaultValue:
-    WebCore:
-      default: false
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
+  defaultValue: false
 
 LayoutFallbackWidth:
   type: uint32_t
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: 980
-    WebKit:
-      default: 980
-    WebCore:
-      default: 980
+  defaultValue: 980
 
 LayoutViewportHeightExpansionFactor:
   type: double
   status: embedder
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
   defaultValue:
-    WebKitLegacy:
-      default: 0
+    default: 0
     WebKit:
       "PLATFORM(WATCHOS) || ENABLE(FLEXIBLE_VIEW_SCALE_FACTOR)" : 1
-      default: 0
-    WebCore:
       default: 0
 
 LazyIframeLoadingEnabled:
@@ -5096,12 +3493,8 @@ LazyIframeLoadingEnabled:
   humanReadableName: "Lazy iframe loading"
   humanReadableDescription: "Enable lazy iframe loading support"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 LazyImageLoadingEnabled:
   type: bool
@@ -5110,12 +3503,8 @@ LazyImageLoadingEnabled:
   humanReadableName: "Lazy image loading"
   humanReadableDescription: "Enable lazy image loading support"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 LegacyEncryptedMediaAPIEnabled:
   type: bool
@@ -5123,13 +3512,7 @@ LegacyEncryptedMediaAPIEnabled:
   humanReadableName: "Enable Legacy EME API"
   humanReadableDescription: "Enable legacy EME API"
   condition: ENABLE(LEGACY_ENCRYPTED_MEDIA)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   sharedPreferenceForWebProcess: true
   mediaPlaybackRelated: true
 
@@ -5141,13 +3524,7 @@ LegacyLineLayoutVisualCoverageEnabled:
   humanReadableName: "Legacy line layout visual coverage"
   humanReadableDescription: "Enable legacy line layout visual coverage"
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 LegacyOverflowScrollingTouchEnabled:
   type: bool
@@ -5156,26 +3533,14 @@ LegacyOverflowScrollingTouchEnabled:
   humanReadableName: "Legacy -webkit-overflow-scrolling property"
   humanReadableDescription: "Support the legacy -webkit-overflow-scrolling CSS property"
   condition: ENABLE(WEBKIT_OVERFLOW_SCROLLING_CSS_PROPERTY)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 LegacyPluginQuirkForMailSignaturesEnabled:
   type: bool
   status: internal
   humanReadableName: "Quirk to get Mail to load signatures correctly with WebKitLegacy"
   humanReadableDescription: "Quirk to get Mail to load signatures correctly with WebKitLegacy"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 LegacyWebRTCOfferOptionsEnabled:
   type: bool
@@ -5184,12 +3549,9 @@ LegacyWebRTCOfferOptionsEnabled:
   humanReadableDescription: "Enable RTCPeerConnection Legacy offer options (offerToReceiveAudio, offerToReceiveVideo)"
   condition: ENABLE(WEB_RTC)
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
       default: false
 
 LimitedMatroskaSupportEnabled:
@@ -5199,13 +3561,7 @@ LimitedMatroskaSupportEnabled:
   humanReadableName: "Limited Matroska Support"
   humanReadableDescription: "Enable H264 and PCM with WebM Player and MediaRecorder"
   condition: ENABLE(MEDIA_RECORDER_WEBM)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 LinearMediaPlayerEnabled:
   type: bool
@@ -5215,24 +3571,17 @@ LinearMediaPlayerEnabled:
   humanReadableDescription: "Enable LinearMediaPlayer for fullscreen video"
   condition: ENABLE(LINEAR_MEDIA_PLAYER)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultLinearMediaPlayerEnabled()
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultLinearMediaPlayerEnabled()
 
 LinkPreconnect:
   type: bool
   status: embedder
   webcoreName: linkPreconnectEnabled
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "ENABLE(SERVER_PRECONNECT)": true
-      default: false
-    WebCore:
       default: false
 
 LinkPreconnectEarlyHintsEnabled:
@@ -5242,12 +3591,9 @@ LinkPreconnectEarlyHintsEnabled:
   humanReadableName: "Link rel=preconnect via HTTP early hints"
   humanReadableDescription: "Enable link rel=preconnect via early hints"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "ENABLE(SERVER_PRECONNECT)": true
-      default: false
-    WebCore:
       default: false
 
 LinkPrefetchEnabled:
@@ -5256,24 +3602,14 @@ LinkPrefetchEnabled:
   category: networking
   humanReadableName: "LinkPrefetch"
   humanReadableDescription: "Enable LinkedPrefetch"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 LinkPreloadEnabled:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 LinkSanitizerEnabled:
   type: bool
@@ -5281,13 +3617,7 @@ LinkSanitizerEnabled:
   category: networking
   humanReadableName: "Link Sanitizer"
   humanReadableDescription: "Enable link sanitizer"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ListMarkerPositionedPostLayoutEnabled:
   type: bool
@@ -5295,24 +3625,15 @@ ListMarkerPositionedPostLayoutEnabled:
   category: css
   humanReadableName: "Position outside list markers after layout"
   humanReadableDescription: "Keep an outside list marker as the list item's first child and position it after layout, instead of reparenting it into the descendant that holds the first line box"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 LoadDeferringEnabled:
   type: bool
   status: embedder
   defaultValue:
+    default: true
     WebKitLegacy:
       PLATFORM(MAC): WebKit::defaultLoadDeferringEnabled()
-      default: true
-    WebKit:
-      default: true
-    WebCore:
       default: true
 
 LoadWebArchiveWithEphemeralStorageEnabled:
@@ -5322,13 +3643,7 @@ LoadWebArchiveWithEphemeralStorageEnabled:
   humanReadableName: "Load Web Archive with ephemeral storage"
   humanReadableDescription: "Enable loading web archive with ephemeral storage"
   condition: ENABLE(WEB_ARCHIVE)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 # This only suppresses the network load of the image URL. A cached image will still be rendered if requested.
 LoadsImagesAutomatically:
@@ -5337,12 +3652,8 @@ LoadsImagesAutomatically:
   webcoreOnChange: imagesEnabledChanged
   webKitLegacyPreferenceKey: WebKitDisplayImagesKey
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: true
+    WebCore: false
 
 LocalFileContentSniffingEnabled:
   type: bool
@@ -5351,13 +3662,7 @@ LocalFileContentSniffingEnabled:
   humanReadableName: "Local File Content Sniffing"
   humanReadableDescription: "Enable Local File Content Sniffing"
   webKitLegacyPreferenceKey: WebKitLocalFileContentSniffingEnabledPreferenceKey
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 LocalNetworkAccessEnabled:
   type: bool
@@ -5366,13 +3671,7 @@ LocalNetworkAccessEnabled:
   humanReadableName: "Local Network Access"
   humanReadableDescription: "Enable Local Network Access"
   webKitLegacyPreferenceKey: WebKitLocalNetworkAccessEnabledPreferenceKey
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 LocalStorageEnabled:
   type: bool
@@ -5381,12 +3680,8 @@ LocalStorageEnabled:
   humanReadableDescription: "Enable Local Storage"
   webKitLegacyPreferenceKey: WebKitLocalStorageEnabledPreferenceKey
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: true
+    WebCore: false
   sharedPreferenceForWebProcess: true
 
 LockdownFontParserEnabled:
@@ -5396,13 +3691,7 @@ LockdownFontParserEnabled:
   humanReadableDescription: "Try parsing Web fonts with safe font parser in Lockdown Mode"
   exposed: [ WebKit ]
   category: security
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   sharedPreferenceForWebProcess: true
 
 LoginStatusAPIEnabled:
@@ -5411,13 +3700,7 @@ LoginStatusAPIEnabled:
   category: dom
   humanReadableName: "Login Status API"
   humanReadableDescription: "Enable the proposed Login Status API"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 LoginStatusAPIRequiresWebAuthnEnabled:
   type: bool
@@ -5425,13 +3708,7 @@ LoginStatusAPIRequiresWebAuthnEnabled:
   category: dom
   humanReadableName: "Require WebAuthn with the Login Status API"
   humanReadableDescription: "Require a recent WebAuthn authentication to set login status"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 LogsPageMessagesToSystemConsoleEnabled:
@@ -5441,45 +3718,31 @@ LogsPageMessagesToSystemConsoleEnabled:
   defaultsOverridable: true
   humanReadableName: "Log page messages to system console"
   humanReadableDescription: "Enable logging page messages to system console"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 LongRunningMediaCaptureStreamRepromptIntervalInHours:
   type: double
   status: embedder
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: 24
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: 24
 
 LowPowerVideoAudioBufferSizeEnabled:
   type: bool
   status: embedder
   webcoreBinding: DeprecatedGlobalSettings
+  excludeFrom: [ WebCore ]
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 MainContentUserGestureOverrideEnabled:
   type: bool
   status: embedder
   humanReadableName: "Main content user gesture override"
   humanReadableDescription: "Enable main content user gesture override"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ManageCaptureStatusBarInGPUProcessEnabled:
   type: bool
@@ -5489,12 +3752,8 @@ ManageCaptureStatusBarInGPUProcessEnabled:
   humanReadableDescription: "Enable Capture Status Bar management in GPU Process"
   condition: ENABLE(MEDIA_STREAM) && PLATFORM(IOS_FAMILY)
   defaultValue:
-    WebKit:
-      default: WebKit::defaultManageCaptureStatusBarInGPUProcessEnabled()
-    WebKitLegacy:
-      default: false
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultManageCaptureStatusBarInGPUProcessEnabled()
 
 ManagedMediaSourceEnabled:
   type: bool
@@ -5504,12 +3763,9 @@ ManagedMediaSourceEnabled:
   humanReadableDescription: "Managed Media Source API"
   condition: ENABLE(MEDIA_SOURCE)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultManagedMediaSourceEnabled()
-    WebCore:
-      default: true
+    default: WebKit::defaultManagedMediaSourceEnabled()
+    WebKitLegacy: false
+    WebCore: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
   mediaPlaybackRelated: true
@@ -5518,21 +3774,15 @@ ManagedMediaSourceHighThreshold:
   type: double
   status: embedder
   condition: ENABLE(MEDIA_SOURCE)
-  defaultValue:
-    WebKit:
-      default: 30
-    WebCore:
-      default: 30
+  excludeFrom: [ WebKitLegacy ]
+  defaultValue: 30
 
 ManagedMediaSourceLowThreshold:
   type: double
   status: embedder
   condition: ENABLE(MEDIA_SOURCE)
-  defaultValue:
-    WebKit:
-      default: 10
-    WebCore:
-      default: 10
+  excludeFrom: [ WebKitLegacy ]
+  defaultValue: 10
 
 ManagedMediaSourceNeedsAirPlay:
   type: bool
@@ -5542,25 +3792,15 @@ ManagedMediaSourceNeedsAirPlay:
   humanReadableDescription: "Managed Media Source Requires AirPlay source"
   condition: ENABLE(MEDIA_SOURCE) && ENABLE(WIRELESS_PLAYBACK_TARGET)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultManagedMediaSourceNeedsAirPlay()
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultManagedMediaSourceNeedsAirPlay()
 
 MathFontFamily:
   type: String
   status: embedder
   webKitLegacyPreferenceKey: WebKitMathFont
   webcoreImplementation: custom
-  defaultValue:
-    WebKitLegacy:
-      default: '""_str'
-    WebKit:
-      default: '""_str'
-    WebCore:
-      default: '""_str'
+  defaultValue: '""_str'
 
 MathMLDisableHrefOnNonAnchorElement:
   type: bool
@@ -5568,58 +3808,35 @@ MathMLDisableHrefOnNonAnchorElement:
   category: dom
   humanReadableName: "Disable href attribute on MathML elements"
   humanReadableDescription: "The only MathML element on which href is allowed is <a>."
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 MathMLEnabled:
   type: bool
   status: embedder
   condition: ENABLE(MATHML)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   disableInLockdownMode: true
 
 MaxParseDuration:
   type: double
   status: embedder
   webKitLegacyPreferenceKey: WebKitMaxParseDurationPreferenceKey
-  defaultValue:
-    WebKitLegacy:
-      default: -1
-    WebKit:
-      default: -1
-    WebCore:
-      default: -1
+  defaultValue: -1
 
 MediaAudioCodecIDsAllowedInLockdownMode:
   type: String
   status: embedder
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: '"aac ,zaac,qaac,caac,.mp3,mp4a"_str'
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: '"aac ,zaac,qaac,caac,.mp3,mp4a"_str'
 
 MediaCapabilitiesEnabled:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 # FIXME: This is on by default in WebKit2. Perhaps we should consider turning it on for WebKitLegacy as well.
 MediaCapabilitiesExtensionsEnabled:
@@ -5629,12 +3846,8 @@ MediaCapabilitiesExtensionsEnabled:
   humanReadableName: "Media Capabilities Extensions"
   humanReadableDescription: "Media Capabilities Extensions"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 MediaCapabilityGrantsEnabled:
   type: bool
@@ -5643,14 +3856,9 @@ MediaCapabilityGrantsEnabled:
   humanReadableName: "Media Capability Grants"
   humanReadableDescription: "Enable granting and revoking of media capabilities"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(IOS_FAMILY_SIMULATOR)": false
-      default: true
-    WebCore:
-      "PLATFORM(IOS_FAMILY_SIMULATOR)": false
-      default: true
+    "PLATFORM(IOS_FAMILY_SIMULATOR)": false
+    default: true
+    WebKitLegacy: false
   sharedPreferenceForWebProcess: true
 
 MediaCaptionFormatTypesAllowedInLockdownMode:
@@ -5658,9 +3866,8 @@ MediaCaptionFormatTypesAllowedInLockdownMode:
   status: embedder
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: '"c608,wvtt"_str'
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: '"c608,wvtt"_str'
 
 MediaCaptureRequiresSecureConnection:
   type: bool
@@ -5670,56 +3877,38 @@ MediaCaptureRequiresSecureConnection:
   humanReadableName: "Limit Media Capture to Secure Sites"
   humanReadableDescription: "Limit Media Capture to Secure Sites"
   condition: ENABLE(MEDIA_STREAM)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 MediaCodecTypesAllowedInLockdownMode:
   type: String
   status: embedder
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: '"mp4a.40,avc1"_str'
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: '"mp4a.40,avc1"_str'
 
 MediaContainerTypesAllowedInLockdownMode:
   type: String
   status: embedder
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: '"video/mp4,audio/mp4,video/x-m4v,audio/x-m4a,audio/mp3,application/x-mpegURL,application/vnd.apple.mpegURL,video/mp2t,video/iso.segment,audio/aac,audio/mpeg,audio/ac3,audio/eac3,video/mpeg2,text/vtt"_str'
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: '"video/mp4,audio/mp4,video/x-m4v,audio/x-m4a,audio/mp3,application/x-mpegURL,application/vnd.apple.mpegURL,video/mp2t,video/iso.segment,audio/aac,audio/mpeg,audio/ac3,audio/eac3,video/mpeg2,text/vtt"_str'
 
 MediaContentTypesRequiringHardwareSupport:
   type: String
   status: embedder
   webcoreExcludeFromInternalSettings: true
   webcoreImplementation: custom
-  defaultValue:
-    WebKitLegacy:
-      default: '""_str'
-    WebKit:
-      default: '""_str'
-    WebCore:
-      default: '""_str'
+  defaultValue: '""_str'
 
 MediaControlsContextMenusEnabled:
   type: bool
   status: embedder
   condition: ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
   sharedPreferenceForWebProcess: true
   mediaPlaybackRelated: true
 
@@ -5731,39 +3920,23 @@ MediaControlsMacInlineSizeSpecsEnabled:
   humanReadableDescription: "Adopt new size specs for media controls"
   condition: HAVE(MATERIAL_HOSTING)
   defaultValue:
-    WebKit:
-      default: defaultHostedBlurMaterialInMediaControlsEnabled()
-    WebKitLegacy:
-      default: false
-    WebCore:
-      default: false
+    default: false
+    WebKit: defaultHostedBlurMaterialInMediaControlsEnabled()
 
 MediaControlsScaleWithPageZoom:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
-    WebKit:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
-    WebCore:
-      default: true
+    "PLATFORM(IOS_FAMILY)": false
+    default: true
+    WebCore: true
 
 MediaDataLoadsAutomatically:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
-    WebKit:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
-    WebCore:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
+    "PLATFORM(IOS_FAMILY)": false
+    default: true
 
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 MediaDevicesEnabled:
@@ -5773,14 +3946,9 @@ MediaDevicesEnabled:
   humanReadableDescription: "Enable media devices"
   condition: ENABLE(MEDIA_STREAM)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
-      "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
+    "PLATFORM(GTK) || PLATFORM(WPE)": true
+    default: false
+    WebKitLegacy: false
   disableInLockdownMode: true
 
 MediaEnabled:
@@ -5789,50 +3957,26 @@ MediaEnabled:
   humanReadableName: "HTML Media Elements"
   humanReadableDescription: "Enable HTML media elements <audio>, <video> and <track>"
   condition: ENABLE(VIDEO)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 MediaPlaybackEnabled:
   type: bool
   status: embedder
   humanReadableName: "Media Playback Functionalities"
   humanReadableDescription: "Enable media playback functionalities"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   sharedPreferenceForWebProcess: true
   mediaPlaybackRelated: true
 
 MediaPreferredFullscreenWidth:
   type: double
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: 960
-    WebKit:
-      default: 960
-    WebCore:
-      default: 960
+  defaultValue: 960
 
 MediaPreloadingEnabled:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 MediaRecorderEnabled:
@@ -5843,13 +3987,10 @@ MediaRecorderEnabled:
   humanReadableDescription: "MediaRecorder"
   condition: ENABLE(MEDIA_RECORDER)
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(COCOA)": true
       "USE(GSTREAMER)": true
-      default: false
-    WebCore:
       default: false
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -5863,12 +4004,9 @@ MediaRecorderEnabledWebM:
   humanReadableDescription: "Enable WebM support with MediaRecorder"
   condition: ENABLE(MEDIA_RECORDER_WEBM)
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
       default: false
   sharedPreferenceForWebProcess: true
 
@@ -5879,12 +4017,9 @@ MediaSessionCaptureToggleAPIEnabled:
   humanReadableName: "MediaSession capture related API"
   humanReadableDescription: "Enable MediaSession capture related API"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
       default: false
 
 MediaSessionCoordinatorEnabled:
@@ -5895,12 +4030,8 @@ MediaSessionCoordinatorEnabled:
   humanReadableDescription: "Enable experimental MediaSession coordinator API"
   condition: ENABLE(MEDIA_SESSION_COORDINATOR)
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: WebKit::defaultMediaSessionCoordinatorEnabled()
-    WebCore:
-      default: true
+    default: true
+    WebKit: WebKit::defaultMediaSessionCoordinatorEnabled()
   sharedPreferenceForWebProcess: true
   richJavaScript: true
   mediaPlaybackRelated: true
@@ -5911,13 +4042,7 @@ MediaSessionEnabled:
   humanReadableName: "Media Session API"
   humanReadableDescription: "Media Session API"
   condition: ENABLE(MEDIA_SESSION)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   sharedPreferenceForWebProcess: true
 
 MediaSessionExtendedActionsEnabled:
@@ -5926,13 +4051,7 @@ MediaSessionExtendedActionsEnabled:
   category: media
   humanReadableName: "MediaSession extended actions"
   humanReadableDescription: "Enable MediaSession hangup, previousslide, nextslide, and enterpictureinpicture actions"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 MediaSessionPlaylistEnabled:
   type: bool
@@ -5942,12 +4061,9 @@ MediaSessionPlaylistEnabled:
   humanReadableDescription: "Enable experimental MediaSession playlist API"
   condition: ENABLE(MEDIA_SESSION_COORDINATOR) && ENABLE(MEDIA_SESSION_PLAYLIST)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultMediaSessionCoordinatorEnabled()
-    WebCore:
-      default: true
+    default: WebKit::defaultMediaSessionCoordinatorEnabled()
+    WebKitLegacy: false
+    WebCore: true
 
 MediaSourceEnabled:
   type: bool
@@ -5956,14 +4072,9 @@ MediaSourceEnabled:
   humanReadableName: "Media Source API"
   humanReadableDescription: "Media Source API"
   defaultValue:
-    WebKitLegacy:
-      "ENABLE(MEDIA_SOURCE) && PLATFORM(IOS_FAMILY)": WebKit::defaultMediaSourceEnabled()
-      "ENABLE(MEDIA_SOURCE) && !PLATFORM(IOS_FAMILY)": true
-      default: false
-    WebKit:
-      "ENABLE(MEDIA_SOURCE) && PLATFORM(IOS_FAMILY)": WebKit::defaultMediaSourceEnabled()
-      "ENABLE(MEDIA_SOURCE) && !PLATFORM(IOS_FAMILY)": true
-      default: false
+    "ENABLE(MEDIA_SOURCE) && PLATFORM(IOS_FAMILY)": WebKit::defaultMediaSourceEnabled()
+    "ENABLE(MEDIA_SOURCE) && !PLATFORM(IOS_FAMILY)": true
+    default: false
     WebCore:
       "ENABLE(MEDIA_SOURCE)": true
       default: false
@@ -5977,14 +4088,10 @@ MediaSourceInWorkerEnabled:
   humanReadableName: "MediaSource in a Worker"
   humanReadableDescription: "MediaSource in a Worker"
   condition: ENABLE(MEDIA_SOURCE_IN_WORKERS)
-  exposed: [ WebCore, WebKit ]
+  exposed: [ WebKit, WebCore ]
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
   mediaPlaybackRelated: true
 
 MediaSourcePrefersDecompressionSession:
@@ -5995,12 +4102,9 @@ MediaSourcePrefersDecompressionSession:
   humanReadableDescription: "MediaSource prefers DecompressionSession"
   condition: ENABLE(MEDIA_SOURCE) && USE(AVFOUNDATION)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultMediaSourcePrefersDecompressionSession()
-    WebCore:
-      default: true
+    default: WebKit::defaultMediaSourcePrefersDecompressionSession()
+    WebKitLegacy: false
+    WebCore: true
   sharedPreferenceForWebProcess: true
 
 MediaStreamTrackHandleEnabled:
@@ -6010,13 +4114,7 @@ MediaStreamTrackHandleEnabled:
   humanReadableName: "MediaStreamTrackHandle"
   humanReadableDescription: "Enable MediaStreamTrackHandle"
   condition: ENABLE(MEDIA_STREAM)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 MediaStreamTrackProcessingEnabled:
   type: bool
@@ -6026,34 +4124,22 @@ MediaStreamTrackProcessingEnabled:
   humanReadableDescription: "Enable MediaStreamTrack Processing"
   condition: ENABLE(MEDIA_STREAM)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)": true
-      default: false
+    "PLATFORM(COCOA)": true
+    default: false
+    WebKitLegacy: false
 
 MediaUserGestureInheritsFromDocument:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 MediaVideoCodecIDsAllowedInLockdownMode:
   type: String
   status: embedder
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: '"avc1,zavc,qavc,cavc"_str'
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: '"avc1,zavc,qavc,cavc"_str'
 
 MetaViewportInteractiveWidgetEnabled:
   type: bool
@@ -6062,51 +4148,33 @@ MetaViewportInteractiveWidgetEnabled:
   humanReadableName: "Meta Viewport Interactive Widget"
   humanReadableDescription: "Enable the interactive-widget attribute on the viewport meta element"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
       default: false
 
 MinimumFontSize:
   type: double
   status: embedder
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
-  defaultValue:
-    WebKitLegacy:
-      default: 0
-    WebKit:
-      default: 0
-    WebCore:
-      default: 0
+  defaultValue: 0
 
 MinimumLogicalFontSize:
   type: double
   status: embedder
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
   defaultValue:
-    WebKitLegacy:
-      default: 9
-    WebKit:
-      default: 9
-    WebCore:
-      default: 0
+    default: 9
+    WebCore: 0
 
 MinimumZoomFontSize:
   type: double
   status: embedder
   webKitLegacyPreferenceKey: WebKitMinimumZoomFontSizePreferenceKey
   defaultValue:
-    WebKitLegacy:
-      default: 15
-    WebKit:
-      "PLATFORM(WATCHOS)": 30
-      default: 15
-    WebCore:
-      "PLATFORM(WATCHOS)": 30
-      default: 15
+    "PLATFORM(WATCHOS)": 30
+    default: 15
+    WebKitLegacy: 15
 
 MockCaptureDevicesEnabled:
   type: bool
@@ -6118,12 +4186,9 @@ MockCaptureDevicesEnabled:
   humanReadableName: "Enable Mock Capture Devices"
   humanReadableDescription: "Enable Mock Capture Devices"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(IOS_FAMILY_SIMULATOR)": true
-      default: false
-    WebCore:
       default: false
 
 MockCaptureDevicesPromptEnabled:
@@ -6131,30 +4196,20 @@ MockCaptureDevicesPromptEnabled:
   status: embedder
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 MockScrollbarsControllerEnabled:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 MockScrollbarsEnabled:
   type: bool
   status: embedder
   webcoreBinding: DeprecatedGlobalSettings
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
+  excludeFrom: [ WebCore ]
+  defaultValue: false
 
 ModelDocumentEnabled:
   type: bool
@@ -6164,11 +4219,8 @@ ModelDocumentEnabled:
   humanReadableDescription: "Enable HTML <model> element for model documents"
   condition: ENABLE(MODEL_ELEMENT)
   webcoreBinding: DeprecatedGlobalSettings
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
+  excludeFrom: [ WebCore ]
+  defaultValue: false
 
 ModelElementEnabled:
   type: bool
@@ -6178,15 +4230,8 @@ ModelElementEnabled:
   humanReadableDescription: "Enable HTML <model> element"
   condition: ENABLE(MODEL_ELEMENT)
   defaultValue:
-    WebKitLegacy:
-      "(PLATFORM(VISION) || ENABLE(GPU_PROCESS_MODEL)) && ENABLE(MODEL_ELEMENT)": true
-      default: false
-    WebKit:
-      "(PLATFORM(VISION) || ENABLE(GPU_PROCESS_MODEL)) && ENABLE(MODEL_ELEMENT)": true
-      default: false
-    WebCore:
-      "(PLATFORM(VISION) || ENABLE(GPU_PROCESS_MODEL)) && ENABLE(MODEL_ELEMENT)": true
-      default: false
+    "(PLATFORM(VISION) || ENABLE(GPU_PROCESS_MODEL)) && ENABLE(MODEL_ELEMENT)": true
+    default: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
 
@@ -6198,15 +4243,8 @@ ModelElementImmersiveEnabled:
   humanReadableName: "Immersive <model> API"
   humanReadableDescription: "Enable <model> element immersive API"
   defaultValue:
-    WebKitLegacy:
-      "ENABLE(MODEL_ELEMENT_IMMERSIVE)": true
-      default: false
-    WebKit:
-      "ENABLE(MODEL_ELEMENT_IMMERSIVE)": true
-      default: false
-    WebCore:
-      "ENABLE(MODEL_ELEMENT_IMMERSIVE)": true
-      default: false
+    "ENABLE(MODEL_ELEMENT_IMMERSIVE)": true
+    default: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
 
@@ -6216,13 +4254,7 @@ ModelNoPortalAttributeEnabled:
   condition: PLATFORM(VISION) && ENABLE(MODEL_PROCESS)
   humanReadableName: "Model noportal attribute"
   humanReadableDescription: "Enable Model noportal attribute support"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   disableInLockdownMode: true
 
 ModelProcessEnabled:
@@ -6232,13 +4264,7 @@ ModelProcessEnabled:
   condition: ENABLE(MODEL_PROCESS)
   humanReadableName: "Enable Model Process"
   humanReadableDescription: "Load <model> content in a separate process"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
 
@@ -6248,12 +4274,8 @@ MomentumScrollingAnimatorEnabled:
   humanReadableName: "Momentum Scrolling Animator"
   humanReadableDescription: "Generate momentum events in WebKit instead of using those delivered by the system"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 MoreCurrencyDisplayChoicesEnabled:
   type: bool
@@ -6264,9 +4286,8 @@ MoreCurrencyDisplayChoicesEnabled:
   webcoreBinding: none
   jscOptionName: useMoreCurrencyDisplayChoices
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 MouseEventsSimulationEnabled:
   type: bool
@@ -6275,26 +4296,14 @@ MouseEventsSimulationEnabled:
   humanReadableName: "Mouse events simulation"
   humanReadableDescription: "Enable mouse events dispatch along with touch events on iOS"
   condition: ENABLE(TOUCH_EVENTS) || ENABLE(TOUCH_EVENT_REGIONS)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 MoveBeforeEnabled:
   type: bool
   status: testable
   category: dom
   humanReadableName: "DOM moveBefore()"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 MultiProcessBackForwardCacheEnabled:
   type: bool
@@ -6302,13 +4311,7 @@ MultiProcessBackForwardCacheEnabled:
   category: security
   humanReadableName: "Multi-Process Back/Forward Cache"
   humanReadableDescription: "Enable back/forward cache when site isolation is active"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 MutationEventsEnabled:
   type: bool
@@ -6316,12 +4319,8 @@ MutationEventsEnabled:
   category: dom
   humanReadableName: "DOM mutation events"
   defaultValue:
-    WebKitLegacy:
-      default: WebKit::defaultMutationEventsEnabled()
-    WebKit:
-      default: WebKit::defaultMutationEventsEnabled()
-    WebCore:
-      default: false
+    default: WebKit::defaultMutationEventsEnabled()
+    WebCore: false
 
 MuteCameraOnMicrophoneInterruptionEnabled:
   type: bool
@@ -6331,12 +4330,9 @@ MuteCameraOnMicrophoneInterruptionEnabled:
   humanReadableDescription: "Mute Camera on Microphone Interruption"
   condition: ENABLE(MEDIA_STREAM)
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(IOS_FAMILY)": true
-      default: false
-    WebCore:
       default: false
 
 NavigationAPIEnabled:
@@ -6346,14 +4342,9 @@ NavigationAPIEnabled:
   humanReadableName: "Navigation API"
   humanReadableDescription: "Enable Navigation API"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
+    "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
+    default: false
+    WebKitLegacy: false
 
 NavigationAPIPrecommitHandlerEnabled:
   type: bool
@@ -6362,14 +4353,9 @@ NavigationAPIPrecommitHandlerEnabled:
   humanReadableName: "Navigation API Precommit Handler"
   humanReadableDescription: "Enable Navigation API Precommit Handler"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
+    "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
+    default: false
+    WebKitLegacy: false
 
 NavigatorUserAgentDataJavaScriptAPIEnabled:
   type: bool
@@ -6377,25 +4363,15 @@ NavigatorUserAgentDataJavaScriptAPIEnabled:
   category: dom
   humanReadableName: "Navigator userAgentData JavaScript API"
   humanReadableDescription: "Enable the navigator.userAgentData JavaScript API"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 NavigatorWebDriverActivePolicy:
   type: uint32_t
   refinedType: WebCore::NavigatorWebDriverActivePolicy
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: static_cast<uint32_t>(WebCore::NavigatorWebDriverActivePolicy::Auto)
-    WebKit:
-      default: static_cast<uint32_t>(WebCore::NavigatorWebDriverActivePolicy::Auto)
-    WebCore:
-      default: NavigatorWebDriverActivePolicy::Auto
+    default: static_cast<uint32_t>(WebCore::NavigatorWebDriverActivePolicy::Auto)
+    WebCore: NavigatorWebDriverActivePolicy::Auto
 
 NeedsAdobeFrameReloadingQuirk:
   comment: 'FIXME: This quirk is needed because of Radar 4674537 and 5211271. We need
@@ -6404,24 +4380,18 @@ NeedsAdobeFrameReloadingQuirk:
   status: embedder
   webcoreGetter: needsAcrobatFrameReloadingQuirk
   defaultValue:
+    default: false
     WebKitLegacy:
       PLATFORM(MAC): WebKit::defaultNeedsAdobeFrameReloadingQuirk()
-      default: false
-    WebKit:
-      default: false
-    WebCore:
       default: false
 
 NeedsFrameNameFallbackToIdQuirk:
   type: bool
   status: embedder
   defaultValue:
+    default: false
     WebKitLegacy:
       PLATFORM(MAC): WebKit::defaultNeedsFrameNameFallbackToIdQuirk()
-      default: false
-    WebKit:
-      default: false
-    WebCore:
       default: false
 
 NeedsInAppBrowserPrivacyQuirks:
@@ -6434,9 +4404,8 @@ NeedsInAppBrowserPrivacyQuirks:
   webcoreBinding: none
   exposed: [ WebKit ]
   condition: ENABLE(APP_BOUND_DOMAINS)
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 NeedsKeyboardEventDisambiguationQuirks:
   comment: This is a quirk we are pro-actively applying to old applications. It changes
@@ -6446,12 +4415,9 @@ NeedsKeyboardEventDisambiguationQuirks:
   type: bool
   status: embedder
   defaultValue:
+    default: false
     WebKitLegacy:
       PLATFORM(MAC): WebKit::defaultNeedsKeyboardEventDisambiguationQuirks()
-      default: false
-    WebKit:
-      default: false
-    WebCore:
       default: false
 
 NeedsSiteSpecificQuirks:
@@ -6462,24 +4428,14 @@ NeedsSiteSpecificQuirks:
   webKitLegacyPreferenceKey: WebKitUseSiteSpecificSpoofing
   inspectorOverride: true
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 NeedsStorageAccessFromFileURLsQuirk:
   type: bool
   status: embedder
   humanReadableName: "Needs storage access from file URLs quirk"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 NotificationEventEnabled:
   type: bool
@@ -6488,13 +4444,10 @@ NotificationEventEnabled:
   humanReadableName: "NotificationEvent support"
   humanReadableDescription: "NotificationEvent and ServiceWorkerRegistration.showNotification() support"
   condition: ENABLE(NOTIFICATION_EVENT)
+  excludeFrom: [ WebKitLegacy ]
   defaultValue:
-    WebCore:
-      "ENABLE(NOTIFICATION_EVENT) && !PLATFORM(IOS_FAMILY)": true
-      default: false
-    WebKit:
-      "ENABLE(NOTIFICATION_EVENT) && !PLATFORM(IOS_FAMILY)": true
-      default: false
+    "ENABLE(NOTIFICATION_EVENT) && !PLATFORM(IOS_FAMILY)": true
+    default: false
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
@@ -6507,15 +4460,8 @@ NotificationsEnabled:
   condition: ENABLE(NOTIFICATIONS)
   inspectorOverride: true
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
-    WebKit:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
-    WebCore:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
+    "PLATFORM(IOS_FAMILY)": false
+    default: true
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -6526,13 +4472,7 @@ ObservableEnabled:
   category: dom
   humanReadableName: "Observable API"
   humanReadableDescription: "Support for the Observable API"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 OffscreenCanvasEnabled:
   type: bool
@@ -6542,14 +4482,10 @@ OffscreenCanvasEnabled:
   humanReadableDescription: "Support for the OffscreenCanvas APIs"
   condition: ENABLE(OFFSCREEN_CANVAS)
   defaultValue:
+    "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
+    default: false
     WebKitLegacy:
       "PLATFORM(COCOA)": true
-      default: false
-    WebKit:
-      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
 
 OffscreenCanvasInWorkersEnabled:
@@ -6560,14 +4496,10 @@ OffscreenCanvasInWorkersEnabled:
   humanReadableDescription: "Support for the OffscreenCanvas APIs in Workers"
   condition: ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
   defaultValue:
+    "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
+    default: false
     WebKitLegacy:
       "PLATFORM(COCOA)": true
-      default: false
-    WebKit:
-      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
 
 OpenPseudoClassEnabled:
@@ -6576,13 +4508,7 @@ OpenPseudoClassEnabled:
   humanReadableName: ":open pseudo-class"
   humanReadableDescription: "Enable the :open CSS pseudo-class"
   category: css
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 OpenXRDMABufRelaxedForTesting:
   type: bool
@@ -6592,9 +4518,8 @@ OpenXRDMABufRelaxedForTesting:
   webcoreBinding: none
   condition: ENABLE(DEVELOPER_MODE) && USE(OPENXR)
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 # FIXME: Reenable this on iOS once we can mitigate impact on memory use.
 OpportunisticSweepingAndGarbageCollectionEnabled:
@@ -6604,12 +4529,8 @@ OpportunisticSweepingAndGarbageCollectionEnabled:
   humanReadableDescription: "Enable Opportunistic Sweeping and GC"
   category: javascript
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 OptInPartitionedCookiesEnabled:
   type: bool
@@ -6618,13 +4539,7 @@ OptInPartitionedCookiesEnabled:
   humanReadableName: "Opt-in partitioned cookies (CHIPS)"
   humanReadableDescription: "Enable opt-in partitioned cookies"
   condition: ENABLE(OPT_IN_PARTITIONED_COOKIES)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 OriginAPIEnabled:
   type: bool
@@ -6632,13 +4547,7 @@ OriginAPIEnabled:
   category: dom
   humanReadableName: "Origin API"
   humanReadableDescription: "Enable the Origin API"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 OriginAgentClusterEnabled:
   type: bool
@@ -6646,13 +4555,7 @@ OriginAgentClusterEnabled:
   category: security
   humanReadableName: "Origin-Agent-Cluster header"
   humanReadableDescription: "Support for the Origin-Agent-Cluster HTTP response header and window.originAgentCluster getter"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 OverlayRegionsEnabled:
   type: bool
@@ -6663,9 +4566,8 @@ OverlayRegionsEnabled:
   condition: ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 OverscrollBehaviorEnabled:
   type: bool
@@ -6674,14 +4576,9 @@ OverscrollBehaviorEnabled:
   humanReadableName: "CSS Overscroll Behavior"
   humanReadableDescription: "Enable CSS overscroll-behavior"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(WIN)": false
-      default: true
-    WebCore:
-      "PLATFORM(WIN)": false
-      default: true
+    "PLATFORM(WIN)": false
+    default: true
+    WebKitLegacy: false
 
 PDFJSViewerEnabled:
   type: bool
@@ -6691,12 +4588,9 @@ PDFJSViewerEnabled:
   humanReadableDescription: "Enable PDF.js viewer"
   condition: ENABLE(PDFJS)
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
       default: false
   disableInLockdownMode: true
 
@@ -6706,38 +4600,28 @@ PDFPluginEnabled:
   condition: PLATFORM(COCOA)
   exposed: [ WebKit ]
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(IOS_FAMILY)": false
       default: true
-    WebCore:
-      default: false
 
 PDFPluginHUDEnabled:
   type: bool
   status: embedder
   condition: PLATFORM(COCOA)
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(IOS_FAMILY)": false
       default: true
-    WebCore:
-      default: false
 
 PDFPluginPageNumberIndicatorEnabled:
   type: bool
   status: embedder
   condition: ENABLE(PDF_PAGE_NUMBER_INDICATOR)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 PageVisibilityBasedProcessSuppressionEnabled:
   type: bool
@@ -6747,22 +4631,16 @@ PageVisibilityBasedProcessSuppressionEnabled:
   humanReadableDescription: "Enable page visibility-based process suppression"
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 PassiveTouchListenersAsDefaultOnDocument:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(IOS_FAMILY)": WebKit::defaultPassiveTouchListenersAsDefaultOnDocument()
-      default: true
-    WebKit:
-      "PLATFORM(IOS_FAMILY)": WebKit::defaultPassiveTouchListenersAsDefaultOnDocument()
-      default: true
-    WebCore:
-      default: true
+    "PLATFORM(IOS_FAMILY)": WebKit::defaultPassiveTouchListenersAsDefaultOnDocument()
+    default: true
+    WebCore: true
 
 PassiveWheelListenersAsDefaultOnDocument:
   type: bool
@@ -6770,14 +4648,9 @@ PassiveWheelListenersAsDefaultOnDocument:
   humanReadableName: "Wheel Event listeners on the root made passive"
   humanReadableDescription: "Force wheel event listeners registered on the window, document or body to be passive"
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(MAC)": WebKit::defaultPassiveWheelListenersAsDefaultOnDocument()
-      default: true
-    WebKit:
-      "PLATFORM(MAC)": WebKit::defaultPassiveWheelListenersAsDefaultOnDocument()
-      default: true
-    WebCore:
-      default: true
+    "PLATFORM(MAC)": WebKit::defaultPassiveWheelListenersAsDefaultOnDocument()
+    default: true
+    WebCore: true
 
 PasswordEchoDuration:
   type: double
@@ -6785,27 +4658,23 @@ PasswordEchoDuration:
   webKitLegacyPreferenceKey: WebKitPasswordEchoDurationPreferenceKey
   webcoreName: passwordEchoDurationInSeconds
   defaultValue:
+    default: 2
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": 2
       default: 1
-    WebKit:
-      default: 2
-    WebCore:
-      default: 1
+    WebCore: 1
 
 PasswordEchoEnabled:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: WebKitEnablePasswordEchoPreferenceKey
   defaultValue:
+    "PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)": true
+    default: false
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": true
       default: false
-    WebKit:
-      "PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)": true
-      default: false
-    WebCore:
-      default: false
+    WebCore: false
 
 PeerConnectionEnabled:
   type: bool
@@ -6814,13 +4683,10 @@ PeerConnectionEnabled:
   humanReadableDescription: "Enable RTCPeerConnection"
   condition: ENABLE(WEB_RTC)
   defaultValue:
-    WebKitLegacy:
-      default: true
+    default: true
     WebKit:
       "USE(LIBWEBRTC)": WebKit::defaultPeerConnectionEnabledAvailable()
       default: false
-    WebCore:
-      default: true
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -6832,13 +4698,7 @@ PeerConnectionVideoScalingAdaptationDisabled:
   humanReadableName: "WebRTC Peer Connection Video Scaling Adaptation"
   humanReadableDescription: "Disable RTCPeerConnection Video Scaling Adaptation"
   condition: ENABLE(WEB_RTC)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 PerElementSpeakerSelectionEnabled:
@@ -6848,12 +4708,12 @@ PerElementSpeakerSelectionEnabled:
   humanReadableName: "Allow per media element speaker device selection"
   humanReadableDescription: "Allow per media element speaker device selection"
   condition: ENABLE(MEDIA_STREAM)
+  excludeFrom: [ WebKitLegacy ]
   defaultValue:
-    WebKit:
-      "PLATFORM(COCOA)": true
-      "PLATFORM(WPE)": true
-      "PLATFORM(GTK)": true
-      default: false
+    "PLATFORM(COCOA)": true
+    "PLATFORM(WPE)": true
+    "PLATFORM(GTK)": true
+    default: false
     WebCore:
       "PLATFORM(WPE)": true
       "PLATFORM(GTK)": true
@@ -6866,12 +4726,9 @@ PermissionsAPIEnabled:
   humanReadableName: "Permissions API"
   humanReadableDescription: "Enable Permissions API"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(WIN)" : true
-      default: false
-    WebCore:
       default: false
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -6884,9 +4741,8 @@ PhotoPickerPrefersOriginalImageFormat:
   webcoreBinding: none
   condition: HAVE(PHOTOS_UI)
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 PictographFontFamily:
   type: String
@@ -6894,30 +4750,24 @@ PictographFontFamily:
   webKitLegacyPreferenceKey: WebKitPictographFont
   webcoreImplementation: custom
   defaultValue:
+    "PLATFORM(COCOA) && PLATFORM(IOS_FAMILY)": '"AppleColorEmoji"_str'
+    "PLATFORM(COCOA) && !PLATFORM(IOS_FAMILY)": '"Apple Color Emoji"_str'
+    default: '"Times"_str'
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": '"AppleColorEmoji"_str'
       default: '"Apple Color Emoji"_str'
-    WebKit:
-      "PLATFORM(COCOA) && PLATFORM(IOS_FAMILY)": '"AppleColorEmoji"_str'
-      "PLATFORM(COCOA) && !PLATFORM(IOS_FAMILY)": '"Apple Color Emoji"_str'
-      default: '"Times"_str'
-    WebCore:
-      default: '""_str'
+    WebCore: '""_str'
 
 PictureInPictureAPIEnabled:
   type: bool
   status: embedder
   condition: ENABLE(PICTURE_IN_PICTURE_API)
   defaultValue:
+    "PLATFORM(VISION)": false
+    default: true
     WebKitLegacy:
       "PLATFORM(VISION)": false
       default: false
-    WebKit:
-      "PLATFORM(VISION)": false
-      default: true
-    WebCore:
-      "PLATFORM(VISION)": false
-      default: true
   disableInLockdownMode: true
 
 PictureInPicturePlaybackStateEnabled:
@@ -6927,12 +4777,8 @@ PictureInPicturePlaybackStateEnabled:
   humanReadableDescription: "Picture-in-Picture Playback State Enabled"
   condition: HAVE(PIP_SKIP_PREROLL)
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: true
+    WebCore: false
   disableInLockdownMode: true
 
 PitchCorrectionAlgorithm:
@@ -6940,14 +4786,9 @@ PitchCorrectionAlgorithm:
   refinedType: WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(COCOA)": static_cast<uint32_t>(WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm::BestForSpeech)
-      default: static_cast<uint32_t>(WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm::BestAllAround)
-    WebKit:
-      "PLATFORM(COCOA)": static_cast<uint32_t>(WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm::BestForSpeech)
-      default: static_cast<uint32_t>(WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm::BestAllAround)
-    WebCore:
-      default: MediaPlayerEnums::PitchCorrectionAlgorithm::BestAllAround
+    "PLATFORM(COCOA)": static_cast<uint32_t>(WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm::BestForSpeech)
+    default: static_cast<uint32_t>(WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm::BestAllAround)
+    WebCore: MediaPlayerEnums::PitchCorrectionAlgorithm::BestAllAround
 
 PointerLockEnabled:
   type: bool
@@ -6958,14 +4799,9 @@ PointerLockEnabled:
   humanReadableDescription: "Enable the Pointer Lock API"
   inspectorOverride: true
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
-    WebKit:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
-    WebCore:
-      default: false
+    "PLATFORM(IOS_FAMILY)": false
+    default: true
+    WebCore: false
 
 PopoverAttributeEnabled:
   type: bool
@@ -6974,12 +4810,8 @@ PopoverAttributeEnabled:
   humanReadableName: "HTML popover attribute"
   humanReadableDescription: "Enable HTML popover attribute support"
   defaultValue:
-    WebKitLegacy:
-      default: WebKit::defaultPopoverAttributeEnabled()
-    WebKit:
-      default: WebKit::defaultPopoverAttributeEnabled()
-    WebCore:
-      default: true
+    default: WebKit::defaultPopoverAttributeEnabled()
+    WebCore: true
 
 PopoverHintEnabled:
   type: bool
@@ -6987,13 +4819,7 @@ PopoverHintEnabled:
   category: html
   humanReadableName: "HTML popover hint type"
   humanReadableDescription: "Enable popover='hint' type support"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 PreferFasterClickOverDoubleTap:
   type: bool
@@ -7004,10 +4830,10 @@ PreferFasterClickOverDoubleTap:
   webcoreBinding: none
   condition: PLATFORM(IOS_FAMILY)
   exposed: [ WebKit ]
+  excludeFrom: [ WebKitLegacy, WebCore ]
   defaultValue:
-    WebKit:
-      "PLATFORM(IOS_FAMILY) && !PLATFORM(WATCHOS)": true
-      default: false
+    "PLATFORM(IOS_FAMILY) && !PLATFORM(WATCHOS)": true
+    default: false
 
 PreferPageRenderingUpdatesNear60FPSEnabled:
   type: bool
@@ -7016,15 +4842,8 @@ PreferPageRenderingUpdatesNear60FPSEnabled:
   humanReadableName: "Prefer Page Rendering Updates near 60fps"
   humanReadableDescription: "Prefer page rendering updates near 60 frames per second rather than using the display's refresh rate"
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(VISION)": false
-      default: true
-    WebKit:
-      "PLATFORM(VISION)": false
-      default: true
-    WebCore:
-      "PLATFORM(VISION)": false
-      default: true
+    "PLATFORM(VISION)": false
+    default: true
 
 PreferSpatialAudioExperience:
   type: bool
@@ -7034,12 +4853,8 @@ PreferSpatialAudioExperience:
   humanReadableName: "Prefer Spatial Audio Experience over Spatial Tracking Labels"
   humanReadableDescription: "Prefer Spatial Audio Experience over Spatial Tracking Labels"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultPreferSpatialAudioExperience()
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultPreferSpatialAudioExperience()
   defaultsOverridable: true
   sharedPreferenceForWebProcess: true
 
@@ -7049,13 +4864,7 @@ PrivateClickMeasurementDebugModeEnabled:
   category: privacy
   humanReadableName: "Private Click Measurement Debug Mode"
   humanReadableDescription: "Enable Private Click Measurement Debug Mode"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 PrivateClickMeasurementEnabled:
   type: bool
@@ -7063,12 +4872,8 @@ PrivateClickMeasurementEnabled:
   humanReadableName: "Private Click Measurement"
   humanReadableDescription: "Enable Private Click Measurement for Cross-Site Link Navigations"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 PrivateClickMeasurementFraudPreventionEnabled:
   type: bool
@@ -7076,13 +4881,10 @@ PrivateClickMeasurementFraudPreventionEnabled:
   category: privacy
   humanReadableName: "Private Click Measurement Fraud Prevention"
   humanReadableDescription: "Enable Private Click Measurement Fraud Prevention"
+  excludeFrom: [ WebKitLegacy ]
   defaultValue:
-    WebKit:
-      "HAVE(RSA_BSSA)": true
-      default: false
-    WebCore:
-      "HAVE(RSA_BSSA)": true
-      default: false
+    "HAVE(RSA_BSSA)": true
+    default: false
 
 PrivateTokenUsageByThirdPartyEnabled:
   type: bool
@@ -7091,12 +4893,8 @@ PrivateTokenUsageByThirdPartyEnabled:
   humanReadableName: "Private Token usage by third party"
   humanReadableDescription: "Enable private token usage by third party"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 ProcessSwapOnCrossSiteNavigationEnabled:
   type: bool
@@ -7106,10 +4904,10 @@ ProcessSwapOnCrossSiteNavigationEnabled:
   humanReadableDescription: "Swap WebContent Processes on cross-site navigations"
   webcoreBinding: none
   exposed: [ WebKit ]
+  excludeFrom: [ WebKitLegacy, WebCore ]
   defaultValue:
-    WebKit:
-      "PLATFORM(PLAYSTATION)": false
-      default: true
+    "PLATFORM(PLAYSTATION)": false
+    default: true
 
 PromiseIsPromiseEnabled:
   type: bool
@@ -7120,37 +4918,27 @@ PromiseIsPromiseEnabled:
   webcoreBinding: none
   jscOptionName: usePromiseIsPromise
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 PropagateDamagingInformation:
-   type: bool
-   status: testable
-   category: dom
-   humanReadableName: "Propagate Damaging Information"
-   humanReadableDescription: "Propagate Damaging Information"
-   condition: ENABLE(DAMAGE_TRACKING)
-   defaultValue:
-     WebKitLegacy:
-       default: false
-     WebKit:
-       "PLATFORM(GTK) || PLATFORM(WPE)": true
-       default: false
-     WebCore:
-       default: false
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "Propagate Damaging Information"
+  humanReadableDescription: "Propagate Damaging Information"
+  condition: ENABLE(DAMAGE_TRACKING)
+  defaultValue:
+    default: false
+    WebKit:
+      "PLATFORM(GTK) || PLATFORM(WPE)": true
+      default: false
 
 PunchOutWhiteBackgroundsInDarkMode:
   type: bool
   status: embedder
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 PushAPIEnabled:
   type: bool
@@ -7159,13 +4947,7 @@ PushAPIEnabled:
   humanReadableName: "Push API"
   humanReadableDescription: "Enable Push API"
   inspectorOverride: true
-  defaultValue:
-    WebCore:
-      default: false
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
+  defaultValue: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -7176,12 +4958,8 @@ RTCEncodedStreamsQuirkEnabled:
   humanReadableName: "RTC Encoded Streams Quirk"
   humanReadableDescription: "Enable RTC Encoded Streams Quirk"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultRTCEncodedStreamsQuirkEnabled()
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultRTCEncodedStreamsQuirkEnabled()
 
 ReadableByteStreamAPIEnabled:
   type: bool
@@ -7189,13 +4967,7 @@ ReadableByteStreamAPIEnabled:
   category: dom
   humanReadableName: "ReadableByteStream"
   humanReadableDescription: "Enable Readable Byte Streams"
-  defaultValue:
-    WebCore:
-      default: true
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
+  defaultValue: true
 
 ReadableStreamFromEnabled:
   type: bool
@@ -7203,13 +4975,7 @@ ReadableStreamFromEnabled:
   category: dom
   humanReadableName: "ReadableStream.from"
   humanReadableDescription: "Enable ReadableStream.from"
-  defaultValue:
-    WebCore:
-      default: true
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
+  defaultValue: true
 
 ReadableStreamIterableEnabled:
   type: bool
@@ -7217,13 +4983,7 @@ ReadableStreamIterableEnabled:
   category: dom
   humanReadableName: "ReadableStream async iterable"
   humanReadableDescription: "Enable ReadableStream async iterable"
-  defaultValue:
-    WebCore:
-      default: true
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
+  defaultValue: true
 
 ReadableStreamTransferEnabled:
   type: bool
@@ -7231,13 +4991,7 @@ ReadableStreamTransferEnabled:
   category: dom
   humanReadableName: "ReadableStream/WritableStream/TransformStream transfer"
   humanReadableDescription: "Enable ReadableStream/WritableStream/TransformStream transfer"
-  defaultValue:
-    WebCore:
-      default: true
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
+  defaultValue: true
 
 RegExpBufferBoundariesEnabled:
   type: bool
@@ -7248,9 +5002,8 @@ RegExpBufferBoundariesEnabled:
   webcoreBinding: none
   jscOptionName: useRegExpBufferBoundaries
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 RemoteMediaSessionManagerEnabled:
   type: bool
@@ -7258,13 +5011,7 @@ RemoteMediaSessionManagerEnabled:
   category: media
   humanReadableName: "Remote MediaSessionManager"
   humanReadableDescription: "Enable MediaSessionManager in the UI process"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
 
@@ -7276,29 +5023,18 @@ RemotePlaybackEnabled:
   humanReadableDescription: "Enable Remote Playback API"
   condition: ENABLE(WIRELESS_PLAYBACK_TARGET)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(VISION)" : false
-      default: true
-    WebCore:
-      "PLATFORM(VISION)" : false
-      default: true
+    "PLATFORM(VISION)" : false
+    default: true
+    WebKitLegacy: false
   disableInLockdownMode: true
 
 RemoteSnapshottingEnabled:
-   type: bool
-   status: testable
-   category: media
-   humanReadableName: "Remote Snapshotting"
-   defaultValue:
-     WebKitLegacy:
-       default: false
-     WebKit:
-       default: false
-     WebCore:
-       default: false
-   sharedPreferenceForWebProcess: true
+  type: bool
+  status: testable
+  category: media
+  humanReadableName: "Remote Snapshotting"
+  defaultValue: false
+  sharedPreferenceForWebProcess: true
 
 RemoveBackgroundEnabled:
   type: bool
@@ -7310,12 +5046,8 @@ RemoveBackgroundEnabled:
   condition: ENABLE(IMAGE_ANALYSIS)
   exposed: [ WebKit ]
   defaultValue:
-    WebCore:
-      default: false
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: defaultRemoveBackgroundEnabled()
+    default: false
+    WebKit: defaultRemoveBackgroundEnabled()
 
 ReplayCGDisplayListsIntoBackingStore:
   type: bool
@@ -7325,9 +5057,8 @@ ReplayCGDisplayListsIntoBackingStore:
   webcoreBinding: none
   condition: ENABLE(RE_DYNAMIC_CONTENT_SCALING)
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 RequestIdleCallbackEnabled:
   type: bool
@@ -7335,13 +5066,7 @@ RequestIdleCallbackEnabled:
   category: dom
   humanReadableName: "requestIdleCallback"
   humanReadableDescription: "Enable requestIdleCallback support"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 RequestStorageAccessThrowsExceptionUntilReload:
   type: bool
@@ -7349,13 +5074,7 @@ RequestStorageAccessThrowsExceptionUntilReload:
   category: dom
   humanReadableName: "requestStorageAccess throws execption until reload"
   humanReadableDescription: "requestStorageAccess throws execption until reload"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 RequestVideoFrameCallbackEnabled:
   type: bool
@@ -7364,16 +5083,11 @@ RequestVideoFrameCallbackEnabled:
   humanReadableName: "RequestVideoFrameCallback"
   humanReadableDescription: "Enable RequestVideoFrameCallback API"
   defaultValue:
+    "PLATFORM(COCOA) && HAVE(AVSAMPLEBUFFERVIDEOOUTPUT)" : true
+    "USE(GSTREAMER)": true
+    default: false
     WebKitLegacy:
       "PLATFORM(COCOA) && HAVE(AVSAMPLEBUFFERVIDEOOUTPUT)" : true
-      default: false
-    WebKit:
-      "PLATFORM(COCOA) && HAVE(AVSAMPLEBUFFERVIDEOOUTPUT)" : true
-      "USE(GSTREAMER)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA) && HAVE(AVSAMPLEBUFFERVIDEOOUTPUT)" : true
-      "USE(GSTREAMER)": true
       default: false
 
 RequiresPageVisibilityForVideoToBeNowPlaying:
@@ -7381,70 +5095,48 @@ RequiresPageVisibilityForVideoToBeNowPlaying:
   status: embedder
   condition: ENABLE(REQUIRES_PAGE_VISIBILITY_FOR_NOW_PLAYING)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: defaultRequiresPageVisibilityForVideoToBeNowPlaying()
-    WebCore:
-      default: false
+    default: false
+    WebKit: defaultRequiresPageVisibilityForVideoToBeNowPlaying()
 
 RequiresPageVisibilityToPlayAudio:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 RequiresUserGestureForAudioPlayback:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: WebKitAudioPlaybackRequiresUserGesture
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(IOS_FAMILY)": true
-      default: false
-    WebCore:
-      PLATFORM(IOS_FAMILY): true
-      default: false
+    "PLATFORM(IOS_FAMILY)": true
+    default: false
+    WebKitLegacy: false
 
 RequiresUserGestureForMediaPlayback:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: WebKitMediaPlaybackRequiresUserGesture
   webcoreBinding: none
+  excludeFrom: [ WebCore ]
   defaultValue:
+    default: false
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": true
-      default: false
-    WebKit:
       default: false
 
 RequiresUserGestureForVideoPlayback:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: WebKitVideoPlaybackRequiresUserGesture
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 RequiresUserGestureToLoadVideo:
   type: bool
   status: embedder
   defaultValue:
+    default: false
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": WebKit::defaultRequiresUserGestureToLoadVideo()
-      default: false
-    WebKit:
       default: false
     WebCore:
       "PLATFORM(IOS_FAMILY)": true
@@ -7457,12 +5149,8 @@ ResourceLoadSchedulingEnabled:
   humanReadableName: "Resource Load Scheduling"
   humanReadableDescription: "Network process side priority and visibility based resource load scheduling"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 ResourceUsageOverlayVisible:
   type: bool
@@ -7473,13 +5161,7 @@ ResourceUsageOverlayVisible:
   humanReadableDescription: "Make resource usage overlay visible"
   condition: ENABLE(RESOURCE_USAGE)
   webcoreOnChange: resourceUsageOverlayVisibleChanged
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 RespondToThermalPressureAggressively:
   type: bool
@@ -7487,38 +5169,22 @@ RespondToThermalPressureAggressively:
   defaultsOverridable: true
   humanReadableName: "Respond to thermal pressure aggressively"
   humanReadableDescription: "Enable responding to thermal pressure aggressively"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 RubberBandingForSubScrollableRegionsEnabled:
   type: bool
   status: embedder
   condition: HAVE(RUBBER_BANDING)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 SKAttributionEnabled:
   type: bool
   status: embedder
   humanReadableName: "SKAttribution"
   humanReadableDescription: "SKAttribution"
-  defaultValue:
-    WebCore:
-      default: true
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
+  defaultValue: true
 
 SVGExternalResourcesEnabled:
   type: bool
@@ -7526,13 +5192,7 @@ SVGExternalResourcesEnabled:
   category: css
   humanReadableName: "SVG external resources"
   humanReadableDescription: "Enable referencing SVG resources (paint servers, etc.) via external or data: URLs"
-  defaultValue:
-    WebCore:
-      default: true
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
+  defaultValue: true
 
 SWVPDecodersAlwaysEnabled:
   type: bool
@@ -7543,14 +5203,9 @@ SWVPDecodersAlwaysEnabled:
   webcoreBinding: none
   condition: ENABLE(VP9)
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(IOS_FAMILY_SIMULATOR)": true
-      default: false
-    WebKit:
-      "PLATFORM(IOS_FAMILY_SIMULATOR)": true
-      default: false
-    WebCore:
-      default: false
+    "PLATFORM(IOS_FAMILY_SIMULATOR)": true
+    default: false
+    WebCore: false
 
 SafeBrowsingEnabled:
   type: bool
@@ -7559,31 +5214,18 @@ SafeBrowsingEnabled:
   humanReadableDescription: "Enable Safe Browsing"
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 SampledPageTopColorMaxDifference:
   type: double
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: 0
-    WebKit:
-      default: 0
-    WebCore:
-      default: 0
+  defaultValue: 0
 
 SampledPageTopColorMinHeight:
   type: double
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: 0
-    WebKit:
-      default: 0
-    WebCore:
-      default: 0
+  defaultValue: 0
 
 SansSerifFontFamily:
   type: String
@@ -7591,12 +5233,8 @@ SansSerifFontFamily:
   webKitLegacyPreferenceKey: WebKitSansSerifFont
   webcoreImplementation: custom
   defaultValue:
-    WebKitLegacy:
-      default: '"Helvetica"_str'
-    WebKit:
-      default: '"Helvetica"_str'
-    WebCore:
-      default: '""_str'
+    default: '"Helvetica"_str'
+    WebCore: '""_str'
 
 ScopedCustomElementRegistryEnabled:
   type: bool
@@ -7605,15 +5243,8 @@ ScopedCustomElementRegistryEnabled:
   humanReadableName: "Scoped custom element registry"
   humanReadableDescription: "Enable scoped custom element registry"
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebKit:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)": true
-      default: false
+    "PLATFORM(COCOA)": true
+    default: false
 
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 # FIXME: This should have it's own ENABLE.
@@ -7625,12 +5256,8 @@ ScreenCaptureEnabled:
   humanReadableName: "ScreenCapture"
   humanReadableDescription: "Enable ScreenCapture"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultShouldEnableScreenCapture()
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultShouldEnableScreenCapture()
 
 ScreenOrientationAPIEnabled:
   type: bool
@@ -7639,12 +5266,8 @@ ScreenOrientationAPIEnabled:
   humanReadableName: "Screen Orientation API"
   humanReadableDescription: "Enable Screen Orientation API"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultShouldEnableScreenOrientationAPI()
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultShouldEnableScreenOrientationAPI()
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
@@ -7654,13 +5277,7 @@ ScreenOrientationLockingAPIEnabled:
   category: dom
   humanReadableName: "Screen Orientation API (Locking / Unlocking)"
   humanReadableDescription: "Enable Screen Orientation API (Locking / Unlocking)"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ScreenTimeEnabled:
   type: bool
@@ -7669,12 +5286,8 @@ ScreenTimeEnabled:
   humanReadableName: "Screen Time"
   humanReadableDescription: "Enable Screen Time"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: defaultScreenTimeEnabled()
-    WebCore:
-      default: false
+    default: false
+    WebKit: defaultScreenTimeEnabled()
 
 ScreenWakeLockAPIEnabled:
   type: bool
@@ -7683,12 +5296,8 @@ ScreenWakeLockAPIEnabled:
   humanReadableName: "Screen Wake Lock API"
   humanReadableDescription: "Enable Screen Wake Lock API"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 ScriptTrackingPrivacyLoggingEnabled:
   type: bool
@@ -7696,13 +5305,7 @@ ScriptTrackingPrivacyLoggingEnabled:
   humanReadableName: "Script Tracking Privacy Logging"
   humanReadableDescription: "Script tracking privacy logging enabled"
   exposed: [ WebKit ]
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ScriptTrackingPrivacyNetworkRequestBlockingEnabled:
   type: bool
@@ -7710,13 +5313,7 @@ ScriptTrackingPrivacyNetworkRequestBlockingEnabled:
   humanReadableName: "Script Tracking Privacy Network Requests Blocking"
   humanReadableDescription: "Block network requests to known tracking domains"
   exposed: [ WebKit ]
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 ScriptTrackingPrivacyProtectionsEnabled:
   type: bool
@@ -7725,9 +5322,8 @@ ScriptTrackingPrivacyProtectionsEnabled:
   humanReadableDescription: "Script tracking privacy protections enabled"
   exposed: [ WebKit ]
   webcoreBinding: none
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 ScrollAnimatorEnabled:
   type: bool
@@ -7735,16 +5331,10 @@ ScrollAnimatorEnabled:
   humanReadableName: "Scroll animator"
   humanReadableDescription: "Enable scroll animator"
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(MAC)": WebKit::defaultScrollAnimatorEnabled()
-      "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebKit:
-      "PLATFORM(MAC)": WebKit::defaultScrollAnimatorEnabled()
-      "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
-      default: false
+    "PLATFORM(MAC)": WebKit::defaultScrollAnimatorEnabled()
+    "PLATFORM(GTK) || PLATFORM(WPE)": true
+    default: false
+    WebCore: false
 
 ScrollToTextFragmentEnabled:
   type: bool
@@ -7753,12 +5343,8 @@ ScrollToTextFragmentEnabled:
   humanReadableName: "Scroll To Text Fragment"
   humanReadableDescription: "Enable Scroll To Text Fragment"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 ScrollToTextFragmentFeatureDetectionEnabled:
   type: bool
@@ -7767,12 +5353,8 @@ ScrollToTextFragmentFeatureDetectionEnabled:
   humanReadableName: "Scroll To Text Fragment Feature Detection"
   humanReadableDescription: "Enable Scroll To Text Fragment Feature Detection"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 ScrollToTextFragmentGenerationEnabled:
   type: bool
@@ -7781,38 +5363,22 @@ ScrollToTextFragmentGenerationEnabled:
   humanReadableName: "Scroll To Text Fragment Generation"
   humanReadableDescription: "Enable Scroll To Text Fragment Generation Menu"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 ScrollToTextFragmentIndicatorEnabled:
   type: bool
   status: embedder
   humanReadableName: "Scroll To Text Fragment Indicator"
   humanReadableDescription: "Enable Scroll To Text Fragment Indicator"
-  defaultValue:
-    WebKit:
-      default: true
-    WebKitLegacy:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 ScrollToTextFragmentMarkingEnabled:
   type: bool
   status: embedder
   humanReadableName: "Scroll To Text Fragment Marking"
   humanReadableDescription: "Enable Scroll To Text Fragment Marking"
-  defaultValue:
-    WebKit:
-      default: true
-    WebKitLegacy:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 ScrollViewAdaptiveDecelerationTrackingEnabled:
   type: bool
@@ -7822,9 +5388,8 @@ ScrollViewAdaptiveDecelerationTrackingEnabled:
   webcoreBinding: none
   exposed: [ WebKit ]
   condition: HAVE(UISCROLLVIEW_DECELERATION_TRACKING_BEHAVIOR)
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 ScrollendEventEnabled:
   type: bool
@@ -7833,12 +5398,8 @@ ScrollendEventEnabled:
   humanReadableName: "scrollend event"
   humanReadableDescription: "Enable scrollend event"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 ScrollingPerformanceTestingEnabled:
   type: bool
@@ -7848,13 +5409,7 @@ ScrollingPerformanceTestingEnabled:
   humanReadableDescription: "Enable behaviors used by scrolling performance tests"
   webcoreOnChange: scrollingPerformanceTestingEnabledChanged
   exposed: [ WebKit ]
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 SearchInputResultsAttributeEnabled:
   type: bool
@@ -7862,12 +5417,9 @@ SearchInputResultsAttributeEnabled:
   humanReadableName: "<input type=search> results=N attribute"
   humanReadableDescription: "Enable the legacy WebKit-only ::-webkit-search-results-button saved-searches dropdown opt-in"
   defaultValue:
+    default: false
     WebKitLegacy:
       "PLATFORM(COCOA)" : WebKit::defaultSearchInputResultsAttributeEnabled()
-      default: false
-    WebKit:
-      default: false
-    WebCore:
       default: false
 
 SecureContextChecksEnabled:
@@ -7876,13 +5428,7 @@ SecureContextChecksEnabled:
   category: security
   humanReadableName: "Secure Context Checks"
   humanReadableDescription: "Allow access to HTTPS-only Web APIs over HTTP"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 SelectShowPickerEnabled:
   type: bool
@@ -7890,26 +5436,14 @@ SelectShowPickerEnabled:
   category: dom
   humanReadableName: "<select> showPicker() method"
   humanReadableDescription: "Enable showPicker() method on <select>"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 # FIXME: This is handled via WebView SPI rather than WebPreferences for WebKitLegacy. We should change the SPI to lookup the WebPreferences value instead.
 SelectTrailingWhitespaceEnabled:
   type: bool
   status: embedder
   webKitLegacyBinding: custom
-  defaultValue:
-    WebKit:
-      default: false
-    WebKitLegacy:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 SelectionFlippingEnabled:
   type: bool
@@ -7917,10 +5451,10 @@ SelectionFlippingEnabled:
   humanReadableName: "Selection Flipping"
   humanReadableDescription: "Enable Selection Flipping"
   webcoreBinding: none
+  excludeFrom: [ WebKitLegacy, WebCore ]
   defaultValue:
-    WebKit:
-      "PLATFORM(VISION)" : false
-      default: true
+    "PLATFORM(VISION)" : false
+    default: true
 
 SelectionHonorsOverflowScrolling:
   type: bool
@@ -7930,12 +5464,9 @@ SelectionHonorsOverflowScrolling:
   condition: PLATFORM(IOS_FAMILY)
   exposed: [ WebKit ]
   defaultValue:
+    default: false
     WebKit:
       "ENABLE(SELECTION_HONORS_OVERFLOW_SCROLLING_BY_DEFAULT)" : true
-      default: false
-    WebKitLegacy:
-      default: false
-    WebCore:
       default: false
 
 SerifFontFamily:
@@ -7944,33 +5475,22 @@ SerifFontFamily:
   webKitLegacyPreferenceKey: WebKitSerifFont
   webcoreImplementation: custom
   defaultValue:
-    WebKitLegacy:
-      default: '"Times"_str'
-    WebKit:
-      default: '"Times"_str'
-    WebCore:
-      default: '""_str'
+    default: '"Times"_str'
+    WebCore: '""_str'
 
 ServiceControlsEnabled:
   type: bool
   status: embedder
   condition: ENABLE(SERVICE_CONTROLS)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ServiceWorkerEntitlementDisabledForTesting:
   type: bool
   status: embedder
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 ServiceWorkerInstallEventEnabled:
   type: bool
@@ -7979,14 +5499,9 @@ ServiceWorkerInstallEventEnabled:
   humanReadableName: "Service Worker Install Event"
   humanReadableDescription: "Enable Service Worker Install Event API"
   defaultValue:
-    WebKit:
-      "PLATFORM(COCOA)" : true
-      default: false
-    WebKitLegacy:
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)" : true
-      default: false
+    "PLATFORM(COCOA)" : true
+    default: false
+    WebKitLegacy: false
   disableInLockdownMode: true
 
 ServiceWorkerNavigationPreloadEnabled:
@@ -7996,12 +5511,8 @@ ServiceWorkerNavigationPreloadEnabled:
   humanReadableName: "Service Worker Navigation Preload"
   humanReadableDescription: "Enable Service Worker Navigation Preload API"
   defaultValue:
-    WebCore:
-      default: true
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
+    default: true
+    WebKitLegacy: false
   sharedPreferenceForWebProcess: true
   richJavaScript: true
   disableInLockdownMode: true
@@ -8014,12 +5525,8 @@ ServiceWorkersEnabled:
   humanReadableDescription: "Enable Service Workers"
   exposed: [ WebKit ]
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
   disableInLockdownMode: true
@@ -8031,12 +5538,8 @@ ServiceWorkersUserGestureEnabled:
   humanReadableName: "Validate UserGesture requirements in Service Workers"
   humanReadableDescription: "Validate UserGesture requirements in Service Workers"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 SessionStorageEnabled:
   type: bool
@@ -8044,12 +5547,8 @@ SessionStorageEnabled:
   humanReadableName: "Session Storage"
   humanReadableDescription: "Enable Session Storage"
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: true
+    WebCore: false
   sharedPreferenceForWebProcess: true
 
 ShadowRealmEnabled:
@@ -8061,9 +5560,8 @@ ShadowRealmEnabled:
   webcoreBinding: none
   jscOptionName: useShadowRealm
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 ShadowRootReferenceTargetEnabled:
   type: bool
@@ -8071,13 +5569,7 @@ ShadowRootReferenceTargetEnabled:
   category: dom
   humanReadableName: "referenceTarget"
   humanReadableDescription: "Enable setting a referenceTarget on shadow roots"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 ShadowRootReferenceTargetEnabledForAriaOwns:
@@ -8086,13 +5578,7 @@ ShadowRootReferenceTargetEnabledForAriaOwns:
   category: dom
   humanReadableName: "referenceTarget support for aria-owns"
   humanReadableDescription: "Enable referenceTarget support for aria-owns and ariaOwnsElements"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 # When enabling this, don't enable on watchOS or the macOS base system (which don't have Vision.framework).
@@ -8103,13 +5589,7 @@ ShapeDetection:
   status: testable
   humanReadableName: "Shape Detection API"
   humanReadableDescription: "Enable the Shape Detection API"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
@@ -8120,12 +5600,8 @@ SharedWorkerEnabled:
   humanReadableName: "SharedWorker"
   humanReadableDescription: "Enabled SharedWorker API"
   defaultValue:
-    WebCore:
-      default: false
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
+    default: false
+    WebKit: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
@@ -8133,82 +5609,42 @@ ShouldAllowUserInstalledFonts:
   type: bool
   status: embedder
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 ShouldConvertInvalidURLsToBlank:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: WebKit::defaultShouldConvertInvalidURLsToBlank()
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: WebKit::defaultShouldConvertInvalidURLsToBlank()
 
 ShouldConvertPositionStyleOnCopy:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ShouldDecidePolicyBeforeLoadingQuickLookPreview:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ShouldDisplayCaptions:
   type: bool
   status: embedder
   condition: ENABLE(VIDEO)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ShouldDisplaySubtitles:
   type: bool
   status: embedder
   condition: ENABLE(VIDEO)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ShouldDisplayTextDescriptions:
   type: bool
   status: embedder
   condition: ENABLE(VIDEO)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ShouldDropNearSuspendedAssertionAfterDelay:
   type: bool
@@ -8216,69 +5652,49 @@ ShouldDropNearSuspendedAssertionAfterDelay:
   humanReadableName: "Drop Near-Suspended Assertion After Delay"
   humanReadableDescription: "Causes processes to fully suspend after a delay"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultShouldDropNearSuspendedAssertionAfterDelay()
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultShouldDropNearSuspendedAssertionAfterDelay()
 
 ShouldEnableTextAutosizingBoost:
   type: bool
   status: embedder
   webcoreOnChange: shouldEnableTextAutosizingBoostChanged
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 ShouldIgnoreMetaViewport:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ShouldPrintBackgrounds:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: WebKitShouldPrintBackgroundsPreferenceKey
   defaultValue:
+    "PLATFORM(IOS_FAMILY)": WebKit::defaultShouldPrintBackgrounds()
+    "PLATFORM(GTK) || PLATFORM(WPE)": true
+    default: false
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": true
       default: false
-    WebKit:
-      "PLATFORM(IOS_FAMILY)": WebKit::defaultShouldPrintBackgrounds()
-      "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
-      default: false
+    WebCore: false
 
 ShouldReportDesktopClassPointingDevice:
   type: bool
   status: embedder
   humanReadableName: "Report Desktop Class Pointing Device"
   humanReadableDescription: "Report a mouse-like pointing device to the hover and pointer media features"
-  defaultValue:
-    WebCore:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebKit ]
+  defaultValue: false
 
 ShouldReportViewportSizeAsScreenSize:
   type: bool
   status: embedder
   humanReadableName: "Report Viewport Size As Screen Size"
   humanReadableDescription: "Report the viewport size instead of the real screen size"
-  defaultValue:
-    WebCore:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebKit ]
+  defaultValue: false
 
 ShouldReportZeroMaxTouchPoints:
   type: bool
@@ -8286,45 +5702,31 @@ ShouldReportZeroMaxTouchPoints:
   humanReadableName: "Report Zero Max Touch Points"
   humanReadableDescription: "Report navigator.maxTouchPoints as 0"
   condition: ENABLE(IOS_TOUCH_EVENTS)
-  defaultValue:
-    WebCore:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebKit ]
+  defaultValue: false
 
 ShouldRespectImageOrientation:
   type: bool
   status: embedder
   defaultValue:
+    "PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)": true
+    default: false
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": true
-      default: false
-    WebKit:
-      "PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
-      "PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
 
 ShouldRestrictBaseURLSchemes:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: WebKit::defaultShouldRestrictBaseURLSchemes()
-    WebKit:
-      default: false
-    WebCore:
-      default: true
+    default: false
+    WebKitLegacy: WebKit::defaultShouldRestrictBaseURLSchemes()
+    WebCore: true
 
 ShouldSuppressTextInputFromEditingDuringProvisionalNavigation:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ShouldTakeNearSuspendedAssertions:
   type: bool
@@ -8334,25 +5736,15 @@ ShouldTakeNearSuspendedAssertions:
   humanReadableDescription: "Take WebKit:NearSuspended assertions on background web content processes"
   exposed: [ WebKit ]
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: defaultShouldTakeNearSuspendedAssertion()
-    WebCore:
-      default: true
+    default: true
+    WebKit: defaultShouldTakeNearSuspendedAssertion()
 
 # FIXME: This is not relevant for WebKitLegacy, so it should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 # FIXME: This is not used in WebCore, so should not have a binding to WebCore::Settings.
 ShouldUseServiceWorkerShortTimeout:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ShowFrameProcessBordersEnabled:
   type: bool
@@ -8362,13 +5754,7 @@ ShowFrameProcessBordersEnabled:
   webcoreName: showFrameProcessBorders
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
   inspectorOverride: true
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ShowMediaStatsContextMenuItemEnabled:
   type: bool
@@ -8376,13 +5762,7 @@ ShowMediaStatsContextMenuItemEnabled:
   category: media
   humanReadableName: "Show Media Stats"
   humanReadableDescription: "Adds a 'Media Stats' context menu item to <video> when the Develop menu is enabled"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ShowModalDialogEnabled:
   type: bool
@@ -8391,48 +5771,30 @@ ShowModalDialogEnabled:
   humanReadableName: "Legacy showModalDialog() API"
   humanReadableDescription: "Legacy showModalDialog() API"
   defaultValue:
+    default: WebKit::defaultShowModalDialogEnabled()
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)": WebKit::defaultShowModalDialogEnabled()
       default: false
-    WebKit:
-      default: WebKit::defaultShowModalDialogEnabled()
-    WebCore:
-      default: false
+    WebCore: false
 
 ShowsToolTipOverTruncatedText:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ShowsURLsInToolTipsEnabled:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: WebKitShowsURLsInToolTips
   webcoreName: showsURLsInToolTips
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ShrinksStandaloneImagesToFit:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 SiteIsolationEnabled:
   type: bool
@@ -8441,13 +5803,7 @@ SiteIsolationEnabled:
   category: security
   humanReadableName: "Site Isolation"
   humanReadableDescription: "Put cross-origin iframes in a different process"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 SiteIsolationHighValueFraudTargetDomainsEnabled:
@@ -8456,13 +5812,7 @@ SiteIsolationHighValueFraudTargetDomainsEnabled:
   category: security
   humanReadableName: "High-value fraud target domains for Site Isolation"
   humanReadableDescription: "Exclude sites on the high-value fraud target domains list from the shared web process"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 SiteIsolationSharedProcessEnabled:
   type: bool
@@ -8471,13 +5821,7 @@ SiteIsolationSharedProcessEnabled:
   category: security
   humanReadableName: "Shared process for Site Isolation"
   humanReadableDescription: "Put cross-site frames in a shared Web process"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 SlowFrameIndicatorVisible:
@@ -8487,26 +5831,14 @@ SlowFrameIndicatorVisible:
   humanReadableName: "Slow frame indicator"
   humanReadableDescription: "Make slow frame indicator visible"
   webcoreName: showSlowFrameIndicator
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 # FIXME: This is handled via WebView SPI rather than WebPreferences for WebKitLegacy. We should change the SPI to lookup the WebPreferences value instead.
 SmartInsertDeleteEnabled:
   type: bool
   status: embedder
   webKitLegacyBinding: custom
-  defaultValue:
-    WebKit:
-      default: true
-    WebKitLegacy:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 SmartListsAvailable:
   type: bool
@@ -8514,27 +5846,16 @@ SmartListsAvailable:
   category: dom
   humanReadableName: "Smart Lists"
   humanReadableDescription: "Allow Smart Lists to be enabled"
-  defaultValue:
-    WebKit:
-      default: false
-    WebKitLegacy:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 SourceBufferChangeTypeEnabled:
   type: bool
   status: embedder
   condition: ENABLE(MEDIA_SOURCE)
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      "USE(GSTREAMER)": false
-      default: true
-    WebCore:
-      "USE(GSTREAMER)": false
-      default: true
+    "USE(GSTREAMER)": false
+    default: true
+    WebKitLegacy: true
 
 SpatialImageControlsEnabled:
   type: bool
@@ -8544,25 +5865,14 @@ SpatialImageControlsEnabled:
   humanReadableName: "Spatial image controls API"
   humanReadableDescription: "Spatial image controls API"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "ENABLE(PANORAMA_IMAGE_CONTROLS)": true
-      default: false
-    WebCore:
-      "ENABLE(PANORAMA_IMAGE_CONTROLS)": true
-      default: false
+    "ENABLE(PANORAMA_IMAGE_CONTROLS)": true
+    default: false
+    WebKitLegacy: false
 
 SpatialNavigationEnabled:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 SpatialPortalEnabled:
   type: bool
@@ -8571,13 +5881,7 @@ SpatialPortalEnabled:
   condition: ENABLE(SPATIAL_PORTAL)
   humanReadableName: "Spatial CSS Portals"
   humanReadableDescription: "Enable the spatial: portal CSS property"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 SpatialVideoRenderingEnabled:
@@ -8586,13 +5890,7 @@ SpatialVideoRenderingEnabled:
   category: media
   humanReadableName: "Spatial Video Rendering"
   humanReadableDescription: "Render projected/spatial (APMP) video onto a draggable projection in the media controls"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 SpeakerSelectionRequiresUserGesture:
@@ -8602,13 +5900,7 @@ SpeakerSelectionRequiresUserGesture:
   humanReadableName: "Require a user gesture for speaker selection"
   humanReadableDescription: "Require a user gesture for speaker selection"
   condition: ENABLE(MEDIA_STREAM)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 SpeculationRulesPrefetchEnabled:
   type: bool
@@ -8616,13 +5908,7 @@ SpeculationRulesPrefetchEnabled:
   category: html
   humanReadableName: "SpeculationRules prefetch"
   humanReadableDescription: "SpeculationRules prefetch"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -8633,12 +5919,9 @@ SpeechRecognitionEnabled:
   humanReadableName: "SpeechRecognition API"
   humanReadableDescription: "Enable SpeechRecognition of WebSpeech API"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "HAVE(SPEECHRECOGNIZER) && ENABLE(MEDIA_STREAM)": true
-      default: false
-    WebCore:
       default: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
@@ -8649,13 +5932,7 @@ SpeechSynthesisAPIEnabled:
   status: embedder
   humanReadableName: "SpeechSynthesis API"
   humanReadableDescription: "SpeechSynthesis API"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -8667,25 +5944,16 @@ SpringTimingFunctionEnabled:
   humanReadableName: "CSS Spring Animations"
   humanReadableDescription: "CSS Spring Animation prototype"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "ENABLE(EXPERIMENTAL_FEATURES)" : true
-      default: false
-    WebCore:
       default: false
 
 Standalone:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: WebKitStandalonePreferenceKey
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 StandardFontFamily:
   type: String
@@ -8693,13 +5961,10 @@ StandardFontFamily:
   webKitLegacyPreferenceKey: WebKitStandardFont
   webcoreImplementation: custom
   defaultValue:
-    WebKitLegacy:
-      default: '"Times"_str'
-    WebKit:
-      "PLATFORM(WATCHOS)": '"system-ui"_str'
-      default: '"Times"_str'
-    WebCore:
-      default: '""_str'
+    "PLATFORM(WATCHOS)": '"system-ui"_str'
+    default: '"Times"_str'
+    WebKitLegacy: '"Times"_str'
+    WebCore: '""_str'
 
 StorageAPIEnabled:
   type: bool
@@ -8708,16 +5973,10 @@ StorageAPIEnabled:
   humanReadableName: "Storage API"
   humanReadableDescription: "Enable Storage API"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(COCOA)" : true
-      "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)" : true
-      "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
+    "PLATFORM(COCOA)" : true
+    "PLATFORM(GTK) || PLATFORM(WPE)": true
+    default: false
+    WebKitLegacy: false
 
 StorageAPIEstimateEnabled:
   type: bool
@@ -8726,29 +5985,17 @@ StorageAPIEstimateEnabled:
   humanReadableName: "Storage API Estimate"
   humanReadableDescription: "Enable Storage API Estimate"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(COCOA)" : true
-      "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)" : true
-      "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
+    "PLATFORM(COCOA)" : true
+    "PLATFORM(GTK) || PLATFORM(WPE)": true
+    default: false
+    WebKitLegacy: false
 
 StorageAccessAPIEnabled:
   type: bool
   status: embedder
   humanReadableName: "Storage Access API"
   humanReadableDescription: "Enable the Storage Access API for cross-site cookie access"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   sharedPreferenceForWebProcess: true
 
 StorageAccessAPIPerPageScopeEnabled:
@@ -8757,13 +6004,7 @@ StorageAccessAPIPerPageScopeEnabled:
   category: dom
   humanReadableName: "Storage Access API Per-Page Scope"
   humanReadableDescription: "When enabled, storage access granted to one frame is shared with all same-origin frames on the page"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 StorageBlockingPolicy:
@@ -8773,12 +6014,9 @@ StorageBlockingPolicy:
   status: embedder
   webcoreOnChange: storageBlockingPolicyChanged
   defaultValue:
-    WebKitLegacy:
-      default: WebAllowAllStorage
-    WebKit:
-      default: WebCore::StorageBlockingPolicy::BlockThirdParty
-    WebCore:
-      default: StorageBlockingPolicy::AllowAll
+    default: WebCore::StorageBlockingPolicy::BlockThirdParty
+    WebKitLegacy: WebAllowAllStorage
+    WebCore: StorageBlockingPolicy::AllowAll
   sharedPreferenceForWebProcess: true
 
 SupportHDRCompositorTonemappingEnabled:
@@ -8788,13 +6026,7 @@ SupportHDRCompositorTonemappingEnabled:
   webcoreOnChange: updateDisplayEDRHeadroom
   humanReadableName: "Support HDR Compositor tonemapping"
   humanReadableDescription: "Support HDR tonemapping during compositing"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 SupportHDRDisplayEnabled:
   type: bool
@@ -8804,25 +6036,14 @@ SupportHDRDisplayEnabled:
   humanReadableName: "Support HDR Display"
   humanReadableDescription: "Support HDR Display"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "ENABLE(SUPPORT_HDR_DISPLAY_BY_DEFAULT)": true
-      default: false
-    WebCore:
-      "ENABLE(SUPPORT_HDR_DISPLAY_BY_DEFAULT)": true
-      default: false
+    "ENABLE(SUPPORT_HDR_DISPLAY_BY_DEFAULT)": true
+    default: false
+    WebKitLegacy: false
 
 SuppressesIncrementalRendering:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 SwitchControlEnabled:
   type: bool
@@ -8831,41 +6052,22 @@ SwitchControlEnabled:
   humanReadableName: "HTML switch control"
   humanReadableDescription: "Enable HTML switch control"
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebKit:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)": true
-      default: false
+    "PLATFORM(COCOA)": true
+    default: false
 
 # FIXME: There is no custom binding implemented for WebKitLegacy.
 SystemLayoutDirection:
   type: uint32_t
   refinedType: WebCore::TextDirection
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: TextDirection::LTR
-    WebKit:
-      default: TextDirection::LTR
-    WebCore:
-      default: TextDirection::LTR
+  defaultValue: TextDirection::LTR
 
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 SystemPreviewEnabled:
   type: bool
   status: embedder
   condition: USE(SYSTEM_PREVIEW)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
 
@@ -8877,21 +6079,19 @@ SystemTextExtractionEnabled:
   condition: ENABLE(SYSTEM_TEXT_EXTRACTION)
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 TabsToLinks:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: WebKitTabToLinksPreferenceKey
   webcoreBinding: none
+  excludeFrom: [ WebCore ]
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
+    "PLATFORM(GTK) || PLATFORM(WPE)": true
+    default: false
+    WebKitLegacy: false
 
 TargetTextPseudoElementEnabled:
   type: bool
@@ -8900,24 +6100,14 @@ TargetTextPseudoElementEnabled:
   humanReadableName: "::target-text pseudo-element"
   humanReadableDescription: "Enable the ::target-text CSS pseudo-element"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 TelephoneNumberParsingEnabled:
   type: bool
   status: embedder
   webKitLegacyPreferenceKey: WebKitTelephoneParsingEnabledPreferenceKey
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 TemporalEnabled:
   type: bool
@@ -8928,20 +6118,16 @@ TemporalEnabled:
   webcoreBinding: none
   jscOptionName: useTemporal
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 TemporaryTileCohortRetentionEnabled:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      default: true
+    default: true
     WebKit:
       "PLATFORM(IOS_FAMILY)": false
-      default: true
-    WebCore:
       default: true
 
 TextAnimationsEnabled:
@@ -8950,41 +6136,25 @@ TextAnimationsEnabled:
   humanReadableName: "Text Animations"
   humanReadableDescription: "Text Animations"
   condition: ENABLE(WRITING_TOOLS)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 TextAreasAreResizable:
   type: bool
   status: embedder
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(IOS_FAMILY)": false
       default: true
-    WebCore:
-      default: false
 
 TextAutosizingEnabled:
   type: bool
   status: embedder
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(IOS_FAMILY)": true
-      default: false
-    WebKit:
-      "PLATFORM(IOS_FAMILY)": true
-      default: false
-    WebCore:
-      "PLATFORM(IOS_FAMILY)": true
-      default: false
+    "PLATFORM(IOS_FAMILY)": true
+    default: false
 
 TextAutosizingEnabledAtLargeInitialScale:
   type: bool
@@ -8992,10 +6162,10 @@ TextAutosizingEnabledAtLargeInitialScale:
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
   humanReadableName: "Enable Text Autosizing at Large Initial Scale"
   humanReadableDescription: "Enable Text Autosizing at Large Initial Scale"
+  excludeFrom: [ WebKitLegacy, WebKit ]
   defaultValue:
-    WebCore:
-      "ENABLE(TEXT_AUTOSIZING_BASED_ON_INITIAL_SCALE)": false
-      default: true
+    "ENABLE(TEXT_AUTOSIZING_BASED_ON_INITIAL_SCALE)": false
+    default: true
 
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 TextAutosizingUsesIdempotentMode:
@@ -9005,12 +6175,9 @@ TextAutosizingUsesIdempotentMode:
   humanReadableName: "Idempotent Text Autosizing"
   humanReadableDescription: "Use idempotent text autosizing mode"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(IOS_FAMILY) && !PLATFORM(VISION)": defaultTextAutosizingUsesIdempotentMode()
-      default: false
-    WebCore:
       default: false
 
 TextEffectsEnabled:
@@ -9019,13 +6186,7 @@ TextEffectsEnabled:
   humanReadableName: "Text Effects"
   humanReadableDescription: "Text Effects"
   condition: ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 TextExtractionDebugUIEnabled:
   type: bool
@@ -9033,23 +6194,17 @@ TextExtractionDebugUIEnabled:
   humanReadableName: "Text Extraction Debug UI"
   humanReadableDescription: "Enable Text Extraction Debug UI"
   exposed: [ WebKit ]
-  defaultValue:
-    WebCore:
-      default: false
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
+  defaultValue: false
 
 TextExtractionEnabled:
   type: bool
   status: embedder
   webcoreBinding: none
   exposed: [ WebKit ]
+  excludeFrom: [ WebKitLegacy, WebCore ]
   defaultValue:
-    WebKit:
-      "HAVE(UIINTELLIGENCESUPPORT_FRAMEWORK)": true
-      default: false
+    "HAVE(UIINTELLIGENCESUPPORT_FRAMEWORK)": true
+    default: false
 
 TextExtractionFilterEnabled:
   type: bool
@@ -9058,10 +6213,10 @@ TextExtractionFilterEnabled:
   humanReadableDescription: "Enable Text Extraction Filter"
   webcoreBinding: none
   exposed: [ WebKit ]
+  excludeFrom: [ WebKitLegacy, WebCore ]
   defaultValue:
-    WebKit:
-      "ENABLE(TEXT_EXTRACTION_FILTER)": true
-      default: false
+    "ENABLE(TEXT_EXTRACTION_FILTER)": true
+    default: false
 
 TextInputClientSelectionUpdatesEnabled:
   type: bool
@@ -9069,23 +6224,15 @@ TextInputClientSelectionUpdatesEnabled:
   webcoreBinding: none
   condition: PLATFORM(MAC)
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: WebKit::defaultTextInputClientSelectionUpdatesEnabled()
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: WebKit::defaultTextInputClientSelectionUpdatesEnabled()
 
 TextInteractionEnabled:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(WATCHOS)": false
-      default: true
-    WebKit:
-      "PLATFORM(WATCHOS)": false
-      default: true
-    WebCore:
-      "PLATFORM(WATCHOS)": false
-      default: true
+    "PLATFORM(WATCHOS)": false
+    default: true
 
 TextRecognitionInVideosEnabled:
   type: bool
@@ -9097,12 +6244,8 @@ TextRecognitionInVideosEnabled:
   condition: ENABLE(IMAGE_ANALYSIS) && ENABLE(VIDEO)
   exposed: [ WebKit ]
   defaultValue:
-    WebCore:
-      default: false
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: defaultTextRecognitionInVideosEnabled()
+    default: false
+    WebKit: defaultTextRecognitionInVideosEnabled()
   sharedPreferenceForWebProcess: true
   mediaPlaybackRelated: true
 
@@ -9112,13 +6255,7 @@ TextShapingAcrossInlineBoxes:
   category: css
   humanReadableName: "Text Shaping Across Inline Boxes"
   humanReadableDescription: "Enable Text Shaping Across Inline Boxes"
-  defaultValue:
-    WebCore:
-      default: true
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
+  defaultValue: true
 
 TextTracksInMSEEnabled:
   type: bool
@@ -9127,13 +6264,7 @@ TextTracksInMSEEnabled:
   humanReadableName: "Text Tracks in MSE"
   humanReadableDescription: "Enable Text Tracks in Media Source Extension"
   condition: ENABLE(MEDIA_SOURCE)
-  defaultValue:
-    WebCore:
-      default: false
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
+  defaultValue: false
 
 ThreadedScrollDrivenAnimationsEnabled:
   type: bool
@@ -9143,21 +6274,16 @@ ThreadedScrollDrivenAnimationsEnabled:
   humanReadableDescription: "Run qualifying scroll-driven animations on a separate thread"
   condition: ENABLE(THREADED_ANIMATIONS)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 ThreadedScrollingEnabled:
   type: bool
   status: embedder
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 ThreadedTimeBasedAnimationsAtHighFrameRateEnabled:
   type: bool
@@ -9166,13 +6292,7 @@ ThreadedTimeBasedAnimationsAtHighFrameRateEnabled:
   humanReadableName: "Threaded Time-based Animations at High Frame Rate"
   humanReadableDescription: "Run qualifying time-based animations on a separate thread at a high frame rate"
   condition: ENABLE(THREADED_ANIMATIONS) && PLATFORM(IOS_FAMILY)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 ThreadedTimeBasedAnimationsEnabled:
   type: bool
@@ -9182,12 +6302,8 @@ ThreadedTimeBasedAnimationsEnabled:
   humanReadableDescription: "Run qualifying time-based animations on a separate thread"
   condition: ENABLE(THREADED_ANIMATIONS)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 # FIXME: This is not relevant for WebKitLegacy, so it should be excluded from WebKitLegacy entirely.
 TiledScrollingIndicatorVisible:
@@ -9197,13 +6313,7 @@ TiledScrollingIndicatorVisible:
   humanReadableName: "Tiled scrolling indicator"
   humanReadableDescription: "Make tiled scrolling indicator visible"
   webcoreName: showTiledScrollingIndicator
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 TopContentInsetBackgroundCanChangeAfterScrolling:
   type: bool
@@ -9211,12 +6321,8 @@ TopContentInsetBackgroundCanChangeAfterScrolling:
   humanReadableName: "Top Content Inset Background Can Change After Scrolling"
   humanReadableDescription: "Top content inset background can change after scrolling"
   defaultValue:
-    WebKit:
-      default: WebKit::defaultTopContentInsetBackgroundCanChangeAfterScrolling()
-    WebKitLegacy:
-      default: false
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultTopContentInsetBackgroundCanChangeAfterScrolling()
 
 TouchEventDOMAttributesEnabled:
   type: bool
@@ -9224,9 +6330,8 @@ TouchEventDOMAttributesEnabled:
   humanReadableName: "Touch Event DOM Attributes"
   humanReadableDescription: "Enable Touch Event DOM Attributes"
   condition: ENABLE(TOUCH_EVENTS)
-  defaultValue:
-    WebCore:
-      default: WebCore::screenHasTouchDevice()
+  excludeFrom: [ WebKitLegacy, WebKit ]
+  defaultValue: WebCore::screenHasTouchDevice()
 
 TouchInputCompatibilityEnabled:
   type: bool
@@ -9235,13 +6340,7 @@ TouchInputCompatibilityEnabled:
   humanReadableName: "Touch Input Compatibility"
   humanReadableDescription: "Touch Input Compatibility"
   condition: ENABLE(WEBXR)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 TrackConfigurationEnabled:
   type: bool
@@ -9249,24 +6348,15 @@ TrackConfigurationEnabled:
   category: media
   humanReadableName: "Track Configuration API"
   humanReadableDescription: "Track Configuration API"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 TreatsAnyTextCSSLinkAsStylesheet:
   type: bool
   status: embedder
   defaultValue:
+    default: false
     WebKitLegacy:
       PLATFORM(MAC): WebKit::defaultTreatsAnyTextCSSLinkAsStylesheet()
-      default: false
-    WebKit:
-      default: false
-    WebCore:
       default: false
 
 TrustedTypesEnabled:
@@ -9276,12 +6366,9 @@ TrustedTypesEnabled:
   humanReadableName: "Trusted Types"
   humanReadableDescription: "Enable Trusted Types"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultTrustedTypesEnabled()
-    WebCore:
-      default: true
+    default: WebKit::defaultTrustedTypesEnabled()
+    WebKitLegacy: false
+    WebCore: true
 
 TwoUpPDFDisplayModeSupportEnabled:
   type: bool
@@ -9290,12 +6377,8 @@ TwoUpPDFDisplayModeSupportEnabled:
   humanReadableDescription: "Enable support for two-up PDF display on iOS"
   condition: ENABLE(UNIFIED_PDF) && PLATFORM(IOS_FAMILY)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 TwoUpPDFTrailingPageLeftAlignmentEnabled:
   type: bool
@@ -9303,13 +6386,7 @@ TwoUpPDFTrailingPageLeftAlignmentEnabled:
   humanReadableName: "Two-Up PDF Trailing Page Left Alignment"
   humanReadableDescription: "In two-up PDF display mode, align the trailing odd page to the same column as the first page instead of centering it"
   condition: ENABLE(UNIFIED_PDF)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 UndoManagerAPIEnabled:
@@ -9318,13 +6395,7 @@ UndoManagerAPIEnabled:
   category: dom
   humanReadableName: "UndoManager DOM API"
   humanReadableDescription: "Enable the UndoManager DOM API"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 UnifiedPDFEnabled:
   type: bool
@@ -9334,28 +6405,21 @@ UnifiedPDFEnabled:
   humanReadableDescription: "Enable Unified PDF Viewer"
   condition: ENABLE(UNIFIED_PDF)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultUnifiedPDFEnabled()
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultUnifiedPDFEnabled()
 
 UnifyDamagedRegions:
-   type: bool
-   status: unstable
-   category: dom
-   humanReadableName: "Unify Damaged Regions"
-   humanReadableDescription: "Unify Damaged Regions"
-   condition: ENABLE(DAMAGE_TRACKING)
-   defaultValue:
-     WebKitLegacy:
-       default: false
-     WebKit:
-       "PLATFORM(GTK) || PLATFORM(WPE)": true
-       default: false
-     WebCore:
-       default: false
+  type: bool
+  status: unstable
+  category: dom
+  humanReadableName: "Unify Damaged Regions"
+  humanReadableDescription: "Unify Damaged Regions"
+  condition: ENABLE(DAMAGE_TRACKING)
+  defaultValue:
+    default: false
+    WebKit:
+      "PLATFORM(GTK) || PLATFORM(WPE)": true
+      default: false
 
 UpdateSceneGeometryEnabled:
   type: bool
@@ -9364,12 +6428,8 @@ UpdateSceneGeometryEnabled:
   humanReadableName: "Enable Update Scene Geometry"
   humanReadableDescription: "Allows for changes to scene geometry"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
   sharedPreferenceForWebProcess: true
 
 UpgradeKnownHostsToHTTPSEnabled:
@@ -9380,9 +6440,8 @@ UpgradeKnownHostsToHTTPSEnabled:
   humanReadableDescription: "Upgrade known hosts to HTTPS"
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 UseAVCaptureDeviceRotationCoordinatorAPI:
   type: bool
@@ -9392,10 +6451,10 @@ UseAVCaptureDeviceRotationCoordinatorAPI:
   webcoreBinding: none
   exposed: [ WebKit ]
   condition: HAVE(AVCAPTUREDEVICEROTATIONCOORDINATOR)
+  excludeFrom: [ WebKitLegacy, WebCore ]
   defaultValue:
-    WebKit:
-      "PLATFORM(APPLETV)": true
-      default: false
+    "PLATFORM(APPLETV)": true
+    default: false
   sharedPreferenceForWebProcess: true
 
 UseAlternatePDFHUD:
@@ -9407,9 +6466,8 @@ UseAlternatePDFHUD:
   webcoreBinding: none
   exposed: [ WebKit ]
   condition: ENABLE(PDF_HUD)
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 UseAppKitGestures:
   type: bool
@@ -9419,12 +6477,8 @@ UseAppKitGestures:
   humanReadableDescription: "Use AppKit Gestures"
   condition: PLATFORM(MAC)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: defaultUseAppKitGestures()
-    WebCore:
-      default: false
+    default: false
+    WebKit: defaultUseAppKitGestures()
 
 UseAppKitGesturesForGestureEvents:
   type: bool
@@ -9433,12 +6487,8 @@ UseAppKitGesturesForGestureEvents:
   humanReadableDescription: "Use AppKit gestures to drive gesture event synthesis"
   condition: PLATFORM(MAC)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: defaultUseAppKitGestures()
-    WebCore:
-      default: false
+    default: false
+    WebKit: defaultUseAppKitGestures()
 
 UseAsyncUIKitInteractions:
   type: bool
@@ -9447,12 +6497,8 @@ UseAsyncUIKitInteractions:
   humanReadableDescription: "Use Async UIKit Interactions"
   condition: PLATFORM(IOS_FAMILY)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultUseAsyncUIKitInteractions()
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultUseAsyncUIKitInteractions()
 
 UseCGDisplayListsForDOMRendering:
   type: bool
@@ -9460,12 +6506,9 @@ UseCGDisplayListsForDOMRendering:
   humanReadableName: "Dynamic Content Scaling: DOM Rendering"
   humanReadableDescription: "Use Dynamic Content Scaling for DOM rendering"
   condition: ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-  exposed: [ WebCore, WebKit ]
-  defaultValue:
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  exposed: [ WebKit, WebCore ]
+  excludeFrom: [ WebKitLegacy ]
+  defaultValue: true
   sharedPreferenceForWebProcess: true
 
 UseDamagingInformationForCompositing:
@@ -9476,12 +6519,9 @@ UseDamagingInformationForCompositing:
   humanReadableDescription: "Use the Damaging Information to optimize compositing"
   condition: ENABLE(DAMAGE_TRACKING)
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(GTK) || PLATFORM(WPE)": true
-      default: false
-    WebCore:
       default: false
 
 UseGPUProcessForCanvasRenderingEnabled:
@@ -9493,11 +6533,11 @@ UseGPUProcessForCanvasRenderingEnabled:
   webcoreBinding: none
   condition: ENABLE(GPU_PROCESS) && !(PLATFORM(GTK) || PLATFORM(WPE))
   exposed: [ WebKit ]
+  excludeFrom: [ WebKitLegacy, WebCore ]
   defaultValue:
-    WebKit:
-      "ENABLE(GPU_PROCESS_BY_DEFAULT)": true
-      "USE(GRAPHICS_LAYER_WC)": true
-      default: false
+    "ENABLE(GPU_PROCESS_BY_DEFAULT)": true
+    "USE(GRAPHICS_LAYER_WC)": true
+    default: false
 
 UseGPUProcessForDOMRenderingEnabled:
   type: bool
@@ -9508,9 +6548,8 @@ UseGPUProcessForDOMRenderingEnabled:
   webcoreBinding: none
   condition: ENABLE(GPU_PROCESS)
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: defaultUseGPUProcessForDOMRenderingEnabled()
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: defaultUseGPUProcessForDOMRenderingEnabled()
   sharedPreferenceForWebProcess: true
 
 UseGPUProcessForDisplayCapture:
@@ -9522,9 +6561,8 @@ UseGPUProcessForDisplayCapture:
   webcoreBinding: none
   condition: HAVE(SCREEN_CAPTURE_KIT)
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 UseGPUProcessForMediaEnabled:
   type: bool
@@ -9534,10 +6572,10 @@ UseGPUProcessForMediaEnabled:
   webcoreBinding: none
   condition: ENABLE(GPU_PROCESS)
   exposed: [ WebKit ]
+  excludeFrom: [ WebKitLegacy, WebCore ]
   defaultValue:
-    WebKit:
-      "ENABLE(GPU_PROCESS_BY_DEFAULT) && !USE(GSTREAMER)": true
-      default: false
+    "ENABLE(GPU_PROCESS_BY_DEFAULT) && !USE(GSTREAMER)": true
+    default: false
   sharedPreferenceForWebProcess: true
   mediaPlaybackRelated: true
 
@@ -9549,51 +6587,32 @@ UseGPUProcessForWebGLEnabled:
   webcoreBinding: none
   condition: ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
   exposed: [ WebKit ]
+  excludeFrom: [ WebKitLegacy, WebCore ]
   defaultValue:
-    WebKit:
-      "ENABLE(GPU_PROCESS_BY_DEFAULT) && ENABLE(GPU_PROCESS_WEBGL_BY_DEFAULT)": true
-      "USE(GRAPHICS_LAYER_WC)": true
-      default: false
+    "ENABLE(GPU_PROCESS_BY_DEFAULT) && ENABLE(GPU_PROCESS_WEBGL_BY_DEFAULT)": true
+    "USE(GRAPHICS_LAYER_WC)": true
+    default: false
   sharedPreferenceForWebProcess: true
 
 UseGiantTiles:
   type: bool
   status: embedder
   humanReadableName: "Use giant tiles"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 UseIFCForSVGText:
   type: bool
   status: internal
   humanReadableName: "Use IFC for SVG text"
   humanReadableDescription: "Use IFC for SVG text rendering"
-  defaultValue:
-    WebCore:
-      default: false
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
+  defaultValue: false
 
 UseImageDocumentForSubframePDF:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      PLATFORM(IOS_FAMILY): true
-      default: false
-    WebKit:
-      PLATFORM(IOS_FAMILY): true
-      default: false
-    WebCore:
-      PLATFORM(IOS_FAMILY): true
-      default: false
+    PLATFORM(IOS_FAMILY): true
+    default: false
 
 UseMicrophoneMuteStatusAPI:
   type: bool
@@ -9602,35 +6621,23 @@ UseMicrophoneMuteStatusAPI:
   humanReadableName: "Use Microphone Mute Status API"
   humanReadableDescription: "Use Microphone Mute Status API"
   condition: ENABLE(MEDIA_STREAM)
-  defaultValue:
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  excludeFrom: [ WebKitLegacy ]
+  defaultValue: false
 
 UsePreHTML5ParserQuirks:
   type: bool
   status: embedder
   defaultValue:
+    default: false
     WebKitLegacy:
       PLATFORM(MAC): WebKit::defaultUsePreHTML5ParserQuirks()
-      default: false
-    WebKit:
-      default: false
-    WebCore:
       default: false
 
 UseSystemAppearance:
   type: bool
   status: embedder
   webcoreOnChange: useSystemAppearanceChanged
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 UseUIProcessForBackForwardItemLoading:
   type: bool
@@ -9638,13 +6645,7 @@ UseUIProcessForBackForwardItemLoading:
   exposed: [ WebKit ]
   humanReadableName: "Use UIProcess for Back/Forward Item Loading"
   humanReadableDescription: "Enable UIProcess-side BackForwardListFrameItem lookup for child frames during Back/Forward navigation"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 UserActivationAPIEnabled:
   type: bool
@@ -9653,12 +6654,8 @@ UserActivationAPIEnabled:
   humanReadableName: "User Activation API"
   humanReadableDescription: "Enable User Activation API"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 UserGesturePromisePropagationEnabled:
   type: bool
@@ -9666,26 +6663,14 @@ UserGesturePromisePropagationEnabled:
   category: dom
   humanReadableName: "UserGesture Promise Propagation"
   humanReadableDescription: "UserGesture Promise Propagation"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 # FIXME: There is no custom binding implemented for WebKitLegacy.
 UserInterfaceDirectionPolicy:
   type: uint32_t
   refinedType: WebCore::UserInterfaceDirectionPolicy
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: UserInterfaceDirectionPolicy::Content
-    WebKit:
-      default: UserInterfaceDirectionPolicy::Content
-    WebCore:
-      default: UserInterfaceDirectionPolicy::Content
+  defaultValue: UserInterfaceDirectionPolicy::Content
 
 UsesBackForwardCache:
   type: bool
@@ -9694,33 +6679,20 @@ UsesBackForwardCache:
   webcoreOnChange: usesBackForwardCacheChanged
   webcoreExcludeFromInternalSettings: true
   webKitLegacyPreferenceKey: WebKitUsesPageCachePreferenceKey
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 UsesEncodingDetector:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 UsesSingleWebProcess:
   type: bool
   status: embedder
   exposed: [ WebKit ]
   webcoreBinding: none
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 VP9DecoderEnabled:
@@ -9728,12 +6700,8 @@ VP9DecoderEnabled:
   status: embedder
   condition: ENABLE(VP9)
   defaultValue:
-    WebCore:
-      default: false
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
+    default: false
+    WebKit: true
 
 VerifyWindowOpenUserGestureFromUIProcess:
   type: bool
@@ -9741,13 +6709,7 @@ VerifyWindowOpenUserGestureFromUIProcess:
   category: security
   humanReadableName: "Verify window.open user gesture"
   humanReadableDescription: "Verifies that the user gesture for window.open came from the UI process"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 VerticalFormControlsEnabled:
   type: bool
@@ -9756,15 +6718,8 @@ VerticalFormControlsEnabled:
   humanReadableName: "Vertical form control support"
   humanReadableDescription: "Enable support for form controls in vertical writing mode"
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(COCOA) || USE(THEME_ADWAITA)": true
-      default: false
-    WebKit:
-      "PLATFORM(COCOA) || USE(THEME_ADWAITA)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA) || USE(THEME_ADWAITA)": true
-      default: false
+    "PLATFORM(COCOA) || USE(THEME_ADWAITA)": true
+    default: false
 
 VideoFullsceenPrefersMostVisibleHeuristic:
   type: bool
@@ -9774,67 +6729,39 @@ VideoFullsceenPrefersMostVisibleHeuristic:
   humanReadableDescription: "Prefers most visible video in element fullscreen."
   condition: ENABLE(FULLSCREEN_API)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 VideoFullscreenRequiresElementFullscreen:
   type: bool
   status: embedder
   condition: ENABLE(FULLSCREEN_API)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: defaultVideoFullscreenRequiresElementFullscreen()
-    WebCore:
-      default: false
+    default: false
+    WebKit: defaultVideoFullscreenRequiresElementFullscreen()
   sharedPreferenceForWebProcess: true
 
 VideoPresentationManagerEnabled:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(VISION)" : true
-      default: false
-    WebKit:
-      "PLATFORM(VISION)" : true
-      default: false
-    WebCore:
-      "PLATFORM(VISION)" : true
-      default: false
+    "PLATFORM(VISION)" : true
+    default: false
   sharedPreferenceForWebProcess: true
 
 VideoPresentationModeAPIEnabled:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(VISION)" : false
-      default: true
-    WebKit:
-      "PLATFORM(VISION)" : false
-      default: true
-    WebCore:
-      "PLATFORM(VISION)" : false
-      default: true
+    "PLATFORM(VISION)" : false
+    default: true
   sharedPreferenceForWebProcess: true
 
 VideoQualityIncludesDisplayCompositingEnabled:
   type: bool
   status: embedder
   condition: ENABLE(VIDEO)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 VideoRendererProtectedFallbackDisabled:
   type: bool
@@ -9844,12 +6771,8 @@ VideoRendererProtectedFallbackDisabled:
   humanReadableDescription: "VideoMediaSampleRenderer fallback to AVSBDL for protected content disabled"
   condition: USE(MODERN_AVCONTENTKEYSESSION_WITH_VTDECOMPRESSIONSESSION)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
   sharedPreferenceForWebProcess: true
 
 VideoRendererUseDecompressionSessionForProtected:
@@ -9860,14 +6783,9 @@ VideoRendererUseDecompressionSessionForProtected:
   humanReadableDescription: "VideoMediaSampleRenderer use DecompressionSession for protected content"
   condition: USE(MODERN_AVCONTENTKEYSESSION_WITH_VTDECOMPRESSIONSESSION)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(VISION)" : true
-      default: false
-    WebCore:
-      "PLATFORM(VISION)" : true
-      default: false
+    "PLATFORM(VISION)" : true
+    default: false
+    WebKitLegacy: false
   sharedPreferenceForWebProcess: true
 
 ViewGestureDebuggingEnabled:
@@ -9877,22 +6795,15 @@ ViewGestureDebuggingEnabled:
   humanReadableDescription: "Enable view gesture debugging"
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 VisibleDebugOverlayRegions:
   type: uint32_t
   status: embedder
   defaultsOverridable: true
   webcoreType: DebugOverlayRegions
-  defaultValue:
-    WebKitLegacy:
-      default: 0
-    WebKit:
-      default: 0
-    WebCore:
-      default: 0
+  defaultValue: 0
 
 VisualTranslationEnabled:
   type: bool
@@ -9904,12 +6815,8 @@ VisualTranslationEnabled:
   condition: ENABLE(IMAGE_ANALYSIS)
   exposed: [ WebKit ]
   defaultValue:
-    WebCore:
-      default: false
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: defaultVisualTranslationEnabled()
+    default: false
+    WebKit: defaultVisualTranslationEnabled()
 
 VisualViewportAPIEnabled:
   type: bool
@@ -9917,25 +6824,20 @@ VisualViewportAPIEnabled:
   humanReadableName: "Visual Viewport API"
   humanReadableDescription: "Enable Visual Viewport API"
   defaultValue:
+    default: true
     WebKitLegacy:
       "PLATFORM(IOS_FAMILY)" : false
       default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    WebCore: false
 
 VisualViewportEnabled:
   type: bool
   status: embedder
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
   defaultValue:
+    default: true
     WebKitLegacy:
       PLATFORM(IOS_FAMILY): false
-      default: true
-    WebKit:
-      default: true
-    WebCore:
       default: true
 
 VisuallyContiguousBidiTextSelectionEnabled:
@@ -9945,23 +6847,13 @@ VisuallyContiguousBidiTextSelectionEnabled:
   humanReadableDescription: "Visually contiguous bidi selection"
   condition: PLATFORM(IOS_FAMILY)
   defaultValue:
-    WebKit:
-      default: WebKit::defaultVisuallyContiguousBidiTextSelectionEnabled()
-    WebKitLegacy:
-      default: false
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultVisuallyContiguousBidiTextSelectionEnabled()
 
 WantsBalancedSetDefersLoadingBehavior:
   type: bool
   status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 WasmJSStringBuiltinsEnabled:
   type: bool
@@ -9972,9 +6864,8 @@ WasmJSStringBuiltinsEnabled:
   webcoreBinding: none
   jscOptionName: useWasmJSStringBuiltins
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 WasmJSTypesEnabled:
   type: bool
@@ -9985,9 +6876,8 @@ WasmJSTypesEnabled:
   webcoreBinding: none
   jscOptionName: useWasmJSTypes
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 WasmMemory64Enabled:
   type: bool
@@ -9998,9 +6888,8 @@ WasmMemory64Enabled:
   webcoreBinding: none
   jscOptionName: useWasmMemory64
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 WasmMemoryToBufferAPIsEnabled:
   type: bool
@@ -10011,9 +6900,8 @@ WasmMemoryToBufferAPIsEnabled:
   webcoreBinding: none
   jscOptionName: useWasmMemoryToBufferAPIs
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 WasmMultiMemoryEnabled:
   type: bool
@@ -10024,9 +6912,8 @@ WasmMultiMemoryEnabled:
   webcoreBinding: none
   jscOptionName: useWasmMultiMemory
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 WasmRelaxedSIMDEnabled:
   type: bool
@@ -10037,9 +6924,8 @@ WasmRelaxedSIMDEnabled:
   webcoreBinding: none
   jscOptionName: useWasmRelaxedSIMD
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 WasmSIMDEnabled:
   type: bool
@@ -10050,9 +6936,8 @@ WasmSIMDEnabled:
   webcoreBinding: none
   jscOptionName: useWasmSIMD
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 WasmTailCallsEnabled:
   type: bool
@@ -10063,9 +6948,8 @@ WasmTailCallsEnabled:
   webcoreBinding: none
   jscOptionName: useWasmTailCalls
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: true
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: true
 
 WasmWideArithmeticEnabled:
   type: bool
@@ -10076,9 +6960,8 @@ WasmWideArithmeticEnabled:
   webcoreBinding: none
   jscOptionName: useWasmWideArithmetic
   sharedPreferenceForWebProcess: true
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false
 
 WebAPIStatisticsEnabled:
   type: bool
@@ -10086,13 +6969,7 @@ WebAPIStatisticsEnabled:
   category: dom
   humanReadableName: "Web API Statistics"
   humanReadableDescription: "Enable Web API Statistics"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 WebAPIsInShadowRealmEnabled:
   type: bool
@@ -10100,13 +6977,7 @@ WebAPIsInShadowRealmEnabled:
   category: dom
   humanReadableName: "Web APIs in ShadowRealm"
   humanReadableDescription: "Enable Web APIs to be exposed in ShadowRealm"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 WebAnimationsCustomEffectsEnabled:
   type: bool
@@ -10114,13 +6985,7 @@ WebAnimationsCustomEffectsEnabled:
   category: animation
   humanReadableName: "Web Animations custom effects"
   humanReadableDescription: "Support for the CustomEffect interface"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 WebAnimationsCustomFrameRateEnabled:
   type: bool
@@ -10128,13 +6993,7 @@ WebAnimationsCustomFrameRateEnabled:
   category: animation
   humanReadableName: "Web Animations custom frame rate"
   humanReadableDescription: "Support for specifying a custom frame rate for Web Animations"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 WebArchiveDebugModeEnabled:
   type: bool
@@ -10143,13 +7002,7 @@ WebArchiveDebugModeEnabled:
   humanReadableDescription: "Enable web archive debug mode"
   webKitLegacyPreferenceKey: WebKitWebArchiveDebugModeEnabledPreferenceKey
   condition: ENABLE(WEB_ARCHIVE)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 WebArchiveTestingModeEnabled:
   type: bool
@@ -10158,13 +7011,7 @@ WebArchiveTestingModeEnabled:
   humanReadableName: "Web Archive testing mode"
   humanReadableDescription: "Enable web archive testing mode"
   condition: ENABLE(WEB_ARCHIVE)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 WebAssemblyDebuggerEnabled:
   type: bool
@@ -10173,13 +7020,7 @@ WebAssemblyDebuggerEnabled:
   humanReadableName: "Experimental WebAssembly Debugger (Disables JIT)"
   humanReadableDescription: "Enable LLDB debugging support for WebAssembly (requires new tab)"
   condition: ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 WebAssemblyESMIntegrationEnabled:
   type: bool
@@ -10188,25 +7029,15 @@ WebAssemblyESMIntegrationEnabled:
   humanReadableName: "WebAssembly ES module integration support"
   humanReadableDescription: "Support for allowing WebAssembly modules to integrate as ES modules"
   condition: ENABLE(WEBASSEMBLY)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 WebAudioEnabled:
   type: bool
   status: embedder
   condition: ENABLE(WEB_AUDIO)
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: true
+    WebCore: false
   sharedPreferenceForWebProcess: true
   disableInLockdownMode: true
   richJavaScript: true
@@ -10219,12 +7050,8 @@ WebAuthenticationASEnabled:
   humanReadableDescription: "Enable Modern Web Authentication support though AuthenticationServices"
   condition: HAVE(WEB_AUTHN_AS_MODERN)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 WebAuthenticationEnabled:
@@ -10234,12 +7061,8 @@ WebAuthenticationEnabled:
   humanReadableDescription: "Enable Web Authentication support"
   condition: ENABLE(WEB_AUTHN)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
@@ -10251,14 +7074,9 @@ WebCodecsAV1Enabled:
   humanReadableDescription: "Enable WebCodecs AV1 codec"
   condition: ENABLE(WEB_CODECS)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "USE(GSTREAMER)": true
-      default: false
-    WebCore:
-      "USE(GSTREAMER)": true
-      default: false
+    "USE(GSTREAMER)": true
+    default: false
+    WebKitLegacy: false
   disableInLockdownMode: true
 
 WebCodecsAudioEnabled:
@@ -10269,12 +7087,8 @@ WebCodecsAudioEnabled:
   humanReadableDescription: "Enable WebCodecs Audio API"
   condition: ENABLE(WEB_CODECS)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 WebCodecsHEVCEnabled:
   type: bool
@@ -10284,16 +7098,10 @@ WebCodecsHEVCEnabled:
   humanReadableDescription: "Enable WebCodecs HEVC codec"
   condition: ENABLE(WEB_CODECS)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "USE(GSTREAMER)": true
-      "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
-      "USE(GSTREAMER)": true
-      "PLATFORM(COCOA)": true
-      default: false
+    "USE(GSTREAMER)": true
+    "PLATFORM(COCOA)": true
+    default: false
+    WebKitLegacy: false
 
 WebCodecsImageEnabled:
   type: bool
@@ -10303,12 +7111,8 @@ WebCodecsImageEnabled:
   humanReadableDescription: "Enable WebCodecs Image API"
   condition: ENABLE(WEB_CODECS)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
 
 WebCodecsVideoEnabled:
   type: bool
@@ -10318,12 +7122,10 @@ WebCodecsVideoEnabled:
   humanReadableDescription: "Enable WebCodecs Video API"
   condition: ENABLE(WEB_CODECS)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "USE(LIBWEBRTC) && PLATFORM(COCOA)": WebKit::defaultPeerConnectionEnabledAvailable()
-      "USE(GSTREAMER)": true
-      default: false
+    "USE(LIBWEBRTC) && PLATFORM(COCOA)": WebKit::defaultPeerConnectionEnabledAvailable()
+    "USE(GSTREAMER)": true
+    default: false
+    WebKitLegacy: false
     WebCore:
       "PLATFORM(COCOA)": true
       "USE(GSTREAMER)": true
@@ -10341,12 +7143,8 @@ WebContentRestrictionsAskToEnabled:
   humanReadableDescription: "Enable Ask To for WebContentRestrictions"
   condition: HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: defaultWebContentRestrictionsAskToEnabled()
-    WebCore:
-      default: false
+    default: false
+    WebKit: defaultWebContentRestrictionsAskToEnabled()
   sharedPreferenceForWebProcess: true
 
 WebContentRestrictionsTransitiveTrustEnabled:
@@ -10358,13 +7156,7 @@ WebContentRestrictionsTransitiveTrustEnabled:
   humanReadableDescription: "Enable Transitive Trust for WebContentRestrictions"
   webcoreBinding: DeprecatedGlobalSettings
   condition: HAVE(WEBCONTENTRESTRICTIONS_TRANSITIVE_TRUST)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   sharedPreferenceForWebProcess: true
 
 WebExtensionBookmarksEnabled:
@@ -10374,13 +7166,7 @@ WebExtensionBookmarksEnabled:
   humanReadableName: "WebExtension Bookmarks API"
   humanReadableDescription: "Enable support for WebExtensions using the Bookmarks API"
   condition: ENABLE(WK_WEB_EXTENSIONS_BOOKMARKS)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 WebExtensionOffscreenEnabled:
   type: bool
@@ -10389,13 +7175,7 @@ WebExtensionOffscreenEnabled:
   humanReadableName: "WebExtension Offscreen API"
   humanReadableDescription: "Enable support for WebExtensions using the Offscreen API"
   condition: ENABLE(WK_WEB_EXTENSIONS_OFFSCREEN)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 WebExtensionSidebarEnabled:
   type: bool
@@ -10404,13 +7184,7 @@ WebExtensionSidebarEnabled:
   humanReadableName: "WebExtension sidebarAction and sidePanel APIs"
   humanReadableDescription: "Enable support for WebExtensions using the sidebarAction / sidePanel family of APIs"
   condition: ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 WebGLDraftExtensionsEnabled:
   type: bool
@@ -10418,13 +7192,7 @@ WebGLDraftExtensionsEnabled:
   category: dom
   humanReadableName: "WebGL Draft Extensions"
   humanReadableDescription: "Enable WebGL extensions that are still in draft status"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 WebGLEnabled:
@@ -10433,12 +7201,8 @@ WebGLEnabled:
   humanReadableName: "WebGL"
   humanReadableDescription: "Enable WebGL"
   defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: true
+    WebCore: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -10449,13 +7213,7 @@ WebGLTimerQueriesEnabled:
   category: dom
   humanReadableName: "WebGL Timer Queries"
   humanReadableDescription: "Enable WebGL extensions that provide GPU timer queries"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 WebGPUEnabled:
   type: bool
@@ -10464,15 +7222,8 @@ WebGPUEnabled:
   humanReadableName: "WebGPU"
   humanReadableDescription: "Enable WebGPU"
   defaultValue:
-    WebKitLegacy:
-      "ENABLE(WEBGPU_BY_DEFAULT)": true
-      default: false
-    WebKit:
-      "ENABLE(WEBGPU_BY_DEFAULT)": true
-      default: false
-    WebCore:
-      "ENABLE(WEBGPU_BY_DEFAULT)": true
-      default: false
+    "ENABLE(WEBGPU_BY_DEFAULT)": true
+    default: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -10484,15 +7235,8 @@ WebGPUHDREnabled:
   humanReadableName: "WebGPU support for HDR"
   humanReadableDescription: "WebGPU High Dynamic Range through canvas configuration tone mapping mode"
   defaultValue:
-    WebKitLegacy:
-      "ENABLE(WEBGPU_BY_DEFAULT) && HAVE(SUPPORT_HDR_DISPLAY)": true
-      default: false
-    WebKit:
-      "ENABLE(WEBGPU_BY_DEFAULT) && HAVE(SUPPORT_HDR_DISPLAY)": true
-      default: false
-    WebCore:
-      "ENABLE(WEBGPU_BY_DEFAULT) && HAVE(SUPPORT_HDR_DISPLAY)": true
-      default: false
+    "ENABLE(WEBGPU_BY_DEFAULT) && HAVE(SUPPORT_HDR_DISPLAY)": true
+    default: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
 
@@ -10502,13 +7246,7 @@ WebInspectorEngineeringSettingsAllowed:
   category: dom
   defaultsOverridable: true
   humanReadableName: "WebInspector engineering settings allowed"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 WebLocksAPIEnabled:
   type: bool
@@ -10517,12 +7255,8 @@ WebLocksAPIEnabled:
   humanReadableName: "Web Locks API"
   humanReadableDescription: "Web Locks API"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+    default: true
+    WebKitLegacy: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -10535,14 +7269,9 @@ WebRTCAV1CodecEnabled:
   humanReadableDescription: "Enable WebRTC AV1 codec"
   condition: ENABLE(WEB_RTC)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "USE(GSTREAMER) || PLATFORM(COCOA)": true
-      default: false
-    WebCore:
-      "USE(GSTREAMER) || PLATFORM(COCOA)": true
-      default: false
+    "USE(GSTREAMER) || PLATFORM(COCOA)": true
+    default: false
+    WebKitLegacy: false
 
 WebRTCAudioLatencyAdaptationEnabled:
   type: bool
@@ -10551,11 +7280,8 @@ WebRTCAudioLatencyAdaptationEnabled:
   humanReadableName: "WebRTC Audio Latency Adaptation"
   humanReadableDescription: "Enable WebRTC Audio Latency Adaptation"
   webcoreBinding: DeprecatedGlobalSettings
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
+  excludeFrom: [ WebCore ]
+  defaultValue: true
 
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 WebRTCDTMFEnabled:
@@ -10565,13 +7291,7 @@ WebRTCDTMFEnabled:
   humanReadableName: "WebRTC DTMF"
   humanReadableDescription: "Enable WebRTC DTMF"
   condition: ENABLE(WEB_RTC)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 WebRTCEncodedTransformEnabled:
   type: bool
@@ -10581,11 +7301,9 @@ WebRTCEncodedTransformEnabled:
   humanReadableName: "WebRTC Encoded Transform API"
   humanReadableDescription: "Enable WebRTC Encoded Transform API"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "USE(LIBWEBRTC) && PLATFORM(COCOA)": WebKit::defaultPeerConnectionEnabledAvailable()
-      default: false
+    "USE(LIBWEBRTC) && PLATFORM(COCOA)": WebKit::defaultPeerConnectionEnabledAvailable()
+    default: false
+    WebKitLegacy: false
     WebCore:
       "USE(LIBWEBRTC)": true
       default: false
@@ -10600,11 +7318,8 @@ WebRTCH264HardwareEncoderEnabled:
   humanReadableDescription: "Enable H264 Hardware encoder"
   webcoreBinding: none
   condition: ENABLE(WEB_RTC)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
+  excludeFrom: [ WebCore ]
+  defaultValue: true
 
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
 WebRTCH265CodecEnabled:
@@ -10615,14 +7330,9 @@ WebRTCH265CodecEnabled:
   humanReadableName: "WebRTC HEVC codec"
   humanReadableDescription: "Enable WebRTC HEVC codec"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)": true
-      default: false
+    "PLATFORM(COCOA)": true
+    default: false
+    WebKitLegacy: false
 
 WebRTCInterfaceMonitoringViaNWEnabled:
   type: bool
@@ -10631,13 +7341,7 @@ WebRTCInterfaceMonitoringViaNWEnabled:
   condition: ENABLE(WEB_RTC) && PLATFORM(COCOA)
   humanReadableName: "WebRTC interface monitoring via NW"
   humanReadableDescription: "Enable WebRTC interface monitoring via NW"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   sharedPreferenceForWebProcess: true
 
 WebRTCL4SEnabled:
@@ -10647,13 +7351,7 @@ WebRTCL4SEnabled:
   condition: ENABLE(WEB_RTC)
   humanReadableName: "WebRTC L4S support"
   humanReadableDescription: "Enable WebRTC L4S support"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 WebRTCMediaPipelineAdditionalLoggingEnabled:
   type: bool
@@ -10661,13 +7359,7 @@ WebRTCMediaPipelineAdditionalLoggingEnabled:
   category: media
   humanReadableName: "WebRTC Media Pipeline Additional Logging"
   humanReadableDescription: "Enable WebRTC Media Pipeline Additional Logging"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 # FIXME: This is not relevant for WebKitLegacy, so it should be excluded from WebKitLegacy entirely.
 WebRTCPlatformCodecsInGPUProcessEnabled:
@@ -10677,12 +7369,9 @@ WebRTCPlatformCodecsInGPUProcessEnabled:
   humanReadableDescription: "Enable WebRTC Platform Codecs in GPU Process"
   condition: ENABLE(WEB_RTC)
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "ENABLE(GPU_PROCESS_BY_DEFAULT)": true
-      default: false
-    WebCore:
       default: false
 
 WebRTCRelayBypassDisabled:
@@ -10692,13 +7381,7 @@ WebRTCRelayBypassDisabled:
   humanReadableName: "Disable WebRTC private relay bypass"
   humanReadableDescription: "Disable WebRTC private relay bypass"
   condition: ENABLE(WEB_RTC)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 WebRTCRemoteVideoFrameEnabled:
   type: bool
@@ -10708,12 +7391,9 @@ WebRTCRemoteVideoFrameEnabled:
   humanReadableDescription: "Enable WebRTC Remote Video Frame"
   condition: ENABLE(WEB_RTC)
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
       default: false
 
 WebRTCSFrameTransformEnabled:
@@ -10723,13 +7403,7 @@ WebRTCSFrameTransformEnabled:
   condition: ENABLE(WEB_RTC)
   humanReadableName: "WebRTC SFrame Transform API"
   humanReadableDescription: "Enable WebRTC SFrame Transform API"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 WebRTCSocketsProxyingEnabled:
   type: bool
@@ -10739,12 +7413,8 @@ WebRTCSocketsProxyingEnabled:
   humanReadableDescription: "Enable WebRTC Sockets Proxying"
   condition: ENABLE(WEB_RTC)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
+    default: false
+    WebKit: true
 
 WebRTCSocketsServiceClassEnabled:
   type: bool
@@ -10754,12 +7424,8 @@ WebRTCSocketsServiceClassEnabled:
   humanReadableDescription: "Enable setting WebRTC Sockets Service Class"
   condition: ENABLE(WEB_RTC)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultWebRTCSocketsServiceClassEnabled()
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultWebRTCSocketsServiceClassEnabled()
 
 WebRTCUDPPortRange:
   type: String
@@ -10768,13 +7434,7 @@ WebRTCUDPPortRange:
   humanReadableName: "WebRTC UDP Port Range"
   humanReadableDescription: "Set a UDP port range for WebRTC. If set to 0:0, the port range is determined by the OS"
   condition: ENABLE(WEB_RTC)
-  defaultValue:
-    WebKitLegacy:
-      default: '"0:0"_str'
-    WebKit:
-      default: '"0:0"_str'
-    WebCore:
-      default: '"0:0"_str'
+  defaultValue: '"0:0"_str'
 
 WebRTCVP9Profile0CodecEnabled:
   type: bool
@@ -10783,13 +7443,7 @@ WebRTCVP9Profile0CodecEnabled:
   humanReadableName: "WebRTC VP9 profile 0 codec"
   humanReadableDescription: "Enable WebRTC VP9 profile 0 codec"
   condition: ENABLE(WEB_RTC)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 WebRTCVP9Profile2CodecEnabled:
   type: bool
@@ -10799,14 +7453,9 @@ WebRTCVP9Profile2CodecEnabled:
   humanReadableDescription: "Enable WebRTC VP9 profile 2 codec"
   condition: ENABLE(WEB_RTC)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "PLATFORM(COCOA)": true
-      default: false
-    WebCore:
-      "PLATFORM(COCOA)": true
-      default: false
+    "PLATFORM(COCOA)": true
+    default: false
+    WebKitLegacy: false
 
 WebSQLEnabled:
   type: bool
@@ -10815,22 +7464,16 @@ WebSQLEnabled:
   humanReadableDescription: "Enable WebSQL"
   webcoreBinding: custom
   exposed: [ WebKitLegacy ]
+  excludeFrom: [ WebKit, WebCore ]
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(IOS_FAMILY)": WebKit::defaultWebSQLEnabled()
-      default: true
+    "PLATFORM(IOS_FAMILY)": WebKit::defaultWebSQLEnabled()
+    default: true
 
 WebSecurityEnabled:
   type: bool
   status: embedder
   inspectorOverride: true
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 # FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 WebShareEnabled:
@@ -10839,12 +7482,9 @@ WebShareEnabled:
   humanReadableName: "Web Share"
   humanReadableDescription: "Enable support for share sheet via Web Share API"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(COCOA) && !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)": true
-      default: false
-    WebCore:
       default: false
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -10857,27 +7497,17 @@ WebShareFileAPIEnabled:
   humanReadableName: "Web Share API Level 2"
   humanReadableDescription: "Enable level 2 of Web Share API"
   defaultValue:
-    WebKitLegacy:
-      default: false
+    default: false
     WebKit:
       "PLATFORM(COCOA) && !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)": true
-      default: false
-    WebCore:
       default: false
 
 WebSocketEnabled:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(WATCHOS)": false
-      default: true
-    WebKit:
-      "PLATFORM(WATCHOS)": false
-      default: true
-    WebCore:
-      "PLATFORM(WATCHOS)": false
-      default: true
+    "PLATFORM(WATCHOS)": false
+    default: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
@@ -10889,12 +7519,8 @@ WebTransportEnabled:
   humanReadableName: "WebTransport"
   humanReadableDescription: "Enable WebTransport"
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: WebKit::defaultWebTransportEnabled()
-    WebCore:
-      default: false
+    default: false
+    WebKit: WebKit::defaultWebTransportEnabled()
   sharedPreferenceForWebProcess: true
   richJavaScript: true
   disableInLockdownMode: true
@@ -10906,13 +7532,7 @@ WebXRAugmentedRealityModuleEnabled:
   humanReadableName: "WebXR Augmented Reality Module"
   humanReadableDescription: "Adds support for the WebXR Augmented Reality Module"
   condition: ENABLE(WEBXR_AR)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
   disableInLockdownMode: true
 
 WebXREnabled:
@@ -10922,13 +7542,7 @@ WebXREnabled:
   humanReadableName: "WebXR Device API"
   humanReadableDescription: "Adds support for accessing virtual reality (VR) and augmented reality (AR) devices, including sensors and head-mounted displays, on the Web"
   condition: ENABLE(WEBXR)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
   richJavaScript: true
@@ -10940,13 +7554,7 @@ WebXRGamepadsModuleEnabled:
   humanReadableName: "WebXR Gamepads Module"
   humanReadableDescription: "Adds support for the WebXR Gamepads Module"
   condition: ENABLE(WEBXR)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 WebXRHandInputModuleEnabled:
   type: bool
@@ -10955,13 +7563,7 @@ WebXRHandInputModuleEnabled:
   humanReadableName: "WebXR Hand Input Module"
   humanReadableDescription: "Adds support for the Hands Input Module for WebXR"
   condition: ENABLE(WEBXR_HANDS)
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
 
 WebXRHitTestModuleEnabled:
   type: bool
@@ -10970,13 +7572,7 @@ WebXRHitTestModuleEnabled:
   humanReadableName: "WebXR Hit Test Module"
   humanReadableDescription: "Adds support for the Hit Test Module for WebXR"
   condition: ENABLE(WEBXR_HIT_TEST)
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
+  defaultValue: false
 
 WebXRLayersAPIEnabled:
   type: bool
@@ -10986,14 +7582,9 @@ WebXRLayersAPIEnabled:
   humanReadableDescription: "Adds support for the WebXR Layers API"
   condition: ENABLE(WEBXR_LAYERS)
   defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      "ENABLE(WEBXR_LAYERS) && USE(OPENXR)": true
-      default: false
-    WebCore:
-      "ENABLE(WEBXR_LAYERS) && USE(OPENXR)": true
-      default: false
+    "ENABLE(WEBXR_LAYERS) && USE(OPENXR)": true
+    default: false
+    WebKitLegacy: false
 
 WebXRWebGPUBindingsEnabled:
   type: bool
@@ -11002,15 +7593,8 @@ WebXRWebGPUBindingsEnabled:
   humanReadableName: "WebGPU support for WebXR"
   humanReadableDescription: "Adds WebGPU support for WebXR"
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(VISION) && ENABLE(WEBXR_WEBGPU)": true
-      default: false
-    WebKit:
-      "PLATFORM(VISION) && ENABLE(WEBXR_WEBGPU)": true
-      default: false
-    WebCore:
-      "PLATFORM(VISION) && ENABLE(WEBXR_WEBGPU)": true
-      default: false
+    "PLATFORM(VISION) && ENABLE(WEBXR_WEBGPU)": true
+    default: false
   disableInLockdownMode: true
   sharedPreferenceForWebProcess: true
 
@@ -11020,14 +7604,9 @@ WheelEventGesturesBecomeNonBlocking:
   humanReadableName: "Wheel Event gestures become non-blocking"
   humanReadableDescription: "preventDefault() is only allowed on the first wheel event in a gesture"
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(MAC)": WebKit::defaultWheelEventGesturesBecomeNonBlocking()
-      default: true
-    WebKit:
-      "PLATFORM(MAC)": WebKit::defaultWheelEventGesturesBecomeNonBlocking()
-      default: true
-    WebCore:
-      default: true
+    "PLATFORM(MAC)": WebKit::defaultWheelEventGesturesBecomeNonBlocking()
+    default: true
+    WebCore: true
 
 WindowFocusRestricted:
   comment: When enabled, window.blur() does not change focus, and window.focus() only
@@ -11035,12 +7614,9 @@ WindowFocusRestricted:
   type: bool
   status: embedder
   defaultValue:
+    default: true
     WebKitLegacy:
       PLATFORM(MAC): WebKit::defaultWindowFocusRestricted()
-      default: true
-    WebKit:
-      default: true
-    WebCore:
       default: true
 
 WirelessPlaybackMediaPlayerEnabled:
@@ -11051,27 +7627,16 @@ WirelessPlaybackMediaPlayerEnabled:
   humanReadableDescription: "Enable wireless playback via MediaPlayerPrivateWirelessPlayback"
   condition: ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
   defaultValue:
-    WebCore:
-      default: false
-    WebKit:
-      default: true
-    WebKitLegacy:
-      default: false
+    default: false
+    WebKit: true
   disableInLockdownMode: true
 
 WirelessPlaybackTargetAPIEnabled:
   type: bool
   status: embedder
   defaultValue:
-    WebKitLegacy:
-      "PLATFORM(VISION)" : false
-      default: true
-    WebKit:
-      "PLATFORM(VISION)" : false
-      default: true
-    WebCore:
-      "PLATFORM(VISION)" : false
-      default: true
+    "PLATFORM(VISION)" : false
+    default: true
 
 WorkerInSharedWorkerEnabled:
   type: bool
@@ -11079,13 +7644,7 @@ WorkerInSharedWorkerEnabled:
   category: dom
   humanReadableName: "Worker in SharedWorker"
   humanReadableDescription: "Allow creating dedicated workers from shared workers"
-  defaultValue:
-    WebCore:
-      default: true
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
+  defaultValue: true
 
 WorkerParseErrorReportingEnabled:
   type: bool
@@ -11093,13 +7652,7 @@ WorkerParseErrorReportingEnabled:
   category: dom
   humanReadableName: "Worker parse error reporting"
   humanReadableDescription: "Report worker script parse errors on the Worker object"
-  defaultValue:
-    WebCore:
-      default: true
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
+  defaultValue: true
 
 WriteRichTextDataWhenCopyingOrDragging:
   type: bool
@@ -11108,12 +7661,9 @@ WriteRichTextDataWhenCopyingOrDragging:
   humanReadableDescription: "Write RTF, RTFD and attributed strings to the pasteboard when copying or dragging"
   condition: PLATFORM(COCOA)
   defaultValue:
-    WebKitLegacy:
-      default: true
+    default: true
     WebKit:
       "PLATFORM(IOS_FAMILY)": WebKit::defaultWriteRichTextDataWhenCopyingOrDragging()
-      default: true
-    WebCore:
       default: true
 
 XSLTEnabled:
@@ -11124,13 +7674,7 @@ XSLTEnabled:
   condition: ENABLE(XSLT)
   humanReadableName: "XSLT Support Enabled"
   humanReadableDescription: "Enables support for XSLT"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
+  defaultValue: true
   disableInLockdownMode: true
 
 ZoomOnDoubleTapWhenRoot:
@@ -11141,6 +7685,5 @@ ZoomOnDoubleTapWhenRoot:
   humanReadableDescription: "Double taps zoom, even if we dispatched a click on the root nodes"
   webcoreBinding: none
   exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: false
+  excludeFrom: [ WebKitLegacy, WebCore ]
+  defaultValue: false

--- a/Source/WebCore/Scripts/GenerateSettings.rb
+++ b/Source/WebCore/Scripts/GenerateSettings.rb
@@ -56,6 +56,24 @@ end
 
 FileUtils.mkdir_p(options[:outputDirectory])
 
+# Keep in sync with GeneratePreferences.rb, which validates this shape.
+FRONTENDS = %w{ WebKitLegacy WebKit WebCore }
+
+# "defaultValue" is the value shared by every frontend the preference is in,
+# either directly or as a map of build conditions ending in "default". A frontend
+# is listed under it only where its value differs.
+def defaultValueFor(name, options, frontend)
+  specification = options["defaultValue"]
+  if specification.nil?
+    puts "ERROR: #{name}: \"defaultValue\" is required and cannot be empty."
+    exit(-1)
+  end
+  return { "default" => specification } if !specification.is_a?(Hash)
+
+  value = specification.fetch(frontend, specification.reject { |key, _| FRONTENDS.include?(key) })
+  value.is_a?(Hash) ? value : { "default" => value }
+end
+
 def load(path)
   parsed = begin
     YAML.load_file(path)
@@ -96,7 +114,7 @@ class Setting
     @options = options
     @type = options["refinedType"] || options["type"]
     @status = options["status"]
-    @defaultValues = options["defaultValue"]["WebCore"]
+    @defaultValues = defaultValueFor(name, options, "WebCore")
     @excludeFromInternalSettings = options["webcoreExcludeFromInternalSettings"] || false
     @disableInLockdownMode = options["disableInLockdownMode"] || false
     @condition = options["condition"]

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -22,65 +22,49 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 # THE POSSIBILITY OF SUCH DAMAGE.
 
+# WebCore settings. See UnifiedWebPreferences.yaml for details on syntax.
+
 AllowAnimationControlsOverride:
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 AnimatedImageDebugCanvasDrawingEnabled:
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 AutoscrollForDragAndDropEnabled:
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 BackForwardCacheExpirationInterval:
   type: double
   refinedType: Seconds
-  defaultValue:
-    WebCore:
-      default: 30_min
+  defaultValue: 30_min
 
 BackgroundShouldExtendBeyondPage:
   type: bool
   webcoreOnChange: backgroundShouldExtendBeyondPageChanged
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 ClientCoordinatesRelativeToLayoutViewport:
   type: bool
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 ClipboardAccessPolicy:
   type: uint32_t
   refinedType: ClipboardAccessPolicy
-  defaultValue:
-    WebCore:
-      default: ClipboardAccessPolicy::RequiresUserGesture
+  defaultValue: ClipboardAccessPolicy::RequiresUserGesture
 
 CrossOriginCheckInGetMatchedCSSRulesDisabled:
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 DefaultVideoPosterURL:
   comment: >-
     Some apps could have a default video poster if it is not set.
   type: String
-  defaultValue:
-    WebCore:
-      default: '{ }'
+  defaultValue: '{ }'
 
 DownloadableBinaryFontTrustedTypes:
   comment: >-
@@ -89,178 +73,137 @@ DownloadableBinaryFontTrustedTypes:
   type: uint32_t
   refinedType: DownloadableBinaryFontTrustedTypes
   defaultValue:
-    WebCore:
-      PLATFORM(WATCHOS): DownloadableBinaryFontTrustedTypes::None
-      default: DownloadableBinaryFontTrustedTypes::Any
+    PLATFORM(WATCHOS): DownloadableBinaryFontTrustedTypes::None
+    default: DownloadableBinaryFontTrustedTypes::Any
 
 EditingBehaviorType:
   type: uint32_t
   refinedType: EditingBehaviorType
   defaultValue:
-    WebCore:
-      PLATFORM(IOS_FAMILY): EditingBehaviorType::iOS
-      OS(DARWIN): EditingBehaviorType::Mac
-      OS(WINDOWS): EditingBehaviorType::Windows
-      OS(UNIX): EditingBehaviorType::Unix
-      default: EditingBehaviorType::Mac
+    PLATFORM(IOS_FAMILY): EditingBehaviorType::iOS
+    OS(DARWIN): EditingBehaviorType::Mac
+    OS(WINDOWS): EditingBehaviorType::Windows
+    OS(UNIX): EditingBehaviorType::Unix
+    default: EditingBehaviorType::Mac
 
 FixedBackgroundsPaintRelativeToDocument:
   type: bool
   inspectorOverride: true
   defaultValue:
-    WebCore:
-      PLATFORM(IOS_FAMILY): true
-      default: false
+    PLATFORM(IOS_FAMILY): true
+    default: false
 
 FixedElementsLayoutRelativeToFrame:
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 FontFallbackPrefersPictographs:
   type: bool
   webcoreOnChange: fontFallbackPrefersPictographsChanged
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 FontLoadTimingOverride:
   type: uint32_t
   refinedType: FontLoadTimingOverride
-  defaultValue:
-    WebCore:
-      default: FontLoadTimingOverride::None
+  defaultValue: FontLoadTimingOverride::None
 
 ForceCompositingMode:
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 ForcedColorsAreInvertedAccessibilityValue:
   type: uint32_t
   refinedType: ForcedAccessibilityValue
-  defaultValue:
-    WebCore:
-      default: ForcedAccessibilityValue::System
+  defaultValue: ForcedAccessibilityValue::System
 
 ForcedDisplayIsMonochromeAccessibilityValue:
   type: uint32_t
   refinedType: ForcedAccessibilityValue
-  defaultValue:
-    WebCore:
-      default: ForcedAccessibilityValue::System
+  defaultValue: ForcedAccessibilityValue::System
 
 ForcedPrefersContrastAccessibilityValue:
   type: uint32_t
   refinedType: ForcedAccessibilityValue
-  defaultValue:
-    WebCore:
-      default: ForcedAccessibilityValue::System
+  defaultValue: ForcedAccessibilityValue::System
 
 ForcedPrefersReducedMotionAccessibilityValue:
   type: uint32_t
   refinedType: ForcedAccessibilityValue
-  defaultValue:
-    WebCore:
-      default: ForcedAccessibilityValue::System
+  defaultValue: ForcedAccessibilityValue::System
 
 ForcedSupportsHighDynamicRangeValue:
   type: uint32_t
   refinedType: ForcedAccessibilityValue
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
-  defaultValue:
-    WebCore:
-      default: ForcedAccessibilityValue::System
+  defaultValue: ForcedAccessibilityValue::System
 
 GeolocationFloorLevelEnabled:
   type: bool
-  defaultValue:
-    WebCore:
-      default: true
+  defaultValue: true
 
 HTMLParserScriptingFlagPolicy:
   type: uint32_t
   refinedType: HTMLParserScriptingFlagPolicy
-  defaultValue:
-    WebCore:
-      default: HTMLParserScriptingFlagPolicy::OnlyIfScriptIsEnabled
+  defaultValue: HTMLParserScriptingFlagPolicy::OnlyIfScriptIsEnabled
 
 IdempotentModeAutosizingOnlyHonorsPercentages:
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 ImageSubsamplingEnabled:
   type: bool
   defaultValue:
-    WebCore:
-      PLATFORM(COCOA): true
-      default: false
+    PLATFORM(COCOA): true
+    default: false
 
 ImagesEnabled:
   type: bool
   webcoreGetter: areImagesEnabled
   webcoreOnChange: imagesEnabledChanged
   inspectorOverride: true
-  defaultValue:
-    WebCore:
-      default: true
+  defaultValue: true
 
 IsPerActivityStateCPUUsageMeasurementEnabled:
   type: bool
   defaultValue:
-    WebCore:
-      PLATFORM(MAC): true
-      default: false
+    PLATFORM(MAC): true
+    default: false
 
 IsPostBackgroundingCPUUsageMeasurementEnabled:
   type: bool
   defaultValue:
-    WebCore:
-      PLATFORM(MAC): true
-      default: false
+    PLATFORM(MAC): true
+    default: false
 
 IsPostBackgroundingMemoryUsageMeasurementEnabled:
   type: bool
   defaultValue:
-    WebCore:
-      PLATFORM(MAC): true
-      default: false
+    PLATFORM(MAC): true
+    default: false
 
 IsPostLoadCPUUsageMeasurementEnabled:
   type: bool
   defaultValue:
-    WebCore:
-      PLATFORM(COCOA): true
-      default: false
+    PLATFORM(COCOA): true
+    default: false
 
 IsPostLoadMemoryUsageMeasurementEnabled:
   type: bool
   defaultValue:
-    WebCore:
-      PLATFORM(COCOA): true
-      default: false
+    PLATFORM(COCOA): true
+    default: false
 
 LangAttributeAwareFormControlUIEnabled:
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 LocalStorageDatabasePath:
   type: String
-  defaultValue:
-    WebCore:
-      default: '{ }'
+  defaultValue: '{ }'
 
 MaximumHTMLParserDOMTreeDepth:
   type: uint32_t
-  defaultValue:
-    WebCore:
-      default: SettingsBase::defaultMaximumHTMLParserDOMTreeDepth
+  defaultValue: SettingsBase::defaultMaximumHTMLParserDOMTreeDepth
 
 MaximumSourceBufferSize:
   comment: >-
@@ -268,28 +211,20 @@ MaximumSourceBufferSize:
     of 1080p video and stereo audio.
   type: uint32_t
   condition: ENABLE(MEDIA_SOURCE)
-  defaultValue:
-    WebCore:
-      default: SettingsBase::defaultMaximumSourceBufferSize()
+  defaultValue: SettingsBase::defaultMaximumSourceBufferSize()
 
 MaximumXMLParserEntityExpansionCount:
   type: uint32_t
-  defaultValue:
-    WebCore:
-      default: SettingsBase::defaultMaximumXMLParserEntityExpansionCount
+  defaultValue: SettingsBase::defaultMaximumXMLParserEntityExpansionCount
 
 MediaKeysStorageDirectory:
   type: String
-  defaultValue:
-    WebCore:
-      default: '{ }'
+  defaultValue: '{ }'
 
 MediaTypeOverride:
   type: String
   webcoreOnChange: mediaTypeOverrideChanged
-  defaultValue:
-    WebCore:
-      default: '"screen"'
+  defaultValue: '"screen"'
 
 MinimumAccelerated2DContextArea:
   comment: >-
@@ -303,9 +238,8 @@ MinimumAccelerated2DContextArea:
     draw canvas in software.
   type: uint64_t
   defaultValue:
-    WebCore:
-      USE(SKIA): 128 * 129
-      default: 0
+    USE(SKIA): 128 * 129
+    default: 0
 
 NeedsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk:
   comment: >-
@@ -316,165 +250,120 @@ NeedsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk:
     until the keyboard performs the insertion or deletion. This gives Google Sheets the illusion that the DOM
     update happened within the same event loop iteration that the keypress event was dispatched in.
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 PaymentRequestEnabled:
   type: bool
   condition: ENABLE(PAYMENT_REQUEST)
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 PitchCorrectionAlgorithm:
   type: uint32_t
   refinedType: MediaPlayerEnums::PitchCorrectionAlgorithm
-  defaultValue:
-    WebCore:
-      default: MediaPlayerEnums::PitchCorrectionAlgorithm::BestAllAround
+  defaultValue: MediaPlayerEnums::PitchCorrectionAlgorithm::BestAllAround
 
 PreferMIMETypeForImages:
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 PreventKeyboardDOMEventDispatch:
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 ScrollingCoordinatorEnabled:
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 ScrollingTreeIncludesFrames:
   type: bool
   defaultValue:
-    WebCore:
-      PLATFORM(IOS_FAMILY): true
-      default: false
+    PLATFORM(IOS_FAMILY): true
+    default: false
 
 SessionStorageQuota:
   comment: >-
     Allow clients concerned with memory consumption to set a quota on session storage
     since the memory used won't be released until the Page is destroyed.
   type: uint32_t
-  defaultValue:
-    WebCore:
-      default: 5242880
+  defaultValue: 5242880
 
 ShouldDispatchSyntheticMouseEventsWhenModifyingSelection:
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 ShouldDispatchSyntheticMouseOutAfterSyntheticClick:
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 ShouldIgnoreFontLoadCompletions:
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 ShouldInjectUserScriptsInInitialEmptyDocument:
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 StorageBlockingPolicy:
   type: uint32_t
   refinedType: StorageBlockingPolicy
   webcoreOnChange: storageBlockingPolicyChanged
-  defaultValue:
-    WebCore:
-      default: StorageBlockingPolicy::AllowAll
+  defaultValue: StorageBlockingPolicy::AllowAll
 
 SuppressHDRShouldBeAllowedInFullscreenVideo:
   type: bool
   defaultValue:
-    WebCore:
-      PLATFORM(MAC): false
-      default: true
+    PLATFORM(MAC): false
+    default: true
 
 TextAutosizingWindowSizeOverrideHeight:
   type: uint32_t
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
-  defaultValue:
-    WebCore:
-      default: 0
+  defaultValue: 0
 
 TextAutosizingWindowSizeOverrideWidth:
   type: uint32_t
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
-  defaultValue:
-    WebCore:
-      default: 0
+  defaultValue: 0
 
 TextDirectionSubmenuInclusionBehavior:
   type: uint32_t
   refinedType: TextDirectionSubmenuInclusionBehavior
-  defaultValue:
-    WebCore:
-      default: TextDirectionSubmenuInclusionBehavior::AutomaticallyIncluded
+  defaultValue: TextDirectionSubmenuInclusionBehavior::AutomaticallyIncluded
 
 TimeWithoutMouseMovementBeforeHidingControls:
   type: double
   refinedType: Seconds
-  defaultValue:
-    WebCore:
-      default: 3_s
+  defaultValue: 3_s
 
 TouchEventEmulationEnabled:
   type: bool
   webcoreGetter: isTouchEventEmulationEnabled
   condition: ENABLE(TOUCH_EVENTS)
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 TreatIPAddressAsDomain:
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false
 
 UnhandledPromiseRejectionToConsoleEnabled:
   type: bool
-  defaultValue:
-    WebCore:
-      default: true
+  defaultValue: true
 
 UnifiedTextCheckerEnabled:
   type: bool
   defaultValue:
-    WebCore:
-      USE(UNIFIED_TEXT_CHECKING): true
-      default: false
+    USE(UNIFIED_TEXT_CHECKING): true
+    default: false
 
 UseAnonymousModeWhenFetchingMaskImages:
   type: bool
-  defaultValue:
-    WebCore:
-      default: true
+  defaultValue: true
 
 UserStyleSheetLocation:
   type: String
   refinedType: URL
   webcoreOnChange: userStyleSheetLocationChanged
-  defaultValue:
-    WebCore:
-      default: '{ }'
+  defaultValue: '{ }'
 
 ValidationMessageTimerMagnification:
   comment: >-
@@ -483,24 +372,16 @@ ValidationMessageTimerMagnification:
     message length * N / 1000 seconds.  If N is equal to or less than 0, a
     validation message doesn't disappears automaticaly.
   type: uint32_t
-  defaultValue:
-    WebCore:
-      default: 50
+  defaultValue: 50
 
 WebGLErrorsToConsoleEnabled:
   type: bool
-  defaultValue:
-    WebCore:
-      default: true
+  defaultValue: true
 
 WebRTCEncryptionEnabled:
   type: bool
-  defaultValue:
-    WebCore:
-      default: true
+  defaultValue: true
 
 WebkitImageReadyEventEnabled:
   type: bool
-  defaultValue:
-    WebCore:
-      default: false
+  defaultValue: false


### PR DESCRIPTION
#### 6f6d92eda135775fd18ca62e5e37f49f5f708fd9
<pre>
Simplify UnifiedWebPreferences.yaml&apos;s defaultValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=323438">https://bugs.webkit.org/show_bug.cgi?id=323438</a>

Reviewed by Chris Dumez.

&quot;defaultValue&quot; now holds the value every frontend shares, either directly
or as a map of build conditions ending in &quot;default&quot;, with a frontend
listed under it only where its value differs:

    defaultValue:
      PLATFORM(COCOA): true
      default: false
      WebKitLegacy: false

440 of 780 preferences collapse to a single defaultValue line, 48 more
share a conditional default, and 292 spell out a deviation. Whichever
frontend needs the fewest deviations supplies the shared default, ties
going to WebKit.

The 123 preferences that are not in all three frontends say so with
&quot;excludeFrom&quot;.

GeneratePreferences.rb validates the shape. A map needs a &quot;default&quot; and no
value may be left empty, with build conditions before the &quot;default&quot; and
frontends after it; frontends are listed in the order WebKitLegacy,
WebKit, WebCore in &quot;defaultValue&quot;, &quot;excludeFrom&quot; and &quot;exposed&quot;, so
grepping a preference always finds them in the same order; a frontend
whose value is the shared default has to be left out; a map that is only a
&quot;default&quot; has to be written inline, whether it is the shared default or a
frontend&apos;s; a frontend cannot be nested under another frontend, which
would generate an &quot;#if WebCore&quot; rather than fail; and an excluded frontend
cannot carry a value. GenerateSettings.rb reports a missing &quot;defaultValue&quot;
as well, since Source/WebCore/page/Settings.yaml sees no validation.

MediaSourceInWorkerEnabled and UseCGDisplayListsForDOMRendering listed
&quot;exposed&quot; as [ WebCore, WebKit ] and are reordered. Preference bodies are
now uniformly indented two, four and six spaces.

Source/WebCore/page/Settings.yaml is converted too, since it shares
GenerateSettings.rb&apos;s parser. Its settings are WebCore-only, so they need
no &quot;excludeFrom&quot;.

No behavior change. The conversion was mechanical, by the script attached
to this bug, whose --compare mode flattens two versions of a file to the
(preference, frontend) -&gt; ordered condition map the generators consume and
diffs them:

    convert-web-preferences-default-values --compare before.yaml after.yaml

All 2121 pairs are identical for UnifiedWebPreferences.yaml and all 67 for
Settings.yaml, and generating every derived file for all six generator
invocations before and after produces 23 byte-identical files.

Canonical link: <a href="https://commits.webkit.org/320613@main">https://commits.webkit.org/320613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cbb6066ac756197616f5ceb2bb061e6c713f6cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195645 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144821 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165413 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125114 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47233 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45296 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7026 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13915 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44983 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6698 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46579 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197594 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58897 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154331 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41332 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59606 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41587 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/153982 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48474 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131925 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128742 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58084 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20005 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57456 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57699 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57523 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->