### PR TITLE
Cherry-pick 320304@main (d4867a890432). https://bugs.webkit.org/show_bug.cgi?id=323060

### DIFF
--- a/JSTests/stress/absence-propertycondition-and-non-reified-static-property-tables.js
+++ b/JSTests/stress/absence-propertycondition-and-non-reified-static-property-tables.js
@@ -1,0 +1,52 @@
+// Absence PropertyCondition should consult non-reified static property tables;
+// otherwise, the Abstract Interpreter folds GetById past Symbol.prototype's
+// static `description`.
+
+function assert(cond) {
+    if (!cond)
+        throw new Error("Assertion failed");
+}
+
+function assertThrows(fn) {
+    try {
+        fn();
+    } catch (e) {
+        return;
+    }
+
+    throw "Expected an exception";
+}
+
+let K = {};
+K.y = 13.37;
+Object.prototype.description = K;
+
+function setup(a) { return a.description; }
+noInline(setup);
+let setupObj = {};
+for (let i = 0; i < 50_000; i++) setup(setupObj);
+
+let o_warm  = Object(Symbol("warm")); o_warm.x  = 1;
+let o_leak  = Object(Symbol("leak")); o_leak.x  = 1;
+let o_crash = Object(Symbol());       o_crash.x = 1;
+
+function f(a, n) {
+    let b = a;
+    if (n > 0) {
+        let r = a.description;
+        let v = r.y;
+        return v;
+    }
+    b.x; b.x; b.x;
+    return undefined;
+}
+noInline(f);
+
+assert(f(o_warm, 1) === undefined);
+for (let i = 0; i < 500_000; i++) f(o_warm, 0);
+
+var hole = f(o_leak, 1);
+assert(hole === undefined);
+assert(typeof hole === "undefined");
+
+assertThrows(() => f(o_crash, 1));

--- a/JSTests/stress/dfg-getscope-fold-stale-cfa-state.js
+++ b/JSTests/stress/dfg-getscope-fold-stale-cfa-state.js
@@ -1,0 +1,29 @@
+function opt(a1, a2, a3, a4, a5) {
+    try {
+        class Trans extends Array {
+        };
+        function inline() {
+            try {
+                a2(["Āሴ￿", a5]);
+            } catch (x) {
+            };
+        };
+        inline();
+    } catch (x) {
+    };
+    function foo(a, b) {
+        for (var x = 0; x < 10000; x++) {
+        };
+        return a == b;
+    }
+    foo(-1, a5);
+    class C {
+    };
+}
+
+for (let i = 0; i < 10000; i++) {
+    try {
+        opt(Function.prototype.apply, Function.prototype.toString, 1.1, '💩', Object.defineProperty);
+    } catch (e) {
+    }
+}

--- a/JSTests/stress/inc-dec-int32-overflow-dce.js
+++ b/JSTests/stress/inc-dec-int32-overflow-dce.js
@@ -1,0 +1,28 @@
+//@ requireOptions("--useConcurrentJIT=0", "--thresholdForFTLOptimizeAfterWarmUp=1000")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("FAIL: got " + actual + ", expected " + expected);
+}
+
+function inc(k) {
+    let y = k;
+    ++y;
+    return (y | 0) === y;
+}
+noInline(inc);
+
+function dec(k) {
+    let y = k;
+    --y;
+    return (y | 0) === y;
+}
+noInline(dec);
+
+for (let i = 0; i < 1e6; ++i) {
+    inc(1);
+    dec(1);
+}
+
+shouldBe(inc(2147483647), false);
+shouldBe(dec(-2147483648), false);

--- a/LayoutTests/http/tests/cookies/resources/set-raw-cookie-in-third-party-iframe-frame.html
+++ b/LayoutTests/http/tests/cookies/resources/set-raw-cookie-in-third-party-iframe-frame.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+try {
+    internals.setCookie({
+        name: 'thirdpartyiframecookie',
+        value: 'value',
+        domain: 'localhost',
+        path: '/',
+        isSession: true,
+    });
+    parent.postMessage('PASS: setCookie from third-party iframe did not terminate the WebProcess', '*');
+} catch (e) {
+    parent.postMessage('FAIL: threw ' + e, '*');
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe-expected.txt
+++ b/LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe-expected.txt
@@ -1,0 +1,4 @@
+Test that internals.setCookie from a third-party iframe does not terminate the WebProcess.
+
+PASS: setCookie from third-party iframe did not terminate the WebProcess
+

--- a/LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe.html
+++ b/LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test that internals.setCookie from a third-party iframe does not terminate the WebProcess.</p>
+<pre id="out"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const log = s => document.getElementById('out').textContent += s + '\n';
+
+window.addEventListener('message', (event) => {
+    log(event.data);
+    testRunner?.notifyDone();
+});
+
+const iframe = document.createElement('iframe');
+iframe.src = 'http://localhost:8000/cookies/resources/set-raw-cookie-in-third-party-iframe-frame.html';
+document.body.appendChild(iframe);
+</script>
+</body>
+</html>

--- a/LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash-expected.txt
+++ b/LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if the NetworkProcess does not crash.

--- a/LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash.html
+++ b/LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash.html
@@ -1,0 +1,42 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if the NetworkProcess does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.onload = async () => {
+    if (!window.IPC)
+        return window.testRunner?.notifyDone();
+
+    const { CoreIPC } = await import('./coreipc.js');
+    const ownOrigin = location.origin + '/';
+
+    CoreIPC.Networking.NetworkConnectionToWebProcess.SetRawCookie(0, {
+        firstParty: { string: ownOrigin },
+        url:        { string: ownOrigin },
+        cookie: {
+            name:         'x',
+            value:        'y',
+            domain:       '127.0.0.1',
+            path:         '/',
+            partitionKey: '',
+            created:      0,
+            expires:      {},
+            httpOnly:     false,
+            secure:       false,
+            session:      true,
+            comment:      '',
+            commentURL:   { string: '' },
+            ports:        [],
+            sameSite:     0,
+        },
+        shouldPartitionCookie: 0,
+    });
+
+    setTimeout(() => {
+        window.testRunner?.notifyDone();
+    }, 500);
+};
+</script>

--- a/LayoutTests/ipc/set-raw-cookie-firstparty-message-check-expected.txt
+++ b/LayoutTests/ipc/set-raw-cookie-firstparty-message-check-expected.txt
@@ -1,0 +1,4 @@
+
+PASS SetRawCookie rejects cross-origin cookie.domain via MESSAGE_CHECK
+PASS SetRawCookie rejects cross-origin url via MESSAGE_CHECK
+

--- a/LayoutTests/ipc/set-raw-cookie-firstparty-message-check.html
+++ b/LayoutTests/ipc/set-raw-cookie-firstparty-message-check.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<title>Test that SetRawCookie validates cookie.domain and url against firstParty via MESSAGE_CHECK</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<body>
+<script>
+promise_test(async (t) => {
+    if (!window.IPC) {
+        done();
+        return;
+    }
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const ownOrigin = location.origin + '/';
+    const victimURL = 'http://victim-bank.test/';
+
+    function makeCookie(domain) {
+        return {
+            name:         'injected-by-poc',
+            value:        'session-fixation-payload',
+            domain:       domain,
+            path:         '/',
+            partitionKey: '',
+            created:      0,
+            expires:      {},
+            httpOnly:     true,
+            secure:       false,
+            session:      true,
+            comment:      '',
+            commentURL:   { string: '' },
+            ports:        [],
+            sameSite:     0,
+        };
+    }
+
+    // Drain any pending invalid-message string.
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {}, () => { });
+
+    // cookie.domain is cross-origin from firstParty -> MESSAGE_CHECK at
+    // NetworkConnectionToWebProcess::setRawCookie should fail.
+    CoreIPC.Networking.NetworkConnectionToWebProcess.SetRawCookie(0, {
+        firstParty: { string: ownOrigin },
+        url:        { string: ownOrigin },
+        cookie:     makeCookie('victim-bank.test'),
+        shouldPartitionCookie: 0,
+    });
+
+    let messageCheck = null;
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {},
+        reply => messageCheck = reply.error);
+
+    assert_true(!!messageCheck && messageCheck.includes('Message check failed'),
+        'SetRawCookie with cross-origin cookie.domain should trigger MESSAGE_CHECK, got: "' + messageCheck + '"');
+}, 'SetRawCookie rejects cross-origin cookie.domain via MESSAGE_CHECK');
+
+promise_test(async (t) => {
+    if (!window.IPC) {
+        done();
+        return;
+    }
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const ownOrigin = location.origin + '/';
+    const victimURL = 'http://victim-bank.test/';
+
+    function makeCookie(domain) {
+        return {
+            name:         'injected-by-poc',
+            value:        'session-fixation-payload',
+            domain:       domain,
+            path:         '/',
+            partitionKey: '',
+            created:      0,
+            expires:      {},
+            httpOnly:     true,
+            secure:       false,
+            session:      true,
+            comment:      '',
+            commentURL:   { string: '' },
+            ports:        [],
+            sameSite:     0,
+        };
+    }
+
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {}, () => { });
+
+    // url is cross-origin from firstParty -> MESSAGE_CHECK should fail.
+    CoreIPC.Networking.NetworkConnectionToWebProcess.SetRawCookie(0, {
+        firstParty: { string: ownOrigin },
+        url:        { string: victimURL },
+        cookie:     makeCookie(new URL(ownOrigin).host),
+        shouldPartitionCookie: 0,
+    });
+
+    let messageCheck = null;
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {},
+        reply => messageCheck = reply.error);
+
+    assert_true(!!messageCheck && messageCheck.includes('Message check failed'),
+        'SetRawCookie with cross-origin url should trigger MESSAGE_CHECK, got: "' + messageCheck + '"');
+}, 'SetRawCookie rejects cross-origin url via MESSAGE_CHECK');
+
+done();
+</script>
+</body>

--- a/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
@@ -74,15 +74,12 @@ void PropertyCondition::dump(PrintStream& out) const
 bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
     Concurrency concurrency, Structure* structure, JSObject* base) const
 {
-    if (PropertyConditionInternal::verbose) {
-        dataLog(
-            "Determining validity of ", *this, " with structure ", pointerDump(structure), " and base ",
-            JSValue(base), " assuming impure property watchpoints are set.\n");
-    }
-    
+    dataLogLnIf(PropertyConditionInternal::verbose,
+        "Determining validity of ", *this, " with structure ", pointerDump(structure), " and base ",
+        JSValue(base), " assuming impure property watchpoints are set.");
+
     if (!*this) {
-        if (PropertyConditionInternal::verbose)
-            dataLog("Invalid because unset.\n");
+        dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because unset.");
         return false;
     }
 
@@ -95,16 +92,14 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
     case Equivalence:
     case HasStaticProperty:
         if (!structure->propertyAccessesAreCacheable()) {
-            if (PropertyConditionInternal::verbose)
-                dataLog("Invalid because property accesses are not cacheable.\n");
+            dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because property accesses are not cacheable.");
             return false;
         }
         break;
         
     case HasPrototype:
         if (!structure->prototypeQueriesAreCacheable()) {
-            if (PropertyConditionInternal::verbose)
-                dataLog("Invalid because prototype queries are not cacheable.\n");
+            dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because prototype queries are not cacheable.");
             return false;
         }
         break;
@@ -116,11 +111,9 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
         unsigned currentAttributes;
         PropertyOffset currentOffset = structure->get(structure->vm(), concurrency, uid(), currentAttributes);
         if (currentOffset != offset() || currentAttributes != attributes()) {
-            if (PropertyConditionInternal::verbose) {
-                dataLogLn(
-                    "Invalid because we need offset, attributes to be ", offset(), ", ", attributes(),
-                    " but they are ", currentOffset, ", ", currentAttributes);
-            }
+            dataLogLnIf(PropertyConditionInternal::verbose,
+                "Invalid because we need offset, attributes to be ", offset(), ", ", attributes(),
+                " but they are ", currentOffset, ", ", currentAttributes);
             return false;
         }
 
@@ -136,8 +129,7 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
         
     case Absence: {
         if (structure->isDictionary()) {
-            if (PropertyConditionInternal::verbose)
-                dataLog("Invalid because it's a dictionary.\n");
+            dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because it's a dictionary.");
             return false;
         }
 
@@ -151,17 +143,21 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
 
         PropertyOffset currentOffset = structure->get(structure->vm(), concurrency, uid());
         if (currentOffset != invalidOffset) {
-            if (PropertyConditionInternal::verbose)
-                dataLog("Invalid because the property exists at offset: ", currentOffset, "\n");
+            dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because the property exists at offset: ", currentOffset);
             return false;
         }
 
-        if (structure->storedPrototypeObject() != prototype()) {
-            if (PropertyConditionInternal::verbose) {
-                dataLog(
-                    "Invalid because the prototype is ", structure->storedPrototype(), " even though "
-                    "it should have been ", JSValue(prototype()), "\n");
+        if (structure->hasNonReifiedStaticProperties()) {
+            if (structure->findPropertyHashEntry(uid())) {
+                dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because the property exists in the non-reified static property table: ", uid(), ".");
+                return false;
             }
+        }
+
+        if (structure->storedPrototypeObject() != prototype()) {
+            dataLogLnIf(PropertyConditionInternal::verbose,
+                "Invalid because the prototype is ", structure->storedPrototype(), " even though "
+                "it should have been ", JSValue(prototype()));
             return false;
         }
         
@@ -170,14 +166,12 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
     
     case AbsenceOfSetEffect: {
         if (structure->isDictionary()) {
-            if (PropertyConditionInternal::verbose)
-                dataLog("Invalid because it's a dictionary.\n");
+            dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because it's a dictionary.");
             return false;
         }
         
         if (structure->typeInfo().overridesPut() && JSObject::mightBeSpecialProperty(structure->vm(), structure->typeInfo().type(), uid())) {
-            if (PropertyConditionInternal::verbose)
-                dataLog("Invalid because its put() override may treat ", uid(), " property as special non-structure one.\n");
+            dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because its put() override may treat ", uid(), " property as special non-structure one.");
             return false;
         }
 
@@ -185,18 +179,15 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
         PropertyOffset currentOffset = structure->get(structure->vm(), concurrency, uid(), currentAttributes);
         if (currentOffset != invalidOffset) {
             if (currentAttributes & (PropertyAttribute::ReadOnly | PropertyAttribute::Accessor | PropertyAttribute::CustomAccessorOrValue)) {
-                if (PropertyConditionInternal::verbose) {
-                    dataLog(
-                        "Invalid because we expected not to have a setter, but we have one at offset ",
-                        currentOffset, " with attributes ", currentAttributes, "\n");
-                }
+                dataLogLnIf(PropertyConditionInternal::verbose,
+                    "Invalid because we expected not to have a setter, but we have one at offset ",
+                    currentOffset, " with attributes ", currentAttributes);
                 return false;
             }
         } else if (structure->hasNonReifiedStaticProperties()) {
             if (auto entry = structure->findPropertyHashEntry(uid())) {
                 if (entry->value->attributes() & PropertyAttribute::ReadOnlyOrAccessorOrCustomAccessorOrValue) {
-                    if (PropertyConditionInternal::verbose)
-                        dataLog("Invalid because we expected not to have a setter, but we have one in non-reified static property table: ", uid(), ".\n");
+                    dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because we expected not to have a setter, but we have one in non-reified static property table: ", uid(), ".");
                     return false;
                 }
             }
@@ -211,11 +202,9 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
         }
         
         if (structure->storedPrototypeObject() != prototype()) {
-            if (PropertyConditionInternal::verbose) {
-                dataLog(
-                    "Invalid because the prototype is ", structure->storedPrototype(), " even though "
-                    "it should have been ", JSValue(prototype()), "\n");
-            }
+            dataLogLnIf(PropertyConditionInternal::verbose,
+                "Invalid because the prototype is ", structure->storedPrototype(), " even though "
+                "it should have been ", JSValue(prototype()));
             return false;
         }
         
@@ -232,23 +221,19 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
         }
 
         if (hasIndexedProperties(structure->indexingType())) {
-            if (PropertyConditionInternal::verbose)
-                dataLog("Invalid because the indexed properties exist: ", structure->indexingType(), "\n");
+            dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because the indexed properties exist: ", structure->indexingType());
             return false;
         }
 
         if (structure->mayInterceptIndexedAccesses() || structure->typeInfo().interceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero()) {
-            if (PropertyConditionInternal::verbose)
-                dataLog("Invalid because structure intercepts index access.\n");
+            dataLogLnIf(PropertyConditionInternal::verbose, "Invalid because structure intercepts index access.");
             return false;
         }
 
         if (structure->storedPrototypeObject() != prototype()) {
-            if (PropertyConditionInternal::verbose) {
-                dataLog(
-                    "Invalid because the prototype is ", structure->storedPrototype(), " even though "
-                    "it should have been ", JSValue(prototype()), "\n");
-            }
+            dataLogLnIf(PropertyConditionInternal::verbose,
+                "Invalid because the prototype is ", structure->storedPrototype(), " even though "
+                "it should have been ", JSValue(prototype()));
             return false;
         }
 
@@ -265,11 +250,9 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
         }
 
         if (structure->storedPrototypeObject() != prototype()) {
-            if (PropertyConditionInternal::verbose) {
-                dataLog(
-                    "Invalid because the prototype is ", structure->storedPrototype(), " even though "
-                    "it should have been ", JSValue(prototype()), "\n");
-            }
+            dataLogLnIf(PropertyConditionInternal::verbose,
+                "Invalid because the prototype is ", structure->storedPrototype(), " even though "
+                "it should have been ", JSValue(prototype()));
             return false;
         }
         
@@ -283,11 +266,9 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
         if (!base || base->structure() != structure) {
             // Conservatively return false, since we cannot verify this one without having the
             // object.
-            if (PropertyConditionInternal::verbose) {
-                dataLog(
-                    "Invalid because we don't have a base or the base has the wrong structure: ",
-                    RawPointer(base), "\n");
-            }
+            dataLogLnIf(PropertyConditionInternal::verbose,
+                "Invalid because we don't have a base or the base has the wrong structure: ",
+                RawPointer(base));
             return false;
         }
         
@@ -296,21 +277,16 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
         
         PropertyOffset currentOffset = structure->get(structure->vm(), concurrency, uid());
         if (currentOffset == invalidOffset) {
-            if (PropertyConditionInternal::verbose) {
-                dataLog(
-                    "Invalid because the base no long appears to have ", uid(), " on its structure: ",
-                        RawPointer(base), "\n");
-            }
+            dataLogLnIf(PropertyConditionInternal::verbose,
+                "Invalid because the base no long appears to have ", uid(), " on its structure: ",
+                RawPointer(base));
             return false;
         }
 
         JSValue currentValue = base->getDirect(cellLocker, concurrency, structure, currentOffset);
         if (currentValue != requiredValue() || !currentValue) {
-            if (PropertyConditionInternal::verbose) {
-                dataLog(
-                    "Invalid because the value is ", currentValue, " but we require ", requiredValue(),
-                    "\n");
-            }
+            dataLogLnIf(PropertyConditionInternal::verbose,
+                "Invalid because the value is ", currentValue, " but we require ", requiredValue());
             return false;
         }
         

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1719,6 +1719,7 @@ private:
                 case NewAsyncFunction: {
                     node->convertToIdentityOn(node->child1()->child1().node());
                     node->child1().setUseKind(KnownCellUse);
+                    m_interpreter.execute(indexInBlock); // Catch the fact that we may overwrite a stale AbstractValue.
                     eliminated = true;
                     break;
                 }

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -295,8 +295,8 @@ private:
                 fixEdge<DoubleRepUse>(node->child1());
                 fixEdge<DoubleRepUse>(node->child2());
                 node->setResult(NodeResultDouble);
+                node->clearFlags(NodeMustGenerate);
             }
-            node->clearFlags(NodeMustGenerate);
             break;
         }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -91,6 +91,7 @@
 #endif
 
 #define MESSAGE_CHECK(assertion, message) MESSAGE_CHECK_WITH_MESSAGE_BASE(assertion, m_streamConnection, message);
+#define MESSAGE_CHECK_WITH_RETURN_VALUE(assertion, returnValue) MESSAGE_CHECK_WITH_RETURN_VALUE_BASE(assertion, m_streamConnection, returnValue)
 
 namespace WebKit {
 using namespace WebCore;
@@ -288,6 +289,12 @@ RefPtr<ImageBuffer> RemoteRenderingBackend::allocateImageBuffer(const FloatSize&
     if (purpose == RenderingPurpose::Canvas && m_sharedResourceCache->reachedImageBufferForCanvasLimit())
         return nullptr;
 
+    // Verify DisplayList rendering mode is only used when RemoteSnapshotting is enabled
+    if (renderingMode == RenderingMode::DisplayList) {
+        auto prefs = sharedPreferencesForWebProcess();
+        MESSAGE_CHECK_WITH_RETURN_VALUE(prefs && prefs->remoteSnapshottingEnabled, nullptr);
+    }
+
     adjustImageBufferCreationContext(m_sharedResourceCache, creationContext);
     adjustImageBufferRenderingMode(m_sharedResourceCache, purpose, renderingMode);
 
@@ -308,12 +315,6 @@ RefPtr<ImageBuffer> RemoteRenderingBackend::allocateImageBuffer(const FloatSize&
 void RemoteRenderingBackend::createImageBuffer(const FloatSize& logicalSize, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, ImageBufferFormat pixelFormat, RenderingResourceIdentifier identifier, RemoteGraphicsContextIdentifier contextIdentifier)
 {
     assertIsCurrent(workQueue());
-
-    // Verify DisplayList rendering mode is only used when RemoteSnapshotting is enabled
-    if (renderingMode == RenderingMode::DisplayList) {
-        auto prefs = sharedPreferencesForWebProcess();
-        MESSAGE_CHECK(prefs && prefs->remoteSnapshottingEnabled, "RemoteSnapshotting is not enabled");
-    }
 
     RefPtr<ImageBuffer> imageBuffer = allocateImageBuffer(logicalSize, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat, { });
     if (!imageBuffer) {
@@ -727,5 +728,6 @@ void RemoteRenderingBackend::getImageBufferResourceLimitsForTesting(CompletionHa
 } // namespace WebKit
 
 #undef MESSAGE_CHECK
+#undef MESSAGE_CHECK_WITH_RETURN_VALUE
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -982,8 +982,7 @@ void NetworkConnectionToWebProcess::setRawCookie(const URL& firstParty, const UR
 {
     auto allowCookieAccess = m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, firstParty);
     MESSAGE_CHECK(allowCookieAccess != NetworkProcess::AllowCookieAccess::Terminate);
-    MESSAGE_CHECK(RegistrableDomain::uncheckedCreateFromHost(cookie.domain).matches(firstParty));
-    MESSAGE_CHECK(RegistrableDomain(url).matches(firstParty));
+    MESSAGE_CHECK(RegistrableDomain::uncheckedCreateFromHost(cookie.domain).matches(url));
     if (allowCookieAccess != NetworkProcess::AllowCookieAccess::Allow)
         return;
 


### PR DESCRIPTION
#### 03eda1e66c764309492350d2013a82d7a01dd564
<pre>
Cherry-pick 320304@main (d4867a890432). <a href="https://bugs.webkit.org/show_bug.cgi?id=323060">https://bugs.webkit.org/show_bug.cgi?id=323060</a>

    Regression(314177@main) SetRawCookie&apos;s MESSAGE_CHECKs reject legitimate cookie writes from third-party iframes
    <a href="https://bugs.webkit.org/show_bug.cgi?id=323060">https://bugs.webkit.org/show_bug.cgi?id=323060</a>
    <a href="https://rdar.apple.com/177769847">rdar://177769847</a>

    Reviewed by Ben Nham.

    NetworkConnectionToWebProcess::setRawCookie validated cookie.domain and
    url against firstParty:
    ```
    MESSAGE_CHECK(RegistrableDomain::uncheckedCreateFromHost(cookie.domain).matches(firstParty));
    MESSAGE_CHECK(RegistrableDomain(url).matches(firstParty));
    ```

    This is too strict. WebCookieJar::setRawCookie passes
    document.firstPartyForCookies() as firstParty (the top-level page&apos;s URL)
    and document.cookieURL() as url (the document&apos;s own URL). For a
    third-party iframe these legitimately differ, so the checks terminate
    the WebProcess whenever Web Inspector or internals.setCookie is used in
    a cross-site iframe.

    Replace the two checks with an integrity check that cookie.domain&apos;s
    registrable domain matches url, mirroring the existing posture of
    setCookieFromDOMAsync which validates firstParty only and trusts the
    url/cookie pair. The new check still rejects a mismatched
    cookie.domain/url pair (the most useful invariant) without coupling
    either to the unrelated top-level firstParty.

    Tests: http/tests/cookies/set-raw-cookie-in-third-party-iframe.html
           ipc/set-raw-cookie-empty-commenturl-crash.html
           ipc/set-raw-cookie-firstparty-message-check.html

    * LayoutTests/http/tests/cookies/resources/set-raw-cookie-in-third-party-iframe-frame.html: Added.
    * LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe-expected.txt: Added.
    * LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe.html: Added.
    Add test coverage for the overly strict checks.

    * LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash-expected.txt: Added.
    * LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash.html: Added.
    * LayoutTests/ipc/set-raw-cookie-firstparty-message-check-expected.txt: Added.
    * LayoutTests/ipc/set-raw-cookie-firstparty-message-check.html: Added.
    Add test coverage for what 314177@main was trying to fix, to make sure
    that we don&apos;t regress it.

    * Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
    (WebKit::NetworkConnectionToWebProcess::setRawCookie):

    Canonical link: <a href="https://commits.webkit.org/320304@main">https://commits.webkit.org/320304@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.201@webkitglib/2.54">https://commits.webkit.org/317695.201@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### f7b3aa828c41ad1a260e0ad5f07292adf34febd1
<pre>
Cherry-pick 305413.1016@safari-7624.5.1.10-branch (33120ad29238). <a href="https://bugs.webkit.org/show_bug.cgi?id=316439">https://bugs.webkit.org/show_bug.cgi?id=316439</a>

    RemoteRenderingBackend can still allocateImageBuffer() with RenderingMode::DisplayList
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316439">https://bugs.webkit.org/show_bug.cgi?id=316439</a>
    <a href="https://rdar.apple.com/176382472">rdar://176382472</a>

    Reviewed by Simon Fraser.

    RemoteRenderingBackend::allocateImageBuffer() is called from
    1. RemoteRenderingBackend::createImageBuffer()
    2. RemoteImageBufferSet::ensureBufferForDisplay().

    In 311931@main, which fixes bug 307843, a MESSAGE_CHECK() was added in
    RemoteRenderingBackend::allocateImageBuffer() to prevent creating a remote
    ImageBufferDisplayListBackend. But this change left the call from
    RemoteImageBufferSet::ensureBufferForDisplay().

    The fix is to move the MESSAGE_CHECK from RemoteRenderingBackend::createImageBuffer()
    to RemoteRenderingBackend::allocateImageBuffer().

    * Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
    (WebKit::RemoteRenderingBackend::allocateImageBuffer):
    (WebKit::RemoteRenderingBackend::createImageBuffer):

    Identifier: 305413.1016@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.200@webkitglib/2.54">https://commits.webkit.org/317695.200@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 6ffbec49a6386c41d16d1af185f26da25b7e40a0
<pre>
Cherry-pick 305413.1015@safari-7624.5.1.10-branch (7951c397a1ba). <a href="https://bugs.webkit.org/show_bug.cgi?id=315213">https://bugs.webkit.org/show_bug.cgi?id=315213</a>

    [JSC] NodeMustGenerate incorrectly cleared on CheckOverflow ArithAdd/ArithSub in DFGFixupPhase Inc/Dec handler
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315213">https://bugs.webkit.org/show_bug.cgi?id=315213</a>
    <a href="https://rdar.apple.com/176984293">rdar://176984293</a>

    Reviewed by Yijia Huang.

    This patch prevents overflow checks for increment/decrement in DFG from being mistakenly DCE&apos;d.

    Test: JSTests/stress/inc-dec-int32-overflow-dce.js

    * JSTests/stress/inc-dec-int32-overflow-dce.js: Added.
    (shouldBe):
    (inc):
    (dec):
    * Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
    (JSC::DFG::FixupPhase::fixupNode):

    Identifier: 305413.1015@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.199@webkitglib/2.54">https://commits.webkit.org/317695.199@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 673d962cd788d7985476681139a6740cb73c115b
<pre>
Cherry-pick 305413.1014@safari-7624.5.1.10-branch (d0cd53048a11). <a href="https://bugs.webkit.org/show_bug.cgi?id=314836">https://bugs.webkit.org/show_bug.cgi?id=314836</a>

    [JavaScriptCore] Absence PropertyCondition does not consult non-reified static property tables
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314836">https://bugs.webkit.org/show_bug.cgi?id=314836</a>
    <a href="https://rdar.apple.com/176792596">rdar://176792596</a>

    Reviewed by Yusuke Suzuki.

    This patch modifies the Absence case for PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint
    to consult the non-reified static property table if the property isn&apos;t present in the property table.
    This prevents the Abstract Interpreter from misfolding GetById.

    Test: JSTests/stress/absence-propertycondition-and-non-reified-static-property-tables.js

    * JSTests/stress/absence-propertycondition-and-non-reified-static-property-tables.js: Added.
    (assert):
    (assertThrows):
    (setup):
    (f):
    * Source/JavaScriptCore/bytecode/PropertyCondition.cpp:
    (JSC::PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint const):

    Identifier: 305413.1014@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.198@webkitglib/2.54">https://commits.webkit.org/317695.198@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 4e66415fa162ad248fcf5d5504f7c8983be7228d
<pre>
Cherry-pick 305413.1012@safari-7624.5.1.10-branch (3efb180e50d2). <a href="https://bugs.webkit.org/show_bug.cgi?id=316803">https://bugs.webkit.org/show_bug.cgi?id=316803</a>

    [JSC] Refresh AI state when folding GetScope to Identity
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316803">https://bugs.webkit.org/show_bug.cgi?id=316803</a>
    <a href="https://rdar.apple.com/178423757">rdar://178423757</a>

    Reviewed by Yusuke Suzuki.

    A GetScope could be constant folded to Identity. When this happens, the
    abstract interpreter isn&apos;t re-executed on the Identity node. If a previous run
    of the AI left the abstract value corresponding to the pre-replacement GetScope
    node as bottom, this stale bottom value can cause downstream consumers to
    assume the Identity is unreachable when it is.

    This PR re-executes AI after folding to Identity.

    Test: JSTests/stress/dfg-getscope-fold-stale-cfa-state.js

    * JSTests/stress/dfg-getscope-fold-stale-cfa-state.js: Added.
    (try.Trans):
    (try.inline):
    (foo):
    (C):
    (opt):
    (i.catch):
    * Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
    (JSC::DFG::ConstantFoldingPhase::foldConstants):

    Identifier: 305413.1012@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.197@webkitglib/2.54">https://commits.webkit.org/317695.197@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac52fd8942a14b4280c7be8a4b4335dbdb26f87f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185055 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/58971 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52799 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195386 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/149972 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60332 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58700 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144610 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/149972 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188010 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60332 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/52799 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124896 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60332 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58700 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6823 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/52799 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60332 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52799 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6441 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/46316 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/51635 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/58700 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197336 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/58639 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/52799 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154101 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59349 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/52799 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153758 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28112 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59349 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/131641 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/128279 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/57836 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/52799 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57199 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57449 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57273 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->