### PR TITLE
[Swift Testing] WebPage.mouseMove(to:) does not deliver mouse moves to the page

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift
@@ -153,7 +153,11 @@ extension WebPage {
     ///   - location: The location in window coordinates.
     ///   - flags: Modifier flags to include in the event.
     public func mouseMove(to location: NSPoint, flags: NSEvent.ModifierFlags = []) {
-        backingWebView.mouseMoved(with: mouseEvent(.mouseMoved, at: location, flags: flags, clickCount: 0, pressure: 0))
+        // WKWebView receives mouse moves through tracking areas rather than the responder
+        // chain, so sending one to the view directly with `-mouseMoved:` would go nowhere.
+        // `_simulateMouseMove:` is the entry point that reaches `WebViewImpl::mouseMoved`.
+        // See precedent established in PlatformWebView, TestWKWebView, and EventSenderProxy.
+        backingWebView._simulateMouseMove(mouseEvent(.mouseMoved, at: location, flags: flags, clickCount: 0, pressure: 0))
     }
 
     /// Sends a left mouse-dragged NSEvent to the web view at the given location.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageMouseEventsTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageMouseEventsTests.swift
@@ -24,10 +24,16 @@
 #if WTF_PLATFORM_MAC && ENABLE_SWIFTUI
 
 import AppKit
+import Foundation
 import SwiftUI
 import Testing
-@_spi(Testing) import WebKit
+@_spi(Testing) @_spi(CrossImportOverlay) import WebKit
 private import TestWebKitAPILibrary
+
+// Certain event delivery (such as mouseMove) is gated behind -isKeyWindow.
+private final class KeyWindow: NSWindow {
+    override var isKeyWindow: Bool { true }
+}
 
 @MainActor
 struct WebPageMouseEventsTests {
@@ -35,7 +41,7 @@ struct WebPageMouseEventsTests {
     private let window: NSWindow
 
     init() async throws {
-        self.window = NSWindow(size: NSSize(width: 400, height: 400)) { [page] in
+        self.window = KeyWindow(size: NSSize(width: 400, height: 400)) { [page] in
             WebView(page)
         }
         self.window.setFrameOrigin(.zero)
@@ -57,6 +63,73 @@ struct WebPageMouseEventsTests {
 
         let fired = try await page.callJavaScript("return window.clicked === true;") as? Bool
         #expect(fired == true)
+    }
+
+    @Test
+    func mouseMoveFiresMouseMoveHandler() async throws {
+        try await loadMouseMoveRecorder()
+
+        page.mouseMove(to: NSPoint(x: 120, y: 200))
+        await page.waitForPendingMouseEvents()
+
+        page.mouseMove(to: NSPoint(x: 280, y: 200))
+        await page.waitForPendingMouseEvents()
+
+        let moves = try await recordedMoves()
+        #expect(moves.count >= 2)
+
+        let first = try #require(moves.first)
+        let last = try #require(moves.last)
+        #expect(last > first)
+    }
+
+    @Test
+    func sendingMouseMovedToWebViewDoesNotReachPage() async throws {
+        try await loadMouseMoveRecorder()
+
+        let event = try #require(
+            NSEvent.mouseEvent(
+                with: .mouseMoved,
+                location: NSPoint(x: 150, y: 200),
+                modifierFlags: [],
+                timestamp: ProcessInfo.processInfo.systemUptime,
+                windowNumber: window.windowNumber,
+                context: nil,
+                eventNumber: 0,
+                clickCount: 0,
+                pressure: 0
+            )
+        )
+
+        page.backingWebView.mouseMoved(with: event)
+        await page.waitForPendingMouseEvents()
+
+        let afterResponderChain = try await recordedMoves()
+        #expect(afterResponderChain.isEmpty)
+    }
+}
+
+extension WebPageMouseEventsTests {
+    private func loadMouseMoveRecorder() async throws {
+        let html = """
+            <body style="margin: 0; width: 100%; height: 100vh;"></body>
+            """
+
+        try await page.load(html: html).wait()
+        await page.waitForNextPresentationUpdate()
+
+        try await page.callJavaScript {
+            """
+            window.moves = [];
+            document.addEventListener("mousemove", event => window.moves.push(event.clientX));
+            """
+        }
+    }
+
+    private func recordedMoves() async throws -> [Double] {
+        try await page.callJavaScript(returning: [Double].self) {
+            "return window.moves;"
+        }
     }
 }
 


### PR DESCRIPTION
#### cc84d838c54ffb5a424cbea22c15f3fe1ac09cf1
<pre>
[Swift Testing] WebPage.mouseMove(to:) does not deliver mouse moves to the page
<a href="https://bugs.webkit.org/show_bug.cgi?id=323489">https://bugs.webkit.org/show_bug.cgi?id=323489</a>
<a href="https://rdar.apple.com/186724077">rdar://186724077</a>

Reviewed by Richard Robinson.

In 312960@main, we taught WebPage.mouseMove(to:) to send -mouseMoved: to
the backing web view, but WKWebView does not override that selector.
Instead, WKWebView utilizes tracking areas to drive mouseMove events,
which rendered the helper a no-op. To work around this, we simply re-use
the established precedent of _simulateMouseMove:, which calls directly
into WebViewImpl::mouseMoved(), and is used by other test harness code.

Test:
  WebPageMouseEventsTests/mouseMoveFiresMouseMoveHandler
  WebPageMouseEventsTests/sendingMouseMovedToWebViewDoesNotReachPage

* Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift:
(mouseMove(to:flags:)):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/WebPageMouseEventsTests.swift:
(KeyWindow.isKeyWindow):
To facilitate testing mouse move delivery, we need the web view to be
in a window that is key. We introduce `KeyWindow`, a helper NSWindow
subclass, to facilitate this, by having this class unconditionally
claim key status (a la TestWKWebViewHostWindow).

(WebPageMouseEventsTests.mouseMoveFiresMouseMoveHandler):
(WebPageMouseEventsTests.sendingMouseMovedToWebViewDoesNotReachPage):
(WebPageMouseEventsTests.loadMouseMoveRecorder):
(WebPageMouseEventsTests.recordedMoves):

Canonical link: <a href="https://commits.webkit.org/320560@main">https://commits.webkit.org/320560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/415e5849860eed8137b8e1365b84e5d08174267e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195458 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/186992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58769 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144661 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165253 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124954 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47075 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45136 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157442 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44823 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6514 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197410 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58706 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154167 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59415 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153819 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28118 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48315 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128363 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57894 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19842 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57265 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57508 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57332 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->