### PR TITLE
[list-marker] align-content leaves the list marker behind

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>An outside list marker follows the line align-content moved</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 40px }
+  div { height: 100px; padding-block-start: 40px; box-sizing: border-box }
+</style>
+</head>
+<body>
+  <ul><li><div>xx</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>An outside list marker follows the line align-content moved</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 40px }
+  div { height: 100px; padding-block-start: 40px; box-sizing: border-box }
+</style>
+</head>
+<body>
+  <ul><li><div>xx</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>An outside list marker follows the line align-content moved</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-position-property">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-content">
+<link rel="match" href="outside-marker-with-align-content-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 40px }
+  div { height: 100px; align-content: center }
+</style>
+</head>
+<body>
+  <ul><li><div>xx</div></li></ul>
+</body>
+</html>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -1536,6 +1536,14 @@ void LineLayout::shiftLinesByInBlockDirection(LayoutUnit blockShift)
     for (size_t lineIndex = 0; lineIndex < displayContent.lines.size(); ++lineIndex)
         displayContent.moveLineInBlockDirection(lineIndex, blockShift);
 
+    // An excluded marker is on one of these lines without being part of the content that moves with them, so the
+    // position it was given has to move too (see RenderListItem::placeExcludedMarker).
+    if (CheckedPtr marker = RenderListItem::excludedMarkerAnchoredTo(flow())) {
+        auto excludedPosition = *marker->excludedPosition();
+        excludedPosition.topLeft.move(0, blockShift.toFloat());
+        marker->setExcludedPosition(excludedPosition);
+    }
+
     auto deltaX = isHorizontalWritingMode ? 0_lu : blockShift;
     auto deltaY = isHorizontalWritingMode ? blockShift : 0_lu;
     for (auto& box : m_inlineContent->displayContent().boxes) {

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -668,6 +668,20 @@ RenderListItem::FirstFormattedLineCandidate RenderListItem::firstFormattedLineRo
     return { { }, fallbackParent, stoppedAtTableRubyOrReplaced };
 }
 
+CheckedPtr<RenderListOutsideMarker> RenderListItem::excludedMarkerAnchoredTo(const RenderBlockFlow& firstFormattedLineRoot)
+{
+    for (CheckedPtr<const RenderBlock> ancestor = &firstFormattedLineRoot; ancestor; ancestor = ancestor->containingBlock()) {
+        CheckedPtr listItem = dynamicDowncast<RenderListItem>(ancestor.get());
+        CheckedPtr marker = listItem ? listItem->markerBox() : nullptr;
+        if (!marker || !marker->isExcludedMarker())
+            continue;
+        auto excludedPosition = marker->excludedPosition();
+        if (excludedPosition && excludedPosition->firstFormattedLineRoot.get() == &firstFormattedLineRoot)
+            return marker;
+    }
+    return { };
+}
+
 Vector<CheckedPtr<RenderListOutsideMarker>> RenderListItem::excludedMarkersForContainer(const RenderBlockFlow& inlineRoot, const Vector<SingleThreadWeakPtr<RenderListOutsideMarker>>& allExcludedMarkers)
 {
     auto markersForContainer = Vector<CheckedPtr<RenderListOutsideMarker>> { };

--- a/Source/WebCore/rendering/RenderListItem.h
+++ b/Source/WebCore/rendering/RenderListItem.h
@@ -66,6 +66,7 @@ public:
     };
     static FirstFormattedLineCandidate firstFormattedLineRootFor(RenderBlock& blockContainer, const RenderBoxModelObject& marker);
     static Vector<CheckedPtr<RenderListOutsideMarker>> excludedMarkersForContainer(const RenderBlockFlow& lineContainer, const Vector<SingleThreadWeakPtr<RenderListOutsideMarker>>&);
+    static CheckedPtr<RenderListOutsideMarker> excludedMarkerAnchoredTo(const RenderBlockFlow& firstFormattedLineRoot);
 
 private:
     ASCIILiteral renderName() const final { return "RenderListItem"_s; }


### PR DESCRIPTION
#### 65dd1d3fccd053730b9e2881484c1694a6a2d794
<pre>
[list-marker] align-content leaves the list marker behind
<a href="https://bugs.webkit.org/show_bug.cgi?id=323445">https://bugs.webkit.org/show_bug.cgi?id=323445</a>
<a href="https://rdar.apple.com/problem/186676835">rdar://problem/186676835</a>

Reviewed by Antti Koivisto.

An outside marker is positioned against a line (RenderListItem::placeExcludedMarker) and takes no part in the inline
content of that line. align-content moves the lines after they are built, and LineLayout::shiftLinesByInBlockDirection
moves the lines and the renderers of the boxes on them, so the marker stayed where the unshifted line was.

Move the position the marker was given by the same amount.

Test: imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content.html: Added.
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::shiftLinesByInBlockDirection):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::excludedMarkerAnchoredTo):
* Source/WebCore/rendering/RenderListItem.h:

Canonical link: <a href="https://commits.webkit.org/320532@main">https://commits.webkit.org/320532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7be32d2d3520ea873be3442a567f198b26c1ccb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195334 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58646 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144572 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187955 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165161 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124859 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46969 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157338 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44728 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6386 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197282 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58586 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164664 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154052 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41267 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59296 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41332 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153710 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48221 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131586 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128222 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57788 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19747 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57148 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57397 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57224 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->