### PR TITLE
NEW TEST(319401@main): [macOS Debug] TestWebKitAPI.ContextMenuTests.MenuTrackingCancelledWhenPageCloses is flaky

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -13038,7 +13038,8 @@ void WebPageProxy::didShowContextMenu()
 
 void WebPageProxy::didDismissContextMenu()
 {
-    send(Messages::WebPage::DidDismissContextMenu());
+    if (hasRunningProcess())
+        send(Messages::WebPage::DidDismissContextMenu());
 
     if (RefPtr pageClient = this->pageClient())
         pageClient->didDismissContextMenu();

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -546,7 +546,7 @@ RetainPtr<NSMenuItem> WebContextMenuProxyMac::createShareMenuItem(ShareMenuItemT
 
 void WebContextMenuProxyMac::cancelTracking()
 {
-    [protect(m_menu) cancelTracking];
+    [protect(m_menu) cancelTrackingWithoutAnimation];
 }
 
 void WebContextMenuProxyMac::show()

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
@@ -227,7 +227,7 @@ void WebPopupMenuProxyMac::hidePopupMenu()
 
 void WebPopupMenuProxyMac::cancelTracking()
 {
-    [protect(menu()) cancelTracking];
+    [protect(menu()) cancelTrackingWithoutAnimation];
     m_wasCanceled = true;
 }
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1099,6 +1099,7 @@
 				WebKit/WKWebView/mac/NSRefreshControllerTests.mm,
 				WebKit/WKWebView/mac/NSResponderTests.mm,
 				WebKit/WKWebView/mac/PageVisibilityStateWithWindowChanges.mm,
+				WebKit/WKWebView/mac/PopupMenuTests.mm,
 				WebKit/WKWebView/mac/RenderedImageFromDOMNode.mm,
 				WebKit/WKWebView/mac/RenderedImageFromDOMRange.mm,
 				WebKit/WKWebView/mac/RunningBoardManagement.mm,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm
@@ -973,27 +973,32 @@ TEST(ContextMenuTests, MenuTrackingCancelledWhenPageCloses)
 
     bool didClosePage = false;
     bool menuStayedOpenAfterPageClose = false;
-    RetainPtr closePageTimer = [NSTimer timerWithTimeInterval:0.25 repeats:YES block:[&didClosePage, &menuStayedOpenAfterPageClose, strongWebView = webView](NSTimer *timer) {
+    RetainPtr<NSTimer> menuWatchdogTimer;
+    RetainPtr closePageTimer = [NSTimer timerWithTimeInterval:0.25 repeats:YES block:[&didClosePage, &menuStayedOpenAfterPageClose, &menuWatchdogTimer, strongWebView = webView](NSTimer *timer) {
         // This timer only fires while AppKit is tracking the context menu.
-        if (didClosePage) {
-            menuStayedOpenAfterPageClose = true;
-            [timer invalidate];
-            return;
-        }
-
-        if (![strongWebView _activeMenu])
+        RetainPtr activeMenu = [strongWebView _activeMenu];
+        if (!activeMenu)
             return;
 
+        [timer invalidate];
         [strongWebView _close];
         didClosePage = true;
+
+        // This timer only fires if AppKit is still tracking the menu long after the page was closed.
+        // Dismiss the menu ourselves so the test fails instead of hanging.
+        menuWatchdogTimer = [NSTimer timerWithTimeInterval:2 repeats:NO block:[&menuStayedOpenAfterPageClose, activeMenu](NSTimer *) {
+            menuStayedOpenAfterPageClose = true;
+            [activeMenu cancelTrackingWithoutAnimation];
+        }];
+        [NSRunLoop.mainRunLoop addTimer:menuWatchdogTimer.get() forMode:NSEventTrackingRunLoopMode];
     }];
 
     [NSRunLoop.mainRunLoop addTimer:closePageTimer.get() forMode:NSEventTrackingRunLoopMode];
     [[webView window] orderFrontRegardless];
-    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
-    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
+    [webView rightClickAtPoint:NSMakePoint(200, 200)];
     Util::run(&didEndTracking);
     [closePageTimer invalidate];
+    [menuWatchdogTimer invalidate];
 
     EXPECT_TRUE(didClosePage);
     EXPECT_FALSE(menuStayedOpenAfterPageClose);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/PopupMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/PopupMenuTests.mm
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 Microsoft Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Microsoft Corporation nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(MAC)
+
+#import "Helpers/PlatformUtilities.h"
+#import "Helpers/Test.h"
+#import "Helpers/Utilities.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebViewPrivateForTesting.h>
+#import <wtf/RetainPtr.h>
+
+namespace TestWebKitAPI {
+
+TEST(PopupMenuTests, MenuTrackingCancelledWhenPageCloses)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView synchronouslyLoadHTMLString:@"<select style='width: 200px; height: 200px;'><option>Alpha</option><option>Bravo</option></select>"];
+
+    RetainPtr<NSMenu> trackingMenu;
+    __block bool didEndTracking = false;
+    RetainPtr beginTrackingObserver = [NSNotificationCenter.defaultCenter addObserverForName:NSMenuDidBeginTrackingNotification object:nil queue:nil usingBlock:[&trackingMenu](NSNotification *notification) {
+        trackingMenu = notification.object;
+    }];
+    RetainPtr endTrackingObserver = [NSNotificationCenter.defaultCenter addObserverForName:NSMenuDidEndTrackingNotification object:nil queue:nil usingBlock:^(NSNotification *) {
+        didEndTracking = true;
+    }];
+
+    bool didClosePage = false;
+    bool menuStayedOpenAfterPageClose = false;
+    RetainPtr<NSTimer> menuWatchdogTimer;
+    RetainPtr closePageTimer = [NSTimer timerWithTimeInterval:0.25 repeats:YES block:[&didClosePage, &menuStayedOpenAfterPageClose, &menuWatchdogTimer, &trackingMenu, strongWebView = webView](NSTimer *timer) {
+        // This timer only fires while AppKit is tracking the popup menu.
+        if (!trackingMenu)
+            return;
+
+        [timer invalidate];
+        [strongWebView _close];
+        didClosePage = true;
+
+        // This timer only fires if AppKit is still tracking the menu long after the page was closed.
+        // Dismiss the menu ourselves so the test fails instead of hanging.
+        menuWatchdogTimer = [NSTimer timerWithTimeInterval:2 repeats:NO block:[&menuStayedOpenAfterPageClose, menu = trackingMenu](NSTimer *) {
+            menuStayedOpenAfterPageClose = true;
+            [menu cancelTrackingWithoutAnimation];
+        }];
+        [NSRunLoop.mainRunLoop addTimer:menuWatchdogTimer.get() forMode:NSEventTrackingRunLoopMode];
+    }];
+
+    [NSRunLoop.mainRunLoop addTimer:closePageTimer.get() forMode:NSEventTrackingRunLoopMode];
+    [[webView window] orderFrontRegardless];
+    [webView sendClickAtPoint:NSMakePoint(100, 300)];
+    Util::run(&didEndTracking);
+    [closePageTimer invalidate];
+    [menuWatchdogTimer invalidate];
+
+    EXPECT_TRUE(didClosePage);
+    EXPECT_FALSE(menuStayedOpenAfterPageClose);
+
+    [NSNotificationCenter.defaultCenter removeObserver:beginTrackingObserver.get()];
+    [NSNotificationCenter.defaultCenter removeObserver:endTrackingObserver.get()];
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(MAC)


### PR DESCRIPTION
#### d995884fd85bb07b7c1be713ec235bd1491b312a
<pre>
NEW TEST(319401@main): [macOS Debug] TestWebKitAPI.ContextMenuTests.MenuTrackingCancelledWhenPageCloses is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=323373">https://bugs.webkit.org/show_bug.cgi?id=323373</a>

Reviewed by Devin Rousso.

WebPageProxy::close() dismissed the active context menu with -[NSMenu cancelTracking],
which fades the menu out inside AppKit&apos;s nested tracking run loop. The fade lasts about
240 ms, and the test polled that run loop every 250 ms to detect a menu that stayed open,
so on slow Debug bots the poll occasionally fired once more before tracking ended and
the test wrongly reported the menu as still open. Closing the page also sent
DidDismissContextMenu to a WebPage that had already been closed, which the web process
logged as an unhandled message.

Dismiss the menu with -[NSMenu cancelTrackingWithoutAnimation] instead, since there is
nothing to animate for a page that is going away, and only send DidDismissContextMenu
when the page still has a running process.

Popup menus for &lt;select&gt; elements run the same kind of nested tracking loop and are
cancelled from close() the same way, so dismiss them without animation too. Add a
counterpart test that opens a popup menu and closes the page while it is tracking.

Make the context menu test stop polling once it has closed the page and instead arm a
one-shot watchdog timer in the tracking run loop mode. The watchdog can only fire if the
menu is still tracking two seconds after the page closed, in which case it records the
failure and dismisses the menu itself so the test fails instead of hanging. The new popup
menu test uses the same approach.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/PopupMenuTests.mm

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didDismissContextMenu):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::cancelTracking):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST(ContextMenuTests, MenuTrackingCancelledWhenPageCloses)):
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm:
(WebKit::WebPopupMenuProxyMac::cancelTracking):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/PopupMenuTests.mm: Added.
(TestWebKitAPI::TEST(PopupMenuTests, MenuTrackingCancelledWhenPageCloses)):

Canonical link: <a href="https://commits.webkit.org/320686@main">https://commits.webkit.org/320686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b6bf9822c5bfebff3cb13ecb8734472e75f525a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195946 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187496 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145056 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188589 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/48755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125351 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/47481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45203 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7006 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52183 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197906 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59204 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154595 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41387 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59913 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154248 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48716 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129168 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58384 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20225 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57759 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58000 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57825 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->