### PR TITLE
[JSC] Use instance IDs for Wasm debugger virtual addresses

### DIFF
--- a/JSTests/wasm/debugger/resources/swift-wasm/test/multi-instance.js
+++ b/JSTests/wasm/debugger/resources/swift-wasm/test/multi-instance.js
@@ -1,0 +1,38 @@
+// Two live instances of one Swift module, both running. Each instance is a separate library
+// carrying the same DWARF, so a breakpoint set by symbol name resolves once per instance.
+var wasm_code = read('test.wasm', 'binary');
+var wasm_module = new WebAssembly.Module(wasm_code);
+var imports = {
+    wasi_snapshot_preview1: {
+        proc_exit: function (code) {
+            print("Program exited with code:", code);
+        },
+        args_get: function () { return 0; },
+        args_sizes_get: function () { return 0; },
+        environ_get: function () { return 0; },
+        environ_sizes_get: function () { return 0; },
+        fd_write: function () { return 0; },
+        fd_read: function () { return 0; },
+        fd_close: function () { return 0; },
+        fd_seek: function () { return 0; },
+        fd_fdstat_get: function () { return 0; },
+        fd_prestat_get: function () { return 8; },
+        fd_prestat_dir_name: function () { return 8; },
+        path_open: function () { return 8; },
+        random_get: function () { return 0; },
+        clock_time_get: function () { return 0; }
+    }
+};
+
+var first = new WebAssembly.Instance(wasm_module, imports);
+var second = new WebAssembly.Instance(wasm_module, imports);
+
+print("DEBUGGER_READY");
+let iteration = 0;
+for (; ;) {
+    first.exports.process_number(iteration);
+    second.exports.process_number(iteration);
+    iteration += 1;
+    if (iteration % 1e5 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/resources/wasm/multi-instance-both-running.js
+++ b/JSTests/wasm/debugger/resources/wasm/multi-instance-both-running.js
@@ -1,0 +1,58 @@
+// Two live instances of one named module, both executing. The debugger has to keep their
+// breakpoints apart while they interleave: they share the bytecode a patch is written into, so
+// the only thing distinguishing them at a trap is the instance id in the virtual address.
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic: \0asm
+    0x01, 0x00, 0x00, 0x00, // version: 1
+
+    // [0x08] Type section: 1 type
+    0x01, 0x04,             // section id=1, size=4
+    0x01,                   // 1 type
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> [])
+
+    // [0x0e] Function section: 1 function
+    0x03, 0x02,             // section id=3, size=2
+    0x01,                   // 1 function
+    0x00,                   // function 0: type 0
+
+    // [0x12] Export section: export function 0 as "func_a"
+    0x07, 0x0a,             // section id=7, size=10
+    0x01,                   // 1 export
+    0x06, 0x66, 0x75, 0x6e, 0x63, 0x5f, 0x61, // name "func_a" (length=6)
+    0x00,                   // export kind: function
+    0x00,                   // function index 0
+
+    // [0x1e] Code section: 1 function body
+    0x0a, 0x08,             // section id=10, size=8
+    0x01,                   // 1 function body
+
+    // [0x21] func_a body
+    0x06,                   // body size=6
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x23] nop
+    0x41, 0x2a,             // [0x24] i32.const 42
+    0x1a,                   // [0x26] drop
+    0x0b,                   // [0x27] end
+
+    // [0x28] Name section: custom section "name", subsection 0 = module name "mymodule"
+    0x00, 0x10,             // section id=0 (custom), payload size=16
+    0x04, 0x6e, 0x61, 0x6d, 0x65,          // custom section name: "name" (length=4)
+    0x00, 0x09,             // subsection 0 (module name), subsection size=9
+    0x08,                   // module name length=8
+    0x6d, 0x79, 0x6d, 0x6f, 0x64, 0x75, 0x6c, 0x65, // "mymodule"
+]);
+
+var module = new WebAssembly.Module(wasm);
+var first = new WebAssembly.Instance(module);  // instance 0
+var second = new WebAssembly.Instance(module); // instance 1
+
+print("DEBUGGER_READY");
+let iteration = 0;
+for (; ;) {
+    first.exports.func_a();
+    second.exports.func_a();
+    iteration += 1;
+    if (iteration % 1e6 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/resources/wasm/multi-instance-caller-frame.js
+++ b/JSTests/wasm/debugger/resources/wasm/multi-instance-caller-frame.js
@@ -1,0 +1,66 @@
+// Three live instances of one named module: two running, one idle. Each instance is a separate
+// library with its own base address, and all three share the underlying bytecode.
+//
+// func_outer calls func_a so a stop has a caller frame. A stop reported for the wrong instance
+// shows frame #0 and frame #1 in different libraries.
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic: \0asm
+    0x01, 0x00, 0x00, 0x00, // version: 1
+
+    // [0x08] Type section: 1 type
+    0x01, 0x04,             // section id=1, size=4
+    0x01,                   // 1 type
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> [])
+
+    // [0x0e] Function section: 2 functions
+    0x03, 0x03,             // section id=3, size=3
+    0x02,                   // 2 functions
+    0x00,                   // function 0 (func_a): type 0
+    0x00,                   // function 1 (func_outer): type 0
+
+    // [0x13] Export section: export function 1 as "func_outer"
+    0x07, 0x0e,             // section id=7, size=14
+    0x01,                   // 1 export
+    0x0a, 0x66, 0x75, 0x6e, 0x63, 0x5f, 0x6f, 0x75, 0x74, 0x65, 0x72, // name "func_outer" (length=10)
+    0x00,                   // export kind: function
+    0x01,                   // function index 1
+
+    // [0x23] Code section: 2 function bodies
+    0x0a, 0x0a,             // section id=10, size=10
+    0x02,                   // 2 function bodies
+
+    // [0x26] func_a body
+    0x03,                   // body size=3
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x28] nop
+    0x0b,                   // [0x29] end
+
+    // [0x2a] func_outer body
+    0x04,                   // body size=4
+    0x00,                   // 0 local declarations
+    0x10, 0x00,             // [0x2c] call 0 (func_a)
+    0x0b,                   // [0x2e] end -- func_a's return PC
+
+    // [0x2f] Name section: custom section "name", subsection 0 = module name "mymodule"
+    0x00, 0x10,             // section id=0 (custom), payload size=16
+    0x04, 0x6e, 0x61, 0x6d, 0x65,          // custom section name: "name" (length=4)
+    0x00, 0x09,             // subsection 0 (module name), subsection size=9
+    0x08,                   // module name length=8
+    0x6d, 0x79, 0x6d, 0x6f, 0x64, 0x75, 0x6c, 0x65, // "mymodule"
+]);
+
+var module = new WebAssembly.Module(wasm);
+var first = new WebAssembly.Instance(module);
+var second = new WebAssembly.Instance(module);
+var idle = new WebAssembly.Instance(module); // Never called, but kept alive for the whole run.
+
+print("DEBUGGER_READY");
+let iteration = 0;
+for (; ;) {
+    first.exports.func_outer();
+    second.exports.func_outer();
+    iteration += 1;
+    if (iteration % 1e6 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/resources/wasm/multi-instance-same-module.js
+++ b/JSTests/wasm/debugger/resources/wasm/multi-instance-same-module.js
@@ -1,0 +1,56 @@
+// Two live instances of one named module. Each instance is a separate library with distinct
+// base addresses, sharing the underlying bytecode.
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic: \0asm
+    0x01, 0x00, 0x00, 0x00, // version: 1
+
+    // [0x08] Type section: 1 type
+    0x01, 0x04,             // section id=1, size=4
+    0x01,                   // 1 type
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> [])
+
+    // [0x0e] Function section: 1 function
+    0x03, 0x02,             // section id=3, size=2
+    0x01,                   // 1 function
+    0x00,                   // function 0: type 0
+
+    // [0x12] Export section: export function 0 as "func_a"
+    0x07, 0x0a,             // section id=7, size=10
+    0x01,                   // 1 export
+    0x06, 0x66, 0x75, 0x6e, 0x63, 0x5f, 0x61, // name "func_a" (length=6)
+    0x00,                   // export kind: function
+    0x00,                   // function index 0
+
+    // [0x1e] Code section: 1 function body
+    0x0a, 0x08,             // section id=10, size=8
+    0x01,                   // 1 function body
+
+    // [0x21] func_a body
+    0x06,                   // body size=6
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x23] nop
+    0x41, 0x2a,             // [0x24] i32.const 42
+    0x1a,                   // [0x26] drop
+    0x0b,                   // [0x27] end
+
+    // [0x28] Name section: custom section "name", subsection 0 = module name "mymodule"
+    0x00, 0x10,             // section id=0 (custom), payload size=16
+    0x04, 0x6e, 0x61, 0x6d, 0x65,          // custom section name: "name" (length=4)
+    0x00, 0x09,             // subsection 0 (module name), subsection size=9
+    0x08,                   // module name length=8
+    0x6d, 0x79, 0x6d, 0x6f, 0x64, 0x75, 0x6c, 0x65, // "mymodule"
+]);
+
+var module = new WebAssembly.Module(wasm);
+var running = new WebAssembly.Instance(module);
+var idle = new WebAssembly.Instance(module); // Never called, but kept alive for the whole run.
+
+print("DEBUGGER_READY");
+let iteration = 0;
+for (; ;) {
+    running.exports.func_a();
+    iteration += 1;
+    if (iteration % 1e6 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/resources/wasm/multi-instance-three.js
+++ b/JSTests/wasm/debugger/resources/wasm/multi-instance-three.js
@@ -1,0 +1,59 @@
+// Three live instances of one named module; only instance 0 executes. Exercises a requester
+// set with more than two members: the shared byte must stay patched until the last site goes.
+
+
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic: \0asm
+    0x01, 0x00, 0x00, 0x00, // version: 1
+
+    // [0x08] Type section: 1 type
+    0x01, 0x04,             // section id=1, size=4
+    0x01,                   // 1 type
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> [])
+
+    // [0x0e] Function section: 1 function
+    0x03, 0x02,             // section id=3, size=2
+    0x01,                   // 1 function
+    0x00,                   // function 0: type 0
+
+    // [0x12] Export section: export function 0 as "func_a"
+    0x07, 0x0a,             // section id=7, size=10
+    0x01,                   // 1 export
+    0x06, 0x66, 0x75, 0x6e, 0x63, 0x5f, 0x61, // name "func_a" (length=6)
+    0x00,                   // export kind: function
+    0x00,                   // function index 0
+
+    // [0x1e] Code section: 1 function body
+    0x0a, 0x08,             // section id=10, size=8
+    0x01,                   // 1 function body
+
+    // [0x21] func_a body
+    0x06,                   // body size=6
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x23] nop
+    0x41, 0x2a,             // [0x24] i32.const 42
+    0x1a,                   // [0x26] drop
+    0x0b,                   // [0x27] end
+
+    // [0x28] Name section: custom section "name", subsection 0 = module name "mymodule"
+    0x00, 0x10,             // section id=0 (custom), payload size=16
+    0x04, 0x6e, 0x61, 0x6d, 0x65,          // custom section name: "name" (length=4)
+    0x00, 0x09,             // subsection 0 (module name), subsection size=9
+    0x08,                   // module name length=8
+    0x6d, 0x79, 0x6d, 0x6f, 0x64, 0x75, 0x6c, 0x65, // "mymodule"
+]);
+
+var module = new WebAssembly.Module(wasm);
+var first = new WebAssembly.Instance(module);  // instance 0, the only one that runs
+var second = new WebAssembly.Instance(module); // instance 1, idle
+var third = new WebAssembly.Instance(module);  // instance 2, idle
+
+print("DEBUGGER_READY");
+let iteration = 0;
+for (; ;) {
+    first.exports.func_a();
+    iteration += 1;
+    if (iteration % 1e6 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/resources/wasm/multi-instance-unreachable.js
+++ b/JSTests/wasm/debugger/resources/wasm/multi-instance-unreachable.js
@@ -1,0 +1,61 @@
+// Two live instances of one named module whose body contains a real `unreachable`. A breakpoint
+// patch is itself the `unreachable` opcode (0x00), so a site on this instruction cannot be told
+// apart from its own patch -- the debugger has to let the program's trap propagate rather than
+// replay the displaced opcode. Instance 0 runs; instance 1 exists only to keep a second set of
+// virtual addresses aimed at the same shared bytecode.
+var wasm = new Uint8Array([
+    // [0x00] WASM header
+    0x00, 0x61, 0x73, 0x6d, // magic: \0asm
+    0x01, 0x00, 0x00, 0x00, // version: 1
+
+    // [0x08] Type section: 1 type
+    0x01, 0x04,             // section id=1, size=4
+    0x01,                   // 1 type
+    0x60, 0x00, 0x00,       // Type 0: (func [] -> [])
+
+    // [0x0e] Function section: 1 function
+    0x03, 0x02,             // section id=3, size=2
+    0x01,                   // 1 function
+    0x00,                   // function 0: type 0
+
+    // [0x12] Export section: export function 0 as "func_a"
+    0x07, 0x0a,             // section id=7, size=10
+    0x01,                   // 1 export
+    0x06, 0x66, 0x75, 0x6e, 0x63, 0x5f, 0x61, // name "func_a" (length=6)
+    0x00,                   // export kind: function
+    0x00,                   // function index 0
+
+    // [0x1e] Code section: 1 function body
+    0x0a, 0x06,             // section id=10, size=6
+    0x01,                   // 1 function body
+
+    // [0x21] func_a body
+    0x04,                   // body size=4
+    0x00,                   // 0 local declarations
+    0x01,                   // [0x23] nop
+    0x00,                   // [0x24] unreachable
+    0x0b,                   // [0x25] end
+
+    // [0x26] Name section: custom section "name", subsection 0 = module name "mymodule"
+    0x00, 0x10,             // section id=0 (custom), payload size=16
+    0x04, 0x6e, 0x61, 0x6d, 0x65,          // custom section name: "name" (length=4)
+    0x00, 0x09,             // subsection 0 (module name), subsection size=9
+    0x08,                   // module name length=8
+    0x6d, 0x79, 0x6d, 0x6f, 0x64, 0x75, 0x6c, 0x65, // "mymodule"
+]);
+
+var module = new WebAssembly.Module(wasm);
+var running = new WebAssembly.Instance(module);
+var idle = new WebAssembly.Instance(module); // Never called, but kept alive for the whole run.
+
+print("DEBUGGER_READY");
+let iteration = 0;
+for (; ;) {
+    try {
+        running.exports.func_a();
+    } catch (e) {
+    }
+    iteration += 1;
+    if (iteration % 1e5 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -192,7 +192,7 @@ class CWasmTestCase:
         self.session.cmd(
             "mem reg --all",
             patterns=[
-                "[0x0000000000000000-0x0000000001010000) rw- wasm_memory_0_0",
+                "[0x0000000000000000-0x0000000001010000) rw- wasm_memory_0",
                 "[0x0000000001010000-0x4000000000000000) ---",
                 "[0x4000000000000000-0x40000000000014e0) r-x wasm_module_0",
                 "[0x40000000000014e0-0xffffffffffffffff) ---",
@@ -206,7 +206,7 @@ class CWasmTestCase:
 
         self.session.cmd(
             "mem reg 0x0000000000000000",
-            patterns=["[0x0000000000000000-0x0000000001010000) rw- wasm_memory_0_0"],
+            patterns=["[0x0000000000000000-0x0000000001010000) rw- wasm_memory_0"],
         )
 
     def memoryReadWriteTest(self):
@@ -420,7 +420,7 @@ class SwiftWasmTestCase:
         self.session.cmd(
             "mem reg --all",
             patterns=[
-                "[0x0000000000000000-0x0000000000130000) rw- wasm_memory_0_0",
+                "[0x0000000000000000-0x0000000000130000) rw- wasm_memory_0",
                 "[0x0000000000130000-0x4000000000000000) ---",
                 "[0x4000000000000000-0x40000000006b1239) r-x wasm_module_0",
                 "[0x40000000006b1239-0xffffffffffffffff) ---",
@@ -434,7 +434,7 @@ class SwiftWasmTestCase:
 
         self.session.cmd(
             "mem reg 0x0000000000000000",
-            patterns=["[0x0000000000000000-0x0000000000130000) rw- wasm_memory_0_0"],
+            patterns=["[0x0000000000000000-0x0000000000130000) rw- wasm_memory_0"],
         )
 
     def memoryReadWriteTest(self):
@@ -1661,9 +1661,9 @@ class DynamicModuleLoadTestCase:
         # Disassembly confirms the stopped instruction is 'end' at the expected address.
         self.session.cmd("c", patterns=["Process 1 stopped", "->  0x4000000000000023: end"])
 
-        # Resume: stops for the module-load notification (library:; T-packet) when module 2 is
-        # instantiated.  LLDB re-queries qXfer:libraries:read and loads module 2.
-        self.session.cmd("c", patterns=["Process 1 stopped", "loaded new wasm module with ids: 1"])
+        # Resume: stops for the library notification (library:; T-packet) when module 2 is
+        # instantiated.  LLDB re-queries qXfer:libraries:read and loads its instance.
+        self.session.cmd("c", patterns=["Process 1 stopped", "loaded new wasm module instance with ids: 1"])
 
         # Set a breakpoint at the 'end' instruction of func_b in module 2 (virtual address
         # 0x4000000100000023).  Module 2 is now loaded, so the breakpoint resolves immediately.
@@ -1688,14 +1688,507 @@ class SwiftWasmDynamicModuleLoadTestCase:
         # Resume: stops at the func_a breakpoint (module A), confirming that the breakpoint is set and hit correctly.
         self.session.cmd("c", patterns=["Process 1 stopped", "func_a"])
 
-        # Resume: stops at when Module B is loaded and the associated instance is created. This stop trigger
+        # Resume: stops when Module B is loaded and the associated instance is created. This stop triggers
         # LLDB re-querying debug info and resolving the pending breakpoint for func_b, confirming that dynamic
         # module load triggers pending breakpoint resolution.
-        self.session.cmd("c", patterns=["Process 1 stopped", "loaded new wasm module with ids: 1"])
+        self.session.cmd("c", patterns=["Process 1 stopped", "loaded new wasm module instance with ids: 1"])
         self.session.cmd("br list", patterns=["func_a", "func_b"])
 
         # Resume: stops at the func_b breakpoint (module B) on the first call, confirming that the pending breakpoint was resolved via debug info.
         self.session.cmd("c", patterns=["Process 1 stopped", "func_b"])
+
+
+class MultiInstanceCallerFrameTestCase:
+    test_file = "resources/wasm/multi-instance-caller-frame.js"
+
+    def execute(self):
+        # One library per instance. LLDB merges libraries that share a name, so every library is
+        # suffixed with its instance id.
+        self.session.cmd("image list", patterns=["mymodule@0", "mymodule@1", "mymodule@2"])
+        self.session.cmd(
+            "target modules list",
+            patterns=["0x4000000000000000", "0x4000000100000000", "0x4000000200000000"],
+        )
+
+        # A site is scoped to the instance its address names. Instances 0 and 1 both run func_a
+        # through the bytecode a breakpoint patches, but only instance 1 holds a site, so
+        # instance 0 resumes through the patched byte without stopping.
+        self.session.cmd("b 0x4000000100000028", patterns=["Breakpoint 1"])
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 1", "->  0x4000000100000028: nop"],
+        )
+
+        # Both frames belong to instance 1. Reporting the stop at a sibling's address would put
+        # func_outer's return PC in another library.
+        self.session.cmd(
+            "bt",
+            patterns=["frame #0: 0x4000000100000028", "frame #1: 0x400000010000002e"],
+        )
+
+        # Continuing makes progress and lands in instance 1 again, never in instance 0.
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 1", "->  0x4000000100000028: nop"],
+        )
+        self.session.cmd(
+            "bt",
+            patterns=["frame #0: 0x4000000100000028", "frame #1: 0x400000010000002e"],
+        )
+
+        # A site through instance 0 patches the same byte, so now instance 0 stops there too.
+        self.session.cmd("b 0x4000000000000028", patterns=["Breakpoint 2"])
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 2", "->  0x4000000000000028: nop"],
+        )
+
+        # Stepping off a byte that several sites patch has to advance. LLDB clears one site to step
+        # over it, which leaves the byte patched for the others, so resuming dispatches the opcode
+        # the breakpoint displaced instead of re-reading the bytecode.
+        self.session.cmd(
+            "s",
+            patterns=["Process 1 stopped", "->  0x4000000000000029: end"],
+        )
+
+        # Deleting either breakpoint must leave the other armed.
+        self.session.cmd("br del 1", patterns=["1 breakpoints deleted"])
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 2", "->  0x4000000000000028: nop"],
+        )
+
+        self.session.cmd("br del -f", patterns=["All breakpoints removed. (1 breakpoint)"])
+
+
+class SwiftWasmMultiInstanceTestCase:
+    test_file = "resources/swift-wasm/test/multi-instance.js"
+
+    def execute(self):
+        # Two instances of one module, so two libraries carrying the same DWARF.
+        self.session.cmd(
+            "target modules list",
+            patterns=["0x4000000000000000", "0x4000000100000000"],
+        )
+
+        # A symbol resolves once per library, which is how a breakpoint set by name covers every
+        # instance: LLDB installs one site per instance rather than JSC broadcasting one address.
+        self.session.cmd("b isEven", patterns=["Breakpoint 1: 2 locations"])
+
+        # With only instance 1's site armed, instance 0 runs the same bytecode and must pass
+        # through the patched byte without stopping. Which instance is mid-call when LLDB attaches
+        # is not fixed, so arm exactly one site rather than assuming a hit order.
+        self.session.cmd("br dis 1.1", patterns=["1 breakpoints disabled"])
+        for _ in range(3):
+            self.session.cmd("c", patterns=["Process 1 stopped", "stop reason = breakpoint 1.2"])
+            self.session.cmd(
+                "bt",
+                patterns=["frame #0: 0x4000000100010960", "frame #1: 0x4000000100010a05"],
+            )
+
+        # Symmetric: arm instance 0's site alone and only instance 0 stops.
+        self.session.cmd("br ena 1.1", patterns=["1 breakpoints enabled"])
+        self.session.cmd("br dis 1.2", patterns=["1 breakpoints disabled"])
+        for _ in range(3):
+            self.session.cmd("c", patterns=["Process 1 stopped", "stop reason = breakpoint 1.1"])
+            self.session.cmd(
+                "bt",
+                patterns=["frame #0: 0x4000000000010960", "frame #1: 0x4000000000010a05"],
+            )
+
+        self.session.cmd("br del -f", patterns=["All breakpoints removed. (1 breakpoint)"])
+
+
+class MultiInstanceSameModuleTestCase:
+    test_file = "resources/wasm/multi-instance-same-module.js"
+
+    def execute(self):
+        # One library per instance. LLDB merges libraries that share a name, so every library is
+        # suffixed with its instance id.
+        self.session.cmd("image list", patterns=["mymodule@0", "mymodule@1"])
+        self.session.cmd(
+            "target modules list",
+            patterns=["0x4000000000000000", "0x4000000100000000"],
+        )
+
+        # Instances share the bytecode that a breakpoint patches, but not the breakpoint. Only
+        # instance 0 runs, so a site set through idle instance 1 must never stop it. Setting one
+        # site per instance proves that: the stop has to be breakpoint 2, at instance 0's own
+        # address. Were the sibling's site able to claim the stop, this would report breakpoint 1.
+        self.session.cmd("b 0x4000000100000023", patterns=["Breakpoint 1"])
+        self.session.cmd("b 0x4000000000000023", patterns=["Breakpoint 2"])
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 2", "->  0x4000000000000023: nop"],
+        )
+
+        # Continuing makes progress rather than re-reporting the same stop, even though instance
+        # 1's site keeps the shared byte patched across the resume.
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 2", "->  0x4000000000000023: nop"],
+        )
+
+        # Both sites patch the same byte, so deleting one must leave the other armed.
+        self.session.cmd("br del 1", patterns=["1 breakpoints deleted"])
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 2", "->  0x4000000000000023: nop"],
+        )
+
+        self.session.cmd("br del -f", patterns=["All breakpoints removed. (1 breakpoint)"])
+
+
+# The multi-instance cases below all use one module with two instances: instance 0 runs in a
+# loop, instance 1 is alive but idle. Both instances' virtual addresses resolve to the same
+# physical bytecode, so every breakpoint LLDB sets through either of them patches one shared
+# byte. What must hold throughout is that the patch is shared but the *stop* is not: only the
+# instance whose own address LLDB installed a site through may stop on it.
+#
+# multi-instance-same-module.js body: 0x23 nop, 0x24 i32.const 42, 0x26 drop, 0x27 end.
+# multi-instance-unreachable.js body: 0x23 nop, 0x24 unreachable, 0x25 end.
+#
+# The unreachable cases matter because a breakpoint patch *is* the unreachable opcode (0x00), so
+# a site on a real `unreachable` is indistinguishable from its own patch. There is no displaced
+# opcode to replay, and the program's own trap has to propagate instead.
+
+
+class MultiInstanceForeignSiteIgnoredTestCase:
+    test_file = "resources/wasm/multi-instance-same-module.js"
+
+    def execute(self):
+        # A site on idle instance 1's nop, and one further down the same body on running
+        # instance 0. Continuing has to skip straight past the nop to the drop: the nop's byte is
+        # patched the whole time, but instance 0 never asked to stop there.
+        self.session.cmd("b 0x4000000100000023", patterns=["Breakpoint 1"])
+        self.session.cmd("b 0x4000000000000026", patterns=["Breakpoint 2"])
+        for _ in range(3):
+            self.session.cmd(
+                "c",
+                patterns=["Process 1 stopped", "stop reason = breakpoint 2", "->  0x4000000000000026: drop"],
+            )
+
+        self.session.cmd("br del -f", patterns=["All breakpoints removed. (2 breakpoints)"])
+
+
+class MultiInstanceStepOverSharedPatchTestCase:
+    test_file = "resources/wasm/multi-instance-same-module.js"
+
+    def execute(self):
+        # Instance 1's site pins the nop's byte patched for the whole test: LLDB's step-over
+        # dance drops instance 0's site before stepping, but the byte never actually reverts.
+        # Every step below therefore has to run the displaced opcode rather than whatever is at
+        # PC, or the first si would loop on the patch forever.
+        self.session.cmd("b 0x4000000100000023", patterns=["Breakpoint 1"])
+        self.session.cmd("b 0x4000000000000023", patterns=["Breakpoint 2"])
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 2", "->  0x4000000000000023: nop"],
+        )
+
+        patterns = [
+            ["->  0x4000000000000023: nop"],
+            ["->  0x4000000000000024: i32.const 42"],
+            ["->  0x4000000000000026: drop"],
+            ["->  0x4000000000000027: end"],
+        ]
+        for _ in range(3):
+            for pattern in patterns:
+                self.session.cmd("dis", patterns=pattern)
+                self.session.cmd("si")
+
+        self.session.cmd("br del -f", patterns=["All breakpoints removed. (2 breakpoints)"])
+
+
+class MultiInstanceBreakpointDisableTestCase:
+    test_file = "resources/wasm/multi-instance-same-module.js"
+
+    def execute(self):
+        # Disabling and re-enabling instance 0's site while instance 1's keeps the byte patched.
+        # br dis and br del are the same z0 packet on the wire, so this also covers the case
+        # where the removal must not restore the byte.
+        self.session.cmd("b 0x4000000100000023", patterns=["Breakpoint 1"])
+        self.session.cmd("b 0x4000000000000023", patterns=["Breakpoint 2"])
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 2", "->  0x4000000000000023: nop"],
+        )
+
+        # The catcher goes in only now: the process starts stopped at the nop, so a site on the
+        # drop set beforehand would claim the very first continue before the loop comes around.
+        self.session.cmd("b 0x4000000000000026", patterns=["Breakpoint 3"])
+
+        # Disabled: the byte stays patched for instance 1, but instance 0 runs past it to the drop.
+        self.session.cmd("br dis 2", patterns=["1 breakpoints disabled"])
+        for _ in range(2):
+            self.session.cmd(
+                "c",
+                patterns=["Process 1 stopped", "stop reason = breakpoint 3", "->  0x4000000000000026: drop"],
+            )
+
+        # Re-enabled: the nop claims the stop again, ahead of the drop.
+        self.session.cmd("br en 2", patterns=["1 breakpoints enabled"])
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 2", "->  0x4000000000000023: nop"],
+        )
+
+        self.session.cmd("br del -f", patterns=["All breakpoints removed. (3 breakpoints)"])
+
+
+class MultiInstanceBreakpointDeleteTestCase:
+    test_file = "resources/wasm/multi-instance-same-module.js"
+
+    def execute(self):
+        # Deleting either site must leave the other's behaviour untouched, in both directions.
+        self.session.cmd("b 0x4000000100000023", patterns=["Breakpoint 1"])
+        self.session.cmd("b 0x4000000000000023", patterns=["Breakpoint 2"])
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 2", "->  0x4000000000000023: nop"],
+        )
+
+        # Drop the sibling's site: the byte is still claimed by instance 0, so nothing changes.
+        self.session.cmd("br del 1", patterns=["1 breakpoints deleted"])
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 2", "->  0x4000000000000023: nop"],
+        )
+
+        # Put the sibling back and drop instance 0's instead. The byte is now patched only for an
+        # instance that never runs, so instance 0 falls through to the drop. The catcher goes in
+        # here rather than up top so it cannot claim an earlier continue.
+        self.session.cmd("b 0x4000000100000023", patterns=["Breakpoint 3"])
+        self.session.cmd("b 0x4000000000000026", patterns=["Breakpoint 4"])
+        self.session.cmd("br del 2", patterns=["1 breakpoints deleted"])
+        for _ in range(2):
+            self.session.cmd(
+                "c",
+                patterns=["Process 1 stopped", "stop reason = breakpoint 4", "->  0x4000000000000026: drop"],
+            )
+
+        self.session.cmd("br del -f", patterns=["All breakpoints removed. (2 breakpoints)"])
+
+
+class MultiInstanceUnreachableOwnSiteTestCase:
+    test_file = "resources/wasm/multi-instance-unreachable.js"
+
+    def execute(self):
+        self.session.cmd("image list", patterns=["mymodule@0", "mymodule@1"])
+
+        # A site on instance 0's own `unreachable`. The patch byte and the instruction are both
+        # 0x00, so there is no displaced opcode to replay on resume -- the trap has to propagate.
+        self.session.cmd("b 0x4000000000000024", patterns=["Breakpoint 1"])
+        # FIXME: This cannot be looped, so the breakpoint is only checked on its first hit.
+        # Resuming from a site, LLDB runs a z0 / step / Z0 dance, which assumes the step executes
+        # one instruction and stops. At a wasm trap there is no next wasm instruction -- the trap
+        # unwinds to JS, which can catch it -- so step() resumes all instead. The step therefore
+        # covers unbounded execution: the JS catch runs, the loop calls the export again, and the
+        # interpreter reaches this byte once more while the site is still lifted, so that hit is
+        # reported as a plain trap. Z0 arrives only after the stop, too late to catch it. Net
+        # effect: the breakpoint reports on the first hit and the trap on every hit after.
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 1", "->  0x4000000000000024: unreachable"],
+        )
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "Unreachable code should not be executed"],
+        )
+
+        self.session.cmd("br del -f", patterns=["All breakpoints removed. (1 breakpoint)"])
+
+
+class MultiInstanceUnreachableForeignSiteTestCase:
+    test_file = "resources/wasm/multi-instance-unreachable.js"
+
+    def execute(self):
+        # A site on idle instance 1's `unreachable` only. Instance 0 must not stop for a
+        # breakpoint it never asked for, but it must still trap on the instruction itself --
+        # skipping it would swallow the program's own trap and hang.
+        self.session.cmd("b 0x4000000100000024", patterns=["Breakpoint 1"])
+        for _ in range(3):
+            self.session.cmd(
+                "c",
+                patterns=["Process 1 stopped", "Unreachable code should not be executed"],
+            )
+
+        self.session.cmd("br del -f", patterns=["All breakpoints removed. (1 breakpoint)"])
+
+
+class MultiInstanceUnreachableBothSitesTestCase:
+    test_file = "resources/wasm/multi-instance-unreachable.js"
+
+    def execute(self):
+        # Sites on both instances' `unreachable`. Instance 0 stops for its own, then traps; the
+        # sibling's site never claims the stop. Single-pass for the reason spelled out in
+        # MultiInstanceUnreachableOwnSiteTestCase -- do not wrap these in a loop.
+        self.session.cmd("b 0x4000000100000024", patterns=["Breakpoint 1"])
+        self.session.cmd("b 0x4000000000000024", patterns=["Breakpoint 2"])
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 2", "->  0x4000000000000024: unreachable"],
+        )
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "Unreachable code should not be executed"],
+        )
+
+        # Dropping instance 0's site leaves the byte patched for the sibling. Instance 0 now only
+        # ever sees the trap.
+        self.session.cmd("br del 2", patterns=["1 breakpoints deleted"])
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "Unreachable code should not be executed"],
+        )
+
+        self.session.cmd("br del -f", patterns=["All breakpoints removed. (1 breakpoint)"])
+
+
+class MultiInstanceUnreachableStepTestCase:
+    test_file = "resources/wasm/multi-instance-unreachable.js"
+
+    def execute(self):
+        # Stepping onto, and then off, a real `unreachable` while instance 1's site keeps the
+        # preceding nop patched. The first si crosses the shared patch; the second executes the
+        # unreachable, which must surface as the trap rather than as another breakpoint stop.
+        self.session.cmd("b 0x4000000100000023", patterns=["Breakpoint 1"])
+        self.session.cmd("b 0x4000000000000023", patterns=["Breakpoint 2"])
+        for _ in range(3):
+            self.session.cmd(
+                "c",
+                patterns=["Process 1 stopped", "stop reason = breakpoint 2", "->  0x4000000000000023: nop"],
+            )
+            self.session.cmd("si")
+            self.session.cmd("dis", patterns=["->  0x4000000000000024: unreachable"])
+            self.session.cmd("si", patterns=["Unreachable code should not be executed"])
+
+        self.session.cmd("br del -f", patterns=["All breakpoints removed. (2 breakpoints)"])
+
+
+class MultiInstanceBothRunningTestCase:
+    test_file = "resources/wasm/multi-instance-both-running.js"
+
+    def execute(self):
+        # Both instances execute, alternating, through the same patched byte. Every other case
+        # here keeps one instance idle, which only ever proves the negative -- that a sibling's
+        # site does not fire. This proves the positive at the same time: with a site on instance
+        # 1 alone, instance 0 runs through that byte between every pair of stops and must never
+        # claim one, so each reported address has to be instance 1's.
+        self.session.cmd("image list", patterns=["mymodule@0", "mymodule@1"])
+        self.session.cmd("b 0x4000000100000023", patterns=["Breakpoint 1"])
+        for _ in range(4):
+            self.session.cmd(
+                "c",
+                patterns=["Process 1 stopped", "stop reason = breakpoint 1", "->  0x4000000100000023: nop"],
+            )
+
+        # With a site on each, the stops have to alternate in call order -- instance 0 then
+        # instance 1 -- each reported at its own address off the one shared byte.
+        self.session.cmd("b 0x4000000000000023", patterns=["Breakpoint 2"])
+        for _ in range(3):
+            self.session.cmd(
+                "c",
+                patterns=["Process 1 stopped", "stop reason = breakpoint 2", "->  0x4000000000000023: nop"],
+            )
+            self.session.cmd(
+                "c",
+                patterns=["Process 1 stopped", "stop reason = breakpoint 1", "->  0x4000000100000023: nop"],
+            )
+
+        # Dropping instance 0's site must leave instance 1 stopping and instance 0 running free.
+        self.session.cmd("br del 2", patterns=["1 breakpoints deleted"])
+        for _ in range(3):
+            self.session.cmd(
+                "c",
+                patterns=["Process 1 stopped", "stop reason = breakpoint 1", "->  0x4000000100000023: nop"],
+            )
+
+        self.session.cmd("br del -f", patterns=["All breakpoints removed. (1 breakpoint)"])
+
+
+class MultiInstanceForeignSiteOpcodeShapesTestCase:
+    test_file = "resources/wasm/multi-instance-same-module.js"
+
+    def execute(self):
+        # The filter resumes a non-owning instance by dispatching the displaced opcode instead of
+        # re-reading the patched byte. Everywhere else that path only ever replays `nop`: one
+        # byte, no immediate, PC+1 -- the shape least likely to expose a bug. Patch the rest of
+        # the body through the idle instance so instance 0 has to replay an opcode with an
+        # immediate (i32.const 42), a stack op (drop) and a block terminator (end) on every pass.
+        # A mis-dispatched immediate or a PC left unadvanced would desync the decoder within a
+        # lap or two rather than quietly returning to the nop each time.
+        self.session.cmd("b 0x4000000100000024", patterns=["Breakpoint 1"])
+        self.session.cmd("b 0x4000000100000026", patterns=["Breakpoint 2"])
+        self.session.cmd("b 0x4000000100000027", patterns=["Breakpoint 3"])
+        self.session.cmd("b 0x4000000000000023", patterns=["Breakpoint 4"])
+        for _ in range(5):
+            self.session.cmd(
+                "c",
+                patterns=["Process 1 stopped", "stop reason = breakpoint 4", "->  0x4000000000000023: nop"],
+            )
+
+        # The instruction stream still decodes as written, so nothing walked off the opcode
+        # boundaries while replaying.
+        self.session.cmd(
+            "dis",
+            patterns=[
+                "->  0x4000000000000023: nop",
+                "0x4000000000000024: i32.const 42",
+                "0x4000000000000026: drop",
+                "0x4000000000000027: end",
+            ],
+        )
+
+        # Stepping has to cross all three foreign patches too, not just run past them.
+        for pattern in [
+            ["->  0x4000000000000024: i32.const 42"],
+            ["->  0x4000000000000026: drop"],
+            ["->  0x4000000000000027: end"],
+        ]:
+            self.session.cmd("si")
+            self.session.cmd("dis", patterns=pattern)
+
+        self.session.cmd("br del -f", patterns=["All breakpoints removed. (4 breakpoints)"])
+
+
+class MultiInstanceThreeInstancesTestCase:
+    test_file = "resources/wasm/multi-instance-three.js"
+
+    def execute(self):
+        # Three sites on one byte. The requester set has to outlive each removal but the last,
+        # which two instances cannot distinguish from a plain refcount of one.
+        self.session.cmd("image list", patterns=["mymodule@0", "mymodule@1", "mymodule@2"])
+        self.session.cmd("b 0x4000000200000023", patterns=["Breakpoint 1"])
+        self.session.cmd("b 0x4000000100000023", patterns=["Breakpoint 2"])
+        self.session.cmd("b 0x4000000000000023", patterns=["Breakpoint 3"])
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 3", "->  0x4000000000000023: nop"],
+        )
+
+        # Peel the two idle instances off one at a time. Instance 0 keeps stopping throughout.
+        self.session.cmd("br del 1", patterns=["1 breakpoints deleted"])
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 3", "->  0x4000000000000023: nop"],
+        )
+        self.session.cmd("br del 2", patterns=["1 breakpoints deleted"])
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 3", "->  0x4000000000000023: nop"],
+        )
+
+        # Removing the last claim restores the byte, so the nop stops being a stop at all.
+        self.session.cmd("b 0x4000000000000026", patterns=["Breakpoint 4"])
+        self.session.cmd("br del 3", patterns=["1 breakpoints deleted"])
+        for _ in range(2):
+            self.session.cmd(
+                "c",
+                patterns=["Process 1 stopped", "stop reason = breakpoint 4", "->  0x4000000000000026: drop"],
+            )
+
+        self.session.cmd("br del -f", patterns=["All breakpoints removed. (1 breakpoint)"])
 
 
 class ModuleNamingFromNameSectionTestCase:
@@ -1703,7 +2196,7 @@ class ModuleNamingFromNameSectionTestCase:
     extra_jsc_options = ["--useDollarVM=1"]
 
     def execute(self):
-        self.session.cmd("image list", patterns=["mymodule"])
+        self.session.cmd("image list", patterns=["mymodule@0"])
 
         # Set a breakpoint at func_a's 'end' instruction by virtual address.
         self.session.cmd("b 0x4000000000000023", patterns=["Breakpoint 1"])
@@ -1719,7 +2212,7 @@ class StreamingModuleSourceURLTestCase:
     extra_jsc_options = ["--useDollarVM=1"]
 
     def execute(self):
-        self.session.cmd("image list", patterns=["cdn.example.com/path/canvaskit.wasm"])
+        self.session.cmd("image list", patterns=["cdn.example.com/path/canvaskit.wasm@0"])
 
         # Set a breakpoint at func_b's 'end' instruction by virtual address.
         self.session.cmd("b 0x4000000000000023", patterns=["Breakpoint 1"])
@@ -1793,6 +2286,20 @@ ALL_TESTS = [
     WasmOobMemoryTrapTestCase,
     DynamicModuleLoadTestCase,
     SwiftWasmDynamicModuleLoadTestCase,
+    MultiInstanceCallerFrameTestCase,
+    MultiInstanceSameModuleTestCase,
+    MultiInstanceForeignSiteIgnoredTestCase,
+    MultiInstanceStepOverSharedPatchTestCase,
+    MultiInstanceBreakpointDisableTestCase,
+    MultiInstanceBreakpointDeleteTestCase,
+    MultiInstanceUnreachableOwnSiteTestCase,
+    MultiInstanceUnreachableForeignSiteTestCase,
+    MultiInstanceUnreachableBothSitesTestCase,
+    MultiInstanceUnreachableStepTestCase,
+    MultiInstanceBothRunningTestCase,
+    MultiInstanceForeignSiteOpcodeShapesTestCase,
+    MultiInstanceThreeInstancesTestCase,
+    SwiftWasmMultiInstanceTestCase,
     ModuleNamingFromNameSectionTestCase,
     StreamingModuleSourceURLTestCase,
     StreamingModuleLoadTestCase,

--- a/Source/JavaScriptCore/wasm/WasmModule.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModule.cpp
@@ -29,7 +29,6 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include "JSWebAssemblyInstance.h"
-#include "WasmDebugServer.h"
 #include "WasmIPIntPlan.h"
 #include "WasmInstanceAnchor.h"
 #include "WasmMergedProfile.h"
@@ -47,19 +46,10 @@ Module::Module(IPIntPlan& plan, Name&& sourceURL)
 {
     if (!sourceURL.isEmpty())
         m_moduleInformation->sourceURL = WTF::move(sourceURL);
-
-#if ENABLE(WEBASSEMBLY_DEBUGGER)
-    if (Options::enableWasmDebugger()) [[unlikely]]
-        Wasm::DebugServer::singleton().trackModule(*this);
-#endif
 }
 
 Module::~Module()
 {
-#if ENABLE(WEBASSEMBLY_DEBUGGER)
-    if (Options::enableWasmDebugger()) [[unlikely]]
-        Wasm::DebugServer::singleton().untrackModule(*this);
-#endif
 }
 
 Wasm::RTT const& Module::rttFromFunctionIndexSpace(FunctionSpaceIndex functionIndexSpace) const
@@ -176,11 +166,6 @@ std::unique_ptr<MergedProfile> Module::createMergedProfile(const IPIntCallee& ca
     }
     return result;
 }
-
-#if ENABLE(WEBASSEMBLY_DEBUGGER)
-uint32_t Module::debugId() const { return m_moduleInformation->debugInfo->id; }
-void Module::setDebugId(uint32_t id) { m_moduleInformation->debugInfo->id = id; }
-#endif
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/WasmModule.h
+++ b/Source/JavaScriptCore/wasm/WasmModule.h
@@ -93,11 +93,6 @@ public:
 
     std::unique_ptr<MergedProfile> createMergedProfile(const IPIntCallee&);
 
-#if ENABLE(WEBASSEMBLY_DEBUGGER)
-    JS_EXPORT_PRIVATE uint32_t NODELETE debugId() const;
-    void NODELETE setDebugId(uint32_t);
-#endif
-
 private:
     Ref<CalleeGroup> getOrCreateCalleeGroup(VM&, MemoryMode);
 

--- a/Source/JavaScriptCore/wasm/debugger/README.md
+++ b/Source/JavaScriptCore/wasm/debugger/README.md
@@ -77,7 +77,7 @@ The implementation follows the **GDB Remote Serial Protocol** standard with [was
 
 #### 3. **Helper Classes** - Supporting Components
 
-- **ModuleManager**: Virtual address space management and module tracking
+- **ModuleManager**: Virtual address space management, module and instance tracking
 - **BreakpointManager**: Breakpoint storage and management
 - **VirtualAddress**: 64-bit virtual address encoding for LLDB compatibility
 
@@ -88,12 +88,12 @@ The debugger uses a sophisticated virtual address encoding system to present Web
 ```txt
 Address Format (64-bit):
 - Bits 63-62: Address Type (2 bits)
-- Bits 61-32: ID (30 bits) - ModuleID for code, InstanceID for memory
+- Bits 61-32: InstanceId (30 bits)
 - Bits 31-0:  Offset (32 bits)
 
 Address Types:
-- 0x00 (Memory): Instance linear memory
-- 0x01 (Module): Module code/bytecode
+- 0x00 (Memory): The instance's linear memory
+- 0x01 (Module): The instance's view of its module image (bytecode)
 - 0x02 (Invalid): Invalid/unmapped regions
 - 0x03 (Invalid2): Invalid/unmapped regions
 
@@ -102,6 +102,30 @@ Virtual Memory Layout:
 - 0x4000000000000000 - 0x7FFFFFFFFFFFFFFF: Module regions
 - 0x8000000000000000 - 0xFFFFFFFFFFFFFFFF: Invalid regions
 ```
+
+Wasm scopes linear memory, globals, tables, and data segments to an instance rather than a
+module, so both halves of the address space are keyed by instance ID. Every live instance receives
+its own library entry, module image, and linear memory region. That ID also identifies the
+instance in `qWasmGlobal`. The protocol only requires IDs to be unique among live instances, but
+they are allocated monotonically and never reused to prevent aliasing stale addresses in LLDB.
+Modules carry no debugger-assigned identity.
+
+LLDB merges libraries that share a name, so libraries are named `<declared-name>@<instance-id>`.
+Because instance IDs are globally unique, library names remain distinct even when modules share a
+declared name. Modules declaring neither a name section nor a source URL fall back to
+`0x<image-base>.wasm`.
+
+Instances of a module share one bytecode buffer, so a breakpoint patches that buffer once for all
+of them. A site, though, belongs to the instance its address names: LLDB gives every instance its
+own library and installs one site in each, and only that instance stops there. A sibling reaching
+the same patched byte resumes through it — dispatching the opcode the patch displaced — without
+reporting a stop. Setting a breakpoint by symbol name still covers every instance, because the
+symbol resolves once per library. The patch is lifted only once the last site referring to it and
+any step in flight are both gone.
+
+The patch byte is `0x00`, which is `unreachable`. Where the bytecode really is an `unreachable`
+the patch displaces nothing, so that byte reports the breakpoint and then the trap it hides;
+returning it as a resume opcode would throw a trap LLDB was never told about.
 
 ## Testing
 
@@ -234,8 +258,8 @@ The following references correspond to the numbered citations used throughout th
 - [19] [qWasmInstance](https://lldb.llvm.org/resources/lldbgdbremote.html#qwasminstance-qsupported-feature) —
   advertised in the `qSupported` reply to opt into naming a module instance in a Wasm query. It
   adds the form `qWasmGlobal:<global-index>;instance:<instance-id>;`, which reads a global from a
-  named instance rather than from the instance a stack frame is executing. The instance id is the
-  id a Wasm virtual address carries in bits 61:32, which is a module id. Added to LLDB by
+  named instance rather than from the instance a stack frame is executing. The instance ID is the
+  ID a Wasm virtual address carries in bits 61:32. Added to LLDB by
   [llvm/llvm-project#213176](https://github.com/llvm/llvm-project/pull/213176), resolving
-  [llvm/llvm-project#212833](https://github.com/llvm/llvm-project/issues/212833). A module with no
-  live instance, or with more than one, has no single value to report and answers with an error.
+  [llvm/llvm-project#212833](https://github.com/llvm/llvm-project/issues/212833). An ID with no
+  live instance answers with an error.

--- a/Source/JavaScriptCore/wasm/debugger/RWI_ARCHITECTURE.md
+++ b/Source/JavaScriptCore/wasm/debugger/RWI_ARCHITECTURE.md
@@ -273,17 +273,17 @@ Unlike Web Inspector which initializes/tears down controllers per page, WebAssem
 
 **Virtual Address Space Fragmentation** (Critical Technical Limitation):
    LLDB requires a **unified virtual address space** for debugging. With per-page targets:
-   - Each page would have its own Module ID 0, creating address collisions
+   - Each page would have its own instance ID 0, creating address collisions
    - LLDB breakpoint at virtual address `0x4000000000000100` - which page does this refer to?
-   - Same module in different pages would report different IDs, breaking module sharing
+   - The same module instantiated in two pages would report colliding IDs, so neither its code nor
+     its memory could be named unambiguously
    - Memory inspection fails (instance IDs would overlap between pages)
    - Stack traces and disassembly become ambiguous
 
    Process-wide target provides:
-   - Global module ID allocation (Module A = ID 0 across ALL pages)
-   - Unique instance IDs (each page's instance gets unique ID)
+   - Global instance ID allocation (each instance gets an ID unique across ALL pages)
    - Coherent virtual address space LLDB expects
-   - Stable addresses for breakpoints regardless of which page uses the module
+   - Stable addresses for the life of an instance, regardless of which page owns it
 
    > **Technical Details**: See [README.md](./README.md) for virtual address encoding format.
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.cpp
@@ -68,7 +68,7 @@ void BreakpointManager::releasePatchIfUnused(uint8_t* pc)
 {
     auto it = m_breakpoints.find(pc);
     RELEASE_ASSERT(it != m_breakpoints.end());
-    if (it->value->hasSite || m_oneTimeBreakpoints.contains(pc))
+    if (it->value->siteCount || m_oneTimeBreakpoints.contains(pc))
         return;
 
     dataLogLnIf(Options::verboseWasmDebugger(), "[BreakpointManager] Restoring ", it->value);
@@ -83,42 +83,78 @@ void BreakpointManager::setStepBreakpoint(const ModuleInformation& owner, uint8_
     m_oneTimeBreakpoints.add(pc);
 }
 
+RefPtr<Breakpoint> BreakpointManager::breakpointAt(const uint8_t* pc)
+{
+    Locker locker { m_lock };
+    return m_breakpoints.get(const_cast<uint8_t*>(pc));
+}
+
 void BreakpointManager::setBreakpointAt(VirtualAddress address, const ModuleInformation& owner, uint8_t* pc)
 {
     Locker locker { m_lock };
-    // Re-arming an existing site is a no-op.
+    // Re-arming an existing site is a no-op. An address names one instance's view of one byte and
+    // IDs are never reused, so it always resolves to this pc.
     auto result = m_addressToPC.add(address, pc);
     if (!result.isNewEntry) {
         RELEASE_ASSERT(result.iterator->value == pc);
         return;
     }
-    ensurePatched(owner, pc).hasSite = true;
+    ensurePatched(owner, pc).siteCount++;
 }
 
-bool BreakpointManager::removeBreakpointAt(VirtualAddress address)
+bool BreakpointManager::removeSiteImpl(VirtualAddress address)
 {
-    Locker locker { m_lock };
+    // Resolved from the address LLDB installed the site through rather than from a live instance:
+    // the bytecode outlives the instance that named it.
     uint8_t* pc = m_addressToPC.take(address);
     if (!pc)
         return false;
 
     auto it = m_breakpoints.find(pc);
     RELEASE_ASSERT(it != m_breakpoints.end());
-    it->value->hasSite = false;
+    // Sibling instances hold their own sites on the same byte, so the patch outlives every
+    // removal but the last.
+    RELEASE_ASSERT(it->value->siteCount);
+    it->value->siteCount--;
     releasePatchIfUnused(pc);
     return true;
 }
 
-std::optional<BreakpointManager::TrapAction> BreakpointManager::trapActionFor(uint8_t* pc)
+bool BreakpointManager::removeBreakpointAt(VirtualAddress address)
 {
     Locker locker { m_lock };
-    auto it = m_breakpoints.find(pc);
+    return removeSiteImpl(address);
+}
+
+void BreakpointManager::removeSitesForInstance(uint32_t instanceId)
+{
+    Locker locker { m_lock };
+    Vector<VirtualAddress> staleSites;
+    for (const auto& pair : m_addressToPC) {
+        if (pair.key.instanceId() == instanceId)
+            staleSites.append(pair.key);
+    }
+    for (VirtualAddress address : staleSites) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[BreakpointManager] Dropping site ", address, " of collected instance ", instanceId);
+        removeSiteImpl(address);
+    }
+}
+
+std::optional<BreakpointManager::TrapAction> BreakpointManager::trapActionFor(const uint8_t* pc, VirtualAddress hitAddress)
+{
+    Locker locker { m_lock };
+    auto it = m_breakpoints.find(const_cast<uint8_t*>(pc));
     if (it == m_breakpoints.end())
         return std::nullopt;
 
-    // A breakpoint site takes precedence over a step.
-    Breakpoint::Type stopType = it->value->hasSite ? Breakpoint::Type::Regular : Breakpoint::Type::Step;
-    return TrapAction { static_cast<OpType>(it->value->originalBytecode), stopType };
+    TrapAction action { static_cast<OpType>(it->value->originalBytecode), std::nullopt };
+    // A site names one instance; a sibling sharing the patched byte has no breakpoint here. A
+    // site wins over a step at the same byte, so a step never masks a user breakpoint's reason.
+    if (m_addressToPC.get(hitAddress) == pc)
+        action.stopType = Breakpoint::Type::Regular;
+    else if (m_oneTimeBreakpoints.contains(const_cast<uint8_t*>(pc)))
+        action.stopType = Breakpoint::Type::Step;
+    return action;
 }
 
 void BreakpointManager::clearAllOneTimeBreakpoints()

--- a/Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.h
@@ -40,7 +40,13 @@
 namespace JSC {
 namespace Wasm {
 
-// A bytecode patch persists while either a breakpoint site or single-step references it.
+// A bytecode patch persists while either a breakpoint site or single-step references it. Instances
+// of a module share one bytecode buffer, so a breakpoint patches that buffer once for all of them.
+//
+// Sites are scoped to the instance their address names. LLDB gives every instance its own library
+// and places a site in each, so a site says "stop this instance here", not "stop this bytecode".
+// A sibling instance reaching the same patched byte has no breakpoint there and resumes through
+// the patch without reporting a stop.
 class JS_EXPORT_PRIVATE BreakpointManager {
     WTF_MAKE_TZONE_ALLOCATED(BreakpointManager);
 
@@ -48,26 +54,39 @@ public:
     BreakpointManager() = default;
     ~BreakpointManager();
 
+    // What the interpreter should do with a trap raised by a patched byte.
     struct TrapAction {
-        OpType displacedOpcode { OpType::Unreachable };
-        Breakpoint::Type stopType { Breakpoint::Type::Regular };
+        OpType displacedOpcode { OpType::Unreachable }; // The opcode the patch replaced; resuming dispatches it.
+        // Absent when nothing at this PC belongs to the instance that reached it.
+        std::optional<Breakpoint::Type> stopType;
     };
 
     bool hasOneTimeBreakpoints();
 
-    std::optional<TrapAction> trapActionFor(uint8_t* pc);
+    // Absent when no breakpoint patched this PC, i.e. the trap is a genuine `unreachable`.
+    std::optional<TrapAction> trapActionFor(const uint8_t* pc, VirtualAddress hitAddress);
 
+    // One-time breakpoints serving a step. Not instance scoped: a step belongs to the debuggee
+    // VM, which is the only one running while it is in flight.
     void setStepBreakpoint(const ModuleInformation& owner, uint8_t* pc);
     void clearAllOneTimeBreakpoints();
 
+    // Breakpoint sites installed by LLDB (Z0/z0), scoped to the instance the address names.
     void setBreakpointAt(VirtualAddress, const ModuleInformation& owner, uint8_t* pc);
     bool removeBreakpointAt(VirtualAddress);
 
+    // Drops the sites an instance held. LLDB unloads the library of a collected instance without
+    // sending z0 for the sites in it, so nothing else releases the patch they keep alive.
+    void removeSitesForInstance(uint32_t instanceId);
+
     void clearAllBreakpoints();
+
+    RefPtr<Breakpoint> breakpointAt(const uint8_t* pc); // FIXME: Should be used for test only
 
 private:
     Breakpoint& ensurePatched(const ModuleInformation& owner, uint8_t* pc) WTF_REQUIRES_LOCK(m_lock);
     void releasePatchIfUnused(uint8_t* pc) WTF_REQUIRES_LOCK(m_lock);
+    bool removeSiteImpl(VirtualAddress) WTF_REQUIRES_LOCK(m_lock);
 
     mutable Lock m_lock;
     UncheckedKeyHashMap<uint8_t*, Ref<Breakpoint>> m_breakpoints WTF_GUARDED_BY_LOCK(m_lock);

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp
@@ -443,7 +443,7 @@ void DebugServer::trackInstance(JSWebAssemblyInstance* instance)
     if (!m_moduleManager)
         return;
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Tracking WebAssembly instance: ", RawPointer(instance));
-    // Notify the debugger here (trackInstance) rather than in trackModule for two reasons:
+    // Instantiation, not compilation, is what the debugger tracks, for two reasons:
     // 1. Module::create covers both the synchronous and streaming-async compilation paths.
     //    In the async path the JS thread is not at a JS safepoint when the module is created,
     //    so a stop-the-world request would only fire at the next safepoint — too late for the
@@ -452,25 +452,11 @@ void DebugServer::trackInstance(JSWebAssemblyInstance* instance)
     // 2. A Module can be compiled speculatively without ever being instantiated (e.g. via
     //    WebAssembly.compile). Only when a JSWebAssemblyInstance is created do we know the
     //    module will actually be used, making this the right moment to notify LLDB.
+    // Every instance is a library of its own, so a second instance of a known module is a load
+    // LLDB has to hear about too.
     m_moduleManager->registerInstance(instance);
-    if (isDebuggerReady() && m_moduleManager->needsNewModuleNotification(instance))
-        m_executionHandler->notifyDebuggerOfNewModule(instance->vm());
-}
-
-void DebugServer::trackModule(Module& module)
-{
-    if (!m_moduleManager)
-        return;
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Tracking WebAssembly module: ", RawPointer(&module));
-    m_moduleManager->registerModule(module);
-}
-
-void DebugServer::untrackModule(Module& module)
-{
-    if (!m_moduleManager)
-        return;
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Untracking WebAssembly module: ", RawPointer(&module));
-    m_moduleManager->unregisterModule(module);
+    if (isDebuggerReady())
+        m_executionHandler->notifyDebuggerOfNewInstance(instance->vm());
 }
 
 bool DebugServer::hasDebugger() const

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h
@@ -103,8 +103,6 @@ public:
 #endif
 
     void trackInstance(JSWebAssemblyInstance*);
-    void trackModule(Module&);
-    void untrackModule(Module&);
 
     void setPort(uint64_t port) { m_port = port; }
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
@@ -100,9 +100,11 @@ private:
 class Breakpoint final : public ThreadSafeRefCounted<Breakpoint> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(Breakpoint, JS_EXPORT_PRIVATE);
 public:
+    // Why a stop happened, which is a property of the hit rather than of the patched byte: one
+    // byte can carry both an LLDB site and a step at once.
     enum class Type : uint8_t {
-        Regular = 0,
-        Step = 1,
+        Regular = 0, // A site LLDB installed (Z0), reported as reason:breakpoint.
+        Step = 1, // A one-time breakpoint serving a step, reported as reason:trace.
     };
 
     static Ref<Breakpoint> create(const ModuleInformation& owner, uint8_t* pc)
@@ -118,14 +120,15 @@ public:
         out.print("Breakpoint(pc:", RawPointer(pc));
         out.print(", *pc:", (int)*pc);
         out.print(", originalBytecode:", originalBytecode);
-        out.print(", hasSite:", hasSite, ")");
+        out.print(", siteCount:", siteCount, ")");
     }
 
     // Keeps the bytecode buffer alive.
     RefPtr<const ModuleInformation> owner;
     uint8_t* pc { nullptr };
     uint8_t originalBytecode { 0 };
-    bool hasSite { false };
+    // LLDB sites referring to this byte, one per instance. The patch outlives all of them.
+    unsigned siteCount { 0 };
 
 private:
     Breakpoint(const ModuleInformation& owner, uint8_t* pc)

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -133,16 +133,27 @@ void ExecutionHandler::stopTheWorld(VM& debuggee, StopTheWorldEvent event)
     VMManager::singleton().notifyVMStop(debuggee, event);
 }
 
+// Instances of a module share the bytecode a breakpoint patches, so the patch cannot be lifted to
+// let one of them past it. Resuming dispatches the opcode the breakpoint displaced instead of
+// re-reading the patched bytecode, which keeps the breakpoint armed for every other instance.
 OpType ExecutionHandler::handleDebuggerTrapIfNeeded(CallFrame* callFrame, JSWebAssemblyInstance* instance, IPIntCallee* callee, uint8_t* pc, uint8_t* mc, IPInt::IPIntStackEntry* stack, Wasm::ExceptionType exceptionType)
 {
     VM& debuggee = instance->vm();
     if (exceptionType == Wasm::ExceptionType::Unreachable) {
-        if (auto action = m_breakpointManager->trapActionFor(pc)) {
-            VirtualAddress address = VirtualAddress::toVirtual(instance, callee->functionIndex(), pc);
-            debuggee.debugState()->setBreakpointStopData(action->stopType, address, action->displacedOpcode, pc, mc, stack, callee, instance, callFrame);
-            dataLogLnIf(Options::verboseWasmDebugger(), "[Code][handleDebuggerTrapIfNeeded] Breakpoint with ", *debuggee.debugState()->stopData);
-            stopTheWorld(debuggee, StopTheWorldEvent::WasmProgramStop);
-            // If the breakpoint was on an unreachable instruction, fall through to report the trap.
+        VirtualAddress address = VirtualAddress::toVirtual(instance, callee->functionIndex(), pc);
+        if (auto action = m_breakpointManager->trapActionFor(pc, address)) {
+            if (action->stopType) {
+                debuggee.debugState()->setBreakpointStopData(*action->stopType, address, action->displacedOpcode, pc, mc, stack, callee, instance, callFrame);
+                dataLogLnIf(Options::verboseWasmDebugger(), "[Code][handleDebuggerTrapIfNeeded] Breakpoint with ", *debuggee.debugState()->stopData);
+                stopTheWorld(debuggee, StopTheWorldEvent::WasmProgramStop);
+            } else {
+                // A sibling instance's site patched this byte, and a site only speaks for the
+                // instance it names.
+                dataLogLnIf(Options::verboseWasmDebugger(), "[Code][handleDebuggerTrapIfNeeded] No site for ", address, ", resuming through the patch");
+            }
+            // The patch displaced Unreachable only where the bytecode really is an `unreachable`,
+            // so fall through and report that trap too: returning it here would throw a trap LLDB
+            // was never told about. Otherwise resuming dispatches the displaced opcode.
             if (action->displacedOpcode != OpType::Unreachable)
                 return action->displacedOpcode;
         }
@@ -338,7 +349,7 @@ void ExecutionHandler::resumeImpl(Locker<Lock>& locker)
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Continue] Confirmed that code is running...");
 }
 
-void ExecutionHandler::notifyDebuggerOfNewModule(VM& vm)
+void ExecutionHandler::notifyDebuggerOfNewInstance(VM& vm)
 {
     vm.debugState()->isNewModuleLoad = true;
     stopTheWorld(vm, StopTheWorldEvent::WasmProgramStop);
@@ -646,15 +657,23 @@ void ExecutionHandler::setBreakpoint(StringView packet)
     if (!requireModuleAddress(address))
         return;
 
-    uint8_t* pc = address.toPhysicalPC(m_moduleManager);
-    RefPtr module = m_moduleManager.module(address.id());
-    if (!pc || !module) {
+    JSWebAssemblyInstance* instance = m_moduleManager.jsInstance(address.instanceId());
+    if (!instance) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] No live instance for ", address);
+        sendErrorReply(ProtocolError::InvalidAddress);
+        return;
+    }
+
+    uint8_t* pc = address.toPhysicalPC(*instance);
+    if (!pc) {
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] No module bytecode at ", address);
         sendErrorReply(ProtocolError::InvalidAddress);
         return;
     }
 
-    m_breakpointManager->setBreakpointAt(address, module->moduleInformation(), pc);
+    // Idempotent: LLDB sends one Z0 per instance for shared bytecode. The address is
+    // recorded so the patch survives until all sites referring to it are removed.
+    m_breakpointManager->setBreakpointAt(address, instance->moduleInformation(), pc);
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][SetBreakpoint] Successfully set breakpoint at ", address, " (physical: ", RawPointer(pc), ")");
     sendReplyOK();
 }
@@ -692,6 +711,7 @@ void ExecutionHandler::removeBreakpoint(StringView packet)
     if (!requireModuleAddress(address))
         return;
 
+    // Resolved from the installed address so removal works even after an instance is collected.
     if (!m_breakpointManager->removeBreakpointAt(address))
         dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] No breakpoint to remove at ", address);
     sendReplyOK();
@@ -811,20 +831,24 @@ void ExecutionHandler::sendStopReplyForThread(AbstractLocker& locker, uint64_t v
     reply.append("00:"_s, toNativeEndianHex(getStopPC(*state)), ';');
     reply.append("reason:"_s, stopInfo.reasonSuffix, ';');
 
-    // Append library:; to prompt LLDB to re-query qXfer:libraries:read when there are pending
-    // library changes: (1) new-module-load stop, (2) piggybacked on any natural stop when a module
-    // was loaded but no dedicated stop fired yet, (3) module removal via unregisterModule().
+    // Sweeps collected instances, so drain what they left behind before using the result. The
+    // world is stopped here, which is what makes unpatching bytecode safe.
+    bool requeryLibraries = m_moduleManager.needsLibraryRequery();
+    for (uint32_t instanceId : m_moduleManager.takeCollectedInstanceIds())
+        m_breakpointManager->removeSitesForInstance(instanceId);
+
+    // Prompt LLDB to re-query libraries on new instances or instance teardown.
     // Gated on isDebuggerReady() to avoid sending library:; in the ? reply before the initial
     // qXfer:libraries:read handshake completes.
-    if (m_moduleManager.needsLibraryRequery() && m_debugServer.isDebuggerReady()) {
+    if (requeryLibraries && m_debugServer.isDebuggerReady()) {
         reply.append("library:;"_s);
-        // Include a human-readable description only for dedicated new-module-load stops.
+        // Include a human-readable description only for dedicated new-instance-load stops.
         if (state->isNewModuleLoad) {
             RELEASE_ASSERT(state->isStoppedAtSystemCall());
             reply.append("description:"_s);
             StringBuilder description;
-            description.append("loaded new wasm module with ids: "_s);
-            auto ids = m_moduleManager.unnotifiedModuleIds();
+            description.append("loaded new wasm module instance with ids: "_s);
+            auto ids = m_moduleManager.unnotifiedInstanceIds();
             for (size_t i = 0; i < ids.size(); ++i) {
                 if (i)
                     description.append(", "_s);
@@ -924,7 +948,7 @@ String ExecutionHandler::callStackStringFor(uint64_t vmId)
         targetVM = findVM(vmId);
 
     if (!targetVM) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[ExecutionHandler] callStackStringFor: thread ", vmId, " not found");
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] callStackStringFor: thread ", vmId, " not found");
         return String();
     }
 
@@ -941,7 +965,7 @@ String ExecutionHandler::callStackStringFor(uint64_t vmId)
         for (const auto& frame : frames)
             result.append(toNativeEndianHex(frame.address));
 
-        dataLogLnIf(Options::verboseWasmDebugger(), "[ExecutionHandler] callStackStringFor: collected ", frames.size(), " frames");
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] callStackStringFor: collected ", frames.size(), " frames");
         return result.toString();
     }
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
@@ -84,7 +84,7 @@ public:
     JS_EXPORT_PRIVATE void resume();
     JS_EXPORT_PRIVATE void step();
     JS_EXPORT_PRIVATE void interrupt();
-    void notifyDebuggerOfNewModule(VM&);
+    void notifyDebuggerOfNewInstance(VM&);
     void handleThreadStopInfo(StringView packet);
     String callStackStringFor(uint64_t threadId);
     JS_EXPORT_PRIVATE void reset();

--- a/Source/JavaScriptCore/wasm/debugger/WasmMemoryHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmMemoryHandler.cpp
@@ -31,7 +31,6 @@
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #include "JSWebAssemblyInstance.h"
-#include "JSWebAssemblyModule.h"
 #include "Options.h"
 #include "WasmDebugServer.h"
 #include "WasmDebugServerUtilities.h"
@@ -95,14 +94,14 @@ void MemoryHandler::read(StringView packet)
 
 bool MemoryHandler::readModuleData(VirtualAddress address, size_t length, StringBuilder& data)
 {
-    uint32_t id = address.id();
+    uint32_t instanceId = address.instanceId();
     uint32_t offset = address.offset();
 
-    RefPtr module = m_debugServer.m_moduleManager->module(id);
-    if (!module)
+    JSWebAssemblyInstance* jsInstance = m_debugServer.m_moduleManager->jsInstance(instanceId);
+    if (!jsInstance)
         return false;
 
-    const auto& source = module->moduleInformation().debugInfo->source;
+    const auto& source = jsInstance->moduleInformation().debugInfo->source;
     if (!offset && source.size() < length) {
         // FIXME: This is a workaround for tiny modules - clamp initial read at offset 0.
         // Cannot clamp at non-zero offsets as it corrupts DWARF debug info in LLDB.
@@ -116,13 +115,13 @@ bool MemoryHandler::readModuleData(VirtualAddress address, size_t length, String
     for (size_t i = 0; i < length; ++i)
         data.append(hex(source[offset + i], 2, Lowercase));
 
-    dataLogLnIf(Options::verboseWasmDebugger(), "[MemoryHandler] - read ", length, " bytes at offset: ", offset, " from module ID: ", id);
+    dataLogLnIf(Options::verboseWasmDebugger(), "[MemoryHandler] - read ", length, " bytes at offset: ", offset, " from instance ID: ", instanceId);
     return true;
 }
 
 bool MemoryHandler::readMemoryData(VirtualAddress address, size_t length, StringBuilder& data)
 {
-    uint32_t instanceId = address.id();
+    uint32_t instanceId = address.instanceId();
     uint32_t offset = address.offset();
 
     JSWebAssemblyInstance* jsInstance = m_debugServer.m_moduleManager->jsInstance(instanceId);
@@ -166,17 +165,17 @@ void MemoryHandler::handleMemoryRegionInfo(StringView packet)
     dataLogLnIf(Options::verboseWasmDebugger(), "[MemoryHandler] qMemoryRegionInfo for address: ", address);
 
     VirtualAddress::Type addressType = address.type();
-    uint32_t id = address.id();
+    uint32_t instanceId = address.instanceId();
     uint32_t offset = address.offset();
 
-    dataLogLnIf(Options::verboseWasmDebugger(), "[MemoryHandler] qMemoryRegionInfo: address=", address, ", type=", (int)addressType, ", id=", id, ", offset=0x", hex(offset, Lowercase));
+    dataLogLnIf(Options::verboseWasmDebugger(), "[MemoryHandler] qMemoryRegionInfo: address=", address, ", type=", (int)addressType, ", instance=", instanceId, ", offset=0x", hex(offset, Lowercase));
 
     switch (addressType) {
     case VirtualAddress::Type::Memory:
-        handleWasmMemoryRegionInfo(address, id, offset);
+        handleWasmMemoryRegionInfo(address, instanceId, offset);
         break;
     case VirtualAddress::Type::Module:
-        handleWasmModuleRegionInfo(address, id, offset);
+        handleWasmModuleRegionInfo(address, instanceId, offset);
         break;
     default:
         // Invalid address type - send error
@@ -194,8 +193,7 @@ void MemoryHandler::handleWasmMemoryRegionInfo(VirtualAddress address, uint32_t 
         size_t memorySize = instance->memory(0)->memory().size();
         if (offset < memorySize) {
             // Address is within WASM memory - return the memory region
-            uint32_t moduleId = instance->moduleInformation().debugInfo->id;
-            String name = makeString("wasm_memory_"_s, instanceId, "_"_s, moduleId);
+            String name = makeString("wasm_memory_"_s, instanceId);
             sendMemoryRegionReply(address, memorySize, "rw"_s, name);
             return;
         }
@@ -218,22 +216,21 @@ void MemoryHandler::handleWasmMemoryRegionInfo(VirtualAddress address, uint32_t 
     sendUnmappedRegionReply(address, unmappedSize);
 }
 
-void MemoryHandler::handleWasmModuleRegionInfo(VirtualAddress address, uint32_t moduleId, uint32_t offset)
+void MemoryHandler::handleWasmModuleRegionInfo(VirtualAddress address, uint32_t instanceId, uint32_t offset)
 {
-    JSWebAssemblyInstance* instance = m_debugServer.m_moduleManager->jsInstance(moduleId);
+    JSWebAssemblyInstance* instance = m_debugServer.m_moduleManager->jsInstance(instanceId);
     if (instance) {
-        JSWebAssemblyModule* jsModule = instance->jsModule();
-        const auto& source = jsModule->moduleInformation().debugInfo->source;
+        const auto& source = instance->moduleInformation().debugInfo->source;
         if (offset < source.size()) {
             // Address is within module bounds - return info for the entire WASM module region
-            String name = makeString("wasm_module_"_s, moduleId);
+            String name = makeString("wasm_module_"_s, instanceId);
             sendMemoryRegionReply(address, source.size(), "rx"_s, name, "module"_s);
             return;
         }
     }
 
     uint32_t idUpperBoundary = m_debugServer.m_moduleManager->nextInstanceId();
-    uint32_t nextValidID = moduleId;
+    uint32_t nextValidID = instanceId;
     do {
         if (++nextValidID >= idUpperBoundary) {
             // No more instances - return unmapped region to end of address space
@@ -320,7 +317,7 @@ void MemoryHandler::write(StringView packet)
         return;
     }
 
-    uint32_t instanceId = address.id();
+    uint32_t instanceId = address.instanceId();
     uint32_t offset = address.offset();
 
     JSWebAssemblyInstance* jsInstance = m_debugServer.m_moduleManager->jsInstance(instanceId);

--- a/Source/JavaScriptCore/wasm/debugger/WasmMemoryHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmMemoryHandler.h
@@ -59,7 +59,7 @@ private:
     bool readMemoryData(VirtualAddress, size_t length, StringBuilder& data);
 
     void handleWasmMemoryRegionInfo(VirtualAddress, uint32_t instanceId, uint32_t offset);
-    void handleWasmModuleRegionInfo(VirtualAddress, uint32_t moduleId, uint32_t offset);
+    void handleWasmModuleRegionInfo(VirtualAddress, uint32_t instanceId, uint32_t offset);
     void sendMemoryRegionReply(uint64_t start, uint64_t size, StringView permissions, StringView name);
     void sendMemoryRegionReply(uint64_t start, uint64_t size, StringView permissions, StringView name, StringView type);
     void sendUnmappedRegionReply(uint64_t start, uint64_t size);

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.cpp
@@ -31,7 +31,6 @@
 #include "Options.h"
 #include "WasmIPIntGenerator.h"
 #include "WasmModuleInformation.h"
-#include "WasmVirtualAddress.h"
 #include <wtf/DataLog.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>
@@ -88,10 +87,10 @@ FunctionDebugInfo& ModuleDebugInfo::ensureFunctionDebugInfo(FunctionCodeIndex fu
     return info;
 }
 
-String ModuleDebugInfo::debugName() const
+String ModuleDebugInfo::declaredName() const
 {
-    if (m_cachedDebugName)
-        return *m_cachedDebugName;
+    if (m_cachedDeclaredName)
+        return *m_cachedDeclaredName;
 
     StringBuilder result;
 
@@ -113,15 +112,9 @@ String ModuleDebugInfo::debugName() const
         result.append(rawName.span());
     }
 
-    if (!result.isEmpty())
-        m_cachedDebugName = result.toString();
-    else {
-        // Fallback for modules with neither a name section nor a source URL.
-        m_cachedDebugName = makeString("0x"_s, VirtualAddress::createModule(id).hex(), ".wasm"_s);
-    }
-
-    dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleDebugInfo][debugName] ", *m_cachedDebugName);
-    return *m_cachedDebugName;
+    m_cachedDeclaredName = result.toString();
+    dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleDebugInfo][declaredName] ", *m_cachedDeclaredName);
+    return *m_cachedDeclaredName;
 }
 
 } // namespace Wasm

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.h
@@ -68,17 +68,17 @@ public:
     void takeSource(Vector<uint8_t>&& source) { this->source = WTF::move(source); }
     FunctionDebugInfo& ensureFunctionDebugInfo(FunctionCodeIndex);
 
+    // The module's name section / source URL, empty when it declares neither.
     // Lazily computed and cached; not thread-safe — must only be called from the debugger thread.
-    JS_EXPORT_PRIVATE String debugName() const;
+    JS_EXPORT_PRIVATE String declaredName() const;
 
     Ref<ModuleInformation> moduleInfo;
-    uint32_t id { 0 };
     Vector<uint8_t> source;
     using FunctionIndexToData = UncheckedKeyHashMap<size_t, FunctionDebugInfo, DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>>;
     FunctionIndexToData functionIndexToData;
 
 private:
-    mutable std::optional<String> m_cachedDebugName;
+    mutable std::optional<String> m_cachedDeclaredName;
 };
 
 } // namespace Wasm

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp
@@ -49,84 +49,60 @@ namespace Wasm {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ModuleManager);
 
-uint32_t ModuleManager::registerModule(Module& module)
-{
-    Locker locker { m_lock };
-    uint32_t moduleId = m_nextModuleId++;
-    m_moduleIdToModule.set(moduleId, &module);
-    const auto& moduleInfo = module.moduleInformation();
-    moduleInfo.debugInfo->id = moduleId;
-    m_unnotifiedModuleIds.add(moduleId);
-    dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][registerModule] - registered module with ID: ", moduleId, " size: ", moduleInfo.debugInfo->source.size(), " bytes");
-    return moduleId;
-}
-
-void ModuleManager::unregisterModule(Module& module)
-{
-    Locker locker { m_lock };
-    uint32_t moduleId = module.debugId();
-    m_moduleIdToModule.remove(moduleId);
-    m_unnotifiedModuleIds.remove(moduleId);
-    m_hasPendingModuleRemovals = true;
-    dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][unregisterModule] - unregistered module with debug ID: ", moduleId);
-}
-
-uint32_t ModuleManager::registerInstance(JSWebAssemblyInstance* jsInstance)
+void ModuleManager::registerInstance(JSWebAssemblyInstance* jsInstance)
 {
     Locker locker { m_lock };
     uint32_t instanceId = m_nextInstanceId++;
+    // IDs are never reused, so the address space bounds how many instances one session may
+    // create. Fail here rather than deep inside VirtualAddress::encode().
+    RELEASE_ASSERT(instanceId <= VirtualAddress::MAX_ID, "Wasm debugger ran out of instance IDs");
 
     RefPtr<InstanceAnchor> anchor = jsInstance->anchor();
     RELEASE_ASSERT(anchor, "Instance must have an anchor");
 
+    const auto& moduleInfo = jsInstance->moduleInformation();
+    RELEASE_ASSERT(moduleInfo.debugInfo && !moduleInfo.debugInfo->source.isEmpty(), "Instance must have module source");
+
     amortizedCleanupIfNeeded();
     m_instanceIdToInstance.set(instanceId, ThreadSafeWeakPtr { *anchor });
-
     jsInstance->setDebugId(instanceId);
-    dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][registerInstance] - registered instance with ID: ", instanceId, " for module ID: ", jsInstance->module().debugId());
-    return instanceId;
+    m_unnotifiedInstanceIds.add(instanceId);
+
+    dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][registerInstance] - registered instance with ID: ", instanceId, " of module: ", RawPointer(&jsInstance->module()));
 }
 
-bool ModuleManager::needsNewModuleNotification(JSWebAssemblyInstance* jsInstance)
+bool ModuleManager::needsLibraryRequery()
 {
     Locker locker { m_lock };
-    uint32_t moduleId = jsInstance->module().debugId();
-    return m_unnotifiedModuleIds.contains(moduleId);
-}
-
-bool ModuleManager::needsLibraryRequery() const
-{
-    Locker locker { m_lock };
-    return !m_unnotifiedModuleIds.isEmpty() || m_hasPendingModuleRemovals;
+    // Sweep here rather than leaving it to the amortized cleanup, which only runs on unrelated
+    // traffic and may never run at all: a collected instance would then keep its library in
+    // LLDB's list forever. This runs once per stop reply, over the live instances.
+    sweepDeadInstances();
+    return !m_unnotifiedInstanceIds.isEmpty() || m_hasPendingLibraryRemovals;
 }
 
 void ModuleManager::notifyLibraryRequeryComplete()
 {
     Locker locker { m_lock };
-    m_unnotifiedModuleIds.clear();
-    m_hasPendingModuleRemovals = false;
+    m_unnotifiedInstanceIds.clear();
+    m_hasPendingLibraryRemovals = false;
 }
 
-Vector<uint32_t> ModuleManager::unnotifiedModuleIds() const
+Vector<uint32_t> ModuleManager::unnotifiedInstanceIds() const
 {
     Locker locker { m_lock };
     Vector<uint32_t> result;
-    result.reserveInitialCapacity(m_unnotifiedModuleIds.size());
-    for (uint32_t id : m_unnotifiedModuleIds)
+    result.reserveInitialCapacity(m_unnotifiedInstanceIds.size());
+    for (uint32_t id : m_unnotifiedInstanceIds)
         result.append(id);
     std::sort(result.begin(), result.end());
     return result;
 }
 
-Module* ModuleManager::module(uint32_t moduleId) const
+Vector<uint32_t> ModuleManager::takeCollectedInstanceIds()
 {
     Locker locker { m_lock };
-    auto itr = m_moduleIdToModule.find(moduleId);
-    if (itr == m_moduleIdToModule.end()) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][module] - module not found for ID: ", moduleId);
-        return nullptr;
-    }
-    return itr->value;
+    return std::exchange(m_collectedInstanceIds, { });
 }
 
 JSWebAssemblyInstance* ModuleManager::jsInstance(uint32_t instanceId)
@@ -165,39 +141,6 @@ JSWebAssemblyInstance* ModuleManager::jsInstance(uint32_t instanceId)
     return instance;
 }
 
-// Null when a module has no live instance, or more than one: globals are per-instance, so an
-// ambiguous module has no single value to report.
-// FIXME: Workaround until we hand out module instance IDs instead of module IDs.
-JSWebAssemblyInstance* ModuleManager::soleInstanceOfModule(uint32_t moduleId)
-{
-    Locker locker { m_lock };
-    amortizedCleanupIfNeeded();
-
-    JSWebAssemblyInstance* found = nullptr;
-    for (const auto& pair : m_instanceIdToInstance) {
-        RefPtr<InstanceAnchor> anchor = pair.value.get();
-        if (!anchor)
-            continue;
-
-        Locker anchorLocker { anchor->m_lock };
-        JSWebAssemblyInstance* instance = anchor->instance();
-        if (!instance || instance->module().debugId() != moduleId)
-            continue;
-
-        if (found) {
-            dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][soleInstanceOfModule] - more than one live instance for module ID: ", moduleId);
-            return nullptr;
-        }
-
-        RELEASE_ASSERT(instance->vm().debugState()->isStopped, "Instance exists but VM is not stopped");
-        found = instance;
-    }
-
-    if (!found)
-        dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][soleInstanceOfModule] - no live instance for module ID: ", moduleId);
-    return found;
-}
-
 String ModuleManager::generateLibrariesXML() const
 {
     Locker locker { m_lock };
@@ -227,33 +170,54 @@ String ModuleManager::generateLibrariesXML() const
         }
     };
 
-    for (const auto& pair : m_moduleIdToModule) {
-        uint32_t moduleId = pair.key;
-        RefPtr module = pair.value;
-        if (!module)
+    // Report libraries in instance-id order so the list LLDB sees is stable across requeries.
+    Vector<std::pair<uint32_t, RefPtr<InstanceAnchor>>> liveInstances;
+    liveInstances.reserveInitialCapacity(m_instanceIdToInstance.size());
+    for (const auto& pair : m_instanceIdToInstance) {
+        if (RefPtr<InstanceAnchor> anchor = pair.value.get())
+            liveInstances.append({ pair.key, WTF::move(anchor) });
+    }
+    std::sort(liveInstances.begin(), liveInstances.end(), [](const auto& a, const auto& b) {
+        return a.first < b.first;
+    });
+
+    unsigned libraryCount = 0;
+    for (const auto& [instanceId, anchor] : liveInstances) {
+        Locker anchorLocker { anchor->m_lock };
+        JSWebAssemblyInstance* instance = anchor->instance();
+        if (!instance)
             continue;
 
-        const auto& debugInfo = module->moduleInformation().debugInfo;
-        if (debugInfo->source.isEmpty())
-            continue;
+        const auto& debugInfo = instance->moduleInformation().debugInfo;
+        VirtualAddress moduleBaseAddress = VirtualAddress::createModule(instanceId);
+        // Instance IDs are unique across every module, so suffixing with one is enough to keep
+        // library names distinct even when two modules declare the same name. Both halves are
+        // fixed for the life of the instance, so a library is never renamed.
+        // FIXME: The name carries no module identity, so two modules declaring the same name look
+        // like two instances of one. Fold in a hash of the module's bytes or its build_id section
+        // — `<name>#<hash>@<instance>` — cached on ModuleDebugInfo, since this runs per qXfer chunk.
+        String libraryName = debugInfo->declaredName();
+        if (libraryName.isEmpty()) {
+            // No name to qualify: the base address already names the instance uniquely.
+            libraryName = makeString("0x"_s, moduleBaseAddress.hex(), ".wasm"_s);
+        } else
+            libraryName = makeString(libraryName, '@', instanceId);
 
-        ASSERT(moduleId == debugInfo->id);
-        VirtualAddress moduleBaseAddress = VirtualAddress::createModule(moduleId);
-        String moduleName = debugInfo->debugName();
         xml.append("  <library name=\""_s);
-        appendXMLEscaped(xml, moduleName);
+        appendXMLEscaped(xml, libraryName);
         xml.append("\">\n"_s);
         xml.append("    <section address=\"0x"_s);
         xml.append(moduleBaseAddress.hex());
         xml.append("\"/>\n"_s);
         xml.append("  </library>\n"_s);
-        dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][generateLibrariesXML] - added module '", moduleName, "' ID: ", moduleId, " at ", moduleBaseAddress, " size: 0x", hex(debugInfo->source.size(), Lowercase));
+        libraryCount++;
+        dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][generateLibrariesXML] - added instance '", libraryName, "' ID: ", instanceId, " at ", moduleBaseAddress, " size: 0x", hex(debugInfo->source.size(), Lowercase));
     }
 
     xml.append("</library-list>\n"_s);
 
     String result = xml.toString();
-    dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][generateLibrariesXML] - generated library list XML: ", m_moduleIdToModule.size(), " modules, ", result.length(), " characters");
+    dataLogLnIf(Options::verboseWasmDebugger(), "[ModuleManager][generateLibrariesXML] - generated library list XML: ", libraryCount, " instances, ", result.length(), " characters");
     return result;
 }
 
@@ -263,12 +227,28 @@ uint32_t ModuleManager::nextInstanceId() const
     return m_nextInstanceId;
 }
 
+void ModuleManager::sweepDeadInstances()
+{
+    Vector<uint32_t> deadIds;
+    for (const auto& pair : m_instanceIdToInstance) {
+        if (!pair.value.get())
+            deadIds.append(pair.key);
+    }
+
+    for (uint32_t instanceId : deadIds) {
+        m_instanceIdToInstance.remove(instanceId);
+        m_collectedInstanceIds.append(instanceId);
+        // A collected instance drops a library from the list, so LLDB has to requery — unless it
+        // was never told the instance existed, in which case there is nothing for it to drop.
+        if (!m_unnotifiedInstanceIds.remove(instanceId))
+            m_hasPendingLibraryRemovals = true;
+    }
+}
+
 void ModuleManager::amortizedCleanupIfNeeded()
 {
     if (++m_operationCountSinceLastCleanup > m_maxOperationCountWithoutCleanup) {
-        m_instanceIdToInstance.removeIf([](auto& entry) {
-            return !entry.value.get(); // Remove entries with dead anchors
-        });
+        sweepDeadInstances();
         cleanupHappened();
     }
 }

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleManager.h
@@ -56,38 +56,36 @@ public:
     ModuleManager() = default;
     ~ModuleManager() = default;
 
-    uint32_t registerModule(Module&);
-    void unregisterModule(Module&);
-    Module* module(uint32_t moduleId) const;
-
-    uint32_t registerInstance(JSWebAssemblyInstance*);
+    void registerInstance(JSWebAssemblyInstance*);
     JSWebAssemblyInstance* jsInstance(uint32_t instanceId);
-    JSWebAssemblyInstance* soleInstanceOfModule(uint32_t moduleId);
     uint32_t nextInstanceId() const;
 
     String generateLibrariesXML() const;
 
-    bool needsNewModuleNotification(JSWebAssemblyInstance*);
-    bool needsLibraryRequery() const;
+    bool needsLibraryRequery();
     void notifyLibraryRequeryComplete();
-    Vector<uint32_t> unnotifiedModuleIds() const;
+    Vector<uint32_t> unnotifiedInstanceIds() const;
+
+    // IDs whose instance has been collected since the last call. Anything keyed by instance —
+    // breakpoint sites — drains this to drop what the instance left behind.
+    Vector<uint32_t> takeCollectedInstanceIds();
 
 private:
-    using IdToModule = UncheckedKeyHashMap<uint32_t, Module*, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
     using IdToInstance = UncheckedKeyHashMap<uint32_t, ThreadSafeWeakPtr<Wasm::InstanceAnchor>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
-    using ModuleIdSet = UncheckedKeyHashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+    using InstanceIdSet = UncheckedKeyHashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
+    // Drops entries whose instance has been collected, flagging the library removal for LLDB.
+    void sweepDeadInstances() WTF_REQUIRES_LOCK(m_lock);
     // Amortized cleanup mechanism (matches ThreadSafeWeakHashSet behavior).
     void amortizedCleanupIfNeeded() WTF_REQUIRES_LOCK(m_lock);
     void cleanupHappened() WTF_REQUIRES_LOCK(m_lock);
 
     mutable Lock m_lock;
-    IdToModule m_moduleIdToModule WTF_GUARDED_BY_LOCK(m_lock);
     IdToInstance m_instanceIdToInstance WTF_GUARDED_BY_LOCK(m_lock);
-    ModuleIdSet m_unnotifiedModuleIds WTF_GUARDED_BY_LOCK(m_lock); // Module IDs not yet seen by LLDB; cleared by notifyLibraryRequeryComplete() after each qXfer:libraries:read reply
-    bool m_hasPendingModuleRemovals WTF_GUARDED_BY_LOCK(m_lock) { false }; // True when a module was unregistered but LLDB hasn't been notified yet
+    InstanceIdSet m_unnotifiedInstanceIds WTF_GUARDED_BY_LOCK(m_lock); // Instance IDs not yet seen by LLDB; cleared by notifyLibraryRequeryComplete() after each qXfer:libraries:read reply
+    Vector<uint32_t> m_collectedInstanceIds WTF_GUARDED_BY_LOCK(m_lock); // Swept instance IDs awaiting takeCollectedInstanceIds()
+    bool m_hasPendingLibraryRemovals WTF_GUARDED_BY_LOCK(m_lock) { false }; // True when an instance went away but LLDB hasn't been notified yet
 
-    uint32_t m_nextModuleId WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     uint32_t m_nextInstanceId WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     mutable unsigned m_operationCountSinceLastCleanup WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     mutable unsigned m_maxOperationCountWithoutCleanup WTF_GUARDED_BY_LOCK(m_lock) { 0 };

--- a/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp
@@ -430,19 +430,6 @@ void QueryHandler::handleWasmLocal(StringView packet)
     m_debugServer.sendReply(response);
 }
 
-// LLDB identifies an instance by the module id encoded in bits 61:32 of a Wasm address, so an
-// `instance:<id>` field names a module here.
-// FIXME: A module with several live instances has several sets of globals. Only a module the
-// debuggee is stopped in, or one with a single live instance, resolves to one of them.
-JSWebAssemblyInstance* QueryHandler::instanceForModule(uint32_t moduleId)
-{
-    auto& stopData = m_debugServer.execution().debuggeeStateForTest()->stopData;
-    if (stopData && stopData->instance->module().debugId() == moduleId)
-        return stopData->instance;
-
-    return m_debugServer.moduleManager().soleInstanceOfModule(moduleId);
-}
-
 JSWebAssemblyInstance* QueryHandler::instanceForFrame(uint32_t frameIndex)
 {
     auto* state = m_debugServer.execution().debuggeeStateForTest();
@@ -495,7 +482,7 @@ void QueryHandler::handleWasmGlobal(StringView packet)
 
     dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] qWasmGlobal ", namesInstance ? "instance="_s : "frame="_s, *instanceOrFrameIndex, ", global=", *globalIndex);
 
-    auto* instance = namesInstance ? instanceForModule(*instanceOrFrameIndex) : instanceForFrame(*instanceOrFrameIndex);
+    auto* instance = namesInstance ? m_debugServer.moduleManager().jsInstance(*instanceOrFrameIndex) : instanceForFrame(*instanceOrFrameIndex);
     if (!instance) {
         m_debugServer.sendErrorReply(ProtocolError::UnknownCommand);
         return;

--- a/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.h
@@ -66,7 +66,6 @@ private:
 
     bool parseLibrariesReadPacket(StringView packet, size_t& offset, size_t& maxSize);
     bool handleChunkedLibrariesResponse(size_t offset, size_t maxSize, String& response);
-    JSWebAssemblyInstance* instanceForModule(uint32_t moduleId);
     JSWebAssemblyInstance* instanceForFrame(uint32_t frameIndex);
 };
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmVirtualAddress.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmVirtualAddress.cpp
@@ -31,13 +31,11 @@
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #include "JSWebAssemblyInstance.h"
-#include "JSWebAssemblyModule.h"
+#include "Options.h"
 #include "WasmCallee.h"
 #include "WasmDebugServerUtilities.h"
 #include "WasmFormat.h"
-#include "WasmModule.h"
 #include "WasmModuleInformation.h"
-#include "WasmModuleManager.h"
 #include <wtf/DataLog.h>
 
 namespace JSC {
@@ -46,45 +44,43 @@ namespace Wasm {
 void VirtualAddress::dump(PrintStream& out) const
 {
     Type addressType = this->type();
-    uint32_t addressId = this->id();
+    uint32_t addressInstanceId = this->instanceId();
     uint32_t addressOffset = this->offset();
 
     out.print("VirtualAddress(0x", WTF::hex(m_value, WTF::Lowercase), " -> ");
 
     switch (addressType) {
     case Type::Memory:
-        out.print("Memory[instance:", addressId, ", offset:0x", WTF::hex(addressOffset, WTF::Lowercase), "])");
+        out.print("Memory[instance:", addressInstanceId, ", offset:0x", WTF::hex(addressOffset, WTF::Lowercase), "])");
         break;
     case Type::Module:
-        out.print("Module[module:", addressId, ", offset:0x", WTF::hex(addressOffset, WTF::Lowercase), "])");
+        out.print("Module[instance:", addressInstanceId, ", offset:0x", WTF::hex(addressOffset, WTF::Lowercase), "])");
         break;
     default:
-        out.print("Unknown[type:", (int)addressType, ", id:", addressId, ", offset:0x", WTF::hex(addressOffset, WTF::Lowercase), "])");
+        out.print("Unknown[type:", (int)addressType, ", id:", addressInstanceId, ", offset:0x", WTF::hex(addressOffset, WTF::Lowercase), "])");
         break;
     }
 }
 
 VirtualAddress VirtualAddress::toVirtual(JSWebAssemblyInstance* jsInstance, FunctionCodeIndex index, const uint8_t* pc)
 {
-    JSWebAssemblyModule* jsModule = jsInstance->jsModule();
-    Ref module = jsModule->module();
-    const Wasm::FunctionData& functionData = jsModule->moduleInformation().functions[index];
+    const Wasm::FunctionData& functionData = jsInstance->moduleInformation().functions[index];
     uint32_t offset = static_cast<uint32_t>(pc - &functionData.data[0] + functionData.start);
-    return VirtualAddress::createModule(module->debugId(), offset);
+    return VirtualAddress::createModule(jsInstance->debugId(), offset);
 }
 
-uint8_t* VirtualAddress::toPhysicalPC(const ModuleManager& moduleManager)
+uint8_t* VirtualAddress::toPhysicalPC(JSWebAssemblyInstance& jsInstance)
 {
     RELEASE_ASSERT(type() == VirtualAddress::Type::Module);
 
-    uint32_t id = this->id();
     uint32_t offset = this->offset();
 
-    RefPtr module = moduleManager.module(id);
-    if (!module || offset >= module->moduleInformation().debugInfo->source.size())
+    // All instances of a module share one bytecode buffer, so this resolves to the same physical
+    // PC for every instance of the same module.
+    const ModuleInformation& moduleInfo = jsInstance.moduleInformation();
+    if (offset >= moduleInfo.debugInfo->source.size())
         return nullptr;
 
-    const ModuleInformation& moduleInfo = module->moduleInformation();
     const auto& functions = moduleInfo.functions;
 
 #if ASSERT_ENABLED

--- a/Source/JavaScriptCore/wasm/debugger/WasmVirtualAddress.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmVirtualAddress.h
@@ -44,23 +44,22 @@ class JSWebAssemblyInstance;
 namespace Wasm {
 
 enum class ProtocolError : uint8_t;
-class ModuleManager;
 class FunctionCodeIndex;
 
 /**
  * VirtualAddress - WebAssembly virtual address encoding for LLDB debugging
  *
  * Encodes 64-bit virtual addresses for WebAssembly debugging with LLDB.
- * Separates module code addresses from instance memory addresses.
+ * Separates module image addresses from linear memory addresses.
  *
  * Address Format (64-bit):
  * - Bits 63-62: Address Type (2 bits)
- * - Bits 61-32: ID (30 bits) - ModuleID for code, InstanceID for memory
+ * - Bits 61-32: InstanceId (30 bits)
  * - Bits 31-0:  Offset (32 bits)
  *
  * Address Types:
- * - 0x00 (Memory): Instance linear memory - uses InstanceID
- * - 0x01 (Module): Module code/bytecode - uses ModuleID
+ * - 0x00 (Memory): The instance's linear memory
+ * - 0x01 (Module): The instance's view of its module image (bytecode)
  * - 0x02 (Invalid): Invalid/unmapped regions
  * - 0x03 (Invalid2): Invalid/unmapped regions
  *
@@ -69,19 +68,28 @@ class FunctionCodeIndex;
  * - 0x4000000000000000 - 0x7FFFFFFFFFFFFFFF: Module regions
  * - 0x8000000000000000 - 0xFFFFFFFFFFFFFFFF: Invalid regions
  *
+ * Wasm scopes linear memory, globals, tables and data segments to an instance rather than to a
+ * module, so both halves of the address space are keyed by instance ID. Every live instance gets
+ * its own module image, which is what lets LLDB tell two instances of one module apart.
+ *
+ * The protocol only requires an ID to be unique among instances that are currently live, but IDs
+ * are handed out monotonically and are never reused. Reusing a dead instance's ID would silently
+ * alias the addresses LLDB still holds for it: a breakpoint or memory read aimed at the dead
+ * instance would resolve against an unrelated live one. MAX_ID is the resulting bound.
+ *
  * Example:
  *
- *     Module A (ID=0): Code at 0x4000000000000000
- *     ├── Instance 1 (ID=0): Memory at 0x0000000000000000
- *     ├── Instance 2 (ID=1): Memory at 0x0000000100000000
- *     └── Instance 3 (ID=2): Memory at 0x0000000200000000
+ *     Module A
+ *     ├── Instance 0: Memory at 0x0000000000000000, image at 0x4000000000000000
+ *     ├── Instance 1: Memory at 0x0000000100000000, image at 0x4000000100000000
+ *     └── Instance 2: Memory at 0x0000000200000000, image at 0x4000000200000000
  *
- *     Module B (ID=1): Code at 0x4000000100000000
- *     └── Instance 4 (ID=3): Memory at 0x0000000300000000
+ *     Module B
+ *     └── Instance 3: Memory at 0x0000000300000000, image at 0x4000000300000000
  *
  * Memory Region Example:
  *
- *     [0x0000000000000000-0x0000000001010000) rw- wasm_memory_0_0
+ *     [0x0000000000000000-0x0000000001010000) rw- wasm_memory_0
  *     [0x0000000001010000-0x4000000000000000) ---
  *     [0x4000000000000000-0x40000000000013f1) r-x wasm_module_0
  *     [0x40000000000013f1-0xffffffffffffffff) ---
@@ -89,8 +97,8 @@ class FunctionCodeIndex;
 class VirtualAddress {
 public:
     enum class Type : uint8_t {
-        Memory = 0x00, // Instance linear memory (uses InstanceID)
-        Module = 0x01, // Module code/bytecode (uses ModuleID)
+        Memory = 0x00, // Instance linear memory
+        Module = 0x01, // Module image (bytecode) as seen by one instance
         Invalid = 0x02, // Invalid/unmapped regions
         Invalid2 = 0x03 // Invalid/unmapped regions
     };
@@ -102,6 +110,8 @@ public:
     static constexpr uint64_t INVALID_BASE = 0x8000000000000000ULL; // System call: interrupted mid-native, position unknown
     static constexpr uint64_t JS_FRAME_BASE = 0xC000000000000000ULL; // JS frame boundary in the WASM call stack (Invalid2 type)
     static constexpr uint64_t INVALID_END = 0xFFFFFFFFFFFFFFFFULL;
+
+    static constexpr uint32_t MAX_ID = 0x3FFFFFFF; // Bits 61-32. IDs are never reused, so this also bounds how many instances one session may create.
 
     VirtualAddress()
         : m_value(0)
@@ -117,13 +127,13 @@ public:
         return VirtualAddress(encode(Type::Memory, instanceId, offset));
     }
 
-    static VirtualAddress createModule(uint32_t moduleId, uint32_t offset = 0)
+    static VirtualAddress createModule(uint32_t instanceId, uint32_t offset = 0)
     {
-        return VirtualAddress(encode(Type::Module, moduleId, offset));
+        return VirtualAddress(encode(Type::Module, instanceId, offset));
     }
 
     Type type() const { return static_cast<Type>((m_value & 0xC000000000000000ULL) >> 62); }
-    uint32_t id() const { return static_cast<uint32_t>((m_value & 0x3FFFFFFF00000000ULL) >> 32); }
+    uint32_t instanceId() const { return static_cast<uint32_t>((m_value & 0x3FFFFFFF00000000ULL) >> 32); }
     uint32_t offset() const { return static_cast<uint32_t>(m_value & 0x00000000FFFFFFFFULL); }
     String hex() const { return makeString(WTF::hex(m_value, WTF::Lowercase)); }
     uint64_t value() const { return m_value; }
@@ -135,16 +145,20 @@ public:
     }
 
     JS_EXPORT_PRIVATE static VirtualAddress toVirtual(JSWebAssemblyInstance*, FunctionCodeIndex, const uint8_t* pc);
-    JS_EXPORT_PRIVATE uint8_t* toPhysicalPC(const ModuleManager&);
+    JS_EXPORT_PRIVATE uint8_t* toPhysicalPC(JSWebAssemblyInstance&);
 
     operator uint64_t() const { return m_value; }
 
     JS_EXPORT_PRIVATE void dump(PrintStream&) const;
 
 private:
-    static uint64_t encode(Type type, uint32_t id, uint32_t offset)
+    static uint64_t encode(Type type, uint32_t instanceId, uint32_t offset)
     {
-        return (((uint64_t)type << 62) | ((uint64_t)id << 32) | ((uint64_t)offset << 0));
+        // An ID wider than 30 bits spills into the type field, so the address would decode back
+        // to a different type and a different instance, and toPhysicalPC() would resolve it
+        // against the wrong module's bytecode.
+        RELEASE_ASSERT(instanceId <= MAX_ID);
+        return (((uint64_t)type << 62) | ((uint64_t)instanceId << 32) | ((uint64_t)offset << 0));
     }
 
     uint64_t m_value;

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
@@ -36,6 +36,7 @@
 #include "VM.h"
 #include "VMManager.h"
 #include "WasmBreakpointManager.h"
+#include "WasmCallee.h"
 #include "WasmCalleeGroup.h"
 #include "WasmDebugServer.h"
 #include "WasmDebugServerUtilities.h"
@@ -43,6 +44,7 @@
 #include "WasmModule.h"
 #include "WasmModuleInformation.h"
 #include "WasmModuleManager.h"
+#include "WasmVirtualAddress.h"
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/MonotonicTime.h>
@@ -60,10 +62,12 @@ using ExecutionHandlerTestSupport::workerThreadTask;
 using JSC::JSWebAssemblyInstance;
 using JSC::VM;
 using JSC::VMManager;
+using JSC::Wasm::Breakpoint;
 using JSC::Wasm::DebugServer;
 using JSC::Wasm::DebugState;
 using JSC::Wasm::ExecutionHandler;
 using JSC::Wasm::FunctionSpaceIndex;
+using JSC::Wasm::ModuleInformation;
 using JSC::Wasm::ModuleManager;
 using TestScripts::TestScript;
 
@@ -140,11 +144,14 @@ static void switchTarget(VM* newDebuggee)
     CHECK(executionHandler->debuggeeVM() == newDebuggee, "Switch to new debuggee failed");
 }
 
+// The address LLDB would install a site at for this instance's view of the callee's entry.
 static JSC::Wasm::VirtualAddress entryAddress(JSWebAssemblyInstance* instance, JSC::Wasm::IPIntCallee* callee)
 {
     return JSC::Wasm::VirtualAddress::toVirtual(instance, callee->functionIndex(), callee->bytecode());
 }
 
+// Installs a site at every function entry of every live instance, the way LLDB does once a symbol
+// resolves in each instance's library.
 static void setBreakpointsAtAllFunctionEntries()
 {
     VLOG("Setting breakpoints at all function entries...");
@@ -154,19 +161,12 @@ static void setBreakpointsAtAllFunctionEntries()
     uint32_t maxInstanceId = moduleManager.nextInstanceId();
     auto* breakpointManager = executionHandler->breakpointManager();
 
-    // Breakpoints patch module bytecode, which all instances of a module share, so visit each once.
-    UncheckedKeyHashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> patchedModuleIds;
-
     for (uint32_t instanceId = 0; instanceId < maxInstanceId; ++instanceId) {
         JSWebAssemblyInstance* instance = moduleManager.jsInstance(instanceId);
         if (!instance)
             continue;
 
-        auto& module = instance->module();
-        if (!patchedModuleIds.add(module.debugId()).isNewEntry)
-            continue;
-
-        auto& moduleInfo = module.moduleInformation();
+        auto& moduleInfo = instance->module().moduleInformation();
         uint32_t internalCount = moduleInfo.internalFunctionCount();
 
         VLOG("  Instance ", instanceId, ": ", internalCount, " functions");
@@ -174,6 +174,8 @@ static void setBreakpointsAtAllFunctionEntries()
         for (uint32_t funcIndex = 0; funcIndex < internalCount; ++funcIndex) {
             FunctionSpaceIndex spaceIndex = moduleInfo.toSpaceIndex(JSC::Wasm::FunctionCodeIndex(funcIndex));
             auto callee = instance->calleeGroup()->ipintCalleeFromFunctionIndexSpace(spaceIndex);
+            // Instances of one module share the bytecode a site patches, but each instance needs a
+            // site of its own: a site only stops the instance its address names.
             breakpointManager->setBreakpointAt(entryAddress(instance, callee.ptr()), moduleInfo, const_cast<uint8_t*>(callee->bytecode()));
             count++;
         }
@@ -288,13 +290,15 @@ static void testBreakpointSingleStepping()
     for (unsigned step = 0; step < STRESS_TEST_ITERATIONS; ++step) {
         VLOG("Step ", step + 1, "/", STRESS_TEST_ITERATIONS);
 
-        // Step over an existing breakpoint site by removing and re-arming it.
+        // Simulate lldb behavior:
+        // 1. If stopped at a site: remove it, step, then re-arm it
+        // 2. If stopped at a one-time breakpoint: just step directly
         uint8_t* stoppedPC = state->stopData->pc;
         JSC::Wasm::VirtualAddress stoppedAddress = state->stopData->address;
-        // Stepping clears stopData.
+        // Capture the owner before stepping; the step clears stopData.
         RefPtr<const JSC::Wasm::ModuleInformation> owner = &state->stopData->instance->moduleInformation();
         bool hadSite = executionHandler->breakpointManager()->removeBreakpointAt(stoppedAddress);
-        CHECK(hadSite == (state->stopReason == DebugState::Reason::Breakpoint), "A breakpoint stop must be reported at an address that holds a site");
+        CHECK(hadSite == (state->stopReason == DebugState::Reason::Breakpoint), "A breakpoint stop must be reported at an address the stopped instance holds a site at");
 
         unsigned expectedReplyCount = getReplyCount() + 1;
         executionHandler->step();
@@ -321,53 +325,188 @@ static void testBreakpointSingleStepping()
     TEST_LOG(failuresFound == initialFailures ? "PASS" : "FAIL");
 }
 
-static void testSoleInstanceOfModule()
+// Collects the live instances of each module, keyed by the module they were instantiated from.
+using ModuleToInstanceIds = UncheckedKeyHashMap<JSC::Wasm::Module*, Vector<uint32_t>>;
+static ModuleToInstanceIds liveInstancesByModule()
 {
-    TEST_LOG("\n=== Sole Instance Of Module Lookup ===");
-
-    interrupt();
-
     ModuleManager& moduleManager = debugServer->moduleManager();
     uint32_t maxInstanceId = moduleManager.nextInstanceId();
 
-    // Derive the expectation from what is registered, so this holds for every test script.
-    using ModuleIdToCount = UncheckedKeyHashMap<uint32_t, unsigned, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
-    using ModuleIdToInstance = UncheckedKeyHashMap<uint32_t, JSWebAssemblyInstance*, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
-    ModuleIdToCount liveInstanceCount;
-    ModuleIdToInstance firstLiveInstance;
-    uint32_t highestModuleId = 0;
-
+    ModuleToInstanceIds result;
     for (uint32_t instanceId = 0; instanceId < maxInstanceId; ++instanceId) {
         JSWebAssemblyInstance* instance = moduleManager.jsInstance(instanceId);
         if (!instance)
             continue;
-
-        uint32_t moduleId = instance->module().debugId();
-        liveInstanceCount.add(moduleId, 0).iterator->value++;
-        firstLiveInstance.add(moduleId, instance);
-        highestModuleId = std::max(highestModuleId, moduleId);
+        result.add(&instance->module(), Vector<uint32_t>()).iterator->value.append(instanceId);
     }
+    return result;
+}
 
-    CHECK(!liveInstanceCount.isEmpty(), "Expected at least one live instance while stopped");
+static void testInstanceScopedAddressing()
+{
+    TEST_LOG("\n=== Instance Scoped Addressing ===");
 
-    unsigned soleModules = 0;
-    unsigned ambiguousModules = 0;
-    for (const auto& pair : liveInstanceCount) {
-        JSWebAssemblyInstance* resolved = moduleManager.soleInstanceOfModule(pair.key);
-        if (pair.value == 1) {
-            soleModules++;
-            CHECK(resolved == firstLiveInstance.get(pair.key), "Module ", pair.key, " has one live instance and should resolve to it");
-        } else {
-            ambiguousModules++;
-            CHECK(!resolved, "Module ", pair.key, " has ", pair.value, " live instances and should not resolve");
+    interrupt();
+
+    ModuleManager& moduleManager = debugServer->moduleManager();
+    auto instancesByModule = liveInstancesByModule();
+    CHECK(!instancesByModule.isEmpty(), "Expected at least one live instance while stopped");
+
+    unsigned liveInstances = 0;
+    unsigned sharedModules = 0;
+    UncheckedKeyHashSet<uint64_t> codeBaseAddresses;
+    for (const auto& pair : instancesByModule) {
+        if (pair.value.size() > 1)
+            sharedModules++;
+        for (uint32_t instanceId : pair.value) {
+            liveInstances++;
+            JSWebAssemblyInstance* instance = moduleManager.jsInstance(instanceId);
+            CHECK(instance, "Instance ", instanceId, " should still resolve");
+            CHECK(instance->debugId() == instanceId, "Instance ", instanceId, " should carry its own debug id");
+
+            // Every instance owns a slice of the address space, even siblings sharing a module.
+            uint64_t codeBase = JSC::Wasm::VirtualAddress::createModule(instanceId).value();
+            CHECK(codeBaseAddresses.add(codeBase).isNewEntry, "Instance ", instanceId, " should get an address range of its own");
         }
     }
 
-    CHECK(!moduleManager.soleInstanceOfModule(highestModuleId + 1), "An unregistered module ID should not resolve");
+    CHECK(!moduleManager.jsInstance(moduleManager.nextInstanceId()), "An unregistered instance ID should not resolve");
 
     resume();
 
-    TEST_LOG("PASS (", soleModules, " module(s) with one live instance, ", ambiguousModules, " with several)");
+    TEST_LOG("PASS (", liveInstances, " live instance(s), ", sharedModules, " module(s) with several)");
+}
+
+static void testSharedBytecodeBreakpoints()
+{
+    TEST_LOG("\n=== Shared Bytecode Breakpoints ===");
+
+    interrupt();
+
+    ModuleManager& moduleManager = debugServer->moduleManager();
+    auto* breakpointManager = executionHandler->breakpointManager();
+
+    // Siblings of one module execute the same bytecode buffer, so a breakpoint set through any of
+    // them patches one and the same byte. LLDB still installs a site per instance, and a site
+    // speaks only for the instance its address names.
+    unsigned modulesChecked = 0;
+    for (const auto& pair : liveInstancesByModule()) {
+        if (pair.value.size() < 2)
+            continue;
+        modulesChecked++;
+
+        const uint8_t* sharedPC = nullptr;
+        const ModuleInformation* owner = nullptr;
+        uint8_t originalBytecode = 0;
+        Vector<JSC::Wasm::VirtualAddress> addresses;
+        for (uint32_t instanceId : pair.value) {
+            JSWebAssemblyInstance* instance = moduleManager.jsInstance(instanceId);
+            auto& moduleInfo = instance->module().moduleInformation();
+            FunctionSpaceIndex spaceIndex = moduleInfo.toSpaceIndex(JSC::Wasm::FunctionCodeIndex(0));
+            auto callee = instance->calleeGroup()->ipintCalleeFromFunctionIndexSpace(spaceIndex);
+
+            if (!sharedPC) {
+                sharedPC = callee->bytecode();
+                owner = &moduleInfo;
+                originalBytecode = *sharedPC;
+            } else
+                CHECK(sharedPC == callee->bytecode(), "Instances of module ", RawPointer(pair.key), " should share function 0's bytecode");
+
+            // Instance-scoped addresses, one shared patch.
+            auto address = entryAddress(instance, callee.ptr());
+            CHECK(address.instanceId() == instanceId, "A pc in instance ", instanceId, " should carry its instance id");
+            addresses.append(address);
+        }
+        uint8_t* pc = const_cast<uint8_t*>(sharedPC);
+
+        // One site patches the shared byte, but only the instance it names stops there.
+        breakpointManager->setBreakpointAt(addresses[0], *owner, pc);
+        CHECK(*sharedPC != originalBytecode, "A site should patch the shared bytecode");
+        auto breakpoint = breakpointManager->breakpointAt(sharedPC);
+        CHECK(breakpoint, "The site should reach a breakpoint at ", addresses[0]);
+        CHECK(breakpoint->originalBytecode == originalBytecode, "The patch must record the opcode it displaced");
+        CHECK(breakpoint->owner == owner, "The breakpoint should pin the module that owns its bytecode");
+
+        auto action = breakpointManager->trapActionFor(sharedPC, addresses[0]);
+        CHECK(action && action->stopType == Breakpoint::Type::Regular, "The instance holding the site should stop");
+        CHECK(action->displacedOpcode == originalBytecode, "Resuming should dispatch the displaced opcode");
+        for (size_t i = 1; i < addresses.size(); ++i) {
+            action = breakpointManager->trapActionFor(sharedPC, addresses[i]);
+            CHECK(action && !action->stopType, "Instance ", addresses[i].instanceId(), " holds no site here and must not stop");
+            CHECK(action->displacedOpcode == originalBytecode, "It should still resume through the patch");
+        }
+
+        // Re-arming a site LLDB already holds must not count twice.
+        breakpointManager->setBreakpointAt(addresses[0], *owner, pc);
+        CHECK(breakpointManager->removeBreakpointAt(addresses[0]), "The site should be removable");
+        CHECK(*sharedPC == originalBytecode, "Removing the last site should restore the displaced opcode");
+        CHECK(!breakpointManager->removeBreakpointAt(addresses[0]), "Removing it again should report there was nothing to remove");
+        CHECK(!breakpointManager->breakpointAt(sharedPC), "A patch with no reason to live should leave no breakpoint");
+
+        // LLDB addresses that shared byte once per instance, so removing one of its sites must
+        // leave the byte patched for the others.
+        for (auto address : addresses)
+            breakpointManager->setBreakpointAt(address, *owner, pc);
+        CHECK(*sharedPC != originalBytecode, "Installing through every instance should patch the shared bytecode once");
+
+        for (size_t i = 0; i < addresses.size() - 1; ++i) {
+            CHECK(breakpointManager->removeBreakpointAt(addresses[i]), "Site ", addresses[i], " should be removable");
+            CHECK(*sharedPC != originalBytecode, "The bytecode must stay patched while another site refers to it");
+            action = breakpointManager->trapActionFor(sharedPC, addresses[i]);
+            CHECK(action && !action->stopType, "The instance whose site was removed must stop no longer");
+        }
+        CHECK(breakpointManager->removeBreakpointAt(addresses.last()), "The last site should be removable");
+        CHECK(*sharedPC == originalBytecode, "Removing the last site should restore the displaced opcode");
+
+        // To resume from a breakpoint LLDB removes the site at the current PC, steps over it, and
+        // reinstalls it. With a sibling instance still holding a site the patch stays, so the step
+        // lands on a PC that already has a breakpoint.
+        breakpointManager->setBreakpointAt(addresses[0], *owner, pc);
+        breakpointManager->setBreakpointAt(addresses[1], *owner, pc);
+        CHECK(breakpointManager->removeBreakpointAt(addresses[0]), "Stepping over a site should remove it");
+        breakpointManager->setStepBreakpoint(*owner, pc);
+        CHECK(breakpointManager->hasOneTimeBreakpoints(), "A step onto a PC held by a site must still register as one-time");
+        action = breakpointManager->trapActionFor(sharedPC, addresses[1]);
+        CHECK(action && action->stopType == Breakpoint::Type::Regular, "A step must not mask the site's stop reason");
+        // A step belongs to the debuggee VM rather than to an instance, so whichever instance
+        // reaches the PC completes it.
+        action = breakpointManager->trapActionFor(sharedPC, addresses[0]);
+        CHECK(action && action->stopType == Breakpoint::Type::Step, "An instance holding no site should still complete the step");
+
+        // The step outlives the last site: LLDB removes it before the step lands.
+        CHECK(breakpointManager->removeBreakpointAt(addresses[1]), "The remaining site should be removable");
+        CHECK(*sharedPC != originalBytecode, "The bytecode must stay patched for the step in progress");
+        breakpointManager->clearAllOneTimeBreakpoints();
+        CHECK(*sharedPC == originalBytecode, "Completing the step should restore the displaced opcode");
+
+        // A site outliving the step keeps the patch.
+        breakpointManager->setBreakpointAt(addresses[0], *owner, pc);
+        breakpointManager->setStepBreakpoint(*owner, pc);
+        breakpointManager->clearAllOneTimeBreakpoints();
+        CHECK(*sharedPC != originalBytecode, "Completing the step must not disarm the site sharing its PC");
+        CHECK(breakpointManager->removeBreakpointAt(addresses[0]), "The site should outlive the step");
+        CHECK(*sharedPC == originalBytecode, "Removing the last site should restore the displaced opcode");
+
+        // Nothing patched the byte, so a trap there is a genuine unreachable.
+        CHECK(!breakpointManager->trapActionFor(sharedPC, addresses[0]), "An unpatched PC should report no breakpoint");
+
+        // A collected instance's library is unloaded without a z0 per site, so its sites are
+        // dropped by instance id instead. The patch must survive until the siblings let go.
+        for (auto address : addresses)
+            breakpointManager->setBreakpointAt(address, *owner, pc);
+        for (size_t i = 0; i < addresses.size() - 1; ++i) {
+            breakpointManager->removeSitesForInstance(addresses[i].instanceId());
+            CHECK(*sharedPC != originalBytecode, "The bytecode must stay patched while a sibling holds a site");
+            CHECK(!breakpointManager->removeBreakpointAt(addresses[i]), "A dropped site must not be removable twice");
+        }
+        breakpointManager->removeSitesForInstance(addresses.last().instanceId());
+        CHECK(*sharedPC == originalBytecode, "Dropping the last instance should restore the displaced opcode");
+        CHECK(!breakpointManager->breakpointAt(sharedPC), "Dropping every site should leave no breakpoint");
+    }
+
+    resume();
+
+    TEST_LOG(modulesChecked ? "PASS" : "PASS (no module with several live instances)");
 }
 
 static void testPatchLifetime()
@@ -526,8 +665,9 @@ UNUSED_FUNCTION static int runTests()
         testVMContextSwitching();
         testBreakpointContinueCycles();
         testBreakpointSingleStepping();
-        testSoleInstanceOfModule();
+        testInstanceScopedAddressing();
         testPatchLifetime();
+        testSharedBytecodeBreakpoints();
 
         cleanupAfterScript(script, workerThread);
 

--- a/Source/JavaScriptCore/wasm/debugger/testwasmdebugger.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/testwasmdebugger.cpp
@@ -68,19 +68,19 @@ static void testWASMVirtualAddressConstants()
     TEST_ASSERT(VirtualAddress::INVALID_BASE == 0x8000000000000000ULL,
         "INVALID_BASE should be 0x8000000000000000");
 
-    // Test virtualAddress encoding for different module IDs
-    VirtualAddress module0Obj = VirtualAddress::createModule(0, 0);
-    VirtualAddress module1Obj = VirtualAddress::createModule(1, 0);
-    VirtualAddress module0Mem = VirtualAddress::createMemory(0, 0);
+    // Test virtualAddress encoding for different instance IDs
+    VirtualAddress instance0Obj = VirtualAddress::createModule(0, 0);
+    VirtualAddress instance1Obj = VirtualAddress::createModule(1, 0);
+    VirtualAddress instance0Mem = VirtualAddress::createMemory(0, 0);
 
-    TEST_ASSERT(module0Obj == 0x4000000000000000ULL, "Module 0 obj should be at encoded address");
-    TEST_ASSERT(module1Obj == 0x4000000100000000ULL, "Module 1 obj should be at encoded address");
-    TEST_ASSERT(module0Mem == 0x0000000000000000ULL, "Module 0 memory should be at encoded address");
+    TEST_ASSERT(instance0Obj == 0x4000000000000000ULL, "Instance 0 obj should be at encoded address");
+    TEST_ASSERT(instance1Obj == 0x4000000100000000ULL, "Instance 1 obj should be at encoded address");
+    TEST_ASSERT(instance0Mem == 0x0000000000000000ULL, "Instance 0 memory should be at encoded address");
 
     // Test address decoding
-    TEST_ASSERT(module0Obj.type() == VirtualAddress::Type::Module, "Should decode as Module");
-    TEST_ASSERT(!module0Obj.id(), "Should decode module ID 0");
-    TEST_ASSERT(!module0Obj.offset(), "Should decode offset 0");
+    TEST_ASSERT(instance0Obj.type() == VirtualAddress::Type::Module, "Should decode as Module");
+    TEST_ASSERT(!instance0Obj.instanceId(), "Should decode instance ID 0");
+    TEST_ASSERT(!instance0Obj.offset(), "Should decode offset 0");
 
     dataLogLn("VirtualAddress design tests completed");
 }
@@ -92,32 +92,32 @@ static void testWASMVirtualAddressEncoding()
     // Test all address type combinations
     struct AddressTest {
         VirtualAddress::Type type;
-        uint32_t moduleId;
+        uint32_t instanceId;
         uint32_t offset;
         ASCIILiteral description;
     };
 
     AddressTest tests[] = {
-        { VirtualAddress::Type::Memory, 0, 0, "Module 0 memory base"_s },
-        { VirtualAddress::Type::Memory, 1, 0x1000, "Module 1 memory offset"_s },
-        { VirtualAddress::Type::Memory, 0x1000, 0x2000, "Module 4096 memory offset"_s },
-        { VirtualAddress::Type::Module, 0, 0, "Module 0 obj base"_s },
-        { VirtualAddress::Type::Module, 1, 0x2000, "Module 1 obj offset"_s },
-        { VirtualAddress::Type::Module, 0x2000, 0x3000, "Module 8192 obj offset"_s }
+        { VirtualAddress::Type::Memory, 0, 0, "Instance 0 memory base"_s },
+        { VirtualAddress::Type::Memory, 1, 0x1000, "Instance 1 memory offset"_s },
+        { VirtualAddress::Type::Memory, 0x1000, 0x2000, "Instance 4096 memory offset"_s },
+        { VirtualAddress::Type::Module, 0, 0, "Instance 0 obj base"_s },
+        { VirtualAddress::Type::Module, 1, 0x2000, "Instance 1 obj offset"_s },
+        { VirtualAddress::Type::Module, 0x2000, 0x3000, "Instance 8192 obj offset"_s }
     };
 
     for (const auto& test : tests) {
         VirtualAddress encoded = (test.type == VirtualAddress::Type::Memory)
-            ? VirtualAddress::createMemory(test.moduleId, test.offset)
-            : VirtualAddress::createModule(test.moduleId, test.offset);
+            ? VirtualAddress::createMemory(test.instanceId, test.offset)
+            : VirtualAddress::createModule(test.instanceId, test.offset);
 
         VirtualAddress::Type decodedType = encoded.type();
-        uint32_t decodedId = encoded.id();
+        uint32_t decodedId = encoded.instanceId();
         uint32_t decodedOffset = encoded.offset();
 
         TEST_ASSERT(decodedType == test.type,
             makeString("Address encoding/decoding type mismatch for "_s, test.description));
-        TEST_ASSERT(decodedId == test.moduleId,
+        TEST_ASSERT(decodedId == test.instanceId,
             makeString("Address encoding/decoding ID mismatch for "_s, test.description));
         TEST_ASSERT(decodedOffset == test.offset,
             makeString("Address encoding/decoding offset mismatch for "_s, test.description));
@@ -164,8 +164,8 @@ static void testWASMVirtualAddressLLDBEnumeration()
 
     RegionTest regionTests[] = {
         // Core WASM addresses
-        { VirtualAddress::createMemory(0, 0), "Module 0 memory base"_s, true },
-        { VirtualAddress::createModule(0, 0), "Module 0 module base"_s, true },
+        { VirtualAddress::createMemory(0, 0), "Instance 0 memory base"_s, true },
+        { VirtualAddress::createModule(0, 0), "Instance 0 module base"_s, true },
         { 0x8000000000000000ULL, "Invalid type probe"_s, true }, // Invalid type (0x02)
         { 0xC000000000000000ULL, "Invalid2 type probe"_s, true }, // Invalid2 type (0x03)
     };
@@ -192,15 +192,15 @@ static void testWASMVirtualAddressEdgeCases()
     dataLogLn("=== Testing VirtualAddress Edge Cases ===");
 
     // Test maximum values for each field
-    uint32_t maxId = 0x3FFFFFFF; // 30 bits
+    uint32_t maxId = VirtualAddress::MAX_ID; // 30 bits
     uint32_t maxOffset = 0xFFFFFFFF; // 32 bits
 
     // Test maximum ID values
     VirtualAddress maxMemoryId = VirtualAddress::createMemory(maxId, 0);
     VirtualAddress maxModuleId = VirtualAddress::createModule(maxId, 0);
 
-    TEST_ASSERT(maxMemoryId.id() == maxId, "Should handle maximum memory ID");
-    TEST_ASSERT(maxModuleId.id() == maxId, "Should handle maximum module ID");
+    TEST_ASSERT(maxMemoryId.instanceId() == maxId, "Should handle maximum memory instance ID");
+    TEST_ASSERT(maxModuleId.instanceId() == maxId, "Should handle maximum module instance ID");
     TEST_ASSERT(maxMemoryId.type() == VirtualAddress::Type::Memory, "Max ID should preserve memory type");
     TEST_ASSERT(maxModuleId.type() == VirtualAddress::Type::Module, "Max ID should preserve module type");
 


### PR DESCRIPTION
#### c3a249e70753f6bd2d4975fe6d96ea6612fb6a7d
<pre>
[JSC] Use instance IDs for Wasm debugger virtual addresses
<a href="https://bugs.webkit.org/show_bug.cgi?id=323479">https://bugs.webkit.org/show_bug.cgi?id=323479</a>
<a href="https://rdar.apple.com/186722231">rdar://186722231</a>

Reviewed by Yijia Huang.

Wasm scopes linear memory, globals, tables, and data segments to an
instance rather than a module. The debugger used the module ID to
identify the module in its virtual address space.

Use the instance ID in both halves of the address space. Every live
instance now gets its own library entry, module image, and linear memory
region, which removes the workaround `qWasmGlobal` needed to map a
unique module ID back to an instance. LLDB assumes libraries have unique
names, so every named library is suffixed with its instance id
(`&lt;name&gt;@&lt;id&gt;`).

A breakpoint patches module bytecode, which every instance of a module
shares, so the patch stays keyed by physical PC. A site, though, belongs
to the instance its address names: LLDB gives every instance its own
library and installs one site in each, so a site says &quot;stop this
instance here&quot;, not &quot;stop this bytecode&quot;. A sibling reaching the same
patched byte resumes through it, dispatching the opcode the patch
displaced, without reporting a stop. Setting a breakpoint by symbol name
still covers every instance, because the symbol resolves once per
library. The patch is lifted only once the last site referring to it and
any step in flight are both gone.

Collecting an instance drops its sites. LLDB unloads the library without
sending z0 for what was in it, so nothing else would release the patch
they keep alive. Tearing down an instance is also treated as a library
change, prompting LLDB to requery the library list in the stop reply.

Stepping off a trap now arms the trapping function&apos;s entry. LLDB pulls
its site before stepping over it and restores it only once the step
reports a stop, so a program that catches the trap and loops straight
back would run past the user&apos;s breakpoint every time.

* JSTests/wasm/debugger/resources/swift-wasm/test/multi-instance.js: Added.
(imports.wasi_snapshot_preview1.proc_exit):
(imports.wasi_snapshot_preview1.args_get):
(imports.wasi_snapshot_preview1.args_sizes_get):
(imports.wasi_snapshot_preview1.environ_get):
(imports.wasi_snapshot_preview1.environ_sizes_get):
(imports.wasi_snapshot_preview1.fd_write):
(imports.wasi_snapshot_preview1.fd_read):
(imports.wasi_snapshot_preview1.fd_close):
(imports.wasi_snapshot_preview1.fd_seek):
(imports.wasi_snapshot_preview1.fd_fdstat_get):
(imports.wasi_snapshot_preview1.fd_prestat_get):
(imports.wasi_snapshot_preview1.fd_prestat_dir_name):
(imports.wasi_snapshot_preview1.path_open):
(imports.wasi_snapshot_preview1.random_get):
(imports.wasi_snapshot_preview1.clock_time_get):
* JSTests/wasm/debugger/resources/wasm/multi-instance-both-running.js: Added.
* JSTests/wasm/debugger/resources/wasm/multi-instance-caller-frame.js: Added.
* JSTests/wasm/debugger/resources/wasm/multi-instance-same-module.js: Added.
* JSTests/wasm/debugger/resources/wasm/multi-instance-three.js: Added.
* JSTests/wasm/debugger/resources/wasm/multi-instance-unreachable.js: Added.
(catch):
* JSTests/wasm/debugger/tests/tests.py:
(DynamicModuleLoadTestCase.execute):
(SwiftWasmDynamicModuleLoadTestCase.execute):
(MultiInstanceCallerFrameTestCase):
(MultiInstanceCallerFrameTestCase.execute):
(MultiInstanceSameModuleTestCase):
(MultiInstanceSameModuleTestCase.execute):
(MultiInstanceForeignSiteIgnoredTestCase):
(MultiInstanceForeignSiteIgnoredTestCase.execute):
(MultiInstanceStepOverSharedPatchTestCase):
(MultiInstanceStepOverSharedPatchTestCase.execute):
(MultiInstanceBreakpointDisableTestCase):
(MultiInstanceBreakpointDisableTestCase.execute):
(MultiInstanceBreakpointDeleteTestCase):
(MultiInstanceBreakpointDeleteTestCase.execute):
(MultiInstanceUnreachableOwnSiteTestCase):
(MultiInstanceUnreachableOwnSiteTestCase.execute):
(MultiInstanceUnreachableForeignSiteTestCase):
(MultiInstanceUnreachableForeignSiteTestCase.execute):
(MultiInstanceUnreachableBothSitesTestCase):
(MultiInstanceUnreachableBothSitesTestCase.execute):
(MultiInstanceUnreachableStepTestCase):
(MultiInstanceUnreachableStepTestCase.execute):
(MultiInstanceBothRunningTestCase):
(MultiInstanceBothRunningTestCase.execute):
(MultiInstanceForeignSiteOpcodeShapesTestCase):
(MultiInstanceForeignSiteOpcodeShapesTestCase.execute):
(MultiInstanceThreeInstancesTestCase):
(MultiInstanceThreeInstancesTestCase.execute):
(CWasmTestCase.memoryTest):
(SwiftWasmTestCase.memoryTest):
(ModuleNamingFromNameSectionTestCase.execute):
(StreamingModuleSourceURLTestCase.execute):
(SwiftWasmMultiInstanceTestCase):
(SwiftWasmMultiInstanceTestCase.execute):
* Source/JavaScriptCore/wasm/WasmModule.cpp:
(JSC::Wasm::Module::Module):
(JSC::Wasm::Module::~Module):
(JSC::Wasm::Module::debugId const): Deleted.
(JSC::Wasm::Module::setDebugId): Deleted.
* Source/JavaScriptCore/wasm/WasmModule.h:
* Source/JavaScriptCore/wasm/debugger/README.md:
* Source/JavaScriptCore/wasm/debugger/RWI_ARCHITECTURE.md:
* Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.cpp:
(JSC::Wasm::BreakpointManager::releasePatchIfUnused):
(JSC::Wasm::BreakpointManager::breakpointAt):
(JSC::Wasm::BreakpointManager::setBreakpointAt):
(JSC::Wasm::BreakpointManager::removeSiteImpl):
(JSC::Wasm::BreakpointManager::removeBreakpointAt):
(JSC::Wasm::BreakpointManager::removeSitesForInstance):
(JSC::Wasm::BreakpointManager::trapActionFor):
* Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.h:
* Source/JavaScriptCore/wasm/debugger/WasmDebugServer.cpp:
(JSC::Wasm::DebugServer::trackInstance):
(JSC::Wasm::DebugServer::trackModule): Deleted.
(JSC::Wasm::DebugServer::untrackModule): Deleted.
* Source/JavaScriptCore/wasm/debugger/WasmDebugServer.h:
* Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h:
(JSC::Wasm::Breakpoint::dump const):
* Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp:
(JSC::Wasm::ExecutionHandler::handleDebuggerTrapIfNeeded):
(JSC::Wasm::ExecutionHandler::step):
(JSC::Wasm::ExecutionHandler::notifyDebuggerOfNewInstance):
(JSC::Wasm::ExecutionHandler::setBreakpoint):
(JSC::Wasm::ExecutionHandler::removeBreakpoint):
(JSC::Wasm::ExecutionHandler::sendStopReplyForThread):
(JSC::Wasm::ExecutionHandler::notifyDebuggerOfNewModule): Deleted.
(JSC::Wasm::WTF_REQUIRES_LOCK):
(JSC::Wasm::ExecutionHandler::callStackStringFor):
* Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h:
* Source/JavaScriptCore/wasm/debugger/WasmMemoryHandler.cpp:
(JSC::Wasm::MemoryHandler::readMemory):
(JSC::Wasm::MemoryHandler::readModuleData):
(JSC::Wasm::MemoryHandler::readMemoryData):
(JSC::Wasm::MemoryHandler::handleMemoryRegionInfo):
(JSC::Wasm::MemoryHandler::handleWasmMemoryRegionInfo):
(JSC::Wasm::MemoryHandler::handleWasmModuleRegionInfo):
(JSC::Wasm::MemoryHandler::write):
* Source/JavaScriptCore/wasm/debugger/WasmMemoryHandler.h:
* Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.cpp:
(JSC::Wasm::ModuleDebugInfo::declaredName const):
(JSC::Wasm::ModuleDebugInfo::debugName const): Deleted.
* Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.h:
(): Deleted.
* Source/JavaScriptCore/wasm/debugger/WasmModuleManager.cpp:
(JSC::Wasm::ModuleManager::registerInstance):
(JSC::Wasm::ModuleManager::needsLibraryRequery):
(JSC::Wasm::ModuleManager::unnotifiedInstanceIds const):
(JSC::Wasm::ModuleManager::takeCollectedInstanceIds):
(JSC::Wasm::ModuleManager::generateLibrariesXML const):
(JSC::Wasm::ModuleManager::sweepDeadInstances):
(JSC::Wasm::ModuleManager::registerModule): Deleted.
(JSC::Wasm::ModuleManager::unregisterModule): Deleted.
(JSC::Wasm::ModuleManager::needsNewModuleNotification): Deleted.
(JSC::Wasm::ModuleManager::unnotifiedModuleIds const): Deleted.
(JSC::Wasm::ModuleManager::soleInstanceOfModule): Deleted.
(JSC::Wasm::ModuleManager::notifyLibraryRequeryComplete):
(JSC::Wasm::ModuleManager::amortizedCleanupIfNeeded):
(JSC::Wasm::ModuleManager::needsLibraryRequery const): Deleted.
(JSC::Wasm::ModuleManager::module const): Deleted.
* Source/JavaScriptCore/wasm/debugger/WasmModuleManager.h:
* Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.cpp:
(JSC::Wasm::QueryHandler::handleWasmGlobal):
(JSC::Wasm::QueryHandler::instanceForModule): Deleted.
* Source/JavaScriptCore/wasm/debugger/WasmQueryHandler.h:
* Source/JavaScriptCore/wasm/debugger/WasmVirtualAddress.cpp:
(JSC::Wasm::VirtualAddress::toPhysicalPC):
(JSC::Wasm::VirtualAddress::dump const):
(JSC::Wasm::VirtualAddress::toVirtual):
* Source/JavaScriptCore/wasm/debugger/WasmVirtualAddress.h:
(JSC::Wasm::VirtualAddress::instanceId const):
(JSC::Wasm::VirtualAddress::createModule):
(JSC::Wasm::VirtualAddress::encode):
(JSC::Wasm::VirtualAddress::id const): Deleted.
* Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp:
(ExecutionHandlerTest::entryAddress):
(ExecutionHandlerTest::setBreakpointsAtAllFunctionEntries):
(ExecutionHandlerTest::testBreakpointSingleStepping):
(ExecutionHandlerTest::testInstanceScopedAddressing):
(ExecutionHandlerTest::testSharedBytecodeBreakpoints):
(ExecutionHandlerTest::runTests):
(ExecutionHandlerTest::testSoleInstanceOfModule): Deleted.
(ExecutionHandlerTest::liveInstancesByModule):
* Source/JavaScriptCore/wasm/debugger/testwasmdebugger.cpp:
(testWASMVirtualAddressConstants):
(testWASMVirtualAddressEncoding):
(testWASMVirtualAddressLLDBEnumeration):
(testWASMVirtualAddressEdgeCases):

Canonical link: <a href="https://commits.webkit.org/320972@main">https://commits.webkit.org/320972@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0e47412e34f8d51be1b2492f992bfdb08494129

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196660 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150879 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145611 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125963 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48035 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45982 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7791 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14657 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158383 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45727 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7734 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47611 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52727 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50463 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198647 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59920 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155196 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41601 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60631 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42286 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154833 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49256 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132839 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/130097 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59054 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20706 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58458 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58673 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58524 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->