### PR TITLE
[CSS Module Scripts] Extend CachedScriptFetcher to load arbitrary resources

### DIFF
--- a/Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp
+++ b/Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp
@@ -52,16 +52,16 @@ CachedModuleScriptLoader::CachedModuleScriptLoader(ModuleScriptLoaderClient& cli
 
 CachedModuleScriptLoader::~CachedModuleScriptLoader()
 {
-    if (m_cachedScript) {
-        protect(m_cachedScript)->removeClient(*this);
-        m_cachedScript = nullptr;
+    if (m_cachedResource) {
+        protect(m_cachedResource)->removeClient(*this);
+        m_cachedResource = nullptr;
     }
 }
 
 bool CachedModuleScriptLoader::load(Document& document, URL&& sourceURL, std::optional<ServiceWorkersMode> serviceWorkersMode, const URL& referrer)
 {
     ASSERT(m_promise);
-    ASSERT(!m_cachedScript);
+    ASSERT(!m_cachedResource);
     String integrity = m_parameters ? m_parameters->integrity() : String { };
     auto destination = FetchOptionsDestination::Script;
     if (m_parameters) {
@@ -76,20 +76,21 @@ bool CachedModuleScriptLoader::load(Document& document, URL&& sourceURL, std::op
             break;
         }
     }
-    m_cachedScript = protect(scriptFetcher())->requestModuleScript(document, sourceURL, destination, WTF::move(integrity), serviceWorkersMode, referrer);
-    if (!m_cachedScript)
+
+    m_cachedResource = protect(scriptFetcher())->requestModuleResource(document, sourceURL, destination, WTF::move(integrity), serviceWorkersMode, referrer);
+    if (!m_cachedResource)
         return false;
     m_sourceURL = WTF::move(sourceURL);
 
     // If the content is already cached, this immediately calls notifyFinished.
-    protect(m_cachedScript)->addClient(*this);
+    protect(m_cachedResource)->addClient(*this);
     return true;
 }
 
 void CachedModuleScriptLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
-    ASSERT_UNUSED(resource, &resource == m_cachedScript);
-    ASSERT(m_cachedScript);
+    ASSERT_UNUSED(resource, &resource == m_cachedResource);
+    ASSERT(m_cachedResource);
     ASSERT(m_promise);
 
     Ref<CachedModuleScriptLoader> protectedThis(*this);
@@ -98,8 +99,8 @@ void CachedModuleScriptLoader::notifyFinished(CachedResource& resource, const Ne
 
     // Remove the client after calling notifyFinished to keep the data buffer in
     // CachedResource alive while notifyFinished processes the resource.
-    protect(m_cachedScript)->removeClient(*this);
-    m_cachedScript = nullptr;
+    protect(m_cachedResource)->removeClient(*this);
+    m_cachedResource = nullptr;
 }
 
 }

--- a/Source/WebCore/bindings/js/CachedModuleScriptLoader.h
+++ b/Source/WebCore/bindings/js/CachedModuleScriptLoader.h
@@ -57,7 +57,7 @@ public:
 
     bool load(Document&, URL&& sourceURL, std::optional<ServiceWorkersMode>, const URL& referrer);
 
-    CachedScript* cachedScript() { return m_cachedScript.get(); }
+    CachedResource* cachedResource() { return m_cachedResource.get(); }
     CachedScriptFetcher& scriptFetcher() { return static_cast<CachedScriptFetcher&>(ModuleScriptLoader::scriptFetcher()); }
 
 private:
@@ -67,7 +67,7 @@ private:
 
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
 
-    CachedResourceHandle<CachedScript> m_cachedScript;
+    CachedResourceHandle<CachedResource> m_cachedResource;
     URL m_sourceURL;
 };
 

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
@@ -41,12 +41,12 @@ Ref<CachedScriptFetcher> CachedScriptFetcher::create(const AtomString& charset)
     return adoptRef(*new CachedScriptFetcher(charset));
 }
 
-CachedResourceHandle<CachedScript> CachedScriptFetcher::requestModuleScript(Document& document, const URL& sourceURL, FetchOptionsDestination destination, String&& integrity, std::optional<ServiceWorkersMode> serviceWorkersMode, const URL& referrer) const
+CachedResourceHandle<CachedResource> CachedScriptFetcher::requestModuleResource(Document& document, const URL& sourceURL, FetchOptionsDestination destination, String&& integrity, std::optional<ServiceWorkersMode> serviceWorkersMode, const URL& referrer) const
 {
-    return requestScriptWithCache(document, sourceURL, destination, String { }, WTF::move(integrity), { }, serviceWorkersMode, referrer);
+    return requestResourceWithCache(document, sourceURL, destination, String { }, WTF::move(integrity), { }, serviceWorkersMode, referrer);
 }
 
-RefPtr<CachedScript> CachedScriptFetcher::requestScriptWithCache(Document& document, const URL& sourceURL, FetchOptionsDestination destination, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority> resourceLoadPriority, std::optional<ServiceWorkersMode> serviceWorkersMode, const URL& referrer) const
+RefPtr<CachedResource> CachedScriptFetcher::requestResourceWithCache(Document& document, const URL& sourceURL, FetchOptionsDestination destination, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority> resourceLoadPriority, std::optional<ServiceWorkersMode> serviceWorkersMode, const URL& referrer) const
 {
     if (!document.settings().isScriptEnabled())
         return nullptr;
@@ -62,7 +62,6 @@ RefPtr<CachedScript> CachedScriptFetcher::requestScriptWithCache(Document& docum
     options.fetchPriority = m_fetchPriority;
     options.nonce = m_nonce;
     options.destination = destination;
-    ASSERT(destination == FetchOptionsDestination::Script || destination == FetchOptionsDestination::Json || destination == FetchOptionsDestination::Text);
 
     auto request = createPotentialAccessControlRequest(URL { sourceURL }, WTF::move(options), document, crossOriginMode);
     request.upgradeInsecureRequestIfNeeded(document);
@@ -76,8 +75,20 @@ RefPtr<CachedScript> CachedScriptFetcher::requestScriptWithCache(Document& docum
     if (!m_initiatorType.isNull())
         request.setInitiatorType(m_initiatorType);
 
-    auto result = protect(document.cachedResourceLoader())->requestScript(WTF::move(request));
-    return result ? RefPtr { WTF::move(result.value()) } : nullptr;
+    switch (destination) {
+    case FetchOptionsDestination::Script:
+    case FetchOptionsDestination::Json:
+    case FetchOptionsDestination::Text: {
+        auto result = protect(document.cachedResourceLoader())->requestScript(WTF::move(request));
+        return result ? RefPtr { WTF::move(result.value()) } : nullptr;
+    }
+
+    default:
+        break;
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
 }
 
 }

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.h
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.h
@@ -42,7 +42,7 @@ enum class FetchOptionsDestination : uint8_t;
 
 class CachedScriptFetcher : public JSC::ScriptFetcher {
 public:
-    virtual CachedResourceHandle<CachedScript> requestModuleScript(Document&, const URL& sourceURL, FetchOptionsDestination, String&& integrity, std::optional<ServiceWorkersMode>, const URL& referrer) const;
+    virtual CachedResourceHandle<CachedResource> requestModuleResource(Document&, const URL& sourceURL, FetchOptionsDestination, String&& integrity, std::optional<ServiceWorkersMode>, const URL& referrer) const;
 
     static Ref<CachedScriptFetcher> create(const AtomString& charset);
 
@@ -62,7 +62,7 @@ protected:
     {
     }
 
-    RefPtr<CachedScript> requestScriptWithCache(Document&, const URL& sourceURL, FetchOptionsDestination, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority>, std::optional<ServiceWorkersMode>, const URL& referrer = { }) const;
+    RefPtr<CachedResource> requestResourceWithCache(Document&, const URL& sourceURL, FetchOptionsDestination, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority>, std::optional<ServiceWorkersMode>, const URL& referrer = { }) const;
 
 private:
     bool isCachedScriptFetcher() const final { return true; }

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -513,25 +513,25 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
     JSC::SourceCode sourceCode;
     if (m_ownerType == OwnerType::Document) {
         auto& loader = downcast<CachedModuleScriptLoader>(moduleScriptLoader);
-        Ref cachedScript = *loader.cachedScript();
+        Ref cachedResource = *loader.cachedResource();
 
-        if (cachedScript->resourceError().isAccessControl()) {
+        if (cachedResource->resourceError().isAccessControl()) {
             rejectToPropagateNetworkError(*context, WTF::move(promise), ModuleFetchFailureKind::WasPropagatedError, "Cross-origin script load denied by Cross-Origin Resource Sharing policy."_s);
             return;
         }
 
-        if (cachedScript->errorOccurred()) {
+        if (cachedResource->errorOccurred()) {
             rejectToPropagateNetworkError(*context, WTF::move(promise), ModuleFetchFailureKind::WasPropagatedError, "Importing a module script failed."_s);
             return;
         }
 
-        if (cachedScript->wasCanceled()) {
+        if (cachedResource->wasCanceled()) {
             rejectToPropagateNetworkError(*context, WTF::move(promise), ModuleFetchFailureKind::WasCanceled, "Importing a module script is canceled."_s);
             return;
         }
 
         ModuleType type = ModuleType::Invalid;
-        auto mimeType = cachedScript->response().mimeType();
+        auto mimeType = cachedResource->response().mimeType();
         auto requestedType = loader.parameters() ? loader.parameters()->type() : JSC::ScriptFetchParameters::Type::None;
         // A text module accepts any MIME type, and its content must never be parsed as JavaScript,
         // so it has to be decided before the JavaScript MIME type is considered.
@@ -549,7 +549,7 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
             // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
             // The result of extracting a MIME type from response's header list (ignoring parameters) is not a JavaScript MIME type.
             // For historical reasons, fetching a classic script does not include MIME type checking. In contrast, module scripts will fail to load if they are not of a correct MIME type.
-            rejectWithFetchError(*context, WTF::move(promise), ExceptionCode::TypeError, makeString('\'', cachedScript->response().mimeType(), "' is not a valid JavaScript MIME type for module script '"_s, sourceURL.string(), "'."_s));
+            rejectWithFetchError(*context, WTF::move(promise), ExceptionCode::TypeError, makeString('\'', cachedResource->response().mimeType(), "' is not a valid JavaScript MIME type for module script '"_s, sourceURL.string(), "'."_s));
             return;
         }
 
@@ -560,31 +560,41 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
             integrity = parameters->integrity();
 
         if (!integrity.isEmpty()) {
-            if (!matchIntegrityMetadata(cachedScript, integrity)) {
-                context->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Cannot load script "_s, integrityMismatchDescription(cachedScript, integrity)));
+            if (!matchIntegrityMetadata(cachedResource, integrity)) {
+                context->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Cannot load script "_s, integrityMismatchDescription(cachedResource, integrity)));
                 rejectWithFetchError(*context, WTF::move(promise), ExceptionCode::TypeError, "Cannot load script due to integrity mismatch"_s);
                 return;
             }
         }
 
-        URL responseURL = canonicalizeAndRegisterResponseURL(cachedScript->response().url(), cachedScript->hasRedirections(), cachedScript->response().source());
+        URL responseURL = canonicalizeAndRegisterResponseURL(cachedResource->response().url(), cachedResource->hasRedirections(), cachedResource->response().source());
         m_requestURLToResponseURLMap.add(sourceURL.string(), WTF::move(responseURL));
         switch (type) {
-        case ModuleType::JavaScript:
+        case ModuleType::JavaScript: {
+            Ref cachedScript = downcast<CachedScript>(cachedResource);
             sourceCode = JSC::SourceCode { ScriptSourceCode { cachedScript.ptr(), JSC::SourceProviderSourceType::Module, loader.scriptFetcher() }.jsSourceCode() };
             break;
+        }
+        case ModuleType::WebAssembly: {
 #if ENABLE(WEBASSEMBLY)
-        case ModuleType::WebAssembly:
+            Ref cachedScript = downcast<CachedScript>(cachedResource);
             sourceCode = JSC::SourceCode { WebAssemblyScriptSourceCode { cachedScript.ptr(), loader.scriptFetcher() }.jsSourceCode() };
             break;
+#else
+            RELEASE_ASSERT_NOT_REACHED();
 #endif
-        case ModuleType::JSON:
+        }
+        case ModuleType::JSON: {
+            Ref cachedScript = downcast<CachedScript>(cachedResource);
             sourceCode = JSC::SourceCode { ScriptSourceCode { cachedScript.ptr(), JSC::SourceProviderSourceType::JSON, loader.scriptFetcher() }.jsSourceCode() };
             break;
-        case ModuleType::Text:
+        }
+        case ModuleType::Text: {
+            Ref cachedScript = downcast<CachedScript>(cachedResource);
             sourceCode = JSC::SourceCode { ScriptSourceCode { cachedScript.ptr(), JSC::SourceProviderSourceType::Text, loader.scriptFetcher() }.jsSourceCode() };
             break;
-        default:
+        }
+        case ModuleType::Invalid:
             RELEASE_ASSERT_NOT_REACHED();
         }
     } else {

--- a/Source/WebCore/dom/LoadableClassicScript.cpp
+++ b/Source/WebCore/dom/LoadableClassicScript.cpp
@@ -149,7 +149,7 @@ bool LoadableNonModuleScriptBase::load(Document& document, const URL& sourceURL)
     };
 
     m_weakDocument = document;
-    m_cachedScript = requestScriptWithCache(document, sourceURL, FetchOptionsDestination::Script, crossOriginMode(), String { integrity() }, priority(), { });
+    m_cachedScript = downcast<CachedScript>(requestResourceWithCache(document, sourceURL, FetchOptionsDestination::Script, crossOriginMode(), String { integrity() }, priority(), { }));
     if (!m_cachedScript)
         return false;
     protect(m_cachedScript)->addClient(*this);

--- a/Source/WebCore/dom/ScriptElementCachedScriptFetcher.cpp
+++ b/Source/WebCore/dom/ScriptElementCachedScriptFetcher.cpp
@@ -34,13 +34,13 @@ namespace WebCore {
 
 const ASCIILiteral ScriptElementCachedScriptFetcher::defaultCrossOriginModeForModule { "anonymous"_s };
 
-CachedResourceHandle<CachedScript> ScriptElementCachedScriptFetcher::requestModuleScript(Document& document, const URL& sourceURL, FetchOptionsDestination destination, String&& integrity, std::optional<ServiceWorkersMode> serviceWorkersMode, const URL& referrer) const
+CachedResourceHandle<CachedResource> ScriptElementCachedScriptFetcher::requestModuleResource(Document& document, const URL& sourceURL, FetchOptionsDestination destination, String&& integrity, std::optional<ServiceWorkersMode> serviceWorkersMode, const URL& referrer) const
 {
     // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes
     // If the fetcher is not module script, credential mode is always "same-origin" ("anonymous").
     // This code is for dynamic module import (`import` operator).
 
-    return requestScriptWithCache(document, sourceURL, destination, isClassicScript() ? defaultCrossOriginModeForModule : m_crossOriginMode, WTF::move(integrity), { }, serviceWorkersMode, referrer);
+    return requestResourceWithCache(document, sourceURL, destination, isClassicScript() ? defaultCrossOriginModeForModule : m_crossOriginMode, WTF::move(integrity), { }, serviceWorkersMode, referrer);
 }
 
 }

--- a/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
+++ b/Source/WebCore/dom/ScriptElementCachedScriptFetcher.h
@@ -35,7 +35,7 @@ class ScriptElementCachedScriptFetcher : public CachedScriptFetcher {
 public:
     static const ASCIILiteral defaultCrossOriginModeForModule;
 
-    virtual CachedResourceHandle<CachedScript> requestModuleScript(Document&, const URL& sourceURL, FetchOptionsDestination, String&& integrity, std::optional<ServiceWorkersMode>, const URL& referrer) const;
+    virtual CachedResourceHandle<CachedResource> requestModuleResource(Document&, const URL& sourceURL, FetchOptionsDestination, String&& integrity, std::optional<ServiceWorkersMode>, const URL& referrer) const;
 
     virtual ScriptType scriptType() const = 0;
     bool isClassicScript() const { return scriptType() == ScriptType::Classic; }


### PR DESCRIPTION
#### 0d534df21fbac38ac625596f21c395cb3174f9df
<pre>
[CSS Module Scripts] Extend CachedScriptFetcher to load arbitrary resources
<a href="https://rdar.apple.com/186710273">rdar://186710273</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=323483">https://bugs.webkit.org/show_bug.cgi?id=323483</a>

Reviewed by NOBODY (OOPS!).

CachedScriptFetcher is used to, among other things, load module scripts when
JavaScript code loads a module using `import ...` or `import()`.

Before, when JS module import only supports JS/WASM/JSON/text modules, modules
are loaded using CachedResourceLoader::requestScript, and therefore they&apos;re
loaded using script semantics (e.g CSP script-src is honored). But to support
CSS Module Scripts, CSS files can&apos;t be loaded this way, because scripts have
their own semantics (e.g they follow CSP style-src instead of script-sec)

This patch extends CachedScriptFetcher to be able to fetch any arbitrary
resource. On a high level, CachedScriptFetcher will return a CachedResources,
instead of CachedScript like before. Its downstreams are changed to handle
the returned CachedResources. CachedScriptFetcher::requestResourceWithCache
still uses requestScript, but given that it now returns a CachedResource,
this allows future work on CSS Module Scripts to extend it by calling
requestCSSStyleSheet to fetch a CachedCSSStyleSheet.

Refactoring, tested by existing test suite.

* Source/WebCore/bindings/js/CachedModuleScriptLoader.cpp:
(WebCore::CachedModuleScriptLoader::~CachedModuleScriptLoader):
(WebCore::CachedModuleScriptLoader::load):
(WebCore::CachedModuleScriptLoader::notifyFinished):
* Source/WebCore/bindings/js/CachedModuleScriptLoader.h:
* Source/WebCore/bindings/js/CachedScriptFetcher.cpp:
(WebCore::CachedScriptFetcher::requestModuleResource const):
(WebCore::CachedScriptFetcher::requestResourceWithCache const):
(WebCore::CachedScriptFetcher::requestModuleScript const): Deleted.
(WebCore::CachedScriptFetcher::requestScriptWithCache const): Deleted.
* Source/WebCore/bindings/js/CachedScriptFetcher.h:
(WebCore::CachedScriptFetcher::requestResourceWithCache):
(WebCore::CachedScriptFetcher::requestScriptWithCache): Deleted.
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::notifyFinished):
* Source/WebCore/dom/LoadableClassicScript.cpp:
(WebCore::LoadableNonModuleScriptBase::load):
* Source/WebCore/dom/ScriptElementCachedScriptFetcher.cpp:
(WebCore::ScriptElementCachedScriptFetcher::requestModuleResource const):
(WebCore::ScriptElementCachedScriptFetcher::requestModuleScript const): Deleted.
* Source/WebCore/dom/ScriptElementCachedScriptFetcher.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d534df21fbac38ac625596f21c395cb3174f9df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195769 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150215 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/12ae8b64-f622-4978-b67d-0c9fc70a0e74) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60722 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59084 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144924 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100465 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ef761328-4ee1-4594-8052-a39d06c05135) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165503 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125216 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd36ef6b-c7c4-4b3e-af19-38a033ce1235) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47328 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45384 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157695 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45075 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6820 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197717 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59021 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165011 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running checkout-pull-request") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154442 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59730 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154091 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48568 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132078 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128945 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58208 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20097 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57580 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57823 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57647 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (warnings)") | | | | 
<!--EWS-Status-Bubble-End-->