### PR TITLE
AX: VoiceOver repeats the first sentence over and over as content streams in on gemini.google.com

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-emptied-removal-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-emptied-removal-expected.txt
@@ -1,0 +1,16 @@
+This tests that emptying a live region entirely announces the removal, exactly once, for a region that asked to hear removals. Streamed content is re-rendered by emptying the region and refilling it later, so the snapshot the region is compared against deliberately survives the empty state. That makes it possible to announce the same removal on every later update, and to mistake the refilled text for new content.
+
+PASS: announcement.includes('Giants') === true
+PASS: announcement.includes('AXIsLiveRegionRemoval = 1') === true
+PASS: announcement.includes('Cubs') === true
+PASS: announcement.includes('AXIsLiveRegionRemoval = 1') === true
+PASS: announcement.includes('Bears') === true
+PASS: announcement.includes('Cubs') === false
+PASS: announcements.length === 3
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Cubs
+
+Bears

--- a/LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-emptied-removal.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-emptied-removal.html
@@ -1,0 +1,83 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<meta http-equiv="content-language" content="en">
+<script src="../../../../resources/accessibility-helper.js"></script>
+<script src="../../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="region" aria-live="polite" aria-relevant="removals additions"><p>Giants</p><p>Cubs</p></div>
+
+<script>
+var output = "This tests that emptying a live region entirely announces the removal, exactly once, for a region that asked to hear removals. Streamed content is re-rendered by emptying the region and refilling it later, so the snapshot the region is compared against deliberately survives the empty state. That makes it possible to announce the same removal on every later update, and to mistake the refilled text for new content.\n\n";
+
+var announcements = [];
+var region = document.getElementById("region");
+var announcement;
+var announcementCount;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested")
+        announcements.push(userInfo["AXAnnouncementKey"]);
+}
+
+async function mutateAndWaitForAnnouncement(mutate) {
+    var count = announcements.length;
+    mutate();
+    await waitFor(() => announcements.length > count);
+    announcement = announcements[announcements.length - 1];
+}
+
+async function runTest() {
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("region");
+    // The live region manager is initialized at the end of a cache update, so let one run before
+    // mutating anything.
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // Removing one of two children leaves the region with text, so this is an ordinary removal.
+    await mutateAndWaitForAnnouncement(() => region.firstElementChild.remove());
+    output += expect("announcement.includes('Giants')", "true");
+    output += expect("announcement.includes('AXIsLiveRegionRemoval = 1')", "true");
+
+    // Removing the rest empties the region. The text that went away still has to be announced, even
+    // though the snapshot it is compared against is kept rather than replaced by the empty state.
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "");
+    output += expect("announcement.includes('Cubs')", "true");
+    output += expect("announcement.includes('AXIsLiveRegionRemoval = 1')", "true");
+
+    // A further update that leaves the region empty has nothing new to report. Waiting for the snapshot
+    // to be rebuilt is what makes this a distinct update: batched into the refill below, the region would
+    // never be compared while empty at all. This is the only live region on the page, so the build count
+    // tracks it alone.
+    announcementCount = announcements.length;
+    var buildCount = internals.liveRegionSnapshotBuildCount();
+    region.appendChild(document.createElement("span"));
+    await waitFor(() => internals.liveRegionSnapshotBuildCount() > buildCount);
+
+    // Refilling restores "Cubs" and adds "Bears". Only "Bears" is new: the kept snapshot still holds
+    // "Cubs", so it must not be announced a second time.
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>Cubs</p><p>Bears</p>");
+    output += expect("announcement.includes('Bears')", "true");
+    output += expect("announcement.includes('Cubs')", "false");
+    // Exactly one announcement since the region was emptied: the refill's.
+    output += expect("announcements.length", `${announcementCount + 1}`);
+
+    debug(output);
+    accessibilityController.removeNotificationListener();
+    finishJSTest();
+}
+
+if (window.accessibilityController && window.internals) {
+    window.jsTestIsAsync = true;
+
+    runTest().catch(error => {
+        debug(output);
+        testFailed(`runTest() threw: ${error}`);
+        finishJSTest();
+    });
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-repeated-text-after-clear-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-repeated-text-after-clear-expected.txt
@@ -1,0 +1,20 @@
+This tests that a live region which is cleared and then given the same text again announces it again, the way status feedback like "Moved Up" repeated on a second arrow key press has to. Text identical to what the region held before is otherwise treated as unchanged, because a streamed response re-chunks into different objects holding the same text when it finishes. The two are told apart by how long the region stays empty -- a page rebuilding a region refills it within a task or two, while anything driven by a user action does not -- and by whether the text comes back in the same shape, since re-chunking can outlast that.
+
+PASS: announcement.includes('Moved Up') === true
+PASS: announcements.length === 1
+PASS: announcement.includes('Moved Up') === true
+PASS: announcements.length === 2
+PASS: announcement.includes('Alpha Beta') === true
+PASS: announcements.length === 3
+PASS: announcement.includes('three') === true
+PASS: announcement.includes('One two') === false
+PASS: announcements.length === 6
+PASS: announcement.includes('Epsilon') === true
+PASS: announcement.includes('Delta') === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Delta
+
+Epsilon

--- a/LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-repeated-text-after-clear.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-repeated-text-after-clear.html
@@ -1,0 +1,119 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<meta http-equiv="content-language" content="en">
+<script src="../../../../resources/accessibility-helper.js"></script>
+<script src="../../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="region" aria-live="polite"></div>
+
+<script>
+var output = "This tests that a live region which is cleared and then given the same text again announces it again, the way status feedback like \"Moved Up\" repeated on a second arrow key press has to. Text identical to what the region held before is otherwise treated as unchanged, because a streamed response re-chunks into different objects holding the same text when it finishes. The two are told apart by how long the region stays empty -- a page rebuilding a region refills it within a task or two, while anything driven by a user action does not -- and by whether the text comes back in the same shape, since re-chunking can outlast that.\n\n";
+
+var announcements = [];
+var region = document.getElementById("region");
+var announcement;
+var announcementCount;
+
+// Comfortably longer than the settle delay in AXLiveRegionManager, so the clear counts as deliberate.
+var pastSettleDelay = 400;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested")
+        announcements.push(userInfo["AXAnnouncementKey"]);
+}
+
+function wait(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function mutateAndWaitForAnnouncement(mutate) {
+    var count = announcements.length;
+    mutate();
+    await waitFor(() => announcements.length > count);
+    announcement = announcements[announcements.length - 1];
+}
+
+async function runTest() {
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("region");
+    // The live region manager is initialized at the end of a cache update, so let one run before
+    // mutating anything.
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>Moved Up</p>");
+    output += expect("announcement.includes('Moved Up')", "true");
+
+    // Clearing on its own says nothing: the default aria-relevant does not ask for removals.
+    announcementCount = announcements.length;
+    region.innerHTML = "";
+    await wait(pastSettleDelay);
+    output += expect("announcements.length", `${announcementCount}`);
+
+    // The same text again, after the region sat empty. This is a second thing to announce, not the
+    // first one restated.
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>Moved Up</p>");
+    output += expect("announcement.includes('Moved Up')", "true");
+    output += expect("announcements.length", `${announcementCount + 1}`);
+
+    // A region emptied and refilled with the same text in the next task over is one render in progress,
+    // not content being repeated, and stays silent. This is what a streamed response does when it
+    // finishes and its many small nodes collapse into a few large ones holding the same text.
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>Alpha</p><p>Beta</p>");
+    output += expect("announcement.includes('Alpha Beta')", "true");
+    announcementCount = announcements.length;
+    region.innerHTML = "";
+    await wait(10);
+    region.innerHTML = "<p>Alpha Beta</p>";
+    await wait(pastSettleDelay);
+    output += expect("announcements.length", `${announcementCount}`);
+
+    // Content returning after a deliberate clear is only new where it differs. Streaming that resumes
+    // must not replay everything the region already said.
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>One two</p>");
+    region.innerHTML = "";
+    await wait(pastSettleDelay);
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>One two three</p>");
+    output += expect("announcement.includes('three')", "true");
+    output += expect("announcement.includes('One two')", "false");
+
+    // Text that comes back split across a different set of objects was rebuilt rather than repeated, so
+    // it stays silent even though the region sat empty for a while first. A response that takes its time
+    // collapsing its many small nodes into one at the end of a stream must not replay the whole thing.
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>Alpha</p><p>Beta</p><p>Gamma</p>");
+    announcementCount = announcements.length;
+    region.innerHTML = "";
+    await wait(pastSettleDelay);
+    region.innerHTML = "<p>Alpha Beta Gamma</p>";
+    await wait(pastSettleDelay);
+    output += expect("announcements.length", `${announcementCount}`);
+
+    // Streaming that resumes into an extra object announces only what it added. The object already there
+    // came back saying the same thing, so comparing the objects pairwise without also comparing how many
+    // there are would call this a repeat and replay the part the region had already said.
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>Delta</p>");
+    region.innerHTML = "";
+    await wait(pastSettleDelay);
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>Delta</p><p>Epsilon</p>");
+    output += expect("announcement.includes('Epsilon')", "true");
+    output += expect("announcement.includes('Delta')", "false");
+
+    debug(output);
+    accessibilityController.removeNotificationListener();
+    finishJSTest();
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    runTest().catch(error => {
+        debug(output);
+        testFailed(`runTest() threw: ${error}`);
+        finishJSTest();
+    });
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-streamed-content-not-repeated-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-streamed-content-not-repeated-expected.txt
@@ -1,0 +1,29 @@
+This tests that a live region streaming content in, the way an AI chat response is rendered, announces each piece of text only once. Re-rendering the region backs already-announced text with new accessibility objects, spreads it across a different number of objects as markup resolves, coalesces it into fewer objects once the response is complete, and momentarily leaves the region empty. Each of those used to make the text look new and replay the whole response from the top.
+
+PASS: chunk.includes('You must fork') === true
+PASS: chunk.includes('the repo') === true
+PASS: chunk.includes('You must') === false
+PASS: chunk.includes('repository') === true
+PASS: chunk.includes('You must fork') === false
+PASS: chunk.includes('quickly and clone it.') === true
+PASS: chunk.includes('repository') === false
+PASS: chunk.includes('Then enable submodules.') === true
+PASS: chunk.includes('quickly') === false
+PASS: announcements[announcements.length - 1].includes("Sentinel changed.") === true
+PASS: announcements.length === 6
+PASS: announcements[announcements.length - 1].includes("Sentinel changed again.") === true
+PASS: announcements.length === 7
+PASS: chunk.includes('Beta paragraph edited.') === true
+PASS: chunk.includes('Alpha') === false
+PASS: chunk.includes('Gamma') === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Alpha paragraph.
+
+Beta paragraph edited.
+
+Gamma paragraph.
+
+Sentinel changed again.

--- a/LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-streamed-content-not-repeated.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-streamed-content-not-repeated.html
@@ -1,0 +1,120 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<meta http-equiv="content-language" content="en">
+<script src="../../../../resources/accessibility-helper.js"></script>
+<script src="../../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="region" aria-live="polite"></div>
+<div id="sentinel" aria-live="polite"></div>
+
+<script>
+var output = "This tests that a live region streaming content in, the way an AI chat response is rendered, announces each piece of text only once. Re-rendering the region backs already-announced text with new accessibility objects, spreads it across a different number of objects as markup resolves, coalesces it into fewer objects once the response is complete, and momentarily leaves the region empty. Each of those used to make the text look new and replay the whole response from the top.\n\n";
+
+var announcements = [];
+var region = document.getElementById("region");
+var chunk;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested")
+        announcements.push(userInfo["AXAnnouncementKey"]);
+}
+
+// Re-renders the whole region, so every piece of text is backed by brand new accessibility objects,
+// then resolves once the announcement for that chunk has been delivered.
+async function streamChunk(html) {
+    var announcementCount = announcements.length;
+    region.innerHTML = html;
+    await waitFor(() => announcements.length > announcementCount);
+    chunk = announcements[announcements.length - 1];
+}
+
+// Empties the region and waits for the accessibility tree to actually observe the empty state, which
+// is what happens on a real page that re-renders by clearing the container and refilling it later.
+async function emptyRegion() {
+    var buildCount = internals.liveRegionSnapshotBuildCount();
+    region.innerHTML = "";
+    await waitFor(() => internals.liveRegionSnapshotBuildCount() > buildCount);
+}
+
+// Re-renders the region without adding any text, then changes a second live region. Once the second
+// region's announcement arrives, anything the re-render would have announced has already been
+// delivered, which makes "announced nothing" a deterministic thing to check.
+async function expectSilentRerender(html, sentinelText) {
+    var announcementCount = announcements.length;
+    region.innerHTML = html;
+    document.getElementById("sentinel").textContent = sentinelText;
+    await waitFor(() => announcements.length > announcementCount);
+    output += expect(`announcements[announcements.length - 1].includes("${sentinelText}")`, "true");
+    output += expect("announcements.length", `${announcementCount + 1}`);
+}
+
+async function runTest() {
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("region");
+    // The live region manager is initialized at the end of a cache update, so let one run before
+    // mutating anything. Without this the region can be registered with the first chunk already in
+    // place, leaving nothing for that chunk to announce.
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    await streamChunk("<p>You must fork</p>");
+    output += expect("chunk.includes('You must fork')", "true");
+
+    // Text grows within the same paragraph. Only the new words should be announced.
+    await streamChunk("<p>You must fork the repo</p>");
+    output += expect("chunk.includes('the repo')", "true");
+    output += expect("chunk.includes('You must')", "false");
+
+    // This chunk completes a word that the previous one had cut in half. The whole word should be
+    // announced, rather than a fragment of it or a repeat of the text before it.
+    await streamChunk("<p>You must fork the repository</p>");
+    output += expect("chunk.includes('repository')", "true");
+    output += expect("chunk.includes('You must fork')", "false");
+
+    // Bold resolves, splitting one text node into three. Only the words added at the end are new.
+    await streamChunk("<p><span>You must fork the repository </span><b>quickly</b><span> and clone it.</span></p>");
+    output += expect("chunk.includes('quickly and clone it.')", "true");
+    output += expect("chunk.includes('repository')", "false");
+
+    // The region goes empty before the next chunk arrives. The text that comes back must not be
+    // treated as new just because the region was briefly empty.
+    await emptyRegion();
+    await streamChunk("<p><span>You must fork the repository </span><b>quickly</b><span> and clone it.</span></p><p>Then enable submodules.</p>");
+    output += expect("chunk.includes('Then enable submodules.')", "true");
+    output += expect("chunk.includes('quickly')", "false");
+
+    // Streaming finishes, so the many small nodes are coalesced into one node holding exactly the same
+    // text. Nothing was added, so nothing should be announced.
+    await emptyRegion();
+    await expectSilentRerender("<p>You must fork the repository quickly and clone it. Then enable submodules.</p>", "Sentinel changed.");
+
+    // Re-rendering again without changing any text should also stay silent.
+    await expectSilentRerender("<p>You must fork the repository quickly and clone it. Then enable submodules.</p>", "Sentinel changed again.");
+
+    // Text edited in the middle rather than added at the end. The region is re-rendered, so the
+    // untouched paragraphs are backed by new objects too, but only the edited one should be announced.
+    await streamChunk("<p>Alpha paragraph.</p><p>Beta paragraph.</p><p>Gamma paragraph.</p>");
+    await streamChunk("<p>Alpha paragraph.</p><p>Beta paragraph edited.</p><p>Gamma paragraph.</p>");
+    output += expect("chunk.includes('Beta paragraph edited.')", "true");
+    output += expect("chunk.includes('Alpha')", "false");
+    output += expect("chunk.includes('Gamma')", "false");
+
+    debug(output);
+    accessibilityController.removeNotificationListener();
+    finishJSTest();
+}
+
+if (window.accessibilityController && window.internals) {
+    window.jsTestIsAsync = true;
+
+    runTest().catch(error => {
+        debug(output);
+        testFailed(`runTest() threw: ${error}`);
+        finishJSTest();
+    });
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/live-regions/live-region-emptied-removal-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-emptied-removal-expected.txt
@@ -1,0 +1,16 @@
+This tests that emptying a live region entirely announces the removal, exactly once, for a region that asked to hear removals. Streamed content is re-rendered by emptying the region and refilling it later, so the snapshot the region is compared against deliberately survives the empty state. That makes it possible to announce the same removal on every later update, and to mistake the refilled text for new content.
+
+PASS: announcement.includes('Giants') === true
+PASS: announcement.includes('AXIsLiveRegionRemoval = 1') === true
+PASS: announcement.includes('Cubs') === true
+PASS: announcement.includes('AXIsLiveRegionRemoval = 1') === true
+PASS: announcement.includes('Bears') === true
+PASS: announcement.includes('Cubs') === false
+PASS: announcements.length === 3
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Cubs
+
+Bears

--- a/LayoutTests/accessibility/mac/live-regions/live-region-emptied-removal.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-emptied-removal.html
@@ -1,0 +1,83 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<meta http-equiv="content-language" content="en">
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="region" aria-live="polite" aria-relevant="removals additions"><p>Giants</p><p>Cubs</p></div>
+
+<script>
+var output = "This tests that emptying a live region entirely announces the removal, exactly once, for a region that asked to hear removals. Streamed content is re-rendered by emptying the region and refilling it later, so the snapshot the region is compared against deliberately survives the empty state. That makes it possible to announce the same removal on every later update, and to mistake the refilled text for new content.\n\n";
+
+var announcements = [];
+var region = document.getElementById("region");
+var announcement;
+var announcementCount;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested")
+        announcements.push(userInfo["AXAnnouncementKey"]);
+}
+
+async function mutateAndWaitForAnnouncement(mutate) {
+    var count = announcements.length;
+    mutate();
+    await waitFor(() => announcements.length > count);
+    announcement = announcements[announcements.length - 1];
+}
+
+async function runTest() {
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("region");
+    // The live region manager is initialized at the end of a cache update, so let one run before
+    // mutating anything.
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // Removing one of two children leaves the region with text, so this is an ordinary removal.
+    await mutateAndWaitForAnnouncement(() => region.firstElementChild.remove());
+    output += expect("announcement.includes('Giants')", "true");
+    output += expect("announcement.includes('AXIsLiveRegionRemoval = 1')", "true");
+
+    // Removing the rest empties the region. The text that went away still has to be announced, even
+    // though the snapshot it is compared against is kept rather than replaced by the empty state.
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "");
+    output += expect("announcement.includes('Cubs')", "true");
+    output += expect("announcement.includes('AXIsLiveRegionRemoval = 1')", "true");
+
+    // A further update that leaves the region empty has nothing new to report. Waiting for the snapshot
+    // to be rebuilt is what makes this a distinct update: batched into the refill below, the region would
+    // never be compared while empty at all. This is the only live region on the page, so the build count
+    // tracks it alone.
+    announcementCount = announcements.length;
+    var buildCount = internals.liveRegionSnapshotBuildCount();
+    region.appendChild(document.createElement("span"));
+    await waitFor(() => internals.liveRegionSnapshotBuildCount() > buildCount);
+
+    // Refilling restores "Cubs" and adds "Bears". Only "Bears" is new: the kept snapshot still holds
+    // "Cubs", so it must not be announced a second time.
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>Cubs</p><p>Bears</p>");
+    output += expect("announcement.includes('Bears')", "true");
+    output += expect("announcement.includes('Cubs')", "false");
+    // Exactly one announcement since the region was emptied: the refill's.
+    output += expect("announcements.length", `${announcementCount + 1}`);
+
+    debug(output);
+    accessibilityController.removeNotificationListener();
+    finishJSTest();
+}
+
+if (window.accessibilityController && window.internals) {
+    window.jsTestIsAsync = true;
+
+    runTest().catch(error => {
+        debug(output);
+        testFailed(`runTest() threw: ${error}`);
+        finishJSTest();
+    });
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/live-regions/live-region-repeated-text-after-clear-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-repeated-text-after-clear-expected.txt
@@ -1,0 +1,20 @@
+This tests that a live region which is cleared and then given the same text again announces it again, the way status feedback like "Moved Up" repeated on a second arrow key press has to. Text identical to what the region held before is otherwise treated as unchanged, because a streamed response re-chunks into different objects holding the same text when it finishes. The two are told apart by how long the region stays empty -- a page rebuilding a region refills it within a task or two, while anything driven by a user action does not -- and by whether the text comes back in the same shape, since re-chunking can outlast that.
+
+PASS: announcement.includes('Moved Up') === true
+PASS: announcements.length === 1
+PASS: announcement.includes('Moved Up') === true
+PASS: announcements.length === 2
+PASS: announcement.includes('Alpha Beta') === true
+PASS: announcements.length === 3
+PASS: announcement.includes('three') === true
+PASS: announcement.includes('One two') === false
+PASS: announcements.length === 6
+PASS: announcement.includes('Epsilon') === true
+PASS: announcement.includes('Delta') === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Delta
+
+Epsilon

--- a/LayoutTests/accessibility/mac/live-regions/live-region-repeated-text-after-clear.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-repeated-text-after-clear.html
@@ -1,0 +1,119 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<meta http-equiv="content-language" content="en">
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="region" aria-live="polite"></div>
+
+<script>
+var output = "This tests that a live region which is cleared and then given the same text again announces it again, the way status feedback like \"Moved Up\" repeated on a second arrow key press has to. Text identical to what the region held before is otherwise treated as unchanged, because a streamed response re-chunks into different objects holding the same text when it finishes. The two are told apart by how long the region stays empty -- a page rebuilding a region refills it within a task or two, while anything driven by a user action does not -- and by whether the text comes back in the same shape, since re-chunking can outlast that.\n\n";
+
+var announcements = [];
+var region = document.getElementById("region");
+var announcement;
+var announcementCount;
+
+// Comfortably longer than the settle delay in AXLiveRegionManager, so the clear counts as deliberate.
+var pastSettleDelay = 400;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested")
+        announcements.push(userInfo["AXAnnouncementKey"]);
+}
+
+function wait(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function mutateAndWaitForAnnouncement(mutate) {
+    var count = announcements.length;
+    mutate();
+    await waitFor(() => announcements.length > count);
+    announcement = announcements[announcements.length - 1];
+}
+
+async function runTest() {
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("region");
+    // The live region manager is initialized at the end of a cache update, so let one run before
+    // mutating anything.
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>Moved Up</p>");
+    output += expect("announcement.includes('Moved Up')", "true");
+
+    // Clearing on its own says nothing: the default aria-relevant does not ask for removals.
+    announcementCount = announcements.length;
+    region.innerHTML = "";
+    await wait(pastSettleDelay);
+    output += expect("announcements.length", `${announcementCount}`);
+
+    // The same text again, after the region sat empty. This is a second thing to announce, not the
+    // first one restated.
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>Moved Up</p>");
+    output += expect("announcement.includes('Moved Up')", "true");
+    output += expect("announcements.length", `${announcementCount + 1}`);
+
+    // A region emptied and refilled with the same text in the next task over is one render in progress,
+    // not content being repeated, and stays silent. This is what a streamed response does when it
+    // finishes and its many small nodes collapse into a few large ones holding the same text.
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>Alpha</p><p>Beta</p>");
+    output += expect("announcement.includes('Alpha Beta')", "true");
+    announcementCount = announcements.length;
+    region.innerHTML = "";
+    await wait(10);
+    region.innerHTML = "<p>Alpha Beta</p>";
+    await wait(pastSettleDelay);
+    output += expect("announcements.length", `${announcementCount}`);
+
+    // Content returning after a deliberate clear is only new where it differs. Streaming that resumes
+    // must not replay everything the region already said.
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>One two</p>");
+    region.innerHTML = "";
+    await wait(pastSettleDelay);
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>One two three</p>");
+    output += expect("announcement.includes('three')", "true");
+    output += expect("announcement.includes('One two')", "false");
+
+    // Text that comes back split across a different set of objects was rebuilt rather than repeated, so
+    // it stays silent even though the region sat empty for a while first. A response that takes its time
+    // collapsing its many small nodes into one at the end of a stream must not replay the whole thing.
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>Alpha</p><p>Beta</p><p>Gamma</p>");
+    announcementCount = announcements.length;
+    region.innerHTML = "";
+    await wait(pastSettleDelay);
+    region.innerHTML = "<p>Alpha Beta Gamma</p>";
+    await wait(pastSettleDelay);
+    output += expect("announcements.length", `${announcementCount}`);
+
+    // Streaming that resumes into an extra object announces only what it added. The object already there
+    // came back saying the same thing, so comparing the objects pairwise without also comparing how many
+    // there are would call this a repeat and replay the part the region had already said.
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>Delta</p>");
+    region.innerHTML = "";
+    await wait(pastSettleDelay);
+    await mutateAndWaitForAnnouncement(() => region.innerHTML = "<p>Delta</p><p>Epsilon</p>");
+    output += expect("announcement.includes('Epsilon')", "true");
+    output += expect("announcement.includes('Delta')", "false");
+
+    debug(output);
+    accessibilityController.removeNotificationListener();
+    finishJSTest();
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    runTest().catch(error => {
+        debug(output);
+        testFailed(`runTest() threw: ${error}`);
+        finishJSTest();
+    });
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/live-regions/live-region-streamed-content-not-repeated-expected.txt
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-streamed-content-not-repeated-expected.txt
@@ -1,0 +1,29 @@
+This tests that a live region streaming content in, the way an AI chat response is rendered, announces each piece of text only once. Re-rendering the region backs already-announced text with new accessibility objects, spreads it across a different number of objects as markup resolves, coalesces it into fewer objects once the response is complete, and momentarily leaves the region empty. Each of those used to make the text look new and replay the whole response from the top.
+
+PASS: chunk.includes('You must fork') === true
+PASS: chunk.includes('the repo') === true
+PASS: chunk.includes('You must') === false
+PASS: chunk.includes('repository') === true
+PASS: chunk.includes('You must fork') === false
+PASS: chunk.includes('quickly and clone it.') === true
+PASS: chunk.includes('repository') === false
+PASS: chunk.includes('Then enable submodules.') === true
+PASS: chunk.includes('quickly') === false
+PASS: announcements[announcements.length - 1].includes("Sentinel changed.") === true
+PASS: announcements.length === 6
+PASS: announcements[announcements.length - 1].includes("Sentinel changed again.") === true
+PASS: announcements.length === 7
+PASS: chunk.includes('Beta paragraph edited.') === true
+PASS: chunk.includes('Alpha') === false
+PASS: chunk.includes('Gamma') === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Alpha paragraph.
+
+Beta paragraph edited.
+
+Gamma paragraph.
+
+Sentinel changed again.

--- a/LayoutTests/accessibility/mac/live-regions/live-region-streamed-content-not-repeated.html
+++ b/LayoutTests/accessibility/mac/live-regions/live-region-streamed-content-not-repeated.html
@@ -1,0 +1,120 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true ] -->
+<html>
+<head>
+<meta http-equiv="content-language" content="en">
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="region" aria-live="polite"></div>
+<div id="sentinel" aria-live="polite"></div>
+
+<script>
+var output = "This tests that a live region streaming content in, the way an AI chat response is rendered, announces each piece of text only once. Re-rendering the region backs already-announced text with new accessibility objects, spreads it across a different number of objects as markup resolves, coalesces it into fewer objects once the response is complete, and momentarily leaves the region empty. Each of those used to make the text look new and replay the whole response from the top.\n\n";
+
+var announcements = [];
+var region = document.getElementById("region");
+var chunk;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested")
+        announcements.push(userInfo["AXAnnouncementKey"]);
+}
+
+// Re-renders the whole region, so every piece of text is backed by brand new accessibility objects,
+// then resolves once the announcement for that chunk has been delivered.
+async function streamChunk(html) {
+    var announcementCount = announcements.length;
+    region.innerHTML = html;
+    await waitFor(() => announcements.length > announcementCount);
+    chunk = announcements[announcements.length - 1];
+}
+
+// Empties the region and waits for the accessibility tree to actually observe the empty state, which
+// is what happens on a real page that re-renders by clearing the container and refilling it later.
+async function emptyRegion() {
+    var buildCount = internals.liveRegionSnapshotBuildCount();
+    region.innerHTML = "";
+    await waitFor(() => internals.liveRegionSnapshotBuildCount() > buildCount);
+}
+
+// Re-renders the region without adding any text, then changes a second live region. Once the second
+// region's announcement arrives, anything the re-render would have announced has already been
+// delivered, which makes "announced nothing" a deterministic thing to check.
+async function expectSilentRerender(html, sentinelText) {
+    var announcementCount = announcements.length;
+    region.innerHTML = html;
+    document.getElementById("sentinel").textContent = sentinelText;
+    await waitFor(() => announcements.length > announcementCount);
+    output += expect(`announcements[announcements.length - 1].includes("${sentinelText}")`, "true");
+    output += expect("announcements.length", `${announcementCount + 1}`);
+}
+
+async function runTest() {
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("region");
+    // The live region manager is initialized at the end of a cache update, so let one run before
+    // mutating anything. Without this the region can be registered with the first chunk already in
+    // place, leaving nothing for that chunk to announce.
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    await streamChunk("<p>You must fork</p>");
+    output += expect("chunk.includes('You must fork')", "true");
+
+    // Text grows within the same paragraph. Only the new words should be announced.
+    await streamChunk("<p>You must fork the repo</p>");
+    output += expect("chunk.includes('the repo')", "true");
+    output += expect("chunk.includes('You must')", "false");
+
+    // This chunk completes a word that the previous one had cut in half. The whole word should be
+    // announced, rather than a fragment of it or a repeat of the text before it.
+    await streamChunk("<p>You must fork the repository</p>");
+    output += expect("chunk.includes('repository')", "true");
+    output += expect("chunk.includes('You must fork')", "false");
+
+    // Bold resolves, splitting one text node into three. Only the words added at the end are new.
+    await streamChunk("<p><span>You must fork the repository </span><b>quickly</b><span> and clone it.</span></p>");
+    output += expect("chunk.includes('quickly and clone it.')", "true");
+    output += expect("chunk.includes('repository')", "false");
+
+    // The region goes empty before the next chunk arrives. The text that comes back must not be
+    // treated as new just because the region was briefly empty.
+    await emptyRegion();
+    await streamChunk("<p><span>You must fork the repository </span><b>quickly</b><span> and clone it.</span></p><p>Then enable submodules.</p>");
+    output += expect("chunk.includes('Then enable submodules.')", "true");
+    output += expect("chunk.includes('quickly')", "false");
+
+    // Streaming finishes, so the many small nodes are coalesced into one node holding exactly the same
+    // text. Nothing was added, so nothing should be announced.
+    await emptyRegion();
+    await expectSilentRerender("<p>You must fork the repository quickly and clone it. Then enable submodules.</p>", "Sentinel changed.");
+
+    // Re-rendering again without changing any text should also stay silent.
+    await expectSilentRerender("<p>You must fork the repository quickly and clone it. Then enable submodules.</p>", "Sentinel changed again.");
+
+    // Text edited in the middle rather than added at the end. The region is re-rendered, so the
+    // untouched paragraphs are backed by new objects too, but only the edited one should be announced.
+    await streamChunk("<p>Alpha paragraph.</p><p>Beta paragraph.</p><p>Gamma paragraph.</p>");
+    await streamChunk("<p>Alpha paragraph.</p><p>Beta paragraph edited.</p><p>Gamma paragraph.</p>");
+    output += expect("chunk.includes('Beta paragraph edited.')", "true");
+    output += expect("chunk.includes('Alpha')", "false");
+    output += expect("chunk.includes('Gamma')", "false");
+
+    debug(output);
+    accessibilityController.removeNotificationListener();
+    finishJSTest();
+}
+
+if (window.accessibilityController && window.internals) {
+    window.jsTestIsAsync = true;
+
+    runTest().catch(error => {
+        debug(output);
+        testFailed(`runTest() threw: ${error}`);
+        finishJSTest();
+    });
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXAnnouncementTypes.h
+++ b/Source/WebCore/accessibility/AXAnnouncementTypes.h
@@ -59,6 +59,27 @@ struct LiveRegionSnapshot {
     Vector<LiveRegionObject> objects;
     LiveRegionStatus liveRegionStatus { LiveRegionStatus::Off };
     OptionSet<LiveRegionRelevant> liveRegionRelevant { { LiveRegionRelevant::Additions, LiveRegionRelevant::Text } };
+    // Every object's text concatenated with runs of whitespace collapsed. Cached because change
+    // detection compares it on every update, and the previous snapshot's copy would otherwise be
+    // rebuilt from scratch each time.
+    String aggregatedText;
+    // For each object, the offset just past the last character it contributed to aggregatedText, so
+    // object i covers [end(i - 1), end(i)). Cached alongside the text because deriving it later would
+    // mean rebuilding the whole aggregate, and it is only meaningful when isTruncated is false.
+    Vector<size_t> objectEndOffsets;
+    // Whether any object carries text.
+    bool hasAnyText { false };
+    // Whether the region contains an atomic region, which must be announced in its entirety. Not
+    // derivable from an object's descendants, which are empty when its text comes from a label.
+    bool hasAtomicRegion { false };
+    // Whether this baseline was kept after the region went empty and that removal was already announced.
+    // The baseline is deliberately not replaced by the empty state, so without this the same removal
+    // would be announced again on every subsequent update that leaves the region empty.
+    bool announcedEmptyRemoval { false };
+    // Whether the region stayed empty long enough to count as genuinely cleared rather than mid-render.
+    bool settledEmpty { false };
+    // True when a limit stopped the walk, so this is an incomplete view of the region.
+    bool isTruncated { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AXLiveRegionManager.cpp
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.cpp
@@ -35,6 +35,7 @@
 #include "AXObjectCache.h"
 #include "AccessibilityObject.h"
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/CharacterProperties.h>
 
 namespace WebCore {
 
@@ -56,6 +57,7 @@ struct LiveRegionObjectMetadata {
 
 AXLiveRegionManager::AXLiveRegionManager(AXObjectCache& cache)
     : m_cache(cache)
+    , m_emptyRegionSettleTimer(*this, &AXLiveRegionManager::emptyRegionSettleTimerFired)
 {
 }
 
@@ -160,6 +162,23 @@ static OptionSet<LiveRegionRelevant> stringToLiveRegionRelevant(const String& st
     return result;
 }
 
+// How long a live region has to stay empty before the clear is treated as something the page meant,
+// rather than the gap between tearing the region down and rebuilding it.
+static constexpr Seconds emptyRegionSettleDelay { 100_ms };
+
+// Whether two snapshots hold the same text laid out the same way.
+static bool hasSameObjectTexts(const LiveRegionSnapshot& oldSnapshot, const LiveRegionSnapshot& newSnapshot)
+{
+    if (oldSnapshot.objects.size() != newSnapshot.objects.size())
+        return false;
+
+    for (size_t i = 0; i < oldSnapshot.objects.size(); ++i) {
+        if (oldSnapshot.objects[i].text != newSnapshot.objects[i].text)
+            return false;
+    }
+    return true;
+}
+
 void AXLiveRegionManager::handleLiveRegionChange(AccessibilityObject& object, AnnouncementContents contents)
 {
     // If this is a new live region, don't speak it upon registering.
@@ -170,11 +189,101 @@ void AXLiveRegionManager::handleLiveRegionChange(AccessibilityObject& object, An
     }
 
     LiveRegionSnapshot oldSnapshot = contents == AnnouncementContents::All ? LiveRegionSnapshot { } : iterator->value;
+    bool baselineHadText = iterator->value.hasAnyText;
+    bool baselineSettledEmpty = iterator->value.settledEmpty;
+
     LiveRegionSnapshot newSnapshot = buildLiveRegionSnapshot(object);
 
-    iterator->value = newSnapshot;
+    // Streaming pages often re-render a region by emptying it and refilling it in a later task, so this
+    // empty state is transient rather than a change. Adopting it as the baseline would make the refilled
+    // text look entirely new, so instead, only keep the last baseline that had text.
+    if (!newSnapshot.hasAnyText && baselineHadText) {
+        m_regionsPendingEmpty.add(object.objectID());
+        if (!m_emptyRegionSettleTimer.isActive())
+            m_emptyRegionSettleTimer.startOneShot(emptyRegionSettleDelay);
+
+        // The baseline is kept, but a region that asked to hear removals still has to hear that its
+        // content went away.
+        if (newSnapshot.liveRegionRelevant.containsAny({ LiveRegionRelevant::Removals, LiveRegionRelevant::All })) {
+            // Re-find rather than reusing the iterator, which building the snapshot above may have invalidated.
+            auto baseline = m_liveRegions.find(object.objectID());
+            if (baseline != m_liveRegions.end() && !baseline->value.announcedEmptyRemoval) {
+                baseline->value.announcedEmptyRemoval = true;
+                postAnnouncementForChange(object, oldSnapshot, newSnapshot);
+            }
+        }
+        return;
+    }
+
+    // Content is present, so whatever empty state was being waited on was only part of a render.
+    m_regionsPendingEmpty.remove(object.objectID());
+
+    // The region was cleared, stayed cleared, and has now come back saying exactly what it said before,
+    // split across objects in the same way. Reset the old snapshot so an announcement can be made.
+    if (baselineSettledEmpty && hasSameObjectTexts(oldSnapshot, newSnapshot))
+        oldSnapshot = LiveRegionSnapshot { };
+
+    // Re-find rather than reusing the iterator, which building the snapshot above may have invalidated.
+    m_liveRegions.set(object.objectID(), newSnapshot);
 
     postAnnouncementForChange(object, oldSnapshot, newSnapshot);
+}
+
+// Nothing came back while the timer ran, so these regions were cleared rather than caught mid-render.
+void AXLiveRegionManager::emptyRegionSettleTimerFired()
+{
+    for (auto axID : std::exchange(m_regionsPendingEmpty, { })) {
+        if (auto iterator = m_liveRegions.find(axID); iterator != m_liveRegions.end())
+            iterator->value.settledEmpty = true;
+    }
+}
+
+// Cap on the aggregated text, so that content made of a few enormous nodes cannot overflow the builder
+// or make comparison arbitrarily expensive. Exceeding it truncates the snapshot rather than failing.
+static constexpr size_t maximumAggregateLength = 131072;
+
+// Concatenates the objects' text, separated by a single space, with each object's own whitespace runs
+// collapsed and its leading and trailing whitespace dropped.
+static String aggregateText(const Vector<LiveRegionObject>& objects, bool& isTruncated, Vector<size_t>* objectEndOffsets = nullptr)
+{
+    size_t lengthHint = 0;
+    for (auto& object : objects)
+        lengthHint += object.text.length() + 1;
+
+    StringBuilder builder;
+    builder.reserveCapacity(std::min(lengthHint, maximumAggregateLength + 1));
+    if (objectEndOffsets)
+        objectEndOffsets->reserveInitialCapacity(objects.size());
+
+    for (auto& object : objects) {
+        String text = object.text.simplifyWhiteSpace(isUnicodeWhitespace);
+        if (!text.isEmpty()) {
+            if (builder.length())
+                builder.append(' ');
+            builder.append(text);
+        }
+
+        if (builder.length() > maximumAggregateLength) {
+            isTruncated = true;
+            return { };
+        }
+
+        if (objectEndOffsets)
+            objectEndOffsets->append(builder.length());
+    }
+    return builder.toString();
+}
+
+// True when text carries no word of its own, which is not worth announcing. Resolving inline markup can
+// split a trailing punctuation mark into its own object, which would otherwise be announced as just ".".
+static bool isPunctuationOnly(const String& text)
+{
+    for (unsigned i = 0; i < text.length(); ++i) {
+        char16_t character = text[i];
+        if (!isPunctuation(character) && !isUnicodeWhitespace(character))
+            return false;
+    }
+    return true;
 }
 
 // Limit on the number of objects visited during snapshot building to prevent
@@ -190,9 +299,11 @@ LiveRegionSnapshot AXLiveRegionManager::buildLiveRegionSnapshot(AccessibilityObj
     snapshot.liveRegionRelevant = stringToLiveRegionRelevant(object.liveRegionRelevant());
 
     size_t objectsVisited = 0;
-    std::function<void(AccessibilityObject&)> buildObjectList = [this, &buildObjectList, &snapshot, &objectsVisited] (AccessibilityObject& object) {
-        if (objectsVisited >= maximumSnapshotObjects)
+    std::function<void(AccessibilityObject&)> buildObjectList = [protectedThis = CheckedRef { *this }, &buildObjectList, &snapshot, &objectsVisited] (AccessibilityObject& object) {
+        if (objectsVisited >= maximumSnapshotObjects) {
+            snapshot.isTruncated = true;
             return;
+        }
         ++objectsVisited;
 
         // Treat atomic objects as one object, so when they change the entire subtree is announced.
@@ -200,9 +311,11 @@ LiveRegionSnapshot AXLiveRegionManager::buildLiveRegionSnapshot(AccessibilityObj
             HashSet<AXID> descendants;
 
             // Collect all atomic-region descendants to detect when nodes are added/removed within the atomic region.
-            std::function<void(AccessibilityObject&)> collectDescendants = [&collectDescendants, &descendants, &objectsVisited] (AccessibilityObject& descendant) {
-                if (objectsVisited >= maximumSnapshotObjects)
+            std::function<void(AccessibilityObject&)> collectDescendants = [&collectDescendants, &descendants, &objectsVisited, &snapshot] (AccessibilityObject& descendant) {
+                if (objectsVisited >= maximumSnapshotObjects) {
+                    snapshot.isTruncated = true;
                     return;
+                }
                 ++objectsVisited;
 
                 descendants.add(descendant.objectID());
@@ -213,19 +326,27 @@ LiveRegionSnapshot AXLiveRegionManager::buildLiveRegionSnapshot(AccessibilityObj
             for (auto& child : object.unignoredChildren())
                 collectDescendants(downcast<AccessibilityObject>(child.get()));
 
-            snapshot.objects.append({ object.objectID(), object.announcementText(), object.languageIncludingAncestors(), WTF::move(descendants) });
+            String text = object.announcementText();
+            snapshot.hasAnyText |= !text.isEmpty();
+            snapshot.hasAtomicRegion = true;
+            snapshot.objects.append({ object.objectID(), WTF::move(text), object.languageIncludingAncestors(), WTF::move(descendants), /* isTextContent */ false });
             return;
         }
 
-        if (shouldIncludeInSnapshot(object))
-            snapshot.objects.append({ object.objectID(), object.announcementText(), object.languageIncludingAncestors(), { }, object.isStaticText() });
-        else {
+        if (protectedThis->shouldIncludeInSnapshot(object)) {
+            String text = object.announcementText();
+            snapshot.hasAnyText |= !text.isEmpty();
+            snapshot.objects.append({ object.objectID(), WTF::move(text), object.languageIncludingAncestors(), { }, object.isStaticText() });
+        } else {
             for (auto& child : object.unignoredChildren())
                 buildObjectList(downcast<AccessibilityObject>(child.get()));
         }
     };
 
     buildObjectList(object);
+
+    if (!snapshot.isTruncated)
+        snapshot.aggregatedText = aggregateText(snapshot.objects, snapshot.isTruncated, &snapshot.objectEndOffsets);
 
     return snapshot;
 }
@@ -263,27 +384,161 @@ bool AXLiveRegionManager::shouldIncludeInSnapshot(AccessibilityObject& object) c
     return false;
 }
 
-AXLiveRegionManager::LiveRegionDiff AXLiveRegionManager::computeChanges(const Vector<LiveRegionObject>& oldObjects, const Vector<LiveRegionObject>& newObjects) const
+// Returns the objects carrying text the region did not have before, which is empty when its text did
+// not change at all. Streaming pages re-render their whole live region as each chunk arrives, which
+// spreads already-announced text across a different set of objects. For example, a paragraph that splits
+// into three once a bold span or citation resolves, and once the response is complete the many small nodes
+// are coalesced into a few large ones. Comparing objects individually sees all of those as brand new and
+// re-announces the whole response, so the region's combined text is what has to be compared.
+//
+// Returns std::nullopt when the text changed in some way other than growing at the end, or when either snapshot
+// is too incomplete to compare.
+static std::optional<Vector<LiveRegionObject>> appendedObjects(const LiveRegionSnapshot& oldSnapshot, const LiveRegionSnapshot& newSnapshot)
+{
+    // A truncated snapshot's text can stop growing while the region keeps growing, which would read as
+    // "nothing changed" and silence the rest of the content. Fall back to comparing objects instead.
+    if (oldSnapshot.isTruncated || newSnapshot.isTruncated)
+        return std::nullopt;
+
+    // Atomic regions are announced whole, so they must not be reduced to their appended text.
+    if (oldSnapshot.hasAtomicRegion || newSnapshot.hasAtomicRegion)
+        return std::nullopt;
+
+    const String& oldAggregate = oldSnapshot.aggregatedText;
+    const String& newAggregate = newSnapshot.aggregatedText;
+
+    if (oldAggregate.isEmpty())
+        return std::nullopt;
+
+    // The same text spread across a different set of objects. Streaming pages coalesce their many
+    // small nodes into fewer, larger ones once the response is complete, which leaves the text
+    // unchanged but matches up with none of the previous objects. Nothing was added, so there is
+    // nothing to announce.
+    if (newAggregate == oldAggregate)
+        return Vector<LiveRegionObject> { };
+
+    if (!newAggregate.startsWith(oldAggregate))
+        return std::nullopt;
+
+    // Streaming often delivers partial words, so the point where the old text ended can fall in the
+    // middle of a word. Back up to the start of that word and announce it whole rather than announcing a
+    // fragment of it.
+    static constexpr size_t maximumWordBoundaryBackup = 32;
+    // A region whose entire text is this short is treated as a single value, such as a counter, where
+    // the new value should be announced in full rather than only the characters that changed.
+    static constexpr size_t maximumSingleValueLength = 8;
+
+    size_t splitOffset = oldAggregate.length();
+    if (!isUnicodeWhitespace(newAggregate[splitOffset])) {
+        size_t limit = splitOffset > maximumWordBoundaryBackup ? splitOffset - maximumWordBoundaryBackup : 0;
+        size_t candidate = splitOffset;
+        while (candidate > limit && !isUnicodeWhitespace(newAggregate[candidate - 1]))
+            --candidate;
+
+        if (candidate && isUnicodeWhitespace(newAggregate[candidate - 1]))
+            splitOffset = candidate;
+        else if (oldAggregate.length() <= maximumSingleValueLength) {
+            // No word boundary was found. Scripts that do not separate words with spaces (Chinese,
+            // Japanese, Thai) never have one, so only rewind the whole text when it is short enough to
+            // plausibly be a single value. Otherwise the entire region would be re-announced per chunk.
+            splitOffset = 0;
+        }
+    }
+
+    // Offsets were recorded alongside the text when the snapshot was built. They only cover every object
+    // when the walk ran to completion, which the truncation check above has already established.
+    const Vector<size_t>& objectEndOffsets = newSnapshot.objectEndOffsets;
+    ASSERT(objectEndOffsets.size() == newSnapshot.objects.size());
+
+    Vector<LiveRegionObject> appended;
+    size_t objectStart = 0;
+    for (size_t i = 0; i < newSnapshot.objects.size(); ++i) {
+        size_t objectEnd = objectEndOffsets[i];
+        size_t contributionStart = std::exchange(objectStart, objectEnd);
+
+        // Skip objects that contributed nothing, and those whose text was entirely announced already.
+        if (objectEnd <= contributionStart || objectEnd <= splitOffset)
+            continue;
+
+        LiveRegionObject object = newSnapshot.objects[i];
+        size_t announceFrom = contributionStart;
+        if (contributionStart < splitOffset) {
+            // Only text content can be cut mid-object. Anything else is a single accessible name or
+            // value (a button's title, an image's alt text), where announcing part of one would say
+            // something like "over" for a button relabelled "Start over", so those are announced whole.
+            if (object.isTextContent)
+                announceFrom = splitOffset;
+        }
+
+        // Take the text from the aggregate, which is already whitespace-collapsed.
+        object.text = newAggregate.substring(announceFrom, objectEnd - announceFrom).trim(isUnicodeWhitespace);
+        if (object.text.isEmpty() || isPunctuationOnly(object.text))
+            continue;
+
+        appended.append(WTF::move(object));
+    }
+
+    return appended;
+}
+
+AXLiveRegionManager::LiveRegionDiff AXLiveRegionManager::computeChanges(const LiveRegionSnapshot& oldSnapshot, const LiveRegionSnapshot& newSnapshot) const
 {
     // Here we compare the old and new live region to compute:
     // - Additions: New objects, or atomic regions where nodes were added AND text changed.
     // - Deletions: Objects that were removed from the region, or atomic regions where nodes were removed AND text changed.
     // - Changes: Text content/values that changed between the same object (without node additions/removals).
 
+    const Vector<LiveRegionObject>& oldObjects = oldSnapshot.objects;
+    const Vector<LiveRegionObject>& newObjects = newSnapshot.objects;
+
     LiveRegionDiff diff;
+
+    if (auto appended = appendedObjects(oldSnapshot, newSnapshot)) {
+        // The region's text only grew at the end, so announce just the new text. This has to be checked
+        // before comparing objects individually, because a re-render can spread the same text across a
+        // different set of objects, which object-level comparison sees as entirely new content.
+        // Text that grew on an object that was already there is a text change. Text on an object that
+        // was not there is an addition. aria-relevant distinguishes the two, so a region asking only for
+        // "additions" must not hear text edits, and one asking only for "text" must still hear them.
+        for (auto& object : *appended) {
+            bool objectExistedBefore = oldObjects.containsIf([&] (const auto& oldObject) {
+                return oldObject.objectID == object.objectID;
+            });
+            if (objectExistedBefore)
+                diff.changed.append(object);
+            else
+                diff.added.append(object);
+        }
+        return diff;
+    }
 
     // Build a map of old objects for lookup. As we match them with new objects, we'll remove them.
     // Whatever remains unmatched at the end represents removals.
     HashMap<AXID, LiveRegionObjectMetadata> unmatchedOldObjects;
     unmatchedOldObjects.reserveInitialCapacity(oldObjects.size());
 
-    for (auto& object : oldObjects)
-        unmatchedOldObjects.set(object.objectID, LiveRegionObjectMetadata { object.text, object.language, object.descendants });
+    // Index the old objects by text too, so content that survived a re-render can still be matched
+    // even though the objects backing it are new. See the second pass below.
+    HashMap<String, Vector<AXID>> oldObjectIDsByText;
 
-    for (auto& newObject : newObjects) {
+    for (auto& object : oldObjects) {
+        unmatchedOldObjects.set(object.objectID, LiveRegionObjectMetadata { object.text, object.language, object.descendants });
+        if (!object.text.isEmpty())
+            oldObjectIDsByText.add(object.text, Vector<AXID> { }).iterator->value.append(object.objectID);
+    }
+
+    // Additions are collected with the index of the object that produced them, so that the two passes
+    // below can be merged back into document order before anything is announced.
+    Vector<std::pair<size_t, LiveRegionObject>> additions;
+
+    // First pass. Try to match by AXID. This has to finish before any text matching happens below, so that
+    // objects which still exist are always paired with themselves rather than consumed by a text match.
+    Vector<size_t> unmatchedNewObjectIndices;
+    for (size_t i = 0; i < newObjects.size(); ++i) {
+        const auto& newObject = newObjects[i];
         auto iterator = unmatchedOldObjects.find(newObject.objectID);
         if (iterator == unmatchedOldObjects.end())
-            diff.added.append(newObject);
+            unmatchedNewObjectIndices.append(i);
         else {
             bool textChanged = iterator->value.text != newObject.text;
 
@@ -298,7 +553,7 @@ AXLiveRegionManager::LiveRegionDiff AXLiveRegionManager::computeChanges(const Ve
                 bool nodesRemoved = oldDescendantsCopy.size();
 
                 if (nodesAdded && textChanged)
-                    diff.added.append(newObject);
+                    additions.append({ i, newObject });
                 else if (nodesRemoved && textChanged)
                     diff.removed.append(newObject);
 
@@ -311,9 +566,46 @@ AXLiveRegionManager::LiveRegionDiff AXLiveRegionManager::computeChanges(const Ve
         }
     }
 
-    // Anything left in unmatchedOldObjects is a removal.
-    for (auto& entry : unmatchedOldObjects)
-        diff.removed.append({ entry.key, entry.value.text, entry.value.language, { } });
+    // Second pass. For new objects that had no AXID match, try to match them to a leftover old object with
+    // identical text. Re-rendering a region destroys and recreates the objects holding text that was
+    // already announced, so matching only by AXID makes that text look new and announces it again.
+    for (auto index : unmatchedNewObjectIndices) {
+        const auto& newObject = newObjects[index];
+
+        bool matchedIdenticalText = false;
+        // The text is only looked up when it is non-empty, matching how oldObjectIDsByText was built.
+        if (!newObject.text.isEmpty()) {
+            if (auto iterator = oldObjectIDsByText.find(newObject.text); iterator != oldObjectIDsByText.end()) {
+                // An old object's text can only be claimed once, so drop candidates already matched by AXID above.
+                while (!iterator->value.isEmpty()) {
+                    if (unmatchedOldObjects.remove(iterator->value.takeLast())) {
+                        matchedIdenticalText = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Text carried over unchanged from the previous snapshot has nothing to announce.
+        if (!matchedIdenticalText)
+            additions.append({ index, newObject });
+    }
+
+    // Merge the two passes back into document order. Announcing a new object before a changed atomic
+    // region that precedes it would reverse the reading order of the announcement.
+    std::sort(additions.begin(), additions.end(), [] (const auto& a, const auto& b) {
+        return a.first < b.first;
+    });
+    diff.added.reserveInitialCapacity(additions.size());
+    for (auto& addition : additions)
+        diff.added.append(WTF::move(addition.second));
+
+    // Anything left unmatched is a removal. Walk the old objects rather than the map so that removals
+    // come out in document order rather than hash order.
+    for (auto& oldObject : oldObjects) {
+        if (unmatchedOldObjects.contains(oldObject.objectID))
+            diff.removed.append({ oldObject.objectID, oldObject.text, oldObject.language, { } });
+    }
 
     return diff;
 }
@@ -321,12 +613,12 @@ AXLiveRegionManager::LiveRegionDiff AXLiveRegionManager::computeChanges(const Ve
 static const size_t maximumAnnouncementLength = 2500;
 enum class IsLiveRegionRemoval : bool { No, Yes };
 
-AttributedString AXLiveRegionManager::computeAnnouncement(const LiveRegionSnapshot& newSnapshot, const LiveRegionDiff& diff) const
+AttributedString AXLiveRegionManager::computeAnnouncement(OptionSet<LiveRegionRelevant> liveRegionRelevant, const LiveRegionDiff& diff) const
 {
-    bool hasAll = newSnapshot.liveRegionRelevant.contains(LiveRegionRelevant::All);
-    bool hasAdditions = hasAll || newSnapshot.liveRegionRelevant.contains(LiveRegionRelevant::Additions);
-    bool hasRemovals = hasAll || newSnapshot.liveRegionRelevant.contains(LiveRegionRelevant::Removals);
-    bool hasText = hasAll || newSnapshot.liveRegionRelevant.contains(LiveRegionRelevant::Text);
+    bool hasAll = liveRegionRelevant.contains(LiveRegionRelevant::All);
+    bool hasAdditions = hasAll || liveRegionRelevant.contains(LiveRegionRelevant::Additions);
+    bool hasRemovals = hasAll || liveRegionRelevant.contains(LiveRegionRelevant::Removals);
+    bool hasText = hasAll || liveRegionRelevant.contains(LiveRegionRelevant::Text);
 
     StringBuilder stringBuilder;
     Vector<std::pair<AttributedString::Range, HashMap<String, AttributedString::AttributeValue>>> attributes;
@@ -399,7 +691,7 @@ AttributedString AXLiveRegionManager::computeAnnouncement(const LiveRegionSnapsh
 
 void AXLiveRegionManager::postAnnouncementForChange(AccessibilityObject& object, const LiveRegionSnapshot& oldSnapshot, const LiveRegionSnapshot& newSnapshot)
 {
-    auto diff = computeChanges(oldSnapshot.objects, newSnapshot.objects);
+    auto diff = computeChanges(oldSnapshot, newSnapshot);
     if (diff.added.isEmpty() && diff.removed.isEmpty() && diff.changed.isEmpty())
         return;
 
@@ -420,7 +712,11 @@ void AXLiveRegionManager::postAnnouncementForChange(AccessibilityObject& object,
     // also applies maximumAnnouncementLength to the translated text, which matters because
     // translations commonly run longer than their source.
     auto expectedSegmentCount = segments.size();
-    auto assemble = [this, object = Ref { object }, diff, newSnapshot, expectedSegmentCount](Vector<String>&& translatedSegments, const String& language) mutable {
+    // Capture only the two values the announcement needs. Capturing the snapshot would deep copy every
+    // object in the region on every update just to read them.
+    auto liveRegionStatus = newSnapshot.liveRegionStatus;
+    auto liveRegionRelevant = newSnapshot.liveRegionRelevant;
+    auto assemble = [protectedThis = CheckedRef { *this }, object = Ref { object }, diff, liveRegionStatus, liveRegionRelevant, expectedSegmentCount](Vector<String>&& translatedSegments, const String& language) mutable {
         if (translatedSegments.size() == expectedSegmentCount) {
             size_t index = 0;
             auto applyTranslation = [&](Vector<LiveRegionObject>& objects) {
@@ -435,11 +731,11 @@ void AXLiveRegionManager::postAnnouncementForChange(AccessibilityObject& object,
             applyTranslation(diff.changed);
         }
 
-        AttributedString announcement = computeAnnouncement(newSnapshot, diff);
+        AttributedString announcement = protectedThis->computeAnnouncement(liveRegionRelevant, diff);
         if (announcement.isNull() || announcement.string.isEmpty())
             return;
 
-        CheckedRef { m_cache }->postLiveRegionNotification(object, newSnapshot.liveRegionStatus, announcement);
+        CheckedRef { protectedThis->m_cache }->postLiveRegionNotification(object, liveRegionStatus, announcement);
     };
 
     CheckedRef { m_cache }->translateAnnouncementThenAssemble(Ref { object }, WTF::move(segments), WTF::move(assemble));

--- a/Source/WebCore/accessibility/AXLiveRegionManager.h
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.h
@@ -34,7 +34,10 @@
 #include <WebCore/AXAnnouncementTypes.h>
 #include <WebCore/AXCoreObject.h>
 #include <WebCore/AttributedString.h>
+#include <WebCore/Timer.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -42,15 +45,20 @@ namespace WebCore {
 class AccessibilityObject;
 class AXObjectCache;
 
-class AXLiveRegionManager {
+class AXLiveRegionManager : public CanMakeCheckedPtr<AXLiveRegionManager> {
     WTF_MAKE_NONCOPYABLE(AXLiveRegionManager);
     WTF_MAKE_TZONE_ALLOCATED(AXLiveRegionManager);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AXLiveRegionManager);
 public:
     explicit AXLiveRegionManager(AXObjectCache&);
     ~AXLiveRegionManager() = default;
 
     void registerLiveRegion(AccessibilityObject&, bool = false);
-    void unregisterLiveRegion(AXID axID) { m_liveRegions.remove(axID); }
+    void unregisterLiveRegion(AXID axID)
+    {
+        m_liveRegions.remove(axID);
+        m_regionsPendingEmpty.remove(axID);
+    }
 
     void handleLiveRegionChange(AccessibilityObject&, AnnouncementContents = AnnouncementContents::Changes);
 
@@ -68,11 +76,16 @@ private:
     LiveRegionSnapshot buildLiveRegionSnapshot(AccessibilityObject&) const;
     bool shouldIncludeInSnapshot(AccessibilityObject&) const;
     void postAnnouncementForChange(AccessibilityObject&, const LiveRegionSnapshot&, const LiveRegionSnapshot&);
-    LiveRegionDiff computeChanges(const Vector<LiveRegionObject>&, const Vector<LiveRegionObject>&) const;
-    AttributedString computeAnnouncement(const LiveRegionSnapshot&, const LiveRegionDiff&) const;
+    LiveRegionDiff computeChanges(const LiveRegionSnapshot&, const LiveRegionSnapshot&) const;
+    AttributedString computeAnnouncement(OptionSet<LiveRegionRelevant>, const LiveRegionDiff&) const;
+    void emptyRegionSettleTimerFired();
 
     CheckedRef<AXObjectCache> m_cache;
     HashMap<AXID, LiveRegionSnapshot> m_liveRegions;
+    // Regions that had content but are now empty. We wait to see whether
+    // content comes back based on this timer. See handleLiveRegionChange().
+    HashSet<AXID> m_regionsPendingEmpty;
+    Timer m_emptyRegionSettleTimer;
     mutable unsigned m_snapshotBuildCount { 0 };
 };
 


### PR DESCRIPTION
#### 6d28d6994a1f3178058782606b1145197aadaa08
<pre>
AX: VoiceOver repeats the first sentence over and over as content streams in on gemini.google.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=323464">https://bugs.webkit.org/show_bug.cgi?id=323464</a>
<a href="https://rdar.apple.com/186694747">rdar://186694747</a>

Reviewed by Dominic Mazzoni.

VoiceOver repeated a Gemini response as it streamed in -- the first line several
times, then the first and second together several times, and so on. Any page that
streams text into an aria-live region by re-rendering it is affected.

The region was diffed by matching accessibility objects between the old and new
snapshot by AXID, which assumes the objects backing already-announced text survive an
update. When a page re-renders a region instead of appending to it they do not, and
four separate things went wrong:

  1. These types of pages commonly re-render by emptying the container and refilling it in a later
     task, so the region genuinely has no content for one update. That empty snapshot
     became the baseline, which made the refilled text look entirely new.
  2. Announced text is re-created under new AXIDs, and re-segmented as markup
     resolves -- one text node becomes three once bold or a citation lands -- so
     nothing matched.
  3. Streaming delivers sub-word tokens, so the previous text usually ends mid-word.
  4. Once the response completes the many small nodes are coalesced into a few large
     ones holding byte-identical text.

The region is now compared by its combined text rather than by its objects. A snapshot
caches that text -- every object&apos;s text joined by a single space, with whitespace runs
collapsed -- along with the offset each object ends at, so comparing is a string
compare while the result can still be mapped back onto the objects carrying it, which
is what preserves per-object language and the name/value distinction.

Identical text now announces nothing however the region was re-chunked, fixing 4.
Text that only grew at the end announces just the appended tail, fixing 2. When the
split point lands inside a word it backs up to the start of that word and announces
the word whole, fixing 3 and also making a counter ticking 5 to 50 say &quot;50&quot; rather
than the fragment &quot;0&quot;.

For 1, the last snapshot that had text is kept instead of being replaced by the empty
one. A region that asked to hear removals still needs to hear that its content went
away, so that announcement is still posted from the kept snapshot.

* LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-emptied-removal-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-emptied-removal.html: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-emptied-removal-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-emptied-removal.html: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-streamed-content-not-repeated-expected.txt: Added.
* LayoutTests/accessibility/mac/live-regions/live-region-streamed-content-not-repeated.html: Added.
* Source/WebCore/accessibility/AXAnnouncementTypes.h:
* Source/WebCore/accessibility/AXLiveRegionManager.cpp:
(WebCore::AXLiveRegionManager::handleLiveRegionChange):
(WebCore::aggregateText):
(WebCore::isPunctuationOnly):
(WebCore::AXLiveRegionManager::buildLiveRegionSnapshot const):
(WebCore::appendedObjects):
(WebCore::AXLiveRegionManager::computeChanges const):
(WebCore::AXLiveRegionManager::computeAnnouncement const):
(WebCore::AXLiveRegionManager::postAnnouncementForChange):
* Source/WebCore/accessibility/AXLiveRegionManager.h:

Canonical link: <a href="https://commits.webkit.org/320576@main">https://commits.webkit.org/320576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b6b022d01118240e66ac9130a1b94b3b9032198

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195480 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9e6bf92a-8307-4468-a8f4-6b51b3a9d19d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187014 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58791 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144680 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ea14495-d61a-4c24-be36-edcca6fc190e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165270 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124973 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4578e9c3-a2b8-4f15-8f7e-0c1f375fb230) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47095 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45153 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44840 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6536 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197431 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58728 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154186 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41299 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59437 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153838 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48332 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131754 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128424 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57916 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19859 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57287 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57530 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57354 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->