### PR TITLE
AX: fix two accessibility client API site isolation tests

### DIFF
--- a/LayoutTests/http/tests/site-isolation/accessibility/client/search-past-remote-frame-immediate-descendants-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/accessibility/client/search-past-remote-frame-immediate-descendants-expected.txt
@@ -2,7 +2,7 @@ Tests that immediateDescendantsOnly AnyType search correctly finds elements afte
 VoiceOver obtains the iframe's FrameHost element via the remote element parent chain.
 Without the fix, the search loops back to the first element.
 
-PASS: frameHost.rawRoleForTesting.includes('FrameHost') === true
+PASS: frameHost !== null === true
 
 Elements after FrameHost (immediateDescendantsOnly=true):
   1: AXRole: AXButton

--- a/LayoutTests/http/tests/site-isolation/accessibility/client/search-past-remote-frame-immediate-descendants.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/client/search-past-remote-frame-immediate-descendants.html
@@ -31,15 +31,25 @@ async function runTest() {
     var root = accessibilityController.rootElement;
     var webArea = root.childAtIndex(0);
 
-    // Get the remote platform element (iframe) from WebArea's children, then get
-    // its parent. The remote token bridge maps the remote element's parent to the
-    // FrameHost (the ignored AccessibilityScrollView wrapping the iframe). This is
-    // how VoiceOver discovers the FrameHost element.
-    frameHost = webArea.childAtIndex(1).parentElement();
-    // We use rawRoleForTesting to verify we're getting an AccessibilityRole::FrameHost (it's platform
-    // role is group which is very generic). FrameHost is what VoiceOver used when
-    // triggering the actual bug, which is why we do this check.
-    output += expect("frameHost.rawRoleForTesting.includes('FrameHost')", "true");
+    // Find the FrameHost (the AccessibilityScrollView wrapping the cross-origin
+    // iframe) among the WebArea's children. It is exposed with the very generic
+    // platform role AXGroup, so we identify it by rawRoleForTesting. FrameHost is
+    // the element VoiceOver was on when it triggered the actual bug, which is why
+    // we search from it below rather than from the iframe's remote element.
+    frameHost = null;
+    for (var i = 0; i < webArea.childrenCount; i++) {
+        var child = webArea.childAtIndex(i);
+        if (child.rawRoleForTesting.includes("FrameHost")) {
+            frameHost = child;
+            break;
+        }
+    }
+    output += expect("frameHost !== null", "true");
+    if (!frameHost) {
+        debug(output);
+        finishJSTest();
+        return;
+    }
 
     // Now search forward from the FrameHost with immediateDescendantsOnly=true.
     // This is the exact search VoiceOver performs. Without the fix, the search

--- a/LayoutTests/http/tests/site-isolation/accessibility/client/walk-up-from-iframe-content.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/client/walk-up-from-iframe-content.html
@@ -19,7 +19,11 @@ accessibilityController.setClientAccessibilityMode(true);
 
 // Walks accessibilityParent until the chain ends or maxHops is exceeded.
 // Records each role visited so the test output documents the cross-process boundary.
-function walkParents(startElement) {
+// Stops at the root element (the main frame's ScrollArea): anything above that is
+// the host application's chrome, which is not what this test is about. WebKitTestRunner
+// reuses its window across tests, so the chrome above the root is present on every run
+// but the first, and walking into it would make this test order-dependent.
+function walkParents(startElement, rootElement) {
     var roles = [];
     var webAreaCount = 0;
     var current = startElement;
@@ -32,6 +36,8 @@ function walkParents(startElement) {
         roles.push(role);
         if (role.includes("AXWebArea"))
             webAreaCount++;
+        if (current.isEqual(rootElement))
+            break;
         current = current.parentElement();
     }
     return { roles, webAreaCount };
@@ -75,7 +81,7 @@ async function runTest() {
 
     output += `\nFound Iframe descendant: ${iframeHeading.role} "${iframeHeading.title}"\n`;
 
-    walk = walkParents(iframeHeading);
+    walk = walkParents(iframeHeading, root);
     output += "\nAccessibility-parent chain:\n";
     for (var i = 0; i < walk.roles.length; i++)
         output += `  ${i + 1}: ${walk.roles[i]}\n`;

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -138,6 +138,8 @@ http/tests/site-isolation/accessibility/client [ Skip ]
 http/tests/site-isolation/accessibility/client/simple-iframe.html [ Pass ]
 http/tests/site-isolation/accessibility/client/iframe-bounds.html [ Pass ]
 http/tests/site-isolation/accessibility/client/absolute-position-iframe.html [ Pass ]
+http/tests/site-isolation/accessibility/client/walk-up-from-iframe-content.html [ Pass ]
+http/tests/site-isolation/accessibility/client/search-past-remote-frame-immediate-descendants.html [ Pass ]
 
 # Shared-process site isolation accessibility tests using the accessibility client API:
 # Skip by default, enable tests that are stable.


### PR DESCRIPTION
#### d9b99eac964c05a01cf77e01aca09c66e4597b14
<pre>
AX: fix two accessibility client API site isolation tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=323485">https://bugs.webkit.org/show_bug.cgi?id=323485</a>
<a href="https://rdar.apple.com/186715057">rdar://186715057</a>

Reviewed by Tyler Wilcock.

These two tests weren&apos;t reliably passing in EWS before, but the underlying bugs have been fixed so they can now be enabled with some minor robustness tweaks.

* LayoutTests/http/tests/site-isolation/accessibility/client/search-past-remote-frame-immediate-descendants-expected.txt:
* LayoutTests/http/tests/site-isolation/accessibility/client/search-past-remote-frame-immediate-descendants.html:
* LayoutTests/http/tests/site-isolation/accessibility/client/walk-up-from-iframe-content.html:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/320938@main">https://commits.webkit.org/320938@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/021d352f523ff6b711e598bdf63f42965e616332

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196512 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150777 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f78fdf75-13c9-4cf3-80c1-3591108694fc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59828 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145505 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d46a3f3f-57ed-4964-a95b-ed9bd15dafad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166035 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125840 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8136c560-5c0c-4b23-bb14-2e227f086ed7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47916 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45892 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45627 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7584 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198499 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59774 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165559 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155074 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41574 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60484 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42201 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154717 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49147 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129897 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58911 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20606 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58313 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58531 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58377 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->