### PR TITLE
[GPUProcess] Move the drawing Font functionalities to a new class named FontBase

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2538,6 +2538,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/FloatSize.h
     platform/graphics/FloatSizeHash.h
     platform/graphics/Font.h
+    platform/graphics/FontBase.h
     platform/graphics/FontBaseline.h
     platform/graphics/FontCache.h
     platform/graphics/FontCascade.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2693,6 +2693,7 @@ platform/graphics/FloatRoundedRect.cpp
 platform/graphics/FloatSegment.cpp
 platform/graphics/FloatSize.cpp
 platform/graphics/Font.cpp
+platform/graphics/FontBase.cpp
 platform/graphics/FontCache.cpp
 platform/graphics/FontCascade.cpp
 platform/graphics/FontCascadeCache.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -3078,6 +3078,7 @@
 		72C99A9F2F9944110070F060 /* ShareableCVPixelFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 72C99A9D2F993DF60070F060 /* ShareableCVPixelFormat.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72C9B6522F99950B0070F060 /* GainMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 72C9B6512F9994AD0070F060 /* GainMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72C9B6532F99998D0070F060 /* ShareableGainMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 72C9B64F2F9992DE0070F060 /* ShareableGainMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		72CC6D36304E3B91006895A1 /* FontBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 72CC6D34304E369F006895A1 /* FontBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72CD9C542FCB794100CFC9BF /* AsyncImageDecoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 72E0375C2FC9323300088DDE /* AsyncImageDecoder.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72D3F66D2A37FE9700F3A82B /* RotationDirection.h in Headers */ = {isa = PBXBuildFile; fileRef = 72D3F66C2A37F48E00F3A82B /* RotationDirection.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		72D73644278461A000398663 /* FilterResults.h in Headers */ = {isa = PBXBuildFile; fileRef = 7211B5D6276536820076FEF8 /* FilterResults.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -14769,6 +14770,8 @@
 		72C9B64F2F9992DE0070F060 /* ShareableGainMap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShareableGainMap.h; sourceTree = "<group>"; };
 		72C9B6502F9992DE0070F060 /* ShareableGainMap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ShareableGainMap.cpp; sourceTree = "<group>"; };
 		72C9B6512F9994AD0070F060 /* GainMap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GainMap.h; sourceTree = "<group>"; };
+		72CC6D34304E369F006895A1 /* FontBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FontBase.h; sourceTree = "<group>"; };
+		72CC6D35304E369F006895A1 /* FontBase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FontBase.cpp; sourceTree = "<group>"; };
 		72CE4EA32970FF8800A2AD95 /* ImageControlsButtonMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ImageControlsButtonMac.mm; sourceTree = "<group>"; };
 		72CE4EA42970FF8800A2AD95 /* ImageControlsButtonMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageControlsButtonMac.h; sourceTree = "<group>"; };
 		72CE4EA5297102B800A2AD95 /* ImageControlsButtonPart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageControlsButtonPart.h; sourceTree = "<group>"; };
@@ -36979,6 +36982,8 @@
 				58CD35CA18EB4C3900B9F3AC /* FloatSizeHash.h */,
 				B2C3DA530D006CD600EF6F26 /* Font.cpp */,
 				B2C3DA540D006CD600EF6F26 /* Font.h */,
+				72CC6D35304E369F006895A1 /* FontBase.cpp */,
+				72CC6D34304E369F006895A1 /* FontBase.h */,
 				BCB92D4E1293550B00C8387F /* FontBaseline.h */,
 				B2C3DA510D006CD600EF6F26 /* FontCache.cpp */,
 				B2C3DA520D006CD600EF6F26 /* FontCache.h */,
@@ -45897,6 +45902,7 @@
 				1AC2D89D1B1E291F00D52E87 /* FontAntialiasingStateSaver.h in Headers */,
 				F4E57EDC213F3F5F004EA98E /* FontAttributeChanges.h in Headers */,
 				F48D2A7E2157182600C6752B /* FontAttributes.h in Headers */,
+				72CC6D36304E3B91006895A1 /* FontBase.h in Headers */,
 				BCB92D4F1293550B00C8387F /* FontBaseline.h in Headers */,
 				B2C3DA630D006CD600EF6F26 /* FontCache.h in Headers */,
 				C2458E631FE897B000594759 /* FontCacheCoreText.h in Headers */,

--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,10 +42,6 @@
 #include "FontCustomPlatformData.h"
 #include "GlyphPage.h"
 #include "SharedBuffer.h"
-
-#if ENABLE(MATHML)
-#include "OpenTypeMathData.h"
-#endif
 
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
@@ -94,20 +90,12 @@ Ref<Font> Font::create(FontInternalAttributes&& attributes, FontPlatformData&& p
 }
 
 Font::Font(const FontPlatformData& platformData, Origin origin, IsInterstitial interstitial, Visibility visibility, IsOrientationFallback orientationFallback, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
-    : m_platformData(platformData)
-    , m_attributes({ renderingResourceIdentifier, origin, interstitial, visibility, orientationFallback })
-    , m_treatAsFixedPitch(false)
-    , m_isBrokenIdeographFallback(false)
-    , m_hasVerticalGlyphs(false)
-    , m_isUsedInSystemFallbackFontCache(false)
-    , m_allowsAntialiasing(true)
-#if PLATFORM(IOS_FAMILY)
-    , m_shouldNotBeUsedForArabic(false)
-#endif
+    : FontBase(platformData, origin, interstitial, visibility, orientationFallback, renderingResourceIdentifier)
 {
     platformInit();
     platformGlyphInit();
     platformCharWidthInit();
+    platformCharHeightInit();
 #if ENABLE(OPENTYPE_VERTICAL)
     if (platformData.orientation() == FontOrientation::Vertical && !isTextOrientationFallback()) {
         m_verticalData = FontCache::forCurrentThread().verticalData(platformData);
@@ -122,25 +110,6 @@ Font::Font(IsSystemFallbackFontPlaceholder isSystemFontFallbackPlaceholder)
 {
     // This ctor is to be used only for representing a system font fallback placeholder (createSystemFallbackFontPlaceholder)
     ASSERT(isSystemFontFallbackPlaceholder == IsSystemFallbackFontPlaceholder::Yes);
-}
-
-void Font::applyFontMetricsOverrides()
-{
-    if (m_platformData.metricsOverrides().ascentOverride.isNormal()
-        && m_platformData.metricsOverrides().descentOverride.isNormal()
-        && m_platformData.metricsOverrides().lineGapOverride.isNormal())
-        return;
-
-    if (!m_platformData.metricsOverrides().ascentOverride.isNormal())
-        m_fontMetrics.setAscent(*m_platformData.metricsOverrides().ascentOverride.value * platformData().size());
-
-    if (!m_platformData.metricsOverrides().descentOverride.isNormal())
-        m_fontMetrics.setDescent(*m_platformData.metricsOverrides().descentOverride.value * platformData().size());
-
-    if (!m_platformData.metricsOverrides().lineGapOverride.isNormal())
-        m_fontMetrics.setLineGap(*m_platformData.metricsOverrides().lineGapOverride.value * platformData().size());
-
-    m_fontMetrics.setLineSpacing(lroundf(m_fontMetrics.ascent()) + lroundf(m_fontMetrics.descent()) + lroundf(m_fontMetrics.lineGap()));
 }
 
 // Estimates of avgCharWidth and maxCharWidth for platforms that don't support accessing these values from the font.
@@ -234,18 +203,6 @@ Font::~Font()
 {
     if (auto* cache = SystemFallbackFontCache::forCurrentThreadIfExists())
         cache->remove(this);
-}
-
-RenderingResourceIdentifier Font::renderingResourceIdentifier() const
-{
-    return m_attributes.ensureRenderingResourceIdentifier();
-}
-
-RenderingResourceIdentifier FontInternalAttributes::ensureRenderingResourceIdentifier() const
-{
-    if (!renderingResourceIdentifier)
-        renderingResourceIdentifier = RenderingResourceIdentifier::generate();
-    return *renderingResourceIdentifier;
 }
 
 static bool fillGlyphPage(GlyphPage& pageToFill, std::span<const char16_t> buffer, const Font& font)
@@ -581,6 +538,10 @@ const Font& Font::brokenIdeographFont() const
 
 #if !USE(CORE_TEXT)
 
+void Font::platformCharHeightInit()
+{
+}
+
 bool Font::isProbablyOnlyUsedToRenderIcons() const
 {
     // FIXME: Not implemented yet.
@@ -596,20 +557,6 @@ String Font::description() const
         return "[custom font]"_s;
 
     return platformData().description();
-}
-#endif
-
-#if ENABLE(MATHML)
-const OpenTypeMathData* Font::mathData() const
-{
-    if (isInterstitial())
-        return nullptr;
-    if (!m_mathData) {
-        Ref mathData = OpenTypeMathData::create(m_platformData);
-        if (mathData->hasMathData())
-            m_mathData = WTF::move(mathData);
-    }
-    return m_mathData.get();
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007-2008 Torch Mobile, Inc.
  *
  * This library is free software; you can redistribute it and/or
@@ -22,28 +22,14 @@
 #pragma once
 
 #include <WebCore/FloatRect.h>
-#include <WebCore/FontMetrics.h>
-#include <WebCore/FontPlatformData.h>
-#include <WebCore/GlyphBuffer.h>
+#include <WebCore/FontBase.h>
 #include <WebCore/GlyphMetricsMap.h>
-#include <WebCore/RenderingResourceIdentifier.h>
 #include <WebCore/TrustedFonts.h>
-#include <wtf/BitVector.h>
 #include <wtf/Platform.h>
 #include <wtf/WeakPtr.h>
 
-#if PLATFORM(COCOA)
-#include <pal/cf/OTSVGTable.h>
-#endif
-
 #if PLATFORM(WIN)
 #include <usp10.h>
-#endif
-
-#if USE(SKIA)
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-#include <skia/core/SkTextBlob.h>
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
 namespace WTF {
@@ -55,71 +41,30 @@ namespace WebCore {
 class FontCache;
 class FontDescription;
 class GlyphPage;
-#if ENABLE(MATHML)
-class OpenTypeMathData;
-#endif
-#if ENABLE(OPENTYPE_VERTICAL)
-class OpenTypeVerticalData;
-#endif
 
 struct GlyphData;
-#if ENABLE(MULTI_REPRESENTATION_HEIC)
-struct MultiRepresentationHEICMetrics;
-#endif
+
 
 enum class FontVariant : uint8_t { Auto, Normal, SmallCaps, EmphasisMark, BrokenIdeograph };
 enum class PitchType : uint8_t { Unknown, Fixed, Variable };
 enum class IsForPlatformFont : bool { No, Yes };
 
-// Used to create platform fonts.
-enum class FontOrigin : bool { Remote, Local };
-enum class FontIsInterstitial : bool { No, Yes };
-enum class FontVisibility : bool { Visible, Invisible };
-enum class FontIsOrientationFallback : bool { No, Yes };
-
 #if USE(CORE_TEXT)
 using IPCFontData = Variant<WebCore::InstalledFont, WebCore::CustomFontCreationData>;
-
-bool fontHasEitherTable(CTFontRef, unsigned tableTag1, unsigned tableTag2);
-bool supportsOpenTypeFeature(CTFontRef, CFStringRef featureTag);
 #endif
 
-struct FontInternalAttributes {
-    WEBCORE_EXPORT RenderingResourceIdentifier ensureRenderingResourceIdentifier() const;
-
-    mutable std::optional<RenderingResourceIdentifier> renderingResourceIdentifier;
-    FontOrigin origin : 1;
-    FontIsInterstitial isInterstitial : 1;
-    FontVisibility visibility : 1;
-    FontIsOrientationFallback isTextOrientationFallback : 1;
-};
-
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Font);
-class Font : public RefCounted<Font>, public CanMakeSingleThreadWeakPtr<Font> {
+class Font : public FontBase, public RefCounted<Font>, public CanMakeSingleThreadWeakPtr<Font> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Font, Font);
 public:
-    using Origin = FontOrigin;
-    using IsInterstitial = FontIsInterstitial;
-    using Visibility = FontVisibility;
-    using IsOrientationFallback = FontIsOrientationFallback;
-
     WEBCORE_EXPORT static Ref<Font> create(const FontPlatformData&, Origin = Origin::Local, IsInterstitial = IsInterstitial::No, Visibility = Visibility::Visible, IsOrientationFallback = IsOrientationFallback::No, std::optional<RenderingResourceIdentifier> = std::nullopt);
     WEBCORE_EXPORT static Ref<Font> create(Ref<SharedBuffer>&& fontFaceData, Font::Origin, float fontSize, bool syntheticBold, bool syntheticItalic, DownloadableBinaryFontTrustedTypes);
-    WEBCORE_EXPORT static Ref<Font> create(WebCore::FontInternalAttributes&&, WebCore::FontPlatformData&&);
+    WEBCORE_EXPORT static Ref<Font> create(FontInternalAttributes&&, FontPlatformData&&);
 
     WEBCORE_EXPORT ~Font();
 
     static Ref<Font> createSystemFallbackFontPlaceholder() { return adoptRef(*new Font(IsSystemFallbackFontPlaceholder::Yes)); }
     bool isSystemFontFallbackPlaceholder() const { return m_isSystemFontFallbackPlaceholder; }
-    const FontPlatformData& platformData() const LIFETIME_BOUND { return m_platformData; }
-#if ENABLE(MATHML)
-    const OpenTypeMathData* mathData() const;
-#endif
-#if ENABLE(OPENTYPE_VERTICAL)
-    inline const OpenTypeVerticalData* verticalData() const;
-#endif
-
-    WEBCORE_EXPORT RenderingResourceIdentifier renderingResourceIdentifier() const;
 
     const Font* smallCapsFont(const FontDescription&) const;
     const Font& noSynthesizableFeaturesFont() const;
@@ -152,45 +97,15 @@ public:
     const Font& uprightOrientationFont() const;
     const Font& invisibleFont() const;
 
-    bool hasVerticalGlyphs() const { return m_hasVerticalGlyphs; }
-    bool isTextOrientationFallback() const { return m_attributes.isTextOrientationFallback == IsOrientationFallback::Yes; }
-
-    const FontMetrics& fontMetrics() const LIFETIME_BOUND { return m_fontMetrics; }
-    float sizePerUnit() const { return platformData().size() / (fontMetrics().unitsPerEm() ? fontMetrics().unitsPerEm() : 1); }
-
-    float maxCharWidth() const { return m_maxCharWidth; }
-    void setMaxCharWidth(float maxCharWidth) { m_maxCharWidth = maxCharWidth; }
-
-    float avgCharWidth() const { return m_avgCharWidth; }
-    void setAvgCharWidth(float avgCharWidth) { m_avgCharWidth = avgCharWidth; }
-
     FloatRect boundsForGlyph(Glyph) const;
 #if USE(CORE_TEXT) || USE(SKIA)
     static constexpr size_t inlineGlyphRunCapacity = 256;
     Vector<FloatRect, inlineGlyphRunCapacity> boundsForGlyphs(std::span<const Glyph>) const;
 #endif
 
-    // Should the result of this function include the results of synthetic bold?
-    enum class SyntheticBoldInclusion {
-        Incorporate,
-        Exclude
-    };
-
-    enum class IsSystemFallbackFontPlaceholder : bool {
-        No,
-        Yes
-    };
-
     float widthForGlyph(Glyph, SyntheticBoldInclusion = SyntheticBoldInclusion::Incorporate) const;
 
     Path pathForGlyph(Glyph) const;
-
-    float NODELETE spaceWidth(SyntheticBoldInclusion SyntheticBoldInclusion = SyntheticBoldInclusion::Incorporate) const
-    {
-        return m_spaceWidth + (SyntheticBoldInclusion == SyntheticBoldInclusion::Incorporate ? syntheticBoldOffset() : 0);
-    }
-
-    float syntheticBoldOffset() const { return m_syntheticBoldOffset; }
 
     Glyph spaceGlyph() const { return m_spaceGlyph; }
     Glyph zeroWidthSpaceGlyph() const { return m_zeroWidthSpaceGlyph; }
@@ -209,42 +124,13 @@ public:
     PitchType pitch() const { return m_treatAsFixedPitch ? PitchType::Fixed : PitchType::Variable; }
     bool canTakeFixedPitchFastContentMeasuring() const { return m_canTakeFixedPitchFastContentMeasuring; }
 
-    Origin origin() const { return m_attributes.origin; }
-    bool isInterstitial() const { return m_attributes.isInterstitial == IsInterstitial::Yes; }
-    Visibility visibility() const { return m_attributes.visibility; }
-    bool allowsAntialiasing() const { return m_allowsAntialiasing; }
-
 #if !LOG_DISABLED
     String description() const;
-#endif
-
-#if PLATFORM(IOS_FAMILY)
-    bool shouldNotBeUsedForArabic() const { return m_shouldNotBeUsedForArabic; };
-#endif
-#if USE(CORE_TEXT)
-    CTFontRef ctFont() const { return m_platformData.ctFont(); }
-    bool supportsSmallCaps() const;
-    bool supportsAllSmallCaps() const;
-    bool supportsPetiteCaps() const;
-    bool supportsAllPetiteCaps() const;
-    bool supportsOpenTypeAlternateHalfWidths() const;
-#if ENABLE(MULTI_REPRESENTATION_HEIC)
-    MultiRepresentationHEICMetrics metricsForMultiRepresentationHEIC() const;
-#endif
-#endif
-
-#if USE(SKIA)
-    sk_sp<SkTextBlob> buildTextBlob(std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, FontSmoothingMode) const;
-    bool enableAntialiasing(FontSmoothingMode) const;
 #endif
 
     bool canRenderCombiningCharacterSequence(StringView) const;
     GlyphBufferAdvance applyTransforms(GlyphBuffer&, unsigned beginningGlyphIndex, unsigned beginningStringIndex, bool enableKerning, bool requiresShaping, const AtomString& locale, StringView text, TextDirection) const;
 
-    // Returns nullopt if none of the glyphs are OT-SVG glyphs.
-    std::optional<BitVector> findOTSVGGlyphs(std::span<const GlyphBufferGlyph>) const;
-
-    bool hasAnyComplexColorFormatGlyphs(std::span<const GlyphBufferGlyph>) const;
 #if USE(CORE_TEXT)
     WEBCORE_EXPORT static std::optional<Ref<Font>> fromIPCData(IPCFontData&&);
     WEBCORE_EXPORT IPCFontData toSerializableFont() const;
@@ -254,28 +140,23 @@ public:
     SCRIPT_CACHE* scriptCache() const LIFETIME_BOUND { return &m_scriptCache; }
 #endif
 
-    void setIsUsedInSystemFallbackFontCache() { m_isUsedInSystemFallbackFontCache = true; }
-    bool isUsedInSystemFallbackFontCache() const { return m_isUsedInSystemFallbackFontCache; }
-
-    using Attributes = FontInternalAttributes;
-    const Attributes& attributes() const LIFETIME_BOUND { return m_attributes; }
-
     ColorGlyphType colorGlyphType(Glyph) const;
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
 private:
     WEBCORE_EXPORT Font(const FontPlatformData&, Origin, IsInterstitial, Visibility, IsOrientationFallback, std::optional<RenderingResourceIdentifier>);
     Font(IsSystemFallbackFontPlaceholder);
 
-    void platformInit();
     void platformGlyphInit();
     void platformCharWidthInit();
-    void NODELETE platformDestroy();
-
-    void applyFontMetricsOverrides();
+    void platformCharHeightInit();
 
     void initCharWidths();
-
     void initZeroWidth(Glyph);
+
+    void NODELETE platformDestroy();
 
     RefPtr<Font> createFontWithoutSynthesizableFeatures() const;
     RefPtr<Font> createScaledFont(const FontDescription&, float scaleFactor) const;
@@ -293,59 +174,12 @@ private:
     float platformWidthForGlyph(Glyph) const;
     Path platformPathForGlyph(Glyph) const;
 
-#if PLATFORM(COCOA)
-    class ComplexColorFormatGlyphs {
-    public:
-        static ComplexColorFormatGlyphs createWithNoRelevantTables();
-        static ComplexColorFormatGlyphs createWithRelevantTablesAndGlyphCount(unsigned glyphCount);
-
-        bool hasValueFor(Glyph) const;
-        bool get(Glyph) const;
-        void set(Glyph, bool value);
-
-        bool hasRelevantTables() const { return m_hasRelevantTables; }
-
-    private:
-        static constexpr size_t bitForInitialized(Glyph glyphID) { return static_cast<size_t>(glyphID) * 2; }
-        static constexpr size_t bitForValue(Glyph glyphID) { return static_cast<size_t>(glyphID) * 2 + 1; }
-        static constexpr size_t bitsRequiredForGlyphCount(unsigned glyphCount) { return glyphCount * 2; }
-
-        ComplexColorFormatGlyphs(bool hasRelevantTables, unsigned glyphCount)
-            : m_hasRelevantTables(hasRelevantTables)
-            , m_bits(bitsRequiredForGlyphCount(glyphCount))
-        { }
-
-        bool m_hasRelevantTables;
-        BitVector m_bits; // pairs of (initialized, value) bits
-    };
-
-    const PAL::OTSVGTable& otSVGTable() const;
-    bool glyphHasComplexColorFormat(Glyph) const;
-    bool hasComplexColorFormatTables() const;
-    ComplexColorFormatGlyphs& glyphsWithComplexColorFormat() const;
-#endif
-
-    FontMetrics m_fontMetrics;
-    float m_maxCharWidth { -1 };
-    float m_avgCharWidth { -1 };
-
-    const FontPlatformData m_platformData;
-
     mutable HashMap<unsigned, RefPtr<GlyphPage>, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_glyphPages;
     mutable GlyphMetricsMap<float> m_glyphToWidthMap;
     mutable std::unique_ptr<GlyphMetricsMap<FloatRect>> m_glyphToBoundsMap;
     // FIXME: Find a more efficient way to represent std::optional<Path>.
     mutable std::unique_ptr<GlyphMetricsMap<std::optional<Path>>> m_glyphPathMap;
     mutable BitVector m_codePointSupport;
-
-#if ENABLE(MATHML)
-    mutable RefPtr<OpenTypeMathData> m_mathData;
-#endif
-#if ENABLE(OPENTYPE_VERTICAL)
-    RefPtr<OpenTypeVerticalData> m_verticalData;
-#endif
-
-    Attributes m_attributes;
 
     struct DerivedFonts {
         WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(DerivedFonts);
@@ -363,36 +197,6 @@ private:
 
     mutable std::unique_ptr<DerivedFonts> m_derivedFontData;
 
-    struct NoEmojiGlyphs { };
-#if USE(SKIA)
-    struct AllEmojiGlyphs { };
-#endif
-    struct SomeEmojiGlyphs {
-        BitVector colorGlyphs;
-    };
-#if USE(SKIA)
-    using EmojiType = Variant<NoEmojiGlyphs, AllEmojiGlyphs, SomeEmojiGlyphs>;
-#else
-    using EmojiType = Variant<NoEmojiGlyphs, SomeEmojiGlyphs>;
-#endif
-    EmojiType m_emojiType { NoEmojiGlyphs { } };
-
-#if PLATFORM(COCOA)
-    mutable std::optional<PAL::OTSVGTable> m_otSVGTable;
-    mutable std::optional<ComplexColorFormatGlyphs> m_glyphsWithComplexColorFormat; // SVG and sbix
-
-    enum class SupportsFeature : uint8_t {
-        No,
-        Yes,
-        Unknown
-    };
-    mutable SupportsFeature m_supportsSmallCaps { SupportsFeature::Unknown };
-    mutable SupportsFeature m_supportsAllSmallCaps { SupportsFeature::Unknown };
-    mutable SupportsFeature m_supportsPetiteCaps { SupportsFeature::Unknown };
-    mutable SupportsFeature m_supportsAllPetiteCaps { SupportsFeature::Unknown };
-    mutable SupportsFeature m_supportsOpenTypeAlternateHalfWidths { SupportsFeature::Unknown };
-#endif
-
 #if PLATFORM(WIN)
     mutable SCRIPT_CACHE m_scriptCache { 0 };
 #endif
@@ -400,23 +204,10 @@ private:
     Glyph m_spaceGlyph { 0 };
     Glyph m_zeroWidthSpaceGlyph { 0 };
 
-    float m_spaceWidth { 0 };
-    float m_syntheticBoldOffset { 0 };
-
-    unsigned m_treatAsFixedPitch : 1;
-    unsigned m_canTakeFixedPitchFastContentMeasuring : 1 { false };
-    unsigned m_isBrokenIdeographFallback : 1;
-    unsigned m_hasVerticalGlyphs : 1;
-
-    unsigned m_isUsedInSystemFallbackFontCache : 1;
-    
-    unsigned m_allowsAntialiasing : 1;
-
     unsigned m_isSystemFontFallbackPlaceholder : 1 { false };
-
-#if PLATFORM(IOS_FAMILY)
-    unsigned m_shouldNotBeUsedForArabic : 1;
-#endif
+    unsigned m_treatAsFixedPitch : 1 { false };
+    unsigned m_canTakeFixedPitchFastContentMeasuring : 1 { false };
+    unsigned m_isBrokenIdeographFallback : 1 { false };
 
     // Adding any non-derived information to Font needs a parallel change in WebCoreArgumentCoders.cpp.
 };

--- a/Source/WebCore/platform/graphics/FontBase.cpp
+++ b/Source/WebCore/platform/graphics/FontBase.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FontBase.h"
+
+#include "FontCache.h"
+
+#if ENABLE(MATHML)
+#include "OpenTypeMathData.h"
+#endif
+
+#if ENABLE(OPENTYPE_VERTICAL)
+#include "OpenTypeVerticalData.h"
+#endif
+
+namespace WebCore {
+
+FontBase::FontBase(const FontPlatformData& platformData, Origin origin, IsInterstitial interstitial, Visibility visibility, IsOrientationFallback orientationFallback, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
+    : m_platformData(platformData)
+    , m_attributes({ renderingResourceIdentifier, origin, interstitial, visibility, orientationFallback })
+{
+}
+
+FontBase::FontBase() = default;
+
+FontBase::~FontBase() = default;
+
+void FontBase::applyFontMetricsOverrides()
+{
+    if (m_platformData.metricsOverrides().ascentOverride.isNormal()
+        && m_platformData.metricsOverrides().descentOverride.isNormal()
+        && m_platformData.metricsOverrides().lineGapOverride.isNormal())
+        return;
+
+    if (!m_platformData.metricsOverrides().ascentOverride.isNormal())
+        m_fontMetrics.setAscent(*m_platformData.metricsOverrides().ascentOverride.value * platformData().size());
+
+    if (!m_platformData.metricsOverrides().descentOverride.isNormal())
+        m_fontMetrics.setDescent(*m_platformData.metricsOverrides().descentOverride.value * platformData().size());
+
+    if (!m_platformData.metricsOverrides().lineGapOverride.isNormal())
+        m_fontMetrics.setLineGap(*m_platformData.metricsOverrides().lineGapOverride.value * platformData().size());
+
+    m_fontMetrics.setLineSpacing(lroundf(m_fontMetrics.ascent()) + lroundf(m_fontMetrics.descent()) + lroundf(m_fontMetrics.lineGap()));
+}
+
+#if ENABLE(MATHML)
+const OpenTypeMathData* FontBase::mathData() const
+{
+    if (isInterstitial())
+        return nullptr;
+    if (!m_mathData) {
+        Ref mathData = OpenTypeMathData::create(m_platformData);
+        if (mathData->hasMathData())
+            m_mathData = WTF::move(mathData);
+    }
+    return m_mathData.get();
+}
+#endif
+
+RenderingResourceIdentifier FontInternalAttributes::ensureRenderingResourceIdentifier() const
+{
+    if (!renderingResourceIdentifier)
+        renderingResourceIdentifier = RenderingResourceIdentifier::generate();
+    return *renderingResourceIdentifier;
+}
+
+RenderingResourceIdentifier FontBase::renderingResourceIdentifier() const
+{
+    return m_attributes.ensureRenderingResourceIdentifier();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontBase.h
+++ b/Source/WebCore/platform/graphics/FontBase.h
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/FontMetrics.h>
+#include <WebCore/FontPlatformData.h>
+#include <WebCore/Glyph.h>
+#include <WebCore/GlyphBufferMembers.h>
+#include <WebCore/RenderingResourceIdentifier.h>
+#include <wtf/AbstractRefCounted.h>
+#include <wtf/BitVector.h>
+
+#if PLATFORM(COCOA)
+#include <pal/cf/OTSVGTable.h>
+#endif
+
+#if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkTextBlob.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#endif
+
+namespace WebCore {
+
+class GlyphBuffer;
+
+#if ENABLE(MATHML)
+class OpenTypeMathData;
+#endif
+#if ENABLE(OPENTYPE_VERTICAL)
+class OpenTypeVerticalData;
+#endif
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+struct MultiRepresentationHEICMetrics;
+#endif
+
+// Used to create platform fonts.
+enum class FontOrigin : bool { Remote, Local };
+enum class FontIsInterstitial : bool { No, Yes };
+enum class FontVisibility : bool { Visible, Invisible };
+enum class FontIsOrientationFallback : bool { No, Yes };
+
+struct FontInternalAttributes {
+    WEBCORE_EXPORT RenderingResourceIdentifier ensureRenderingResourceIdentifier() const;
+
+    mutable std::optional<RenderingResourceIdentifier> renderingResourceIdentifier;
+    FontOrigin origin : 1;
+    FontIsInterstitial isInterstitial : 1;
+    FontVisibility visibility : 1;
+    FontIsOrientationFallback isTextOrientationFallback : 1;
+};
+
+class FontBase : public AbstractRefCounted {
+public:
+    using Attributes = FontInternalAttributes;
+    using Origin = FontOrigin;
+    using IsInterstitial = FontIsInterstitial;
+    using Visibility = FontVisibility;
+    using IsOrientationFallback = FontIsOrientationFallback;
+
+    // Should the result of this function include the results of synthetic bold?
+    enum class SyntheticBoldInclusion {
+        Incorporate,
+        Exclude
+    };
+
+    WEBCORE_EXPORT ~FontBase();
+
+    const FontPlatformData& platformData() const LIFETIME_BOUND { return m_platformData; }
+#if ENABLE(MATHML)
+    const OpenTypeMathData* mathData() const;
+#endif
+#if ENABLE(OPENTYPE_VERTICAL)
+    const OpenTypeVerticalData* verticalData() const { return m_verticalData; }
+#endif
+
+    const Attributes& attributes() const LIFETIME_BOUND { return m_attributes; }
+
+    Origin origin() const { return m_attributes.origin; }
+    bool isInterstitial() const { return m_attributes.isInterstitial == IsInterstitial::Yes; }
+    Visibility visibility() const { return m_attributes.visibility; }
+    bool isTextOrientationFallback() const { return m_attributes.isTextOrientationFallback == IsOrientationFallback::Yes; }
+    WEBCORE_EXPORT RenderingResourceIdentifier renderingResourceIdentifier() const;
+
+    const FontMetrics& fontMetrics() const LIFETIME_BOUND { return m_fontMetrics; }
+    float sizePerUnit() const { return platformData().size() / (fontMetrics().unitsPerEm() ? fontMetrics().unitsPerEm() : 1); }
+
+    float syntheticBoldOffset() const { return m_syntheticBoldOffset; }
+
+    float NODELETE spaceWidth(SyntheticBoldInclusion syntheticBoldInclusion = SyntheticBoldInclusion::Incorporate) const
+    {
+        return m_spaceWidth + (syntheticBoldInclusion == SyntheticBoldInclusion::Incorporate ? syntheticBoldOffset() : 0);
+    }
+
+    float maxCharWidth() const { return m_maxCharWidth; }
+    void setMaxCharWidth(float maxCharWidth) { m_maxCharWidth = maxCharWidth; }
+
+    float avgCharWidth() const { return m_avgCharWidth; }
+    void setAvgCharWidth(float avgCharWidth) { m_avgCharWidth = avgCharWidth; }
+
+    bool allowsAntialiasing() const { return m_allowsAntialiasing; }
+    bool hasVerticalGlyphs() const { return m_hasVerticalGlyphs; }
+    bool isUsedInSystemFallbackFontCache() const { return m_isUsedInSystemFallbackFontCache; }
+    void setIsUsedInSystemFallbackFontCache() { m_isUsedInSystemFallbackFontCache = true; }
+#if PLATFORM(IOS_FAMILY)
+    bool shouldNotBeUsedForArabic() const { return m_shouldNotBeUsedForArabic; };
+#endif
+
+#if USE(CORE_TEXT)
+    CTFontRef ctFont() const { return m_platformData.ctFont(); }
+    bool supportsSmallCaps() const;
+    bool supportsAllSmallCaps() const;
+    bool supportsPetiteCaps() const;
+    bool supportsAllPetiteCaps() const;
+    bool supportsOpenTypeAlternateHalfWidths() const;
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+    MultiRepresentationHEICMetrics metricsForMultiRepresentationHEIC() const;
+#endif
+#endif
+
+#if USE(SKIA)
+    sk_sp<SkTextBlob> buildTextBlob(std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, FontSmoothingMode) const;
+    bool enableAntialiasing(FontSmoothingMode) const;
+#endif
+
+    // Returns nullopt if none of the glyphs are OT-SVG glyphs.
+    std::optional<BitVector> findOTSVGGlyphs(std::span<const GlyphBufferGlyph>) const;
+
+    bool hasAnyComplexColorFormatGlyphs(std::span<const GlyphBufferGlyph>) const;
+
+protected:
+    struct NoEmojiGlyphs { };
+#if USE(SKIA)
+    struct AllEmojiGlyphs { };
+#endif
+    struct SomeEmojiGlyphs {
+        BitVector colorGlyphs;
+    };
+#if USE(SKIA)
+    using EmojiType = Variant<NoEmojiGlyphs, AllEmojiGlyphs, SomeEmojiGlyphs>;
+#else
+    using EmojiType = Variant<NoEmojiGlyphs, SomeEmojiGlyphs>;
+#endif
+
+    enum class IsSystemFallbackFontPlaceholder : bool { No, Yes };
+
+#if PLATFORM(COCOA)
+    enum class SupportsFeature : uint8_t {
+        No,
+        Yes,
+        Unknown
+    };
+
+    class ComplexColorFormatGlyphs {
+    public:
+        static ComplexColorFormatGlyphs createWithNoRelevantTables();
+        static ComplexColorFormatGlyphs createWithRelevantTablesAndGlyphCount(unsigned glyphCount);
+
+        bool hasValueFor(Glyph) const;
+        bool get(Glyph) const;
+        void set(Glyph, bool value);
+
+        bool hasRelevantTables() const { return m_hasRelevantTables; }
+
+    private:
+        static constexpr size_t bitForInitialized(Glyph glyphID) { return static_cast<size_t>(glyphID) * 2; }
+        static constexpr size_t bitForValue(Glyph glyphID) { return static_cast<size_t>(glyphID) * 2 + 1; }
+        static constexpr size_t bitsRequiredForGlyphCount(unsigned glyphCount) { return glyphCount * 2; }
+
+        ComplexColorFormatGlyphs(bool hasRelevantTables, unsigned glyphCount)
+            : m_hasRelevantTables(hasRelevantTables)
+            , m_bits(bitsRequiredForGlyphCount(glyphCount))
+        { }
+
+        bool m_hasRelevantTables;
+        BitVector m_bits; // pairs of (initialized, value) bits
+    };
+#endif
+
+    WEBCORE_EXPORT FontBase(const FontPlatformData&, Origin, IsInterstitial, Visibility, IsOrientationFallback, std::optional<RenderingResourceIdentifier>);
+    FontBase();
+
+    void platformInit();
+    void applyFontMetricsOverrides();
+
+#if PLATFORM(COCOA)
+    const PAL::OTSVGTable& otSVGTable() const;
+    bool glyphHasComplexColorFormat(Glyph) const;
+    bool hasComplexColorFormatTables() const;
+    ComplexColorFormatGlyphs& glyphsWithComplexColorFormat() const;
+#endif
+
+    const FontPlatformData m_platformData;
+    Attributes m_attributes;
+
+#if ENABLE(MATHML)
+    mutable RefPtr<OpenTypeMathData> m_mathData;
+#endif
+#if ENABLE(OPENTYPE_VERTICAL)
+    RefPtr<OpenTypeVerticalData> m_verticalData;
+#endif
+
+#if PLATFORM(COCOA)
+    mutable SupportsFeature m_supportsSmallCaps { SupportsFeature::Unknown };
+    mutable SupportsFeature m_supportsAllSmallCaps { SupportsFeature::Unknown };
+    mutable SupportsFeature m_supportsPetiteCaps { SupportsFeature::Unknown };
+    mutable SupportsFeature m_supportsAllPetiteCaps { SupportsFeature::Unknown };
+    mutable SupportsFeature m_supportsOpenTypeAlternateHalfWidths { SupportsFeature::Unknown };
+
+    mutable std::optional<PAL::OTSVGTable> m_otSVGTable;
+    mutable std::optional<ComplexColorFormatGlyphs> m_glyphsWithComplexColorFormat; // SVG and sbix
+#endif
+
+    FontMetrics m_fontMetrics;
+    EmojiType m_emojiType { NoEmojiGlyphs { } };
+
+    float m_syntheticBoldOffset { 0 };
+    float m_maxCharWidth { -1 };
+    float m_avgCharWidth { -1 };
+    float m_spaceWidth { 0 };
+
+    unsigned m_allowsAntialiasing : 1 { true };
+    unsigned m_hasVerticalGlyphs : 1 { false };
+    unsigned m_isUsedInSystemFallbackFontCache : 1 { false };
+#if PLATFORM(IOS_FAMILY)
+    unsigned m_shouldNotBeUsedForArabic : 1 { false };
+#endif
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontBaseline.h
+++ b/Source/WebCore/platform/graphics/FontBaseline.h
@@ -23,8 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-#ifndef FontBaseline_h
-#define FontBaseline_h
+#pragma once
 
 namespace WebCore {
 
@@ -33,5 +32,3 @@ enum class FontBaseline : uint8_t { Alphabetic, Ideographic, Central };
 enum class BaselineSynthesisEdge : uint8_t { ContentBox, BorderBox, MarginBox };
 
 } // namespace WebCore
-
-#endif // FontBaseline_h

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -72,7 +72,7 @@ AffineTransform computeBaseOverallTextMatrix(const std::optional<AffineTransform
 AffineTransform computeBaseVerticalTextMatrix(const AffineTransform& previousTextMatrix);
 // The text matrix to use when drawing a run of `font`, including the Y-flip, synthetic oblique and, for vertical
 // fonts, the upright rotation.
-AffineTransform computeTextMatrix(const Font&);
+AffineTransform computeTextMatrix(const FontBase&);
 #endif
 
 class TextLayoutDeleter {
@@ -118,7 +118,7 @@ public:
 
     using CustomFontNotReadyAction = FontCascadeCustomFontNotReadyAction;
     WEBCORE_EXPORT FloatSize drawText(GraphicsContext&, const TextRun&, const FloatPoint&, unsigned from = 0, std::optional<unsigned> to = std::nullopt, CustomFontNotReadyAction = CustomFontNotReadyAction::DoNotPaintIfFontNotReady) const;
-    static void drawGlyphs(GraphicsContext&, const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint&, FontSmoothingMode);
+    static void drawGlyphs(GraphicsContext&, const FontBase&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint&, FontSmoothingMode);
     void drawEmphasisMarks(GraphicsContext&, const TextRun&, const AtomString& mark, const FloatPoint&, unsigned from = 0, std::optional<unsigned> to = std::nullopt) const;
 
     Vector<FloatSegment> lineSegmentsForIntersectionsWithRect(const TextRun&, const FloatPoint& textOrigin, const FloatRect& lineExtents) const;

--- a/Source/WebCore/platform/graphics/FontInlines.h
+++ b/Source/WebCore/platform/graphics/FontInlines.h
@@ -37,10 +37,6 @@
 
 namespace WebCore {
 
-#if ENABLE(OPENTYPE_VERTICAL)
-inline const OpenTypeVerticalData* Font::verticalData() const { return m_verticalData.get(); }
-#endif
-
 ALWAYS_INLINE FloatRect Font::boundsForGlyph(Glyph glyph) const
 {
     if (isZeroWidthSpaceGlyph(glyph))

--- a/Source/WebCore/platform/graphics/FontMetrics.h
+++ b/Source/WebCore/platform/graphics/FontMetrics.h
@@ -17,8 +17,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef FontMetrics_h
-#define FontMetrics_h
+#pragma once
 
 #include <WebCore/FontBaseline.h>
 #include <wtf/Markable.h>
@@ -176,5 +175,3 @@ static inline float scaleEmToUnits(float x, unsigned unitsPerEm)
 }
 
 } // namespace WebCore
-
-#endif // FontMetrics_h

--- a/Source/WebCore/platform/graphics/cairo/FontCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/FontCairo.cpp
@@ -49,7 +49,7 @@
 
 namespace WebCore {
 
-void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, std::span<const GlyphBufferGlyph> glyphs,
+void FontCascade::drawGlyphs(GraphicsContext& context, const FontBase& font, std::span<const GlyphBufferGlyph> glyphs,
     std::span<const GlyphBufferAdvance> advances, const FloatPoint& point,
     FontSmoothingMode fontSmoothingMode)
 {

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -88,7 +88,7 @@ AffineTransform NODELETE computeBaseVerticalTextMatrix(const AffineTransform& pr
     return rotateLeftTransform() * previousTextMatrix;
 }
 
-AffineTransform computeTextMatrix(const Font& font)
+AffineTransform computeTextMatrix(const FontBase& font)
 {
     auto& platformData = font.platformData();
     bool isVertical = platformData.orientation() == FontOrientation::Vertical;
@@ -269,7 +269,7 @@ namespace {
 class RepeatedDrawGlyphs {
     WTF_MAKE_NONCOPYABLE(RepeatedDrawGlyphs);
 public:
-    RepeatedDrawGlyphs(const Font& font, std::span<const CGGlyph> glyphs, std::span<const CGSize> advances, const AffineTransform& textMatrix)
+    RepeatedDrawGlyphs(const FontBase& font, std::span<const CGGlyph> glyphs, std::span<const CGSize> advances, const AffineTransform& textMatrix)
         : m_ctFont(font.platformData().ctFont())
         , m_glyphs(glyphs)
         , m_advances(advances)
@@ -322,7 +322,7 @@ static void setCGFontRenderingMode(GraphicsContext& context)
     CGContextSetShouldSubpixelQuantizeFonts(cgContext.get(), doSubpixelQuantization);
 }
 
-void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& anchorPoint, FontSmoothingMode smoothingMode)
+void FontCascade::drawGlyphs(GraphicsContext& context, const FontBase& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& anchorPoint, FontSmoothingMode smoothingMode)
 {
     const auto& platformData = font.platformData();
     if (!platformData.size())

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov
  *
  * Redistribution and use in source and binary forms, with or without
@@ -63,6 +63,11 @@ static inline bool caseInsensitiveCompare(CFStringRef a, CFStringRef b)
     return a && CFStringCompare(a, b, kCFCompareCaseInsensitive) == kCFCompareEqualTo;
 }
 
+static bool fontHasEitherTable(CTFontRef ctFont, unsigned tableTag1, unsigned tableTag2)
+{
+    return CTFontHasTable(ctFont, tableTag1) || CTFontHasTable(ctFont, tableTag2);
+}
+
 static bool fontHasVerticalGlyphs(CTFontRef font)
 {
     return fontHasEitherTable(font, kCTFontTableVhea, kCTFontTableVORG);
@@ -93,12 +98,7 @@ static bool isAhemFont(CFStringRef familyName)
     return familyName && caseInsensitiveCompare(familyName, CFSTR("Ahem"));
 }
 
-bool fontHasEitherTable(CTFontRef ctFont, unsigned tableTag1, unsigned tableTag2)
-{
-    return CTFontHasTable(ctFont, tableTag1) || CTFontHasTable(ctFont, tableTag2);
-}
-
-void Font::platformInit()
+void FontBase::platformInit()
 {
     auto constexpr syntheticBoldScaleFactor = 36.0f;
     m_syntheticBoldOffset = m_platformData.syntheticBold() ? (m_platformData.size() / syntheticBoldScaleFactor) : 0.f;
@@ -166,20 +166,6 @@ void Font::platformInit()
     m_shouldNotBeUsedForArabic = fontFamilyShouldNotBeUsedForArabic(familyName.get());
 #endif
 
-    CGFloat xHeight = 0;
-    if (m_platformData.size()) {
-        if (platformData().orientation() == FontOrientation::Horizontal) {
-            // Measure the actual character "x", since it's possible for it to extend below the baseline, and we need the
-            // reported x-height to only include the portion of the glyph that is above the baseline.
-            Glyph xGlyph = glyphForCharacter('x');
-            if (xGlyph)
-                xHeight = -CGRectGetMinY(platformBoundsForGlyph(xGlyph));
-            else
-                xHeight = CTFontGetXHeight(ctFont.get());
-        } else
-            xHeight = verticalRightOrientationFont().fontMetrics().xHeight().value_or(0);
-    }
-
     if (CTFontGetSymbolicTraits(ctFont.get()) & kCTFontTraitColorGlyphs) {
         if (RetainPtr cfBitVector = adoptCF(CTFontCopyColorGlyphCoverage(ctFont.get())))
             m_emojiType = SomeEmojiGlyphs { BitVector(cfBitVector.get()) };
@@ -193,7 +179,6 @@ void Font::platformInit()
     m_fontMetrics.setDescent(descent);
     m_fontMetrics.setCapHeight(capHeight);
     m_fontMetrics.setLineGap(lineGap);
-    m_fontMetrics.setXHeight(xHeight);
     m_fontMetrics.setLineSpacing(lineSpacing);
     m_fontMetrics.setUnderlinePosition(-CTFontGetUnderlinePosition(ctFont.get()));
     m_fontMetrics.setUnderlineThickness(CTFontGetUnderlineThickness(ctFont.get()));
@@ -225,6 +210,27 @@ void Font::platformCharWidthInit()
 
     // Fallback to a cross-platform estimate, which will populate these values if they are non-positive.
     initCharWidths();
+}
+
+void Font::platformCharHeightInit()
+{
+    CGFloat xHeight = 0;
+    if (m_platformData.size()) {
+        if (platformData().orientation() == FontOrientation::Horizontal) {
+            // Measure the actual character "x", since it's possible for it to extend below the baseline, and we need the
+            // reported x-height to only include the portion of the glyph that is above the baseline.
+            Glyph xGlyph = glyphForCharacter('x');
+            if (xGlyph)
+                xHeight = -CGRectGetMinY(platformBoundsForGlyph(xGlyph));
+            else {
+                RetainPtr ctFont = this->ctFont();
+                xHeight = CTFontGetXHeight(ctFont);
+            }
+        } else
+            xHeight = verticalRightOrientationFont().fontMetrics().xHeight().value_or(0);
+    }
+
+    m_fontMetrics.setXHeight(xHeight);
 }
 
 bool Font::variantCapsSupportedForSynthesis(FontVariantCaps fontVariantCaps) const
@@ -287,14 +293,45 @@ static void injectTrueTypeCoverage(int type, int selector, CTFontRef font, BitVe
     unionBitVectors(result, source.get());
 }
 
-bool Font::supportsOpenTypeAlternateHalfWidths() const
+static bool supportsOpenTypeFeature(CTFontRef font, CFStringRef featureTag)
+{
+    RetainPtr<CFArrayRef> features = adoptCF(CTFontCopyFeatures(font));
+    CFIndex featureCount = CFArrayGetCount(features.get());
+    for (CFIndex featureIndex = 0; featureIndex < featureCount; ++featureIndex) {
+        RetainPtr feature = static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(features.get(), featureIndex));
+        RetainPtr featureTypeIdentifier = static_cast<CFNumberRef>(CFDictionaryGetValue(feature.get(), kCTFontFeatureTypeIdentifierKey));
+        if (!featureTypeIdentifier)
+            continue;
+
+        int rawFeatureTypeIdentifier;
+        CFNumberGetValue(featureTypeIdentifier.get(), kCFNumberIntType, &rawFeatureTypeIdentifier);
+        if (rawFeatureTypeIdentifier != kTextSpacingType)
+            continue;
+
+        RetainPtr featureSelectors = static_cast<CFArrayRef>(CFDictionaryGetValue(feature.get(), kCTFontFeatureTypeSelectorsKey));
+        if (!featureSelectors)
+            continue;
+        auto selectorsCount = CFArrayGetCount(featureSelectors.get());
+        for (CFIndex selectorIndex = 0; selectorIndex < selectorsCount; ++selectorIndex) {
+            RetainPtr featureSelector = static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(featureSelectors.get(), selectorIndex));
+            RetainPtr openTypeTag = static_cast<CFStringRef>(CFDictionaryGetValue(featureSelector.get(), kCTFontOpenTypeFeatureTag));
+            if (!openTypeTag)
+                continue;
+            if (CFStringCompare(openTypeTag.get(), featureTag, 0) == kCFCompareEqualTo)
+                return true;
+        }
+    }
+    return false;
+}
+
+bool FontBase::supportsOpenTypeAlternateHalfWidths() const
 {
     if (m_supportsOpenTypeAlternateHalfWidths == SupportsFeature::Unknown)
         m_supportsOpenTypeAlternateHalfWidths = supportsOpenTypeFeature(protect(ctFont()).get(), CFSTR("halt")) ? SupportsFeature::Yes : SupportsFeature::No;
     return m_supportsOpenTypeAlternateHalfWidths == SupportsFeature::Yes;
 }
 
-bool Font::supportsSmallCaps() const
+bool FontBase::supportsSmallCaps() const
 {
     if (m_supportsSmallCaps == SupportsFeature::Unknown) {
         BitVector glyphsSupportedBySmallCaps;
@@ -306,7 +343,7 @@ bool Font::supportsSmallCaps() const
     return m_supportsSmallCaps == SupportsFeature::Yes;
 }
 
-bool Font::supportsAllSmallCaps() const
+bool FontBase::supportsAllSmallCaps() const
 {
     if (m_supportsAllSmallCaps == SupportsFeature::Unknown) {
         BitVector glyphsSupportedByAllSmallCaps;
@@ -320,7 +357,7 @@ bool Font::supportsAllSmallCaps() const
     return m_supportsAllSmallCaps == SupportsFeature::Yes;
 }
 
-bool Font::supportsPetiteCaps() const
+bool FontBase::supportsPetiteCaps() const
 {
     if (m_supportsPetiteCaps == SupportsFeature::Unknown) {
         BitVector glyphsSupportedByPetiteCaps;
@@ -332,7 +369,7 @@ bool Font::supportsPetiteCaps() const
     return m_supportsPetiteCaps == SupportsFeature::Yes;
 }
 
-bool Font::supportsAllPetiteCaps() const
+bool FontBase::supportsAllPetiteCaps() const
 {
     if (m_supportsAllPetiteCaps == SupportsFeature::Unknown) {
         BitVector glyphsSupportedByAllPetiteCaps;
@@ -513,37 +550,6 @@ RefPtr<Font> Font::platformCreateScaledFont(const FontDescription&, float scaleF
     RetainPtr<CTFontRef> scaledFont = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), size, nullptr));
 
     return createDerivativeFont(scaledFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), protect(m_platformData.customPlatformData()).get(), m_platformData.metricsOverrides());
-}
-
-bool supportsOpenTypeFeature(CTFontRef font, CFStringRef featureTag)
-{
-    RetainPtr<CFArrayRef> features = adoptCF(CTFontCopyFeatures(font));
-    CFIndex featureCount = CFArrayGetCount(features.get());
-    for (CFIndex featureIndex = 0; featureIndex < featureCount; ++featureIndex) {
-        RetainPtr feature = static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(features.get(), featureIndex));
-        RetainPtr featureTypeIdentifier = static_cast<CFNumberRef>(CFDictionaryGetValue(feature.get(), kCTFontFeatureTypeIdentifierKey));
-        if (!featureTypeIdentifier)
-            continue;
-
-        int rawFeatureTypeIdentifier;
-        CFNumberGetValue(featureTypeIdentifier.get(), kCFNumberIntType, &rawFeatureTypeIdentifier);
-        if (rawFeatureTypeIdentifier != kTextSpacingType)
-            continue;
-
-        RetainPtr featureSelectors = static_cast<CFArrayRef>(CFDictionaryGetValue(feature.get(), kCTFontFeatureTypeSelectorsKey));
-        if (!featureSelectors)
-            continue;
-        auto selectorsCount = CFArrayGetCount(featureSelectors.get());
-        for (CFIndex selectorIndex = 0; selectorIndex < selectorsCount; ++selectorIndex) {
-            RetainPtr featureSelector = static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(featureSelectors.get(), selectorIndex));
-            RetainPtr openTypeTag = static_cast<CFStringRef>(CFDictionaryGetValue(featureSelector.get(), kCTFontOpenTypeFeatureTag));
-            if (!openTypeTag)
-                continue;
-            if (CFStringCompare(openTypeTag.get(), featureTag, 0) == kCFCompareEqualTo)
-                return true;
-        }
-    }
-    return false;
 }
 
 RefPtr<Font> Font::platformCreateHalfWidthFont() const
@@ -855,7 +861,7 @@ bool Font::isProbablyOnlyUsedToRenderIcons() const
     return !hasGlyphsForCharacterRange(platformFont.get(), ' ', '~', false) && !hasGlyphsForCharacterRange(platformFont.get(), 0x0600, 0x06FF, true);
 }
 
-const PAL::OTSVGTable& Font::otSVGTable() const
+const PAL::OTSVGTable& FontBase::otSVGTable() const
 {
     if (!m_otSVGTable) {
         if (auto tableData = adoptCF(CTFontCopyTable(protect(ctFont()).get(), kCTFontTableSVG, kCTFontTableOptionNoOptions)))
@@ -896,7 +902,7 @@ void Font::ComplexColorFormatGlyphs::set(Glyph glyph, bool value)
         m_bits.set(bitForValue(glyph));
 }
 
-bool Font::hasComplexColorFormatTables() const
+bool FontBase::hasComplexColorFormatTables() const
 {
     if (otSVGTable().table)
         return true;
@@ -909,7 +915,7 @@ bool Font::hasComplexColorFormatTables() const
     return false;
 }
 
-Font::ComplexColorFormatGlyphs& Font::glyphsWithComplexColorFormat() const
+Font::ComplexColorFormatGlyphs& FontBase::glyphsWithComplexColorFormat() const
 {
     if (!m_glyphsWithComplexColorFormat) {
         if (hasComplexColorFormatTables()) {
@@ -924,7 +930,7 @@ Font::ComplexColorFormatGlyphs& Font::glyphsWithComplexColorFormat() const
     return m_glyphsWithComplexColorFormat.value();
 }
 
-bool Font::glyphHasComplexColorFormat(Glyph glyphID) const
+bool FontBase::glyphHasComplexColorFormat(Glyph glyphID) const
 {
 #if HAVE(CORE_TEXT_GLYPHHASCOMPLEXCOLOR_FUNCTION)
     if (PAL::canLoad_CoreText_CTFontHasComplexColorFormatForGlyph())
@@ -945,7 +951,7 @@ bool Font::glyphHasComplexColorFormat(Glyph glyphID) const
     return false;
 }
 
-std::optional<BitVector> Font::findOTSVGGlyphs(std::span<const GlyphBufferGlyph> glyphs) const
+std::optional<BitVector> FontBase::findOTSVGGlyphs(std::span<const GlyphBufferGlyph> glyphs) const
 {
     auto table = otSVGTable().table;
     if (!table)
@@ -962,7 +968,7 @@ std::optional<BitVector> Font::findOTSVGGlyphs(std::span<const GlyphBufferGlyph>
     return result;
 }
 
-bool Font::hasAnyComplexColorFormatGlyphs(std::span<const GlyphBufferGlyph> glyphs) const
+bool FontBase::hasAnyComplexColorFormatGlyphs(std::span<const GlyphBufferGlyph> glyphs) const
 {
     auto& complexGlyphs = glyphsWithComplexColorFormat();
     if (!complexGlyphs.hasRelevantTables())
@@ -1049,7 +1055,7 @@ IPCFontData Font::toSerializableFont() const
 
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
 
-MultiRepresentationHEICMetrics Font::metricsForMultiRepresentationHEIC() const
+MultiRepresentationHEICMetrics FontBase::metricsForMultiRepresentationHEIC() const
 {
     CGRect bounds = CTFontGetTypographicBoundsForAdaptiveImageProvider(ctFont(), nullptr);
 

--- a/Source/WebCore/platform/graphics/freetype/SimpleFontDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/SimpleFontDataFreeType.cpp
@@ -104,7 +104,7 @@ static float heightOfCharacter(cairo_scaled_font_t* scaledFont, const char* char
     return narrowPrecisionToFloat(orientation == FontOrientation::Horizontal ? textExtents.height : textExtents.width);
 }
 
-void Font::platformInit()
+void FontBase::platformInit()
 {
     if (!m_platformData.size())
         return;

--- a/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-void FontCascade::drawGlyphs(GraphicsContext& graphicsContext, const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& position, FontSmoothingMode smoothingMode)
+void FontCascade::drawGlyphs(GraphicsContext& graphicsContext, const FontBase& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& position, FontSmoothingMode smoothingMode)
 {
     auto blob = font.buildTextBlob(glyphs, advances, smoothingMode);
     if (!blob)

--- a/Source/WebCore/platform/graphics/skia/FontSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontSkia.cpp
@@ -96,7 +96,7 @@ float Font::platformWidthForGlyph(Glyph glyph) const
     return SkScalarToFloat(width);
 }
 
-void Font::platformInit()
+void FontBase::platformInit()
 {
     if (!m_platformData.size())
         return;
@@ -223,7 +223,7 @@ static inline SkFont::Edging edgingForFontSmoothingMode(const SkFont& font, Font
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-sk_sp<SkTextBlob> Font::buildTextBlob(std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, FontSmoothingMode smoothingMode) const
+sk_sp<SkTextBlob> FontBase::buildTextBlob(std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, FontSmoothingMode smoothingMode) const
 {
     if (!m_platformData.size() || !glyphs.size())
         return nullptr;
@@ -262,7 +262,7 @@ sk_sp<SkTextBlob> Font::buildTextBlob(std::span<const GlyphBufferGlyph> glyphs, 
     return builder.make();
 }
 
-bool Font::enableAntialiasing(FontSmoothingMode smoothingMode) const
+bool FontBase::enableAntialiasing(FontSmoothingMode smoothingMode) const
 {
     return allowsAntialiasing() && edgingForFontSmoothingMode(m_platformData.skFont(), smoothingMode) != SkFont::Edging::kAlias;
 }

--- a/Source/WebCore/platform/graphics/win/SimpleFontDataWin.cpp
+++ b/Source/WebCore/platform/graphics/win/SimpleFontDataWin.cpp
@@ -47,7 +47,7 @@ void Font::platformCharWidthInit()
     initCharWidths();
 }
 
-void Font::platformInit()
+void FontBase::platformInit()
 {
     m_syntheticBoldOffset = m_platformData.syntheticBold() ? 1.0f : 0.f;
 


### PR DESCRIPTION
#### 00ef3983cae0373502e9816a7e7f4ab9ec5b8b83
<pre>
[GPUProcess] Move the drawing Font functionalities to a new class named FontBase
<a href="https://bugs.webkit.org/show_bug.cgi?id=323588">https://bugs.webkit.org/show_bug.cgi?id=323588</a>
<a href="https://rdar.apple.com/186827128">rdar://186827128</a>

Reviewed by Cameron McCormack.

This work is a step toward using thread-safe Font objects in GPUProcess.

Similar to what we did for images in GPUProcess, we want to separate Font&apos;s drawing
functionality from the rest of the class. For images, we split NativeImage out
from BitmapImageSource/ImageFrame: the former is used for displaying the image and
is what gets transferred from the WebContent process to GPUProcess, while the latter
handles image layout, providing information such as image size and orientation.

This change introduces a new class, FontBase, which can be passed to
FontCascade::drawGlyphs and is capable of drawing glyphs only. Font now inherits
from FontBase, and in addition to drawing, it still owns the glyph tables and
handles glyph measurement and layout. Font remains RefCounted, as before.

A follow-up PR will add a thread-safe class that also inherits from FontBase and,
like it, can only draw glyphs. This restriction makes sense because GPUProcess
shouldn&apos;t be responsible for mapping characters to glyphs or decomposing colored
glyphs into their components — it should only call drawGlyphsImmediate().

RemoteRenderingBackend will create instances of this new class instead of Font,
so they can be shared across threads. This also means 317722@main will be reverted:
DrawGlyphs will hold a Ref&lt;FontBase&gt;, and DrawGlyphs::draw() will call
drawGlyphsImmediate() instead of calling drawGlyphs().

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::Font::Font):
(WebCore::m_shouldNotBeUsedForArabic): Deleted.
(WebCore::Font::renderingResourceIdentifier const): Deleted.
(WebCore::FontInternalAttributes::ensureRenderingResourceIdentifier const): Deleted.
(WebCore::Font::mathData const): Deleted.
(WebCore::Font::platformCharHeightInit):
(WebCore::Font::applyFontMetricsOverrides): Deleted.
* Source/WebCore/platform/graphics/Font.h:
(WebCore::Font::createSystemFallbackFontPlaceholder):
(WebCore::Font::isSystemFontFallbackPlaceholder const): Deleted.
(WebCore::Font::hasVerticalGlyphs const): Deleted.
(WebCore::Font::origin const): Deleted.
(WebCore::Font::isInterstitial const): Deleted.
(WebCore::Font::visibility const): Deleted.
(WebCore::Font::allowsAntialiasing const): Deleted.
(WebCore::Font::shouldNotBeUsedForArabic const): Deleted.
(WebCore::Font::setIsUsedInSystemFallbackFontCache): Deleted.
(WebCore::Font::isUsedInSystemFallbackFontCache const): Deleted.
(WebCore::Font::isTextOrientationFallback const): Deleted.
(WebCore::Font::sizePerUnit const): Deleted.
(WebCore::Font::syntheticBoldOffset const): Deleted.
(WebCore::Font::ctFont const): Deleted.
(WebCore::Font::ComplexColorFormatGlyphs::hasRelevantTables const): Deleted.
(WebCore::Font::ComplexColorFormatGlyphs::bitForInitialized): Deleted.
(WebCore::Font::ComplexColorFormatGlyphs::bitForValue): Deleted.
(WebCore::Font::ComplexColorFormatGlyphs::bitsRequiredForGlyphCount): Deleted.
(WebCore::Font::ComplexColorFormatGlyphs::ComplexColorFormatGlyphs): Deleted.
(WebCore::Font::maxCharWidth const): Deleted.
(WebCore::Font::setMaxCharWidth): Deleted.
(WebCore::Font::avgCharWidth const): Deleted.
(WebCore::Font::setAvgCharWidth): Deleted.
(WebCore::Font::spaceWidth const): Deleted.
* Source/WebCore/platform/graphics/FontBase.cpp: Added.
(WebCore::FontBase::FontBase):
(WebCore::FontBase::mathData const):
(WebCore::FontInternalAttributes::ensureRenderingResourceIdentifier const):
(WebCore::FontBase::renderingResourceIdentifier const):
(WebCore::FontBase::applyFontMetricsOverrides):
* Source/WebCore/platform/graphics/FontBase.h: Added.
(WebCore::FontBase::origin const):
(WebCore::FontBase::isInterstitial const):
(WebCore::FontBase::visibility const):
(WebCore::FontBase::isTextOrientationFallback const):
(WebCore::FontBase::isSystemFontFallbackPlaceholder const):
(WebCore::FontBase::allowsAntialiasing const):
(WebCore::FontBase::hasVerticalGlyphs const):
(WebCore::FontBase::isUsedInSystemFallbackFontCache const):
(WebCore::FontBase::setIsUsedInSystemFallbackFontCache):
(WebCore::FontBase::shouldNotBeUsedForArabic const):
(WebCore::FontBase::verticalData const):
(WebCore::FontBase::sizePerUnit const):
(WebCore::FontBase::syntheticBoldOffset const):
(WebCore::FontBase::ctFont const):
(WebCore::FontBase::ComplexColorFormatGlyphs::hasRelevantTables const):
(WebCore::FontBase::ComplexColorFormatGlyphs::bitForInitialized):
(WebCore::FontBase::ComplexColorFormatGlyphs::bitForValue):
(WebCore::FontBase::ComplexColorFormatGlyphs::bitsRequiredForGlyphCount):
(WebCore::FontBase::ComplexColorFormatGlyphs::ComplexColorFormatGlyphs):
(WebCore::FontBase::spaceWidth const):
(WebCore::FontBase::maxCharWidth const):
(WebCore::FontBase::setMaxCharWidth):
(WebCore::FontBase::avgCharWidth const):
(WebCore::FontBase::setAvgCharWidth):
* Source/WebCore/Headers.cmake:
* Source/WebCore/platform/graphics/FontInlines.h:
(WebCore::Font::verticalData const): Deleted.
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::FontBase::supportsOpenTypeAlternateHalfWidths const):
(WebCore::FontBase::supportsSmallCaps const):
(WebCore::FontBase::supportsAllSmallCaps const):
(WebCore::FontBase::supportsPetiteCaps const):
(WebCore::FontBase::supportsAllPetiteCaps const):
(WebCore::FontBase::otSVGTable const):
(WebCore::FontBase::hasComplexColorFormatTables const):
(WebCore::FontBase::glyphsWithComplexColorFormat const):
(WebCore::FontBase::glyphHasComplexColorFormat const):
(WebCore::FontBase::metricsForMultiRepresentationHEIC const):
(WebCore::Font::supportsOpenTypeAlternateHalfWidths const): Deleted.
(WebCore::Font::supportsSmallCaps const): Deleted.
(WebCore::Font::supportsAllSmallCaps const): Deleted.
(WebCore::Font::supportsPetiteCaps const): Deleted.
(WebCore::Font::supportsAllPetiteCaps const): Deleted.
(WebCore::Font::otSVGTable const): Deleted.
(WebCore::Font::hasComplexColorFormatTables const): Deleted.
(WebCore::Font::glyphsWithComplexColorFormat const): Deleted.
(WebCore::Font::glyphHasComplexColorFormat const): Deleted.
(WebCore::Font::metricsForMultiRepresentationHEIC const): Deleted.
(WebCore::fontHasEitherTable):
(WebCore::supportsOpenTypeFeature):
(WebCore::FontBase::platformInit):
(WebCore::Font::platformCharHeightInit):
(WebCore::FontBase::findOTSVGGlyphs const):
(WebCore::FontBase::hasAnyComplexColorFormatGlyphs const):
(WebCore::Font::platformInit): Deleted.
(WebCore::Font::findOTSVGGlyphs const): Deleted.
(WebCore::Font::hasAnyComplexColorFormatGlyphs const): Deleted.
* Source/WebCore/platform/graphics/skia/FontSkia.cpp:
(WebCore::FontBase::buildTextBlob const):
(WebCore::FontBase::enableAntialiasing const):
(WebCore::Font::buildTextBlob const): Deleted.
(WebCore::Font::enableAntialiasing const): Deleted.
(WebCore::FontBase::platformInit):
(WebCore::Font::platformInit): Deleted.
* Source/WebCore/platform/graphics/FontBaseline.h:
* Source/WebCore/platform/graphics/FontMetrics.h:
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/cairo/FontCairo.cpp:
(WebCore::FontCascade::drawGlyphs):
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::computeOverallTextMatrix):
(WebCore::computeVerticalTextMatrix):
(WebCore::showGlyphsWithAdvances):
(WebCore::FontCascade::drawGlyphs):
* Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp:
(WebCore::FontCascade::drawGlyphs):
* Source/WebCore/platform/graphics/freetype/SimpleFontDataFreeType.cpp:
(WebCore::FontBase::platformInit):
(WebCore::Font::platformInit): Deleted.
* Source/WebCore/platform/graphics/win/SimpleFontDataWin.cpp:
(WebCore::FontBase::platformInit):
(WebCore::Font::platformInit): Deleted.

Canonical link: <a href="https://commits.webkit.org/320875@main">https://commits.webkit.org/320875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/507b54e18553db470a438a4c5a60ce4b0a04e80e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186146 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196436 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150723 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188008 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59760 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49128 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125787 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47860 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/158214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45575 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7507 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/50300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198414 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59697 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/155020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41525 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60409 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/154670 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49096 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129823 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58848 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58241 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58470 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58300 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->