### PR TITLE
[Build speed] Collect swift/ninja traces in measure-build-time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,6 @@ if (SWIFT_REQUIRED)
         # Avoid cmd.exe due to command-line length limits.
         set(CMAKE_Swift_COMPILER "${Python_EXECUTABLE}")
         set(CMAKE_Swift_COMPILER_ARG1 "${CMAKE_SOURCE_DIR}/Tools/Scripts/swift/swiftc-wrapper.py")
-    elseif (SWIFT_NINJA_TRACE)
-        # The rest of the tracing logic is in OptionsCommon.cmake, but the
-        # compiler override needs to be given up front.
-        set(CMAKE_Swift_COMPILER "${CMAKE_SOURCE_DIR}/Tools/Scripts/swift/swiftc_job_recorder.py")
     else ()
         set(CMAKE_Swift_COMPILER "${CMAKE_SOURCE_DIR}/Tools/Scripts/swift/swiftc-wrapper.py")
     endif ()

--- a/Source/cmake/OptionsCommon.cmake
+++ b/Source/cmake/OptionsCommon.cmake
@@ -197,12 +197,18 @@ endif ()
 
 option(SWIFT_NINJA_TRACE "Collect ninja and swift driver execution data and produce a Perfetto-style trace" OFF)
 if (SWIFT_NINJA_TRACE)
-    # Tracing replaces the normal swiftc-wrapper with a harness that collects
-    # extra information from swift's driver. It has a finalizer step that
-    # correlates this info with .ninja_log, so it must be run manually.
+    if (WIN32)
+        # Would need to adapt clang-cl argument parsing logic and provide a
+        # Windows finalizer script.
+        message(FATAL_ERROR "SWIFT_NINJA_TRACE is not supported on Windows")
+    endif ()
+    # Tracing uses a swiftc harness that captures job info from stdio.
+    # --swift-wrapper= is recognized by swiftc-wrapper.py, so we end up
+    # with nested, independent harnesses.
     set(SWIFT_JOBS_LOG "${CMAKE_BINARY_DIR}/swift-jobs.jsonl")
     set(SWIFT_STATS_DIR "${CMAKE_BINARY_DIR}/swift-stats")
     set(SWIFT_NINJA_TRACE_FINALIZE "${CMAKE_BINARY_DIR}/swift-trace-finalize.sh")
+    add_compile_options($<$<COMPILE_LANGUAGE:Swift>:--swift-wrapper=${CMAKE_SOURCE_DIR}/Tools/Scripts/swift/swiftc_job_recorder.py>)
     add_compile_options($<$<COMPILE_LANGUAGE:Swift>:--jobs-log=${SWIFT_JOBS_LOG}>)
     add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-stats-output-dir ${SWIFT_STATS_DIR}>")
 
@@ -213,7 +219,7 @@ if (SWIFT_NINJA_TRACE)
 ${CMAKE_SOURCE_DIR}/Tools/Scripts/swift/ninja_build_trace.py \
 --ninja-log ${CMAKE_BINARY_DIR}/.ninja_log \
 --jobs-log ${SWIFT_JOBS_LOG} \
---stats-dir ${SWIFT_STATS_DIR} $@"
+--stats-dir ${SWIFT_STATS_DIR} \"$@\""
         FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
             GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
     )

--- a/Tools/Scripts/measure-build-time
+++ b/Tools/Scripts/measure-build-time
@@ -18,6 +18,10 @@ log = logging.getLogger('measure-build-time')
 
 SCRIPTS = Path(__file__).parent
 
+# Written into the build directory by -DSWIFT_NINJA_TRACE=ON, and already bound
+# to that build's swift jobs log and stats directory.
+TRACE_FINALIZE_SCRIPT = 'swift-trace-finalize.sh'
+
 # --- Tests and subtests -----------------------------------------------------
 
 class Task:
@@ -30,6 +34,7 @@ class Task:
     stdout_filter: str | None
     build_dir: Path
     source_dir: Path
+    trace_dir: Path | None
 
     result: TestResult | None
 
@@ -38,6 +43,7 @@ class Task:
         self.stdout_filter = args.stdout_filter
         self.source_dir = args.source_dir
         self.build_dir = args.build_dir
+        self.trace_dir = args.trace_dir if args.trace else None
 
     def __enter__(self):
         pass
@@ -48,7 +54,10 @@ class Task:
     def run(self):
         log.info('--- %s %s', self.name, '-' * (74 - len(self.name)))
         with self:
+            started_epoch_ms = int(time.time() * 1000)
             self.result = run_test(self.name, self.build_command, self.stdout_filter)
+        if self.trace_dir:
+            write_build_trace(self.build_dir, self.trace_dir, self.name, started_epoch_ms)
         return self.result
 
 
@@ -367,6 +376,27 @@ def run_test(name: str, command: str, stdout_filter: str | None = None) -> TestR
     return build_type_result(wall_time_ms, timing_summary)
 
 
+def write_build_trace(build_dir: Path, trace_dir: Path, name: str,
+                      since_epoch_ms: int) -> Path | None:
+    finalize = build_dir / TRACE_FINALIZE_SCRIPT
+    if not finalize.exists():
+        log.warning('No %s; configure with -DSWIFT_NINJA_TRACE=ON to trace builds', finalize)
+        return None
+    trace_dir.mkdir(parents=True, exist_ok=True)
+    output = trace_dir / f'{name}.json.gz'
+    trace = subprocess.run((str(finalize), '--relative',
+                            f'--since-epoch-ms={since_epoch_ms}', '-o', str(output)))
+    if trace.returncode:
+        log.warning('%s exited %d, so %s has no build trace',
+                    finalize, trace.returncode, name)
+        return None
+    if not output.exists():
+        log.info('No ninja invocation to trace for %s', name)
+        return None
+    log.info('Wrote build trace %s', output)
+    return output
+
+
 # --- Test runner ------------------------------------------------------------
 
 DEFAULT_MAKE_COMMAND = (
@@ -396,6 +426,9 @@ class Arguments(argparse.Namespace):
     tests: list[str]
     unapply_patch: bool
     keep_going: bool
+
+    trace: bool | None
+    trace_dir: Path
 
     stdout_filter: str | None
     output: str
@@ -433,12 +466,20 @@ def get_args() -> Arguments:
     parser.add_argument('--metric-key',
                         help='Top-level test key in the results. '
                         'Can be omitted, but must be provided when emitting a real benchmark score.')
+    parser.add_argument('--trace', action=argparse.BooleanOptionalAction, default=None,
+                        help='Write a Perfetto trace of each build to --trace-dir '
+                        '(default: on for --cmake). Configures with -DSWIFT_NINJA_TRACE=ON.')
+    parser.add_argument('--trace-dir', type=Path, default=Path('build-time-traces'),
+                        help='Directory to write build traces into (default: build-time-traces)')
     parser.add_argument('--stdout-filter', default=None,
                         help='Shell command to filter build stdout through (e.g. filter-build-webkit)')
     parser.add_argument('--output', '-o', default='build-time-results.json',
                         help='Output JSON file path (default: build-time-results.json)')
 
     args = parser.parse_args(namespace=Arguments())
+
+    if args.trace is None:
+        args.trace = args.cmake
 
     if not args.build_dir:
         args.build_dir = Path(subprocess.check_output(
@@ -490,6 +531,8 @@ def get_args() -> Arguments:
             preset=cmake_preset,
             sdk_version=sdk_version,
         )
+        if args.trace:
+            args.configure_command += ' -DSWIFT_NINJA_TRACE=ON'
     if not args.metric_key:
         # e.g. "BuildTime-Debug"
         args.metric_key = f'BuildTime-{args.configuration.capitalize()}'
@@ -502,6 +545,12 @@ def main():
     )
 
     args = get_args()
+
+    if args.trace:
+        # A CI workdir outlives the build, and a test that produces no trace this
+        # time would otherwise leave the last run's behind to be collected.
+        for stale in args.trace_dir.glob('*.json.gz'):
+            stale.unlink()
 
     # Read each test's `depends` lists to compute a topological order to run
     # all the tests. Ties are broken by AVAILABLE_TESTS order, so the plan is

--- a/Tools/Scripts/swift/ninja_build_trace.py
+++ b/Tools/Scripts/swift/ninja_build_trace.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import argparse
 import collections
+import gzip
 import json
 import os
 import re
@@ -1325,7 +1326,13 @@ def main(argv: list[str] | None = None) -> int:
         help="a swiftc_job_recorder.py log; adds the explicit-module-build jobs that "
         "write no stats file",
     )
-    parser.add_argument("-o", "--out", type=Path, default=None, help="output JSON (default stdout)")
+    parser.add_argument(
+        "-o",
+        "--out",
+        type=Path,
+        default=None,
+        help="output JSON (default stdout); a .gz suffix writes gzip, which Perfetto reads",
+    )
     parser.add_argument(
         "--cores", type=int, default=os.cpu_count() or 1, help="core budget for oversubscription"
     )
@@ -1340,6 +1347,13 @@ def main(argv: list[str] | None = None) -> int:
         choices=("last", "all"),
         default="last",
         help="which ninja invocation in the log to emit (default: last)",
+    )
+    parser.add_argument(
+        "--since-epoch-ms",
+        type=float,
+        default=None,
+        help="ignore ninja invocations, stats files and recorded jobs from before this "
+        "epoch time; picks one build out of logs that accumulate across builds",
     )
     parser.add_argument(
         "--relative",
@@ -1364,6 +1378,16 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: no usable records in {args.ninja_log}", file=sys.stderr)
         return 1
     runs, undated = group_runs(edges)
+    if args.since_epoch_ms is not None:
+        recent = [r for r in runs if r.anchor_ms >= args.since_epoch_ms]
+        if not recent:
+            print(
+                f"note: none of the {len(runs)} ninja invocation(s) in {args.ninja_log} "
+                "started at or after --since-epoch-ms; nothing to trace",
+                file=sys.stderr,
+            )
+            return 0
+        runs = recent
     if not runs:
         if args.anchor_epoch_ms is None:
             print(
@@ -1385,6 +1409,10 @@ def main(argv: list[str] | None = None) -> int:
 
     jobs = load_stats_dir(args.stats_dir, args.verbose) if args.stats_dir else []
     recorded = load_jobs_log(args.jobs_log) if args.jobs_log else []
+    if args.since_epoch_ms is not None:
+        since_us = args.since_epoch_ms * 1000.0
+        jobs = [j for j in jobs if j.start_us >= since_us]
+        recorded = [i for i in recorded if i.start_us >= since_us]
 
     if args.run == "all":
         run = merge_runs(runs)
@@ -1486,7 +1514,11 @@ def main(argv: list[str] | None = None) -> int:
 
     text = json.dumps(trace)
     if args.out:
-        args.out.write_text(text)
+        if args.out.suffix == ".gz":
+            with gzip.open(args.out, "wt", encoding="utf-8") as f:
+                f.write(text)
+        else:
+            args.out.write_text(text)
         print(f"wrote {args.out} ({len(trace['traceEvents'])} events)", file=sys.stderr)
     else:
         sys.stdout.write(text)

--- a/Tools/Scripts/swift/ninja_build_trace_unittest.py
+++ b/Tools/Scripts/swift/ninja_build_trace_unittest.py
@@ -7,6 +7,7 @@ Run with: Tools/Scripts/test-webkitpy swift
 from __future__ import annotations
 
 import contextlib
+import gzip
 import io
 import json
 import tempfile
@@ -898,6 +899,77 @@ class MainTest(ScratchDirectoryTest):
             self.assertEqual(nbt.main(["--ninja-log", str(log)]), 1)
         self.assertIn("no usable records", stderr.getvalue())
 
+    def _two_invocation_log(self):
+        """A big first invocation carrying all the stats, then a small later one."""
+        first_ns, second_ns = 1_700_000_000_000_000_000, 1_700_003_600_000_000_000
+        log = self.tmp_path / ".ninja_log"
+        log.write_text(
+            ninja_log(
+                [
+                    f"0\t1000\t{first_ns}\tA.swiftmodule\tabc",
+                    f"0\t2000\t{first_ns}\tB.swiftmodule\tdef",
+                    f"0\t500\t{second_ns}\tC.swiftmodule\tghi",
+                ]
+            )
+        )
+        stats = self.tmp_path / "stats"
+        stats.mkdir()
+        write_stats(stats, 1_700_000_000_100_000, 0.5)
+        write_stats(stats, 1_700_000_000_200_000, 0.5, aux=AUX.replace("Demo", "Demo2"))
+        return log, stats
+
+    def _run_main(self, extra: list[str]) -> str:
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            self.assertEqual(nbt.main(extra), 0)
+        return stderr.getvalue()
+
+    def test_the_busiest_invocation_wins_when_nothing_bounds_the_time(self):
+        log, stats = self._two_invocation_log()
+        stderr = self._run_main(
+            ["--ninja-log", str(log), "--stats-dir", str(stats), "-o", str(self.tmp_path / "t.json")]
+        )
+        self.assertIn("ninja run: 2 edges", stderr)
+
+    def test_since_epoch_ms_picks_the_later_invocation(self):
+        # Logs accumulate across builds, so without a lower bound the invocation
+        # the stats files came from beats the one that just ran.
+        log, stats = self._two_invocation_log()
+        out = self.tmp_path / "t.json"
+        stderr = self._run_main(
+            [
+                "--ninja-log", str(log),
+                "--stats-dir", str(stats),
+                "--since-epoch-ms", "1700003000000",
+                "-o", str(out),
+            ]
+        )
+        self.assertIn("ninja run: 1 edges", stderr)
+        names = {e["name"] for e in json.loads(out.read_text())["traceEvents"] if e["ph"] == "X"}
+        self.assertEqual(names, {"C.swiftmodule"})
+
+    def test_since_epoch_ms_after_every_invocation_writes_nothing(self):
+        log, stats = self._two_invocation_log()
+        out = self.tmp_path / "t.json"
+        stderr = self._run_main(
+            [
+                "--ninja-log", str(log),
+                "--stats-dir", str(stats),
+                "--since-epoch-ms", "1700007200000",
+                "-o", str(out),
+            ]
+        )
+        self.assertIn("nothing to trace", stderr)
+        self.assertFalse(out.exists())
+
+    def test_a_gz_suffix_writes_a_gzipped_trace(self):
+        log, stats = self._two_invocation_log()
+        out = self.tmp_path / "t.json.gz"
+        self._run_main(["--ninja-log", str(log), "--stats-dir", str(stats), "-o", str(out)])
+        with gzip.open(out, "rt") as f:
+            trace = json.load(f)
+        self.assertEqual(trace["displayTimeUnit"], "ms")
+
 
 # ---------------------------------------------------------------------------
 # The recorder
@@ -947,19 +1019,13 @@ class RecorderTest(unittest.TestCase):
         self.assertIsNone(jobs_log)
         self.assertEqual(args, ["-emit-library", "-static"])
 
-    def test_recorder_drops_only_the_wrapper_flags_it_knows(self):
-        # The recorder stands in for swiftc-wrapper.py, so the wrapper's flags ride
-        # along in CMAKE_Swift_FLAGS and swiftc would reject them.
+    def test_recorder_forwards_every_flag_it_does_not_own(self):
+        # swiftc-wrapper.py runs above the recorder and consumes its own flags
+        # before they reach here, so anything left over belongs to the compiler.
         _, _, args = recorder.parse_args(
-            [
-                "-c",
-                "--emit-ninja-depfile=/tmp/t.d",
-                "--ninja-depfile-target=/tmp/t.stamp",
-                "--ninja-depfile-exclude=/tmp/t.swiftmodule",
-                "f0.swift",
-            ]
+            ["-c", "--emit-ninja-depfile=/tmp/t.d", "f0.swift"]
         )
-        self.assertEqual(args, ["-c", "f0.swift"])
+        self.assertEqual(args, ["-c", "--emit-ninja-depfile=/tmp/t.d", "f0.swift"])
         # Dropping every `--` argument instead would eat the version probe in
         # WebKitFeatures.cmake, and the operand of an `-Xcc --foo` pair.
         _, _, args = recorder.parse_args(["--version"])

--- a/Tools/Scripts/swift/swiftc-wrapper.py
+++ b/Tools/Scripts/swift/swiftc-wrapper.py
@@ -4,6 +4,8 @@
 #   - relays the command line through a response file on Windows
 #   - forwards the MSVC-style linker switches that CMake's own defaults inject
 #   - merges per-frontend depfiles into one depfile for the whole module
+#   - optionally runs another wrapper in the compiler's place, so a tool that
+#     needs to spawn swiftc itself can be nested below this one
 #
 # Flags that swiftc cannot accept are kept off the Swift command line by the
 # CMake configuration, using $<COMPILE_LANGUAGE:Swift> / $<LINK_LANGUAGE:Swift>
@@ -171,9 +173,12 @@ def main(argv):
     depfile_path = None
     depfile_target = None
     depfile_excludes = []
+    inner_wrapper = None
     for arg in argv:
         if arg.startswith("--original-swift-compiler="):
             real_swiftc = arg[len("--original-swift-compiler="):]
+        elif arg.startswith("--swift-wrapper="):
+            inner_wrapper = arg[len("--swift-wrapper="):]
         elif arg.startswith("--emit-ninja-depfile="):
             depfile_path = arg[len("--emit-ninja-depfile="):]
         elif arg.startswith("--ninja-depfile-target="):
@@ -192,12 +197,16 @@ def main(argv):
     if depfile_path and depfile_target and not linking:
         depfile = DepfileRequest(depfile_path, depfile_target, frozenset(depfile_excludes))
 
-    flat_command = [real_swiftc] + args
+    if inner_wrapper:
+        flat_command = [inner_wrapper, f"--original-swift-compiler={real_swiftc}"] + args
+    else:
+        flat_command = [real_swiftc] + args
 
-    if os.name == "nt" and "-explicit-module-build" not in args:
+    if os.name == "nt" and "-explicit-module-build" not in args and not inner_wrapper:
         # WebKit's swiftc invocations run tens of thousands of characters long
         # (hundreds of -I flags); Windows' CreateProcess caps a command line at
-        # ~32767 characters
+        # ~32767 characters. An inner wrapper is excluded because it would have
+        # to expand the response file itself.
         response_file = write_response_file(args)
         command = [real_swiftc, "@" + response_file]
     else:
@@ -206,8 +215,8 @@ def main(argv):
             if len(cmdline) >= 32767:
                 sys.stderr.write(
                     f"swiftc-wrapper: command line is {len(cmdline)} characters, "
-                    "over the Windows 32767 limit, and -explicit-module-build "
-                    "prevents relaying it through a response file\n")
+                    "over the Windows 32767 limit, and a response file cannot be "
+                    "used here\n")
                 return 1
         command = flat_command
         response_file = None

--- a/Tools/Scripts/swift/swiftc_job_recorder.py
+++ b/Tools/Scripts/swift/swiftc_job_recorder.py
@@ -41,11 +41,7 @@ With no --jobs-log it execs the compiler unchanged, so leaving the recorder
 configured costs nothing (and configure-time probes stay untouched).
 
 Timestamps come from when each message reaches this process, which means nothing
-between here and the driver may buffer stderr. If your build already wraps
-swiftc in a script that captures stderr and re-emits it after the child exits
-(WebKit's Tools/Scripts/swift/swiftc-wrapper.py did), every message arrives at
-once and the spans collapse -- make that wrapper stream stderr line by line, or
-put this recorder below it.
+between here and the driver may buffer stderr.
 """
 
 from __future__ import annotations
@@ -57,14 +53,6 @@ import sys
 import time
 
 MESSAGE_KEYS = ("kind", "name", "pid")
-
-# swiftc-wrapper.py's own dependency-tracking flags for functionality that the
-# recorder does not implement.
-IGNORED_WRAPPER_FLAGS = (
-    "--emit-ninja-depfile=",
-    "--ninja-depfile-target=",
-    "--ninja-depfile-exclude=",
-)
 
 
 def log_line(handle, payload: dict) -> None:
@@ -141,8 +129,6 @@ def parse_args(argv: list[str]) -> tuple[str, str | None, list[str]]:
             compiler = arg[len("--original-swift-compiler="):]
         elif arg.startswith("--jobs-log="):
             jobs_log = arg[len("--jobs-log="):]
-        elif arg.startswith(IGNORED_WRAPPER_FLAGS):
-            pass
         else:
             compiler_args.append(arg)
     return compiler, jobs_log, compiler_args

--- a/Tools/Scripts/webkitpy/scripts/measure_build_time_unittest.py
+++ b/Tools/Scripts/webkitpy/scripts/measure_build_time_unittest.py
@@ -28,6 +28,7 @@
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -55,7 +56,7 @@ class MeasureBuildTimeTest(unittest.TestCase):
             if extra_args:
                 cmd.extend(extra_args)
 
-            proc = subprocess.run(cmd, stdin=subprocess.DEVNULL,
+            proc = subprocess.run(cmd, stdin=subprocess.DEVNULL, cwd=tmpdir,
                                   capture_output=True, text=True)
             results = None
             if os.path.exists(output_file):
@@ -124,3 +125,83 @@ class MeasureBuildTimeTest(unittest.TestCase):
         self.assertEqual(proc.returncode, 0)
         self.assertIn('BuildTime-Release', results)
         self.assertNotIn('BuildTime-Debug', results)
+
+
+# The trace finalizer CMake generates when configured with -DSWIFT_NINJA_TRACE=ON.
+# The stub records its argv and produces the file it was asked for.
+TRACE_FINALIZE_STUB = textwrap.dedent('''\
+    #!/bin/sh
+    echo "$@" >> "$(dirname "$0")/finalize-argv.txt"
+    while [ $# -gt 1 ]; do shift; done
+    : > "$1"
+''')
+
+
+class MeasureBuildTimeTraceTest(unittest.TestCase):
+    def setUp(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.tmpdir = Path(directory.name)
+        self.build_dir = self.tmpdir / 'Build'
+        self.build_dir.mkdir()
+        self.traces = self.tmpdir / 'build-time-traces'
+
+        self.stub = self.tmpdir / 'finalize-stub.sh'
+        self.stub.write_text(TRACE_FINALIZE_STUB)
+        self.stub.chmod(0o755)
+
+    @property
+    def finalizer(self):
+        return self.build_dir / 'swift-trace-finalize.sh'
+
+    def _run_script(self, tests, extra_args=()):
+        cmd = [
+            sys.executable, SCRIPT,
+            '--build-command', 'echo ok',
+            '--build-dir', str(self.build_dir),
+            '--source-dir', str(self.tmpdir),
+            '--output', str(self.tmpdir / 'results.json'),
+            '--tests', *tests,
+            *extra_args,
+        ]
+        return subprocess.run(cmd, stdin=subprocess.DEVNULL, cwd=self.tmpdir,
+                              capture_output=True, text=True)
+
+    def test_a_trace_is_written_for_each_test(self):
+        # The clean test deletes the build directory, so the finalizer arrives the
+        # way CMake writes it: at configure time.
+        proc = self._run_script(['clean', 'null'], [
+            '--trace',
+            '--configure-command',
+            f'mkdir -p {self.build_dir} && cp {self.stub} {self.finalizer}',
+        ])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+        self.assertEqual(sorted(p.name for p in self.traces.iterdir()),
+                         ['clean.json.gz', 'null.json.gz'])
+
+        invocations = (self.build_dir / 'finalize-argv.txt').read_text().splitlines()
+        self.assertEqual(len(invocations), 2)
+        for argv in invocations:
+            # The build's logs accumulate across builds, so each trace has to be
+            # bounded to the ninja invocation this test just ran.
+            self.assertIn('--since-epoch-ms=', argv)
+
+    def test_stale_traces_do_not_survive_a_later_run(self):
+        self.traces.mkdir()
+        (self.traces / 'webcore-header.json.gz').write_text('stale')
+
+        self._run_script(['null'], ['--trace'])
+        self.assertEqual(list(self.traces.iterdir()), [])
+
+    def test_an_untraced_build_directory_only_warns(self):
+        proc = self._run_script(['null'], ['--trace'])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn('SWIFT_NINJA_TRACE', proc.stderr)
+        self.assertFalse(self.traces.exists())
+
+    def test_tracing_is_off_without_cmake(self):
+        shutil.copy(self.stub, self.finalizer)
+        proc = self._run_script(['null'])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertFalse((self.build_dir / 'finalize-argv.txt').exists())


### PR DESCRIPTION
#### 34aca645c7fa15db0ea062c9259d824834be9792
<pre>
[Build speed] Collect swift/ninja traces in measure-build-time
<a href="https://bugs.webkit.org/show_bug.cgi?id=323380">https://bugs.webkit.org/show_bug.cgi?id=323380</a>
<a href="https://rdar.apple.com/186613991">rdar://186613991</a>

Reviewed by Geoffrey Garen.

Add --trace and --trace-dir options to mbt that configure a CMake build
with SWIFT_NINJA_TRACE=ON and produce a directory of JSON traces. This
will be consumed by CI to collect and upload traces for builds.

To support tracing without breaking Swift-C++ dependency tracking added
in 320311@main, refactor swiftc-wrapper.py to support a nested wrapper.
Now, trace mode causes CMake to invoke swiftc-wrapper which in turn
invokes swiftc_job_recorder which is what actually calls the frontend.

* Source/cmake/OptionsCommon.cmake:
* Tools/Scripts/measure-build-time:
(Task):
(Task.__init__):
(Task.run):
(run_test):
(write_build_trace):
(Arguments):
(get_args):
(main):
* Tools/Scripts/swift/ninja_build_trace.py:
(main):
* Tools/Scripts/swift/ninja_build_trace_unittest.py:
(MainTest._two_invocation_log):
(MainTest):
(MainTest._run_main):
(MainTest.test_the_busiest_invocation_wins_when_nothing_bounds_the_time):
(MainTest.test_since_epoch_ms_picks_the_later_invocation):
(MainTest.test_since_epoch_ms_after_every_invocation_writes_nothing):
(MainTest.test_a_gz_suffix_writes_a_gzipped_trace):
(RecorderTest.test_recorder_forwards_every_flag_it_does_not_own):
(RecorderTest.test_recorder_drops_only_the_wrapper_flags_it_knows): Deleted.
* Tools/Scripts/webkitpy/scripts/measure_build_time_unittest.py:
(MeasureBuildTimeTest._run_script):
(MeasureBuildTimeTest):
* CMakeLists.txt:
* Tools/Scripts/swift/swiftc-wrapper.py:
(main):
* Tools/Scripts/swift/swiftc_job_recorder.py:
(parse_args):

Canonical link: <a href="https://commits.webkit.org/320545@main">https://commits.webkit.org/320545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb379fff0ee61519d06f37bb93d491cb4323386f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185089 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/195418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186951 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/195418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188044 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/52822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/195418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/184417 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/195418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/52822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/6474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/46347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/58730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/197370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/58667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/52822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/197370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/197370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28107 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/128308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/57859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/52822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->