### PR TITLE
Cherry-pick 320513@main (2a20415140e2). https://bugs.webkit.org/show_bug.cgi?id=322203

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2205,7 +2205,7 @@ private:
     WeakPtr<HTMLMetaElement, WeakPtrImplWithEventTargetData> determineActiveThemeColorMetaElement();
     void themeColorChanged();
 
-    void NODELETE invalidateAccessKeyCacheSlowCase();
+    void invalidateAccessKeyCacheSlowCase();
     void buildAccessKeyCache();
 
     void intersectionObserversInitialUpdateTimerFired();

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2429,7 +2429,7 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
         }
         break;
     case AttributeNames::accesskeyAttr:
-        document().invalidateAccessKeyCache();
+        protect(document())->invalidateAccessKeyCache();
         break;
     case AttributeNames::dirAttr:
         dirAttributeChanged(newValue);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4411,7 +4411,10 @@ Vector<String> Internals::getReferencedFilePaths() const
     if (!localFrame)
         return { };
     localFrame->loader().history().saveDocumentAndScrollState();
-    return FormController::referencedFilePaths(localFrame->loader().history().currentItem()->documentState());
+    RefPtr currentItem = localFrame->loader().history().currentItem();
+    if (!currentItem)
+        return { };
+    return FormController::referencedFilePaths(currentItem->documentState());
 }
 
 ExceptionOr<void> Internals::startTrackingRepaints()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2876,12 +2876,27 @@ String WebPage::dumpHistoryForTesting(const String& directory)
 
     CheckedRef list = m_page->backForward();
 
-    StringBuilder builder;
-    int begin = -list->backCount();
-    if (list->itemAtIndex(begin)->url() == aboutBlankURL())
+    // A page with no current item has nothing to dump. That is the state a window.open() page is
+    // in before its initial load commits, and WebKitTestRunner dumps every page it knows about.
+    if (!list->currentItem())
+        return { };
+
+    // itemAtIndex() takes an offset relative to the current item, so the range of valid offsets is
+    // [-backCount(), forwardCount()] inclusive. It is a synchronous round trip to the UI process,
+    // while backCount() and forwardCount() are served from a cache in this process, so the bounds
+    // and the items are sampled at different times and an item can be absent at an offset the
+    // bounds include. Skip those rather than crashing.
+    int begin = -static_cast<int>(list->backCount());
+    int end = static_cast<int>(list->forwardCount());
+
+    if (RefPtr item = list->itemAtIndex(begin); item && item->url() == aboutBlankURL())
         ++begin;
-    for (int i = begin; i <= static_cast<int>(list->forwardCount()); ++i)
-        dumpHistoryItem(*list->itemAtIndex(i), 8, !i, builder, directory);
+
+    StringBuilder builder;
+    for (int i = begin; i <= end; ++i) {
+        if (RefPtr item = list->itemAtIndex(i))
+            dumpHistoryItem(*item, 8, !i, builder, directory);
+    }
     return builder.toString();
 }
 


### PR DESCRIPTION
#### 1f24b788db7fff4cc95e03d5a84ad561505fae5a
<pre>
Cherry-pick 320513@main (2a20415140e2). <a href="https://bugs.webkit.org/show_bug.cgi?id=322203">https://bugs.webkit.org/show_bug.cgi?id=322203</a>

    Null-check history items in history dumping testing code
    <a href="https://bugs.webkit.org/show_bug.cgi?id=322203">https://bugs.webkit.org/show_bug.cgi?id=322203</a>
    <a href="https://rdar.apple.com/185442169">rdar://185442169</a>

    Reviewed by David Kilzer.

    WebPage::dumpHistoryForTesting() and Internals::getReferencedFilePaths()
    dereferenced a nullable history item without checking it.

    In dumpHistoryForTesting(), itemAtIndex() takes an offset relative to the
    current item, so the range of valid offsets is [-backCount(), forwardCount()]
    inclusive. backCount() and forwardCount() are served from a cached value in
    WebBackForwardListProxy, while itemAtIndex() is a separate synchronous message
    to the UI process, so the bounds and the items are sampled at different times
    and itemAtIndex() can return null at an offset the bounds include. Skip those
    entries. A page with no current item at all has nothing to dump, so return
    early: WebKitTestRunner dumps every page it knows about, and a page created by
    window.open() has no current item until its initial load commits.

    In getReferencedFilePaths(), only the frame was checked.
    HistoryController::currentItem() is null until a load commits, and
    saveDocumentAndScrollState() does not create an item.

    Both are only reachable from test infrastructure, so this replaces a WebContent
    process crash with a skipped entry.

    * Source/WebCore/testing/Internals.cpp:
    (WebCore::Internals::getReferencedFilePaths const):
    * Source/WebKit/WebProcess/WebPage/WebPage.cpp:
    (WebKit::WebPage::dumpHistoryForTesting):

    Canonical link: <a href="https://commits.webkit.org/320513@main">https://commits.webkit.org/320513@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.196@webkitglib/2.54">https://commits.webkit.org/317695.196@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 36ddec04375f64888872779e90a57d418d146cf3
<pre>
Cherry-pick 320499@main (c9d3d549bac5). <a href="https://bugs.webkit.org/show_bug.cgi?id=323388">https://bugs.webkit.org/show_bug.cgi?id=323388</a>

    Remove incorrect `NODELETE` annotation from `Document::invalidateAccessKeyCacheSlowCase()`
    <a href="https://bugs.webkit.org/show_bug.cgi?id=323388">https://bugs.webkit.org/show_bug.cgi?id=323388</a>
    <a href="https://rdar.apple.com/186618132">rdar://186618132</a>

    Reviewed by Chris Dumez.

    Drop `NODELETE` from function that destroys objects since it is a lie.

    * Source/WebCore/dom/Document.h:
    * Source/WebCore/dom/Element.cpp:
    (WebCore::Element::attributeChanged):

    Canonical link: <a href="https://commits.webkit.org/320499@main">https://commits.webkit.org/320499@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.195@webkitglib/2.54">https://commits.webkit.org/317695.195@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/649bd8d09d31d65a407adfbf8e6af31d02f9ee80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185002 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/58921 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52750 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195336 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149941 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186864 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60279 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58648 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144578 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149941 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187957 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60279 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/52750 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124865 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60279 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58648 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/52750 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60279 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52750 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6388 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/51583 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/58648 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197284 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/58588 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/52750 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154061 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59298 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52750 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153719 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28109 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59298 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/131588 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/128224 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/57790 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/52750 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57150 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57399 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57226 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->