### PR TITLE
[list-marker] text-indent moves the list marker with the text

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-indent moves the line, not the outside list marker</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 60px }
+  div { padding-inline-start: 60px }
+</style>
+</head>
+<body>
+  <ul><li><div>xx</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-indent moves the line, not the outside list marker</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 60px }
+  div { padding-inline-start: 60px }
+</style>
+</head>
+<body>
+  <ul><li><div>xx</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-indent moves the line, not the outside list marker</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-position-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#text-indent-property">
+<link rel="match" href="outside-marker-with-text-indent-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 60px }
+  div { text-indent: 60px }
+</style>
+</head>
+<body>
+  <ul><li><div>xx</div></li></ul>
+</body>
+</html>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -141,6 +141,16 @@ InlineRect InlineFormattingUtils::flipVisualRectToLogicalForWritingMode(const In
     return visualRect;
 }
 
+InlineLayoutUnit InlineFormattingUtils::computedTextIndentForFirstLine(const ElementBox& root, InlineLayoutUnit availableWidth)
+{
+    auto shouldIndent = root.style().textIndent().eachLine.has_value() || (root.isAnonymousTextIndentCandidateForIntegration() || !root.isAnonymous() || (!root.isInlineIntegrationRoot() && root.parent().firstInFlowChild() == &root));
+    // Specifying 'hanging' inverts whether the line should be indented or not.
+    if (shouldIndent == root.style().textIndent().hanging.has_value())
+        return { };
+    auto& textIndentAmount = root.style().textIndent().amount;
+    return textIndentAmount == 0_css_px ? 0.f : Style::evaluate<InlineLayoutUnit>(textIndentAmount, availableWidth, root.style().usedZoomForLength());
+}
+
 InlineLayoutUnit InlineFormattingUtils::computedTextIndent(IsIntrinsicWidthMode isIntrinsicWidthMode, IsFirstFormattedLine isFirstFormattedLine, std::optional<PreviousLineEndsParagraph> previousLineEndsParagraph, InlineLayoutUnit availableWidth) const
 {
     CheckedRef root = formattingContext().root();

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h
@@ -47,6 +47,7 @@ public:
     enum class IsIntrinsicWidthMode : bool { No, Yes };
     enum class PreviousLineEndsParagraph : bool { No, Yes };
     InlineLayoutUnit computedTextIndent(IsIntrinsicWidthMode, IsFirstFormattedLine, std::optional<PreviousLineEndsParagraph>, InlineLayoutUnit availableWidth) const;
+    static InlineLayoutUnit computedTextIndentForFirstLine(const ElementBox& root, InlineLayoutUnit availableWidth);
 
     bool inlineLevelBoxAffectsLineBox(const InlineLevelBox&, const LineBox&) const;
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -550,6 +550,9 @@ void LineLayout::setExcludedMarkerPositions(const ExcludedMarkerList& excludedMa
     // (right in a right to left inline direction) a nesting list item's marker may go. An intruding float is the usual
     // reason for it to be non zero.
     auto lineStartInset = isLeftToRight ? lineBoxLogicalRect.x() : flow().contentBoxLogicalWidth() - lineBoxLogicalRect.maxX();
+    // text-indent is a margin on the line box, not content the marker hangs off.
+    ASSERT(m_inlineContentConstraints);
+    auto textIndent = Layout::InlineFormattingUtils::computedTextIndentForFirstLine(rootLayoutBox(), m_inlineContentConstraints->horizontal().logicalWidth);
     for (auto& marker : excludedMarkers) {
         // Vertical: baseline aligned, with the ascent the inline formatting context would have given it.
         auto markerAscent = [&]() -> float {
@@ -562,8 +565,8 @@ void LineLayout::setExcludedMarkerPositions(const ExcludedMarkerList& excludedMa
         // inline direction (the marker's start margin is what holds the gap, hence negative).
         auto markerLogicalLeft = [&]() -> float {
             if (isLeftToRight)
-                return lineBoxLogicalRect.x() + marker->marginStart();
-            return lineBoxLogicalRect.maxX() - marker->marginStart() - marker->logicalWidth();
+                return lineBoxLogicalRect.x() - textIndent + marker->marginStart();
+            return lineBoxLogicalRect.maxX() + textIndent - marker->marginStart() - marker->logicalWidth();
         }();
         auto topLeft = FloatPoint { markerLogicalLeft, lineBoxLogicalRect.y() + firstContentfulLine->baseline() - markerAscent };
         marker->setExcludedPosition({ flow(), topLeft, lineStartInset });


### PR DESCRIPTION
#### 67bf126de00740d0aa051144d4c4a23ef7482bec
<pre>
[list-marker] text-indent moves the list marker with the text
<a href="https://bugs.webkit.org/show_bug.cgi?id=323448">https://bugs.webkit.org/show_bug.cgi?id=323448</a>
<a href="https://rdar.apple.com/problem/186678552">rdar://problem/186678552</a>

Reviewed by Antti Koivisto.

text-indent is a margin on the line box, so the line&apos;s inline start edge already includes it and the marker hung off
that edge moved in with the text. Take the indent off first.

Test: imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::InlineFormattingUtils::computedTextIndentForFirstLine):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::setExcludedMarkerPositions):

Canonical link: <a href="https://commits.webkit.org/320533@main">https://commits.webkit.org/320533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23c4819e6d07470cadcc9fd5946bec17d80d4c31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195335 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ef8e420-9c97-41a4-aaee-2b207d4b9460) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144569 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/45dea9bc-0d88-402c-87db-ffbd94a3482a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124856 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/302d3167-267d-4834-8495-59fe1e59911d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46974 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44733 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6387 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51582 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197283 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58587 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164669 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154055 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41268 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59297 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41337 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153713 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48223 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131587 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128223 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57789 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19752 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57149 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57398 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57225 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->