### PR TITLE
Make SystemHeap-enabled failure actions equivalent to SystemHeap-disabled failure actions.

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_flex_internal.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_flex_internal.h
@@ -129,7 +129,8 @@ static PAS_ALWAYS_INLINE void* bmalloc_try_reallocate_flex_inline(
         bmalloc_try_allocate_flex_impl_for_realloc,
         &bmalloc_flex_runtime_config.base,
         pas_reallocate_disallow_heap_teleport,
-        pas_reallocate_free_if_successful).begin;
+        pas_reallocate_free_if_successful,
+        pas_allocation_result_identity).begin;
 }
 
 static PAS_ALWAYS_INLINE void* bmalloc_reallocate_flex_inline(
@@ -144,7 +145,8 @@ static PAS_ALWAYS_INLINE void* bmalloc_reallocate_flex_inline(
         bmalloc_allocate_flex_impl_for_realloc,
         &bmalloc_flex_runtime_config.base,
         pas_reallocate_disallow_heap_teleport,
-        pas_reallocate_free_if_successful).begin;
+        pas_reallocate_free_if_successful,
+        pas_allocation_result_crash_on_error).begin;
 }
 
 PAS_END_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
@@ -187,7 +187,8 @@ static PAS_ALWAYS_INLINE void* bmalloc_try_reallocate_auxiliary_inline(
         bmalloc_try_allocate_auxiliary_impl_for_realloc,
         &bmalloc_primitive_runtime_config.base,
         pas_reallocate_allow_heap_teleport,
-        free_mode).begin;
+        free_mode,
+        pas_allocation_result_identity).begin;
 }
 
 static PAS_ALWAYS_INLINE void* bmalloc_reallocate_auxiliary_inline(void* old_ptr,
@@ -205,7 +206,8 @@ static PAS_ALWAYS_INLINE void* bmalloc_reallocate_auxiliary_inline(void* old_ptr
         bmalloc_allocate_auxiliary_impl_for_realloc,
         &bmalloc_primitive_runtime_config.base,
         pas_reallocate_allow_heap_teleport,
-        free_mode).begin;
+        free_mode,
+        pas_allocation_result_crash_on_error).begin;
 }
 
 PAS_CREATE_TRY_ALLOCATE_INTRINSIC(
@@ -351,7 +353,8 @@ bmalloc_try_reallocate_inline(void* old_ptr, size_t new_size,
         BMALLOC_HEAP_CONFIG,
         bmalloc_try_allocate_impl_for_realloc,
         pas_reallocate_allow_heap_teleport,
-        free_mode).begin;
+        free_mode,
+        pas_allocation_result_identity).begin;
 }
 
 static PAS_ALWAYS_INLINE void*
@@ -369,7 +372,8 @@ bmalloc_reallocate_inline(void* old_ptr, size_t new_size,
         BMALLOC_HEAP_CONFIG,
         bmalloc_allocate_impl_for_realloc,
         pas_reallocate_allow_heap_teleport,
-        free_mode).begin;
+        free_mode,
+        pas_allocation_result_crash_on_error).begin;
 }
 
 PAS_API PAS_PRESERVE_MOST void bmalloc_deallocate_casual(void* ptr);

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_iso_internal.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_iso_internal.h
@@ -190,7 +190,8 @@ static PAS_ALWAYS_INLINE void* bmalloc_try_iso_reallocate_array_by_size_inline(
         bmalloc_try_iso_allocate_array_impl_for_realloc,
         &bmalloc_typed_runtime_config.base,
         pas_reallocate_disallow_heap_teleport,
-        pas_reallocate_free_if_successful).begin;
+        pas_reallocate_free_if_successful,
+        pas_allocation_result_identity).begin;
 }
 
 static PAS_ALWAYS_INLINE void* bmalloc_iso_reallocate_array_by_size_inline(
@@ -205,7 +206,8 @@ static PAS_ALWAYS_INLINE void* bmalloc_iso_reallocate_array_by_size_inline(
         bmalloc_iso_allocate_array_impl_for_realloc,
         &bmalloc_typed_runtime_config.base,
         pas_reallocate_disallow_heap_teleport,
-        pas_reallocate_free_if_successful).begin;
+        pas_reallocate_free_if_successful,
+        pas_allocation_result_crash_on_error).begin;
 }
 
 static PAS_ALWAYS_INLINE void* bmalloc_try_iso_reallocate_array_by_count_inline(
@@ -220,7 +222,8 @@ static PAS_ALWAYS_INLINE void* bmalloc_try_iso_reallocate_array_by_count_inline(
         bmalloc_try_iso_allocate_array_impl_for_realloc,
         &bmalloc_typed_runtime_config.base,
         pas_reallocate_disallow_heap_teleport,
-        pas_reallocate_free_if_successful).begin;
+        pas_reallocate_free_if_successful,
+        pas_allocation_result_identity).begin;
 }
 
 static PAS_ALWAYS_INLINE void* bmalloc_iso_reallocate_array_by_count_inline(
@@ -235,7 +238,8 @@ static PAS_ALWAYS_INLINE void* bmalloc_iso_reallocate_array_by_count_inline(
         bmalloc_iso_allocate_array_impl_for_realloc,
         &bmalloc_typed_runtime_config.base,
         pas_reallocate_disallow_heap_teleport,
-        pas_reallocate_free_if_successful).begin;
+        pas_reallocate_free_if_successful,
+        pas_allocation_result_crash_on_error).begin;
 }
 
 PAS_END_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/hotbit_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/hotbit_heap_inlines.h
@@ -83,7 +83,8 @@ hotbit_try_reallocate_inline(void* old_ptr, size_t new_size,
         HOTBIT_HEAP_CONFIG,
         hotbit_try_allocate_impl_for_realloc,
         pas_reallocate_allow_heap_teleport,
-        free_mode).begin;
+        free_mode,
+        pas_allocation_result_identity).begin;
 }
 
 static PAS_ALWAYS_INLINE void hotbit_deallocate_inline(void* ptr)

--- a/Source/bmalloc/libpas/src/libpas/iso_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/iso_heap_inlines.h
@@ -134,7 +134,8 @@ iso_try_reallocate_common_primitive_inline(void* old_ptr, size_t new_size,
         ISO_HEAP_CONFIG,
         iso_try_allocate_common_primitive_impl_for_realloc,
         pas_reallocate_allow_heap_teleport,
-        free_mode).begin;
+        free_mode,
+        pas_allocation_result_set_errno).begin;
 }
 
 static PAS_ALWAYS_INLINE void*
@@ -149,7 +150,8 @@ iso_reallocate_common_primitive_inline(void* old_ptr, size_t new_size,
         ISO_HEAP_CONFIG,
         iso_allocate_common_primitive_impl_for_realloc,
         pas_reallocate_allow_heap_teleport,
-        free_mode).begin;
+        free_mode,
+        pas_allocation_result_crash_on_error).begin;
 }
 
 PAS_CREATE_TRY_ALLOCATE(
@@ -243,7 +245,8 @@ static PAS_ALWAYS_INLINE void* iso_try_reallocate_array_by_count_inline(void* ol
         iso_try_allocate_array_impl_for_realloc,
         &iso_typed_runtime_config.base,
         pas_reallocate_allow_heap_teleport,
-        free_mode).begin;
+        free_mode,
+        pas_allocation_result_set_errno).begin;
 }
 
 static PAS_ALWAYS_INLINE void* iso_reallocate_array_by_count_inline(void* old_ptr, pas_heap_ref* heap_ref,
@@ -260,7 +263,8 @@ static PAS_ALWAYS_INLINE void* iso_reallocate_array_by_count_inline(void* old_pt
         iso_allocate_array_impl_for_realloc,
         &iso_typed_runtime_config.base,
         pas_reallocate_allow_heap_teleport,
-        free_mode).begin;
+        free_mode,
+        pas_allocation_result_crash_on_error).begin;
 }
 
 PAS_CREATE_TRY_ALLOCATE_PRIMITIVE(
@@ -338,7 +342,8 @@ static PAS_ALWAYS_INLINE void* iso_try_reallocate_primitive_inline(void* old_ptr
         iso_try_allocate_primitive_impl_for_realloc,
         &iso_primitive_runtime_config.base,
         pas_reallocate_allow_heap_teleport,
-        free_mode).begin;
+        free_mode,
+        pas_allocation_result_set_errno).begin;
 }
 
 static PAS_ALWAYS_INLINE void* iso_reallocate_primitive_inline(void* old_ptr,
@@ -356,7 +361,8 @@ static PAS_ALWAYS_INLINE void* iso_reallocate_primitive_inline(void* old_ptr,
         iso_allocate_primitive_impl_for_realloc,
         &iso_primitive_runtime_config.base,
         pas_reallocate_allow_heap_teleport,
-        free_mode).begin;
+        free_mode,
+        pas_allocation_result_crash_on_error).begin;
 }
 
 PAS_CREATE_TRY_ALLOCATE_PRIMITIVE(

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -1255,8 +1255,8 @@ pas_local_allocator_try_allocate(pas_local_allocator* allocator,
     }
 
     if (PAS_UNLIKELY(pas_system_heap_should_supplant_bmalloc(config.kind)))
-        return pas_system_heap_allocate(size, alignment, allocation_mode);
-    
+        return result_filter(pas_system_heap_allocate(size, alignment, allocation_mode));
+
     if (config.small_segregated_config.base.is_enabled &&
         allocator->config_kind == pas_local_allocator_config_kind_create_normal(
             config.small_segregated_config.kind)) {

--- a/Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h
@@ -96,7 +96,8 @@ pas_try_allocate_intrinsic_impl_casual_case(
     pas_heap_config config,
     pas_try_allocate_common_fast try_allocate_common_fast,
     pas_try_allocate_common_slow try_allocate_common_slow,
-    pas_intrinsic_heap_designation_mode designation_mode)
+    pas_intrinsic_heap_designation_mode designation_mode,
+    pas_allocation_result_filter result_filter)
 {
     static const bool verbose = PAS_SHOULD_LOG(PAS_LOG_OTHER);
     
@@ -115,7 +116,7 @@ pas_try_allocate_intrinsic_impl_casual_case(
         return pas_allocation_result_create_failure();
 
     if (PAS_UNLIKELY(pas_system_heap_should_supplant_bmalloc(config.kind)))
-        return pas_system_heap_allocate(size, alignment, allocation_mode);
+        return result_filter(pas_system_heap_allocate(size, alignment, allocation_mode));
 
     if (verbose)
         pas_log("not doing system heap in impl_casual_case for %s\n", pas_heap_config_kind_get_string(config.kind));
@@ -293,7 +294,7 @@ pas_try_allocate_intrinsic_impl_inline_only(
     { \
         return pas_try_allocate_intrinsic_impl_casual_case( \
             (heap), size, alignment, allocation_mode, (heap_support), (heap_config), \
-            name ## _impl_fast, name ## _impl_slow, (designation_mode)); \
+            name ## _impl_fast, name ## _impl_slow, (designation_mode), (result_filter)); \
     } \
     \
     static PAS_ALWAYS_INLINE pas_allocation_result name ## _inline_only(size_t size, size_t alignment, pas_allocation_mode allocation_mode) \

--- a/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h
@@ -215,7 +215,8 @@ pas_try_reallocate(void* old_ptr,
                    pas_reallocate_heap_teleport_rule teleport_rule,
                    pas_reallocate_free_mode free_mode,
                    pas_try_reallocate_allocate_callback allocate_callback,
-                   void* allocate_callback_arg)
+                   void* allocate_callback_arg,
+                   pas_allocation_result_filter result_filter)
 {
     uintptr_t begin;
     begin = (uintptr_t)old_ptr;
@@ -325,7 +326,7 @@ pas_try_reallocate(void* old_ptr,
                 result.did_succeed = true;
             }
 
-            return result;
+            return result_filter(result);
         }
 
         pas_heap_lock_lock();
@@ -399,12 +400,13 @@ pas_try_reallocate_intrinsic(
     pas_heap_config config,
     pas_try_allocate_intrinsic_for_realloc try_allocate_intrinsic,
     pas_reallocate_heap_teleport_rule teleport_rule,
-    pas_reallocate_free_mode free_mode)
+    pas_reallocate_free_mode free_mode,
+    pas_allocation_result_filter result_filter)
 {
     pas_try_reallocate_intrinsic_allocate_data data;
-    
+
     data.try_allocate_intrinsic = try_allocate_intrinsic;
-    
+
     return pas_try_reallocate(
         old_ptr,
         heap,
@@ -414,7 +416,8 @@ pas_try_reallocate_intrinsic(
         teleport_rule,
         free_mode,
         pas_try_reallocate_intrinsic_allocate_callback,
-        &data);
+        &data,
+        result_filter);
 }
 
 typedef struct {
@@ -450,13 +453,14 @@ pas_try_reallocate_single(
     pas_try_allocate try_allocate,
     pas_heap_runtime_config* runtime_config,
     pas_reallocate_heap_teleport_rule teleport_rule,
-    pas_reallocate_free_mode free_mode)
+    pas_reallocate_free_mode free_mode,
+    pas_allocation_result_filter result_filter)
 {
     pas_try_reallocate_single_allocate_data data;
-    
+
     data.heap_ref = heap_ref;
     data.try_allocate = try_allocate;
-    
+
     return pas_try_reallocate(
         old_ptr,
         pas_ensure_heap(heap_ref,
@@ -469,7 +473,8 @@ pas_try_reallocate_single(
         teleport_rule,
         free_mode,
         pas_try_reallocate_single_allocate_callback,
-        &data);
+        &data,
+        result_filter);
 }
 
 typedef struct {
@@ -504,13 +509,14 @@ pas_try_reallocate_array_by_size(
     pas_try_allocate_array_for_realloc try_allocate_array,
     pas_heap_runtime_config* runtime_config,
     pas_reallocate_heap_teleport_rule teleport_rule,
-    pas_reallocate_free_mode free_mode)
+    pas_reallocate_free_mode free_mode,
+    pas_allocation_result_filter result_filter)
 {
     pas_try_reallocate_array_allocate_data data;
-    
+
     data.try_allocate_array = try_allocate_array;
     data.heap_ref = heap_ref;
-    
+
     return pas_try_reallocate(
         old_ptr,
         pas_ensure_heap(heap_ref,
@@ -523,7 +529,8 @@ pas_try_reallocate_array_by_size(
         teleport_rule,
         free_mode,
         pas_try_reallocate_array_allocate_callback,
-        &data);
+        &data,
+        result_filter);
 }
 
 static PAS_ALWAYS_INLINE pas_allocation_result
@@ -536,20 +543,21 @@ pas_try_reallocate_array_by_count(
     pas_try_allocate_array_for_realloc try_allocate_array,
     pas_heap_runtime_config* runtime_config,
     pas_reallocate_heap_teleport_rule teleport_rule,
-    pas_reallocate_free_mode free_mode)
+    pas_reallocate_free_mode free_mode,
+    pas_allocation_result_filter result_filter)
 {
     const pas_heap_type* type;
     size_t type_size;
     size_t new_size;
-    
+
     type = heap_ref->type;
     type_size = config.get_type_size(type);
-    
+
     if (__builtin_mul_overflow(new_count, type_size, &new_size))
         return pas_allocation_result_create_failure();
 
     return pas_try_reallocate_array_by_size(
-        old_ptr, heap_ref, new_size, allocation_mode, config, try_allocate_array, runtime_config, teleport_rule, free_mode);
+        old_ptr, heap_ref, new_size, allocation_mode, config, try_allocate_array, runtime_config, teleport_rule, free_mode, result_filter);
 }
 
 typedef struct {
@@ -591,13 +599,14 @@ pas_try_reallocate_primitive(
     pas_try_allocate_primitive_for_realloc try_allocate_primitive,
     pas_heap_runtime_config* runtime_config,
     pas_reallocate_heap_teleport_rule teleport_rule,
-    pas_reallocate_free_mode free_mode)
+    pas_reallocate_free_mode free_mode,
+    pas_allocation_result_filter result_filter)
 {
     pas_try_reallocate_primitive_allocate_data data;
-    
+
     data.heap_ref = heap_ref;
     data.try_allocate_primitive = try_allocate_primitive;
-    
+
     return pas_try_reallocate(
         old_ptr,
         pas_ensure_heap(&heap_ref->base,
@@ -610,7 +619,8 @@ pas_try_reallocate_primitive(
         teleport_rule,
         free_mode,
         pas_try_reallocate_primitive_allocate_callback,
-        &data);
+        &data,
+        result_filter);
 }
 
 PAS_END_EXTERN_C;

--- a/Source/bmalloc/libpas/src/libpas/tagged_bmalloc_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/tagged_bmalloc_heap_inlines.h
@@ -169,7 +169,8 @@ tagged_bmalloc_try_reallocate_inline(void* old_ptr, size_t new_size,
         TAGGED_BMALLOC_HEAP_CONFIG,
         tagged_bmalloc_try_allocate_impl_for_realloc,
         pas_reallocate_allow_heap_teleport,
-        free_mode).begin;
+        free_mode,
+        pas_allocation_result_identity).begin;
 }
 
 static PAS_ALWAYS_INLINE void*
@@ -184,7 +185,8 @@ tagged_bmalloc_reallocate_inline(void* old_ptr, size_t new_size,
         TAGGED_BMALLOC_HEAP_CONFIG,
         tagged_bmalloc_allocate_impl_for_realloc,
         pas_reallocate_allow_heap_teleport,
-        free_mode).begin;
+        free_mode,
+        pas_allocation_result_crash_on_error).begin;
 }
 
 static PAS_ALWAYS_INLINE void tagged_bmalloc_deallocate_inline(void* ptr)

--- a/Source/bmalloc/libpas/src/libpas/thingy_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/thingy_heap.c
@@ -98,7 +98,8 @@ void* thingy_try_reallocate_primitive(void* old_ptr, size_t new_size, pas_alloca
         THINGY_HEAP_CONFIG,
         try_allocate_primitive_for_realloc,
         pas_reallocate_disallow_heap_teleport,
-        pas_reallocate_free_if_successful).begin;
+        pas_reallocate_free_if_successful,
+        pas_allocation_result_identity).begin;
 }
 
 PAS_CREATE_TRY_ALLOCATE(
@@ -160,7 +161,8 @@ void* thingy_try_reallocate_array(
                                                     try_allocate_array_for_realloc,
                                                     &thingy_typed_runtime_config.base,
                                                     pas_reallocate_disallow_heap_teleport,
-                                                    pas_reallocate_free_if_successful).begin;
+                                                    pas_reallocate_free_if_successful,
+                                                    pas_allocation_result_identity).begin;
 }
 
 void thingy_deallocate(void* ptr)


### PR DESCRIPTION
#### c0121e11c12f57c279705344e09bc1270491df97
<pre>
Make SystemHeap-enabled failure actions equivalent to SystemHeap-disabled failure actions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=323456">https://bugs.webkit.org/show_bug.cgi?id=323456</a>
<a href="https://rdar.apple.com/185783006">rdar://185783006</a>

Reviewed by Marcus Plutowski.

This means:
1. non-&quot;try&quot; allocators should crash on failure to allocate memory.
2. &quot;try&quot; allocators just return a nullptr on failure to allocate memory.  See exception in (3) below.
3. For iso_try_reallocate allocators, existing SystemHeap-disabled allocators will also set errno
   to ENOMEM in addition to returning nullptr.  Make the SystemHeap-enabled path do the same

No new tests because failures to allocate memory is not a condition we can force, and the expected
behavior is to crash in some cases (which is not testable).

* Source/bmalloc/libpas/src/libpas/bmalloc_heap_flex_internal.h:
(bmalloc_try_reallocate_flex_inline):
(bmalloc_reallocate_flex_inline):
* Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h:
(bmalloc_try_reallocate_auxiliary_inline):
(bmalloc_reallocate_auxiliary_inline):
(bmalloc_try_reallocate_inline):
(bmalloc_reallocate_inline):
* Source/bmalloc/libpas/src/libpas/bmalloc_heap_iso_internal.h:
(bmalloc_try_iso_reallocate_array_by_size_inline):
(bmalloc_iso_reallocate_array_by_size_inline):
(bmalloc_try_iso_reallocate_array_by_count_inline):
(bmalloc_iso_reallocate_array_by_count_inline):
* Source/bmalloc/libpas/src/libpas/hotbit_heap_inlines.h:
(hotbit_try_reallocate_inline):
* Source/bmalloc/libpas/src/libpas/iso_heap_inlines.h:
(iso_try_reallocate_common_primitive_inline):
(iso_reallocate_common_primitive_inline):
(iso_try_reallocate_array_by_count_inline):
(iso_reallocate_array_by_count_inline):
(iso_try_reallocate_primitive_inline):
(iso_reallocate_primitive_inline):
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
(pas_local_allocator_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_try_allocate_intrinsic.h:
(pas_try_allocate_intrinsic_impl_casual_case):
* Source/bmalloc/libpas/src/libpas/pas_try_reallocate.h:
(pas_try_reallocate):
(pas_try_reallocate_intrinsic):
(pas_try_reallocate_single):
(pas_try_reallocate_array_by_size):
(pas_try_reallocate_array_by_count):
(pas_try_reallocate_primitive):
* Source/bmalloc/libpas/src/libpas/tagged_bmalloc_heap_inlines.h:
(tagged_bmalloc_try_reallocate_inline):
(tagged_bmalloc_reallocate_inline):
* Source/bmalloc/libpas/src/libpas/thingy_heap.c:
(thingy_try_reallocate_primitive):
(thingy_try_reallocate_array):

Canonical link: <a href="https://commits.webkit.org/320539@main">https://commits.webkit.org/320539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebd9bce53a68b6707321699ab84163770f6b087e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195356 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d4213cf-1fa2-4fa1-b869-dbc885e1f029) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58667 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144586 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f787d853-ff4b-47a7-a79a-b5971b4c1e8c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48263 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165179 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124873 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb28e5c0-4b27-4543-b454-566262e1dd67) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/46990 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/6805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13681 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44749 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6408 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46286 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197303 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58607 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154083 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59317 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41353 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153732 "Found 1 new API test failure: TestWebViewEditor:/webkit/WebKitWebView/editable/editable (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28105 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48238 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128249 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57808 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19768 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57169 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57418 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57245 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->