### PR TITLE
[GTK][WPE] `steps()` and `linear()` animations can be accelerated

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2634,6 +2634,14 @@ webkit.org/b/295127  transitions/svg-text-shadow-transition.html [ Pass Failure 
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # WebAnimations-related bugs
+
+# Apple ports dont's support `steps()` and `linear()` accelerated animations
+webkit.org/b/323852 webanimations/combining-transform-animations-with-different-acceleration-capabilities-2.html [ Skip ]
+webkit.org/b/323852 webanimations/combining-transform-animations-with-different-acceleration-capabilities-3.html [ Skip ]
+webkit.org/b/323852 webanimations/combining-transform-animations-with-different-acceleration-capabilities-6.html [ Skip ]
+webkit.org/b/323852 webanimations/combining-transform-animations-with-different-acceleration-capabilities-7.html [ Skip ]
+webkit.org/b/323852 webanimations/transform-animation-with-steps-timing-function-not-accelerated.html [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 
 webkit.org/b/263870 imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored.html [ Skip ]

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2005,11 +2005,13 @@ bool KeyframeEffect::canBeAccelerated(AccountForTimelineAccelerationAbility acco
     if (m_isAssociatedWithProgressBasedTimeline)
         return false;
 
+#if USE(CA)
     if (m_someKeyframesUseStepsTimingFunction || is<StepsTimingFunction>(timingFunction()))
         return false;
 
     if (m_someKeyframesUseLinearTimingFunctionWithPoints || isLinearTimingFunctionWithPoints(timingFunction()))
         return false;
+#endif
 
     if (m_compositeOperation != CompositeOperation::Replace)
         return false;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.cpp
@@ -144,19 +144,11 @@ static TransformationMatrix applyTransformAnimation(const TransformOperations& f
     return matrix;
 }
 
-static const TimingFunction& timingFunctionForAnimationValue(const GraphicsLayerAnimationValue& animationValue, const TextureMapperAnimation& animation)
-{
-    if (auto* function = animationValue.timingFunction())
-        return *function;
-    if (auto* function = animation.timingFunction())
-        return *function;
-    return CubicBezierTimingFunction::defaultTimingFunction();
-}
-
 TextureMapperAnimation::TextureMapperAnimation(const String& name, const GraphicsLayerKeyframeValueList& keyframes, const GraphicsLayerAnimation& animation, MonotonicTime startTime, Seconds pauseTime, State state)
     : m_name(name.isSafeToSendToAnotherThread() ? name : name.isolatedCopy())
     , m_keyframes(keyframes)
-    , m_timingFunction(animation.defaultTimingFunctionForKeyframes() ? animation.defaultTimingFunctionForKeyframes()->clone() : animation.timingFunction()->clone())
+    , m_timingFunction(animation.timingFunction()->clone())
+    , m_defaultTimingFunctionForKeyframes(animation.defaultTimingFunctionForKeyframes() ? animation.defaultTimingFunctionForKeyframes()->clone() : RefPtr<TimingFunction> { })
     , m_iterationCount(animation.iterationCount())
     , m_duration(animation.duration().value_or(0))
     , m_direction(animation.direction())
@@ -173,6 +165,7 @@ TextureMapperAnimation::TextureMapperAnimation(const TextureMapperAnimation& oth
     : m_name(other.m_name.isSafeToSendToAnotherThread() ? other.m_name : other.m_name.isolatedCopy())
     , m_keyframes(other.m_keyframes)
     , m_timingFunction(other.m_timingFunction->clone())
+    , m_defaultTimingFunctionForKeyframes(other.m_defaultTimingFunctionForKeyframes ? other.m_defaultTimingFunctionForKeyframes->clone() : RefPtr<TimingFunction> { })
     , m_iterationCount(other.m_iterationCount)
     , m_duration(other.m_duration)
     , m_direction(other.m_direction)
@@ -190,6 +183,7 @@ TextureMapperAnimation& TextureMapperAnimation::operator=(const TextureMapperAni
     m_name = other.m_name.isSafeToSendToAnotherThread() ? other.m_name : other.m_name.isolatedCopy();
     m_keyframes = other.m_keyframes;
     m_timingFunction = other.m_timingFunction->clone();
+    m_defaultTimingFunctionForKeyframes = other.m_defaultTimingFunctionForKeyframes ? other.m_defaultTimingFunctionForKeyframes->clone() : RefPtr<TimingFunction> { };
     m_iterationCount = other.m_iterationCount;
     m_duration = other.m_duration;
     m_direction = other.m_direction;
@@ -238,12 +232,18 @@ void TextureMapperAnimation::apply(ApplicationResult& applicationResults, Monoto
         applyInternal(applicationResults, m_keyframes.at(m_keyframes.size() - 2), m_keyframes.at(m_keyframes.size() - 1), 1);
         return;
     }
+
     if (m_keyframes.size() == 2) {
-        auto& timingFunction = timingFunctionForAnimationValue(m_keyframes.at(0), *this);
-        normalizedValue = timingFunction.transformProgress(normalizedValue, m_duration);
+        if (!m_defaultTimingFunctionForKeyframes)
+            normalizedValue = timingFunction()->transformProgress(normalizedValue, m_duration);
+
+        normalizedValue = timingFunctionForKeyframe(m_keyframes.at(0)).transformProgress(normalizedValue, m_duration);
         applyInternal(applicationResults, m_keyframes.at(0), m_keyframes.at(1), normalizedValue);
         return;
     }
+
+    if (!m_defaultTimingFunctionForKeyframes)
+        normalizedValue = timingFunction()->transformProgress(normalizedValue, m_duration);
 
     for (size_t i = 0; i < m_keyframes.size() - 1; ++i) {
         const auto& from = m_keyframes.at(i);
@@ -252,8 +252,7 @@ void TextureMapperAnimation::apply(ApplicationResult& applicationResults, Monoto
             continue;
 
         normalizedValue = (normalizedValue - from.keyTime()) / (to.keyTime() - from.keyTime());
-        auto& timingFunction = timingFunctionForAnimationValue(from, *this);
-        normalizedValue = timingFunction.transformProgress(normalizedValue, m_duration);
+        normalizedValue = timingFunctionForKeyframe(from).transformProgress(normalizedValue, m_duration);
         applyInternal(applicationResults, from, to, normalizedValue);
         break;
     }
@@ -284,6 +283,17 @@ Seconds TextureMapperAnimation::computeTotalRunningTime(MonotonicTime time)
     m_lastRefreshedTime = time;
     m_totalRunningTime += m_lastRefreshedTime - oldLastRefreshedTime;
     return m_totalRunningTime;
+}
+
+const TimingFunction& TextureMapperAnimation::timingFunctionForKeyframe(const GraphicsLayerAnimationValue& from) const
+{
+    if (auto* keyframeTimingFunction = from.timingFunction())
+        return *keyframeTimingFunction;
+
+    if (m_defaultTimingFunctionForKeyframes)
+        return *m_defaultTimingFunctionForKeyframes;
+
+    return LinearTimingFunction::identity();
 }
 
 void TextureMapperAnimation::applyInternal(ApplicationResult& applicationResults, const GraphicsLayerAnimationValue& from, const GraphicsLayerAnimationValue& to, float progress)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.h
@@ -62,10 +62,12 @@ public:
 private:
     void applyInternal(ApplicationResult&, const GraphicsLayerAnimationValue& from, const GraphicsLayerAnimationValue& to, float progress);
     Seconds computeTotalRunningTime(MonotonicTime);
+    const TimingFunction& timingFunctionForKeyframe(const GraphicsLayerAnimationValue& from) const;
 
     String m_name;
     GraphicsLayerKeyframeValueList m_keyframes { AnimatedProperty::Invalid };
     RefPtr<TimingFunction> m_timingFunction;
+    RefPtr<TimingFunction> m_defaultTimingFunctionForKeyframes;
     double m_iterationCount { 0 };
     double m_duration { 0 };
     GraphicsLayerAnimation::Direction m_direction { GraphicsLayerAnimation::Direction::Normal };


### PR DESCRIPTION
#### 7b265b345c261337cd1148ee074baf3167a9e714
<pre>
[GTK][WPE] `steps()` and `linear()` animations can be accelerated
<a href="https://bugs.webkit.org/show_bug.cgi?id=323852">https://bugs.webkit.org/show_bug.cgi?id=323852</a>

Reviewed by Carlos Garcia Campos.

`steps()` and `linear()` easing functions are currently excluded from
acceleration on all ports. This restriction only needs to apply to Apple
ports, because accelerated animations running on the compositor are
implemented using `CAMediaTimingFunction`, which cannot fully represent
them. GTK and WPE use `TextureMapperAnimation`, which doesn&apos;t have this
limitation, so these animations can be accelerated there.

`TextureMapperAnimation` kept a single `m_timingFunction` field for two
different things — the overall timing function of a Web Animation, and
the CSS Animation&apos;s `animation-timing-function`, which only acts as a
fallback for keyframes that don&apos;t specify their own easing.

Because of this, that fallback easing could be applied to the whole
animation progress instead of just to the individual keyframe interval,
which produces the wrong `steps()`/`linear()` results.

`TextureMapperAnimation` now keeps the fallback as a separate
`m_defaultTimingFunctionForKeyframes` field, and a new
`timingFunctionForKeyframe()` helper applies it only where it&apos;s supposed
to.

Test: webanimations/transform-animation-with-steps-timing-function.html

Removed
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::canBeAccelerated const):
(WebCore::KeyframeEffect::updateAcceleratedActions):
* Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.cpp:
(WebCore::timingFunctionIsIdentity):
(WebCore::TextureMapperAnimation::TextureMapperAnimation):
(WebCore::TextureMapperAnimation::operator=):
(WebCore::TextureMapperAnimation::apply):
(WebCore::TextureMapperAnimation::applyTimingFunctionForKeyframe const):
(WebCore::timingFunctionForAnimationValue): Deleted.
(WebCore::TextureMapperAnimation::timingFunctionForKeyframe const):
* Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.h:
* LayoutTests/platform/glib/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/320878@main">https://commits.webkit.org/320878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e24f89b69c6dd9577c1a4e85b1f2f06a526a45f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196290 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150618 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59614 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145353 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100753 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165883 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125653 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47750 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45757 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158105 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45473 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7361 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198267 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59550 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154894 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41529 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60259 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154539 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48990 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132589 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129638 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58707 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20474 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58097 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58327 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58155 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->