### PR TITLE
[JSC] Move CodeOrigin instead of copying it when creating DFG nodes

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -1105,7 +1105,7 @@ private:
         CodeOrigin semantic = m_currentSemanticOrigin.isSet() ? m_currentSemanticOrigin : currentCodeOrigin();
         CodeOrigin forExit = m_currentExitOrigin.isSet() ? m_currentExitOrigin : currentCodeOrigin();
 
-        return NodeOrigin(semantic, forExit, m_exitOK);
+        return NodeOrigin(WTF::move(semantic), WTF::move(forExit), m_exitOK);
     }
     
     BranchData* branchData(unsigned taken, unsigned notTaken)

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -256,14 +256,14 @@ public:
     template<typename... Params>
     Node* addNode(Params... params)
     {
-        Node* node = m_nodes.addNew(params...);
+        Node* node = m_nodes.addNew(WTF::move(params)...);
         return node;
     }
 
     template<typename... Params>
     Node* addNode(SpeculatedType type, Params... params)
     {
-        Node* node = addNode(params...);
+        Node* node = addNode(WTF::move(params)...);
         node->predict(type);
         return node;
     }

--- a/Source/JavaScriptCore/dfg/DFGInsertionSet.h
+++ b/Source/JavaScriptCore/dfg/DFGInsertionSet.h
@@ -65,7 +65,7 @@ public:
     template<typename... Params>
     Node* insertNode(size_t index, SpeculatedType type, Params... params)
     {
-        return insert(index, m_graph.addNode(type, params...));
+        return insert(index, m_graph.addNode(type, WTF::move(params)...));
     }
     
     Node* insertConstant(size_t index, NodeOrigin, FrozenValue*, NodeType op = JSConstant);

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -342,7 +342,7 @@ public:
     Node(const Node&) = default;
 
     Node(NodeType op, NodeOrigin nodeOrigin, const AdjacencyList& children)
-        : origin(nodeOrigin)
+        : origin(WTF::move(nodeOrigin))
         , children(children)
         , m_virtualRegister(VirtualRegister())
         , m_refCount(1)
@@ -355,7 +355,7 @@ public:
     
     // Construct a node with up to 3 children, no immediate value.
     Node(NodeType op, NodeOrigin nodeOrigin, Edge child1 = Edge(), Edge child2 = Edge(), Edge child3 = Edge())
-        : origin(nodeOrigin)
+        : origin(WTF::move(nodeOrigin))
         , children(AdjacencyList::Fixed, child1, child2, child3)
         , m_virtualRegister(VirtualRegister())
         , m_refCount(1)
@@ -369,7 +369,7 @@ public:
 
     // Construct a node with up to 3 children, no immediate value.
     Node(NodeFlags result, NodeType op, NodeOrigin nodeOrigin, Edge child1 = Edge(), Edge child2 = Edge(), Edge child3 = Edge())
-        : origin(nodeOrigin)
+        : origin(WTF::move(nodeOrigin))
         , children(AdjacencyList::Fixed, child1, child2, child3)
         , m_virtualRegister(VirtualRegister())
         , m_refCount(1)
@@ -384,7 +384,7 @@ public:
 
     // Construct a node with up to 3 children and an immediate value.
     Node(NodeType op, NodeOrigin nodeOrigin, OpInfo imm, Edge child1 = Edge(), Edge child2 = Edge(), Edge child3 = Edge())
-        : origin(nodeOrigin)
+        : origin(WTF::move(nodeOrigin))
         , children(AdjacencyList::Fixed, child1, child2, child3)
         , m_virtualRegister(VirtualRegister())
         , m_refCount(1)
@@ -399,7 +399,7 @@ public:
 
     // Construct a node with up to 3 children and an immediate value.
     Node(NodeFlags result, NodeType op, NodeOrigin nodeOrigin, OpInfo imm, Edge child1 = Edge(), Edge child2 = Edge(), Edge child3 = Edge())
-        : origin(nodeOrigin)
+        : origin(WTF::move(nodeOrigin))
         , children(AdjacencyList::Fixed, child1, child2, child3)
         , m_virtualRegister(VirtualRegister())
         , m_refCount(1)
@@ -415,7 +415,7 @@ public:
 
     // Construct a node with up to 3 children and two immediate values.
     Node(NodeType op, NodeOrigin nodeOrigin, OpInfo imm1, OpInfo imm2, Edge child1 = Edge(), Edge child2 = Edge(), Edge child3 = Edge())
-        : origin(nodeOrigin)
+        : origin(WTF::move(nodeOrigin))
         , children(AdjacencyList::Fixed, child1, child2, child3)
         , m_virtualRegister(VirtualRegister())
         , m_refCount(1)
@@ -431,7 +431,7 @@ public:
     
     // Construct a node with a variable number of children and two immediate values.
     Node(VarArgTag, NodeType op, NodeOrigin nodeOrigin, OpInfo imm1, OpInfo imm2, unsigned firstChild, unsigned numChildren)
-        : origin(nodeOrigin)
+        : origin(WTF::move(nodeOrigin))
         , children(AdjacencyList::Variable, firstChild, numChildren)
         , m_virtualRegister(VirtualRegister())
         , m_refCount(1)

--- a/Source/JavaScriptCore/dfg/DFGNodeOrigin.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeOrigin.h
@@ -39,8 +39,8 @@ struct NodeOrigin {
     NodeOrigin() { }
     
     NodeOrigin(CodeOrigin semantic, CodeOrigin forExit, bool exitOK)
-        : semantic(semantic)
-        , forExit(forExit)
+        : semantic(WTF::move(semantic))
+        , forExit(WTF::move(forExit))
         , exitOK(exitOK)
     {
     }
@@ -56,9 +56,8 @@ struct NodeOrigin {
         if (!isSet())
             return NodeOrigin();
         
-        NodeOrigin result = *this;
-        if (semantic.isSet())
-            result.semantic = semantic;
+        NodeOrigin result(semantic.isSet() ? WTF::move(semantic) : this->semantic, forExit, exitOK);
+        result.wasHoisted = wasHoisted;
         return result;
     }
 
@@ -67,10 +66,8 @@ struct NodeOrigin {
         if (!isSet())
             return NodeOrigin();
         
-        NodeOrigin result = *this;
-        if (forExit.isSet())
-            result.forExit = forExit;
-        result.exitOK = exitOK;
+        NodeOrigin result(semantic, forExit.isSet() ? WTF::move(forExit) : this->forExit, exitOK);
+        result.wasHoisted = wasHoisted;
         return result;
     }
 


### PR DESCRIPTION
#### e2f1a867ae69cfe07c4fe23b51b24186b32ab991
<pre>
[JSC] Move CodeOrigin instead of copying it when creating DFG nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=323490">https://bugs.webkit.org/show_bug.cgi?id=323490</a>
<a href="https://rdar.apple.com/186725447">rdar://186725447</a>

Reviewed by Yusuke Suzuki.

Copying a CodeOrigin heap allocates an OutOfLineCodeOrigin when the bytecode index is too large to
pack into the spare top address bits. Its move constructor just steals the composite word, so every
copy we avoid along the node creation path is one malloc/free avoided for large or deeply inlined
code.

withSemantic() and withForExitAndExitOK() now construct the result directly rather than copying
*this and overwriting a field, propagating wasHoisted explicitly.

No behavior change.

* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::currentNodeOrigin):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGInsertionSet.h:
(JSC::DFG::InsertionSet::insertNode):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::Node):
* Source/JavaScriptCore/dfg/DFGNodeOrigin.h:
(JSC::DFG::NodeOrigin::NodeOrigin):
(JSC::DFG::NodeOrigin::withSemantic const):
(JSC::DFG::NodeOrigin::withForExitAndExitOK const):

Canonical link: <a href="https://commits.webkit.org/320556@main">https://commits.webkit.org/320556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d0c300a6ba83c1be27d363fa2e2d8233012f289

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52850 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195449 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a65558f7-55a6-4f45-8a84-c7a3f53a552d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144655 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3e0d1e6f-4bcd-4583-8e75-3064ca3fc91a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188076 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124948 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47067 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45129 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/6865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13748 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157434 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44816 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6505 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46379 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197401 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58697 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154159 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59406 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41420 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153811 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28116 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48308 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131707 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128345 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57885 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19835 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57256 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57499 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57323 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->