### PR TITLE
Tab character renders too narrow when tab-size is small (proportional fonts)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/reference/tab-stop-threshold-007-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/reference/tab-stop-threshold-007-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test reference</title>
+<style>
+div {
+    white-space: pre;
+    font-family: serif;
+    font-size: 32px;
+    tab-size: 0.8ch;
+}
+span {
+    background-color: green;
+}
+</style>
+<p>Test passes if the green bar below is 2.4 times as wide as the advance of a "0" glyph, and identical to the reference.</p>
+<div><span>&#9;&#9;&#9;</span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/tab-stop-threshold-007-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/tab-stop-threshold-007-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test reference</title>
+<style>
+div {
+    white-space: pre;
+    font-family: serif;
+    font-size: 32px;
+    tab-size: 0.8ch;
+}
+span {
+    background-color: green;
+}
+</style>
+<p>Test passes if the green bar below is 2.4 times as wide as the advance of a "0" glyph, and identical to the reference.</p>
+<div><span>&#9;&#9;&#9;</span></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/tab-stop-threshold-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/tab-stop-threshold-007.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: the minimum tab advance is measured against the '0' glyph, not against the space</title>
+<link rel="help" href="https://drafts.csswg.org/css-text-4/#white-space-phase-2">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#tab-size-property">
+<link rel="match" href="reference/tab-stop-threshold-007-ref.html">
+<meta name="assert" content="A preserved tab whose distance to the next tab stop is less than 0.5ch advances to the subsequent tab stop, even when that distance is not less than half the advance of a space. In a proportional font a 0.4ch tab stop is wider than half a space but narrower than 0.5ch, so every tab advances two tab stops, which renders the same as a 0.8ch tab size.">
+<style>
+div {
+    white-space: pre;
+    font-family: serif;
+    font-size: 32px;
+    tab-size: 0.4ch;
+}
+span {
+    background-color: green;
+}
+</style>
+<p>Test passes if the green bar below is 2.4 times as wide as the advance of a "0" glyph, and identical to the reference.</p>
+<div><span>&#9;&#9;&#9;</span></div>

--- a/Source/WebCore/platform/graphics/FontCascadeInlines.h
+++ b/Source/WebCore/platform/graphics/FontCascadeInlines.h
@@ -84,7 +84,9 @@ inline float FontCascade::tabWidth(const Font& font, const TabSize& tabSize, flo
         if (remainder < 0)
             remainder += baseTabWidth;
         result = baseTabWidth - remainder;
-        if (result < font.spaceWidth() / 2)
+        // A tab shorter than half the advance of the '0' glyph (0.5ch) is not recognizable as a tab, so it advances to the subsequent tab stop.
+        // https://drafts.csswg.org/css-text-4/#white-space-phase-2
+        if (result < zeroWidth() / 2)
             result += baseTabWidth;
     }
     // If our caller passes in SyntheticBoldInclusion::Exclude, that means they're going to apply synthetic bold themselves later.


### PR DESCRIPTION
#### 681c0a0ad8ad1cdcc78ee7d0ceded7bcc624ea86
<pre>
Tab character renders too narrow when tab-size is small (proportional fonts)
<a href="https://bugs.webkit.org/show_bug.cgi?id=323466">https://bugs.webkit.org/show_bug.cgi?id=323466</a>
&lt;<a href="https://rdar.apple.com/problem/186698040">rdar://problem/186698040</a>&gt;

Reviewed by Antti Koivisto.

    &lt;div style=&quot;font: 32px serif; white-space: pre; tab-size: 0.4ch&quot;&gt;&amp;#9;&amp;#9;&amp;#9;&lt;/div&gt;

Each tab should advance to the second tab stop, making the run 2.4ch wide. Instead it advanced to the first one and the run was 1.2ch.

A tab is not a glyph but a shift to the next tab stop, and a shift too short to read as a tab takes the subsequent stop instead.
The spec measures &quot;too short&quot; against 0.5ch, half the advance of the &quot;0&quot; glyph, while we measured it against the space character.
In a proportional font the space is a lot narrower than the &quot;0&quot; (2.2px vs 4px in 16px Times)

* LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/reference/tab-stop-threshold-007-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/tab-stop-threshold-007-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/tab-stop-threshold-007.html: Added.
* Source/WebCore/platform/graphics/FontCascadeInlines.h:
(WebCore::FontCascade::tabWidth):

Canonical link: <a href="https://commits.webkit.org/320671@main">https://commits.webkit.org/320671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88e75e18bb643ef314cbe095d2cdf2b1d5b5e8ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/58967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/149969 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d3d8449f-432f-4fa7-b21f-94d50bba5ff5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186913 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58696 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144609 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100325 "Exiting early after 60 failures. 60 tests run. 61 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/43c6467b-dbf2-4d0d-96f3-40f931c7a2cd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124895 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7038880b-8485-4354-a88d-553e1e1bcf66) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47012 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45086 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157381 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44770 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6437 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51631 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49456 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197332 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58635 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154099 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41383 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59345 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41374 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153756 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48260 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131637 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128275 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57832 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19789 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57195 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57445 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57269 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->