### PR TITLE
[list-marker] A float in the list item's content pushes the list marker out with the line

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>A float in the list item's content does not move the outside marker</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 60px }
+  .box { display: inline-block; width: 60px; height: 20px; background: green; vertical-align: top }
+</style>
+</head>
+<body>
+  <ul><li><div><span class="box"></span>xx</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>A float in the list item's content does not move the outside marker</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 60px }
+  .box { display: inline-block; width: 60px; height: 20px; background: green; vertical-align: top }
+</style>
+</head>
+<body>
+  <ul><li><div><span class="box"></span>xx</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>A float in the list item's content does not move the outside marker</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-position-property">
+<link rel="match" href="outside-marker-with-float-in-content-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 60px }
+  .float { float: left; width: 60px; height: 20px; background: green }
+</style>
+</head>
+<body>
+  <ul><li><div><div class="float"></div>xx</div></li></ul>
+</body>
+</html>

--- a/Source/WebCore/layout/floats/PlacedFloats.cpp
+++ b/Source/WebCore/layout/floats/PlacedFloats.cpp
@@ -114,12 +114,16 @@ void PlacedFloats::add(Item newFloatItem)
 bool PlacedFloats::Item::isInFormattingContextOf(const ElementBox& formattingContextRoot) const
 {
     ASSERT(formattingContextRoot.establishesFormattingContext());
+    // FIXME: No layout box means the render tree integration codepath put it here, which it only does for intruding floats from outside the inline formatting context.
+    // This works as long as the incoming formattingContextRoot is the current IFC.
+    if (!m_layoutBox)
+        return false;
+
     ASSERT(!is<InitialContainingBlock>(m_layoutBox));
     for (CheckedRef containingBlock : containingBlockChain(*m_layoutBox)) {
         if (containingBlock.ptr() == &formattingContextRoot)
             return true;
     }
-    ASSERT_NOT_REACHED();
     return false;
 }
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -546,13 +546,28 @@ void LineLayout::setExcludedMarkerPositions(const ExcludedMarkerList& excludedMa
 
     auto lineBoxLogicalRect = firstContentfulLine->lineBoxLogicalRect();
     auto isLeftToRight = flow().writingMode().isLogicalLeftInlineStart();
-    // How far the line start sits inwards from our content box start, which is what caps how far to the logical left
-    // (right in a right to left inline direction) a nesting list item's marker may go. An intruding float is the usual
-    // reason for it to be non zero.
-    auto lineStartInset = isLeftToRight ? lineBoxLogicalRect.x() : flow().contentBoxLogicalWidth() - lineBoxLogicalRect.maxX();
     // text-indent is a margin on the line box, not content the marker hangs off.
     ASSERT(m_inlineContentConstraints);
     auto textIndent = Layout::InlineFormattingUtils::computedTextIndentForFirstLine(rootLayoutBox(), m_inlineContentConstraints->horizontal().logicalWidth);
+    auto lineStartEdge = [&] {
+        auto edge = isLeftToRight ? lineBoxLogicalRect.x() : lineBoxLogicalRect.maxX();
+        edge += isLeftToRight ? -textIndent : textIndent;
+        // A float of this formatting context took room from the line, but the marker hangs off where the line would
+        // have started without it. One intruding from earlier content moves the marker with the line instead
+        // (webkit.org/b/166528).
+        for (auto& floatItem : m_blockFormattingState.placedFloats().list()) {
+            if (!floatItem.isInFormattingContextOf(rootLayoutBox()))
+                continue;
+            auto floatRect = floatItem.absoluteRectWithMargin();
+            if (floatRect.bottom() <= lineBoxLogicalRect.y() || floatRect.top() >= lineBoxLogicalRect.maxY())
+                continue;
+            edge += isLeftToRight ? -floatRect.width() : floatRect.width();
+        }
+        return edge;
+    }();
+
+    auto contentBoxStartEdge = isLeftToRight ? 0.f : flow().contentBoxLogicalWidth().toFloat();
+    auto isLineStartConstrainedByFloat = lineStartEdge != contentBoxStartEdge;
     for (auto& marker : excludedMarkers) {
         // Vertical: baseline aligned, with the ascent the inline formatting context would have given it.
         auto markerAscent = [&]() -> float {
@@ -565,11 +580,11 @@ void LineLayout::setExcludedMarkerPositions(const ExcludedMarkerList& excludedMa
         // inline direction (the marker's start margin is what holds the gap, hence negative).
         auto markerLogicalLeft = [&]() -> float {
             if (isLeftToRight)
-                return lineBoxLogicalRect.x() - textIndent + marker->marginStart();
-            return lineBoxLogicalRect.maxX() + textIndent - marker->marginStart() - marker->logicalWidth();
+                return lineStartEdge + marker->marginStart();
+            return lineStartEdge - marker->marginStart() - marker->logicalWidth();
         }();
         auto topLeft = FloatPoint { markerLogicalLeft, lineBoxLogicalRect.y() + firstContentfulLine->baseline() - markerAscent };
-        marker->setExcludedPosition({ flow(), topLeft, lineStartInset });
+        marker->setExcludedPosition({ flow(), topLeft, isLineStartConstrainedByFloat });
     }
 }
 

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -96,7 +96,7 @@ static MarkerSearchBoxType markerSearchBoxType(const RenderObject& box)
     return MarkerSearchBoxType::BlockContainer;
 }
 
-static LayoutUnit excludedMarkerLogicalLeftOffsetFor(const RenderBlockFlow& firstFormattedLineRoot, const RenderListItem& listItem, LayoutUnit lineStartInset)
+static LayoutUnit excludedMarkerLogicalLeftOffsetFor(const RenderBlockFlow& firstFormattedLineRoot, const RenderListItem& listItem, bool isLineStartConstrainedByFloat)
 {
     // <ul><li id=o><ul><li id=i><div style="border-left: 5px solid">text</div></li></ul></li></ul>
     // UA sets 40px start padding on <ul>
@@ -134,10 +134,10 @@ static LayoutUnit excludedMarkerLogicalLeftOffsetFor(const RenderBlockFlow& firs
             if (box.get() == &listItem)
                 break;
         }
-        // A float pushing the line start inwards also constrains the marker, which sits to the logical left of it.
-        // Nesting list items then all end up with their marker in the same place, just left of the line.
-        if (lineStartInset)
-            toAssociatedListItem = std::min(0_lu, std::max(lineStartInset, toAssociatedListItem));
+        // A float pushing the line start inwards also constrains the marker, so it stays with the line rather than
+        // moving out to its own list item. Nesting list items then all end up with their marker in the same place.
+        if (isLineStartConstrainedByFloat)
+            toAssociatedListItem = { };
     }
 
     // The offsets above are inline start relative (negative means further towards the inline start), while what we return is a logical left offset, so in a right to left inline direction it points the other way.
@@ -590,7 +590,7 @@ void RenderListItem::placeExcludedMarker(RenderListOutsideMarker& marker)
     // Line layout placed the marker on the line as if it belonged to the list item establishing that formatting context.
     // Take it from there: out to our own border box start, then across the in-flow content up to us.
     auto logicalTop = LayoutUnit { excludedPosition->topLeft.y() };
-    auto logicalLeft = LayoutUnit { excludedPosition->topLeft.x() } + excludedMarkerLogicalLeftOffsetFor(*firstFormattedLineRoot, *this, LayoutUnit { excludedPosition->lineStartInset });
+    auto logicalLeft = LayoutUnit { excludedPosition->topLeft.x() } + excludedMarkerLogicalLeftOffsetFor(*firstFormattedLineRoot, *this, excludedPosition->isLineStartConstrainedByFloat);
     for (CheckedPtr<RenderBlock> ancestor = firstFormattedLineRoot; ancestor && ancestor != this; ancestor = ancestor->containingBlock()) {
         // Inside a fragmented flow the coordinates are in flow thread space, where the content is one continuous
         // strip. The column the line ended up in is a sibling of the flow thread rather than an ancestor, so leave

--- a/Source/WebCore/rendering/RenderListOutsideMarker.h
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.h
@@ -85,7 +85,7 @@ public:
     struct ExcludedPosition {
         SingleThreadWeakPtr<RenderBlockFlow> firstFormattedLineRoot;
         FloatPoint topLeft;
-        float lineStartInset { 0 };
+        bool isLineStartConstrainedByFloat { false };
     };
     void setExcludedPosition(ExcludedPosition);
     std::optional<ExcludedPosition> excludedPosition() const { return m_excludedPosition; }


### PR DESCRIPTION
#### c714b8656601d77dd8855d9aa3a3a54e49b442e4
<pre>
[list-marker] A float in the list item&apos;s content pushes the list marker out with the line
<a href="https://bugs.webkit.org/show_bug.cgi?id=323453">https://bugs.webkit.org/show_bug.cgi?id=323453</a>
<a href="https://rdar.apple.com/problem/186680551">rdar://problem/186680551</a>

Reviewed by Antti Koivisto.

The marker hangs off the line&apos;s inline start edge, which a float of that formatting context has already pushed
inwards. Give that room back. A float intruding from earlier content keeps the marker with the line (webkit.org/b/166528).

Test: imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content.html: Added.
* Source/WebCore/layout/floats/PlacedFloats.cpp:
(WebCore::Layout::PlacedFloats::Item::isInFormattingContextOf const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::setExcludedMarkerPositions):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::excludedMarkerLogicalLeftOffsetFor):
(WebCore::RenderListItem::placeExcludedMarker):
* Source/WebCore/rendering/RenderListOutsideMarker.h:

Canonical link: <a href="https://commits.webkit.org/320549@main">https://commits.webkit.org/320549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bbaf478b0fcf28298eab66f7a5249a5f2ce54c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59002 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195417 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c58bbf59-abbf-46b8-852a-8f933958d3bd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186950 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58729 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dba6d232-e290-477a-88fc-5b28c61e5a9a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48308 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/52821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124922 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/91c4e0cb-4e05-4353-a235-e3d9128f4af3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47036 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/52821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6473 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/51661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197369 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58666 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/52821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41280 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59375 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/153783 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/48282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131670 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128307 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/57858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/52821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57225 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->