### PR TITLE
[list-marker]

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5563,7 +5563,6 @@ imported/w3c/web-platform-tests/css/css-lists/marker-counter.html [ ImageOnlyFai
 # list-style
 
 # list-style bidi support
-webkit.org/b/202849 imported/w3c/web-platform-tests/css/css-lists/list-style-type-string-005b.html [ ImageOnlyFailure ]
 webkit.org/b/249918 imported/w3c/web-platform-tests/css/css-lists/list-marker-symbol-bidi.html [ ImageOnlyFailure ]
 
 

--- a/LayoutTests/accessibility/listmarker-text-with-block-content-expected.txt
+++ b/LayoutTests/accessibility/listmarker-text-with-block-content-expected.txt
@@ -1,0 +1,13 @@
+This test makes sure the marker of a list item whose content is a block is part of the item's stitched text, the way it is for an item with inline content.
+
+PASS: blockText.x === inlineText.x === true
+PASS: blockText.width === inlineText.width === true
+
+block content: x=40 width=69
+inline content: x=40 width=69
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+item
+item

--- a/LayoutTests/accessibility/listmarker-text-with-block-content.html
+++ b/LayoutTests/accessibility/listmarker-text-with-block-content.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<style>
+body { margin: 0; font: 20px/1 monospace; }
+ul { margin: 0; padding-inline-start: 60px; }
+</style>
+</head>
+<body>
+
+<ul>
+<li id="blockContent"><div>item</div></li>
+<li id="inlineContent">item</li>
+</ul>
+
+<script>
+let output = "This test makes sure the marker of a list item whose content is a block is part of the item's stitched text, the way it is for an item with inline content.\n\n";
+
+function staticTextIn(element) {
+    if (element.role === platformRoleForStaticText())
+        return element;
+    for (let i = 0; i < element.childrenCount; ++i) {
+        let found = staticTextIn(element.childAtIndex(i));
+        if (found)
+            return found;
+    }
+    return null;
+}
+
+if (window.accessibilityController) {
+    var blockText = staticTextIn(accessibilityController.accessibleElementById("blockContent"));
+    var inlineText = staticTextIn(accessibilityController.accessibleElementById("inlineContent"));
+
+    // The marker is drawn to the left of the text, so a stitched run that includes it starts further left and is wider.
+    output += expect("blockText.x === inlineText.x", "true");
+    output += expect("blockText.width === inlineText.width", "true");
+    output += `\nblock content: x=${blockText.x} width=${blockText.width}\ninline content: x=${inlineText.x} width=${inlineText.width}\n`;
+
+    debug(output);
+    finishJSTest();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/inside-marker-with-block-in-inline-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/inside-marker-with-block-in-inline-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>An inside list marker goes before the block a nested inline's content starts with</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 40px; list-style-position: inside }
+</style>
+</head>
+<body>
+  <ul><li><div>xx</div></li></ul>
+  <ul><li><div>xx</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/inside-marker-with-block-in-inline-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/inside-marker-with-block-in-inline-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>An inside list marker goes before the block a nested inline's content starts with</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 40px; list-style-position: inside }
+</style>
+</head>
+<body>
+  <ul><li><div>xx</div></li></ul>
+  <ul><li><div>xx</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/inside-marker-with-block-in-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/inside-marker-with-block-in-inline.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>An inside list marker goes before the block a nested inline's content starts with</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-position-property">
+<link rel="match" href="inside-marker-with-block-in-inline-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 40px; list-style-position: inside }
+</style>
+</head>
+<body>
+  <ul><li><span><div>xx</div></span></li></ul>
+  <ul><li><span><span><div>xx</div></span></span></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-position-with-cached-line-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-position-with-cached-line-content-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Outside list marker position does not depend on text-overflow</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0 }
+  ul { margin: 0; padding-left: 40px }
+  li { font-family: Ahem; font-size: 20px }
+  .indented { padding-left: 40px }
+</style>
+</head>
+<body>
+  <ul><li><div class="indented" style="width: max-content">one</div></li></ul>
+
+  <ul><li><div style="display: flex"><div class="indented">two</div></div></li></ul>
+
+  <ul><li><div style="display: grid"><div class="indented">three</div></div></li></ul>
+
+  <ul><li><div class="indented" style="display: inline-block">four</div></li></ul>
+
+  <ul><li><div style="display: table"><div class="indented" style="display: table-cell">five</div></div></li></ul>
+
+  <ul><li><div style="width: max-content; border-left: 40px solid transparent">six</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-position-with-cached-line-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-position-with-cached-line-content-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Outside list marker position does not depend on text-overflow</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0 }
+  ul { margin: 0; padding-left: 40px }
+  li { font-family: Ahem; font-size: 20px }
+  .indented { padding-left: 40px }
+</style>
+</head>
+<body>
+  <ul><li><div class="indented" style="width: max-content">one</div></li></ul>
+
+  <ul><li><div style="display: flex"><div class="indented">two</div></div></li></ul>
+
+  <ul><li><div style="display: grid"><div class="indented">three</div></div></li></ul>
+
+  <ul><li><div class="indented" style="display: inline-block">four</div></li></ul>
+
+  <ul><li><div style="display: table"><div class="indented" style="display: table-cell">five</div></div></li></ul>
+
+  <ul><li><div style="width: max-content; border-left: 40px solid transparent">six</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-position-with-cached-line-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-position-with-cached-line-content.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Outside list marker position does not depend on text-overflow</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-position-outside">
+<link rel="match" href="outside-marker-position-with-cached-line-content-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0 }
+  ul { margin: 0; padding-left: 40px }
+  li { font-family: Ahem; font-size: 20px }
+  .indented { padding-left: 40px }
+  .ellipsis { text-overflow: ellipsis }
+</style>
+</head>
+<body>
+  <ul><li><div class="indented ellipsis" style="width: max-content">one</div></li></ul>
+
+  <ul><li><div style="display: flex"><div class="indented ellipsis">two</div></div></li></ul>
+
+  <ul><li><div style="display: grid"><div class="indented ellipsis">three</div></div></li></ul>
+
+  <ul><li><div class="indented ellipsis" style="display: inline-block">four</div></li></ul>
+
+  <ul><li><div style="display: table"><div class="indented ellipsis" style="display: table-cell">five</div></div></li></ul>
+
+  <ul><li><div class="ellipsis" style="width: max-content; border-left: 40px solid transparent">six</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-taller-than-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-taller-than-content-expected.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>A list item takes the height of the line its outside marker sits on</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 10px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 60px; list-style-type: none }
+  li { background: silver }
+  /* The same marker image as ordinary inline content, so the line it sits on sizes the item just as the
+     marker's line does in the test. */
+  li::before {
+    content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40"><rect width="40" height="40" fill="green"/></svg>');
+    margin-inline-start: -47px;
+    margin-inline-end: 7px;
+  }
+</style>
+</head>
+<body>
+  <ul><li></li></ul>
+  <ul><li></li></ul>
+  <ul><li></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-taller-than-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-taller-than-content-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>A list item takes the height of the line its outside marker sits on</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 10px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 60px; list-style-type: none }
+  li { background: silver }
+  /* The same marker image as ordinary inline content, so the line it sits on sizes the item just as the
+     marker's line does in the test. */
+  li::before {
+    content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40"><rect width="40" height="40" fill="green"/></svg>');
+    margin-inline-start: -47px;
+    margin-inline-end: 7px;
+  }
+</style>
+</head>
+<body>
+  <ul><li></li></ul>
+  <ul><li></li></ul>
+  <ul><li></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-taller-than-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-taller-than-content.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>A list item takes the height of the line its outside marker sits on</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-position-outside">
+<link rel="match" href="outside-marker-taller-than-content-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 10px/1 Ahem }
+  ul {
+    margin: 0;
+    padding-inline-start: 60px;
+    list-style-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40"><rect width="40" height="40" fill="green"/></svg>');
+  }
+  li { background: silver }
+</style>
+</head>
+<body>
+  <ul><li></li></ul>
+  <ul><li> </li></ul>
+  <ul><li><span></span></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>An outside list marker follows the line align-content moved</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 40px }
+  div { height: 100px; padding-block-start: 40px; box-sizing: border-box }
+</style>
+</head>
+<body>
+  <ul><li><div>xx</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>An outside list marker follows the line align-content moved</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 40px }
+  div { height: 100px; padding-block-start: 40px; box-sizing: border-box }
+</style>
+</head>
+<body>
+  <ul><li><div>xx</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>An outside list marker follows the line align-content moved</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-position-property">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-content">
+<link rel="match" href="outside-marker-with-align-content-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 40px }
+  div { height: 100px; align-content: center }
+</style>
+</head>
+<body>
+  <ul><li><div>xx</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-block-in-nested-inline-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-block-in-nested-inline-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>An outside list marker aligns with the block a nested inline's content starts with</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 40px }
+</style>
+</head>
+<body>
+  <ul><li><span><div>xx</div></span><br></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-block-in-nested-inline-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-block-in-nested-inline-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>An outside list marker aligns with the block a nested inline's content starts with</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 40px }
+</style>
+</head>
+<body>
+  <ul><li><span><div>xx</div></span><br></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-block-in-nested-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-block-in-nested-inline.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>An outside list marker aligns with the block a nested inline's content starts with</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-position-outside">
+<link rel="match" href="outside-marker-with-block-in-nested-inline-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 40px }
+</style>
+</head>
+<body>
+  <ul><li><span><span><div>xx</div></span></span><br></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>A float in the list item's content does not move the outside marker</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 60px }
+  .box { display: inline-block; width: 60px; height: 20px; background: green; vertical-align: top }
+</style>
+</head>
+<body>
+  <ul><li><div><span class="box"></span>xx</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>A float in the list item's content does not move the outside marker</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 60px }
+  .box { display: inline-block; width: 60px; height: 20px; background: green; vertical-align: top }
+</style>
+</head>
+<body>
+  <ul><li><div><span class="box"></span>xx</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>A float in the list item's content does not move the outside marker</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-position-property">
+<link rel="match" href="outside-marker-with-float-in-content-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 60px }
+  .float { float: left; width: 60px; height: 20px; background: green }
+</style>
+</head>
+<body>
+  <ul><li><div><div class="float"></div>xx</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-indent moves the line, not the outside list marker</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 60px }
+  div { padding-inline-start: 60px }
+</style>
+</head>
+<body>
+  <ul><li><div>xx</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-indent moves the line, not the outside list marker</title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 60px }
+  div { padding-inline-start: 60px }
+</style>
+</head>
+<body>
+  <ul><li><div>xx</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>text-indent moves the line, not the outside list marker</title>
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#list-style-position-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#text-indent-property">
+<link rel="match" href="outside-marker-with-text-indent-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  body { margin: 0; font: 20px/1 Ahem }
+  ul { margin: 0; padding-inline-start: 60px }
+  div { text-indent: 60px }
+</style>
+</head>
+<body>
+  <ul><li><div>xx</div></li></ul>
+</body>
+</html>

--- a/LayoutTests/platform/glib/fast/doctypes/001-expected.txt
+++ b/LayoutTests/platform/glib/fast/doctypes/001-expected.txt
@@ -10,8 +10,7 @@ layer at (0,0) size 800x600
           text run at (159,0) width 188: "We should be in quirks mode."
       RenderBlock {UL} at (0,134) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-17,0) size 7x17: bullet
           RenderBlock {UL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
               RenderListMarker at (-17,0) size 7x18: white bullet

--- a/LayoutTests/platform/glib/fast/doctypes/003-expected.txt
+++ b/LayoutTests/platform/glib/fast/doctypes/003-expected.txt
@@ -10,8 +10,7 @@ layer at (0,0) size 800x600
           text run at (299,0) width 188: "We should be in quirks mode."
       RenderBlock {UL} at (0,134) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-17,0) size 7x17: bullet
           RenderBlock {UL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
               RenderListMarker at (-17,0) size 7x18: white bullet

--- a/LayoutTests/platform/glib/fast/doctypes/004-expected.txt
+++ b/LayoutTests/platform/glib/fast/doctypes/004-expected.txt
@@ -10,8 +10,7 @@ layer at (0,0) size 800x600
           text run at (159,0) width 188: "We should be in quirks mode."
       RenderBlock {UL} at (0,134) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-17,0) size 7x17: bullet
           RenderBlock {UL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
               RenderListMarker at (-17,0) size 7x18: white bullet

--- a/LayoutTests/platform/ios/fast/doctypes/001-expected.txt
+++ b/LayoutTests/platform/ios/fast/doctypes/001-expected.txt
@@ -10,8 +10,7 @@ layer at (0,0) size 800x600
           text run at (161,0) width 192: "We should be in quirks mode."
       RenderBlock {UL} at (0,134) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-17,0) size 7x17: bullet
           RenderBlock {UL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
               RenderListMarker at (-17,0) size 7x18: white bullet

--- a/LayoutTests/platform/ios/fast/doctypes/003-expected.txt
+++ b/LayoutTests/platform/ios/fast/doctypes/003-expected.txt
@@ -10,8 +10,7 @@ layer at (0,0) size 800x600
           text run at (305,0) width 191: "We should be in quirks mode."
       RenderBlock {UL} at (0,134) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-17,0) size 7x17: bullet
           RenderBlock {UL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
               RenderListMarker at (-17,0) size 7x18: white bullet

--- a/LayoutTests/platform/ios/fast/doctypes/004-expected.txt
+++ b/LayoutTests/platform/ios/fast/doctypes/004-expected.txt
@@ -10,8 +10,7 @@ layer at (0,0) size 800x600
           text run at (161,0) width 192: "We should be in quirks mode."
       RenderBlock {UL} at (0,134) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-17,0) size 7x17: bullet
           RenderBlock {UL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
               RenderListMarker at (-17,0) size 7x18: white bullet

--- a/LayoutTests/platform/ios/fast/lists/001-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/001-expected.txt
@@ -16,6 +16,6 @@ layer at (0,0) size 800x600
                 text run at (132,11) width 90: "List item text."
       RenderBlock {UL} at (0,122) size 784x122
         RenderListItem {LI} at (40,0) size 744x122 [border: (2px solid #FF0000)]
-          RenderListMarker at (753,52) size 8x18: bullet
+          RenderListMarker at (754,52) size 7x18: bullet
           RenderText {#text} at (52,52) size 504x18
             text run at (52,52) width 504: "Foo fofodfosjlkdf dslkdjlk asdlksjald djklsd klasjdkas sdajd lsadjkl asjdlksajdk"

--- a/LayoutTests/platform/mac/fast/doctypes/001-expected.txt
+++ b/LayoutTests/platform/mac/fast/doctypes/001-expected.txt
@@ -10,8 +10,7 @@ layer at (0,0) size 800x600
           text run at (160,0) width 192: "We should be in quirks mode."
       RenderBlock {UL} at (0,134) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-17,0) size 7x18: bullet
           RenderBlock {UL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
               RenderListMarker at (-17,0) size 7x18: white bullet

--- a/LayoutTests/platform/mac/fast/doctypes/003-expected.txt
+++ b/LayoutTests/platform/mac/fast/doctypes/003-expected.txt
@@ -10,8 +10,7 @@ layer at (0,0) size 800x600
           text run at (304,0) width 192: "We should be in quirks mode."
       RenderBlock {UL} at (0,134) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-17,0) size 7x18: bullet
           RenderBlock {UL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
               RenderListMarker at (-17,0) size 7x18: white bullet

--- a/LayoutTests/platform/mac/fast/doctypes/004-expected.txt
+++ b/LayoutTests/platform/mac/fast/doctypes/004-expected.txt
@@ -10,8 +10,7 @@ layer at (0,0) size 800x600
           text run at (160,0) width 192: "We should be in quirks mode."
       RenderBlock {UL} at (0,134) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x18: bullet
+          RenderListMarker at (-17,0) size 7x18: bullet
           RenderBlock {UL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
               RenderListMarker at (-17,0) size 7x18: white bullet

--- a/LayoutTests/platform/mac/fast/lists/001-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/001-expected.txt
@@ -16,6 +16,6 @@ layer at (0,0) size 800x585
                 text run at (132,11) width 90: "List item text."
       RenderBlock {UL} at (0,122) size 784x122
         RenderListItem {LI} at (40,0) size 744x122 [border: (2px solid #FF0000)]
-          RenderListMarker at (753,52) size 8x18: bullet
+          RenderListMarker at (754,52) size 7x18: bullet
           RenderText {#text} at (52,52) size 504x18
             text run at (52,52) width 504: "Foo fofodfosjlkdf dslkdjlk asdlksjald djklsd klasjdkas sdajd lsadjkl asjdlksajdk"

--- a/LayoutTests/platform/win/fast/doctypes/001-expected.txt
+++ b/LayoutTests/platform/win/fast/doctypes/001-expected.txt
@@ -10,8 +10,7 @@ layer at (0,0) size 800x600
           text run at (159,0) width 188: "We should be in quirks mode."
       RenderBlock {UL} at (0,134) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x17: bullet
+          RenderListMarker at (-17,0) size 7x17: bullet
           RenderBlock {UL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
               RenderListMarker at (-17,0) size 7x17: white bullet

--- a/LayoutTests/platform/win/fast/doctypes/003-expected.txt
+++ b/LayoutTests/platform/win/fast/doctypes/003-expected.txt
@@ -10,8 +10,7 @@ layer at (0,0) size 800x600
           text run at (299,0) width 188: "We should be in quirks mode."
       RenderBlock {UL} at (0,134) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x17: bullet
+          RenderListMarker at (-17,0) size 7x17: bullet
           RenderBlock {UL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
               RenderListMarker at (-17,0) size 7x17: white bullet

--- a/LayoutTests/platform/win/fast/doctypes/004-expected.txt
+++ b/LayoutTests/platform/win/fast/doctypes/004-expected.txt
@@ -10,8 +10,7 @@ layer at (0,0) size 800x600
           text run at (159,0) width 188: "We should be in quirks mode."
       RenderBlock {UL} at (0,134) size 784x36
         RenderListItem {LI} at (40,0) size 744x36
-          RenderBlock (anonymous) at (0,0) size 744x18
-            RenderListMarker at (-17,0) size 7x17: bullet
+          RenderListMarker at (-17,0) size 7x17: bullet
           RenderBlock {UL} at (0,18) size 744x18
             RenderListItem {LI} at (40,0) size 704x18
               RenderListMarker at (-17,0) size 7x17: white bullet

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -4172,6 +4172,27 @@ Vector<AXStitchGroup> AccessibilityNodeObject::stitchGroups() const
             currentGroup.clear();
         representativeID = std::nullopt;
     };
+    // Our own outside marker takes no part in our lines, so it is not one of the leaf boxes below, but it belongs at
+    // the start of the group for the line it was positioned against, when that line is one of ours.
+    auto stitchableExcludedMarker = [&]() -> CheckedPtr<RenderListOutsideMarker> {
+        // The marker's list item is this block flow itself when the item's own content makes the line, and an
+        // ancestor of it when the line is in a descendant block of the item.
+        for (CheckedPtr<const RenderBlock> ancestor = renderBlockFlow.get(); ancestor; ancestor = ancestor->containingBlock()) {
+            CheckedPtr listItem = dynamicDowncast<RenderListItem>(ancestor.get());
+            CheckedPtr marker = listItem ? listItem->markerBox() : nullptr;
+            if (!marker || !marker->isExcludedMarker() || marker->isDisclosureMarker())
+                continue;
+            auto excludedPosition = marker->excludedPosition();
+            if (excludedPosition && excludedPosition->firstFormattedLineRoot.get() == renderBlockFlow.get())
+                return marker;
+        }
+        return { };
+    }();
+    if (stitchableExcludedMarker) {
+        if (RefPtr object = cache->getOrCreate(*stitchableExcludedMarker))
+            appendToCurrentGroup(object->objectID());
+    }
+
     for (auto lineBox = inlineLayout->firstLineBox(); lineBox; lineBox.traverseNext()) {
         for (auto box = lineBox->logicalLeftmostLeafBox(); box; box.traverseLogicalRightwardOnLine()) {
             auto updateLastRenderer = makeScopeExit([&] {

--- a/Source/WebCore/layout/floats/PlacedFloats.cpp
+++ b/Source/WebCore/layout/floats/PlacedFloats.cpp
@@ -114,12 +114,16 @@ void PlacedFloats::add(Item newFloatItem)
 bool PlacedFloats::Item::isInFormattingContextOf(const ElementBox& formattingContextRoot) const
 {
     ASSERT(formattingContextRoot.establishesFormattingContext());
+    // FIXME: No layout box means the render tree integration codepath put it here, which it only does for intruding floats from outside the inline formatting context.
+    // This works as long as the incoming formattingContextRoot is the current IFC.
+    if (!m_layoutBox)
+        return false;
+
     ASSERT(!is<InitialContainingBlock>(m_layoutBox));
     for (CheckedRef containingBlock : containingBlockChain(*m_layoutBox)) {
         if (containingBlock.ptr() == &formattingContextRoot)
             return true;
     }
-    ASSERT_NOT_REACHED();
     return false;
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
@@ -83,6 +83,9 @@ static std::optional<InlineItemRange> NODELETE partialRangeForDamage(const Inlin
 
 static bool NODELETE isEmptyInlineContent(const InlineItemList& inlineItemList)
 {
+    if (inlineItemList.isEmpty())
+        return true;
+
     // Very common, pseudo before/after empty content.
     if (inlineItemList.size() != 1)
         return false;
@@ -114,7 +117,8 @@ std::unique_ptr<InlineLayoutResult> InlineFormattingContext::layout(const Constr
         return { };
     }
 
-    if (!root().hasInFlowChild() && !root().hasOutOfFlowChild()) {
+    auto hasExcludedMarker = !layoutState().excludedMarkerLayoutBounds().isEmpty();
+    if (!root().hasInFlowChild() && !root().hasOutOfFlowChild() && !hasExcludedMarker) {
         // Float only content does not support partial layout.
         ASSERT(!InlineInvalidation::mayOnlyNeedPartialLayout(lineDamage));
         layoutFloatContentOnly(constraints);
@@ -123,6 +127,13 @@ std::unique_ptr<InlineLayoutResult> InlineFormattingContext::layout(const Constr
 
     auto& inlineItems = inlineContentCache().inlineItems();
     auto& inlineItemList = inlineItems.content();
+    if (inlineItemList.isEmpty() && hasExcludedMarker) {
+        auto layoutResult = makeUniqueRef<InlineLayoutResult>();
+        createDisplayContentForEmptyInlineContent(constraints, inlineItemList, layoutResult.get());
+        layoutResult->range = InlineLayoutResult::Range::Full;
+        return layoutResult.moveToUniquePtr();
+    }
+
     auto needsLayoutRange = [&]() -> InlineItemRange {
         if (!InlineInvalidation::mayOnlyNeedPartialLayout(lineDamage))
             return { { }, { inlineItemList.size(), { } } };

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -139,6 +139,16 @@ InlineRect InlineFormattingUtils::flipVisualRectToLogicalForWritingMode(const In
     return visualRect;
 }
 
+InlineLayoutUnit InlineFormattingUtils::computedTextIndentForFirstLine(const ElementBox& root, InlineLayoutUnit availableWidth)
+{
+    auto shouldIndent = root.style().textIndent().eachLine.has_value() || (root.isAnonymousTextIndentCandidateForIntegration() || !root.isAnonymous() || (!root.isInlineIntegrationRoot() && root.parent().firstInFlowChild() == &root));
+    // Specifying 'hanging' inverts whether the line should be indented or not.
+    if (shouldIndent == root.style().textIndent().hanging.has_value())
+        return { };
+    auto& textIndentAmount = root.style().textIndent().amount;
+    return textIndentAmount == 0_css_px ? 0.f : Style::evaluate<InlineLayoutUnit>(textIndentAmount, availableWidth, root.style().usedZoomForLength());
+}
+
 InlineLayoutUnit InlineFormattingUtils::computedTextIndent(IsIntrinsicWidthMode isIntrinsicWidthMode, IsFirstFormattedLine isFirstFormattedLine, std::optional<PreviousLineEndsParagraph> previousLineEndsParagraph, InlineLayoutUnit availableWidth) const
 {
     CheckedRef root = formattingContext().root();

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h
@@ -46,6 +46,7 @@ public:
     enum class IsIntrinsicWidthMode : bool { No, Yes };
     enum class PreviousLineEndsParagraph : bool { No, Yes };
     InlineLayoutUnit computedTextIndent(IsIntrinsicWidthMode, IsFirstFormattedLine, std::optional<PreviousLineEndsParagraph>, InlineLayoutUnit availableWidth) const;
+    static InlineLayoutUnit computedTextIndentForFirstLine(const ElementBox& root, InlineLayoutUnit availableWidth);
 
     bool inlineLevelBoxAffectsLineBox(const InlineLevelBox&) const;
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -398,8 +398,10 @@ InlineItemsBuilder::LayoutQueue InlineItemsBuilder::initializeLayoutQueue(Inline
 {
     CheckedRef root = this->root();
     if (!root->firstChild()) {
-        // There should always be at least one inflow child in this inline formatting context.
-        ASSERT_NOT_REACHED();
+        // A list item's outside marker is not in the box tree and takes no part in the line, so a list item with
+        // nothing else in it has no inflow child at all while still needing the line the marker sits on
+        // (see InlineFormattingContext::layout). Nothing else establishes a childless inline formatting context.
+        ASSERT(root->isListItem());
         return { };
     }
 
@@ -745,7 +747,9 @@ static inline void buildBidiParagraph(const Style::ComputedStyle& rootStyle, con
 
 void InlineItemsBuilder::breakAndComputeBidiLevels(InlineItemList& inlineItemList)
 {
-    ASSERT(!inlineItemList.isEmpty());
+    // A list item with nothing but its outside marker has no inline items at all, the marker not being in the box
+    // tree, and still needs the line the marker sits on (see InlineFormattingContext::layout).
+    ASSERT(!inlineItemList.isEmpty() || root().isListItem());
 
     StringBuilder paragraphContentBuilder;
     InlineItemOffsetList inlineItemOffsets;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
@@ -861,7 +861,8 @@ void LineBoxBuilder::stretchRootInlineBoxForExcludedMarkers(LineBox& lineBox) co
 
 void LineBoxBuilder::computeLineBoxGeometry(LineBox& lineBox) const
 {
-    auto lineBoxLogicalHeight = applyTextBoxTrimOnLineBoxIfNeeded(LineBoxVerticalAligner { formattingContext() }.computeLogicalHeightAndAlign(lineBox, lineLayoutResult().hasContentfulInlineContent()), lineBox);
+    auto hasContentfulInlineContent = lineLayoutResult().hasContentfulInlineContent() || (isFirstFormattedLine() && !layoutState().excludedMarkerLayoutBounds().isEmpty());
+    auto lineBoxLogicalHeight = applyTextBoxTrimOnLineBoxIfNeeded(LineBoxVerticalAligner { formattingContext() }.computeLogicalHeightAndAlign(lineBox, hasContentfulInlineContent), lineBox);
     if (formattingContext().quirks().shouldCollapseLineBoxHeight(lineLayoutResult().runs, m_outsideListMarkers.size()))
         lineBoxLogicalHeight = { };
     lineBox.setLogicalRect({ lineLayoutResult().lineGeometry.logicalTopLeft, lineLayoutResult().lineGeometry.logicalWidth, lineBoxLogicalHeight });

--- a/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
@@ -245,11 +245,6 @@ bool InlineQuirks::shouldCollapseLineBoxHeight(const Line::RunList& lineContent,
     if (emptyInlineBoxCount && emptyInlineBoxCount == lineContent.size() - 1)
         return true;
 
-    // When an outside marker ends up in an anonymous block because blockification (e.g., by a flex/grid container)
-    // prevented finding a line box parent, collapse the line box so it doesn’t inflate the list item.
-    if (markerBox->shouldCollapseAnonymousBlockParentForListMarker())
-        return true;
-
     auto& rootBox = formattingContext().root();
     if (rootBox.isAnonymous() || rootBox.isListItem())
         return false;

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
@@ -138,8 +138,13 @@ InlineDisplay::Line InlineDisplayLineBuilder::build(const LineLayoutResult& line
         ? rootInlineBoxRect.left()
         : lineBoxLogicalRect.width() - lineLayoutResult.contentGeometry.logicalRightIncludingNegativeMargin; // Note that with hanging content lineLayoutResult.contentGeometry.logicalRight is not the same as rootLineBoxRect.right().
 
-    auto hasInflowContent = [&] {
+    auto hasContentfulContent = [&] {
         if (lineLayoutResult.hasContentfulInFlowContent())
+            return true;
+        return lineLayoutResult.isFirstLast.isFirstFormattedLine == IsFirstFormattedLine::Yes && !formattingContext().layoutState().excludedMarkerLayoutBounds().isEmpty();
+    };
+    auto hasInflowContent = [&] {
+        if (hasContentfulContent())
             return true;
         for (auto& run : lineLayoutResult.runs) {
             if (!run.isOutOfFlow())
@@ -149,7 +154,7 @@ InlineDisplay::Line InlineDisplayLineBuilder::build(const LineLayoutResult& line
     };
     auto writingMode = root().writingMode();
     return InlineDisplay::Line { hasInflowContent()
-        , lineLayoutResult.hasContentfulInFlowContent()
+        , hasContentfulContent()
         , lineLayoutResult.isBlockContent()
         , lineBoxLogicalRect
         , mapLineRectLogicalToVisual(lineBoxLogicalRect, constraints.formattingRootBorderBoxSize(), writingMode)

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -704,8 +704,9 @@ void BoxGeometryUpdater::setFormattingContextContentGeometry(std::optional<Layou
 
     if (rootLayoutBox().establishesInlineFormattingContext()) {
         for (auto walker = InlineWalker(downcast<RenderBlockFlow>(rootRenderer())); !walker.atEnd(); walker.advance()) {
-            if (!is<RenderText>(walker.current()))
-                updateBoxGeometry(downcast<RenderElement>(*walker.current()), availableLogicalWidth, intrinsicWidthMode);
+            if (walker.current()->isExcludedMarker() || is<RenderText>(walker.current()))
+                continue;
+            updateBoxGeometry(downcast<RenderElement>(*walker.current()), availableLogicalWidth, intrinsicWidthMode);
         }
         return;
     }

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -235,9 +235,6 @@ static EnumSet<Layout::ElementBox::ListMarkerAttribute> calculateListMarkerAttri
     auto listMarkerAttributes = EnumSet<Layout::ElementBox::ListMarkerAttribute> { };
     if (listMarkerRenderer.isImage())
         listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Image);
-    if (listMarkerRenderer.shouldCollapseAnonymousBlockParent())
-        listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::ShouldCollapseAnonymousBlockParent);
-
     return listMarkerAttributes;
 }
 
@@ -318,7 +315,8 @@ void BoxTreeUpdater::buildTreeForInlineContent()
 {
     for (auto walker = InlineWalker(downcast<RenderBlockFlow>(m_rootRenderer)); !walker.atEnd(); walker.advance()) {
         CheckedRef childRenderer = *walker.current();
-        ASSERT_IMPLIES(is<RenderBox>(childRenderer.get()), !childRenderer->isExcludedMarker());
+        if (childRenderer->isExcludedMarker())
+            continue;
         auto childLayoutBox = [&] {
             if (auto existingChildBox = childRenderer->layoutBox())
                 return existingChildBox->removeFromParent();

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -546,8 +546,12 @@ void LineLayout::setExcludedMarkerPositions(const ExcludedMarkerList& excludedMa
 
     auto lineBoxLogicalRect = firstContentfulLine->lineBoxLogicalRect();
     auto isLeftToRight = flow().writingMode().isLogicalLeftInlineStart();
+    // text-indent is a margin on the line box, not content the marker hangs off.
+    ASSERT(m_inlineContentConstraints);
+    auto textIndent = Layout::InlineFormattingUtils::computedTextIndentForFirstLine(rootLayoutBox(), m_inlineContentConstraints->horizontal().logicalWidth);
     auto lineStartEdge = [&] {
         auto edge = isLeftToRight ? lineBoxLogicalRect.x() : lineBoxLogicalRect.maxX();
+        edge += isLeftToRight ? -textIndent : textIndent;
         // A float of this formatting context took room from the line, but the marker hangs off where the line would
         // have started without it. One intruding from earlier content moves the marker with the line instead
         // (webkit.org/b/166528).

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -546,10 +546,24 @@ void LineLayout::setExcludedMarkerPositions(const ExcludedMarkerList& excludedMa
 
     auto lineBoxLogicalRect = firstContentfulLine->lineBoxLogicalRect();
     auto isLeftToRight = flow().writingMode().isLogicalLeftInlineStart();
-    // How far the line start sits inwards from our content box start, which is what caps how far to the logical left
-    // (right in a right to left inline direction) a nesting list item's marker may go. An intruding float is the usual
-    // reason for it to be non zero.
-    auto lineStartInset = isLeftToRight ? lineBoxLogicalRect.x() : flow().contentBoxLogicalWidth() - lineBoxLogicalRect.maxX();
+    auto lineStartEdge = [&] {
+        auto edge = isLeftToRight ? lineBoxLogicalRect.x() : lineBoxLogicalRect.maxX();
+        // A float of this formatting context took room from the line, but the marker hangs off where the line would
+        // have started without it. One intruding from earlier content moves the marker with the line instead
+        // (webkit.org/b/166528).
+        for (auto& floatItem : m_blockFormattingState.placedFloats().list()) {
+            if (!floatItem.isInFormattingContextOf(rootLayoutBox()))
+                continue;
+            auto floatRect = floatItem.absoluteRectWithMargin();
+            if (floatRect.bottom() <= lineBoxLogicalRect.y() || floatRect.top() >= lineBoxLogicalRect.maxY())
+                continue;
+            edge += isLeftToRight ? -floatRect.width() : floatRect.width();
+        }
+        return edge;
+    }();
+
+    auto contentBoxStartEdge = isLeftToRight ? 0.f : flow().contentBoxLogicalWidth().toFloat();
+    auto isLineStartConstrainedByFloat = lineStartEdge != contentBoxStartEdge;
     for (auto& marker : excludedMarkers) {
         // Vertical: baseline aligned, with the ascent the inline formatting context would have given it.
         auto markerAscent = [&]() -> float {
@@ -562,11 +576,11 @@ void LineLayout::setExcludedMarkerPositions(const ExcludedMarkerList& excludedMa
         // inline direction (the marker's start margin is what holds the gap, hence negative).
         auto markerLogicalLeft = [&]() -> float {
             if (isLeftToRight)
-                return lineBoxLogicalRect.x() + marker->marginStart();
-            return lineBoxLogicalRect.maxX() - marker->marginStart() - marker->logicalWidth();
+                return lineStartEdge + marker->marginStart();
+            return lineStartEdge - marker->marginStart() - marker->logicalWidth();
         }();
         auto topLeft = FloatPoint { markerLogicalLeft, lineBoxLogicalRect.y() + firstContentfulLine->baseline() - markerAscent };
-        marker->setExcludedPosition({ flow(), topLeft, lineStartInset });
+        marker->setExcludedPosition({ flow(), topLeft, isLineStartConstrainedByFloat });
     }
 }
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -569,21 +569,15 @@ void LineLayout::setExcludedMarkerPositions(const ExcludedMarkerList& excludedMa
     auto contentBoxStartEdge = isLeftToRight ? 0.f : flow().contentBoxLogicalWidth().toFloat();
     auto isLineStartConstrainedByFloat = lineStartEdge != contentBoxStartEdge;
     for (auto& marker : excludedMarkers) {
-        // Vertical: baseline aligned, with the ascent the inline formatting context would have given it.
-        auto markerAscent = [&]() -> float {
+        auto markerLogicalTop = [&]() -> float {
             if (firstContentfulLine->baselineType() == FontBaseline::Ideographic)
-                return flow().style().metricsOfPrimaryFont().ascent(FontBaseline::Ideographic);
-            // An image marker's baseline is its margin box bottom (it has no block axis margins), a text driven one behaves as text and sits on the font baseline.
-            return marker->isImage() ? marker->logicalHeight().toFloat() : marker->style().metricsOfPrimaryFont().ascent(FontBaseline::Alphabetic);
+                return lineBoxLogicalRect.y() + (lineBoxLogicalRect.height() - marker->logicalHeight().toFloat()) / 2;
+            auto markerAscent = marker->isImage() ? marker->logicalHeight().toFloat() : marker->style().metricsOfPrimaryFont().ascent(FontBaseline::Alphabetic);
+            return lineBoxLogicalRect.y() + firstContentfulLine->baseline() - markerAscent;
         }();
-        // Horizontal: just outside the line's inline start edge, which is the line's logical right in a right to left
-        // inline direction (the marker's start margin is what holds the gap, hence negative).
-        auto markerLogicalLeft = [&]() -> float {
-            if (isLeftToRight)
-                return lineStartEdge + marker->marginStart();
-            return lineStartEdge - marker->marginStart() - marker->logicalWidth();
-        }();
-        auto topLeft = FloatPoint { markerLogicalLeft, lineBoxLogicalRect.y() + firstContentfulLine->baseline() - markerAscent };
+        auto markerMarginStart = marker->marginStart(flow().writingMode()).toFloat();
+        auto markerLogicalLeft = isLeftToRight ? lineStartEdge + markerMarginStart : lineStartEdge - markerMarginStart - marker->logicalWidth().toFloat();
+        auto topLeft = FloatPoint { markerLogicalLeft, markerLogicalTop };
         marker->setExcludedPosition({ flow(), topLeft, isLineStartConstrainedByFloat });
     }
 }

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -1554,6 +1554,14 @@ void LineLayout::shiftLinesByInBlockDirection(LayoutUnit blockShift)
     for (size_t lineIndex = 0; lineIndex < displayContent.lines.size(); ++lineIndex)
         displayContent.moveLineInBlockDirection(lineIndex, blockShift);
 
+    // An excluded marker is on one of these lines without being part of the content that moves with them, so the
+    // position it was given has to move too (see RenderListItem::placeExcludedMarker).
+    if (CheckedPtr marker = RenderListItem::excludedMarkerAnchoredTo(flow())) {
+        auto excludedPosition = *marker->excludedPosition();
+        excludedPosition.topLeft.move(0, blockShift.toFloat());
+        marker->setExcludedPosition(excludedPosition);
+    }
+
     auto deltaX = isHorizontalWritingMode ? 0_lu : blockShift;
     auto deltaY = isHorizontalWritingMode ? blockShift : 0_lu;
     for (auto& box : m_inlineContent->displayContent().boxes) {

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.h
@@ -48,7 +48,6 @@ public:
 
     enum class ListMarkerAttribute : uint8_t {
         Image,
-        ShouldCollapseAnonymousBlockParent,
     };
     ElementBox(ElementAttributes&&, EnumSet<ListMarkerAttribute>, Style::ComputedStyle&&, std::unique_ptr<Style::ComputedStyle>&& firstLineStyle = nullptr);
 
@@ -100,7 +99,6 @@ public:
     void setListMarkerAttributes(EnumSet<ListMarkerAttribute> listMarkerAttributes) { m_replacedData->listMarkerAttributes = listMarkerAttributes; }
 
     bool isListMarkerImage() const { return m_replacedData && m_replacedData->listMarkerAttributes.contains(ListMarkerAttribute::Image); }
-    bool shouldCollapseAnonymousBlockParentForListMarker() const { return m_replacedData && m_replacedData->listMarkerAttributes.contains(ListMarkerAttribute::ShouldCollapseAnonymousBlockParent); }
 
     // FIXME: This is temporary until after list marker content is accessible by IFC (webkit.org/b/294342)
     void setListMarkerLayoutBounds(std::pair<float, float> layoutBounds) { m_replacedData->layoutBounds = layoutBounds; }

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1132,6 +1132,8 @@ void RenderBlockFlow::computeAndSetLineLayoutPath()
 
 void RenderBlockFlow::layoutInlineChildren(RelayoutChildren relayoutChildren, LayoutUnit previousHeight, LayoutUnit& repaintLogicalTop, LayoutUnit& repaintLogicalBottom)
 {
+    layoutExcludedChildren(relayoutChildren);
+
     computeAndSetLineLayoutPath();
 
     if (lineLayoutPath() == InlinePath)
@@ -4309,8 +4311,9 @@ RenderBlockFlow::InlineContentStatus RenderBlockFlow::markInlineContentDirtyForL
         auto isInFlowBlockLevelElement = box && box->isBlockLevelBox() && box->isInFlow();
         hasInFlowBlockLevelElement |= isInFlowBlockLevelElement;
         hasDirtyInFlowBlockLevelElement |= (isInFlowBlockLevelElement && box->needsLayout());
-        auto childNeedsLayout = relayoutChildren == RelayoutChildren::Yes || (box && box->hasRelativeDimensions() && !box->isBlockLevelBox());
-        auto childNeedsIntrinsicWidthComputation = relayoutChildren == RelayoutChildren::Yes && box && box->shouldInvalidateContentWidths();
+        auto childNeedsLayout = !renderer.isExcludedFromNormalLayout() && (relayoutChildren == RelayoutChildren::Yes || (box && box->hasRelativeDimensions() && !box->isBlockLevelBox()));
+        auto childNeedsIntrinsicWidthComputation = !renderer.isExcludedFromNormalLayout() && relayoutChildren == RelayoutChildren::Yes && box && box->shouldInvalidateContentWidths();
+
         if (childNeedsLayout)
             renderer.setNeedsLayout(MarkingBehavior::MarkOnlyThis);
         if (childNeedsIntrinsicWidthComputation)

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -805,21 +805,31 @@ void RenderInline::collectLineBoxRects(Vector<LayoutRect>& rects, const LayoutPo
     generateLineBoxRects(context);
 }
 
-bool isEmptyInline(const RenderInline& renderer)
+static RenderObject* firstContentfulChild(const RenderInline& renderer)
 {
     for (auto& current : childrenOfType<RenderObject>(renderer)) {
         if (current.isFloatingOrOutOfFlowPositioned())
             continue;
-        if (auto* text = dynamicDowncast<RenderText>(current)) {
-            if (!text->containsOnlyCollapsibleWhitespace())
-                return false;
+        if (auto* text = dynamicDowncast<RenderText>(current); text && text->containsOnlyCollapsibleWhitespace())
+            continue;
+        if (auto* renderInline = dynamicDowncast<RenderInline>(current)) {
+            if (auto* nested = firstContentfulChild(*renderInline))
+                return nested;
             continue;
         }
-        auto* renderInline = dynamicDowncast<RenderInline>(current);
-        if (!renderInline || !isEmptyInline(*renderInline))
-            return false;
+        return const_cast<RenderObject*>(&current);
     }
-    return true;
+    return { };
+}
+
+bool isEmptyInline(const RenderInline& renderer)
+{
+    return !firstContentfulChild(renderer);
+}
+
+RenderObject* firstContentfulChild(RenderInline& renderer)
+{
+    return firstContentfulChild(const_cast<const RenderInline&>(renderer));
 }
 
 bool RenderInline::requiresLayer() const

--- a/Source/WebCore/rendering/RenderInline.h
+++ b/Source/WebCore/rendering/RenderInline.h
@@ -29,6 +29,7 @@
 namespace WebCore {
 
 class Position;
+class RenderBlock;
 class RenderFragmentContainer;
 
 class RenderInline : public RenderBoxModelObject {
@@ -145,6 +146,7 @@ private:
 };
 
 bool isEmptyInline(const RenderInline&);
+RenderObject* firstContentfulChild(RenderInline&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -96,7 +96,7 @@ static MarkerSearchBoxType markerSearchBoxType(const RenderObject& box)
     return MarkerSearchBoxType::BlockContainer;
 }
 
-static LayoutUnit excludedMarkerLogicalLeftOffsetFor(const RenderBlockFlow& firstFormattedLineRoot, const RenderListItem& listItem, LayoutUnit lineStartInset)
+static LayoutUnit excludedMarkerLogicalLeftOffsetFor(const RenderBlockFlow& firstFormattedLineRoot, const RenderListItem& listItem, bool isLineStartConstrainedByFloat)
 {
     // <ul><li id=o><ul><li id=i><div style="border-left: 5px solid">text</div></li></ul></li></ul>
     // UA sets 40px start padding on <ul>
@@ -134,10 +134,10 @@ static LayoutUnit excludedMarkerLogicalLeftOffsetFor(const RenderBlockFlow& firs
             if (box.get() == &listItem)
                 break;
         }
-        // A float pushing the line start inwards also constrains the marker, which sits to the logical left of it.
-        // Nesting list items then all end up with their marker in the same place, just left of the line.
-        if (lineStartInset)
-            toAssociatedListItem = std::min(0_lu, std::max(lineStartInset, toAssociatedListItem));
+        // A float pushing the line start inwards also constrains the marker, so it stays with the line rather than
+        // moving out to its own list item. Nesting list items then all end up with their marker in the same place.
+        if (isLineStartConstrainedByFloat)
+            toAssociatedListItem = { };
     }
 
     // The offsets above are inline start relative (negative means further towards the inline start), while what we return is a logical left offset, so in a right to left inline direction it points the other way.
@@ -590,7 +590,7 @@ void RenderListItem::placeExcludedMarker(RenderListOutsideMarker& marker)
     // Line layout placed the marker on the line as if it belonged to the list item establishing that formatting context.
     // Take it from there: out to our own border box start, then across the in-flow content up to us.
     auto logicalTop = LayoutUnit { excludedPosition->topLeft.y() };
-    auto logicalLeft = LayoutUnit { excludedPosition->topLeft.x() } + excludedMarkerLogicalLeftOffsetFor(*firstFormattedLineRoot, *this, LayoutUnit { excludedPosition->lineStartInset });
+    auto logicalLeft = LayoutUnit { excludedPosition->topLeft.x() } + excludedMarkerLogicalLeftOffsetFor(*firstFormattedLineRoot, *this, excludedPosition->isLineStartConstrainedByFloat);
     for (CheckedPtr<RenderBlock> ancestor = firstFormattedLineRoot; ancestor && ancestor != this; ancestor = ancestor->containingBlock()) {
         // Inside a fragmented flow the coordinates are in flow thread space, where the content is one continuous
         // strip. The column the line ended up in is a sibling of the flow thread rather than an ancestor, so leave

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -458,12 +458,27 @@ void RenderListItem::styleDidChange(Style::Difference diff, const Style::Compute
     }
 }
 
+void RenderListItem::computeIntrinsicLogicalWidthContributions()
+{
+    // FIXME: RenderListOutsideMarker::updateInlineMargins() mutates margin style which affects preferred widths.
+    if (CheckedPtr marker = markerBox(); marker && marker->hasInvalidContentLogicalWidths())
+        marker->updateInlineMarginsAndContent();
+
+    RenderBlockFlow::computeIntrinsicLogicalWidthContributions();
+}
+
+std::pair<LayoutUnit, LayoutUnit> RenderListItem::computeIntrinsicLogicalWidths() const
+{
+    if (CheckedPtr excludedMarker = this->excludedMarker(); excludedMarker && !excludedMarker->nextSibling())
+        return { };
+
+    return RenderBlockFlow::computeIntrinsicLogicalWidths();
+}
+
 RenderListOutsideMarker* RenderListItem::excludedMarker() const
 {
     auto* marker = markerBox();
-    if (marker && marker->parent() == this && marker->isExcludedMarker())
-        return marker;
-    return { };
+    return marker && marker->isExcludedMarker() ? marker : nullptr;
 }
 
 void RenderListItem::layoutBlock(RelayoutChildren relayoutChildren, LayoutUnit pageLogicalHeight)
@@ -483,6 +498,23 @@ void RenderListItem::layoutExcludedChildren(RelayoutChildren relayoutChildren)
     CheckedPtr excludedMarker = this->excludedMarker();
     if (!excludedMarker)
         return RenderBlockFlow::layoutExcludedChildren(relayoutChildren);
+
+    auto markerNeedsOwnLine = [&] {
+        // Quirks mode puts the marker of a list item that starts with a nested list on a line of its own above that list, rather than on the line its first item makes.
+        if (!document().inQuirksMode())
+            return false;
+        for (CheckedPtr child = firstChild(); child; child = child->nextSibling()) {
+            if (child.get() == m_marker.get() || child->isFloatingOrOutOfFlowPositioned() || is<RenderMenuList>(*child))
+                continue;
+            return child->node() && isHTMLListElement(*child->node());
+        }
+        return false;
+    };
+
+    // The marker takes no part in layout, so a line of its own is room this list item makes for it before its block
+    // children are placed. layoutBlockChildren calls us right after it starts them at the content edge.
+    if (!childrenInline() && markerNeedsOwnLine())
+        setLogicalHeight(logicalHeight() + lineHeight());
 
     excludedMarker->setIsExcludedFromNormalLayout(true);
     if (relayoutChildren == RelayoutChildren::Yes)
@@ -510,6 +542,28 @@ void RenderListItem::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintO
         excludedMarker->paintAsInlineBlock(paintInfo, flipForWritingModeForChild(*excludedMarker, paintOffset));
 
     RenderBlockFlow::paintObject(paintInfo, paintOffset);
+}
+
+bool RenderListItem::hasLineIfEmpty() const
+{
+    if (excludedMarker())
+        return true;
+
+    return RenderBlockFlow::hasLineIfEmpty();
+}
+
+bool RenderListItem::nodeAtPoint(const HitTestRequest& request, HitTestResult& result, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction hitTestAction)
+{
+    if (RenderBlockFlow::nodeAtPoint(request, result, locationInContainer, accumulatedOffset, hitTestAction))
+        return true;
+
+    CheckedPtr excludedMarker = this->excludedMarker();
+    if (!excludedMarker || excludedMarker->hasSelfPaintingLayer())
+        return false;
+
+    // The marker's own location is relative to us, so it needs our adjusted one, the way hitTestChildren gets it.
+    auto adjustedLocation = accumulatedOffset + location();
+    return excludedMarker->nodeAtPoint(request, result, locationInContainer, flipForWritingModeForChild(*excludedMarker, adjustedLocation), hitTestAction);
 }
 
 RenderListOutsideMarker* RenderListItem::markerBox() const
@@ -613,8 +667,21 @@ void RenderListItem::placeExcludedMarker(RenderListOutsideMarker& marker)
 
 RenderListItem::FirstFormattedLineCandidate RenderListItem::firstFormattedLineRootFor(RenderBlock& blockContainer, const RenderBoxModelObject& marker)
 {
-    RenderBlock* fallbackParent = { };
-    bool stoppedAtTableRubyOrReplaced = false;
+    RenderBlock* fallbackParent = is<RenderListItem>(blockContainer) && blockContainer.childrenInline() ? &blockContainer : nullptr;
+
+    auto firstFormattedLineRootIn = [&](RenderBlock& block) -> CheckedPtr<RenderBlock> {
+        auto nestedResult = firstFormattedLineRootFor(block, marker);
+        if (nestedResult.parent)
+            return nestedResult.parent;
+
+        if (!fallbackParent) {
+            if (nestedResult.fallbackParent)
+                fallbackParent = nestedResult.fallbackParent.get();
+            else if (auto* firstInFlowChild = block.firstInFlowChild(); !firstInFlowChild || firstInFlowChild == &marker)
+                fallbackParent = &block;
+        }
+        return { };
+    };
 
     for (auto& child : childrenOfType<RenderObject>(blockContainer)) {
         if (&child == &marker)
@@ -624,18 +691,30 @@ RenderListItem::FirstFormattedLineCandidate RenderListItem::firstFormattedLineRo
         case MarkerSearchBoxType::Opaque:
             break;
         case MarkerSearchBoxType::NestedListInQuirksMode:
-            return { { }, fallbackParent, stoppedAtTableRubyOrReplaced };
+            return { { }, fallbackParent };
         case MarkerSearchBoxType::TableRubyOrReplaced:
-            return { { }, fallbackParent, true };
+            return { { }, fallbackParent };
         case MarkerSearchBoxType::InlineContent:
             // Neither an empty inline (e.g. <a id="anchor"></a>) nor collapsible whitespace produces a line.
-            if (CheckedPtr inlineBox = dynamicDowncast<RenderInline>(child); inlineBox && isEmptyInline(*inlineBox)) {
+            if (CheckedPtr text = dynamicDowncast<RenderText>(child); text && text->containsOnlyCollapsibleWhitespace()) {
                 fallbackParent = &blockContainer;
                 break;
             }
-            if (CheckedPtr text = dynamicDowncast<RenderText>(child); text && text->containsOnlyCollapsibleWhitespace())
-                break;
-            return { &blockContainer, { }, false };
+            if (CheckedPtr inlineBox = dynamicDowncast<RenderInline>(child)) {
+                if (isEmptyInline(*inlineBox)) {
+                    fallbackParent = &blockContainer;
+                    break;
+                }
+                // An inside marker takes a line ahead of the block, so only an outside marker follows the content in.
+                if (is<RenderListOutsideMarker>(marker)) {
+                    if (CheckedPtr leadingBlock = dynamicDowncast<RenderBlock>(firstContentfulChild(*inlineBox))) {
+                        if (auto firstFormattedLineRoot = firstFormattedLineRootIn(*leadingBlock))
+                            return { firstFormattedLineRoot, { } };
+                        break;
+                    }
+                }
+            }
+            return { &blockContainer, { } };
         case MarkerSearchBoxType::BlockContainer:
         case MarkerSearchBoxType::SpannerPlaceholder: {
             auto blockToDescendInto = [&] {
@@ -644,28 +723,14 @@ RenderListItem::FirstFormattedLineCandidate RenderListItem::firstFormattedLineRo
                 return dynamicDowncast<RenderBlock>(child);
             };
             if (CheckedPtr block = blockToDescendInto()) {
-                auto nestedResult = firstFormattedLineRootFor(*block, marker);
-                if (nestedResult.parent) {
-                    // Finding a line box parent is mutually exclusive with having stopped at one of those.
-                    ASSERT(!nestedResult.stoppedAtTableRubyOrReplaced);
-                    return { nestedResult.parent, { }, false };
-                }
-
-                // Propagate it from nested searches, so we know whether the search failed on such a box or simply found no inline content.
-                stoppedAtTableRubyOrReplaced |= nestedResult.stoppedAtTableRubyOrReplaced;
-
-                if (!fallbackParent) {
-                    if (nestedResult.fallbackParent)
-                        fallbackParent = nestedResult.fallbackParent;
-                    else if (auto* firstInFlowChild = block->firstInFlowChild(); !firstInFlowChild || firstInFlowChild == &marker)
-                        fallbackParent = block.get();
-                }
+                if (auto firstFormattedLineRoot = firstFormattedLineRootIn(*block))
+                    return { firstFormattedLineRoot, { } };
             }
             break;
         }
         }
     }
-    return { { }, fallbackParent, stoppedAtTableRubyOrReplaced };
+    return { { }, fallbackParent };
 }
 
 CheckedPtr<RenderListOutsideMarker> RenderListItem::excludedMarkerAnchoredTo(const RenderBlockFlow& firstFormattedLineRoot)
@@ -692,7 +757,8 @@ Vector<CheckedPtr<RenderListOutsideMarker>> RenderListItem::excludedMarkersForCo
             ASSERT_NOT_REACHED();
             continue;
         }
-        if (firstFormattedLineRootFor(*listItem, *marker).parent == &inlineRoot)
+        auto candidate = firstFormattedLineRootFor(*listItem, *marker);
+        if ((candidate.parent ? candidate.parent : candidate.fallbackParent) == &inlineRoot)
             markersForContainer.append(marker.get());
     }
     return markersForContainer;

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -668,6 +668,20 @@ RenderListItem::FirstFormattedLineCandidate RenderListItem::firstFormattedLineRo
     return { { }, fallbackParent, stoppedAtTableRubyOrReplaced };
 }
 
+CheckedPtr<RenderListOutsideMarker> RenderListItem::excludedMarkerAnchoredTo(const RenderBlockFlow& firstFormattedLineRoot)
+{
+    for (CheckedPtr<const RenderBlock> ancestor = &firstFormattedLineRoot; ancestor; ancestor = ancestor->containingBlock()) {
+        CheckedPtr listItem = dynamicDowncast<RenderListItem>(ancestor.get());
+        CheckedPtr marker = listItem ? listItem->markerBox() : nullptr;
+        if (!marker || !marker->isExcludedMarker())
+            continue;
+        auto excludedPosition = marker->excludedPosition();
+        if (excludedPosition && excludedPosition->firstFormattedLineRoot.get() == &firstFormattedLineRoot)
+            return marker;
+    }
+    return { };
+}
+
 Vector<CheckedPtr<RenderListOutsideMarker>> RenderListItem::excludedMarkersForContainer(const RenderBlockFlow& inlineRoot, const Vector<SingleThreadWeakPtr<RenderListOutsideMarker>>& allExcludedMarkers)
 {
     auto markersForContainer = Vector<CheckedPtr<RenderListOutsideMarker>> { };

--- a/Source/WebCore/rendering/RenderListItem.h
+++ b/Source/WebCore/rendering/RenderListItem.h
@@ -66,6 +66,7 @@ public:
     };
     static FirstFormattedLineCandidate firstFormattedLineRootFor(RenderBlock& blockContainer, const RenderBoxModelObject& marker);
     static Vector<CheckedPtr<RenderListOutsideMarker>> excludedMarkersForContainer(const RenderBlockFlow& lineContainer, const Vector<SingleThreadWeakPtr<RenderListOutsideMarker>>&);
+    static CheckedPtr<RenderListOutsideMarker> excludedMarkerAnchoredTo(const RenderBlockFlow& firstFormattedLineRoot);
 
 private:
     ASCIILiteral renderName() const final { return "RenderListItem"_s; }

--- a/Source/WebCore/rendering/RenderListItem.h
+++ b/Source/WebCore/rendering/RenderListItem.h
@@ -61,8 +61,6 @@ public:
     struct FirstFormattedLineCandidate {
         CheckedPtr<RenderBlock> parent;
         CheckedPtr<RenderBlock> fallbackParent;
-        // FIXME: handle all block level children, not just replaced elements that got blockified.
-        bool stoppedAtTableRubyOrReplaced { false };
     };
     static FirstFormattedLineCandidate firstFormattedLineRootFor(RenderBlock& blockContainer, const RenderBoxModelObject& marker);
     static Vector<CheckedPtr<RenderListOutsideMarker>> excludedMarkersForContainer(const RenderBlockFlow& lineContainer, const Vector<SingleThreadWeakPtr<RenderListOutsideMarker>>&);
@@ -73,6 +71,8 @@ private:
 
     void paint(PaintInfo&, const LayoutPoint&) final;
     void paintObject(PaintInfo&, const LayoutPoint&) final;
+    bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) final;
+    bool hasLineIfEmpty() const final;
 
     void layoutBlock(RelayoutChildren, LayoutUnit pageLogicalHeight = 0_lu) final;
     void layoutExcludedChildren(RelayoutChildren) final;
@@ -82,6 +82,8 @@ private:
 
     void styleDidChange(Style::Difference, const Style::ComputedStyle* oldStyle) final;
 
+    void computeIntrinsicLogicalWidthContributions() final;
+    std::pair<LayoutUnit, LayoutUnit> computeIntrinsicLogicalWidths() const final;
 
     void updateValueAndMarkerContent();
     void updateValueNow() const;

--- a/Source/WebCore/rendering/RenderListOutsideMarker.cpp
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.cpp
@@ -44,8 +44,6 @@
 #include "RenderLayer.h"
 #include "RenderListItem.h"
 #include "RenderMenuList.h"
-#include "RenderMultiColumnFlow.h"
-#include "RenderMultiColumnSpannerPlaceholder.h"
 #include "RenderObjectInlines.h"
 #include "RenderTable.h"
 #include "RenderText.h"
@@ -306,9 +304,10 @@ void RenderListOutsideMarker::paint(PaintInfo& paintInfo, const LayoutPoint& pai
         context.translate(-markerRect.x(), -markerRect.maxY());
     }
 
-    if (writingMode().isHorizontal()) {
+    if (writingMode().isHorizontal() && !isExcludedMarker()) {
         // This is required because RenderListOutsideMarker hand-draws the text, instead of running inline
         // layout and paint on its (RenderText) subtree (LayoutUnit vs. float precision)
+        // An excluded marker has no inline box to correct against: the list item placed it directly.
         // FIXME: The vertical path mispositions the marker line box separately (it ignores fallback-font
         // metrics), so this is limited to horizontal writing modes for now. See webkit.org/b/319618.
         if (auto markerInlineBox = InlineIterator::boxFor(*this))
@@ -320,27 +319,10 @@ void RenderListOutsideMarker::paint(PaintInfo& paintInfo, const LayoutPoint& pai
     context.drawText(style().fontCascade(), textRunForContent(m_textContent, style()), textOrigin);
 }
 
-RenderBox* RenderListOutsideMarker::parentBox(RenderBox& box)
-{
-    ASSERT(m_listItem);
-    CheckedPtr multiColumnFlow = dynamicDowncast<RenderMultiColumnFlow>(m_listItem->enclosingFragmentedFlow());
-    if (!multiColumnFlow)
-        return box.parentBox();
-    auto* placeholder = multiColumnFlow->findColumnSpannerPlaceholder(box);
-    return placeholder ? placeholder->parentBox() : box.parentBox();
-};
-
 void RenderListOutsideMarker::layout()
 {
     StackStats::LayoutCheckPoint layoutCheckPoint;
     ASSERT(needsLayout());
-
-    LayoutUnit blockOffset;
-    for (auto* ancestor = parentBox(*this); ancestor && ancestor != m_listItem.get(); ancestor = parentBox(*ancestor))
-        blockOffset += ancestor->logicalTop();
-
-    m_lineLogicalOffsetForListItem = m_listItem->logicalLeftOffsetForLine(blockOffset);
-    m_lineOffsetForListItem = writingMode().isLogicalLeftInlineStart() ? m_lineLogicalOffsetForListItem : m_listItem->logicalRightOffsetForLine(blockOffset);
 
     if (CheckedPtr container = contentContainer()) {
         updateInlineMarginsAndContent();

--- a/Source/WebCore/rendering/RenderListOutsideMarker.h
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.h
@@ -85,7 +85,7 @@ public:
     struct ExcludedPosition {
         SingleThreadWeakPtr<RenderBlockFlow> firstFormattedLineRoot;
         FloatPoint topLeft;
-        float lineStartInset { 0 };
+        bool isLineStartConstrainedByFloat { false };
     };
     void setExcludedPosition(ExcludedPosition);
     std::optional<ExcludedPosition> excludedPosition() const { return m_excludedPosition; }

--- a/Source/WebCore/rendering/RenderListOutsideMarker.h
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.h
@@ -77,7 +77,6 @@ public:
 
     RenderBlockFlow* contentContainer() const;
 
-    LayoutUnit lineLogicalOffsetForListItem() const { return m_lineLogicalOffsetForListItem; }
     RenderListItem* NODELETE listItem() const;
 
     std::pair<float, float> layoutBounds() const { return m_layoutBounds; }
@@ -91,16 +90,6 @@ public:
     std::optional<ExcludedPosition> excludedPosition() const { return m_excludedPosition; }
 
     void invalidateExcludedMarkerContainer();
-
-    bool shouldCollapseAnonymousBlockParent() const { return m_shouldCollapseAnonymousBlockParent; }
-    void setShouldCollapseAnonymousBlockParent(bool value)
-    {
-        if (value) {
-            ASSERT(parent());
-            ASSERT(parent()->isAnonymousBlock());
-        }
-        m_shouldCollapseAnonymousBlockParent = value;
-    }
 
 private:
     void willBeDestroyed() final;
@@ -124,7 +113,6 @@ private:
     void updateInlineMargins();
     void updateContent();
     void updateContentContainerText();
-    RenderBox* parentBox(RenderBox&);
     void layoutContentContainer(RenderBlockFlow&);
 
     FloatRect relativeMarkerRect();
@@ -138,11 +126,8 @@ private:
     RefPtr<Style::Image> m_image;
 
     SingleThreadWeakPtr<RenderListItem> m_listItem;
-    LayoutUnit m_lineOffsetForListItem;
-    LayoutUnit m_lineLogicalOffsetForListItem;
     std::pair<float, float> m_layoutBounds;
     std::optional<ExcludedPosition> m_excludedPosition;
-    bool m_shouldCollapseAnonymousBlockParent { false };
 };
 
 // The room an image marker keeps between itself and the content it labels.

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -69,6 +69,7 @@
 #include "RenderLayerCompositor.h"
 #include "RenderLayerScrollableArea.h"
 #include "RenderLineBreak.h"
+#include "RenderListItem.h"
 #include "RenderListOutsideMarker.h"
 #include "RenderMultiColumnFlow.h"
 #include "RenderMultiColumnSet.h"
@@ -3150,13 +3151,12 @@ VisibleInViewportState RenderObject::imageFrameAvailable(CachedImage& image, Ima
 bool RenderObject::isExcludedMarker() const
 {
     // An excluded list marker is the direct child of its list item, never wrapped in an anonymous block, and no part of in-flow layout.
-    // Only markers whose first formatted line lives in a descendant block qualify (see childrenInline)
     auto* marker = dynamicDowncast<RenderListOutsideMarker>(*this);
     if (!marker)
         return false;
     if (!document().settings().listMarkerPositionedPostLayoutEnabled())
         return false;
-    return parent() && !parent()->childrenInline();
+    return parent() && parent() == marker->listItem();
 }
 
 #if ENABLE(TREE_DEBUGGING)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
@@ -94,8 +94,7 @@ static bool isExcludedMarker(const RenderBlock& parent, const RenderObject& chil
     CheckedPtr marker = dynamicDowncast<RenderListOutsideMarker>(child);
     if (!marker || !marker->document().settings().listMarkerPositionedPostLayoutEnabled())
         return false;
-    CheckedPtr listItem = dynamicDowncast<RenderListItem>(parent);
-    return listItem && !markerNeedsOwnLine(*listItem);
+    return is<RenderListItem>(parent);
 }
 
 static bool hasInlineInFlowChild(const RenderBlock& parent)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -60,32 +60,19 @@ RenderTreeBuilder::List::List(RenderTreeBuilder& builder)
 {
 }
 
-bool markerNeedsOwnLine(const RenderListItem& listItemRenderer)
-{
-    if (!listItemRenderer.document().inQuirksMode())
-        return false;
-    for (CheckedPtr child = listItemRenderer.firstChild(); child; child = child->nextSibling()) {
-        if (child.get() == listItemRenderer.markerRenderer() || child->isFloatingOrOutOfFlowPositioned() || is<RenderMenuList>(*child))
-            continue;
-        return child->node() && isHTMLListElement(*child->node());
-    }
-    return false;
-}
-
 struct MarkerParentSearchResult {
     CheckedPtr<RenderBlock> parent;
-    bool shouldCollapseAnonymousBlockParent { false };
 };
 
 static MarkerParentSearchResult parentCandidateForMarker(RenderListItem& listItemRenderer, const RenderListOutsideMarker& marker)
 {
-    if (listItemRenderer.document().settings().listMarkerPositionedPostLayoutEnabled() && !markerNeedsOwnLine(listItemRenderer)) {
+    if (listItemRenderer.document().settings().listMarkerPositionedPostLayoutEnabled()) {
         // The outside marker is always the list item's first child and it takes no part in in-flow layout.
-        return { &listItemRenderer, false };
+        return { &listItemRenderer };
     }
 
     auto result = RenderListItem::firstFormattedLineRootFor(listItemRenderer, marker);
-    return { result.parent ? result.parent : result.fallbackParent, result.stoppedAtTableRubyOrReplaced };
+    return { result.parent ? result.parent : result.fallbackParent };
 }
 
 // An inside marker among the list item's own inline content is not a box of its own: it is an anonymous inline box
@@ -180,9 +167,6 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
         markerRenderer->setIsExcludedFromNormalLayout(false);
         if (!searchResult.parent) {
             if (currentParent->isAnonymousBlock()) {
-                // For outside markers, if the search failed because a flex/grid container blockified a replaced
-                // child (e.g., <img>), we should collapse the anonymous block's height so it doesn't inflate the list item.
-                markerRenderer->setShouldCollapseAnonymousBlockParent(searchResult.shouldCollapseAnonymousBlockParent);
                 // If the marker is currently contained inside an anonymous box, we are the only item in that anonymous box
                 // since no line box parent was found. It's ok to just leave the marker where it is in this case.
                 return;
@@ -216,16 +200,12 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
     m_builder.addListItemNeedingMarkerUpdate(listItemRenderer);
     listItemRenderer.setMarkerRenderer(*newMarkerRenderer);
     auto searchResult = parentCandidateForMarker(listItemRenderer, *newMarkerRenderer);
-    auto shouldCollapseAnonymousBlockParent = !searchResult.parent && searchResult.shouldCollapseAnonymousBlockParent;
     if (!searchResult.parent) {
         searchResult.parent = &listItemRenderer;
         if (auto* multiColumnFlow = listItemRenderer.multiColumnFlow())
             searchResult.parent = multiColumnFlow;
     }
     m_builder.attach(*searchResult.parent, WTF::move(newMarkerRenderer), firstNonMarkerChild(*searchResult.parent));
-    // For outside markers, if the search failed because a flex/grid container blockified a replaced
-    // child (e.g., <img>), we should collapse the anonymous block's height so it doesn't inflate the list item.
-    listItemRenderer.markerBox()->setShouldCollapseAnonymousBlockParent(shouldCollapseAnonymousBlockParent);
 
     if (listItemRenderer.markerBox()->needsContentContainer())
         buildMarkerContentRenderers(*listItemRenderer.markerBox());

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.h
@@ -50,6 +50,5 @@ private:
 };
 
 // <ul><li><ul><li>marker on the first li gets its own line in quirks mode, so it cannot be positioned after layout.
-bool markerNeedsOwnLine(const RenderListItem&);
 
 }


### PR DESCRIPTION
#### 9b348f12b1f5d136545bdccdeff01e06bed1c418
<pre>
[list-marker] Position every outside list marker after layout, not just the ones whose first formatted line is in a descendant block
<a href="https://bugs.webkit.org/show_bug.cgi?id=321802">https://bugs.webkit.org/show_bug.cgi?id=321802</a>
&lt;<a href="https://rdar.apple.com/problem/185529863">rdar://problem/185529863</a>&gt;

Reviewed by NOBODY (OOPS!).

An outside marker was excluded from in-flow layout only when its list item had block level children. Exclude every
outside marker and position them all after layout.

Tests: imported/w3c/web-platform-tests/css/css-lists/inside-marker-with-block-in-inline.html
       imported/w3c/web-platform-tests/css/css-lists/outside-marker-position-with-cached-line-content.html
       imported/w3c/web-platform-tests/css/css-lists/outside-marker-taller-than-content.html
       imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-block-in-nested-inline.html

* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
* Source/WebCore/layout/floats/PlacedFloats.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h:
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp:
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
* Source/WebCore/layout/layouttree/LayoutElementBox.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderInline.cpp:
* Source/WebCore/rendering/RenderInline.h:
* Source/WebCore/rendering/RenderListItem.cpp:
* Source/WebCore/rendering/RenderListItem.h:
* Source/WebCore/rendering/RenderListOutsideMarker.cpp:
* Source/WebCore/rendering/RenderListOutsideMarker.h:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderList.h:
* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/inside-marker-with-block-in-inline-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/inside-marker-with-block-in-inline-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/inside-marker-with-block-in-inline.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-position-with-cached-line-content-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-position-with-cached-line-content-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-position-with-cached-line-content.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-taller-than-content-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-taller-than-content-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-taller-than-content.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-block-in-nested-inline-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-block-in-nested-inline-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-block-in-nested-inline.html:
* LayoutTests/platform/glib/fast/doctypes/001-expected.txt:
* LayoutTests/platform/glib/fast/doctypes/003-expected.txt:
* LayoutTests/platform/glib/fast/doctypes/004-expected.txt:
* LayoutTests/platform/ios/fast/doctypes/001-expected.txt:
* LayoutTests/platform/ios/fast/doctypes/003-expected.txt:
* LayoutTests/platform/ios/fast/doctypes/004-expected.txt:
* LayoutTests/platform/ios/fast/lists/001-expected.txt:
* LayoutTests/platform/mac/fast/doctypes/001-expected.txt:
* LayoutTests/platform/mac/fast/doctypes/003-expected.txt:
* LayoutTests/platform/mac/fast/doctypes/004-expected.txt:
* LayoutTests/platform/mac/fast/lists/001-expected.txt:
* LayoutTests/platform/win/fast/doctypes/001-expected.txt:
* LayoutTests/platform/win/fast/doctypes/003-expected.txt:
* LayoutTests/platform/win/fast/doctypes/004-expected.txt:
</pre>
----------------------------------------------------------------------
#### f5eebdb863eea72b744c9906dcfd8f9056f1b48c
<pre>
[list-marker] align-content leaves the list marker behind
<a href="https://bugs.webkit.org/show_bug.cgi?id=323445">https://bugs.webkit.org/show_bug.cgi?id=323445</a>
<a href="https://rdar.apple.com/problem/186676835">rdar://problem/186676835</a>

Reviewed by Antti Koivisto.

An outside marker is positioned against a line (RenderListItem::placeExcludedMarker) and takes no part in the inline
content of that line. align-content moves the lines after they are built, and LineLayout::shiftLinesByInBlockDirection
moves the lines and the renderers of the boxes on them, so the marker stayed where the unshifted line was.

Move the position the marker was given by the same amount.

Test: imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-align-content.html: Added.
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::shiftLinesByInBlockDirection):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::excludedMarkerAnchoredTo):
* Source/WebCore/rendering/RenderListItem.h:
</pre>
----------------------------------------------------------------------
#### fba2733eb43855a28e07709499a031dd6efd4e5e
<pre>
[list-marker] text-indent moves the list marker with the text
<a href="https://bugs.webkit.org/show_bug.cgi?id=323448">https://bugs.webkit.org/show_bug.cgi?id=323448</a>
<a href="https://rdar.apple.com/problem/186678552">rdar://problem/186678552</a>

Reviewed by Antti Koivisto.

text-indent is a margin on the line box, so the line&apos;s inline start edge already includes it and the marker hung off
that edge moved in with the text. Take the indent off first.

Test: imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-text-indent.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::InlineFormattingUtils::computedTextIndentForFirstLine):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::setExcludedMarkerPositions):
</pre>
----------------------------------------------------------------------
#### f5dae91ee36070c92f58dd65eda185341094eca5
<pre>
[list-marker] A float in the list item&apos;s content pushes the list marker out with the line
<a href="https://bugs.webkit.org/show_bug.cgi?id=323453">https://bugs.webkit.org/show_bug.cgi?id=323453</a>
<a href="https://rdar.apple.com/problem/186680551">rdar://problem/186680551</a>

Reviewed by Antti Koivisto.

The marker hangs off the line&apos;s inline start edge, which a float of that formatting context has already pushed
inwards. Give that room back. A float intruding from earlier content keeps the marker with the line (webkit.org/b/166528).

Test: imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-with-float-in-content.html: Added.
* Source/WebCore/layout/floats/PlacedFloats.cpp:
(WebCore::Layout::PlacedFloats::Item::isInFormattingContextOf const):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::setExcludedMarkerPositions):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::excludedMarkerLogicalLeftOffsetFor):
(WebCore::RenderListItem::placeExcludedMarker):
* Source/WebCore/rendering/RenderListOutsideMarker.h:
</pre>
----------------------------------------------------------------------
#### 198974a9736e49f34ed494e63d2a58abd557c16a
<pre>
[list-marker] AX: The list marker is missing from the stitched text of a list item with block content
<a href="https://bugs.webkit.org/show_bug.cgi?id=323457">https://bugs.webkit.org/show_bug.cgi?id=323457</a>
<a href="https://rdar.apple.com/problem/186687365">rdar://problem/186687365</a>

Reviewed by Antti Koivisto.

An excluded marker is on no line&apos;s leaf boxes, so the stitch group for the line it was positioned against left it
out. Put it at the start of that group.

Test: accessibility/listmarker-text-with-block-content.html

* LayoutTests/accessibility/listmarker-text-with-block-content-expected.txt: Added.
* LayoutTests/accessibility/listmarker-text-with-block-content.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::stitchGroups const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b348f12b1f5d136545bdccdeff01e06bed1c418

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185029 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58948 "Failed to checkout and rebase branch from PR 73268") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52777 "Failed to checkout and rebase branch from PR 73268") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195364 "Failed to checkout and rebase branch from PR 73268") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186891 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60306 "Failed to checkout and rebase branch from PR 73268") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58675 "Failed to checkout and rebase branch from PR 73268") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/195364 "Failed to checkout and rebase branch from PR 73268") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/187984 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/60306 "Failed to checkout and rebase branch from PR 73268") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/52777 "Failed to checkout and rebase branch from PR 73268") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/195364 "Failed to checkout and rebase branch from PR 73268") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/60306 "Failed to checkout and rebase branch from PR 73268") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/58675 "Failed to checkout and rebase branch from PR 73268") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/195364 "Failed to checkout and rebase branch from PR 73268") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/52777 "Failed to checkout and rebase branch from PR 73268") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/60306 "Failed to checkout and rebase branch from PR 73268") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/52777 "Failed to checkout and rebase branch from PR 73268") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6416 "Failed to checkout and rebase branch from PR 73268") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51610 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/58675 "Failed to checkout and rebase branch from PR 73268") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197311 "Failed to checkout and rebase branch from PR 73268") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58615 "Failed to checkout and rebase branch from PR 73268") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/52777 "Failed to checkout and rebase branch from PR 73268") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/197311 "Failed to checkout and rebase branch from PR 73268") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59325 "Failed to checkout and rebase branch from PR 73268") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/52777 "Failed to checkout and rebase branch from PR 73268") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/197311 "Failed to checkout and rebase branch from PR 73268") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/59325 "Failed to checkout and rebase branch from PR 73268") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131615 "Built successfully") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128257 "Failed to checkout and rebase branch from PR 73268") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57815 "Failed to checkout and rebase branch from PR 73268") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/52777 "Failed to checkout and rebase branch from PR 73268") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57177 "Failed to checkout and rebase branch from PR 73268") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57426 "Failed to checkout and rebase branch from PR 73268") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57252 "Failed to checkout and rebase branch from PR 73268") | | | | 
<!--EWS-Status-Bubble-End-->