### PR TITLE
[Swift in WebKit] Annotate a few more WTF container types as Escapable & Copyable

### DIFF
--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -31,6 +31,7 @@
 #include <wtf/OptionSetHash.h>
 #include <wtf/Packed.h>
 #include <wtf/RangeAdaptors.h>
+#include <wtf/SwiftBridging.h>
 
 namespace WTF {
 
@@ -262,7 +263,7 @@ private:
     }
 
     HashTableType m_impl;
-};
+} SWIFT_ESCAPABLE_IF(KeyArg, MappedArg) SWIFT_COPYABLE_IF(KeyArg, MappedArg);
 
 template<typename ValueTraits, typename HashFunctions>
 struct HashMapTranslator {

--- a/Source/WTF/wtf/Variant.h
+++ b/Source/WTF/wtf/Variant.h
@@ -406,6 +406,7 @@ namespace mpark {
 #include <type_traits>
 #include <utility>
 #include <wtf/Assertions.h>
+#include <wtf/SwiftBridging.h>
 
 #define MPARK_RETURN(...) \
   noexcept(noexcept(__VA_ARGS__)) -> decltype(__VA_ARGS__) { return __VA_ARGS__; }
@@ -2025,7 +2026,7 @@ IGNORE_GCC_WARNINGS_END
 
     friend struct detail::access::variant;
     friend struct detail::visitation::variant;
-  };
+  } SWIFT_ESCAPABLE_IF(Ts) SWIFT_COPYABLE_IF(Ts);
 
   template <std::size_t I, typename... Ts>
   [[nodiscard]] inline constexpr bool holds_alternative(const variant<Ts...> &v) noexcept {

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -1018,7 +1018,7 @@ private:
 #if ASAN_ENABLED
     using Base::endOfBuffer;
 #endif
-} SWIFT_ESCAPABLE_IF(T);
+} SWIFT_ESCAPABLE_IF(T) SWIFT_COPYABLE_IF(T);
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
 Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::Vector(const Vector& other)

--- a/Source/WTF/wtf/module.modulemap
+++ b/Source/WTF/wtf/module.modulemap
@@ -1,4 +1,4 @@
-// FIXME (rdar://173516139): When you add a header to WTF, touch this line to invalidate the module cache. Touch count: 18.
+// FIXME (rdar://173516139): When you add a header to WTF, touch this line to invalidate the module cache. Touch count: 1.
 
 module wtf [system] {
     explicit module Assertions {


### PR DESCRIPTION
#### 7e1a50ea089419edd8fd798542ea34445c30bbce
<pre>
[Swift in WebKit] Annotate a few more WTF container types as Escapable &amp; Copyable
<a href="https://bugs.webkit.org/show_bug.cgi?id=323454">https://bugs.webkit.org/show_bug.cgi?id=323454</a>
<a href="https://rdar.apple.com/186682706">rdar://186682706</a>

Reviewed by Abrar Rahman Protyasha.

Add Copyable to Vector, and add Escapable &amp; Copyable to HashMap and Variant.

* Source/WTF/wtf/HashMap.h:
* Source/WTF/wtf/Variant.h:
* Source/WTF/wtf/Vector.h:
* Source/WTF/wtf/module.modulemap:

Canonical link: <a href="https://commits.webkit.org/320526@main">https://commits.webkit.org/320526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ac5ef106510264a06ef38912433d1a55225ff2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185012 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195347 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58658 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144593 "Build is in progress. Recent messages:") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48258 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/124880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46985 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/6810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/13678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44746 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6399 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46280 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51593 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49427 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197294 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58598 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154069 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41260 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59308 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153726 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48235 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/131598 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128237 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57800 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19765 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57160 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57409 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57236 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->