### PR TITLE
SkiaCompositingLayer: canSkipClip should account for filter outsets

### DIFF
--- a/LayoutTests/compositing/filters/drop-shadow-clipped-by-parent-overflow-expected.html
+++ b/LayoutTests/compositing/filters/drop-shadow-clipped-by-parent-overflow-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<style>
+    .clipper {
+        width: 150px;
+        height: 150px;
+        overflow: hidden;
+        position: relative;
+        background: white;
+    }
+    .filtered {
+        width: 100%;
+        height: 100%;
+        background: green;
+        will-change: transform;
+    }
+</style>
+
+You should see no red.
+
+<div class="clipper">
+    <div class="filtered"></div>
+</div>

--- a/LayoutTests/compositing/filters/drop-shadow-clipped-by-parent-overflow.html
+++ b/LayoutTests/compositing/filters/drop-shadow-clipped-by-parent-overflow.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<style>
+    .clipper {
+        width: 150px;
+        height: 150px;
+        overflow: hidden;
+        position: relative;
+        background: white;
+    }
+    .filtered {
+        width: 100%;
+        height: 100%;
+        background: green;
+        will-change: transform;
+        filter: drop-shadow(100px 100px 10px red);
+    }
+</style>
+
+You should see no red.
+
+<div class="clipper">
+    <div class="filtered"></div>
+</div>

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -1046,6 +1046,10 @@ void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& 
             childBounds = m_children[0]->m_rect;
         if (m_children[0]->m_contentsBuffer || m_children[0]->m_imageBackingStore || (m_children[0]->m_contentsSolidColor.isValid() && m_children[0]->m_contentsSolidColor.isVisible()))
             childBounds.unite(m_children[0]->m_contentsRect);
+
+        if (auto childFilter = m_children[0]->filter(); childFilter && !childFilter->outsets.isZero() && !m_children[0]->m_masksToBounds && !m_children[0]->m_mask)
+            childBounds.expand(toFloatBoxExtent(childFilter->outsets));
+
         return matrix.mapRect(SkRect(rect.rect())).contains(childMatrix.mapRect(SkRect(childBounds)));
     };
 


### PR DESCRIPTION
#### d010ad1606e1e21670a028b594a54196e998c726
<pre>
SkiaCompositingLayer: canSkipClip should account for filter outsets
<a href="https://bugs.webkit.org/show_bug.cgi?id=323410">https://bugs.webkit.org/show_bug.cgi?id=323410</a>

Reviewed by Carlos Garcia Campos.

A single child layer which has a filter outsets was not clipped properly.

* LayoutTests/compositing/filters/drop-shadow-clipped-by-parent-overflow-expected.html: Added.
* LayoutTests/compositing/filters/drop-shadow-clipped-by-parent-overflow.html: Added.
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paintSelfAndChildren):

Canonical link: <a href="https://commits.webkit.org/320607@main">https://commits.webkit.org/320607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59fefe5ecf4f5c8c4a5126d757b0b495efd159c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195478 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144678 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165268 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124971 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47089 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45151 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157456 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44838 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6534 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197429 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58726 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164774 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154184 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59435 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153836 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28129 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48330 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131740 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128418 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57914 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19857 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57285 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57528 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57352 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->