### PR TITLE
[JSC] `RegExp#test` minimum-length filter must not skip the `lastIndex` read

### DIFF
--- a/JSTests/stress/regexp-test-minimum-length-filter-last-index.js
+++ b/JSTests/stress/regexp-test-minimum-length-filter-last-index.js
@@ -1,0 +1,97 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected ${expected}`);
+}
+
+function test(regExp, input) {
+    return regExp.test(input);
+}
+noInline(test);
+
+const constantRegExp = /abcdef\u{1F600}/u;
+function testConstantUnicode(input) {
+    return constantRegExp.test(input);
+}
+noInline(testConstantUnicode);
+
+var valueOfCalls = 0;
+
+function warmUp(regExps, input) {
+    for (var regExp of regExps)
+        regExp.lastIndex = 0;
+    for (var i = 0; i < testLoopCount; ++i)
+        test(regExps[i & 1], input);
+}
+
+// RegExpBuiltinExec performs ToLength(? Get(R, "lastIndex")) for every RegExp, global or not, so a
+// throwing valueOf on lastIndex must propagate from RegExp.prototype.test even when the input is
+// shorter than the pattern's minimum length.
+function testThrowingValueOf(regExps, input) {
+    warmUp(regExps, input);
+    var before = valueOfCalls;
+    regExps[0].lastIndex = { valueOf() { ++valueOfCalls; throw new Error("boom"); } };
+    for (var i = 0; i < testLoopCount; ++i) {
+        test(regExps[1], input);
+        var thrown = null;
+        try {
+            test(regExps[0], input);
+        } catch (error) {
+            thrown = error;
+        }
+        shouldBe(thrown !== null, true);
+        shouldBe(thrown.message, "boom");
+    }
+    shouldBe(valueOfCalls - before, testLoopCount);
+}
+
+function testCountingValueOf(regExps, input, expected) {
+    warmUp(regExps, input);
+    var before = valueOfCalls;
+    regExps[0].lastIndex = { valueOf() { ++valueOfCalls; return 0; } };
+    for (var i = 0; i < testLoopCount; ++i) {
+        test(regExps[1], input);
+        shouldBe(test(regExps[0], input), expected);
+    }
+    shouldBe(valueOfCalls - before, testLoopCount);
+}
+
+function testSymbolLastIndex(regExps, input) {
+    warmUp(regExps, input);
+    regExps[0].lastIndex = Symbol("lastIndex");
+    for (var i = 0; i < testLoopCount; ++i) {
+        test(regExps[1], input);
+        var thrown = null;
+        try {
+            test(regExps[0], input);
+        } catch (error) {
+            thrown = error;
+        }
+        shouldBe(thrown instanceof TypeError, true);
+    }
+}
+
+testThrowingValueOf([/abcdef/, /uvwxyz/], "abc");
+testThrowingValueOf([/ab\u{1F600}/u, /cd\u{1F600}/u], "ab");
+testCountingValueOf([/abcdef/, /uvwxyz/], "abc", false);
+testSymbolLastIndex([/abcdef/, /uvwxyz/], "abc");
+
+// Control: an input that is long enough still matches with an object lastIndex.
+testCountingValueOf([/abc/, /uvw/], "xxabcxx", true);
+
+for (var i = 0; i < testLoopCount; ++i)
+    shouldBe(testConstantUnicode("abc"), false);
+constantRegExp.lastIndex = { valueOf() { ++valueOfCalls; throw new Error("boom"); } };
+{
+    var before = valueOfCalls;
+    for (var i = 0; i < testLoopCount; ++i) {
+        var thrown = null;
+        try {
+            testConstantUnicode("abc");
+        } catch (error) {
+            thrown = error;
+        }
+        shouldBe(thrown !== null, true);
+        shouldBe(thrown.message, "boom");
+    }
+    shouldBe(valueOfCalls - before, testLoopCount);
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -10068,15 +10068,17 @@ void SpeculativeJIT::emitRegExpMinimumLengthFilterGuards(std::optional<unsigned>
         done.link(this);
     }
 
-    if (constantMinimumSize) {
+    if (constantMinimumSize)
         slowCases.append(branch32(AboveOrEqual, scratch1GPR, TrustedImm32(static_cast<int32_t>(*constantMinimumSize))));
-        return;
+    else {
+        loadPtr(Address(baseGPR, RegExpObject::offsetOfRegExpAndFlags()), scratch2GPR);
+        andPtr(TrustedImmPtr(RegExpObject::regExpMask), scratch2GPR);
+        slowCases.append(branch32(AboveOrEqual, scratch1GPR, Address(scratch2GPR, RegExp::offsetOfMinimumSize())));
+        slowCases.append(branchTest16(NonZero, Address(scratch2GPR, RegExp::offsetOfFlags()), TrustedImm32(RegExp::globalOrStickyFlagsMask)));
     }
 
-    loadPtr(Address(baseGPR, RegExpObject::offsetOfRegExpAndFlags()), scratch2GPR);
-    andPtr(TrustedImmPtr(RegExpObject::regExpMask), scratch2GPR);
-    slowCases.append(branch32(AboveOrEqual, scratch1GPR, Address(scratch2GPR, RegExp::offsetOfMinimumSize())));
-    slowCases.append(branchTest16(NonZero, Address(scratch2GPR, RegExp::offsetOfFlags()), TrustedImm32(RegExp::globalOrStickyFlagsMask)));
+    load64(Address(baseGPR, RegExpObject::offsetOfLastIndex()), scratch1GPR);
+    slowCases.append(branchIfNotInt32(scratch1GPR));
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -19756,6 +19756,7 @@ IGNORE_CLANG_WARNINGS_END
         LBasicBlock nonRopeCase = m_out.newBlock();
         LBasicBlock checkLength = m_out.newBlock();
         LBasicBlock checkFlags = constantMinimumSize ? nullptr : m_out.newBlock();
+        LBasicBlock checkLastIndex = m_out.newBlock();
 
         if (!knownString)
             emitFirstCharacterGuardStringCheck(argument, argumentEdge, isCellCase, isStringCase, ropeCase, operationCase);
@@ -19770,19 +19771,22 @@ IGNORE_CLANG_WARNINGS_END
         ValueFromBlock nonRopeLength = m_out.anchor(m_out.load32(m_out.loadPtr(argument, m_heaps.JSString_value), m_heaps.StringImpl_length));
         m_out.jump(checkLength);
 
-        m_out.appendTo(checkLength, constantMinimumSize ? noMatchCase : checkFlags);
+        m_out.appendTo(checkLength, constantMinimumSize ? checkLastIndex : checkFlags);
         LValue stringLength = m_out.phi(Int32, ropeLength, nonRopeLength);
-        if (constantMinimumSize) {
-            m_out.branch(m_out.below(stringLength, m_out.constInt32(static_cast<int32_t>(*constantMinimumSize))), unsure(noMatchCase), unsure(operationCase));
-            return;
+        if (constantMinimumSize)
+            m_out.branch(m_out.below(stringLength, m_out.constInt32(static_cast<int32_t>(*constantMinimumSize))), unsure(checkLastIndex), unsure(operationCase));
+        else {
+            LValue regExp = m_out.bitAnd(m_out.loadPtr(base, m_heaps.RegExpObject_regExpAndFlags), m_out.constIntPtr(RegExpObject::regExpMask));
+            m_out.branch(m_out.below(stringLength, m_out.load32(regExp, m_heaps.RegExp_minimumSize)), unsure(checkFlags), unsure(operationCase));
+
+            m_out.appendTo(checkFlags, checkLastIndex);
+            LValue flags = m_out.load16ZeroExt32(regExp, m_heaps.RegExp_flags);
+            m_out.branch(m_out.testNonZero32(flags, m_out.constInt32(RegExp::globalOrStickyFlagsMask)), unsure(operationCase), unsure(checkLastIndex));
         }
 
-        LValue regExp = m_out.bitAnd(m_out.loadPtr(base, m_heaps.RegExpObject_regExpAndFlags), m_out.constIntPtr(RegExpObject::regExpMask));
-        m_out.branch(m_out.below(stringLength, m_out.load32(regExp, m_heaps.RegExp_minimumSize)), unsure(checkFlags), unsure(operationCase));
-
-        m_out.appendTo(checkFlags, noMatchCase);
-        LValue flags = m_out.load16ZeroExt32(regExp, m_heaps.RegExp_flags);
-        m_out.branch(m_out.testNonZero32(flags, m_out.constInt32(RegExp::globalOrStickyFlagsMask)), unsure(operationCase), unsure(noMatchCase));
+        m_out.appendTo(checkLastIndex, noMatchCase);
+        LValue lastIndexJSValue = m_out.load64(base, m_heaps.RegExpObject_lastIndex);
+        m_out.branch(isNotInt32(lastIndexJSValue), rarely(operationCase), usually(noMatchCase));
     }
 
     void compileRegExpTestMinimumLengthFilter(LValue globalObject, LValue base, LValue argument, Edge baseEdge, Edge argumentEdge)


### PR DESCRIPTION
#### fea77037ca1f856086ae677086b51233c27eb1e8
<pre>
[JSC] `RegExp#test` minimum-length filter must not skip the `lastIndex` read
<a href="https://bugs.webkit.org/show_bug.cgi?id=323501">https://bugs.webkit.org/show_bug.cgi?id=323501</a>

Reviewed by Yusuke Suzuki.

RegExpBuiltinExec reads lastIndex through ToLength(? Get(R, &quot;lastIndex&quot;)) for
every RegExp, global or not, so a non-numeric lastIndex has observable effects
(a valueOf call, or the TypeError a Symbol throws) even when RegExp#test
answers false. The minimum-length fast path added in 320487@main answers false
without reading lastIndex, so after DFG / FTL tier-up those effects silently
disappear.

Take the fast path only when lastIndex is an Int32, the way the sticky
first-character filter already does, and leave everything else to the slow
path call.

Test: JSTests/stress/regexp-test-minimum-length-filter-last-index.js

* JSTests/stress/regexp-test-minimum-length-filter-last-index.js: Added.
(shouldBe):
(testConstantUnicode):
(warmUp):
(testThrowingValueOf):
(testCountingValueOf):
(testSymbolLastIndex):
(constantRegExp.lastIndex.valueOf):
(throw.new.Error):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::emitRegExpMinimumLengthFilterGuards):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/320582@main">https://commits.webkit.org/320582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/823b3969877072bcba7da73318f3f49c5d5096bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195476 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144675 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165266 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124968 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47087 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45148 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6881 "Found 1 new JSC stress test failure: Too many failures: 2103 jsc tests failed (failure)") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13768 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157454 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44836 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6532 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46406 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197427 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58724 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154182 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41303 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59433 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153834 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48326 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131737 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128404 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57912 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19855 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57283 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57526 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57350 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->