### PR TITLE
userSpaceOnUse SVG filter referenced from a layout-offset HTML element resolves coordinates against the document origin instead of the element's box

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-user-space-html-layout-offset-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-user-space-html-layout-offset-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-user-space-html-layout-offset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-user-space-html-layout-offset.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>An SVG userSpaceOnUse filter referenced from a layout-offset HTML element resolves coordinates against the element's box</title>
+<link rel="help" href="https://drafts.csswg.org/filter-effects-1/#FilterEffectsRegion">
+<link rel="help" href="https://drafts.fxtf.org/filter-effects/#FilterProperty">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-1/#local-coordinate-system">
+<link rel="match" href="reference/green-100x100.html">
+<meta name="assert" content="The element is offset from the canvas origin by layout (the UA default body margin, not a transform). Its userSpaceOnUse SVG filter floods green at x=0,y=0,width=100,height=100. userSpaceOnUse (0,0) must map to the element's border-box top-left, so the green flood covers the element rather than landing at the document origin.">
+<style>
+  #target {
+    width: 100px;
+    height: 100px;
+    background: red;
+    filter: url(#f);
+  }
+</style>
+</head>
+<body>
+  <div id="target"></div>
+  <svg width="0" height="0" aria-hidden="true">
+    <filter id="f" filterUnits="userSpaceOnUse" x="0" y="0" width="100" height="100" primitiveUnits="userSpaceOnUse">
+      <feFlood flood-color="green" x="0" y="0" width="100" height="100"/>
+    </filter>
+  </svg>
+</body>
+</html>

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -81,7 +81,8 @@ FloatRect SVGLengthContext::resolveRectangle(const SVGElement* context, SVGUnitT
     }
 
     SVGLengthContext lengthContext(context, viewport.size());
-    return FloatRect(x.value(lengthContext), y.value(lengthContext), width.value(lengthContext), height.value(lengthContext));
+    auto origin = context ? FloatPoint { } : viewport.location();
+    return FloatRect(origin.x() + x.value(lengthContext), origin.y() + y.value(lengthContext), width.value(lengthContext), height.value(lengthContext));
 }
 
 FloatPoint SVGLengthContext::resolvePoint(const SVGElement* context, SVGUnitTypes::SVGUnitType type, const SVGLengthValue& x, const SVGLengthValue& y)


### PR DESCRIPTION
#### ba4e49a2dbc342a6311c12aafc67fa8204d6bf84
<pre>
userSpaceOnUse SVG filter referenced from a layout-offset HTML element resolves coordinates against the document origin instead of the element&apos;s box
<a href="https://bugs.webkit.org/show_bug.cgi?id=323497">https://bugs.webkit.org/show_bug.cgi?id=323497</a>
<a href="https://rdar.apple.com/186736413">rdar://186736413</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When a filter element with filterUnits=&quot;userSpaceOnUse&quot; is referenced from a
non-SVG element such as an HTML box, x, y, width, height &quot;represent values in
the current user coordinate system in place at the time when the filter element
is referenced (i.e., the user coordinate system for the element referencing the
filter element via a filter property)&quot; [1]. The resulting filter region has &quot;its
X-axis and Y-axis each parallel to the X-axis and Y-axis, respectively, of the
local coordinate system for the element to which the filter will be applied&quot; [1],
whose origin is that element&apos;s reference box (border box) top-left [2]. The
resolved rectangle must therefore be offset by that origin.

Previously SVGLengthContext::resolveRectangle() ignored the reference-box
origin and resolved the rectangle at the document origin, so a filter region
anchored at x=0, y=0 landed at the top-left of the document rather than
covering the referencing element.

Offset the resolved rectangle by the viewport (reference box) origin when there
is no SVG context element. SVG-hosted resources (context != null) continue to
resolve in SVG user space and take no offset; a transform-offset host has a
zero-origin reference box, so this remains a no-op for those cases.

[1] <a href="https://drafts.csswg.org/filter-effects-1/#FilterEffectsRegion">https://drafts.csswg.org/filter-effects-1/#FilterEffectsRegion</a>
[2] <a href="https://drafts.csswg.org/css-transforms-1/#local-coordinate-system">https://drafts.csswg.org/css-transforms-1/#local-coordinate-system</a>

Test: imported/w3c/web-platform-tests/css/filter-effects/svg-filter-user-space-html-layout-offset.html

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-user-space-html-layout-offset.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/svg-filter-user-space-html-layout-offset-expected.html: Added.
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::resolveRectangle):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba4e49a2dbc342a6311c12aafc67fa8204d6bf84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195473 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150017 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144673 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100352 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48355 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124966 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47083 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45146 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157450 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44835 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6529 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197425 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58721 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154179 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59430 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41439 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153831 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48327 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131734 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128400 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57909 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19854 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57280 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57523 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57347 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->