### PR TITLE
[Custom Highlight] Support `::highlight(*)`

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5825,14 +5825,6 @@ webkit.org/b/217931 imported/w3c/web-platform-tests/html/semantics/scripting-1/t
 webkit.org/b/217931 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/move-back-iframe-success-external-module.html [ Pass Failure ]
 webkit.org/b/217931 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/move-back-iframe-success-inline-classic.html [ Pass Failure ]
 
-
-imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-deep-chain-001.tentative.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-inheritance-001.tentative.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-no-named-rule-001.tentative.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-no-named-rule-002.tentative.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-painting-001.tentative.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-painting-002.tentative.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-painting-003.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/highlight-image-currentcolor.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/highlight-image-stacked.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-escaped-star.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-escaped-star.tentative-expected.txt
@@ -1,0 +1,4 @@
+text
+
+PASS ::highlight(\*) computed style is the escaped literal name's rule, merged with the universal base
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-escaped-star.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-escaped-star.tentative.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Custom Highlight: ::highlight(*) computed style must not be confused with the escaped name \*</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/9091">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #outer::highlight(\*) { color: red; }
+  #outer::highlight(*) { color: green; background-color: yellow; }
+</style>
+<div id="outer">text</div>
+<script>
+test(() => {
+  const style = getComputedStyle(outer, "::highlight(\\*)");
+  assert_equals(style.color, "rgb(255, 0, 0)");
+  assert_equals(style.backgroundColor, "rgb(255, 255, 0)");
+}, "::highlight(\\*) computed style is the escaped literal name's rule, merged with the universal base");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-parsing-and-computed-style.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-parsing-and-computed-style.tentative-expected.txt
@@ -1,14 +1,13 @@
 text
 
-FAIL "::highlight(*)" should be a valid selector '::highlight(*)' is not a valid selector.
-FAIL "div::highlight(*)" should be a valid selector 'div::highlight(*)' is not a valid selector.
-FAIL ":root::highlight(*)" should be a valid selector ':root::highlight(*)' is not a valid selector.
+PASS "::highlight(*)" should be a valid selector
+PASS "div::highlight(*)" should be a valid selector
+PASS ":root::highlight(*)" should be a valid selector
 PASS "::highlight()" should be an invalid selector
 PASS "::highlight(* foo)" should be an invalid selector
 PASS "::highlight(*.class)" should be an invalid selector
 PASS "::highlight(foo*)" should be an invalid selector
 PASS "::highlight(**)" should be an invalid selector
-FAIL named highlight merges with the universal base on the same element assert_equals: expected "rgb(255, 255, 0)" but got "rgba(0, 0, 0, 0)"
-FAIL named highlight without its own rule falls back to the universal style assert_equals: expected "rgb(255, 0, 0)" but got "rgb(0, 0, 0)"
-FAIL ::highlight(*) computed style is exposed assert_equals: expected "rgb(255, 0, 0)" but got ""
+PASS named highlight merges with the universal base on the same element
+PASS named highlight without its own rule falls back to the universal style
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-parsing-and-computed-style.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-parsing-and-computed-style.tentative.html
@@ -33,10 +33,4 @@ test(() => {
   assert_equals(style.color, "rgb(255, 0, 0)");
   assert_equals(style.backgroundColor, "rgb(255, 255, 0)");
 }, "named highlight without its own rule falls back to the universal style");
-
-test(() => {
-  const style = getComputedStyle(outer, "::highlight(*)");
-  assert_equals(style.color, "rgb(255, 0, 0)");
-  assert_equals(style.backgroundColor, "rgb(255, 255, 0)");
-}, "::highlight(*) computed style is exposed");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-parsing-expected.txt
@@ -5,9 +5,9 @@ PASS "div ::highlight(foo)" should be a valid selector
 PASS "::part(my-part)::highlight(foo)" should be a valid selector
 PASS "::highlight(multi\\ word)" should be a valid selector
 PASS "::highlight(\\31\\32\\33)" should be a valid selector
-FAIL "::highlight(\\*)" should be a valid selector assert_equals: serialization should be canonical expected "::highlight(\\*)" but got "::highlight(*)"
-FAIL "div::highlight(\\*)" should be a valid selector assert_equals: serialization should be canonical expected "div::highlight(\\*)" but got "div::highlight(*)"
-FAIL ":root::highlight(\\*)" should be a valid selector assert_equals: serialization should be canonical expected ":root::highlight(\\*)" but got ":root::highlight(*)"
+PASS "::highlight(\\*)" should be a valid selector
+PASS "div::highlight(\\*)" should be a valid selector
+PASS ":root::highlight(\\*)" should be a valid selector
 PASS "::highlight" should be an invalid selector
 PASS "::before::highlight(foo)" should be an invalid selector
 PASS "::highlight(foo).a" should be an invalid selector

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid-expected.txt
@@ -11,6 +11,14 @@ PASS "::view-transition-group(*):only-child" should be a valid selector
 PASS ":root::view-transition-group(*):only-child" should be a valid selector
 PASS ".a::view-transition-group(*):only-child" should be a valid selector
 PASS "div ::view-transition-group(*):only-child" should be a valid selector
+PASS "::view-transition-group(\\*)" should be a valid selector
+PASS ":root::view-transition-group(\\*)" should be a valid selector
+PASS ".a::view-transition-group(\\*)" should be a valid selector
+PASS "div ::view-transition-group(\\*)" should be a valid selector
+PASS "::view-transition-group(\\*):only-child" should be a valid selector
+PASS ":root::view-transition-group(\\*):only-child" should be a valid selector
+PASS ".a::view-transition-group(\\*):only-child" should be a valid selector
+PASS "div ::view-transition-group(\\*):only-child" should be a valid selector
 PASS "::view-transition-group(root)" should be a valid selector
 PASS ":root::view-transition-group(root)" should be a valid selector
 PASS ".a::view-transition-group(root)" should be a valid selector
@@ -35,6 +43,14 @@ PASS "::view-transition-image-pair(*):only-child" should be a valid selector
 PASS ":root::view-transition-image-pair(*):only-child" should be a valid selector
 PASS ".a::view-transition-image-pair(*):only-child" should be a valid selector
 PASS "div ::view-transition-image-pair(*):only-child" should be a valid selector
+PASS "::view-transition-image-pair(\\*)" should be a valid selector
+PASS ":root::view-transition-image-pair(\\*)" should be a valid selector
+PASS ".a::view-transition-image-pair(\\*)" should be a valid selector
+PASS "div ::view-transition-image-pair(\\*)" should be a valid selector
+PASS "::view-transition-image-pair(\\*):only-child" should be a valid selector
+PASS ":root::view-transition-image-pair(\\*):only-child" should be a valid selector
+PASS ".a::view-transition-image-pair(\\*):only-child" should be a valid selector
+PASS "div ::view-transition-image-pair(\\*):only-child" should be a valid selector
 PASS "::view-transition-image-pair(root)" should be a valid selector
 PASS ":root::view-transition-image-pair(root)" should be a valid selector
 PASS ".a::view-transition-image-pair(root)" should be a valid selector
@@ -59,6 +75,14 @@ PASS "::view-transition-old(*):only-child" should be a valid selector
 PASS ":root::view-transition-old(*):only-child" should be a valid selector
 PASS ".a::view-transition-old(*):only-child" should be a valid selector
 PASS "div ::view-transition-old(*):only-child" should be a valid selector
+PASS "::view-transition-old(\\*)" should be a valid selector
+PASS ":root::view-transition-old(\\*)" should be a valid selector
+PASS ".a::view-transition-old(\\*)" should be a valid selector
+PASS "div ::view-transition-old(\\*)" should be a valid selector
+PASS "::view-transition-old(\\*):only-child" should be a valid selector
+PASS ":root::view-transition-old(\\*):only-child" should be a valid selector
+PASS ".a::view-transition-old(\\*):only-child" should be a valid selector
+PASS "div ::view-transition-old(\\*):only-child" should be a valid selector
 PASS "::view-transition-old(root)" should be a valid selector
 PASS ":root::view-transition-old(root)" should be a valid selector
 PASS ".a::view-transition-old(root)" should be a valid selector
@@ -83,6 +107,14 @@ PASS "::view-transition-new(*):only-child" should be a valid selector
 PASS ":root::view-transition-new(*):only-child" should be a valid selector
 PASS ".a::view-transition-new(*):only-child" should be a valid selector
 PASS "div ::view-transition-new(*):only-child" should be a valid selector
+PASS "::view-transition-new(\\*)" should be a valid selector
+PASS ":root::view-transition-new(\\*)" should be a valid selector
+PASS ".a::view-transition-new(\\*)" should be a valid selector
+PASS "div ::view-transition-new(\\*)" should be a valid selector
+PASS "::view-transition-new(\\*):only-child" should be a valid selector
+PASS ":root::view-transition-new(\\*):only-child" should be a valid selector
+PASS ".a::view-transition-new(\\*):only-child" should be a valid selector
+PASS "div ::view-transition-new(\\*):only-child" should be a valid selector
 PASS "::view-transition-new(root)" should be a valid selector
 PASS ":root::view-transition-new(root)" should be a valid selector
 PASS ".a::view-transition-new(root)" should be a valid selector

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid-with-classes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid-with-classes-expected.txt
@@ -11,6 +11,14 @@ PASS "::view-transition-group(*.class):only-child" should be a valid selector
 PASS ":root::view-transition-group(*.class):only-child" should be a valid selector
 PASS ".a::view-transition-group(*.class):only-child" should be a valid selector
 PASS "div ::view-transition-group(*.class):only-child" should be a valid selector
+PASS "::view-transition-group(\\*.class)" should be a valid selector
+PASS ":root::view-transition-group(\\*.class)" should be a valid selector
+PASS ".a::view-transition-group(\\*.class)" should be a valid selector
+PASS "div ::view-transition-group(\\*.class)" should be a valid selector
+PASS "::view-transition-group(\\*.class):only-child" should be a valid selector
+PASS ":root::view-transition-group(\\*.class):only-child" should be a valid selector
+PASS ".a::view-transition-group(\\*.class):only-child" should be a valid selector
+PASS "div ::view-transition-group(\\*.class):only-child" should be a valid selector
 PASS "::view-transition-group(*.class.class)" should be a valid selector
 PASS ":root::view-transition-group(*.class.class)" should be a valid selector
 PASS ".a::view-transition-group(*.class.class)" should be a valid selector
@@ -19,6 +27,14 @@ PASS "::view-transition-group(*.class.class):only-child" should be a valid selec
 PASS ":root::view-transition-group(*.class.class):only-child" should be a valid selector
 PASS ".a::view-transition-group(*.class.class):only-child" should be a valid selector
 PASS "div ::view-transition-group(*.class.class):only-child" should be a valid selector
+PASS "::view-transition-group(\\*.class.class)" should be a valid selector
+PASS ":root::view-transition-group(\\*.class.class)" should be a valid selector
+PASS ".a::view-transition-group(\\*.class.class)" should be a valid selector
+PASS "div ::view-transition-group(\\*.class.class)" should be a valid selector
+PASS "::view-transition-group(\\*.class.class):only-child" should be a valid selector
+PASS ":root::view-transition-group(\\*.class.class):only-child" should be a valid selector
+PASS ".a::view-transition-group(\\*.class.class):only-child" should be a valid selector
+PASS "div ::view-transition-group(\\*.class.class):only-child" should be a valid selector
 PASS "::view-transition-group(dashed-ident.someclass)" should be a valid selector
 PASS ":root::view-transition-group(dashed-ident.someclass)" should be a valid selector
 PASS ".a::view-transition-group(dashed-ident.someclass)" should be a valid selector
@@ -51,6 +67,14 @@ PASS "::view-transition-image-pair(*.class):only-child" should be a valid select
 PASS ":root::view-transition-image-pair(*.class):only-child" should be a valid selector
 PASS ".a::view-transition-image-pair(*.class):only-child" should be a valid selector
 PASS "div ::view-transition-image-pair(*.class):only-child" should be a valid selector
+PASS "::view-transition-image-pair(\\*.class)" should be a valid selector
+PASS ":root::view-transition-image-pair(\\*.class)" should be a valid selector
+PASS ".a::view-transition-image-pair(\\*.class)" should be a valid selector
+PASS "div ::view-transition-image-pair(\\*.class)" should be a valid selector
+PASS "::view-transition-image-pair(\\*.class):only-child" should be a valid selector
+PASS ":root::view-transition-image-pair(\\*.class):only-child" should be a valid selector
+PASS ".a::view-transition-image-pair(\\*.class):only-child" should be a valid selector
+PASS "div ::view-transition-image-pair(\\*.class):only-child" should be a valid selector
 PASS "::view-transition-image-pair(*.class.class)" should be a valid selector
 PASS ":root::view-transition-image-pair(*.class.class)" should be a valid selector
 PASS ".a::view-transition-image-pair(*.class.class)" should be a valid selector
@@ -59,6 +83,14 @@ PASS "::view-transition-image-pair(*.class.class):only-child" should be a valid 
 PASS ":root::view-transition-image-pair(*.class.class):only-child" should be a valid selector
 PASS ".a::view-transition-image-pair(*.class.class):only-child" should be a valid selector
 PASS "div ::view-transition-image-pair(*.class.class):only-child" should be a valid selector
+PASS "::view-transition-image-pair(\\*.class.class)" should be a valid selector
+PASS ":root::view-transition-image-pair(\\*.class.class)" should be a valid selector
+PASS ".a::view-transition-image-pair(\\*.class.class)" should be a valid selector
+PASS "div ::view-transition-image-pair(\\*.class.class)" should be a valid selector
+PASS "::view-transition-image-pair(\\*.class.class):only-child" should be a valid selector
+PASS ":root::view-transition-image-pair(\\*.class.class):only-child" should be a valid selector
+PASS ".a::view-transition-image-pair(\\*.class.class):only-child" should be a valid selector
+PASS "div ::view-transition-image-pair(\\*.class.class):only-child" should be a valid selector
 PASS "::view-transition-image-pair(dashed-ident.someclass)" should be a valid selector
 PASS ":root::view-transition-image-pair(dashed-ident.someclass)" should be a valid selector
 PASS ".a::view-transition-image-pair(dashed-ident.someclass)" should be a valid selector
@@ -91,6 +123,14 @@ PASS "::view-transition-old(*.class):only-child" should be a valid selector
 PASS ":root::view-transition-old(*.class):only-child" should be a valid selector
 PASS ".a::view-transition-old(*.class):only-child" should be a valid selector
 PASS "div ::view-transition-old(*.class):only-child" should be a valid selector
+PASS "::view-transition-old(\\*.class)" should be a valid selector
+PASS ":root::view-transition-old(\\*.class)" should be a valid selector
+PASS ".a::view-transition-old(\\*.class)" should be a valid selector
+PASS "div ::view-transition-old(\\*.class)" should be a valid selector
+PASS "::view-transition-old(\\*.class):only-child" should be a valid selector
+PASS ":root::view-transition-old(\\*.class):only-child" should be a valid selector
+PASS ".a::view-transition-old(\\*.class):only-child" should be a valid selector
+PASS "div ::view-transition-old(\\*.class):only-child" should be a valid selector
 PASS "::view-transition-old(*.class.class)" should be a valid selector
 PASS ":root::view-transition-old(*.class.class)" should be a valid selector
 PASS ".a::view-transition-old(*.class.class)" should be a valid selector
@@ -99,6 +139,14 @@ PASS "::view-transition-old(*.class.class):only-child" should be a valid selecto
 PASS ":root::view-transition-old(*.class.class):only-child" should be a valid selector
 PASS ".a::view-transition-old(*.class.class):only-child" should be a valid selector
 PASS "div ::view-transition-old(*.class.class):only-child" should be a valid selector
+PASS "::view-transition-old(\\*.class.class)" should be a valid selector
+PASS ":root::view-transition-old(\\*.class.class)" should be a valid selector
+PASS ".a::view-transition-old(\\*.class.class)" should be a valid selector
+PASS "div ::view-transition-old(\\*.class.class)" should be a valid selector
+PASS "::view-transition-old(\\*.class.class):only-child" should be a valid selector
+PASS ":root::view-transition-old(\\*.class.class):only-child" should be a valid selector
+PASS ".a::view-transition-old(\\*.class.class):only-child" should be a valid selector
+PASS "div ::view-transition-old(\\*.class.class):only-child" should be a valid selector
 PASS "::view-transition-old(dashed-ident.someclass)" should be a valid selector
 PASS ":root::view-transition-old(dashed-ident.someclass)" should be a valid selector
 PASS ".a::view-transition-old(dashed-ident.someclass)" should be a valid selector
@@ -131,6 +179,14 @@ PASS "::view-transition-new(*.class):only-child" should be a valid selector
 PASS ":root::view-transition-new(*.class):only-child" should be a valid selector
 PASS ".a::view-transition-new(*.class):only-child" should be a valid selector
 PASS "div ::view-transition-new(*.class):only-child" should be a valid selector
+PASS "::view-transition-new(\\*.class)" should be a valid selector
+PASS ":root::view-transition-new(\\*.class)" should be a valid selector
+PASS ".a::view-transition-new(\\*.class)" should be a valid selector
+PASS "div ::view-transition-new(\\*.class)" should be a valid selector
+PASS "::view-transition-new(\\*.class):only-child" should be a valid selector
+PASS ":root::view-transition-new(\\*.class):only-child" should be a valid selector
+PASS ".a::view-transition-new(\\*.class):only-child" should be a valid selector
+PASS "div ::view-transition-new(\\*.class):only-child" should be a valid selector
 PASS "::view-transition-new(*.class.class)" should be a valid selector
 PASS ":root::view-transition-new(*.class.class)" should be a valid selector
 PASS ".a::view-transition-new(*.class.class)" should be a valid selector
@@ -139,6 +195,14 @@ PASS "::view-transition-new(*.class.class):only-child" should be a valid selecto
 PASS ":root::view-transition-new(*.class.class):only-child" should be a valid selector
 PASS ".a::view-transition-new(*.class.class):only-child" should be a valid selector
 PASS "div ::view-transition-new(*.class.class):only-child" should be a valid selector
+PASS "::view-transition-new(\\*.class.class)" should be a valid selector
+PASS ":root::view-transition-new(\\*.class.class)" should be a valid selector
+PASS ".a::view-transition-new(\\*.class.class)" should be a valid selector
+PASS "div ::view-transition-new(\\*.class.class)" should be a valid selector
+PASS "::view-transition-new(\\*.class.class):only-child" should be a valid selector
+PASS ":root::view-transition-new(\\*.class.class):only-child" should be a valid selector
+PASS ".a::view-transition-new(\\*.class.class):only-child" should be a valid selector
+PASS "div ::view-transition-new(\\*.class.class):only-child" should be a valid selector
 PASS "::view-transition-new(dashed-ident.someclass)" should be a valid selector
 PASS ":root::view-transition-new(dashed-ident.someclass)" should be a valid selector
 PASS ".a::view-transition-new(dashed-ident.someclass)" should be a valid selector

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid-with-classes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid-with-classes.html
@@ -24,8 +24,11 @@ function test_valid_selector_combinations(pseudo) {
 test_valid_selector_combinations("::view-transition");
 
 for (const functionName of functionPseudoElements) {
+    // "\*" is an escaped <custom-ident> that spells the character "*". It must stay
+    // distinct from the literal, unescaped universal selector "*" instead of
+    // collapsing into it.
     for (const validArgument of
-        ["*.class", "*.class.class", "dashed-ident.someclass", "dash-id.dash-id", "foo.bar.baz"]) {
+        ["*.class", "\\*.class", "*.class.class", "\\*.class.class", "dashed-ident.someclass", "dash-id.dash-id", "foo.bar.baz"]) {
         test_valid_selector_combinations(`${functionName}(${validArgument})`);
         test_valid_selector_combinations(`${functionName}(${validArgument}):only-child`);
     }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid.html
@@ -24,7 +24,10 @@ function test_valid_selector_combinations(pseudo) {
 test_valid_selector_combinations("::view-transition");
 
 for (const functionName of functionPseudoElements) {
-    for (const validArgument of ["*", "root", "dashed-ident"]) {
+    // "\*" is an escaped <custom-ident> that spells the character "*". It must stay
+    // distinct from the literal, unescaped universal selector "*" instead of
+    // collapsing into it.
+    for (const validArgument of ["*", "\\*", "root", "dashed-ident"]) {
         test_valid_selector_combinations(`${functionName}(${validArgument})`);
         test_valid_selector_combinations(`${functionName}(${validArgument}):only-child`);
     }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-escaped-star-specificity-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-escaped-star-specificity-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: reference expectation</title>
+<style>
+div {
+  position: relative;
+  left: 100px;
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+<body>
+<div></div>
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-escaped-star-specificity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-escaped-star-specificity.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: an escaped \* selector should win over the universal * selector despite coming first in source order</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="match" href="pseudo-with-classes-ref.html">
+<script src="/common/rendering-utils.js"></script>
+<script src="/common/reftest-wait.js"></script>
+
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+}
+
+#target {
+  background: green;
+  view-transition-name: \*;
+}
+
+::view-transition-group(*),
+::view-transition-image-pair(*),
+::view-transition-old(*),
+::view-transition-new(*) {
+  animation-play-state: paused;
+}
+
+/* "\*" is an ordinary name with normal specificity, unlike the universal "*"
+   selector below (which contributes 0 specificity). It must win this conflict
+   even though it comes first in source order. */
+::view-transition-new(\*),
+::view-transition-old(\*) {
+  left: 100px;
+}
+
+::view-transition-new(*),
+::view-transition-old(*) {
+  left: 0;
+}
+
+</style>
+<div id=target></div>
+
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+window.addEventListener("load", () => {
+  document.startViewTransition().ready.then(takeScreenshot);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-escaped-star-view-transition-group-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-escaped-star-view-transition-group-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: reference expectation</title>
+<style>
+div {
+  position: relative;
+  left: 100px;
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+<body>
+<div></div>
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-escaped-star-view-transition-group.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-escaped-star-view-transition-group.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: group selector should match an escaped \* name</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="match" href="pseudo-with-classes-ref.html">
+<script src="/common/rendering-utils.js"></script>
+<script src="/common/reftest-wait.js"></script>
+
+<style>
+#target {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+  background: green;
+  view-transition-name: \*;
+}
+
+:root::view-transition-group(*),
+:root::view-transition-image-pair(*),
+:root::view-transition-new(*),
+:root::view-transition-old(*) {
+  animation-play-state: paused;
+}
+
+/* "\*" is an escaped <custom-ident> that spells the character "*". It must match
+   the group whose view-transition-name computes to the literal string "*". */
+:root::view-transition-group(\*) {
+  left: 100px;
+}
+
+</style>
+<div id=target></div>
+
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+window.addEventListener("load", () => {
+  document.startViewTransition().ready.then(() => requestAnimationFrame(() => takeScreenshot()));
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-escaped-star-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-escaped-star-expected.txt
@@ -1,0 +1,3 @@
+
+PASS getComputedStyle() for ::view-transition-group(*) is not confused with the escaped name \*
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-escaped-star.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-escaped-star.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: getComputedStyle() distinguishes ::view-transition-group(*) from the escaped name \*</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+#target {
+  width: 100px;
+  height: 100px;
+  view-transition-name: target;
+}
+
+::view-transition-group(*) {
+  outline-color: green;
+}
+
+/* "\*" is an escaped <custom-ident> that spells the character "*", an ordinary name. It
+   must not be confused with the universal "*" selector above when queried through
+   getComputedStyle(), in either direction. */
+::view-transition-group(\*) {
+  outline-color: red;
+}
+</style>
+
+<div id=target></div>
+
+<script>
+promise_test(async () => {
+  assert_implements(document.startViewTransition, "Missing document.startViewTransition");
+  let transition = document.startViewTransition();
+  await transition.ready;
+
+  assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(target)").outlineColor, "rgb(0, 128, 0)", "a group with an ordinary name should still see the universal rule");
+  assert_equals(getComputedStyle(document.documentElement, "::view-transition-group(\\*)").outlineColor, "rgb(255, 0, 0)", "::view-transition-group(\\*) should reflect the escaped literal name's rule");
+
+  await transition.finished;
+}, "getComputedStyle() for ::view-transition-group(*) is not confused with the escaped name \\*");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-match-escaped-star-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-match-escaped-star-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: reference expectation</title>
+<style>
+div {
+  position: relative;
+  left: 100px;
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+<body>
+<div></div>
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-match-escaped-star.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-match-escaped-star.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: selector should match an escaped \* name</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="match" href="pseudo-with-classes-ref.html">
+<script src="/common/rendering-utils.js"></script>
+<script src="/common/reftest-wait.js"></script>
+
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+}
+
+#target {
+  background: green;
+  view-transition-name: \*;
+}
+
+::view-transition-group(*),
+::view-transition-image-pair(*),
+::view-transition-old(*),
+::view-transition-new(*) {
+  animation-play-state: paused;
+}
+
+/* "\*" is an escaped <custom-ident> that spells the character "*". It must match
+   the group whose view-transition-name computes to the literal string "*". */
+::view-transition-new(\*),
+::view-transition-old(\*) {
+  left: 100px;
+}
+
+</style>
+<div id=target></div>
+
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+window.addEventListener("load", () => {
+  document.startViewTransition().ready.then(takeScreenshot);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-mismatch-escaped-star-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-mismatch-escaped-star-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: reference expectation</title>
+<style>
+div {
+  position: relative;
+  left: 100px;
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+<body>
+<div></div>
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-mismatch-escaped-star.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-mismatch-escaped-star.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: an escaped \* selector should not match a differently-named group</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="match" href="pseudo-with-classes-ref.html">
+<script src="/common/rendering-utils.js"></script>
+<script src="/common/reftest-wait.js"></script>
+
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+}
+
+#target {
+  background: green;
+  view-transition-name: target;
+}
+
+::view-transition-group(*),
+::view-transition-image-pair(*),
+::view-transition-old(*),
+::view-transition-new(*) {
+  animation-play-state: paused;
+}
+
+::view-transition-new(*),
+::view-transition-old(*) {
+  left: 100px;
+}
+
+/* "\*" is an escaped <custom-ident> that spells the character "*", an ordinary
+   name. It must not match a group named "target". If it incorrectly collapsed
+   into the universal "*" selector, this would reset the square to left: 0. */
+::view-transition-new(\*),
+::view-transition-old(\*) {
+  left: 0;
+}
+
+</style>
+<div id=target></div>
+
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+window.addEventListener("load", () => {
+  document.startViewTransition().ready.then(takeScreenshot);
+});
+</script>

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -215,13 +215,14 @@ SelectorSpecificity simpleSelectorSpecificity(const CSSSelector& simpleSelector,
         // so whether we add the ClassC specificity shouldn't be observable.
         case CSSSelector::PseudoElement::Slotted:
             return maxSpecificity(simpleSelector.selectorList());
+        case CSSSelector::PseudoElement::Highlight:
         case CSSSelector::PseudoElement::ViewTransitionGroup:
         case CSSSelector::PseudoElement::ViewTransitionImagePair:
         case CSSSelector::PseudoElement::ViewTransitionNew:
         case CSSSelector::PseudoElement::ViewTransitionOld:
             ASSERT(simpleSelector.stringList() && simpleSelector.stringList()->size());
             // Standalone universal selector gets 0 specificity.
-            if (simpleSelector.stringList()->first() == starAtom() && simpleSelector.stringList()->size() == 1)
+            if (simpleSelector.stringList()->first() == universalPseudoElementNameAtom() && simpleSelector.stringList()->size() == 1)
                 return 0;
             break;
         default:
@@ -593,12 +594,15 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
             case PseudoElement::ViewTransitionImagePair:
             case PseudoElement::ViewTransitionOld:
             case PseudoElement::ViewTransitionNew:
-                // Name or universal selector always comes first, followed by classes.
+                // Name or universal selector always comes first, followed by classes (view-transition pseudo-elements only).
                 ASSERT(selector->stringList() && !selector->stringList()->isEmpty());
 
                 builder.append("::"_s, selector->serializingValue(), '(',
                     interleave(*selector->stringList(), [&](auto& builder, auto& nameOrClass) {
-                        serializeIdentifierOrStar(nameOrClass, builder);
+                        if (nameOrClass == universalPseudoElementNameAtom())
+                            builder.append('*');
+                        else
+                            serializeIdentifier(builder, nameOrClass);
                     }, '.'),
                 ')');
                 break;

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -33,6 +33,11 @@ namespace WebCore {
 class CSSSelectorList;
 struct CSSSelectorParserContext;
 
+// The universal pseudo-element argument (::highlight(*), ::view-transition-group(*), etc.)
+// is represented by this otherwise-invalid <custom-ident> value (a real name can never be
+// empty).
+inline const AtomString& universalPseudoElementNameAtom() { return emptyAtom(); }
+
 struct PossiblyQuotedIdentifier {
     AtomString identifier;
     bool wasQuoted { false };

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1404,13 +1404,6 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
         }
 
         case CSSSelector::PseudoElement::Highlight:
-            // Always matches when not specifically requested so it gets added to the collectedPseudoElements.
-            if (!requestedPseudoElement)
-                return true;
-            if (requestedPseudoElement->type != PseudoElementType::Highlight || !selector.stringList())
-                return false;
-            return selector.stringList()->first() == requestedPseudoElement->nameOrPart;
-
         case CSSSelector::PseudoElement::ViewTransitionGroup:
         case CSSSelector::PseudoElement::ViewTransitionImagePair:
         case CSSSelector::PseudoElement::ViewTransitionOld:
@@ -1421,9 +1414,11 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
             if (requestedPseudoElement->type != CSSSelector::stylePseudoElementTypeFor(selector.pseudoElement()) || !selector.stringList())
                 return false;
 
+            // universalPseudoElementNameAtom() means ::highlight(*) or ::view-transition-*(*), which matches any name.
             auto& list = *selector.stringList();
+            ASSERT(selector.pseudoElement() != CSSSelector::PseudoElement::Highlight || list.size() == 1);
             auto& name = list.first();
-            if (name != starAtom() && name != requestedPseudoElement->nameOrPart)
+            if (name != universalPseudoElementNameAtom() && name != requestedPseudoElement->nameOrPart)
                 return false;
 
             if (list.size() == 1)

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1039,11 +1039,18 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumePseudo(CSSParserTo
         }
 #endif
         case CSSSelector::PseudoElement::Highlight: {
-            auto& ident = block.consumeIncludingWhitespace();
-            if (ident.type() != IdentToken || !block.atEnd())
+            auto& token = block.consumeIncludingWhitespace();
+            if (!block.atEnd())
                 return nullptr;
-            selector->setStringList({ { ident.value().toAtomString() } });
-            return selector;
+            if (token.type() == IdentToken) {
+                selector->setStringList({ { token.value().toAtomString() } });
+                return selector;
+            }
+            if (token.type() == DelimiterToken && token.delimiter() == '*') {
+                selector->setStringList({ { universalPseudoElementNameAtom() } });
+                return selector;
+            }
+            return nullptr;
         }
 
         case CSSSelector::PseudoElement::Picker: {
@@ -1063,7 +1070,7 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumePseudo(CSSParserTo
 
             // Check for implicit universal selector.
             if (block.peek().type() == DelimiterToken && block.peek().delimiter() == '.')
-                nameAndClasses.append(starAtom());
+                nameAndClasses.append(universalPseudoElementNameAtom());
 
             // Parse name or explicit universal selector.
             if (nameAndClasses.isEmpty()) {
@@ -1071,7 +1078,7 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumePseudo(CSSParserTo
                 if (ident.type() == IdentToken && isValidCustomIdentifier(ident.id()))
                     nameAndClasses.append(ident.value().toAtomString());
                 else if (ident.type() == DelimiterToken && ident.delimiter() == '*')
-                    nameAndClasses.append(starAtom());
+                    nameAndClasses.append(universalPseudoElementNameAtom());
                 else
                     return nullptr;
             }
@@ -1548,20 +1555,21 @@ std::optional<Style::PseudoElementIdentifier> CSSSelectorParser::parsePseudoElem
         return { };
     block.consumeWhitespace();
     switch (*pseudoElement) {
-    case CSSSelector::PseudoElement::Highlight: {
-        auto& ident = block.consumeIncludingWhitespace();
-        if (ident.type() != IdentToken || !block.atEnd())
-            return { };
-        return { Style::PseudoElementIdentifier { PseudoElementType::Highlight, ident.value().toAtomString() } };
-    }
+    case CSSSelector::PseudoElement::Highlight:
     case CSSSelector::PseudoElement::ViewTransitionGroup:
     case CSSSelector::PseudoElement::ViewTransitionImagePair:
     case CSSSelector::PseudoElement::ViewTransitionOld:
     case CSSSelector::PseudoElement::ViewTransitionNew: {
-        auto& ident = block.consumeIncludingWhitespace();
-        if (ident.type() != IdentToken || !isValidCustomIdentifier(ident.id()) || !block.atEnd())
+        auto& token = block.consumeIncludingWhitespace();
+        if (!block.atEnd())
             return { };
-        return { Style::PseudoElementIdentifier { *CSSSelector::stylePseudoElementTypeFor(*pseudoElement), ident.value().toAtomString() } };
+        if (token.type() == IdentToken) {
+            if (!isValidCustomIdentifier(token.id()) && *pseudoElement != CSSSelector::PseudoElement::Highlight)
+                return { };
+            return { Style::PseudoElementIdentifier { *CSSSelector::stylePseudoElementTypeFor(*pseudoElement), token.value().toAtomString() } };
+        }
+        // Intentionally don't parse the universal selector here, because getComputedStyle() only supports returning styles for unique identifiers.
+        return { };
     }
     case CSSSelector::PseudoElement::Picker: {
         auto argument = consumePickerArgument(block);

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -274,7 +274,7 @@ void RuleSet::addRuleToBucket(RuleData& ruleData)
                 case CSSSelector::PseudoElement::ViewTransitionImagePair:
                 case CSSSelector::PseudoElement::ViewTransitionOld:
                 case CSSSelector::PseudoElement::ViewTransitionNew:
-                    if (current->stringList()->first() != starAtom())
+                    if (current->stringList()->first() != universalPseudoElementNameAtom())
                         namedPseudoElementSelector = current;
                     break;
                 default:


### PR DESCRIPTION
#### 5ed89fc0abf85e2613cd16c9c16ac66c6d64e17d
<pre>
[Custom Highlight] Support `::highlight(*)`
<a href="https://bugs.webkit.org/show_bug.cgi?id=323469">https://bugs.webkit.org/show_bug.cgi?id=323469</a>
<a href="https://rdar.apple.com/186700364">rdar://186700364</a>

Reviewed by Megan Gardner.

::highlight(*) matches all highlights, with specificity 0.

emptyAtom() now represents * under the alias `universalPseudoElementNameAtom()`, to differentiate with \* which is represented by starAtom().

\* is now fixed in view transitions and tested:

Tests: imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-escaped-star.tentative.html
       imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-escaped-star-specificity.html
       imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-escaped-star-view-transition-group.html
       imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-escaped-star.html
       imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-match-escaped-star.html
       imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-mismatch-escaped-star.html

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-escaped-star.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-escaped-star.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-parsing-and-computed-style.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/highlight-pseudo-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid-with-classes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid-with-classes.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/parsing/pseudo-elements-valid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-escaped-star-specificity-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-escaped-star-specificity.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-escaped-star-view-transition-group-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-escaped-star-view-transition-group.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-escaped-star-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-get-computed-style-escaped-star.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-match-escaped-star-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-match-escaped-star.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-mismatch-escaped-star-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-mismatch-escaped-star.html: Added.
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::simpleSelectorSpecificity):
(WebCore::CSSSelector::selectorText const):
* Source/WebCore/css/CSSSelector.h:
(WebCore::universalPseudoElementNameAtom):
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumePseudo):
(WebCore::CSSSelectorParser::parsePseudoElement):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRuleToBucket):
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-parsing-and-computed-style.tentative.html:

Canonical link: <a href="https://commits.webkit.org/320952@main">https://commits.webkit.org/320952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb01e33821e8b7bdb3b881dbce2b2417fa33f91b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196494 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150761 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59810 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145488 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100850 "1 flakes 15 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189162 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125822 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47898 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45878 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158252 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45613 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7564 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47442 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50342 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198475 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59755 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165545 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155059 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41581 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60466 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42187 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154702 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49140 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132724 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129879 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58893 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20592 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58295 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58513 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58356 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->