### PR TITLE
[JSC] Move WarmUp thread to libpas

### DIFF
--- a/JSTests/stress/warm-up-marked-blocks-state-machine.js
+++ b/JSTests/stress/warm-up-marked-blocks-state-machine.js
@@ -1,52 +1,59 @@
-//@ runDefault("--useDollarVM=1", "--warmUpMarkedBlockCount=8", "--warmUpMarkedBlockIdleTimeout=0.2")
+//@ runDefault("--useDollarVM=1", "--warmUpMarkedBlockCount=8", "--warmUpMarkedBlockIdleTimeout=0.02")
 
-// Drives the warm-up supply through its whole state machine: fill, release on idle, restart,
-// stand-down on allocation failure, and recovery once allocation works again. Every assertion is
-// "reaches this state eventually", since a helper thread drives the transitions.
+// Drives the warm-up supply: it fills while blocks are being asked for, hands the memory back once
+// nothing has asked for a while, survives an allocation failure, and comes back once allocation
+// works again. Every assertion is "reaches this state eventually", since a libpas helper thread
+// drives the transitions on its own.
 
-const pollSeconds = 0.05;
+const pollSeconds = 0.01;
 const timeoutSeconds = 20;
 
 const retained = [];
 
 function allocateBlocks() {
     // Retaining these is the point: a heap that can recycle stops asking the allocator for blocks,
-    // and sustained block demand is what the stand-down and restart paths are driven by. The count
-    // is kept small so that a run which ends up timing out still reports rather than exhausting
-    // memory first.
+    // and sustained block demand is what keeps the supply refilling. The count is kept small so
+    // that a run which ends up timing out still reports rather than exhausting memory first.
     for (let i = 0; i < 2000; ++i)
         retained.push({ a: i, b: i, c: i });
 }
 
 function waitFor(description, predicate, betweenAttempts = () => { }) {
     for (let attempt = 0; attempt < timeoutSeconds / pollSeconds; ++attempt) {
-        if (predicate($vm.warmUpMarkedBlockState()))
+        if (predicate($vm.warmUpMarkedBlockCount()))
             return;
         betweenAttempts();
         sleepSeconds(pollSeconds);
     }
-    const state = $vm.warmUpMarkedBlockState();
-    throw new Error(`Timed out waiting for ${description}; blocks=${state.blocks} phase=${state.phase}`);
+    throw new Error(`Timed out waiting for ${description}; blocks=${$vm.warmUpMarkedBlockCount()}`);
 }
 
-const isFilled = state => state.phase === "armed" && state.blocks > 0;
+function driveTheSupply() {
+    // The supply lives in libpas, so a build that does not use libpas has nothing to drive: it
+    // reports itself disabled even though a depth was configured on the command line.
+    if (!$vm.warmUpMarkedBlocksAreEnabled())
+        return;
 
-// Demand starts the helper, which arms to the configured depth and fills.
-allocateBlocks();
-waitFor("the supply to fill", isFilled, allocateBlocks);
+    // Demand makes the helper fill the supply.
+    allocateBlocks();
+    waitFor("the supply to fill", blocks => blocks > 0, allocateBlocks);
 
-// With no demand at all, the helper hands everything back and shuts down.
-waitFor("the supply to be released when idle", state => state.phase === "stopped");
+    // With no demand at all, the memory goes back rather than staying resident on the chance that
+    // somebody will want it. This is what keeps the supply from surviving a quiet period.
+    waitFor("the supply to be released when idle", blocks => !blocks);
 
-// Fresh demand brings it back.
-allocateBlocks();
-waitFor("the helper to restart", isFilled, allocateBlocks);
+    // Fresh demand fills it again.
+    allocateBlocks();
+    waitFor("the supply to refill", blocks => blocks > 0, allocateBlocks);
 
-// An allocation failure makes it stand down rather than spin against an exhausted heap.
-$vm.setWarmUpMarkedBlockAllocationShouldFail(true);
-waitFor("the helper to stand down", state => state.phase === "standingDown", allocateBlocks);
+    // An empty supply cannot tell a filler that has stood down from one refilling as fast as the
+    // demand here consumes, so draining is only the setup.
+    $vm.setWarmUpMarkedBlockAllocationShouldFail(true);
+    waitFor("the supply to drain while allocation fails", blocks => !blocks, allocateBlocks);
 
-// Standing down must not be permanent: the idle timeout still fires while demand continues, and
-// lifts it once allocation works again.
-$vm.setWarmUpMarkedBlockAllocationShouldFail(false);
-waitFor("the stand-down to lift", isFilled, allocateBlocks);
+    // The real assertion, since a filler that treated the failure as fatal never refills.
+    $vm.setWarmUpMarkedBlockAllocationShouldFail(false);
+    waitFor("the supply to recover", blocks => blocks > 0, allocateBlocks);
+}
+
+driveTheSupply();

--- a/Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.cpp
@@ -29,218 +29,74 @@
 #include "MarkedBlock.h"
 #include "Options.h"
 #include "VM.h"
-#include <wtf/AutomaticThread.h>
-#include <wtf/Box.h>
+#include <mutex>
 #include <wtf/FastMalloc.h>
-#include <wtf/Lock.h>
-#include <wtf/NeverDestroyed.h>
-#include <wtf/PageBlock.h>
-#include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/Vector.h>
+
+#if USE(LIBPAS)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#include <bmalloc/bmalloc_prefault_supply.h>
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+#endif
 
 namespace JSC {
 
 #if !ENABLE(MALLOC_HEAP_BREAKDOWN)
 
-namespace {
+#if USE(LIBPAS)
 
-// Lets a test drive the exhaustion path without running the machine out of memory.
-std::atomic<bool> s_allocationFailsForTesting { false };
-
-void* tryAllocateBlock()
+static bool warmUpMarkedBlocksIsEnabled()
 {
-    if (s_allocationFailsForTesting.load(std::memory_order_relaxed)) [[unlikely]]
-        return nullptr;
-    return tryFastCompactAlignedMalloc(MarkedBlock::blockSize, MarkedBlock::blockSize);
+    // Mini mode trades throughput for footprint, which is the opposite bargain.
+    return Options::useWarmUpMarkedBlocks() && Options::warmUpMarkedBlockCount() && !VM::isInMiniMode();
 }
 
-// The first store into a freshly allocated MarkedBlock takes a write fault, and a heap that is
-// ramping up pays that fault thousands of times on the mutator thread. WarmUpBlockProvider keeps a
-// supply of blocks whose pages a helper thread has already made resident, so the fault lands on the
-// helper instead.
-//
-// The supply has to be deep from the very first request, because ramp demand runs at tens of blocks
-// per millisecond and a depth that grows in proportion to observed demand arrives too late to help.
-// Warming a page is not free even when it is handed back promptly, so the supply is given up once an
-// interval passes with no demand at all.
-class WarmUpBlockProvider {
-public:
-    using Phase = WarmUpMarkedBlockPhase;
-
-    WarmUpBlockProvider()
-        : m_lock(Box<Lock>::create())
-        , m_condition(AutomaticThreadCondition::create())
-        , m_thread(adoptRef(*new WarmUpThread(Locker { *m_lock }, *this)))
-    {
-    }
-
-    static bool isEnabled()
-    {
-        // Mini mode trades throughput for footprint, which is the opposite of the bargain here.
-        return Options::useWarmUpMarkedBlocks() && Options::warmUpMarkedBlockCount() && !VM::isInMiniMode();
-    }
-
-    static WarmUpBlockProvider& singleton()
-    {
-        static LazyNeverDestroyed<WarmUpBlockProvider> provider;
-        static std::once_flag flag;
-        std::call_once(flag, [] {
-            provider.construct();
-        });
-        return provider;
-    }
-
-    void* tryTake()
-    {
-        Locker locker { *m_lock };
-        void* result = m_blocks.isEmpty() ? nullptr : m_blocks.takeLast();
-        m_demandSinceRefill = true;
-        m_demandSinceIdleCheck = true;
-        // A miss means the mutator is about to take the very fault this exists to avoid, and it is
-        // also the only thing that brings the helper back once it has shut itself down. While it is
-        // standing down, a notify would only postpone the timeout that lifts the stand-down.
-        if ((!result || isRunningLow()) && m_phase != Phase::StandingDown)
-            m_condition->notifyOne(locker);
-        return result;
-    }
-
-    WarmUpMarkedBlockState stateForTesting()
-    {
-        Locker locker { *m_lock };
-        return { m_blocks.size(), m_phase };
-    }
-
-private:
-    // AutomaticThread has no voluntary temporary stop: PollResult::Stop is permanent, and start()
-    // release-asserts that the thread is still running. So giving up after an allocation failure has
-    // to be a wait that suppresses notifies, which is what leaves the idle timeout free to lift it.
-    class WarmUpThread final : public AutomaticThread {
-        WTF_MAKE_TZONE_ALLOCATED_INLINE(WarmUpThread);
-        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WarmUpThread);
-    public:
-        WarmUpThread(const AbstractLocker& locker, WarmUpBlockProvider& provider)
-            : AutomaticThread(locker, provider.m_lock, provider.m_condition.copyRef(), Seconds(Options::warmUpMarkedBlockIdleTimeout()))
-            , m_provider(provider)
-        {
-        }
-
-        ASCIILiteral name() const final { return "JSCWarmUp"_s; }
-
-    protected:
-        void threadDidStart() final
-        {
-            Locker locker { *m_provider.m_lock };
-            m_provider.m_phase = Phase::Armed;
-        }
-
-        PollResult poll(const AbstractLocker&) final
-        {
-            assertIsHeld(*m_provider.m_lock);
-            if (m_provider.m_phase != Phase::Armed)
-                return PollResult::Wait;
-            // Topping the supply back up while demand is still arriving keeps it near its full depth
-            // on a ramp, rather than letting it drain to the watermark first.
-            if (m_provider.m_demandSinceRefill || m_provider.isRunningLow())
-                return PollResult::Work;
-            return PollResult::Wait;
-        }
-
-        WorkResult work() final
-        {
-            m_provider.refill();
-            return WorkResult::Continue;
-        }
-
-        bool shouldSleep(const AbstractLocker&) final
-        {
-            assertIsHeld(*m_provider.m_lock);
-            if (!std::exchange(m_provider.m_demandSinceIdleCheck, false))
-                return true;
-            m_provider.m_phase = Phase::Armed;
-            return false;
-        }
-
-        void threadIsStopping(const AbstractLocker&) final
-        {
-            assertIsHeld(*m_provider.m_lock);
-            // fastFree does not reach back into this lock, so it is safe to call with it held.
-            m_provider.m_phase = Phase::Stopped;
-            for (void* block : std::exchange(m_provider.m_blocks, { }))
-                fastFree(block);
-        }
-
-    private:
-        WarmUpBlockProvider& m_provider;
-    };
-
-    size_t targetDepth() WTF_REQUIRES_LOCK(*m_lock) { return m_phase == Phase::Armed ? Options::warmUpMarkedBlockCount() : 0; }
-
-    bool isRunningLow() WTF_REQUIRES_LOCK(*m_lock) { return m_blocks.size() * 4 < targetDepth(); }
-
-    static void makeResident(void* block)
-    {
-        // One store per page is what takes the fault. Striding by the real page size rather than by
-        // the smallest a supported system could have avoids repeating the store within a page.
-        size_t pageSize = WTF::pageSize();
-        ASSERT(!(MarkedBlock::blockSize % pageSize));
-        auto bytes = unsafeMakeSpan(static_cast<volatile char*>(block), MarkedBlock::blockSize);
-        for (size_t offset = 0; offset < bytes.size(); offset += pageSize)
-            bytes[offset] = 0;
-    }
-
-    void refill()
-    {
-        size_t want;
-        {
-            Locker locker { *m_lock };
-            m_demandSinceRefill = false;
-            size_t target = targetDepth();
-            want = target > m_blocks.size() ? target - m_blocks.size() : 0;
-        }
-
-        Vector<void*, 32> staging;
-        bool exhausted = false;
-        for (size_t i = 0; i < want; ++i) {
-            void* block = tryAllocateBlock();
-            if (!block) {
-                exhausted = true;
-                break;
-            }
-            makeResident(block);
-            staging.append(block);
-        }
-
-        Locker locker { *m_lock };
-        m_blocks.appendVector(WTF::move(staging));
-        if (exhausted)
-            m_phase = Phase::StandingDown;
-    }
-
-    const Box<Lock> m_lock;
-    const Ref<AutomaticThreadCondition> m_condition;
-    const Ref<WarmUpThread> m_thread;
-    Vector<void*, 32> m_blocks WTF_GUARDED_BY_LOCK(*m_lock);
-    Phase m_phase WTF_GUARDED_BY_LOCK(*m_lock) { Phase::Stopped };
-    bool m_demandSinceRefill WTF_GUARDED_BY_LOCK(*m_lock) { false };
-    bool m_demandSinceIdleCheck WTF_GUARDED_BY_LOCK(*m_lock) { false };
-};
-
-} // anonymous namespace
-
-WarmUpMarkedBlockState warmUpMarkedBlockStateForTesting()
+static void configureWarmUpSupply()
 {
-    return WarmUpBlockProvider::singleton().stateForTesting();
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        bmalloc_prefault_supply_set_block_size(MarkedBlock::blockSize);
+        bmalloc_prefault_supply_idle_timeout_in_milliseconds = Options::warmUpMarkedBlockIdleTimeout() * 1000;
+        bmalloc_prefault_supply_target = warmUpMarkedBlocksIsEnabled() ? Options::warmUpMarkedBlockCount() : 0;
+    });
+}
+
+#endif
+
+bool warmUpMarkedBlocksAreEnabledForTesting()
+{
+#if USE(LIBPAS)
+    configureWarmUpSupply();
+    return !!bmalloc_prefault_supply_target;
+#else
+    return false;
+#endif
+}
+
+unsigned warmUpMarkedBlockCountForTesting()
+{
+#if USE(LIBPAS)
+    configureWarmUpSupply();
+    return bmalloc_prefault_supply_block_count();
+#else
+    return 0;
+#endif
 }
 
 void setWarmUpMarkedBlockAllocationShouldFailForTesting(bool shouldFail)
 {
-    s_allocationFailsForTesting.store(shouldFail, std::memory_order_relaxed);
+#if USE(LIBPAS)
+    // Read by the libpas filling thread, written here by whichever thread runs the test.
+    __atomic_store_n(&bmalloc_prefault_supply_allocation_should_fail_for_testing, shouldFail, __ATOMIC_RELAXED);
+#else
+    UNUSED_PARAM(shouldFail);
+#endif
 }
 
 #else // ENABLE(MALLOC_HEAP_BREAKDOWN)
 
-WarmUpMarkedBlockState warmUpMarkedBlockStateForTesting() { return { }; }
+bool warmUpMarkedBlocksAreEnabledForTesting() { return false; }
+unsigned warmUpMarkedBlockCountForTesting() { return 0; }
 void setWarmUpMarkedBlockAllocationShouldFailForTesting(bool) { }
 
 #endif
@@ -259,15 +115,18 @@ void* FastMallocAlignedMemoryAllocator::tryAllocateAlignedMemory(size_t alignmen
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
     return m_heap.memalign(alignment, size, true);
 #else
+
+#if USE(LIBPAS)
     // MarkedBlock::tryCreate is the only caller today and always asks for a block-shaped region.
     // The guard keeps a future caller of some other size from being handed a block.
-    if (alignment == MarkedBlock::blockSize && size == MarkedBlock::blockSize && WarmUpBlockProvider::isEnabled()) {
-        if (void* block = WarmUpBlockProvider::singleton().tryTake())
-            return block;
+    if (alignment == MarkedBlock::blockSize && size == MarkedBlock::blockSize && warmUpMarkedBlocksIsEnabled()) {
+        configureWarmUpSupply();
+        return bmalloc_prefault_supply_try_allocate();
     }
-    return tryFastCompactAlignedMalloc(alignment, size);
 #endif
 
+    return tryFastCompactAlignedMalloc(alignment, size);
+#endif
 }
 
 void FastMallocAlignedMemoryAllocator::freeAlignedMemory(void* basePtr)

--- a/Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.h
@@ -55,12 +55,8 @@ private:
 
 // The supply of pre-warmed MarkedBlocks is a process-wide singleton with no other observer, so $vm
 // reaches its state through these rather than through any VM.
-enum class WarmUpMarkedBlockPhase : uint8_t { Stopped, Armed, StandingDown };
-struct WarmUpMarkedBlockState {
-    size_t blockCount { 0 };
-    WarmUpMarkedBlockPhase phase { WarmUpMarkedBlockPhase::Stopped };
-};
-WarmUpMarkedBlockState warmUpMarkedBlockStateForTesting();
+bool warmUpMarkedBlocksAreEnabledForTesting();
+unsigned warmUpMarkedBlockCountForTesting();
 void setWarmUpMarkedBlockAllocationShouldFailForTesting(bool);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2219,7 +2219,8 @@ static JSC_DECLARE_HOST_FUNCTION(functionInstallPropertyInlineCacheClearingWatch
 static JSC_DECLARE_HOST_FUNCTION(functionDeltaBetweenButterflies);
 static JSC_DECLARE_HOST_FUNCTION(functionCurrentCPUTime);
 static JSC_DECLARE_HOST_FUNCTION(functionTotalGCTime);
-static JSC_DECLARE_HOST_FUNCTION(functionWarmUpMarkedBlockState);
+static JSC_DECLARE_HOST_FUNCTION(functionWarmUpMarkedBlocksAreEnabled);
+static JSC_DECLARE_HOST_FUNCTION(functionWarmUpMarkedBlockCount);
 static JSC_DECLARE_HOST_FUNCTION(functionSetWarmUpMarkedBlockAllocationShouldFail);
 static JSC_DECLARE_HOST_FUNCTION(functionParseCount);
 static JSC_DECLARE_HOST_FUNCTION(functionIsWasmSupported);
@@ -3981,26 +3982,16 @@ JSC_DEFINE_HOST_FUNCTION(functionTotalGCTime, (JSGlobalObject* globalObject, Cal
     return JSValue::encode(jsNumber(vm.heap.totalGCTime().seconds()));
 }
 
-JSC_DEFINE_HOST_FUNCTION(functionWarmUpMarkedBlockState, (JSGlobalObject* globalObject, CallFrame*))
+JSC_DEFINE_HOST_FUNCTION(functionWarmUpMarkedBlocksAreEnabled, (JSGlobalObject*, CallFrame*))
 {
     DollarVMAssertScope assertScope;
-    VM& vm = globalObject->vm();
-    auto state = warmUpMarkedBlockStateForTesting();
-    ASCIILiteral phase = [&] {
-        switch (state.phase) {
-        case WarmUpMarkedBlockPhase::Stopped:
-            return "stopped"_s;
-        case WarmUpMarkedBlockPhase::Armed:
-            return "armed"_s;
-        case WarmUpMarkedBlockPhase::StandingDown:
-            return "standingDown"_s;
-        }
-        RELEASE_ASSERT_NOT_REACHED();
-    }();
-    JSObject* result = constructEmptyObject(globalObject);
-    result->putDirect(vm, Identifier::fromString(vm, "blocks"_s), jsNumber(static_cast<unsigned>(state.blockCount)));
-    result->putDirect(vm, Identifier::fromString(vm, "phase"_s), jsString(vm, String(phase)));
-    return JSValue::encode(result);
+    return JSValue::encode(jsBoolean(warmUpMarkedBlocksAreEnabledForTesting()));
+}
+
+JSC_DEFINE_HOST_FUNCTION(functionWarmUpMarkedBlockCount, (JSGlobalObject*, CallFrame*))
+{
+    DollarVMAssertScope assertScope;
+    return JSValue::encode(jsNumber(warmUpMarkedBlockCountForTesting()));
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionSetWarmUpMarkedBlockAllocationShouldFail, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -4757,7 +4748,8 @@ void JSDollarVM::finishCreation(VM& vm)
     
     addFunction(vm, alwaysAllow, "currentCPUTime"_s, functionCurrentCPUTime, 0);
     addFunction(vm, alwaysAllow, "totalGCTime"_s, functionTotalGCTime, 0);
-    addFunction(vm, alwaysAllow, "warmUpMarkedBlockState"_s, functionWarmUpMarkedBlockState, 0);
+    addFunction(vm, alwaysAllow, "warmUpMarkedBlocksAreEnabled"_s, functionWarmUpMarkedBlocksAreEnabled, 0);
+    addFunction(vm, alwaysAllow, "warmUpMarkedBlockCount"_s, functionWarmUpMarkedBlockCount, 0);
     addFunction(vm, alwaysAllow, "setWarmUpMarkedBlockAllocationShouldFail"_s, functionSetWarmUpMarkedBlockAllocationShouldFail, 1);
 
     addFunction(vm, alwaysAllow, "parseCount"_s, functionParseCount, 0);

--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -34,6 +34,7 @@ set(bmalloc_SOURCES
     libpas/src/libpas/bmalloc_heap_flex.c
     libpas/src/libpas/bmalloc_heap_iso.c
     libpas/src/libpas/bmalloc_heap_utils.c
+    libpas/src/libpas/bmalloc_prefault_supply.c
     libpas/src/libpas/jit_heap.c
     libpas/src/libpas/pas_bitfit_page_config_kind.c
     libpas/src/libpas/pas_heap_config_kind.c
@@ -49,6 +50,7 @@ set_source_files_properties(
     libpas/src/libpas/bmalloc_heap_flex.c
     libpas/src/libpas/bmalloc_heap_iso.c
     libpas/src/libpas/bmalloc_heap_utils.c
+    libpas/src/libpas/bmalloc_prefault_supply.c
     libpas/src/libpas/jit_heap.c
     libpas/src/libpas/pas_bitfit_page_config_kind.c
     libpas/src/libpas/pas_heap_config_kind.c
@@ -249,6 +251,7 @@ set(bmalloc_PUBLIC_HEADERS
     libpas/src/libpas/bmalloc_heap_iso_internal.h
     libpas/src/libpas/bmalloc_heap_ref.h
     libpas/src/libpas/bmalloc_heap_utils.h
+    libpas/src/libpas/bmalloc_prefault_supply.h
     libpas/src/libpas/bmalloc_type.h
     libpas/src/libpas/hotbit_heap_config.h
     libpas/src/libpas/hotbit_heap.h

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -92,6 +92,8 @@
 		AD14AD2A202529C700890E3B /* ProcessCheck.mm in Sources */ = {isa = PBXBuildFile; fileRef = AD14AD28202529B000890E3B /* ProcessCheck.mm */; };
 		AF7B6AD7B2954EA99121E719 /* pas_process.c in Sources */ = {isa = PBXBuildFile; fileRef = 2843EB80047B4B46A4A00AE8 /* pas_process.c */; };
 		BB00000003000000000000BB /* bmalloc_heap_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = BB00000004000000000000BB /* bmalloc_heap_utils.c */; };
+		7D78FA9592EC48859E8B9155 /* bmalloc_prefault_supply.c in Sources */ = {isa = PBXBuildFile; fileRef = 6BEA9595554C41DC91A6C33B /* bmalloc_prefault_supply.c */; };
+		467853C5B3B0403E9A923FEB /* bmalloc_prefault_supply.h in Headers */ = {isa = PBXBuildFile; fileRef = 87ED133FE5104AEF94FCA029 /* bmalloc_prefault_supply.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BB00000007000000000000BB /* bmalloc_heap_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = BB00000008000000000000BB /* bmalloc_heap_utils.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C5E4C2B62E0E12F1001E806C /* VMAllocate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C5E4C2B52E0E12F1001E806C /* VMAllocate.cpp */; };
 		DD4BEC2629CBA49700398E35 /* pas_large_heap_physical_page_sharing_cache.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FC40A832451498B00876DA0 /* pas_large_heap_physical_page_sharing_cache.c */; };
@@ -1232,6 +1234,8 @@
 		AD14AD27202529A600890E3B /* ProcessCheck.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ProcessCheck.h; path = bmalloc/ProcessCheck.h; sourceTree = "<group>"; };
 		AD14AD28202529B000890E3B /* ProcessCheck.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ProcessCheck.mm; path = bmalloc/ProcessCheck.mm; sourceTree = "<group>"; };
 		BB00000004000000000000BB /* bmalloc_heap_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bmalloc_heap_utils.c; path = libpas/src/libpas/bmalloc_heap_utils.c; sourceTree = "<group>"; };
+		6BEA9595554C41DC91A6C33B /* bmalloc_prefault_supply.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = bmalloc_prefault_supply.c; path = libpas/src/libpas/bmalloc_prefault_supply.c; sourceTree = "<group>"; };
+		87ED133FE5104AEF94FCA029 /* bmalloc_prefault_supply.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bmalloc_prefault_supply.h; path = libpas/src/libpas/bmalloc_prefault_supply.h; sourceTree = "<group>"; };
 		BB00000008000000000000BB /* bmalloc_heap_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = bmalloc_heap_utils.h; path = libpas/src/libpas/bmalloc_heap_utils.h; sourceTree = "<group>"; };
 		C5E4C2B52E0E12F1001E806C /* VMAllocate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = VMAllocate.cpp; path = bmalloc/VMAllocate.cpp; sourceTree = "<group>"; };
 		DE8B13B221CC5D9F00A63FCD /* BVMTags.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BVMTags.h; path = bmalloc/BVMTags.h; sourceTree = "<group>"; };
@@ -1326,6 +1330,8 @@
 				0F8A812325F83E2400790B4A /* bmalloc_heap_ref.h */,
 				BB00000004000000000000BB /* bmalloc_heap_utils.c */,
 				BB00000008000000000000BB /* bmalloc_heap_utils.h */,
+				6BEA9595554C41DC91A6C33B /* bmalloc_prefault_supply.c */,
+				87ED133FE5104AEF94FCA029 /* bmalloc_prefault_supply.h */,
 				2C11E8932728DE27002162D0 /* bmalloc_type.c */,
 				2C11E8922728DE27002162D0 /* bmalloc_type.h */,
 				0F8A812025F83E2400790B4A /* hotbit_heap.c */,
@@ -1994,6 +2000,7 @@
 				AA00000017000000000000AA /* bmalloc_heap_iso_internal.h in Headers */,
 				DD4BED7329CBA49700398E35 /* bmalloc_heap_ref.h in Headers */,
 				BB00000007000000000000BB /* bmalloc_heap_utils.h in Headers */,
+				467853C5B3B0403E9A923FEB /* bmalloc_prefault_supply.h in Headers */,
 				DD4BEC8C29CBA49700398E35 /* bmalloc_type.h in Headers */,
 				0F7EB84D1F9541C700F1ABCB /* BMalloced.h in Headers */,
 				14C919C918FCC59F0028DB43 /* BPlatform.h in Headers */,
@@ -2590,6 +2597,7 @@
 				AA00000011000000000000AA /* bmalloc_heap_flex.c in Sources */,
 				AA00000015000000000000AA /* bmalloc_heap_iso.c in Sources */,
 				BB00000003000000000000BB /* bmalloc_heap_utils.c in Sources */,
+				7D78FA9592EC48859E8B9155 /* bmalloc_prefault_supply.c in Sources */,
 				DD4BEC5429CBA49700398E35 /* bmalloc_type.c in Sources */,
 				0F74B93F1F89713E00B935D3 /* CryptoRandom.cpp in Sources */,
 				14895D911A3A319C0006235D /* Environment.cpp in Sources */,

--- a/Source/bmalloc/libpas/CMakeLists.txt
+++ b/Source/bmalloc/libpas/CMakeLists.txt
@@ -24,6 +24,7 @@ set_source_files_properties(
     src/libpas/bmalloc_heap_flex.c
     src/libpas/bmalloc_heap_iso.c
     src/libpas/bmalloc_heap_utils.c
+    src/libpas/bmalloc_prefault_supply.c
     src/libpas/hotbit_heap.c
     src/libpas/hotbit_heap_config.c
     src/libpas/iso_heap.c

--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -242,6 +242,8 @@
 		AA00000003000000000000AA /* bmalloc_heap_flex_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = AA00000004000000000000AA /* bmalloc_heap_flex_internal.h */; };
 		AA00000005000000000000AA /* bmalloc_heap_iso.c in Sources */ = {isa = PBXBuildFile; fileRef = AA00000006000000000000AA /* bmalloc_heap_iso.c */; };
 		BB00000001000000000000BB /* bmalloc_heap_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = BB00000002000000000000BB /* bmalloc_heap_utils.c */; };
+		8D9924B2E61245CA83DCD073 /* bmalloc_prefault_supply.c in Sources */ = {isa = PBXBuildFile; fileRef = C43178A6ED524EC5A633719F /* bmalloc_prefault_supply.c */; };
+		49D6D953FB44436894E0BD1B /* bmalloc_prefault_supply.h in Headers */ = {isa = PBXBuildFile; fileRef = 1ACBCCD621BF4BC5A2674F5C /* bmalloc_prefault_supply.h */; };
 		AA00000007000000000000AA /* bmalloc_heap_iso_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = AA00000008000000000000AA /* bmalloc_heap_iso_internal.h */; };
 		0F8A806625EECC1D00790B4A /* bmalloc_heap.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F8A805F25EECC1C00790B4A /* bmalloc_heap.c */; };
 		0F8A806725EECC1D00790B4A /* bmalloc_heap.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F8A806025EECC1C00790B4A /* bmalloc_heap.h */; };
@@ -982,6 +984,8 @@
 		AA00000004000000000000AA /* bmalloc_heap_flex_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bmalloc_heap_flex_internal.h; sourceTree = "<group>"; };
 		0F8A806325EECC1D00790B4A /* bmalloc_heap_ref.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bmalloc_heap_ref.h; sourceTree = "<group>"; };
 		BB00000002000000000000BB /* bmalloc_heap_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bmalloc_heap_utils.c; sourceTree = "<group>"; };
+		C43178A6ED524EC5A633719F /* bmalloc_prefault_supply.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bmalloc_prefault_supply.c; sourceTree = "<group>"; };
+		1ACBCCD621BF4BC5A2674F5C /* bmalloc_prefault_supply.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bmalloc_prefault_supply.h; sourceTree = "<group>"; };
 		BB00000006000000000000BB /* bmalloc_heap_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bmalloc_heap_utils.h; sourceTree = "<group>"; };
 		0F8A806425EECC1D00790B4A /* bmalloc_heap_innards.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bmalloc_heap_innards.h; sourceTree = "<group>"; };
 		AA00000006000000000000AA /* bmalloc_heap_iso.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bmalloc_heap_iso.c; sourceTree = "<group>"; };
@@ -1526,6 +1530,8 @@
 				0F8A806325EECC1D00790B4A /* bmalloc_heap_ref.h */,
 				BB00000002000000000000BB /* bmalloc_heap_utils.c */,
 				BB00000006000000000000BB /* bmalloc_heap_utils.h */,
+				C43178A6ED524EC5A633719F /* bmalloc_prefault_supply.c */,
+				1ACBCCD621BF4BC5A2674F5C /* bmalloc_prefault_supply.h */,
 				2C11E8902728A893002162D0 /* bmalloc_type.c */,
 				2C11E88C2728A783002162D0 /* bmalloc_type.h */,
 				0F8A80FE25F6A79500790B4A /* hotbit_heap.c */,
@@ -2154,6 +2160,7 @@
 				AA00000007000000000000AA /* bmalloc_heap_iso_internal.h in Headers */,
 				0F8A806A25EECC1D00790B4A /* bmalloc_heap_ref.h in Headers */,
 				BB00000005000000000000BB /* bmalloc_heap_utils.h in Headers */,
+				49D6D953FB44436894E0BD1B /* bmalloc_prefault_supply.h in Headers */,
 				2C11E88E2728A783002162D0 /* bmalloc_type.h in Headers */,
 				0F8A810525F6A79500790B4A /* hotbit_heap.h in Headers */,
 				0F8A810325F6A79500790B4A /* hotbit_heap_config.h in Headers */,
@@ -2832,6 +2839,7 @@
 				AA00000001000000000000AA /* bmalloc_heap_flex.c in Sources */,
 				AA00000005000000000000AA /* bmalloc_heap_iso.c in Sources */,
 				BB00000001000000000000BB /* bmalloc_heap_utils.c in Sources */,
+				8D9924B2E61245CA83DCD073 /* bmalloc_prefault_supply.c in Sources */,
 				2C11E8912728A893002162D0 /* bmalloc_type.c in Sources */,
 				0F8A810425F6A79500790B4A /* hotbit_heap.c in Sources */,
 				0F8A810125F6A79500790B4A /* hotbit_heap_config.c in Sources */,

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_prefault_supply.c
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_prefault_supply.c
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "pas_config.h"
+
+#if LIBPAS_ENABLED
+
+#include "bmalloc_prefault_supply.h"
+
+#if PAS_ENABLE_BMALLOC
+
+#include "bmalloc_heap_inlines.h"
+#include "pas_dyld_state.h"
+#include "pas_page_malloc.h"
+#include "pas_thread.h"
+#if PAS_OS(WINDOWS)
+#include "pas_monotonic_time.h"
+#else
+#include <sys/time.h>
+#endif
+#if PAS_OS(DARWIN)
+#include <sys/qos.h>
+#endif
+
+PAS_BEGIN_EXTERN_C;
+
+unsigned bmalloc_prefault_supply_target;
+double bmalloc_prefault_supply_idle_timeout_in_milliseconds = 10. * 1000.;
+bool bmalloc_prefault_supply_allocation_should_fail_for_testing;
+
+static pthread_mutex_t supply_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t supply_cond = PTHREAD_COND_INITIALIZER;
+
+/* Read on every take and written only while configuring, so it is kept clear of the line the take
+   path writes: otherwise recording demand evicts it from every other core on every take. */
+static PAS_ALIGNED(64) size_t supply_block_size;
+
+/* On its own cache line, so that a taker claiming a slot does not also take away the line holding
+   the counters the filler reads on every pass. */
+static PAS_ALIGNED(64) void* slots[BMALLOC_PREFAULT_SUPPLY_MAX_BLOCKS];
+
+/* One struct rather than three objects because the layout is the point: num_blocks and demand_count
+   are both written by every take and want one line between them, and neither may share a line with
+   supply_block_size. Separate objects cannot express that, since the compiler groups them by
+   alignment rather than by which thread touches them. thread_is_running rides along, being touched
+   only on the slow path, under supply_lock. */
+static PAS_ALIGNED(64) struct {
+    unsigned num_blocks;
+    /* Counted rather than flagged: a flag has to be cleared, and a take landing next to the clear
+       would be erased rather than merely late. Only ever compared against a snapshot taken one
+       interval earlier, so it may wrap freely. */
+    unsigned demand_count;
+    bool thread_is_running;
+} supply_state;
+
+/* Far longer than any client could mean, and short of what would overflow the deadline. */
+#define MAX_IDLE_TIMEOUT_IN_MILLISECONDS (24. * 60. * 60. * 1000.)
+
+/* A floor, so that a client asking for no wait at all cannot turn the filling thread into a spin. */
+#define MIN_IDLE_TIMEOUT_IN_MILLISECONDS 1.
+
+static unsigned supply_target(void)
+{
+    if (!supply_block_size)
+        return 0;
+    return PAS_MIN(bmalloc_prefault_supply_target, (unsigned)BMALLOC_PREFAULT_SUPPLY_MAX_BLOCKS);
+}
+
+void bmalloc_prefault_supply_set_block_size(size_t block_size)
+{
+    PAS_ASSERT(pas_is_power_of_2(block_size));
+    PAS_ASSERT(!supply_block_size || supply_block_size == block_size);
+    supply_block_size = block_size;
+}
+
+unsigned bmalloc_prefault_supply_block_count(void)
+{
+    return __atomic_load_n(&supply_state.num_blocks, __ATOMIC_RELAXED);
+}
+
+void bmalloc_prefault_supply_scavenge(void)
+{
+    unsigned index;
+
+    for (index = 0; index < BMALLOC_PREFAULT_SUPPLY_MAX_BLOCKS; ++index) {
+        void* block = __atomic_exchange_n(&slots[index], (void*)NULL, __ATOMIC_ACQUIRE);
+        if (!block)
+            continue;
+        __atomic_fetch_sub(&supply_state.num_blocks, 1, __ATOMIC_RELAXED);
+
+        /* An ordinary bmalloc block, so this hands the memory back the way the client would. */
+        bmalloc_deallocate_inline(block);
+    }
+}
+
+/* Fills every empty slot, taking no lock at all. Returns false if the heap could not satisfy a
+   request, which is the caller's cue to back off instead of asking again straight away. */
+static bool refill(void)
+{
+    unsigned target;
+    unsigned index;
+    bool should_fail_for_testing;
+
+    should_fail_for_testing = __atomic_load_n(&bmalloc_prefault_supply_allocation_should_fail_for_testing, __ATOMIC_RELAXED);
+
+    target = supply_target();
+    for (index = 0; index < target; ++index) {
+        void* block;
+        void* previous;
+
+        if (__atomic_load_n(&slots[index], __ATOMIC_RELAXED))
+            continue;
+
+        if (PAS_UNLIKELY(should_fail_for_testing))
+            return false;
+
+        block = bmalloc_try_allocate_with_alignment_inline(supply_block_size, supply_block_size, pas_always_compact_allocation_mode);
+        if (!block)
+            return false;
+
+        pas_page_malloc_populate(block, supply_block_size);
+
+        /* Counted before it is reachable, so that a taker's decrement can never be ordered ahead
+           of this increment and wrap the count below zero. */
+        __atomic_fetch_add(&supply_state.num_blocks, 1, __ATOMIC_RELAXED);
+        /* Only this thread fills, so the slot seen empty above is still empty. */
+        previous = __atomic_exchange_n(&slots[index], block, __ATOMIC_RELEASE);
+        PAS_ASSERT(!previous);
+    }
+    return true;
+}
+
+static uint64_t now_in_nanoseconds(void)
+{
+#if PAS_OS(WINDOWS)
+    /* The deadline pthread_cond_timedwait takes is measured against QueryPerformanceCounter there,
+       which is the clock this reads. */
+    return pas_get_current_monotonic_time_nanoseconds();
+#else
+    struct timeval now;
+
+    /* pthread_cond_timedwait measures its deadline against the realtime clock. */
+    gettimeofday(&now, NULL);
+    return (uint64_t)now.tv_sec * 1000000000ULL + (uint64_t)now.tv_usec * 1000ULL;
+#endif
+}
+
+static void compute_idle_deadline(struct timespec* deadline)
+{
+    double milliseconds;
+    uint64_t nanoseconds;
+
+    /* Clamped rather than trusted: an interval that lands outside what a timespec can hold makes
+       pthread_cond_timedwait fail rather than wait, which would spin the filling thread. */
+    milliseconds = bmalloc_prefault_supply_idle_timeout_in_milliseconds;
+    if (!(milliseconds > MIN_IDLE_TIMEOUT_IN_MILLISECONDS))
+        milliseconds = MIN_IDLE_TIMEOUT_IN_MILLISECONDS;
+    else if (milliseconds > MAX_IDLE_TIMEOUT_IN_MILLISECONDS)
+        milliseconds = MAX_IDLE_TIMEOUT_IN_MILLISECONDS;
+
+    nanoseconds = now_in_nanoseconds() + (uint64_t)(milliseconds * 1000000.);
+    deadline->tv_sec = (time_t)(nanoseconds / 1000000000ULL);
+    deadline->tv_nsec = (long)(nanoseconds % 1000000000ULL);
+}
+
+/* pthread_create takes a different entry point shape on Windows, where pthreads is the shim in
+   pas_thread.h rather than the system's. */
+#if PAS_OS(WINDOWS)
+#define SUPPLY_THREAD_RESULT_NULL 0
+static unsigned supply_thread_main(void* arg)
+#else
+#define SUPPLY_THREAD_RESULT_NULL NULL
+static void* supply_thread_main(void* arg)
+#endif
+{
+    PAS_UNUSED_PARAM(arg);
+
+#if PAS_OS(DARWIN) || PAS_PLATFORM(PLAYSTATION)
+#if PAS_BMALLOC
+    pthread_setname_np("JavaScriptCore libpas prefault");
+#else
+    pthread_setname_np("libpas prefault");
+#endif
+#endif
+
+#if PAS_OS(DARWIN)
+    /* Set rather than inherited: the thread is created by whichever mutator happened to find the
+       supply empty, and keeping a ramping heap supplied is not background work. */
+    pthread_set_qos_class_self_np(QOS_CLASS_USER_INITIATED, 0);
+#endif
+
+    for (;;) {
+        struct timespec deadline;
+        unsigned demand_at_start;
+        bool is_full;
+        bool should_exit;
+
+        /* Snapshotted before the refill, so that a take landing while this pass refills, or while
+           it waits to acquire the lock, still counts towards this interval. */
+        demand_at_start = __atomic_load_n(&supply_state.demand_count, __ATOMIC_RELAXED);
+
+        is_full = refill();
+
+        pthread_mutex_lock(&supply_lock);
+
+        /* Computed with the lock held, so the interval measures the wait rather than the wait plus
+           however long acquiring the lock took. */
+        compute_idle_deadline(&deadline);
+
+        /* A supply the heap refused to fill waits out the whole interval instead of asking again,
+           which is what keeps an exhausted heap from turning this into a spin. Any error from the
+           wait is treated as the interval being over for the same reason. */
+        while (supply_target() && (!is_full || __atomic_load_n(&supply_state.num_blocks, __ATOMIC_RELAXED) >= supply_target())) {
+            if (pthread_cond_timedwait(&supply_cond, &supply_lock, &deadline))
+                break;
+        }
+
+        /* An interval with no demand at all means the memory is being held on the chance that
+           somebody will want it. Give it back and let the thread go; a later take starts a new
+           one. */
+        should_exit = !supply_target()
+            || __atomic_load_n(&supply_state.demand_count, __ATOMIC_RELAXED) == demand_at_start;
+        pthread_mutex_unlock(&supply_lock);
+
+        if (!should_exit)
+            continue;
+
+        bmalloc_prefault_supply_scavenge();
+
+        pthread_mutex_lock(&supply_lock);
+        /* thread_is_running stays set until the blocks are gone, so that a replacement filler
+           cannot install a block this one is about to free. Demand that arrived in the meantime
+           therefore started nobody, and has to be picked up here. */
+        should_exit = __atomic_load_n(&supply_state.demand_count, __ATOMIC_RELAXED) == demand_at_start;
+        if (should_exit)
+            supply_state.thread_is_running = false;
+        pthread_mutex_unlock(&supply_lock);
+
+        if (should_exit)
+            return SUPPLY_THREAD_RESULT_NULL;
+    }
+}
+
+/* Reserves the right to be the one that creates the filling thread. Claiming and creating are split
+   so that pthread_create runs with supply_lock dropped: it allocates, and holding a lock across an
+   allocation is how a lock cycle gets built once this entrypoint sits on an allocation path.
+   Caller holds supply_lock. */
+static bool claim_filling_thread(void)
+{
+    if (supply_state.thread_is_running)
+        return false;
+    if (!pas_dyld_is_libsystem_initialized())
+        return false;
+
+    /* Marked as running before the thread exists, so that a second taker cannot claim it too. */
+    supply_state.thread_is_running = true;
+    return true;
+}
+
+/* Caller has claimed the thread and dropped supply_lock. */
+static void create_filling_thread(void)
+{
+    pthread_t thread;
+
+    if (pthread_create(&thread, NULL, supply_thread_main, NULL)) {
+        pthread_mutex_lock(&supply_lock);
+        supply_state.thread_is_running = false;
+        pthread_mutex_unlock(&supply_lock);
+        return;
+    }
+    pthread_detach(thread);
+}
+
+void* bmalloc_prefault_supply_try_allocate(void)
+{
+    void* result;
+    unsigned target;
+    unsigned index;
+
+    /* Without a size there is nothing to hand back, not even an ordinary allocation. */
+    if (!supply_block_size)
+        return NULL;
+
+    result = NULL;
+    target = supply_target();
+    for (index = 0; index < target; ++index) {
+        /* Probed with a load rather than an exchange, so that walking past the slots earlier
+           takers emptied does not take those lines away from the filler. */
+        if (!__atomic_load_n(&slots[index], __ATOMIC_RELAXED))
+            continue;
+
+        result = __atomic_exchange_n(&slots[index], (void*)NULL, __ATOMIC_ACQUIRE);
+        if (result) {
+            __atomic_fetch_sub(&supply_state.num_blocks, 1, __ATOMIC_RELAXED);
+            break;
+        }
+    }
+
+    /* A disabled supply wants no thread and no record of demand, but the caller still wants its
+       block, so the ordinary allocation below is what it gets. */
+    if (target) {
+        __atomic_fetch_add(&supply_state.demand_count, 1, __ATOMIC_RELAXED);
+
+        /* Waking the filler on every take would cost a signal per block during a ramp, which is
+           more than the faults being avoided, so it happens only once the supply is nearly gone. */
+        if (!result || __atomic_load_n(&supply_state.num_blocks, __ATOMIC_RELAXED) * 4 < target) {
+            bool should_create;
+
+            pthread_mutex_lock(&supply_lock);
+            should_create = claim_filling_thread();
+            pthread_cond_broadcast(&supply_cond);
+            pthread_mutex_unlock(&supply_lock);
+
+            if (should_create)
+                create_filling_thread();
+        }
+    }
+
+    if (result)
+        return result;
+
+    return bmalloc_try_allocate_with_alignment_inline(supply_block_size, supply_block_size, pas_always_compact_allocation_mode);
+}
+
+PAS_END_EXTERN_C;
+
+#endif /* PAS_ENABLE_BMALLOC */
+
+#endif /* LIBPAS_ENABLED */

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_prefault_supply.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_prefault_supply.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef BMALLOC_PREFAULT_SUPPLY_H
+#define BMALLOC_PREFAULT_SUPPLY_H
+
+#include "pas_config.h"
+
+#if PAS_ENABLE_BMALLOC
+
+#include "pas_utils.h"
+
+PAS_BEGIN_EXTERN_C;
+
+/* A supply of ordinary bmalloc blocks that a helper thread has already written to, so that the
+   thread taking one does not have to fault the memory in.
+
+   This exists for JavaScriptCore's MarkedBlock: a heap that is ramping up asks for thousands of
+   fresh blocks and pays a write fault for each one on the mutator thread. The blocks are ordinary
+   bmalloc allocations and are freed with the ordinary bmalloc entrypoint, so nothing about how the
+   memory is shared with the rest of the process changes; the only difference is which thread takes
+   the fault.
+
+   No blocks are kept ready until a client sets the block size and a nonzero target. */
+
+#define BMALLOC_PREFAULT_SUPPLY_MAX_BLOCKS 64
+
+/* How many blocks to keep ready, silently capped at BMALLOC_PREFAULT_SUPPLY_MAX_BLOCKS, or zero to
+   disable the supply. Must be set after the block size and before the first take, and must not
+   change afterwards. */
+PAS_API extern unsigned bmalloc_prefault_supply_target;
+
+/* How long the supply goes without anyone wanting a block before it hands the memory back and lets
+   its thread exit. A later take starts a new one. */
+PAS_API extern double bmalloc_prefault_supply_idle_timeout_in_milliseconds;
+
+/* The one size served. Must be set before the target, and must not change afterwards. */
+PAS_API void bmalloc_prefault_supply_set_block_size(size_t block_size);
+
+/* A block of the configured size: prefaulted if the supply had one ready, allocated the ordinary
+   way if it did not. NULL means the allocation failed, or that no block size has been set. Free it
+   with the ordinary bmalloc entrypoint, exactly like a block that never came from here. */
+PAS_API void* bmalloc_prefault_supply_try_allocate(void);
+
+/* Frees everything being held. */
+PAS_API void bmalloc_prefault_supply_scavenge(void);
+
+/* How many blocks are ready right now. For tests. */
+PAS_API unsigned bmalloc_prefault_supply_block_count(void);
+
+/* Makes the filling thread behave as if the heap were exhausted, so that a test can reach the
+   standing-down path without running the machine out of memory. */
+PAS_API extern bool bmalloc_prefault_supply_allocation_should_fail_for_testing;
+
+PAS_END_EXTERN_C;
+
+#endif /* PAS_ENABLE_BMALLOC */
+
+#endif /* BMALLOC_PREFAULT_SUPPLY_H */

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
@@ -64,6 +64,18 @@ size_t pas_page_malloc_cached_alignment_shift;
 bool pas_page_malloc_decommit_zero_fill = false;
 #endif /* PAS_OS(DARWIN) */
 
+void pas_page_malloc_populate(void* base, size_t size)
+{
+    size_t page_size;
+    size_t offset;
+    volatile char* bytes;
+
+    page_size = pas_page_malloc_alignment();
+    bytes = (volatile char*)base;
+    for (offset = 0; offset < size; offset += page_size)
+        bytes[offset] = 0;
+}
+
 #if PAS_USE_MADV_ZERO
 /* It is possible that MADV_ZERO is defined but still not supported by the
  * running OS. In this case, we check once to see if we get ENOSUP, and if

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.h
@@ -40,6 +40,10 @@ PAS_API extern size_t pas_page_malloc_cached_alignment_shift;
 PAS_API extern bool pas_page_malloc_decommit_zero_fill;
 #endif /* PAS_OS(DARWIN) */
 
+/* Writes one byte per page so that the physical memory is in place before anyone reads or writes
+   the range for real. */
+PAS_API void pas_page_malloc_populate(void* base, size_t size);
+
 PAS_API PAS_NEVER_INLINE size_t pas_page_malloc_alignment_slow(void);
 
 static inline size_t pas_page_malloc_alignment(void)

--- a/Source/bmalloc/libpas/src/libpas/pas_thread.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread.h
@@ -22,6 +22,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef PAS_THREAD_H
+#define PAS_THREAD_H
+
+#include "pas_config.h"
 #include "pas_platform.h"
 
 #if !PAS_OS(WINDOWS)
@@ -29,16 +33,21 @@
 #else
 
 /* Implement the subset of pthread that libpas requires to run on Windows */
-#pragma once
+
+/* pas_utils.h includes this header before it defines the PAS_ macros, so the __PAS_ spellings from
+   the prefix are the only ones available here. */
+#include "pas_utils_prefix.h"
+
 #include <process.h>
 #include <time.h>
 #include <windows.h>
 
-#define pthread_t uintptr_t
-
 /* Threads */
 
+#define pthread_t uintptr_t
+
 typedef INIT_ONCE pthread_once_t;
+#define PTHREAD_ONCE_INIT INIT_ONCE_STATIC_INIT
 
 struct pthread_attr_t_internal { };
 typedef struct pthread_attr_t_internal * pthread_attr_t;
@@ -46,30 +55,37 @@ typedef struct pthread_attr_t_internal * pthread_attr_t;
 struct pas_thread_t_internal { };
 typedef struct pas_thread_t_internal pas_thread_t;
 
-int pthread_create(pthread_t *thread, const pthread_attr_t *attr, unsigned (*start_routine)(void*), void *arg);
-int pthread_detach(pthread_t thread);
-
-int pthread_getname_np(pthread_t thread, const char *name, size_t len);
-pthread_t pthread_self(void);
-int sched_yield();
-
-#define PTHREAD_ONCE_INIT INIT_ONCE_STATIC_INIT
-int pthread_once(pthread_once_t *once_control, void (*init_routine)(void));
-
 /* Mutexes, conditions */
 
 typedef SRWLOCK pthread_mutex_t;
 typedef CONDITION_VARIABLE pthread_cond_t;
+#define PTHREAD_MUTEX_INITIALIZER SRWLOCK_INIT
+#define PTHREAD_COND_INITIALIZER CONDITION_VARIABLE_INIT
 
-int pthread_mutex_init(pthread_mutex_t *mutex, const void *unused_attr);
-int pthread_cond_init(pthread_cond_t *cond, const void *unused_attr);
+__PAS_BEGIN_EXTERN_C;
 
-int pthread_cond_broadcast(pthread_cond_t *cond);
+__PAS_API int pthread_create(pthread_t *thread, const pthread_attr_t *attr, unsigned (*start_routine)(void*), void *arg);
+__PAS_API int pthread_detach(pthread_t thread);
 
-int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex);
-int pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const struct timespec *abstime);
+__PAS_API int pthread_getname_np(pthread_t thread, const char *name, size_t len);
+__PAS_API pthread_t pthread_self(void);
+__PAS_API int sched_yield();
 
-int pthread_mutex_lock(pthread_mutex_t *mutex);
-int pthread_mutex_unlock(pthread_mutex_t *mutex);
+__PAS_API int pthread_once(pthread_once_t *once_control, void (*init_routine)(void));
+
+__PAS_API int pthread_mutex_init(pthread_mutex_t *mutex, const void *unused_attr);
+__PAS_API int pthread_cond_init(pthread_cond_t *cond, const void *unused_attr);
+
+__PAS_API int pthread_cond_broadcast(pthread_cond_t *cond);
+
+__PAS_API int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex);
+__PAS_API int pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex, const struct timespec *abstime);
+
+__PAS_API int pthread_mutex_lock(pthread_mutex_t *mutex);
+__PAS_API int pthread_mutex_unlock(pthread_mutex_t *mutex);
+
+__PAS_END_EXTERN_C;
 
 #endif /* PAS_OS(WINDOWS) */
+
+#endif /* PAS_THREAD_H */


### PR DESCRIPTION
#### b8d7e24add9bdcbd3ac7c6870730c29a84a06038
<pre>
[JSC] Move WarmUp thread to libpas
<a href="https://bugs.webkit.org/show_bug.cgi?id=323480">https://bugs.webkit.org/show_bug.cgi?id=323480</a>
<a href="https://rdar.apple.com/186706616">rdar://186706616</a>

Reviewed by Marcus Plutowski.

This is a preparation for extending tailord MarkedBlock heap in libpas.
This patch moves JSC&apos;s WarmUp pre-fault thread from JSC to libpas as
MarkedBlock is allocated and managed by libpas, so the policy like this
should be handled inside libpas. We make prefault page supply via
lock-free manner for supplying and consuming. And using lock etc. only
for refill request / shutdown request.

* JSTests/stress/warm-up-marked-blocks-state-machine.js:
* Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.cpp:
(JSC::warmUpMarkedBlocksIsEnabled):
(JSC::configureWarmUpSupply):
(JSC::warmUpMarkedBlocksAreEnabledForTesting):
(JSC::warmUpMarkedBlockCountForTesting):
(JSC::setWarmUpMarkedBlockAllocationShouldFailForTesting):
(JSC::FastMallocAlignedMemoryAllocator::tryAllocateAlignedMemory):
(): Deleted.
(JSC::warmUpMarkedBlockStateForTesting):
* Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.h:
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSDollarVM::finishCreation):
* Source/bmalloc/CMakeLists.txt:
* Source/bmalloc/bmalloc.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/CMakeLists.txt:
* Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/src/libpas/bmalloc_prefault_supply.c: Added.
(PAS_ALIGNED):
(supply_target):
(bmalloc_prefault_supply_set_block_size):
(bmalloc_prefault_supply_block_count):
(bmalloc_prefault_supply_scavenge):
(refill):
(now_in_nanoseconds):
(compute_idle_deadline):
(supply_thread_main):
(claim_filling_thread):
(create_filling_thread):
(bmalloc_prefault_supply_try_allocate):
* Source/bmalloc/libpas/src/libpas/bmalloc_prefault_supply.h: Added.
* Source/bmalloc/libpas/src/libpas/pas_page_malloc.c:
(pas_page_malloc_populate):
* Source/bmalloc/libpas/src/libpas/pas_page_malloc.h:
* Source/bmalloc/libpas/src/libpas/pas_thread.h:

Canonical link: <a href="https://commits.webkit.org/320895@main">https://commits.webkit.org/320895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dce6b0678c021188f9ca9a175bf0b770caf116f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186145 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60040 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196435 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150722 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145450 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100820 "1 flakes 13 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125779 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47867 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45843 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7629 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14509 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158221 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45579 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7506 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47385 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52559 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198413 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59696 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155016 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60408 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154654 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28269 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49097 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132688 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129822 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58847 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20558 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58240 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58469 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58299 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->