### PR TITLE
AX: a cross-process iframe's FrameHost reports the whole page's bounds

### DIFF
--- a/LayoutTests/http/tests/site-isolation/accessibility/client/iframe-bounds-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/accessibility/client/iframe-bounds-expected.txt
@@ -2,6 +2,8 @@ Test iframe bounds (in screen position) in site isolation.
 
 PASS: iframeX === 100
 PASS: iframeY === 50
+PASS: iframeWidth === 400
+PASS: iframeHeight === 300
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/http/tests/site-isolation/accessibility/client/iframe-bounds.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/client/iframe-bounds.html
@@ -21,7 +21,7 @@ body { margin: 0; padding: 0; }
 <script>
 var output = "Test iframe bounds (in screen position) in site isolation.\n\n";
 
-var iframe, iframeX, iframeY, webArea;
+var iframe, iframeX, iframeY, iframeWidth, iframeHeight, webArea;
 if (window.accessibilityController) {
     window.jsTestIsAsync = true;
     accessibilityController.setForceInitialFrameCaching(true);
@@ -33,21 +33,48 @@ if (window.accessibilityController) {
             return webArea;
         });
 
-        var pageOrigin = { x: webArea.x, y: webArea.y };
+        if (!webArea) {
+            output += "FAIL: the web area never appeared in the accessibility tree.\n";
+            debug(output);
+            finishJSTest();
+            return;
+        }
 
+        // Wait for the settled tree before asserting anything. The cross-process iframe is briefly
+        // exposed as a bare ScrollArea and is only wrapped in the FrameHost that VoiceOver actually
+        // navigates to about a second later. Asserting on whichever child happens to be there first
+        // lets the test pass on that early transient while the settled tree is still wrong, which is
+        // exactly the regression this test exists to catch.
         await waitFor(() => {
             iframe = webArea.childAtIndex(0);
-            if (!iframe)
-                return false;
+            return iframe && iframe.rawRoleForTesting.includes("FrameHost");
+        });
 
+        if (!iframe || !iframe.rawRoleForTesting.includes("FrameHost")) {
+            output += "FAIL: the iframe's FrameHost never appeared in the accessibility tree.\n";
+            debug(output);
+            finishJSTest();
+            return;
+        }
+
+        // Re-read the page origin on every poll rather than sampling it once up front: the
+        // async frame screen-position update may not have arrived yet, and a stale origin
+        // makes the comparison below wrong forever.
+        await waitFor(() => {
+            var pageOrigin = { x: webArea.x, y: webArea.y };
             iframeX = iframe.x - pageOrigin.x;
             iframeY = iframe.y - pageOrigin.y;
+            iframeWidth = iframe.width;
+            iframeHeight = iframe.height;
 
             return iframeX == 100 && iframeY == 50;
         });
 
         output += expect("iframeX", "100");
         output += expect("iframeY", "50");
+        // The FrameHost must report the iframe's own box, not the whole hosting page's.
+        output += expect("iframeWidth", "400");
+        output += expect("iframeHeight", "300");
 
         debug(output);
         finishJSTest();

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -136,6 +136,8 @@ webkit.org/b/306558 accessibility/mac/style-range.html [ Failure ]
 # Skip by default, enable tests that are stable.
 http/tests/site-isolation/accessibility/client [ Skip ]
 http/tests/site-isolation/accessibility/client/simple-iframe.html [ Pass ]
+http/tests/site-isolation/accessibility/client/iframe-bounds.html [ Pass ]
+http/tests/site-isolation/accessibility/client/absolute-position-iframe.html [ Pass ]
 
 # Shared-process site isolation accessibility tests using the accessibility client API:
 # Skip by default, enable tests that are stable.

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -2539,9 +2539,12 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
         std::optional frame = geometryManager ? geometryManager->cachedRectForID(object.objectID()) : std::nullopt;
         if (frame)
             setProperty(AXProperty::RelativeFrame, WTF::move(*frame));
-        else if (isScrollArea || isWebArea || object.isScrollbar()) {
+        else if (isScrollArea || isWebArea || object.isScrollbar() || object.role() == AccessibilityRole::FrameHost) {
             // The GeometryManager does not have a relative frame for ScrollViews, WebAreas, or scrollbars yet. We need to get it from the
             // live object so that we don't need to hit the main thread in the case a request comes in while the whole isolated tree is being built.
+            //
+            // FrameHosts (the AccessibilityScrollView standing in for a cross-process iframe) are included
+            // because the remote frame is never painted in this process, so GeometryManager will never receive a rect for one.
             setProperty(AXProperty::RelativeFrame, enclosingIntRect(object.relativeFrame()));
         } else if (!object.renderer() && object.node() && is<AccessibilityNodeObject>(object) && !object.isImageMapLink()) {
             // The frame of node-only AX objects is made up of their children.


### PR DESCRIPTION
#### ce735212c16b5e411236f63f0270083c48c44bb2
<pre>
AX: a cross-process iframe&apos;s FrameHost reports the whole page&apos;s bounds
<a href="https://bugs.webkit.org/show_bug.cgi?id=323486">https://bugs.webkit.org/show_bug.cgi?id=323486</a>
<a href="https://rdar.apple.com/186715659">rdar://186715659</a>

Reviewed by Tyler Wilcock.

AXProperty::RelativeFrame needs to be cached on FrameHosts too. With
this fix, that caused multiple tests to be flaky depending on when
they queried the bounds.

This fix makes it possible to re-enable two tests.

* LayoutTests/http/tests/site-isolation/accessibility/client/iframe-bounds-expected.txt:
* LayoutTests/http/tests/site-isolation/accessibility/client/iframe-bounds.html:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::createIsolatedObjectData):

Canonical link: <a href="https://commits.webkit.org/320830@main">https://commits.webkit.org/320830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09e690e910a5ae2d945b338bf6be17e2b01b438a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196014 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150408 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4e34f80-6a96-4900-9749-30d9000cda76) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145118 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100613 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf4d3228-26c9-4a2b-a333-86b1d79a9b2b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165688 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125413 "Found 5 new API test failures: TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/4294967297444MallocReadOnly, TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/42949672971MallocReadOnly, TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/42949672974097MallocReadOnly, TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/42949672970MallocReadWrite, TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/4294967297444MallocReadWrite (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bbfd1dc3-b3e4-44d4-8f89-50037d986c05) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47529 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45570 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157889 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45263 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7077 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52242 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197980 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165199 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154654 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41495 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59982 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154307 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48771 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132331 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129268 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58449 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20285 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57827 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58063 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57890 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->