### PR TITLE
[JSC] Optimize Wasm globals initialization related code

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -56,9 +56,13 @@ public:
     {
     }
 
-    std::expected<uint64_t, String> run(std::span<const uint8_t> bytes)
+    std::expected<uint64_t, String> run(std::span<const uint8_t> bytes, uint32_t maxStackHeight)
     {
         Vector<ConstExprValue, 16> stack;
+        stack.reserveInitialCapacity(maxStackHeight);
+        auto push = [&](ConstExprValue value) ALWAYS_INLINE_LAMBDA {
+            stack.append(value);
+        };
         auto pop = [&] ALWAYS_INLINE_LAMBDA {
             ASSERT(!stack.isEmpty());
             return stack.takeLast();
@@ -117,20 +121,20 @@ public:
 
             switch (op) {
             case I32Const:
-                stack.append(ConstExprValue(static_cast<uint64_t>(varInt32())));
+                push(ConstExprValue(static_cast<uint64_t>(varInt32())));
                 continue;
             case I64Const:
-                stack.append(ConstExprValue(static_cast<uint64_t>(varInt64())));
+                push(ConstExprValue(static_cast<uint64_t>(varInt64())));
                 continue;
             case F32Const:
-                stack.append(ConstExprValue(static_cast<uint64_t>(uint32())));
+                push(ConstExprValue(static_cast<uint64_t>(uint32())));
                 continue;
             case F64Const:
-                stack.append(ConstExprValue(uint64()));
+                push(ConstExprValue(uint64()));
                 continue;
             case RefNull:
                 varInt32(); // Heap type, which only affects the static type of the null.
-                stack.append(ConstExprValue(static_cast<uint64_t>(JSValue::encode(jsNull()))));
+                push(ConstExprValue(static_cast<uint64_t>(JSValue::encode(jsNull()))));
                 continue;
             case RefFunc:
                 result = refFunc(FunctionSpaceIndex(varUInt32()));
@@ -162,7 +166,7 @@ public:
                 v128_t vector;
                 memcpySpan(asMutableByteSpan(vector), bytes.subspan(offset, sizeof(vector)));
                 offset += sizeof(vector);
-                stack.append(ConstExprValue(vector));
+                push(ConstExprValue(vector));
                 continue;
             }
             case ExtGC: {
@@ -186,9 +190,9 @@ public:
                     size_t fieldCount = m_info.rtt(typeIndex).fieldCount();
                     ASSERT(stack.size() >= fieldCount);
                     result = createNewStruct(typeIndex, stack.subspan(stack.size() - fieldCount));
+                    stack.shrink(stack.size() - fieldCount);
                     if (result.isInvalid()) [[unlikely]]
                         return failedToAllocate("struct"_s, offset);
-                    stack.shrink(stack.size() - fieldCount);
                     break;
                 }
                 case ExtGCOpType::ArrayNew: {
@@ -213,9 +217,9 @@ public:
                     size_t elementCount = varUInt32();
                     ASSERT(stack.size() >= elementCount);
                     result = createNewArray(typeIndex, stack.subspan(stack.size() - elementCount));
+                    stack.shrink(stack.size() - elementCount);
                     if (result.isInvalid()) [[unlikely]]
                         return failedToAllocate("array"_s, offset);
-                    stack.shrink(stack.size() - elementCount);
                     break;
                 }
                 default:
@@ -231,7 +235,7 @@ public:
                 RELEASE_ASSERT_NOT_REACHED();
             }
 
-            stack.append(result);
+            push(result);
         }
     }
 
@@ -398,20 +402,25 @@ private:
     ConstExprValue createNewArray(TypeSignatureIndex typeIndex, std::span<const ConstExprValue> elements)
     {
         auto* structure = m_instance->gcObjectStructure(typeIndex.rawIndex());
-        bool isV128 = structure->rtt().elementType().type.unpacked().isV128();
-        ConstExprValue result = createNewArray(structure, elements.size(), isV128 ? ConstExprValue(vectorAllZeros()) : ConstExprValue());
-        if (result.isInvalid()) [[unlikely]]
-            return result;
+        VM& vm = m_instance->vm();
+        JSWebAssemblyArray* array = JSWebAssemblyArray::tryCreate(vm, structure, elements.size());
+        if (!array) [[unlikely]]
+            return ConstExprValue(InvalidConstExpr);
+        m_keepAlive.appendWithCrashOnOverflow(array);
 
-        JSWebAssemblyArray* array = uncheckedDowncast<JSWebAssemblyArray>(JSValue::decode(result.getValue()));
-        VM& vm = array->vm();
-        for (size_t i = 0; i < elements.size(); ++i) {
-            if (isV128)
-                array->set(vm, i, elements[i].getVector());
-            else
-                array->set(vm, i, elements[i].getValue());
+        if (structure->rtt().elementType().type.unpacked().isV128()) {
+            auto span = array->span<v128_t>();
+            for (size_t i = 0; i < elements.size(); ++i)
+                span[i] = elements[i].getVector();
+        } else {
+            array->visitSpanNonVector([&]<typename T>(std::span<T> span) ALWAYS_INLINE_LAMBDA {
+                for (size_t i = 0; i < elements.size(); ++i)
+                    span[i] = static_cast<T>(elements[i].getValue());
+            });
+            if (array->elementsAreRefTypes())
+                vm.writeBarrier(array);
         }
-        return result;
+        return ConstExprValue(JSValue(array));
     }
 
     ConstExprValue createNewStruct(TypeSignatureIndex typeIndex)
@@ -422,18 +431,20 @@ private:
 
     ConstExprValue createNewStruct(TypeSignatureIndex typeIndex, std::span<const ConstExprValue> fields)
     {
-        ConstExprValue result = createNewStruct(typeIndex);
-        if (result.isInvalid()) [[unlikely]]
-            return result;
+        auto* structure = m_instance->gcObjectStructure(typeIndex.rawIndex());
+        JSWebAssemblyStruct* structObject = JSWebAssemblyStruct::tryCreate(m_instance->vm(), structure);
+        if (!structObject) [[unlikely]]
+            return ConstExprValue(InvalidConstExpr);
+        m_keepAlive.appendWithCrashOnOverflow(structObject);
 
-        JSWebAssemblyStruct* structObject = uncheckedDowncast<JSWebAssemblyStruct>(JSValue::decode(result.getValue()));
+        ASSERT(fields.size() == structure->rtt().fieldCount());
         for (size_t i = 0; i < fields.size(); ++i) {
             if (fields[i].type() == ConstExprValue::Vector)
                 structObject->set(i, fields[i].getVector());
             else
                 structObject->set(i, fields[i].getValue());
         }
-        return result;
+        return ConstExprValue(JSValue(structObject));
     }
 
     const size_t m_offsetInSource;
@@ -515,6 +526,7 @@ public:
     }
 
     const Vector<FunctionSpaceIndex>& NODELETE declaredFunctions() const { return m_declaredFunctions; }
+    uint32_t NODELETE maxStackHeight() const { return m_maxStackHeight; }
     void NODELETE setParser(FunctionParser<ConstExprGenerator>* parser) { m_parser = parser; };
 
     bool NODELETE addArguments(const RTT&) { RELEASE_ASSERT_NOT_REACHED(); }
@@ -881,6 +893,8 @@ public:
     ALWAYS_INLINE void didParseOpcode() {
         if (m_parser->currentOpcode() == Nop)
             m_shouldError = true;
+
+        m_maxStackHeight = std::max<uint32_t>(m_maxStackHeight, m_parser->expressionStack().size());
     }
     void NODELETE didFinishParsingLocals() { }
     void NODELETE didPopValueFromStack(ExpressionType, ASCIILiteral) { }
@@ -891,15 +905,17 @@ private:
     size_t m_offsetInSource { 0 };
     const Ref<const ModuleInformation> m_info;
     bool m_shouldError = false;
+    uint32_t m_maxStackHeight { 0 };
     Vector<FunctionSpaceIndex> m_declaredFunctions;
 };
 
-std::expected<void, String> parseExtendedConstExpr(std::span<const uint8_t> source, size_t offsetInSource, size_t& offset, ModuleInformation& info, Type expectedType)
+std::expected<void, String> parseExtendedConstExpr(std::span<const uint8_t> source, size_t offsetInSource, size_t& offset, uint32_t& maxStackHeight, ModuleInformation& info, Type expectedType)
 {
     ConstExprGenerator generator(offsetInSource, info);
     FunctionParser<ConstExprGenerator> parser(generator, source, BlockSignature { expectedType }, info);
     WASM_FAIL_IF_HELPER_FAILS(parser.parseConstantExpression());
     offset = parser.offset();
+    maxStackHeight = generator.maxStackHeight();
 
     for (const auto& declaredFunctionIndex : generator.declaredFunctions())
         info.addDeclaredFunction(declaredFunctionIndex);
@@ -907,10 +923,10 @@ std::expected<void, String> parseExtendedConstExpr(std::span<const uint8_t> sour
     return { };
 }
 
-std::expected<uint64_t, String> evaluateExtendedConstExpr(const ModuleInformation::ConstantExpressionAndSourceOffset& constantExpressionAndSourceOffset, JSWebAssemblyInstance* instance, const ModuleInformation& info)
+std::expected<uint64_t, String> evaluateExtendedConstExpr(const ModuleInformation::ConstantExpression& constantExpression, JSWebAssemblyInstance* instance, const ModuleInformation& info)
 {
-    ConstExprInterpreter interpreter(constantExpressionAndSourceOffset.second, info, instance);
-    return interpreter.run(constantExpressionAndSourceOffset.first.span());
+    ConstExprInterpreter interpreter(constantExpression.sourceOffset, info, instance);
+    return interpreter.run(constantExpression.bytes.span(), constantExpression.maxStackHeight);
 }
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.h
@@ -35,8 +35,8 @@ class JSWebAssemblyInstance;
 
 namespace Wasm {
 
-std::expected<void, String> parseExtendedConstExpr(std::span<const uint8_t>, size_t, size_t&, ModuleInformation&, Type);
-std::expected<uint64_t, String> evaluateExtendedConstExpr(const ModuleInformation::ConstantExpressionAndSourceOffset&, JSWebAssemblyInstance*, const ModuleInformation&);
+std::expected<void, String> parseExtendedConstExpr(std::span<const uint8_t>, size_t, size_t&, uint32_t& maxStackHeight, ModuleInformation&, Type);
+std::expected<uint64_t, String> evaluateExtendedConstExpr(const ModuleInformation::ConstantExpression&, JSWebAssemblyInstance*, const ModuleInformation&);
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -228,8 +228,12 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
     Vector<CustomSection> customSections;
     BranchHints branchHints;
     std::optional<uint32_t> numberOfDataSegments;
-    using ConstantExpressionAndSourceOffset = std::pair<Vector<uint8_t>, size_t>;
-    Vector<ConstantExpressionAndSourceOffset> constantExpressions;
+    struct ConstantExpression {
+        Vector<uint8_t> bytes;
+        size_t sourceOffset { 0 };
+        uint32_t maxStackHeight { 0 };
+    };
+    Vector<ConstantExpression> constantExpressions;
     Name sourceURL;
     uint64_t requestIdentifier { 0 };
     Name sourceMappingURL;

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -471,15 +471,14 @@ inline JSValue structNew(JSWebAssemblyInstance* instance, WebAssemblyGCStructure
     const Wasm::RTT& structRTT = structure->rtt();
     JSWebAssemblyStruct* structValue = JSWebAssemblyStruct::create(vm, structure);
     if (static_cast<Wasm::UseDefaultValue>(useDefault) == Wasm::UseDefaultValue::Yes) {
-        for (unsigned i = 0; i < structRTT.fieldCount(); ++i) {
-            if (structRTT.field(i).type.unpacked().isV128()) {
-                structValue->set(i, vectorAllZeros());
-                continue;
+        // The constructor zeroed the payload, which is already the default for every numeric,
+        // packed and v128 field. Only a reference field needs a write, since its default is null
+        // rather than an all-zero JSValue.
+        if (structRTT.hasRefFieldTypes()) {
+            for (unsigned i = 0; i < structRTT.fieldCount(); ++i) {
+                if (Wasm::isRefType(structRTT.field(i).type))
+                    structValue->set(i, JSValue::encode(jsNull()));
             }
-            EncodedJSValue value = 0;
-            if (Wasm::isRefType(structRTT.field(i).type))
-                value = JSValue::encode(jsNull());
-            structValue->set(i, value);
         }
     } else {
         ASSERT(arguments);

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -864,10 +864,11 @@ auto SectionParser::parseInitExpr(uint8_t& opcode, bool& isExtendedConstantExpre
     // If an End doesn't appear, we have to assume it's an extended constant expression
     // and use the full Wasm expression parser to validate.
     size_t initExprOffset;
+    uint32_t maxStackHeight = 0;
     const size_t offsetOfExprInSource = initialOffset + m_offsetInSource;
-    WASM_FAIL_IF_HELPER_FAILS(parseExtendedConstExpr(source().subspan(initialOffset), offsetOfExprInSource, initExprOffset, m_info, expectedType));
+    WASM_FAIL_IF_HELPER_FAILS(parseExtendedConstExpr(source().subspan(initialOffset), offsetOfExprInSource, initExprOffset, maxStackHeight, m_info, expectedType));
     m_offset += (initExprOffset - (m_offset - initialOffset));
-    WASM_PARSER_FAIL_IF(!m_info->constantExpressions.tryConstructAndAppend(std::make_pair(source().subspan(initialOffset, initExprOffset), offsetOfExprInSource)), "could not allocate memory for init expr"_s);
+    WASM_PARSER_FAIL_IF(!m_info->constantExpressions.tryConstructAndAppend(ModuleInformation::ConstantExpression { source().subspan(initialOffset, initExprOffset), offsetOfExprInSource, maxStackHeight }), "could not allocate memory for init expr"_s);
     bitsOrImportNumber = m_info->constantExpressions.size() - 1;
     isExtendedConstantExpression = true;
     resultType = expectedType;

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -310,11 +310,16 @@ FuncRefTable::FuncRefTable(VM& vm, uint32_t initial, std::optional<uint64_t> max
 
     m_wrappers = MallocPtr<WriteBarrier<WebAssemblyFunctionBase>, VMMalloc>::malloc(sizeof(WriteBarrier<WebAssemblyFunctionBase>) * Checked<size_t>(allocatedLength(m_length)));
 
-    for (uint32_t i = 0; i < allocatedLength(m_length); ++i) {
-        new (&m_importableFunctions.get()[i]) Function();
+    // Every member of both element types defaults to a null pointer, so one bulk zero stands in
+    // for a placement-new per slot. Tables here run to thousands of entries and are then
+    // overwritten by the element segments.
+    uint32_t slots = allocatedLength(m_length);
+    zeroSpan(std::span { std::bit_cast<uint8_t*>(m_importableFunctions.get()), sizeof(Function) * slots });
+    zeroSpan(std::span { std::bit_cast<uint8_t*>(m_wrappers.get()), sizeof(WriteBarrier<WebAssemblyFunctionBase>) * slots });
+#if ASSERT_ENABLED
+    for (uint32_t i = 0; i < slots; ++i)
         ASSERT(m_importableFunctions.get()[i].isEmpty()); // We rely on this in compiled code.
-        new (&m_wrappers.get()[i]) WriteBarrier<WebAssemblyFunctionBase>();
-    }
+#endif
 }
 
 FuncRefTable::~FuncRefTable()

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -635,6 +635,7 @@ public:
     StructFieldCount fieldCount() const { return m_fields.size(); }
     const FieldType& field(StructFieldCount i) const LIFETIME_BOUND { return m_fields[i].type; }
     unsigned offsetOfFieldInPayload(StructFieldCount i) const { return m_fields[i].offset; }
+    const StructFieldEntry& fieldEntry(StructFieldCount i) const LIFETIME_BOUND { return m_fields[i]; }
     size_t instancePayloadSize() const { return m_instancePayloadSize; }
     bool hasRefFieldTypes() const { return m_hasRefFieldTypes; }
     bool hasRecursiveReference() const { return m_hasRecursiveReference; }
@@ -801,6 +802,13 @@ public:
         return structPayload().field(i);
     }
     unsigned offsetOfFieldInPayload(StructFieldCount i) const { return structPayload().offsetOfFieldInPayload(i); }
+
+    const StructFieldEntry& fieldEntry(StructFieldCount i) const LIFETIME_BOUND
+    {
+        ASSERT(m_kind == RTTKind::Struct);
+        return structPayload().fieldEntry(i);
+    }
+
     size_t instancePayloadSize() const { return structPayload().instancePayloadSize(); }
     bool hasRefFieldTypes() const { return structPayload().hasRefFieldTypes(); }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp
@@ -71,19 +71,20 @@ uint64_t JSWebAssemblyStruct::get(uint32_t fieldIndex) const
 {
     using Wasm::TypeKind;
 
-    const uint8_t* targetPointer = fieldPointer(fieldIndex);
+    SUPPRESS_UNCOUNTED_LOCAL const auto& entry = structType().fieldEntry(fieldIndex);
+    const uint8_t* targetPointer = payload() + entry.offset;
 
-    if (fieldType(fieldIndex).type.is<Wasm::PackedType>()) {
-        switch (fieldType(fieldIndex).type.as<Wasm::PackedType>()) {
+    if (entry.type.type.is<Wasm::PackedType>()) {
+        switch (entry.type.type.as<Wasm::PackedType>()) {
         case Wasm::PackedType::I8:
             return *std::bit_cast<uint8_t*>(targetPointer);
         case Wasm::PackedType::I16:
             return *std::bit_cast<uint16_t*>(targetPointer);
         }
     }
-    ASSERT(fieldType(fieldIndex).type.is<Wasm::Type>());
+    ASSERT(entry.type.type.is<Wasm::Type>());
 
-    switch (fieldType(fieldIndex).type.as<Wasm::Type>().kind()) {
+    switch (entry.type.type.as<Wasm::Type>().kind()) {
     case TypeKind::I32:
     case TypeKind::F32:
         return *std::bit_cast<uint32_t*>(targetPointer);
@@ -116,10 +117,11 @@ void JSWebAssemblyStruct::set(uint32_t fieldIndex, uint64_t argument)
 {
     using Wasm::TypeKind;
 
-    uint8_t* targetPointer = fieldPointer(fieldIndex);
+    SUPPRESS_UNCOUNTED_LOCAL const auto& entry = structType().fieldEntry(fieldIndex);
+    uint8_t* targetPointer = payload() + entry.offset;
 
-    if (fieldType(fieldIndex).type.is<Wasm::PackedType>()) {
-        switch (fieldType(fieldIndex).type.as<Wasm::PackedType>()) {
+    if (entry.type.type.is<Wasm::PackedType>()) {
+        switch (entry.type.type.as<Wasm::PackedType>()) {
         case Wasm::PackedType::I8:
             *std::bit_cast<uint8_t*>(targetPointer) = static_cast<uint8_t>(argument);
             return;
@@ -128,9 +130,9 @@ void JSWebAssemblyStruct::set(uint32_t fieldIndex, uint64_t argument)
             return;
         }
     }
-    ASSERT(fieldType(fieldIndex).type.is<Wasm::Type>());
+    ASSERT(entry.type.type.is<Wasm::Type>());
 
-    switch (fieldType(fieldIndex).type.as<Wasm::Type>().kind()) {
+    switch (entry.type.type.as<Wasm::Type>().kind()) {
     case TypeKind::I32:
     case TypeKind::F32: {
         *std::bit_cast<uint32_t*>(targetPointer) = static_cast<uint32_t>(argument);


### PR DESCRIPTION
#### 1b46b208061c4dbf3f8514b88d68d53bf124eb90
<pre>
[JSC] Optimize Wasm globals initialization related code
<a href="https://bugs.webkit.org/show_bug.cgi?id=323465">https://bugs.webkit.org/show_bug.cgi?id=323465</a>
<a href="https://rdar.apple.com/186697890">rdar://186697890</a>

Reviewed by Yijia Huang.

This patch optimizes Wasm globals initialization related code,

1. constant expression validator should collect maxStackHeight. So we
   can use this when evaluating constant expression.
2. Wasm array / struct are initialized with zeros. So we should set a
   new value only when it is not zero (jsNull() for example).

* Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp:
(JSC::Wasm::ConstExprInterpreter::run):
(JSC::Wasm::ConstExprInterpreter::createNewArray):
(JSC::Wasm::ConstExprInterpreter::createNewStruct):
(JSC::Wasm::ConstExprGenerator::maxStackHeight const):
(JSC::Wasm::ConstExprGenerator::didParseOpcode):
(JSC::Wasm::parseExtendedConstExpr):
(JSC::Wasm::evaluateExtendedConstExpr):
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.h:
* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::structNew):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseInitExpr):
* Source/JavaScriptCore/wasm/WasmTable.cpp:
(JSC::Wasm::FuncRefTable::FuncRefTable):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::get const):
(JSC::JSWebAssemblyStruct::set):

Canonical link: <a href="https://commits.webkit.org/320548@main">https://commits.webkit.org/320548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbb8f5d3ac20be6ff9d2c7830ecd8736f3fcc492

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195379 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58693 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144608 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48285 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124894 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47013 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/6821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13701 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157382 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44769 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6434 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46309 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51628 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197329 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58632 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154103 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59342 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41373 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153759 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28110 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48258 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131634 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128272 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57829 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19788 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57192 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57442 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57266 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->