### PR TITLE
Add missing thread-safety annotations and address potential issues they uncovered

### DIFF
--- a/Source/JavaScriptCore/assembler/PerfLog.h
+++ b/Source/JavaScriptCore/assembler/PerfLog.h
@@ -55,10 +55,10 @@ private:
     void write(const AbstractLocker& locker, std::span<const char> span) WTF_REQUIRES_LOCK(m_lock) { write(locker, unsafeMakeSpan(std::bit_cast<const uint8_t*>(span.data()), span.size_bytes())); }
     void flush(const AbstractLocker&) WTF_REQUIRES_LOCK(m_lock);
 
-    WTF::FileSystemImpl::FileHandle m_file { };
+    WTF::FileSystemImpl::FileHandle m_file WTF_GUARDED_BY_LOCK(m_lock) { };
     CString m_irDumpDirectory;
     CString m_sourceCodeDumpDirectory;
-    uint64_t m_codeIndex { 0 };
+    uint64_t m_codeIndex WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     Lock m_lock;
 };
 

--- a/Source/JavaScriptCore/ftl/FTLThunks.h
+++ b/Source/JavaScriptCore/ftl/FTLThunks.h
@@ -96,7 +96,7 @@ public:
     
 private:
     Lock m_lock;
-    ThunkMap<SlowPathCallKey> m_slowPathCallThunks;
+    ThunkMap<SlowPathCallKey> m_slowPathCallThunks WTF_GUARDED_BY_LOCK(m_lock);
 };
 
 } } // namespace JSC::FTL

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -977,13 +977,13 @@ private:
     std::unique_ptr<MarkStackArray> m_sharedCollectorMarkStack;
     std::unique_ptr<MarkStackArray> m_sharedMutatorMarkStack;
     unsigned m_numberOfActiveParallelMarkers { 0 };
-    unsigned m_numberOfWaitingParallelMarkers { 0 };
+    unsigned m_numberOfWaitingParallelMarkers WTF_GUARDED_BY_LOCK(m_markingMutex) { 0 };
 
     ConcurrentPtrHashSet m_opaqueRoots;
     static constexpr size_t s_blockFragmentLength = 32;
 
     ParallelHelperClient m_helperClient;
-    RefPtr<SharedTask<void(SlotVisitor&)>> m_bonusVisitorTask;
+    RefPtr<SharedTask<void(SlotVisitor&)>> m_bonusVisitorTask WTF_GUARDED_BY_LOCK(m_markingMutex);
 
 #if ENABLE(RESOURCE_USAGE)
     size_t m_blockBytesAllocated { 0 };
@@ -1019,7 +1019,7 @@ private:
     bool m_threadShouldStop { false };
     bool m_mutatorDidRun { true };
     bool m_didDeferGCWork { false };
-    bool m_shouldStopCollectingContinuously { false };
+    bool m_shouldStopCollectingContinuously WTF_GUARDED_BY_LOCK(m_collectContinuouslyLock) { false };
     bool m_isCompilerThreadsSuspended { false };
 
     uint64_t m_mutatorExecutionVersion { 0 };

--- a/Source/JavaScriptCore/heap/HeapSnapshotBuilder.h
+++ b/Source/JavaScriptCore/heap/HeapSnapshotBuilder.h
@@ -177,7 +177,7 @@ private:
     UncheckedKeyHashMap<JSCell*, RootData> m_rootData;
     UncheckedKeyHashMap<JSCell*, void*> m_wrappedObjectPointers;
     UncheckedKeyHashMap<JSCell*, String> m_cellLabels;
-    UncheckedKeyHashSet<JSCell*> m_appendedCells;
+    UncheckedKeyHashSet<JSCell*> m_appendedCells WTF_GUARDED_BY_LOCK(m_buildingNodeMutex);
     SnapshotType m_snapshotType;
 };
 

--- a/Source/JavaScriptCore/heap/ParallelSourceAdapter.h
+++ b/Source/JavaScriptCore/heap/ParallelSourceAdapter.h
@@ -56,7 +56,7 @@ public:
 
 private:
     RefPtr<SharedTask<OuterType()>> m_outerSource;
-    RefPtr<SharedTask<InnerType()>> m_innerSource;
+    RefPtr<SharedTask<InnerType()>> m_innerSource WTF_GUARDED_BY_LOCK(m_lock);
     UnwrapFunc m_unwrapFunc;
     Lock m_lock;
 };

--- a/Source/JavaScriptCore/heap/SlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/SlotVisitor.cpp
@@ -632,6 +632,7 @@ NEVER_INLINE SlotVisitor::SharedDrainResult SlotVisitor::drainFromShared(SharedD
                 m_heap.m_numberOfActiveParallelMarkers--;
             m_heap.m_numberOfWaitingParallelMarkers++;
             auto stopWaiting = makeScopeExit([&] {
+                locker.assertIsHolding(m_heap.m_markingMutex);
                 m_heap.m_numberOfWaitingParallelMarkers--;
             });
 
@@ -675,6 +676,7 @@ NEVER_INLINE SlotVisitor::SharedDrainResult SlotVisitor::drainFromShared(SharedD
                 }
 
                 auto isReady = [&] () -> bool {
+                    locker.assertIsHolding(m_heap.m_markingMutex);
                     return hasWork(locker)
                         || m_heap.m_bonusVisitorTask
                         || m_heap.m_parallelMarkersShouldExit;
@@ -692,6 +694,7 @@ NEVER_INLINE SlotVisitor::SharedDrainResult SlotVisitor::drainFromShared(SharedD
             if (!bonusTask && isEmpty()) {
                 forEachMarkStack(
                     [&] (MarkStackArray& stack) -> IterationStatus {
+                        locker.assertIsHolding(m_heap.m_markingMutex);
                         stack.stealSomeCellsFrom(
                             correspondingGlobalStack(stack),
                             m_heap.m_numberOfWaitingParallelMarkers);

--- a/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.h
@@ -74,9 +74,9 @@ public:
     NSString *connectionIdentifier() const;
     NSString *destination() const;
 
-    Lock& queueMutex() LIFETIME_BOUND { return m_queueMutex; }
-    const RemoteTargetQueue& queue() const LIFETIME_BOUND { return m_queue; }
-    RemoteTargetQueue takeQueue();
+    Lock& queueMutex() LIFETIME_BOUND WTF_RETURNS_LOCK(m_queueMutex) { return m_queueMutex; }
+    const RemoteTargetQueue& queue() const LIFETIME_BOUND WTF_REQUIRES_LOCK(m_queueMutex) { return m_queue; }
+    RemoteTargetQueue takeQueue() WTF_REQUIRES_LOCK(m_queueMutex);
 #endif
 
     // FrontendChannel overrides.
@@ -102,7 +102,7 @@ private:
     // we setup our run loop sources on that specific run loop.
     RetainPtr<CFRunLoopRef> m_runLoop;
     RetainPtr<CFRunLoopSourceRef> m_runLoopSource;
-    RemoteTargetQueue m_queue;
+    RemoteTargetQueue m_queue WTF_GUARDED_BY_LOCK(m_queueMutex);
     Lock m_queueMutex;
 #endif
 

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -1103,7 +1103,7 @@ private:
 
 #if ENABLE(MPROTECT_RX_TO_RWX)
     Lock m_pageLock;
-    uint8_t* m_pageWriterCounts;
+    uint8_t* m_pageWriterCounts WTF_GUARDED_BY_LOCK(m_pageLock);
 #endif
 
     size_t m_bytesReserved { 0 };

--- a/Source/JavaScriptCore/jit/GdbJIT.h
+++ b/Source/JavaScriptCore/jit/GdbJIT.h
@@ -67,7 +67,7 @@ private:
     static GdbJIT& singleton();
 
     Lock m_lock;
-    GdbJITCodeMap m_map;
+    GdbJITCodeMap m_map WTF_GUARDED_BY_LOCK(m_lock);
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/profiler/ProfilerDatabase.h
+++ b/Source/JavaScriptCore/profiler/ProfilerDatabase.h
@@ -68,7 +68,7 @@ public:
     JS_EXPORT_PRIVATE void logEvent(CodeBlock* codeBlock, const char* summary, const CString& detail);
     
 private:
-    Bytecodes* ensureBytecodesFor(const AbstractLocker&, CodeBlock*);
+    Bytecodes* ensureBytecodesFor(const AbstractLocker&, CodeBlock*) WTF_REQUIRES_LOCK(m_lock);
     
     void addDatabaseToAtExit();
     void removeDatabaseFromAtExit();
@@ -79,9 +79,9 @@ private:
     DatabaseID m_databaseID;
     VM& m_vm;
     SegmentedVector<Bytecodes> m_bytecodes;
-    UncheckedKeyHashMap<CodeBlock*, Bytecodes*> m_bytecodesMap;
+    UncheckedKeyHashMap<CodeBlock*, Bytecodes*> m_bytecodesMap WTF_GUARDED_BY_LOCK(m_lock);
     Vector<Ref<Compilation>> m_compilations;
-    UncheckedKeyHashMap<CodeBlock*, Ref<Compilation>> m_compilationMap;
+    UncheckedKeyHashMap<CodeBlock*, Ref<Compilation>> m_compilationMap WTF_GUARDED_BY_LOCK(m_lock);
     Vector<Event> m_events;
     bool m_shouldSaveAtExit;
     CString m_atExitSaveFilename;

--- a/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
+++ b/Source/JavaScriptCore/runtime/JSRunLoopTimer.h
@@ -86,7 +86,7 @@ public:
             Vector<std::pair<Ref<JSRunLoopTimer>, MonotonicTime>> timers;
         };
 
-        UncheckedKeyHashMap<Ref<JSLock>, std::unique_ptr<PerVMData>> m_mapping;
+        UncheckedKeyHashMap<Ref<JSLock>, std::unique_ptr<PerVMData>> m_mapping WTF_GUARDED_BY_LOCK(m_lock);
     };
 
     JSRunLoopTimer(VM&);
@@ -115,7 +115,7 @@ private:
 
     void timerDidFire();
 
-    UncheckedKeyHashSet<TimerNotificationCallback> m_timerSetCallbacks;
+    UncheckedKeyHashSet<TimerNotificationCallback> m_timerSetCallbacks WTF_GUARDED_BY_LOCK(m_timerCallbacksLock);
     Lock m_timerCallbacksLock;
 
     Lock m_lock;

--- a/Source/JavaScriptCore/runtime/NumberPredictionFuzzerAgent.h
+++ b/Source/JavaScriptCore/runtime/NumberPredictionFuzzerAgent.h
@@ -40,7 +40,7 @@ public:
     NumberPredictionFuzzerAgent(VM&);
 
 protected:
-    WeakRandom m_random;
+    WeakRandom m_random WTF_GUARDED_BY_LOCK(m_lock);
     Lock m_lock;
     static Vector<SpeculatedType> bytecodeNumberTypes();
 };

--- a/Source/JavaScriptCore/runtime/ProfilerSupport.h
+++ b/Source/JavaScriptCore/runtime/ProfilerSupport.h
@@ -80,8 +80,8 @@ private:
     void write(const AbstractLocker&, uint64_t start, uint64_t end, const CString& message) WTF_REQUIRES_LOCK(m_lock);
 
     const Ref<WorkQueue> m_queue;
-    std::array<HashMap<const void*, uint64_t>, numberOfCategories> m_markers;
-    WTF::FileSystemImpl::FileHandle m_file { };
+    std::array<HashMap<const void*, uint64_t>, numberOfCategories> m_markers WTF_GUARDED_BY_LOCK(m_tableLock);
+    WTF::FileSystemImpl::FileHandle m_file WTF_GUARDED_BY_LOCK(m_lock) { };
     Lock m_tableLock;
     Lock m_lock;
 };

--- a/Source/JavaScriptCore/runtime/RandomizingFuzzerAgent.h
+++ b/Source/JavaScriptCore/runtime/RandomizingFuzzerAgent.h
@@ -42,7 +42,7 @@ public:
     SpeculatedType getPrediction(CodeBlock*, const CodeOrigin&, SpeculatedType) final;
 
 private:
-    WeakRandom m_random;
+    WeakRandom m_random WTF_GUARDED_BY_LOCK(m_lock);
     Lock m_lock;
 };
 

--- a/Source/JavaScriptCore/runtime/RegExpCache.h
+++ b/Source/JavaScriptCore/runtime/RegExpCache.h
@@ -77,7 +77,7 @@ private:
 
     unsigned m_nextEntryInStrongCache { 0 };
     Lock m_lock;
-    RegExpCacheMap m_weakCache; // Holds all regular expressions currently live.
+    RegExpCacheMap m_weakCache WTF_GUARDED_BY_LOCK(m_lock); // Holds all regular expressions currently live.
     std::array<RegExp*, maxStrongCacheableEntries> m_strongCache { }; // Holds a select few regular expressions that have compiled and executed
     RegExp* m_emptyRegExp { nullptr };
 };

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -276,7 +276,7 @@ private:
 
     CalleeGroup(VM&, MemoryMode, ModuleInformation&, Ref<IPIntCallees>&&);
     CalleeGroup(MemoryMode, const CalleeGroup&);
-    void setCompilationFinished();
+    void setCompilationFinished() WTF_REQUIRES_LOCK(m_lock);
 
     OptimizedCallees* optimizedCalleesTuple(const AbstractLocker&, FunctionCodeIndex index) WTF_REQUIRES_LOCK(m_lock)
     {
@@ -345,7 +345,7 @@ private:
     FixedVector<CodePtr<WasmEntryPtrTag>> m_wasmIndirectCallEntrypoints;
     FixedVector<RefPtr<Wasm::IPIntCallee>> m_wasmIndirectCallWasmCallees;
     FixedVector<MacroAssemblerCodeRef<WasmEntryPtrTag>> m_wasmToWasmExitStubs;
-    RefPtr<EntryPlan> m_plan;
+    RefPtr<EntryPlan> m_plan WTF_GUARDED_BY_LOCK(m_lock);
     std::atomic<bool> m_compilationFinished { false };
     String m_errorMessage;
 public:

--- a/Source/JavaScriptCore/wasm/WasmPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmPlan.h
@@ -99,7 +99,7 @@ protected:
 
     Ref<ModuleInformation> m_moduleInformation; // noconst
 
-    Vector<std::pair<VM*, CompletionTask>, 1> m_completionTasks;
+    Vector<std::pair<VM*, CompletionTask>, 1> m_completionTasks WTF_GUARDED_BY_LOCK(m_lock);
 
     String m_errorMessage;
     std::optional<FunctionCodeIndex> m_errorFunctionIndex;

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
@@ -84,7 +84,7 @@ private:
     bool m_eagerFailed WTF_GUARDED_BY_LOCK(m_lock) { false };
     bool m_finalized WTF_GUARDED_BY_LOCK(m_lock) { false };
     bool m_threadedCompilationStarted { false };
-    std::optional<WebAssemblyCompileOptions> m_compileOptions;
+    std::optional<WebAssemblyCompileOptions> m_compileOptions WTF_GUARDED_BY_LOCK(m_lock);
     Lock m_lock;
     unsigned m_remainingCompilationRequests { 0 };
     ThreadSafeWeakPtr<DeferredWorkTimer::Ticket> m_ticket;

--- a/Source/JavaScriptCore/wasm/WasmThunks.cpp
+++ b/Source/JavaScriptCore/wasm/WasmThunks.cpp
@@ -344,6 +344,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> Thunks::stub(ThunkGenerator generator)
 
 MacroAssemblerCodeRef<JITThunkPtrTag> Thunks::stub(const AbstractLocker& locker, ThunkGenerator generator)
 {
+    assertIsHeld(m_lock);
     ASSERT(!!generator);
     {
         auto addResult = m_stubs.add(generator, MacroAssemblerCodeRef<JITThunkPtrTag>());

--- a/Source/JavaScriptCore/wasm/WasmThunks.h
+++ b/Source/JavaScriptCore/wasm/WasmThunks.h
@@ -74,7 +74,7 @@ public:
 private:
     Thunks() = default;
 
-    UncheckedKeyHashMap<ThunkGenerator, MacroAssemblerCodeRef<JITThunkPtrTag>> m_stubs;
+    UncheckedKeyHashMap<ThunkGenerator, MacroAssemblerCodeRef<JITThunkPtrTag>> m_stubs WTF_GUARDED_BY_LOCK(m_lock);
     Lock m_lock;
 };
 

--- a/Source/WTF/wtf/ConcurrentPtrHashSet.h
+++ b/Source/WTF/wtf/ConcurrentPtrHashSet.h
@@ -119,7 +119,7 @@ private:
         return PtrHash<const void*>::hash(ptr);
     }
     
-    void initialize();
+    void initialize() WTF_REQUIRES_LOCK(m_lock);
     
     template<typename T>
     static void* cast(T value)
@@ -179,7 +179,7 @@ private:
     void resizeIfNecessary();
     bool resizeAndAdd(void* ptr);
 
-    Vector<std::unique_ptr<Table>, 4> m_allTables;
+    Vector<std::unique_ptr<Table>, 4> m_allTables WTF_GUARDED_BY_LOCK(m_lock);
     Atomic<Table*> m_table; // This is never null.
     std::unique_ptr<Table> m_stubTable;
     mutable Lock m_lock; // We just use this to control resize races.

--- a/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
+++ b/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
@@ -61,14 +61,14 @@ public:
     void randomValues(std::span<uint8_t>);
 
 private:
-    inline void NODELETE addRandomData(std::span<const uint8_t, 128>);
+    inline void NODELETE addRandomData(std::span<const uint8_t, 128>) WTF_REQUIRES_LOCK(m_lock);
     void stir() WTF_REQUIRES_LOCK(m_lock);
     void stirIfNeeded() WTF_REQUIRES_LOCK(m_lock);
     inline uint8_t NODELETE getByte() WTF_REQUIRES_LOCK(m_lock);
 
     Lock m_lock;
-    ARC4Stream m_stream;
-    int m_count { 0 };
+    ARC4Stream m_stream WTF_GUARDED_BY_LOCK(m_lock);
+    int m_count WTF_GUARDED_BY_LOCK(m_lock) { 0 };
 };
 
 ARC4Stream::ARC4Stream()

--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -316,7 +316,7 @@ private:
 #else
     mutable Lock m_registeredTimerLock;
 #endif
-    HashSet<TimerBase *> m_registeredTimers;
+    HashSet<TimerBase *> m_registeredTimers WTF_GUARDED_BY_LOCK(m_registeredTimerLock);
 
     Deque<Function<void()>> m_currentIteration;
 

--- a/Source/WTF/wtf/darwin/OSLogPrintStream.h
+++ b/Source/WTF/wtf/darwin/OSLogPrintStream.h
@@ -54,7 +54,7 @@ private:
     Lock m_stringLock;
     // We need a buffer because os_log doesn't wait for a new line to print the characters.
     CString m_string WTF_GUARDED_BY_LOCK(m_stringLock);
-    size_t m_offset { 0 };
+    size_t m_offset WTF_GUARDED_BY_LOCK(m_stringLock) { 0 };
 };
 
 } // namespace WTF

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h
@@ -115,7 +115,7 @@ private:
     // If true, it will wrap around to the start of the buffer each time it reaches the end.
     bool m_isLooping WTF_GUARDED_BY_LOCK(m_processLock) { false }; // Only modified on the main thread but queried on the audio thread.
 
-    bool m_wasBufferSet { false };
+    bool m_wasBufferSet { false }; // Only used on the main thread, in setBufferForBindings().
 
     double m_loopStart WTF_GUARDED_BY_LOCK(m_processLock) { 0 }; // Only modified on the main thread but queried on the audio thread.
     double m_loopEnd WTF_GUARDED_BY_LOCK(m_processLock) { 0 }; // Only modified on the main thread but queried on the audio thread.

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.h
@@ -80,7 +80,7 @@ private:
 
     enum class ProcessorError { ConstructorError, ProcessError };
     void fireProcessorErrorOnMainThread(ProcessorError, std::optional<ExceptionDetails>&& = std::nullopt);
-    void didFinishProcessingOnRenderingThread(std::optional<ExceptionDetails>&&);
+    void didFinishProcessingOnRenderingThread(std::optional<ExceptionDetails>&&) WTF_REQUIRES_LOCK(m_processLock);
 
     // AudioNode.
     void process(size_t framesToProcess) final;
@@ -103,9 +103,9 @@ private:
     // destructor since the node is destroyed on the main thread.
     NO_UNIQUE_ADDRESS ThreadLikeAssertion m_renderingThread { noneThreadLike };
 
-    RefPtr<AudioWorkletProcessor> m_processor; // Should only be used on the rendering thread.
+    RefPtr<AudioWorkletProcessor> m_processor WTF_GUARDED_BY_LOCK(m_processLock); // Should only be used on the rendering thread.
     MemoryCompactLookupOnlyRobinHoodHashMap<String, std::unique_ptr<AudioFloatArray>> m_paramValuesMap;
-    RefPtr<WTF::Thread> m_workletThread;
+    RefPtr<WTF::Thread> m_workletThread WTF_GUARDED_BY_LOCK(m_processLock);
 
     // Keeps the reference of AudioBus objects from AudioNodeInput and AudioNodeOutput in order
     // to pass them to AudioWorkletProcessor.

--- a/Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp
@@ -1269,7 +1269,7 @@ static Lock notificationLock;
 
 using NotificationQueue = Vector<std::pair<SecurityOriginData, String>>;
 
-static NotificationQueue& NODELETE notificationQueue()
+static NotificationQueue& NODELETE notificationQueue() WTF_REQUIRES_LOCK(notificationLock)
 {
     static NeverDestroyed<NotificationQueue> queue;
     return queue;

--- a/Source/WebCore/dom/Event.cpp
+++ b/Source/WebCore/dom/Event.cpp
@@ -124,7 +124,10 @@ void Event::initEvent(const AtomString& eventTypeArg, bool canBubbleArg, bool ca
     m_immediatePropagationStopped = false;
     m_wasCanceled = false;
     m_isTrusted = false;
-    m_target = nullptr;
+    {
+        Locker targetLocker { m_targetLock };
+        m_target = nullptr;
+    }
     m_type = eventTypeArg;
     m_canBubble = canBubbleArg;
     m_cancelable = cancelableArg;

--- a/Source/WebCore/page/scrolling/ScrollingTreeLatchingController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeLatchingController.cpp
@@ -104,6 +104,7 @@ void ScrollingTreeLatchingController::nodeDidHandleEvent(ScrollingNodeID scrolli
     }
 
     auto shouldLatch = [&]() {
+        locker.assertIsHolding(m_latchedNodeLock);
         if (wheelEvent.delta().isZero())
             return false;
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeLatchingController.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeLatchingController.h
@@ -59,12 +59,12 @@ public:
     void clearLatchedNode();
 
 private:
-    bool latchedNodeHasRecentInteraction() const;
+    bool latchedNodeHasRecentInteraction() const WTF_REQUIRES_LOCK(m_latchedNodeLock);
 
     mutable Lock m_latchedNodeLock;
     std::optional<ScrollingNodeAndProcessingSteps> m_latchedNodeAndSteps WTF_GUARDED_BY_LOCK(m_latchedNodeLock);
-    std::optional<OptionSet<WheelEventProcessingSteps>> m_processingStepsForCurrentGesture;
-    MonotonicTime m_lastLatchedNodeInterationTime;
+    std::optional<OptionSet<WheelEventProcessingSteps>> m_processingStepsForCurrentGesture WTF_GUARDED_BY_LOCK(m_latchedNodeLock);
+    MonotonicTime m_lastLatchedNodeInterationTime WTF_GUARDED_BY_LOCK(m_latchedNodeLock);
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
@@ -116,7 +116,7 @@ private:
     const Ref<WTF::WorkQueue> m_delegateQueue;
     Semaphore m_hasKeyRequestSemaphore;
     mutable Lock m_keyRequestLock;
-    RetainPtr<AVContentKeyRequest> m_keyRequest;
+    RetainPtr<AVContentKeyRequest> m_keyRequest WTF_GUARDED_BY_LOCK(m_keyRequestLock);
     RefPtr<Uint8Array> m_identifier;
     RefPtr<SharedBuffer> m_sourceBufferInitData;
     RefPtr<SharedBuffer> m_initData;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
@@ -423,6 +423,10 @@ void ImageDecoderAVFObjC::readSamples()
 
 void ImageDecoderAVFObjC::readTrackMetadata()
 {
+    // m_imageRotationSession and m_size are read on the image decoding work queue by
+    // createFrameImageAtIndex(), so replacing them here must not race with it.
+    Locker locker { m_sampleGeneratorLock };
+
     AffineTransform finalTransform = CGAffineTransformConcat(m_asset.get().preferredTransform, m_track.get().preferredTransform);
     auto size = expandedIntSize(FloatSize(m_track.get().naturalSize));
     if (finalTransform.isIdentity()) {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -443,7 +443,7 @@ private:
 
     friend class WebCoreAVFResourceLoader;
     mutable Lock m_resourceLoaderMapLock;
-    HashMap<RetainPtr<AVAssetResourceLoadingRequest>, Ref<WebCoreAVFResourceLoader>> m_resourceLoaderMap;
+    HashMap<RetainPtr<AVAssetResourceLoadingRequest>, Ref<WebCoreAVFResourceLoader>> m_resourceLoaderMap WTF_GUARDED_BY_LOCK(m_resourceLoaderMapLock);
     const RetainPtr<WebCoreAVFLoaderDelegate> m_loaderDelegate;
     MemoryCompactRobinHoodHashMap<String, RetainPtr<AVAssetResourceLoadingRequest>> m_keyURIToRequestMap;
 

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
@@ -94,9 +94,9 @@ private:
     RefPtr<VideoInfo> m_videoInfo WTF_GUARDED_BY_CAPABILITY(vpxDecoderQueueSingleton());
     RetainPtr<CVPixelBufferPoolRef> m_pixelBufferPool WTF_GUARDED_BY_LOCK(m_pixelBufferPoolLock);
     Lock m_pixelBufferPoolLock;
-    size_t m_pixelBufferPoolWidth { 0 };
-    size_t m_pixelBufferPoolHeight { 0 };
-    OSType m_pixelBufferPoolType;
+    size_t m_pixelBufferPoolWidth WTF_GUARDED_BY_LOCK(m_pixelBufferPoolLock) { 0 };
+    size_t m_pixelBufferPoolHeight WTF_GUARDED_BY_LOCK(m_pixelBufferPoolLock) { 0 };
+    OSType m_pixelBufferPoolType WTF_GUARDED_BY_LOCK(m_pixelBufferPoolLock);
     const UniqueRef<webrtc::VideoDecoder> m_internalDecoder WTF_GUARDED_BY_CAPABILITY(vpxDecoderQueueSingleton());
     const bool m_useIOSurface { false };
     const bool m_treatNoOutputAsError { true };

--- a/Source/WebCore/platform/mediastream/cocoa/MediaStreamTrackAudioSourceProviderCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/MediaStreamTrackAudioSourceProviderCocoa.h
@@ -32,6 +32,7 @@
 #include "RealtimeMediaSource.h"
 #include "WebAudioSourceProvider.h"
 #include <CoreAudio/CoreAudioTypes.h>
+#include <atomic>
 #include <wtf/CheckedRef.h>
 #include <wtf/MediaTime.h>
 #include <wtf/TZoneMalloc.h>
@@ -97,13 +98,14 @@ private:
     WeakPtr<AudioSourceProviderClient> m_client;
 
     std::optional<CAAudioStreamDescription> m_inputDescription;
-    std::optional<CAAudioStreamDescription> m_outputDescription;
-    std::unique_ptr<WebAudioBufferList> m_audioBufferList;
+    std::optional<CAAudioStreamDescription> m_outputDescription WTF_GUARDED_BY_LOCK(m_lock);
+    std::unique_ptr<WebAudioBufferList> m_audioBufferList WTF_GUARDED_BY_LOCK(m_lock);
     RefPtr<AudioSampleDataSource> m_dataSource;
 
     size_t m_pollSamplesCount { 3 };
-    uint64_t m_writeCount { 0 };
-    uint64_t m_readCount { 0 };
+    // Written by the capture thread without the lock and read by the rendering thread under it.
+    std::atomic<uint64_t> m_writeCount { 0 };
+    uint64_t m_readCount WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     WeakPtr<MediaStreamTrackPrivate> m_captureSource;
     const Ref<RealtimeMediaSource> m_source;
     bool m_enabled { true };

--- a/Source/WebCore/platform/mediastream/cocoa/RealtimeIncomingVideoSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/RealtimeIncomingVideoSourceCocoa.h
@@ -50,7 +50,7 @@ public:
 private:
     RealtimeIncomingVideoSourceCocoa(Ref<webrtc::VideoTrackInterface>&&, String&&);
     RetainPtr<CVPixelBufferRef> pixelBufferFromVideoFrame(const webrtc::VideoFrame&);
-    CVPixelBufferPoolRef pixelBufferPool(size_t width, size_t height, webrtc::BufferType);
+    CVPixelBufferPoolRef pixelBufferPool(size_t width, size_t height, webrtc::BufferType) WTF_REQUIRES_LOCK(m_pixelBufferPoolLock);
     RefPtr<VideoFrame> toVideoFrame(const webrtc::VideoFrame&, VideoFrameRotation);
     Ref<VideoFrame> createVideoSampleFromCVPixelBuffer(RetainPtr<CVPixelBufferRef>&&, VideoFrameRotation, int64_t);
 
@@ -65,9 +65,9 @@ private:
 #endif
     Lock m_pixelBufferPoolLock;
     RetainPtr<CVPixelBufferPoolRef> m_pixelBufferPool WTF_GUARDED_BY_LOCK(m_pixelBufferPoolLock);
-    size_t m_pixelBufferPoolWidth { 0 };
-    size_t m_pixelBufferPoolHeight { 0 };
-    webrtc::BufferType m_pixelBufferPoolBufferType;
+    size_t m_pixelBufferPoolWidth WTF_GUARDED_BY_LOCK(m_pixelBufferPoolLock) { 0 };
+    size_t m_pixelBufferPoolHeight WTF_GUARDED_BY_LOCK(m_pixelBufferPoolLock) { 0 };
+    webrtc::BufferType m_pixelBufferPoolBufferType WTF_GUARDED_BY_LOCK(m_pixelBufferPoolLock);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/cocoa/RealtimeIncomingVideoSourceCocoa.mm
+++ b/Source/WebCore/platform/mediastream/cocoa/RealtimeIncomingVideoSourceCocoa.mm
@@ -68,7 +68,7 @@ RealtimeIncomingVideoSourceCocoa::~RealtimeIncomingVideoSourceCocoa()
     stop();
 }
 
-CVPixelBufferPoolRef RealtimeIncomingVideoSourceCocoa::pixelBufferPool(size_t width, size_t height, webrtc::BufferType bufferType) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
+CVPixelBufferPoolRef RealtimeIncomingVideoSourceCocoa::pixelBufferPool(size_t width, size_t height, webrtc::BufferType bufferType)
 {
     if (!m_pixelBufferPool || m_pixelBufferPoolWidth != width || m_pixelBufferPoolHeight != height || m_pixelBufferPoolBufferType != bufferType) {
         OSType poolBufferType;

--- a/Source/WebCore/platform/mediastream/cocoa/WebAudioSourceProviderCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/WebAudioSourceProviderCocoa.h
@@ -90,15 +90,15 @@ private:
     bool provideInputInternal(AudioBus&, size_t);
     WEBCORE_EXPORT void setClient(WeakPtr<AudioSourceProviderClient>&&) final;
 
-    void prepare(const AudioStreamBasicDescription&);
+    void prepare(const AudioStreamBasicDescription&) WTF_REQUIRES_LOCK(m_lock);
 
     Lock m_lock;
     WeakPtr<AudioSourceProviderClient> m_client;
 
-    std::unique_ptr<PitchShiftAudioUnit> m_pitchShifter;
-    std::unique_ptr<MultiChannelResampler> m_multiChannelResampler;
-    std::optional<CAAudioStreamDescription> m_inputDescription;
-    std::optional<CAAudioStreamDescription> m_outputDescription;
+    std::unique_ptr<PitchShiftAudioUnit> m_pitchShifter WTF_GUARDED_BY_LOCK(m_lock);
+    std::unique_ptr<MultiChannelResampler> m_multiChannelResampler WTF_GUARDED_BY_LOCK(m_lock);
+    std::optional<CAAudioStreamDescription> m_inputDescription WTF_GUARDED_BY_LOCK(m_lock);
+    std::optional<CAAudioStreamDescription> m_outputDescription WTF_GUARDED_BY_LOCK(m_lock);
     std::unique_ptr<AudioBufferList, WTF::SystemFree<AudioBufferList>> m_list;
     AudioConverterRef m_converter;
     std::unique_ptr<CARingBuffer> m_ringBuffer;

--- a/Source/WebCore/platform/mediastream/cocoa/WebAudioSourceProviderCocoa.mm
+++ b/Source/WebCore/platform/mediastream/cocoa/WebAudioSourceProviderCocoa.mm
@@ -260,6 +260,7 @@ void WebAudioSourceProviderCocoa::receivedNewAudioSamples(const PlatformAudioDat
 
 void WebAudioSourceProviderCocoa::setNeedsFlush()
 {
+    Locker locker { m_lock };
     if (!m_ringBuffer)
         return;
     auto [startFrame, endFrame, writeAhead] = m_ringBuffer->getFetchTimeBounds();

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
@@ -178,7 +178,8 @@ private:
     std::optional<PhotoSettings> m_photoSettings;
     bool m_beingConfigured { false };
     bool m_isUsingRotationAngleForHorizonLevelDisplayChanged { false };
-    bool m_isTakingPhoto { false };
+    // Set on the caller's thread by takePhotoInternal() and cleared on m_runLoop's thread, like m_captureWasInterrupted.
+    std::atomic<bool> m_isTakingPhoto { false };
     std::atomic<bool> m_captureWasInterrupted { false };
 };
 

--- a/Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.h
+++ b/Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.h
@@ -50,7 +50,7 @@ private:
     void displayLinkFired(WebCore::PlatformDisplayID, WebCore::DisplayUpdate, bool wantsFullSpeedUpdates, bool anyObserverWantsCallback) override;
 
     Lock m_connectionLock;
-    RefPtr<IPC::Connection> m_connection;
+    RefPtr<IPC::Connection> m_connection WTF_GUARDED_BY_LOCK(m_connectionLock);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -206,7 +206,7 @@ private:
     SynchronizationState m_state WTF_GUARDED_BY_LOCK(m_scrollingTreeLock) { SynchronizationState::Idle };
     Condition m_stateCondition;
 
-    MonotonicTime m_lastDisplayDidRefreshTime;
+    MonotonicTime m_lastDisplayDidRefreshTime WTF_GUARDED_BY_LOCK(m_scrollingTreeLock);
 
     std::unique_ptr<RunLoop::Timer> m_delayedRenderingUpdateDetectionTimer;
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -495,7 +495,10 @@ void LibWebRTCCodecs::failedDecoding(VideoDecoderIdentifier decoderIdentifier)
     assertIsCurrent(workQueue());
 
     if (auto* decoder = m_decoders.get(decoderIdentifier)) {
-        decoder->hasError = true;
+        {
+            Locker locker { m_connectionLock };
+            decoder->hasError = true;
+        }
         Locker locker { decoder->decodedImageCallbackLock };
         if (decoder->decoderCallback)
             decoder->decoderCallback(nullptr, 0);

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -104,7 +104,7 @@ public:
         String codec;
         std::optional<WebCore::PlatformVideoColorSpace> colorSpaceOverride;
         void* decodedImageCallback WTF_GUARDED_BY_LOCK(decodedImageCallbackLock) { nullptr };
-        DecoderCallback decoderCallback;
+        DecoderCallback decoderCallback WTF_GUARDED_BY_LOCK(decodedImageCallbackLock);
         Lock decodedImageCallbackLock;
         bool hasError { false };
         RefPtr<IPC::Connection> connection;
@@ -159,9 +159,9 @@ public:
         std::optional<EncoderInitializationData> initializationData;
         Vector<PendingFrame> pendingFrames;
         void* encodedImageCallback WTF_GUARDED_BY_LOCK(encodedImageCallbackLock) { nullptr };
-        EncoderCallback encoderCallback;
+        EncoderCallback encoderCallback WTF_GUARDED_BY_LOCK(encodedImageCallbackLock);
 #if ENABLE(WEB_CODECS)
-        DescriptionCallback descriptionCallback;
+        DescriptionCallback descriptionCallback WTF_GUARDED_BY_LOCK(encodedImageCallbackLock);
 #endif
         Lock encodedImageCallbackLock;
         RefPtr<IPC::Connection> connection;
@@ -257,7 +257,7 @@ private:
     Lock m_connectionLock;
     RefPtr<IPC::Connection> m_connection WTF_GUARDED_BY_LOCK(m_connectionLock);
     RefPtr<RemoteVideoFrameObjectHeapProxy> m_videoFrameObjectHeapProxy WTF_GUARDED_BY_LOCK(m_connectionLock);
-    Vector<Function<void()>> m_tasksToDispatchAfterEstablishingConnection;
+    Vector<Function<void()>> m_tasksToDispatchAfterEstablishingConnection WTF_GUARDED_BY_LOCK(m_connectionLock);
 
     const Ref<WorkQueue> m_queue;
     RetainPtr<CVPixelBufferPoolRef> m_pixelBufferPool;

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
@@ -67,7 +67,7 @@ bool SharedVideoFrameWriter::wait(const Function<void(IPC::Semaphore&)>& newSema
         newSemaphoreCallback(m_semaphore.get());
         return true;
     }
-    return !m_isDisabled && m_semaphore->waitFor(defaultTimeout);
+    return !WTF::atomicLoad(&m_isDisabled, std::memory_order_relaxed) && m_semaphore->waitFor(defaultTimeout);
 }
 
 bool SharedVideoFrameWriter::allocateStorage(size_t size, NOESCAPE const Function<void(SharedMemory::Handle&&)>& newMemoryCallback)
@@ -201,7 +201,7 @@ void SharedVideoFrameWriter::signalInCaseOfError()
 
 void SharedVideoFrameWriter::disable()
 {
-    m_isDisabled = true;
+    WTF::atomicStore(&m_isDisabled, true, std::memory_order_relaxed);
     m_semaphore->signal();
 }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
@@ -34,6 +34,8 @@
 #include <WebCore/PlatformVideoColorSpace.h>
 #include <WebCore/ProcessIdentity.h>
 #include <WebCore/SharedMemory.h>
+#include <atomic>
+#include <wtf/Atomics.h>
 #include <wtf/MediaTime.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
@@ -80,7 +82,7 @@ public:
     std::optional<SharedVideoFrame::Buffer> writeBuffer(const WebCore::VideoFrame&, NOESCAPE const Function<void(IPC::Semaphore&)>&, NOESCAPE const Function<void(WebCore::SharedMemory::Handle&&)>&);
 
     void disable();
-    bool isDisabled() const { return m_isDisabled; }
+    bool isDisabled() { return WTF::atomicLoad(&m_isDisabled, std::memory_order_relaxed); }
 
 private:
     static constexpr Seconds defaultTimeout = 3_s;
@@ -98,6 +100,10 @@ private:
     RefPtr<WebCore::SharedMemory> m_storage;
     std::unique_ptr<WebCore::PixelBufferConformerCV> m_compressedPixelBufferConformer;
     bool m_isSemaphoreInUse { false };
+    // Written by disable() from another thread without holding any lock, so that a writer
+    // blocked in wait() while holding m_encodersConnectionLock can be unblocked without deadlock.
+    // Accessed with WTF::atomicLoad/atomicStore rather than declared std::atomic so that this
+    // class stays assignable from a default-constructed temporary.
     bool m_isDisabled { false };
     bool m_shouldSignalInCaseOfError { false };
 };

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
@@ -271,7 +271,10 @@ void WebServiceWorkerFetchTaskClient::doCancel()
 
 void WebServiceWorkerFetchTaskClient::convertFetchToDownload()
 {
-    m_isDownload = true;
+    {
+        Locker lock { m_connectionLock };
+        m_isDownload = true;
+    }
     continueDidReceiveResponse();
 }
 

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h
@@ -108,12 +108,12 @@ private:
     WebCore::FetchIdentifier m_fetchIdentifier;
     RefPtr<BlobLoader> m_blobLoader;
     bool m_needsContinueDidReceiveResponseMessage { false };
-    bool m_waitingForContinueDidReceiveResponseMessage { false };
-    Variant<std::nullptr_t, WebCore::SharedBufferBuilder, Ref<WebCore::FormData>, UniqueRef<WebCore::ResourceError>> m_responseData;
-    WebCore::NetworkLoadMetrics m_networkLoadMetrics;
-    bool m_didFinish { false };
-    bool m_isDownload { false };
-    bool m_didSendResponse { false };
+    bool m_waitingForContinueDidReceiveResponseMessage WTF_GUARDED_BY_LOCK(m_connectionLock) { false };
+    Variant<std::nullptr_t, WebCore::SharedBufferBuilder, Ref<WebCore::FormData>, UniqueRef<WebCore::ResourceError>> m_responseData WTF_GUARDED_BY_LOCK(m_connectionLock);
+    WebCore::NetworkLoadMetrics m_networkLoadMetrics WTF_GUARDED_BY_LOCK(m_connectionLock);
+    bool m_didFinish WTF_GUARDED_BY_LOCK(m_connectionLock) { false };
+    bool m_isDownload WTF_GUARDED_BY_LOCK(m_connectionLock) { false };
+    bool m_didSendResponse WTF_GUARDED_BY_LOCK(m_connectionLock) { false };
     Function<void()> m_cancelledCallback;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h
@@ -50,7 +50,7 @@ class AXIsolatedTree;
     ThreadSafeWeakPtr<WebCore::AXIsolatedTree> m_isolatedTree;
 
     Lock m_windowLock;
-    WeakObjCPtr<id> m_window;
+    WeakObjCPtr<id> m_window WTF_GUARDED_BY_LOCK(m_windowLock);
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
     WebCore::IntPoint m_remoteFrameOffset;

--- a/Source/WebKitLegacy/Storage/StorageAreaSync.h
+++ b/Source/WebKitLegacy/Storage/StorageAreaSync.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/SQLiteDatabase.h>
 #include <WebCore/Timer.h>
+#include <atomic>
 #include <wtf/Condition.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
@@ -90,13 +91,15 @@ private:
     const String m_databaseIdentifier;
 
     Lock m_syncLock;
-    HashMap<String, String> m_itemsPendingSync;
-    bool m_clearItemsWhileSyncing;
-    bool m_syncScheduled;
-    bool m_syncInProgress;
+    HashMap<String, String> m_itemsPendingSync WTF_GUARDED_BY_LOCK(m_syncLock);
+    bool m_clearItemsWhileSyncing WTF_GUARDED_BY_LOCK(m_syncLock);
+    bool m_syncScheduled WTF_GUARDED_BY_LOCK(m_syncLock);
+    bool m_syncInProgress WTF_GUARDED_BY_LOCK(m_syncLock);
     bool m_databaseOpenFailed;
 
-    bool m_syncCloseDatabase;
+    // Set on the main thread by scheduleCloseDatabase() and cleared on the sync thread by sync(),
+    // which runs without m_syncLock held.
+    std::atomic<bool> m_syncCloseDatabase;
 
     mutable Lock m_importLock;
     Condition m_importCondition;

--- a/Source/WebKitLegacy/Storage/StorageTracker.cpp
+++ b/Source/WebKitLegacy/Storage/StorageTracker.cpp
@@ -109,7 +109,6 @@ StorageTracker::StorageTracker(const String& storagePath)
 
 String StorageTracker::trackerDatabasePath()
 {
-    ASSERT(!m_databaseMutex.tryLock());
     return FileSystem::pathByAppendingComponent(m_storageDirectoryPath, "LegacyStorageTracker.db"_s);
 }
 
@@ -127,8 +126,6 @@ void StorageTracker::openTrackerDatabase(bool createIfDoesNotExist)
     ASSERT(!isMainThread());
 
     SQLiteTransactionInProgressAutoCounter transactionCounter;
-
-    ASSERT(!m_databaseMutex.tryLock());
 
     if (m_database.isOpen())
         return;
@@ -168,7 +165,7 @@ void StorageTracker::importOriginIdentifiers()
 
 void StorageTracker::finishedImportingOriginIdentifiers()
 {
-    Locker locker { m_databaseMutex };
+    Locker locker { m_clientMutex };
     if (m_client)
         m_client->didFinishLoadingOrigins();
 }
@@ -561,7 +558,6 @@ void StorageTracker::syncDeleteOrigin(const String& originIdentifier)
     
 void StorageTracker::willDeleteAllOrigins()
 {
-    ASSERT(!m_originSetMutex.tryLock());
 
     OriginSet::const_iterator end = m_originSet.end();
     for (OriginSet::const_iterator it = m_originSet.begin(); it != end; ++it)
@@ -571,14 +567,12 @@ void StorageTracker::willDeleteAllOrigins()
 void StorageTracker::willDeleteOrigin(const String& originIdentifier)
 {
     ASSERT(isMainThread());
-    ASSERT(!m_originSetMutex.tryLock());
 
     m_originsBeingDeleted.add(originIdentifier);
 }
     
 bool StorageTracker::canDeleteOrigin(const String& originIdentifier)
 {
-    ASSERT(!m_databaseMutex.tryLock());
     Locker locker { m_originSetMutex };
     return m_originsBeingDeleted.contains(originIdentifier);
 }
@@ -603,7 +597,6 @@ void StorageTracker::setIsActive(bool flag)
     
 String StorageTracker::databasePathForOrigin(const String& originIdentifier)
 {
-    ASSERT(!m_databaseMutex.tryLock());
     ASSERT(m_isActive);
     
     if (!m_database.isOpen())

--- a/Source/WebKitLegacy/Storage/StorageTracker.h
+++ b/Source/WebKitLegacy/Storage/StorageTracker.h
@@ -73,17 +73,17 @@ private:
     void internalInitialize();
 
     String trackerDatabasePath();
-    void openTrackerDatabase(bool createIfDoesNotExist);
+    void openTrackerDatabase(bool createIfDoesNotExist) WTF_REQUIRES_LOCK(m_databaseMutex);
 
     void importOriginIdentifiers();
     void finishedImportingOriginIdentifiers();
     
     void deleteTrackerFiles();
-    String databasePathForOrigin(const String& originIdentifier);
+    String databasePathForOrigin(const String& originIdentifier) WTF_REQUIRES_LOCK(m_databaseMutex);
 
     bool canDeleteOrigin(const String& originIdentifier);
-    void willDeleteOrigin(const String& originIdentifier);
-    void willDeleteAllOrigins();
+    void willDeleteOrigin(const String& originIdentifier) WTF_REQUIRES_LOCK(m_originSetMutex);
+    void willDeleteAllOrigins() WTF_REQUIRES_LOCK(m_originSetMutex);
 
     void originFilePaths(Vector<String>& paths);
     
@@ -95,10 +95,10 @@ private:
     void syncSetOriginDetails(const String& originIdentifier, const String& databaseFile);
     void syncImportOriginIdentifiers();
 
-    // Mutex for m_database and m_storageDirectoryPath.
+    // Mutex for m_database. m_storageDirectoryPath is set in the constructor and never changes.
     Lock m_databaseMutex;
-    WebCore::SQLiteDatabase m_database;
-    String m_storageDirectoryPath;
+    WebCore::SQLiteDatabase m_database WTF_GUARDED_BY_LOCK(m_databaseMutex);
+    const String m_storageDirectoryPath;
 
     Lock m_clientMutex;
     WebCore::StorageTrackerClient* m_client;
@@ -106,8 +106,8 @@ private:
     // Guard for m_originSet and m_originsBeingDeleted.
     Lock m_originSetMutex;
     typedef HashSet<String> OriginSet;
-    OriginSet m_originSet;
-    OriginSet m_originsBeingDeleted;
+    OriginSet m_originSet WTF_GUARDED_BY_LOCK(m_originSetMutex);
+    OriginSet m_originsBeingDeleted WTF_GUARDED_BY_LOCK(m_originSetMutex);
 
     const UniqueRef<WebCore::StorageThread> m_thread;
     


### PR DESCRIPTION
#### f2535d35a033d8a1d80b0ff0b1b713941dd98675
<pre>
Add missing thread-safety annotations and address potential issues they uncovered
<a href="https://bugs.webkit.org/show_bug.cgi?id=323492">https://bugs.webkit.org/show_bug.cgi?id=323492</a>

Reviewed by Keith Miller and Darin Adler.

Audited data members of type Lock across Source/ and annotated the state
each one actually protects with WTF_GUARDED_BY_LOCK, so that -Wthread-safety
enforces the locking discipline at compile time instead of leaving it to
comments and runtime assertions.

A member was only annotated where accessing it without the lock would be a bug,
i.e. where it is genuinely reached from more than one thread (parallel GC
markers, concurrent JIT/Wasm compiler threads, audio render vs. capture threads,
IPC and media work queues, the scrolling and accessibility threads, worker and
storage threads). Members that merely happen to be touched inside a critical
section that exists for a different member were deliberately left alone; for
example AudioBufferSourceNode::m_wasBufferSet is only used on the main thread in
setBufferForBindings(), and just happens to sit inside the m_processLock region
that synchronizes m_buffer with the audio thread.

Enforcing the annotations exposed several pre-existing bugs, fixed here:

- Event::initEvent() cleared m_target without holding m_targetLock, racing the
  locked read in Event::visitInGCThread() on the GC thread. Every other write
  goes through setTarget(), which does lock.

- ImageDecoderAVFObjC::readTrackMetadata() replaced m_imageRotationSession on
  the main thread with no lock, while createFrameImageAtIndex() dereferences it
  on the org.webkit.ImageDecoder work queue under m_sampleGeneratorLock.

- LibWebRTCCodecs::failedDecoding() set Decoder::hasError on the work queue
  without m_connectionLock, which flushDecoder() and decodeFrameInternal() hold
  when reading it. Taken in a scope that closes before decodedImageCallbackLock
  is acquired, since the two locks are nowhere else nested.

- SharedVideoFrameWriter::m_isDisabled was a plain bool written by disable()
  from another thread and read by wait(). disable() is intentionally called
  without m_encodersConnectionLock (a writer blocked in wait() holds that lock,
  so locking here would deadlock), so it is now accessed with
  WTF::atomicLoad/atomicStore. It stays a plain bool rather than becoming a
  std::atomic so that SharedVideoFrameWriter remains assignable from a
  default-constructed temporary, which two call sites rely on to reset it.

- WebAudioSourceProviderCocoa::setNeedsFlush() mutated m_readCount and
  m_underflowed from the work queue without m_lock, racing provideInputInternal()
  on the audio render thread. The render thread is unaffected because
  provideInput() uses tryLock().

- MediaStreamTrackAudioSourceProviderCocoa::m_writeCount was written unlocked on
  the capture thread and read under m_lock on the render thread. Made atomic
  rather than locked, because prepare() already takes m_lock and is called from
  audioSamplesAvailable(), so locking the callback would self-deadlock.

- WebServiceWorkerFetchTaskClient::convertFetchToDownload() set m_isDownload
  without m_connectionLock, which the five reads hold. Taken in a scope that
  closes before continueDidReceiveResponse() re-acquires the same lock.

- StorageAreaSync::m_syncCloseDatabase was set on the main thread and cleared on
  the sync thread with no synchronization. Made atomic. Note the set/clear
  interleaving is unchanged and still pre-existing: a close request landing
  exactly as the sync thread clears the flag can be dropped.

- MockRealtimeVideoSource::m_isTakingPhoto was cleared on m_runLoop&apos;s thread and
  read on the caller&apos;s thread. Made atomic, matching its sibling
  m_captureWasInterrupted, which already was for that same thread pair.

- StorageTracker::finishedImportingOriginIdentifiers() guarded m_client with
  m_databaseMutex, while the five other m_client accesses use m_clientMutex.

Two analysis escape hatches were replaced with real enforcement:
RealtimeIncomingVideoSourceCocoa::pixelBufferPool() was marked
WTF_IGNORES_THREAD_SAFETY_ANALYSIS and is now WTF_REQUIRES_LOCK, and the
ASSERT(!mutex.tryLock()) contracts in StorageTracker became WTF_REQUIRES_LOCK.
Two of those assertions were dropped rather than converted, because they
asserted a caller context rather than a requirement of the function&apos;s own
accesses: trackerDatabasePath() only reads m_storageDirectoryPath, which is set
in the constructor and never reassigned (now const), and canDeleteOrigin()
acquires m_originSetMutex itself and never touches m_database.

Where the lock is provably held but the analyzer cannot see it -- inside a lambda
body, or through an opaque AbstractLocker&amp; witness parameter -- assertIsHeld()
records the invariant rather than suppressing the check.

* Source/JavaScriptCore/assembler/PerfLog.h:
* Source/JavaScriptCore/ftl/FTLThunks.h:
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/HeapSnapshotBuilder.h:
* Source/JavaScriptCore/heap/ParallelSourceAdapter.h:
* Source/JavaScriptCore/heap/SlotVisitor.cpp:
(JSC::SlotVisitor::drainFromShared):
* Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.h:
(Inspector::RemoteConnectionToTarget::queueMutex):
(Inspector::RemoteConnectionToTarget::queue const):
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
* Source/JavaScriptCore/jit/GdbJIT.h:
* Source/JavaScriptCore/profiler/ProfilerDatabase.h:
* Source/JavaScriptCore/runtime/JSRunLoopTimer.h:
* Source/JavaScriptCore/runtime/NumberPredictionFuzzerAgent.h:
* Source/JavaScriptCore/runtime/ProfilerSupport.h:
* Source/JavaScriptCore/runtime/RandomizingFuzzerAgent.h:
* Source/JavaScriptCore/runtime/RegExpCache.h:
* Source/JavaScriptCore/wasm/WasmCalleeGroup.h:
* Source/JavaScriptCore/wasm/WasmPlan.h:
* Source/JavaScriptCore/wasm/WasmStreamingCompiler.h:
* Source/JavaScriptCore/wasm/WasmThunks.cpp:
(JSC::Wasm::Thunks::stub):
* Source/JavaScriptCore/wasm/WasmThunks.h:
* Source/WTF/wtf/ConcurrentPtrHashSet.h:
* Source/WTF/wtf/CryptographicallyRandomNumber.cpp:
* Source/WTF/wtf/RunLoop.h:
* Source/WTF/wtf/darwin/OSLogPrintStream.h:
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.h:
* Source/WebCore/Modules/webaudio/AudioWorkletNode.h:
* Source/WebCore/Modules/webdatabase/DatabaseTracker.cpp:
(WebCore::notificationQueue):
* Source/WebCore/dom/Event.cpp:
(WebCore::Event::initEvent):
* Source/WebCore/page/scrolling/ScrollingTreeLatchingController.cpp:
(WebCore::ScrollingTreeLatchingController::nodeDidHandleEvent):
* Source/WebCore/page/scrolling/ScrollingTreeLatchingController.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h:
* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm:
(WebCore::ImageDecoderAVFObjC::readTrackMetadata):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
* Source/WebCore/platform/mediastream/cocoa/MediaStreamTrackAudioSourceProviderCocoa.h:
* Source/WebCore/platform/mediastream/cocoa/RealtimeIncomingVideoSourceCocoa.h:
* Source/WebCore/platform/mediastream/cocoa/RealtimeIncomingVideoSourceCocoa.mm:
(WebCore::RealtimeIncomingVideoSourceCocoa::pixelBufferPool):
* Source/WebCore/platform/mediastream/cocoa/WebAudioSourceProviderCocoa.h:
* Source/WebCore/platform/mediastream/cocoa/WebAudioSourceProviderCocoa.mm:
(WebCore::WebAudioSourceProviderCocoa::setNeedsFlush):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.h:
* Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::failedDecoding):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp:
(WebKit::SharedVideoFrameWriter::wait):
(WebKit::SharedVideoFrameWriter::disable):
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h:
* Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp:
(WebKit::WebServiceWorkerFetchTaskClient::convertFetchToDownload):
* Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.h:
* Source/WebKitLegacy/Storage/StorageAreaSync.h:
* Source/WebKitLegacy/Storage/StorageTracker.cpp:
(WebKit::StorageTracker::trackerDatabasePath):
(WebKit::StorageTracker::openTrackerDatabase):
(WebKit::StorageTracker::finishedImportingOriginIdentifiers):
(WebKit::StorageTracker::willDeleteAllOrigins):
(WebKit::StorageTracker::willDeleteOrigin):
(WebKit::StorageTracker::canDeleteOrigin):
(WebKit::StorageTracker::databasePathForOrigin):
* Source/WebKitLegacy/Storage/StorageTracker.h:

Canonical link: <a href="https://commits.webkit.org/320645@main">https://commits.webkit.org/320645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39457d422f11085eda44e8988f58098a66092305

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195790 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150231 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a87a2967-f45d-4b22-ac69-0762dc83add1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59105 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144942 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100482 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fc80f157-aad5-4bfd-84b7-49b2a70a0d78) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165522 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125234 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4c045bf-83b9-4d48-af50-cb67c4a52277) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47346 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45402 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7139 "Found 2104 jsc stress test failures: jsc-layout-tests.yaml/js/script-tests/weakref-finalizationregistry.js.layout, jsc-layout-tests.yaml/js/script-tests/weakref-finalizationregistry.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/weakref-finalizationregistry.js.layout-ftl-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/weakref-finalizationregistry.js.layout-ftl-no-cjit, jsc-layout-tests.yaml/js/script-tests/weakref-finalizationregistry.js.layout-no-cjit ...") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14026 "Found 1 new JSC binary failure: testapi (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157713 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45094 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6841 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46723 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52034 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49791 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197738 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59042 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154461 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41359 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59751 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41699 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154110 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48585 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132094 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128977 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58229 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20116 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57601 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57844 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57668 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->