### PR TITLE
[SVG] feImage with a fragmented external href never loads the image

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/utf-8_include=svg-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/utf-8_include=svg-expected.txt
@@ -1,6 +1,6 @@
 
 PASS SVG <a>
-TIMEOUT SVG <feImage> Test timed out
+PASS SVG <feImage>
 PASS SVG <image>
 PASS SVG <use>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251_include=svg-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251_include=svg-expected.txt
@@ -1,6 +1,6 @@
 
 PASS SVG <a>
-TIMEOUT SVG <feImage> Test timed out
+PASS SVG <feImage>
 PASS SVG <image>
 PASS SVG <use>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252_include=svg-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252_include=svg-expected.txt
@@ -1,6 +1,6 @@
 
 PASS SVG <a>
-TIMEOUT SVG <feImage> Test timed out
+PASS SVG <feImage>
 PASS SVG <image>
 PASS SVG <use>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/href-feImage-external-fragment-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/href-feImage-external-fragment-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - feImage element with a fragmented external reference reference</title>
+<body>
+  <svg width="256" height="256" viewBox="0 0 256 256"
+       xmlns:xlink="http://www.w3.org/1999/xlink">
+    <filter id="Fitted" x="0" y="0" width="100%" height="100%">
+      <feImage xlink:href="/images/green-256x256.png"
+               preserveAspectRatio="none"/>
+    </filter>
+    <rect width="256" height="256" filter="url(#Fitted)"/>
+  </svg>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/href-feImage-external-fragment-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/href-feImage-external-fragment-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - feImage element with a fragmented external reference reference</title>
+<body>
+  <svg width="256" height="256" viewBox="0 0 256 256"
+       xmlns:xlink="http://www.w3.org/1999/xlink">
+    <filter id="Fitted" x="0" y="0" width="100%" height="100%">
+      <feImage xlink:href="/images/green-256x256.png"
+               preserveAspectRatio="none"/>
+    </filter>
+    <rect width="256" height="256" filter="url(#Fitted)"/>
+  </svg>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/href-feImage-external-fragment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/href-feImage-external-fragment.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - feImage element with a fragmented external reference</title>
+<link rel="help" href="https://drafts.fxtf.org/filter-effects/#feImageElement">
+<meta name="assert" content="feImage loads an external resource whose href carries a fragment identifier that does not resolve to a local element.">
+<link rel="match" href="href-feImage-external-fragment-ref.html">
+<body>
+  <svg width="256" height="256" viewBox="0 0 256 256"
+       xmlns:xlink="http://www.w3.org/1999/xlink">
+    <filter id="Fitted" x="0" y="0" width="100%" height="100%">
+      <feImage xlink:href="/images/green-256x256.png#foo"
+               preserveAspectRatio="none"/>
+    </filter>
+    <rect width="256" height="256" filter="url(#Fitted)"/>
+  </svg>
+</body>

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -109,7 +109,9 @@ void SVGFEImageElement::buildPendingResource()
 
     auto target = SVGURIReference::targetElementFromIRIString(href(), treeScopeForSVGReferences());
     if (!target.element) {
-        if (target.identifier.isEmpty())
+        Ref document = this->document();
+        auto url = document->encodingParseURL(href());
+        if (url.protocolIsData() || isExternalURIReference(href(), document))
             requestImageResource();
         else {
             treeScopeForSVGReferences().addPendingSVGResource(target.identifier, *this);


### PR DESCRIPTION
#### 9adfa6764dd31e76dec7bf21beb9585252c1ff11
<pre>
[SVG] feImage with a fragmented external href never loads the image
<a href="https://bugs.webkit.org/show_bug.cgi?id=323470">https://bugs.webkit.org/show_bug.cgi?id=323470</a>
<a href="https://rdar.apple.com/186700753">rdar://186700753</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

SVGFEImageElement::buildPendingResource() treated any href that contained a
fragment identifier as a reference to a local element, registering it as a
pending SVG resource. For an external reference such as &quot;image.png#foo&quot; the
element &quot;foo&quot; never appears in this document, so the image was never fetched.
This is what made the SVG &lt;feImage&gt; case of
html/infrastructure/urls/resolving-urls/query-encoding/ time out, since the
query-encoded request was never sent -- unlike SVG &lt;a&gt;, &lt;image&gt; and &lt;use&gt;,
which resolve the URL correctly.

Reuse the existing SVGURIReference::isExternalURIReference() helper (already
used by SVGUseElement) to decide when to request the image resource, instead
of open-coding the URL comparison. Since that helper ASSERTs it is not called
on a data: URL, the data: case is checked first -- feImage legitimately
supports data: image URLs.

* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/utf-8_include=svg-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1251_include=svg-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/urls/resolving-urls/query-encoding/windows-1252_include=svg-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/href-feImage-external-fragment.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/href-feImage-external-fragment-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/linking/reftests/href-feImage-external-fragment-expected.html: Added.
* Source/WebCore/svg/SVGFEImageElement.cpp:
(WebCore::SVGFEImageElement::buildPendingResource):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9adfa6764dd31e76dec7bf21beb9585252c1ff11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195448 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150007 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e4c883a6-079f-4c98-b317-76e898ec766d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144653 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100347 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90b903e2-0d57-49e2-aa1a-afe747fa06cd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188075 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48337 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165245 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124946 "Found 1 new API test failure: TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/42949672974097MallocReadOnly (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/98c57451-5c0d-484c-93bd-4a258fb82ee2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47065 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45128 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157432 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44815 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6504 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197400 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58696 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164751 "1 flakes") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154158 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59405 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41419 "1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153810 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48306 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131704 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128344 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57884 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19834 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57255 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57498 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57322 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->