### PR TITLE
[YARR] `\-` following a class set operand in a `/v` class throws a SyntaxError

### DIFF
--- a/JSTests/stress/regexp-v-flag-escaped-hyphen-after-set-operand.js
+++ b/JSTests/stress/regexp-v-flag-escaped-hyphen-after-set-operand.js
@@ -1,0 +1,41 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+function shouldThrowSyntaxError(source) {
+    try {
+        new RegExp(source, "v");
+    } catch (error) {
+        if (error instanceof SyntaxError)
+            return;
+        throw new Error(`bad error for /${source}/v: ${error}`);
+    }
+    throw new Error(`/${source}/v did not throw`);
+}
+
+// An escaped hyphen following a class set operand (a nested class or a \q{}
+// string disjunction) is a valid ClassSetReservedPunctuator escape.
+for (const [source, matching, nonMatching] of [
+    ["^[[a]\\-]$", ["a", "-"], ["b", "\0"]],
+    ["^[\\q{ab}\\-]$", ["ab", "-"], ["a", "b", "\0"]],
+    ["^[[a][b]\\-]$", ["a", "b", "-"], ["c"]],
+    ["^[[a]\\-x]$", ["a", "-", "x"], ["b"]],
+    ["^[[a]\\-\\-]$", ["a", "-"], ["b"]],
+    ["^[\\-[a]]$", ["a", "-"], ["b"]],
+    ["^[[\\d]\\-]$", ["0", "-"], ["a"]],
+] ) {
+    const regExp = new RegExp(source, "v");
+    for (const string of matching)
+        shouldBe(regExp.test(string), true);
+    for (const string of nonMatching)
+        shouldBe(regExp.test(string), false);
+}
+
+// An unescaped hyphen there is still a syntax error.
+shouldThrowSyntaxError("[[a]-]");
+shouldThrowSyntaxError("[\\q{ab}-]");
+shouldThrowSyntaxError("[[a]-c]");
+shouldThrowSyntaxError("[[\\d]-]");
+shouldThrowSyntaxError("[[\\d]-c]");
+shouldThrowSyntaxError("[\\q{ab}-c]");

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -450,6 +450,7 @@ private:
         bool nestedClassEnd()
         {
             flushCachedCharacterIfNeeded();
+            m_processingEscape = false;
 
             if (m_inverted && m_mayContainStrings)
                 m_errorCode = ErrorCode::NegatedClassSetMayContainStrings;
@@ -548,6 +549,7 @@ private:
         void afterSetOperand()
         {
             flushCachedCharacterIfNeeded();
+            m_processingEscape = false;
             m_state = ClassSetConstructionState::AfterSetOperand;
         }
 
@@ -674,7 +676,7 @@ private:
                 if (!unionOpActive)
                     m_errorCode = ErrorCode::InvalidClassSetOperation;
 
-                if (ch == '-')
+                if (!processingEscape && ch == '-')
                     m_errorCode = ErrorCode::InvalidClassSetOperation;
                 else {
                     switchFromDefaultOpToUnionOpIfNeeded();


### PR DESCRIPTION
#### 1a29b8cfcf8d065176502b18ca611443e3a1b615
<pre>
[YARR] `\-` following a class set operand in a `/v` class throws a SyntaxError
<a href="https://bugs.webkit.org/show_bug.cgi?id=323496">https://bugs.webkit.org/show_bug.cgi?id=323496</a>

Reviewed by Yusuke Suzuki.

In the AfterSetOperand state, atomPatternCharacter() rejected every
hyphen, so /[[a]\-]/v and /[\q{ab}\-]/v threw SyntaxError even though
\- is a valid ClassSetReservedPunctuator escape. The other states
added in 320216@main accept an escaped hyphen by checking
processingEscape; this state did not.

Checking processingEscape here also requires clearing
m_processingEscape when a set operand ends without reaching
atomPatternCharacter(): a nested class or a \q{} string disjunction
leaves the flag set by its last escape, so an unescaped hyphen right
after it, as in /[[\d]-c]/v or /[\q{ab}-c]/v, would have been treated
as escaped. nestedClassEnd() and afterSetOperand() now reset it.

Test: JSTests/stress/regexp-v-flag-escaped-hyphen-after-set-operand.js

* JSTests/stress/regexp-v-flag-escaped-hyphen-after-set-operand.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::ClassSetParserDelegate::nestedClassEnd):
(JSC::Yarr::Parser::ClassSetParserDelegate::afterSetOperand):
(JSC::Yarr::Parser::ClassSetParserDelegate::atomPatternCharacter):

Canonical link: <a href="https://commits.webkit.org/320683@main">https://commits.webkit.org/320683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7761dfac3b29baf8e098f4208e453e28b7deeb69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150015 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144671 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100350 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124964 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47080 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45142 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6877 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13763 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44831 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6524 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46398 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197420 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58716 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154175 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41393 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59425 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41435 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153827 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48323 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131728 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128394 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57904 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19850 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57275 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57518 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57342 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->