### PR TITLE
[css-content] A gradient in the content property paints blank

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3134,7 +3134,6 @@ webkit.org/b/148650 fast/repaint/add-table-overpaint.html [ Pass Failure ]
 
 # Initial failures on the import of css-content
 
-imported/w3c/web-platform-tests/css/css-content/element-replacement-gradient.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-content/element-replacement-on-replaced-element.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-content/quotes-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-content/quotes-006.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-gradient-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-gradient-expected.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  background-image: linear-gradient(purple, yellow);
+}
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-gradient-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-gradient-ref.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  background-image: linear-gradient(purple, yellow);
+}
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-gradient.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-gradient.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>content: gradient on a pseudo element</title>
+<link rel="match" href="pseudo-element-gradient-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property">
+<style>
+#target::before {
+  content: linear-gradient(purple, yellow);
+  display: block;
+  width: 100px;
+  height: 100px;
+}
+</style>
+<div id="target"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-image-set-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-image-set-expected.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  background-image: linear-gradient(purple, purple);
+}
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-image-set-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-image-set-ref.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  background-image: linear-gradient(purple, purple);
+}
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-image-set.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-image-set.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>content: image-set() of a gradient on a pseudo element</title>
+<link rel="match" href="pseudo-element-image-set-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property">
+<link rel="help" href="https://drafts.csswg.org/css-images-4/#image-set-notation">
+<style>
+#target::before {
+  content: image-set(linear-gradient(purple, purple) 1x);
+  display: block;
+  width: 100px;
+  height: 100px;
+}
+</style>
+<div id="target"></div>

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -456,7 +456,7 @@ void RenderImage::setImageDevicePixelRatio(float factor)
 
 bool RenderImage::isShowingMissingOrImageError() const
 {
-    return !imageResource().cachedImage() || imageResource().errorOccurred();
+    return !imageResource().hasStyleImage() || imageResource().errorOccurred();
 }
 
 bool RenderImage::isShowingAltText() const
@@ -662,7 +662,7 @@ void RenderImage::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
         return;
     }
 
-    if (!imageResource().cachedImage() || shouldDisplayBrokenImageIcon()) {
+    if (!imageResource().hasStyleImage() || shouldDisplayBrokenImageIcon()) {
         paintMissingImageState(paintInfo, paintOffset);
         return;
     }
@@ -787,7 +787,7 @@ void RenderImage::areaElementFocusChanged(HTMLAreaElement* element)
 
 ImageDrawResult RenderImage::paintIntoRect(PaintInfo& paintInfo, const FloatRect& rect)
 {
-    if (!imageResource().cachedImage() || imageResource().errorOccurred() || rect.width() <= 0 || rect.height() <= 0)
+    if (isShowingMissingOrImageError() || rect.width() <= 0 || rect.height() <= 0)
         return ImageDrawResult::DidNothing;
 
     RefPtr<Image> img = imageResource().image(flooredIntSize(rect.size()));

--- a/Source/WebCore/rendering/RenderImageResource.h
+++ b/Source/WebCore/rendering/RenderImageResource.h
@@ -52,6 +52,7 @@ public:
     void clearCachedImage();
     void setCachedImage(CachedImage*);
     CachedImage* cachedImage() const { return m_styleImage ? m_styleImage->cachedImage() : nullptr; }
+    bool hasStyleImage() const { return !!m_styleImage; }
 
     void resetAnimation();
 


### PR DESCRIPTION
#### 1517ece5d3861d16062f382f9a84008f9d758de3
<pre>
[css-content] A gradient in the content property paints blank
<a href="https://bugs.webkit.org/show_bug.cgi?id=323503">https://bugs.webkit.org/show_bug.cgi?id=323503</a>
<a href="https://rdar.apple.com/problem/186742805">rdar://problem/186742805</a>

Reviewed by Sam Weinig.

RenderImage only painted when it had a CachedImage behind it, so a generated image (gradient, cross-fade,
canvas) drew the missing image state instead.

Tests: imported/w3c/web-platform-tests/css/css-content/pseudo-element-gradient-ref.html
       imported/w3c/web-platform-tests/css/css-content/pseudo-element-gradient.html
       imported/w3c/web-platform-tests/css/css-content/pseudo-element-image-set-ref.html
       imported/w3c/web-platform-tests/css/css-content/pseudo-element-image-set.html

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-gradient-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-gradient-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-gradient.html: Added.
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::isShowingMissingOrImageError const):
(WebCore::RenderImage::paintReplaced):
(WebCore::RenderImage::paintIntoRect):
* Source/WebCore/rendering/RenderImageResource.h:
(WebCore::RenderImageResource::hasStyleImage const):
* LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-image-set-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-image-set-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-content/pseudo-element-image-set.html: Added.

Canonical link: <a href="https://commits.webkit.org/320620@main">https://commits.webkit.org/320620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/867a08377e6152f97af0b028be1a75454f90abbe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195686 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/36864bf2-20da-44cb-93f9-7c2c08e8ed64) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144857 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db6021f0-9836-4fd2-85ff-6b071528d9d1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48536 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165443 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/125150 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2c6e0263-16d0-4ea0-a346-43c66116356b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/47264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157631 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45014 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6739 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51930 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49709 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197635 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164950 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41335 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59647 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154018 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48509 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131972 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128804 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58125 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20036 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57497 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57740 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57564 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->