### PR TITLE
[JSC] Keep doubles outside the int32 range on the `ToInt32` fast path on x86_64

### DIFF
--- a/JSTests/microbenchmarks/double-to-int32-out-of-int32-range.js
+++ b/JSTests/microbenchmarks/double-to-int32-out-of-int32-range.js
@@ -1,0 +1,24 @@
+const size = 256;
+const table = new Array(size);
+for (let i = 0; i < size; ++i)
+    table[i] = (i & 1) ? 0x80000000 + i * 0x10001 : i * 0x1001;
+
+const indices = new Int32Array(size);
+let state = 0x12345678;
+for (let i = 0; i < size; ++i) {
+    state = (Math.imul(state, 1103515245) + 12345) | 0;
+    indices[i] = (state >>> 8) & (size - 1);
+}
+
+function run()
+{
+    let sum = 0;
+    for (let i = 0; i < size; ++i)
+        sum ^= table[indices[i]];
+    return sum;
+}
+noInline(run);
+
+let result = 0;
+for (let i = 0; i < 4e5; ++i)
+    result ^= run();

--- a/JSTests/stress/to-int32-out-of-int32-range-doubles.js
+++ b/JSTests/stress/to-int32-out-of-int32-range-doubles.js
@@ -1,0 +1,86 @@
+function shouldBe(actual, expected, input)
+{
+    if (actual !== expected)
+        throw new Error(`bad value for ${input}: ${actual}, expected ${expected}`);
+}
+
+// Reference ToInt32 through BigInt, independent of the JIT.
+function toInt32Reference(x)
+{
+    if (!Number.isFinite(x))
+        return 0;
+    return Number(BigInt.asIntN(32, BigInt(Math.trunc(x))));
+}
+
+const inputs = [
+    0, -0, 1, -1, 0.5, -0.5, 2147483647, -2147483648, 2147483648, -2147483649,
+    2147483647.9, -2147483648.9, 0xc66363a5, 0xffffffff, 0x100000000, 0x100000001,
+    4294967295.5, -4294967296, 2 ** 52 + 1, -(2 ** 52 + 1), 2 ** 53, 2 ** 53 + 2,
+    2 ** 62, -(2 ** 62), 2 ** 63 - 1024, -(2 ** 63 - 1024), 2 ** 63, -(2 ** 63),
+    2 ** 63 + 2048, -(2 ** 63 + 2048), 2 ** 64, 2 ** 84, 2 ** 85, 2 ** 100,
+    Number.MAX_VALUE, -Number.MAX_VALUE, Number.MIN_VALUE, Infinity, -Infinity, NaN,
+];
+const expected = inputs.map(toInt32Reference);
+
+const float64 = new Float64Array(inputs);
+
+// A plain array stays ArrayWithDouble only without NaN.
+const doubles = inputs.filter(x => x === x);
+const expectedDoubles = doubles.map(toInt32Reference);
+
+function bitOr(array, i)
+{
+    return array[i] | 0;
+}
+noInline(bitOr);
+
+function xorWith(array, i, other)
+{
+    return array[i] ^ other;
+}
+noInline(xorWith);
+
+function shiftRight(array, i)
+{
+    return array[i] >> 0;
+}
+noInline(shiftRight);
+
+function bitOrTyped(array, i)
+{
+    return array[i] | 0;
+}
+noInline(bitOrTyped);
+
+function xorWithTyped(array, i, other)
+{
+    return array[i] ^ other;
+}
+noInline(xorWithTyped);
+
+function shiftRightTyped(array, i)
+{
+    return array[i] >> 0;
+}
+noInline(shiftRightTyped);
+
+// A JSValue operand, so the conversion takes the NumberUse path.
+function bitOrValue(object)
+{
+    return object.value | 0;
+}
+noInline(bitOrValue);
+
+for (let iteration = 0; iteration < testLoopCount; ++iteration) {
+    for (let i = 0; i < inputs.length; ++i) {
+        shouldBe(bitOrTyped(float64, i), expected[i], inputs[i]);
+        shouldBe(xorWithTyped(float64, i, 0x5a5a5a5a), expected[i] ^ 0x5a5a5a5a, inputs[i]);
+        shouldBe(shiftRightTyped(float64, i), expected[i], inputs[i]);
+        shouldBe(bitOrValue({ value: inputs[i] }), expected[i], inputs[i]);
+    }
+    for (let i = 0; i < doubles.length; ++i) {
+        shouldBe(bitOr(doubles, i), expectedDoubles[i], doubles[i]);
+        shouldBe(xorWith(doubles, i, 0x5a5a5a5a), expectedDoubles[i] ^ 0x5a5a5a5a, doubles[i]);
+        shouldBe(shiftRight(doubles, i), expectedDoubles[i], doubles[i]);
+    }
+}

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -2519,6 +2519,15 @@ public:
         return branch32(branchType ? NotEqual : Equal, dest, TrustedImm32(0x80000000));
     }
 
+    Jump branchTruncateDoubleToInt32ViaInt64(FPRegisterID src, RegisterID dest)
+    {
+        truncateDoubleToInt64(src, dest);
+        m_assembler.cmpq_ir(1, dest);
+        Jump failed(m_assembler.jo());
+        zeroExtend32ToWord(dest, dest);
+        return failed;
+    }
+
     void truncateDoubleToInt32(FPRegisterID src, RegisterID dest)
     {
         if (supportsAVX())

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -2769,6 +2769,27 @@ GeneratedOperandType SpeculativeJIT::checkGeneratedTypeForToInt32(Node* node)
     }
 }
 
+void SpeculativeJIT::emitDoubleToInt32(FPRReg fpr, GPRReg gpr)
+{
+#if CPU(ARM64)
+    if (MacroAssemblerARM64::supportsDoubleToInt32ConversionUsingJavaScriptSemantics()) {
+        convertDoubleToInt32UsingJavaScriptSemantics(fpr, gpr);
+        return;
+    }
+#endif
+#if CPU(X86_64)
+    if (hasSensibleDoubleToInt()) {
+        Jump notTruncatedToInteger = branchTruncateDoubleToInt32ViaInt64(fpr, gpr);
+        addSlowPathGenerator(slowPathCall(notTruncatedToInteger, this,
+            operationToInt32SensibleSlow, NeedToSpill, ExceptionCheckRequirement::CheckNotNeeded, gpr, fpr));
+        return;
+    }
+#endif
+    Jump notTruncatedToInteger = branchTruncateDoubleToInt32(fpr, gpr, BranchIfTruncateFailed);
+    addSlowPathGenerator(slowPathCall(notTruncatedToInteger, this,
+        hasSensibleDoubleToInt() ? operationToInt32SensibleSlow : operationToInt32, NeedToSpill, ExceptionCheckRequirement::CheckNotNeeded, gpr, fpr));
+}
+
 void SpeculativeJIT::compileValueToInt32(Node* node)
 {
     switch (node->child1().useKind()) {
@@ -2787,16 +2808,7 @@ void SpeculativeJIT::compileValueToInt32(Node* node)
         SpeculateDoubleOperand op1(this, node->child1());
         FPRReg fpr = op1.fpr();
         GPRReg gpr = result.gpr();
-#if CPU(ARM64)
-        if (MacroAssemblerARM64::supportsDoubleToInt32ConversionUsingJavaScriptSemantics())
-            convertDoubleToInt32UsingJavaScriptSemantics(fpr, gpr);
-        else
-#endif
-        {
-            Jump notTruncatedToInteger = branchTruncateDoubleToInt32(fpr, gpr, BranchIfTruncateFailed);
-            addSlowPathGenerator(slowPathCall(notTruncatedToInteger, this,
-                hasSensibleDoubleToInt() ? operationToInt32SensibleSlow : operationToInt32, NeedToSpill, ExceptionCheckRequirement::CheckNotNeeded, gpr, fpr));
-        }
+        emitDoubleToInt32(fpr, gpr);
         strictInt32Result(gpr, node);
         return;
     }
@@ -2846,17 +2858,7 @@ void SpeculativeJIT::compileValueToInt32(Node* node)
 
             // First, if we get here we have a double encoded as a JSValue
             unboxDouble(gpr, resultGpr, fpr);
-#if CPU(ARM64)
-            if (MacroAssemblerARM64::supportsDoubleToInt32ConversionUsingJavaScriptSemantics())
-                convertDoubleToInt32UsingJavaScriptSemantics(fpr, resultGpr);
-            else
-#endif
-            {
-                silentSpillAllRegisters(resultGpr);
-                callOperationWithoutExceptionCheck(operationToInt32, resultGpr, fpr);
-                silentFillAllRegisters();
-            }
-
+            emitDoubleToInt32(fpr, resultGpr);
             converted.append(jump());
 
             isInteger.link(this);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1442,6 +1442,7 @@ public:
     void compileValueRep(Node*);
     void compileDoubleRep(Node*);
     
+    void emitDoubleToInt32(FPRReg, GPRReg);
     void compileValueToInt32(Node*);
     void compileUInt32ToNumber(Node*);
     void compileDoubleAsInt32(Node*);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -24700,11 +24700,19 @@ IGNORE_CLANG_WARNINGS_END
             LBasicBlock slowPath = m_out.newBlock();
             LBasicBlock continuation = m_out.newBlock();
 
+#if CPU(X86_64)
+            LValue fastResult64 = m_out.doubleToInt64(doubleValue);
+            ValueFromBlock fastResult = m_out.anchor(m_out.castToInt32(fastResult64));
+            m_out.branch(
+                m_out.equal(fastResult64, m_out.constInt64(std::numeric_limits<int64_t>::min())),
+                rarely(slowPath), usually(continuation));
+#else
             LValue fastResultValue = m_out.doubleToInt32(doubleValue);
             ValueFromBlock fastResult = m_out.anchor(fastResultValue);
             m_out.branch(
                 m_out.equal(fastResultValue, m_out.constInt32(0x80000000)),
                 rarely(slowPath), usually(continuation));
+#endif
 
             LBasicBlock lastNext = m_out.appendTo(slowPath, continuation);
             ValueFromBlock slowResult = m_out.anchor(m_out.castToInt32(m_out.callWithoutSideEffects(Int64, operationToInt32SensibleSlow, doubleValue)));


### PR DESCRIPTION
#### 8e7f96f9a5dbad82750e21e61a99177085d518c3
<pre>
[JSC] Keep doubles outside the int32 range on the `ToInt32` fast path on x86_64
<a href="https://bugs.webkit.org/show_bug.cgi?id=323498">https://bugs.webkit.org/show_bug.cgi?id=323498</a>

Reviewed by Yusuke Suzuki.

On x86_64, the DFG and FTL convert a double to int32 with the 32-bit
cvttsd2si, which fails for every value outside [-2^31, 2^31) and falls
back to a call to operationToInt32SensibleSlow. Code that keeps 32-bit
constants in ordinary numbers, such as the lookup tables of aes-js,
takes the call for about half of its loads, through a data-dependent
branch that keeps mispredicting. arm64 does not pay this cost because
fjcvtzs implements ToInt32 directly.

Truncate with the 64-bit cvttsd2siq instead and keep the low 32 bits,
which is ToInt32 for every |x| &lt; 2^63. The slow path now only sees NaN,
the infinities, and |x| &gt;= 2^63, which cvttsd2siq all reports as
INT64_MIN -- a subset of the previous failure set, so
operationToInt32SensibleSlow needs no change. The new
branchTruncateDoubleToInt32ViaInt64 detects INT64_MIN as the only value
whose subtraction of 1 overflows, so it needs no scratch register.

Measured with run-jsc-benchmarks on Linux x64:

                                        baseline                  patched

double-to-int32-out-of-int32-range   200.4000+-11.2357    ^    63.3957+-0.3318    ^ definitely 3.1611x faster

Tests: JSTests/microbenchmarks/double-to-int32-out-of-int32-range.js
       JSTests/stress/to-int32-out-of-int32-range-doubles.js

* JSTests/microbenchmarks/double-to-int32-out-of-int32-range.js: Added.
(run):
* JSTests/stress/to-int32-out-of-int32-range-doubles.js: Added.
(shouldBe):
(bitOr):
(xorWith):
(shiftRight):
(bitOrTyped):
(xorWithTyped):
(shiftRightTyped):
(bitOrValue):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::branchTruncateDoubleToInt32ViaInt64):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileDoubleToInt32):
(JSC::DFG::SpeculativeJIT::compileValueToInt32):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/320602@main">https://commits.webkit.org/320602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7251c2d1c7a3ca2763eb48ff23c8ee19c70cb925

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195620 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58933 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144805 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48484 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165393 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125098 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47212 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45275 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/7011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13895 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157579 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44963 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6674 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46552 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51862 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49655 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197569 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58870 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154313 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41322 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59579 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153964 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48457 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131897 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128706 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58057 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19989 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57429 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57672 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57496 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->