### PR TITLE
[list-marker] AX: The list marker is missing from the stitched text of a list item with block content

### DIFF
--- a/LayoutTests/accessibility/listmarker-text-with-block-content-expected.txt
+++ b/LayoutTests/accessibility/listmarker-text-with-block-content-expected.txt
@@ -1,0 +1,10 @@
+This test makes sure the marker of a list item whose content is a block is part of the item's stitched text, the way it is for an item with inline content.
+
+PASS: blockText.x === inlineText.x === true
+PASS: blockText.width === inlineText.width === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+item
+item

--- a/LayoutTests/accessibility/listmarker-text-with-block-content.html
+++ b/LayoutTests/accessibility/listmarker-text-with-block-content.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<style>
+body { margin: 0; font: 20px/1 monospace; }
+ul { margin: 0; padding-inline-start: 60px; }
+</style>
+</head>
+<body>
+
+<ul>
+<li id="blockContent"><div>item</div></li>
+<li id="inlineContent">item</li>
+</ul>
+
+<script>
+let output = "This test makes sure the marker of a list item whose content is a block is part of the item's stitched text, the way it is for an item with inline content.\n\n";
+
+function staticTextIn(element) {
+    if (element.role === platformRoleForStaticText())
+        return element;
+    for (let i = 0; i < element.childrenCount; ++i) {
+        let found = staticTextIn(element.childAtIndex(i));
+        if (found)
+            return found;
+    }
+    return null;
+}
+
+if (window.accessibilityController) {
+    var blockText = staticTextIn(accessibilityController.accessibleElementById("blockContent"));
+    var inlineText = staticTextIn(accessibilityController.accessibleElementById("inlineContent"));
+
+    // The marker is drawn to the left of the text, so a stitched run that includes it starts further left and is wider.
+    output += expect("blockText.x === inlineText.x", "true");
+    output += expect("blockText.width === inlineText.width", "true");
+
+    debug(output);
+    finishJSTest();
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -4172,6 +4172,27 @@ Vector<AXStitchGroup> AccessibilityNodeObject::stitchGroups() const
             currentGroup.clear();
         representativeID = std::nullopt;
     };
+    // Our own outside marker takes no part in our lines, so it is not one of the leaf boxes below, but it belongs at
+    // the start of the group for the line it was positioned against, when that line is one of ours.
+    auto stitchableExcludedMarker = [&]() -> CheckedPtr<RenderListOutsideMarker> {
+        // The marker's list item is this block flow itself when the item's own content makes the line, and an
+        // ancestor of it when the line is in a descendant block of the item.
+        for (CheckedPtr<const RenderBlock> ancestor = renderBlockFlow.get(); ancestor; ancestor = ancestor->containingBlock()) {
+            CheckedPtr listItem = dynamicDowncast<RenderListItem>(ancestor.get());
+            CheckedPtr marker = listItem ? listItem->markerBox() : nullptr;
+            if (!marker || !marker->isExcludedMarker() || marker->isDisclosureMarker())
+                continue;
+            auto excludedPosition = marker->excludedPosition();
+            if (excludedPosition && excludedPosition->firstFormattedLineRoot.get() == renderBlockFlow.get())
+                return marker;
+        }
+        return { };
+    }();
+    if (stitchableExcludedMarker) {
+        if (RefPtr object = cache->getOrCreate(*stitchableExcludedMarker))
+            appendToCurrentGroup(object->objectID());
+    }
+
     for (auto lineBox = inlineLayout->firstLineBox(); lineBox; lineBox.traverseNext()) {
         for (auto box = lineBox->logicalLeftmostLeafBox(); box; box.traverseLogicalRightwardOnLine()) {
             auto updateLastRenderer = makeScopeExit([&] {


### PR DESCRIPTION
#### 321cf5cc81d703c02cd32e628b755a3dc4499063
<pre>
[list-marker] AX: The list marker is missing from the stitched text of a list item with block content
<a href="https://bugs.webkit.org/show_bug.cgi?id=323457">https://bugs.webkit.org/show_bug.cgi?id=323457</a>
<a href="https://rdar.apple.com/problem/186687365">rdar://problem/186687365</a>

Reviewed by Antti Koivisto.

An excluded marker is on no line&apos;s leaf boxes, so the stitch group for the line it was positioned against left it
out. Put it at the start of that group.

Test: accessibility/listmarker-text-with-block-content.html

* LayoutTests/accessibility/listmarker-text-with-block-content-expected.txt: Added.
* LayoutTests/accessibility/listmarker-text-with-block-content.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::stitchGroups const):

Canonical link: <a href="https://commits.webkit.org/320550@main">https://commits.webkit.org/320550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69b34868e501ece1090d73ed1c555d80c7317348

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195408 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e95214db-a307-461b-948c-7e764458d4a0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186941 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58720 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144625 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/926de1f0-c9f0-4454-8a1a-22b0b238dd39) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48300 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124914 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b49593ec-a326-412a-b769-6baeb7441b86) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47028 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157397 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44787 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6464 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197360 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58657 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164723 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41282 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59367 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153775 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48275 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131662 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128298 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57852 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19806 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57216 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57465 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57289 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->