### PR TITLE
[AppKit Gestures] Very short (or coalesced) trackpad flick doesn't result in momentum scrolling

### DIFF
--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.h
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.h
@@ -106,6 +106,8 @@ NS_SWIFT_UI_ACTOR
 - (void)resetDOMDoubleClickGestureRecognizer;
 - (WKDeferringGestureRecognizer *)makeImageAnalysisDeferringGestureRecognizerWithName:(NSString *)name;
 
+- (NSPoint)panVelocityInView:(nullable NSView *)view;
+
 + (NSString *)loggingDescriptionForGestureRecognizer:(nullable NSGestureRecognizer *)gestureRecognizer;
 
 @end

--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
@@ -109,11 +109,6 @@ static WebKit::WebEventPhase toWebEventPhase(NSGestureRecognizerState state)
     }
 }
 
-static WebCore::FloatSize velocityInView(NSPanGestureRecognizer *gesture, WKWebView *view)
-{
-    return WebCore::toFloatSize(WebCore::FloatPoint { [gesture velocityInView:view] });
-}
-
 static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
 {
     // rawPlatformDelta uses IOHIDEvent coordinate conventions, which have the opposite
@@ -1565,7 +1560,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     if (![self supportsMomentumScroll:gesture])
         return;
 
-    auto unfilteredVelocity = velocityInView(gesture, webView.get());
+    auto unfilteredVelocity = WebCore::toFloatSize(WebCore::FloatPoint { [self panVelocityInView:webView.get()] });
 
     // Continue the scroll along the same axis the drag was locked to rather than reintroducing
     // diagonal drift; also keeps _fastScrollTracker's velocity heuristics off-axis-clean.

--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.swift
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.swift
@@ -32,7 +32,17 @@ private import WebCore_Private
 import struct Swift.String
 
 final class WKPanGestureRecognizer: NSPanGestureRecognizer {
+    private static let stalenessWindow: TimeInterval = 0.2
+
     private weak var webView: WKWebView?
+
+    var gestureStartTime: TimeInterval?
+    var gestureStartLocationInWindow: NSPoint = .zero
+
+    var lastMovementTime: TimeInterval?
+    var lastMovementLocationInWindow: NSPoint = .zero
+
+    var reachedChangedState = false
 
     init(webView: WKWebView, target: Any?, action: Selector?) {
         self.webView = webView
@@ -43,6 +53,42 @@ final class WKPanGestureRecognizer: NSPanGestureRecognizer {
     @objc
     public required dynamic init?(coder: NSCoder) {
         super.init(coder: coder)
+    }
+
+    override func reset() {
+        gestureStartTime = nil
+        gestureStartLocationInWindow = .zero
+        lastMovementTime = nil
+        lastMovementLocationInWindow = .zero
+        reachedChangedState = false
+        super.reset()
+    }
+
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    func wk_velocity(in view: NSView?) -> NSPoint {
+        let appKitVelocity = velocity(in: view)
+
+        // Prefer AppKit's velocity if available.
+        // If we've seen "changed" events and AppKit gave us zero, then the velocity is legitimately zero.
+        if reachedChangedState || appKitVelocity != .zero {
+            return appKitVelocity
+        }
+
+        // If we have seen less than two events, we can't work out a velocity at all.
+        guard let gestureStartTime, let lastMovementTime, lastMovementTime > gestureStartTime
+        else {
+            return .zero
+        }
+
+        guard timestamp - lastMovementTime < Self.stalenessWindow else {
+            return .zero
+        }
+
+        let start = view.map { $0.convert(gestureStartLocationInWindow, from: nil) } ?? gestureStartLocationInWindow
+        let end = view.map { $0.convert(lastMovementLocationInWindow, from: nil) } ?? lastMovementLocationInWindow
+
+        let duration = lastMovementTime - gestureStartTime
+        return NSPoint(x: (end.x - start.x) / duration, y: (end.y - start.y) / duration)
     }
 
     #if canImport(AppKit, _version: "2759")
@@ -127,6 +173,14 @@ extension WKAppKitGestureController {
         return deferringGestureRecognizer
     }
 
+    @objc(panVelocityInView:)
+    func panVelocity(in view: NSView?) -> NSPoint {
+        guard let panGestureRecognizer = panGestureRecognizer as? WKPanGestureRecognizer else {
+            return .zero
+        }
+        return panGestureRecognizer.wk_velocity(in: view)
+    }
+
     @objc(loggingDescriptionForGestureRecognizer:)
     class func loggingDescription(for gestureRecognizer: NSGestureRecognizer?) -> String {
         guard let gestureRecognizer else {
@@ -134,7 +188,7 @@ extension WKAppKitGestureController {
         }
 
         var parts: [String] = []
-        parts.append("\(type(of: gestureRecognizer)): \(UInt(bitPattern: ObjectIdentifier(self)))")
+        parts.append("\(type(of: gestureRecognizer)): \(UInt(bitPattern: ObjectIdentifier(gestureRecognizer)))")
 
         if let name = gestureRecognizer.name {
             parts.append("name = \(name)")

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -1421,20 +1421,60 @@ extension AppKitGesturesTests.Basic {
         #expect(selection == .range(base: .init(in: "before", at: 6), extent: .init(in: "after", at: 0)))
     }
 
+    @Test(
+        .bug("https://webkit.org/b/323472", "Fast flicks whose event deliveries coalesce should start momentum scrolling")
+    )
+    func quickFlickWithCoalescedEventDeliveriesStillFlings() async throws {
+        try await loadTallDocument()
+        await page.waitForNextPresentationUpdate()
+
+        let dragDistance = 250.0
+        let center = screenBounds(ofPointInWindowCoordinates: window.frame.center)
+        let end = CGPoint(x: center.x, y: center.y - dragDistance)
+
+        await recap.play { composer in
+            composer._wk_eventFrequency = coalescedFlickEventFrequency
+            composer._wk_drag(withStart: center, end: end, duration: coalescedFlickDuration, release: false)
+            composer._wk_mouseUp()
+        }
+
+        let settled = try await settledScrollPosition()
+
+        // The gesture itself only accounts for `dragDistance`; anything well beyond it came from momentum.
+        #expect(settled.y > dragDistance * 2)
+    }
+
+    @Test(
+        .bug("https://webkit.org/b/323472", "A flick that comes to rest before liftoff should not start momentum scrolling")
+    )
+    func quickFlickThatRestsBeforeLiftoffDoesNotFling() async throws {
+        try await loadTallDocument()
+        await page.waitForNextPresentationUpdate()
+
+        let dragDistance = 250.0
+        let center = screenBounds(ofPointInWindowCoordinates: window.frame.center)
+        let end = CGPoint(x: center.x, y: center.y - dragDistance)
+
+        await recap.play { composer in
+            composer._wk_eventFrequency = coalescedFlickEventFrequency
+            composer._wk_drag(withStart: center, end: end, duration: coalescedFlickDuration, release: false)
+            composer.advanceTime(0.5)
+            composer._wk_mouseUp()
+        }
+
+        let settled = try await settledScrollPosition()
+
+        #expect(settled.y < dragDistance * 1.5)
+    }
+
     @Test(.disabled("This test takes an unavoidable ~10 seconds to run"))
     func consecutiveQuickFlicksAccelerateScrolling() async throws {
-        let html = """
-            <body style="margin: 0; width: 100%; height: 200000px;
-                         background: repeating-linear-gradient(to bottom, blue 0 50px, white 50px 100px);">
-            </body>
-            """
-
         let center = screenBounds(ofPointInWindowCoordinates: window.frame.center)
         let down = CGPoint(x: center.x, y: center.y - 250)
         let up = CGPoint(x: center.x, y: center.y + 250)
 
         func finalFlingDistance(flicks count: Int, reverseLast: Bool = false) async throws -> Double {
-            try await page.load(html: html).wait()
+            try await loadTallDocument()
             await page.waitForNextPresentationUpdate()
 
             await recap.play { composer in
@@ -1624,6 +1664,9 @@ extension AppKitGesturesTests.Basic {
     }
 }
 
+private let coalescedFlickEventFrequency = 20
+private let coalescedFlickDuration = Duration.seconds(0.1)
+
 nonisolated(nonsending) private func withSwizzledContextMenu(perform body: () async -> Void) async {
     typealias CompletionHandler = @convention(block) () -> Void
     typealias ObjCImplementation = @convention(block) (NSMenu.Type, NSMenu, _NSViewMenuContext, NSView, CompletionHandler?) -> Void
@@ -1729,6 +1772,15 @@ extension AppKitGesturesTests.Basic {
         let html = """
             <body style="margin: 0; width: 5000px; height: 20000px;
                          background: repeating-linear-gradient(45deg, blue 0 50px, white 50px 100px);">
+            </body>
+            """
+        try await page.load(html: html).wait()
+    }
+
+    private func loadTallDocument() async throws {
+        let html = """
+            <body style="margin: 0; width: 100%; height: 200000px;
+                         background: repeating-linear-gradient(to bottom, blue 0 50px, white 50px 100px);">
             </body>
             """
         try await page.load(html: html).wait()


### PR DESCRIPTION
#### 3077fc7befd476203eccd6352d7931e3eb9a042b
<pre>
[AppKit Gestures] Very short (or coalesced) trackpad flick doesn&apos;t result in momentum scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=323472">https://bugs.webkit.org/show_bug.cgi?id=323472</a>
<a href="https://rdar.apple.com/185580451">rdar://185580451</a>

Reviewed by Abrar Rahman Protyasha.

Because of how AppKit&apos;s velocity filter is hooked up, it reports zero velocity
if no &quot;changed&quot; events are ever seen, which can happen if you flick impossibly
quickly, or (more likely) if events are coalesced. Keep track of enough information
to compute the velocity ourselves in this case.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift

* Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.h:
* Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm:
(-[WKAppKitGestureController startMomentumIfNeededForGesture:]):
(velocityInView): Deleted.
* Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.swift:
(WKPanGestureRecognizer.gestureStartTime):
(WKPanGestureRecognizer.gestureStartLocationInWindow):
(WKPanGestureRecognizer.lastMovementTime):
(WKPanGestureRecognizer.lastMovementLocationInWindow):
(WKPanGestureRecognizer.reset):
(WKPanGestureRecognizer.wk_velocity(in:)):
(WKAppKitGestureController.panVelocity(in:)):
Compute the velocity from two points if we never saw a &quot;changed&quot; event; otherwise, trust the one we&apos;re given.
Also, mimic AppKit&apos;s 200ms timeout and bail from momentum if the two events are far apart in time.

(WKAppKitGestureController.loggingDescription(for:)):
Drive-by fix to stop logging the (static) class and log the gesture recognizer instead.

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:
Add tests both for the named bug, and also that we don&apos;t fling if there&apos;s too much time between the two events.

Canonical link: <a href="https://commits.webkit.org/320665@main">https://commits.webkit.org/320665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/117d20501e9777dc0e122d5b9633c3ca4bdcdb1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59475 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195885 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/38ac8c59-53a3-4a04-a00b-dd07c5b11b9e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187429 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59202 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1faffeae-d9b7-4ef3-a15c-9760e8058d57) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48693 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125306 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d026206-633b-4077-b0a0-794864845335) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47420 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6939 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197839 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59139 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41377 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59848 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154194 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48659 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129097 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57696 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57937 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57761 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->