### PR TITLE
[list-marker] Give every outside list marker its content as renderers instead of hand-drawing the text and the image

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4020,7 +4020,6 @@ imported/w3c/web-platform-tests/css/css-pseudo/first-letter-width-2.html [ Image
 imported/w3c/web-platform-tests/css/css-pseudo/highlight-custom-properties-dynamic-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-currentcolor-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-currentcolor-001a.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-pseudo/marker-text-transform-dynamic.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/selection-link-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/selection-link-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-pseudo/selection-over-highlight-001.html [ ImageOnlyFailure ]
@@ -5740,7 +5739,6 @@ webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/first-line-op
 webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/grammar-error-001.html [ ImageOnlyFailure ]
 webkit.org/b/204163 imported/w3c/web-platform-tests/css/css-pseudo/marker-content-010.html [ ImageOnlyFailure ]
 webkit.org/b/204163 imported/w3c/web-platform-tests/css/css-pseudo/marker-content-017.html [ ImageOnlyFailure ]
-webkit.org/b/204163 imported/w3c/web-platform-tests/css/css-pseudo/marker-content-018.html [ ImageOnlyFailure ]
 webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/marker-list-style-position.html [ ImageOnlyFailure ]
 webkit.org/b/214461 imported/w3c/web-platform-tests/css/css-pseudo/spelling-error-001.html [ ImageOnlyFailure ]
 
@@ -6093,7 +6091,6 @@ webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/marker-letter
 webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/marker-line-break.html [ ImageOnlyFailure ]
 webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/marker-overflow-wrap.html [ ImageOnlyFailure ]
 webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/marker-text-decoration-skip-ink.html [ ImageOnlyFailure ]
-webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/marker-text-transform-uppercase.html [ ImageOnlyFailure ]
 webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/marker-word-break.html [ ImageOnlyFailure ]
 webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/selection-contenteditable-011.html [ ImageOnlyFailure ]
 webkit.org/b/230004 imported/w3c/web-platform-tests/css/css-pseudo/selection-input-011.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/glib/fast/lists/008-expected.txt
+++ b/LayoutTests/platform/glib/fast/lists/008-expected.txt
@@ -150,30 +150,15 @@ layer at (0,0) size 785x1808
       RenderBlock {OL} at (0,1350) size 189x134 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 147x38 [border: (5px solid #FFA500)]
           RenderListMarker at (146,10) size 17x18: "1"
-            RenderBlock (generated) at (0,-1) size 16x19
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "1"
           RenderText {#text} at (77,10) size 60x18
             text run at (77,10) width 60: "First item"
         RenderListItem {LI} at (1,39) size 147x56 [border: (5px solid #FFA500)]
           RenderListMarker at (146,10) size 17x18: "2"
-            RenderBlock (generated) at (0,-1) size 16x19
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "2"
           RenderText {#text} at (30,10) size 107x36
             text run at (30,10) width 107: "Second and very"
             text run at (45,28) width 92: "very long item"
         RenderListItem {LI} at (1,95) size 147x38 [border: (5px solid #FFA500)]
           RenderListMarker at (146,10) size 17x18: "3"
-            RenderBlock (generated) at (0,-1) size 16x19
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "3"
           RenderText {#text} at (70,10) size 67x18
             text run at (70,10) width 67: "Third item"
       RenderBlock {OL} at (0,1500) size 189x134 [border: (1px solid #0000FF)]

--- a/LayoutTests/platform/glib/fast/lists/008-vertical-expected.txt
+++ b/LayoutTests/platform/glib/fast/lists/008-vertical-expected.txt
@@ -150,30 +150,15 @@ layer at (0,0) size 1808x585
       RenderBlock {OL} at (1350,0) size 134x189 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x147 [border: (5px solid #FFA500)]
           RenderListMarker at (10,146) size 18x17: "1"
-            RenderBlock (generated) at (-1,0) size 19x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 5 RTL: " "
-                text run at (0,4) width 5 RTL: "."
-                text run at (0,8) width 9: "1"
           RenderText {#text} at (10,77) size 18x60
             text run at (10,77) width 60: "First item"
         RenderListItem {LI} at (39,1) size 56x147 [border: (5px solid #FFA500)]
           RenderListMarker at (10,146) size 18x17: "2"
-            RenderBlock (generated) at (-1,0) size 19x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 5 RTL: " "
-                text run at (0,4) width 5 RTL: "."
-                text run at (0,8) width 9: "2"
           RenderText {#text} at (10,30) size 36x107
             text run at (10,30) width 107: "Second and very"
             text run at (28,45) width 92: "very long item"
         RenderListItem {LI} at (95,1) size 38x147 [border: (5px solid #FFA500)]
           RenderListMarker at (10,146) size 18x17: "3"
-            RenderBlock (generated) at (-1,0) size 19x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 5 RTL: " "
-                text run at (0,4) width 5 RTL: "."
-                text run at (0,8) width 9: "3"
           RenderText {#text} at (10,70) size 18x67
             text run at (10,70) width 67: "Third item"
       RenderBlock {OL} at (1500,0) size 134x189 [border: (1px solid #0000FF)]

--- a/LayoutTests/platform/ios/fast/lists/008-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/008-expected.txt
@@ -152,30 +152,15 @@ layer at (0,0) size 800x1844
       RenderBlock {OL} at (0,1386) size 186x134 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 144x38 [border: (5px solid #FFA500)]
           RenderListMarker at (143,10) size 17x18: "1"
-            RenderBlock (generated) at (0,-1) size 16x19
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "1"
           RenderText {#text} at (71,10) size 63x18
             text run at (71,10) width 63: "First item"
         RenderListItem {LI} at (1,39) size 144x56 [border: (5px solid #FFA500)]
           RenderListMarker at (143,10) size 17x18: "2"
-            RenderBlock (generated) at (0,-1) size 16x19
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "2"
           RenderText {#text} at (26,10) size 108x36
             text run at (26,10) width 108: "Second and very"
             text run at (39,28) width 95: "very long item"
         RenderListItem {LI} at (1,95) size 144x38 [border: (5px solid #FFA500)]
           RenderListMarker at (143,10) size 17x18: "3"
-            RenderBlock (generated) at (0,-1) size 16x19
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "3"
           RenderText {#text} at (65,10) size 69x18
             text run at (65,10) width 69: "Third item"
       RenderBlock {OL} at (0,1536) size 186x134 [border: (1px solid #0000FF)]

--- a/LayoutTests/platform/ios/fast/lists/008-vertical-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/008-vertical-expected.txt
@@ -152,30 +152,15 @@ layer at (0,0) size 1844x600
       RenderBlock {OL} at (1386,0) size 134x186 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,143) size 18x17: "1"
-            RenderBlock (generated) at (-1,0) size 19x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 5 RTL: " "
-                text run at (0,4) width 5 RTL: "."
-                text run at (0,8) width 9: "1"
           RenderText {#text} at (10,71) size 18x63
             text run at (10,71) width 62: "First item"
         RenderListItem {LI} at (39,1) size 56x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,143) size 18x17: "2"
-            RenderBlock (generated) at (-1,0) size 19x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 5 RTL: " "
-                text run at (0,4) width 5 RTL: "."
-                text run at (0,8) width 9: "2"
           RenderText {#text} at (10,26) size 36x108
             text run at (10,26) width 107: "Second and very"
             text run at (28,39) width 94: "very long item"
         RenderListItem {LI} at (95,1) size 38x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,143) size 18x17: "3"
-            RenderBlock (generated) at (-1,0) size 19x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 5 RTL: " "
-                text run at (0,4) width 5 RTL: "."
-                text run at (0,8) width 9: "3"
           RenderText {#text} at (10,65) size 18x69
             text run at (10,65) width 69: "Third item"
       RenderBlock {OL} at (1536,0) size 134x186 [border: (1px solid #0000FF)]

--- a/LayoutTests/platform/mac/fast/lists/008-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/008-expected.txt
@@ -152,30 +152,15 @@ layer at (0,0) size 785x1844
       RenderBlock {OL} at (0,1386) size 186x134 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 144x38 [border: (5px solid #FFA500)]
           RenderListMarker at (143,10) size 17x18: "1"
-            RenderBlock (generated) at (0,0) size 16x18
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "1"
           RenderText {#text} at (71,10) size 63x18
             text run at (71,10) width 63: "First item"
         RenderListItem {LI} at (1,39) size 144x56 [border: (5px solid #FFA500)]
           RenderListMarker at (143,10) size 17x18: "2"
-            RenderBlock (generated) at (0,0) size 16x18
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "2"
           RenderText {#text} at (26,10) size 108x36
             text run at (26,10) width 108: "Second and very"
             text run at (40,28) width 94: "very long item"
         RenderListItem {LI} at (1,95) size 144x38 [border: (5px solid #FFA500)]
           RenderListMarker at (143,10) size 17x18: "3"
-            RenderBlock (generated) at (0,0) size 16x18
-              RenderText at (0,0) size 16x18
-                text run at (0,0) width 4 RTL: " "
-                text run at (4,0) width 4 RTL: "."
-                text run at (8,0) width 8: "3"
           RenderText {#text} at (65,10) size 69x18
             text run at (65,10) width 69: "Third item"
       RenderBlock {OL} at (0,1536) size 186x134 [border: (1px solid #0000FF)]

--- a/LayoutTests/platform/mac/fast/lists/008-vertical-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/008-vertical-expected.txt
@@ -152,30 +152,15 @@ layer at (0,0) size 1844x585
       RenderBlock {OL} at (1386,0) size 134x186 [border: (1px solid #FF0000)]
         RenderListItem {LI} at (1,1) size 38x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,143) size 18x17: "1"
-            RenderBlock (generated) at (0,0) size 18x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 4 RTL: " "
-                text run at (0,4) width 4 RTL: "."
-                text run at (0,8) width 8: "1"
           RenderText {#text} at (10,71) size 18x63
             text run at (10,71) width 62: "First item"
         RenderListItem {LI} at (39,1) size 56x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,143) size 18x17: "2"
-            RenderBlock (generated) at (0,0) size 18x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 4 RTL: " "
-                text run at (0,4) width 4 RTL: "."
-                text run at (0,8) width 8: "2"
           RenderText {#text} at (10,26) size 36x108
             text run at (10,26) width 107: "Second and very"
             text run at (28,40) width 94: "very long item"
         RenderListItem {LI} at (95,1) size 38x144 [border: (5px solid #FFA500)]
           RenderListMarker at (10,143) size 18x17: "3"
-            RenderBlock (generated) at (0,0) size 18x16
-              RenderText at (0,0) size 18x16
-                text run at (0,0) width 4 RTL: " "
-                text run at (0,4) width 4 RTL: "."
-                text run at (0,8) width 8: "3"
           RenderText {#text} at (10,65) size 18x69
             text run at (10,65) width 68: "Third item"
       RenderBlock {OL} at (1536,0) size 134x186 [border: (1px solid #0000FF)]

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
@@ -525,8 +525,7 @@ void LineBoxBuilder::constructInlineLevelBoxes(LineBox& lineBox)
                 lineBox.parentInlineBox(run).setHasContent();
             }
 
-            if (run.isListMarker())
-                m_outsideListMarkers.append(index);
+            m_outsideListMarkers.append(index);
 
             auto atomicInlineBox = InlineLevelBox::createAtomicInlineBox(listMarkerBox, style, logicalLeft, formattingContext.geometryForBox(listMarkerBox).borderBoxWidth());
             setVerticalPropertiesForInlineLevelBox(lineBox, atomicInlineBox);

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -230,12 +230,9 @@ void BoxTreeUpdater::adjustStyleIfNeeded(const RenderElement& renderer, Style::C
         adjustStyle(*firstLineStyle);
 }
 
-static EnumSet<Layout::ElementBox::ListMarkerAttribute> calculateListMarkerAttribute(const RenderListOutsideMarker& listMarkerRenderer)
+static Layout::ElementBox::IsListMarkerImage isListMarkerImage(const RenderListOutsideMarker& listMarkerRenderer)
 {
-    auto listMarkerAttributes = EnumSet<Layout::ElementBox::ListMarkerAttribute> { };
-    if (listMarkerRenderer.isImage())
-        listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Image);
-    return listMarkerAttributes;
+    return listMarkerRenderer.isImage() ? Layout::ElementBox::IsListMarkerImage::Yes : Layout::ElementBox::IsListMarkerImage::No;
 }
 
 static bool markerTextSynthesizesGlyph(const RenderText& textRenderer)
@@ -306,7 +303,7 @@ UniqueRef<Layout::Box> BoxTreeUpdater::createLayoutBox(RenderObject& renderer)
     adjustStyleIfNeeded(renderElement, style, firstLineStyle.get());
 
     if (CheckedPtr listMarkerRenderer = dynamicDowncast<RenderListOutsideMarker>(renderElement))
-        return makeUniqueRef<Layout::ElementBox>(elementAttributes(renderElement), calculateListMarkerAttribute(*listMarkerRenderer), WTF::move(style), WTF::move(firstLineStyle));
+        return makeUniqueRef<Layout::ElementBox>(elementAttributes(renderElement), isListMarkerImage(*listMarkerRenderer), WTF::move(style), WTF::move(firstLineStyle));
 
     return makeUniqueRef<Layout::ElementBox>(elementAttributes(renderElement), WTF::move(style), WTF::move(firstLineStyle));
 };
@@ -411,7 +408,7 @@ void BoxTreeUpdater::updateStyle(const RenderObject& renderer)
     layoutBox->updateStyle(WTF::move(newStyle), WTF::move(firstLineNewStyle));
     if (auto* listMarkerRenderer = dynamicDowncast<RenderListOutsideMarker>(renderer)) {
         if (auto* elementBox = dynamicDowncast<Layout::ElementBox>(*layoutBox))
-            elementBox->setListMarkerAttributes(calculateListMarkerAttribute(*listMarkerRenderer));
+            elementBox->setIsListMarkerImage(isListMarkerImage(*listMarkerRenderer));
     }
 }
 

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.cpp
@@ -40,12 +40,12 @@ ElementBox::ElementBox(ElementAttributes&& attributes, Style::ComputedStyle&& st
 {
 }
 
-ElementBox::ElementBox(ElementAttributes&& attributes, EnumSet<ListMarkerAttribute> listMarkerAttributes, Style::ComputedStyle&& style, std::unique_ptr<Style::ComputedStyle>&& firstLineStyle)
+ElementBox::ElementBox(ElementAttributes&& attributes, IsListMarkerImage isListMarkerImage, Style::ComputedStyle&& style, std::unique_ptr<Style::ComputedStyle>&& firstLineStyle)
     : Box(WTF::move(attributes), WTF::move(style), WTF::move(firstLineStyle), ElementBoxFlag)
     , m_replacedData(makeUnique<ReplacedData>())
 {
     ASSERT(isListMarkerBox());
-    m_replacedData->listMarkerAttributes = listMarkerAttributes;
+    m_replacedData->isListMarkerImage = isListMarkerImage == IsListMarkerImage::Yes;
 }
 
 ElementBox::ElementBox(ElementAttributes&& attributes, ReplacedAttributes&& replacedAttributes, Style::ComputedStyle&& style, std::unique_ptr<Style::ComputedStyle>&& firstLineStyle)

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.h
@@ -46,10 +46,8 @@ class ElementBox : public Box {
 public:
     ElementBox(ElementAttributes&&, Style::ComputedStyle&&, std::unique_ptr<Style::ComputedStyle>&& firstLineStyle = nullptr, EnumSet<BaseTypeFlag> = { ElementBoxFlag });
 
-    enum class ListMarkerAttribute : uint8_t {
-        Image,
-    };
-    ElementBox(ElementAttributes&&, EnumSet<ListMarkerAttribute>, Style::ComputedStyle&&, std::unique_ptr<Style::ComputedStyle>&& firstLineStyle = nullptr);
+    enum class IsListMarkerImage : bool { No, Yes };
+    ElementBox(ElementAttributes&&, IsListMarkerImage, Style::ComputedStyle&&, std::unique_ptr<Style::ComputedStyle>&& firstLineStyle = nullptr);
 
     struct ReplacedAttributes {
         LayoutSize intrinsicSize;
@@ -96,9 +94,9 @@ public:
     LayoutUnit NODELETE intrinsicRatio() const;
     bool NODELETE hasAspectRatio() const;
 
-    void setListMarkerAttributes(EnumSet<ListMarkerAttribute> listMarkerAttributes) { m_replacedData->listMarkerAttributes = listMarkerAttributes; }
+    void setIsListMarkerImage(IsListMarkerImage isListMarkerImage) { m_replacedData->isListMarkerImage = isListMarkerImage == IsListMarkerImage::Yes; }
 
-    bool isListMarkerImage() const { return m_replacedData && m_replacedData->listMarkerAttributes.contains(ListMarkerAttribute::Image); }
+    bool isListMarkerImage() const { return m_replacedData && m_replacedData->isListMarkerImage; }
 
     // FIXME: This is temporary until after list marker content is accessible by IFC (webkit.org/b/294342)
     void setListMarkerLayoutBounds(std::pair<float, float> layoutBounds) { m_replacedData->layoutBounds = layoutBounds; }
@@ -115,7 +113,7 @@ private:
     struct ReplacedData {
         WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(ReplacedData);
 
-        EnumSet<ListMarkerAttribute> listMarkerAttributes;
+        bool isListMarkerImage { false };
         std::pair<float, float> layoutBounds;
 
         std::optional<LayoutSize> intrinsicSize;

--- a/Source/WebCore/rendering/RenderListOutsideMarker.cpp
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.cpp
@@ -41,6 +41,7 @@
 #include "RenderBlockFlow.h"
 #include "RenderBlockInlines.h"
 #include "RenderBoxInlines.h"
+#include "RenderImage.h"
 #include "RenderLayer.h"
 #include "RenderListItem.h"
 #include "RenderMenuList.h"
@@ -55,7 +56,6 @@
 #include "StyleListStyleType.h"
 #include "StyleScope.h"
 #include "TextUtil.h"
-#include <wtf/HashSet.h>
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
@@ -128,96 +128,14 @@ bool RenderListOutsideMarker::hasContentProperty() const
     return document().settings().cssMarkerContentEnabled() && style().content().isData();
 }
 
-static bool symbolsContainStrongDirectionalityText(const CSSRegisteredCounterStyle& counterStyle)
-{
-    auto isStrongDirectionalitySymbol = [](auto& symbol) {
-        return Layout::TextUtil::containsStrongDirectionalityText(symbol.text);
-    };
-    return isStrongDirectionalitySymbol(counterStyle.prefix())
-        || isStrongDirectionalitySymbol(counterStyle.suffix())
-        || isStrongDirectionalitySymbol(counterStyle.negative().m_prefix)
-        || isStrongDirectionalitySymbol(counterStyle.negative().m_suffix)
-        || isStrongDirectionalitySymbol(counterStyle.pad().m_padSymbol)
-        || std::ranges::any_of(counterStyle.symbols(), isStrongDirectionalitySymbol)
-        || std::ranges::any_of(counterStyle.additiveSymbols(), [&](auto& additiveSymbol) {
-            return isStrongDirectionalitySymbol(additiveSymbol.first);
-        });
-}
-
-static bool counterStyleChainHasStrongDirectionalitySymbols(const CSSRegisteredCounterStyle& counterStyle)
-{
-    // A counter style draws its fallback's text whenever a value is out of range or its own system cannot
-    // represent it (CSSRegisteredCounterStyle::text), so every style the chain can reach has to be
-    // left-to-right before the marker can go without content renderers. Measuring and painting the text
-    // directly follows memory order, so text this gets wrong is painted wrong.
-    HashSet<const CSSRegisteredCounterStyle*> visitedCounterStyles;
-    RefPtr currentCounterStyle = &counterStyle;
-    while (true) {
-        // A cycle draws decimal instead (see fallbackText), which never reorders.
-        if (!visitedCounterStyles.add(currentCounterStyle.get()).isNewEntry)
-            return false;
-
-        if (symbolsContainStrongDirectionalityText(*currentCounterStyle))
-            return true;
-
-        // No fallback to follow is the same condition fallbackText draws decimal on, whether the chain
-        // ends here or its reference was never resolved.
-        RefPtr fallbackCounterStyle = currentCounterStyle->fallbackStyle();
-        if (!fallbackCounterStyle)
-            return false;
-
-        currentCounterStyle = WTF::move(fallbackCounterStyle);
-    }
-}
-
-bool RenderListOutsideMarker::textNeedsBidiResolution() const
-{
-    if (hasContentProperty() || isImage() || synthesizesGlyph() || style().listStyleType().isNone())
-        return false;
-
-    if (auto markerString = style().listStyleType().tryString())
-        return !style().writingMode().isBidiLTR() || Layout::TextUtil::containsStrongDirectionalityText(*markerString);
-
-    RefPtr counterStyle = this->counterStyle();
-    if (!counterStyle)
-        return false;
-
-    if (!style().writingMode().isBidiLTR())
-        return true;
-
-    return counterStyleChainHasStrongDirectionalitySymbols(*counterStyle);
-}
-
-bool RenderListOutsideMarker::needsContentContainer() const
-{
-    return hasContentProperty() || textNeedsBidiResolution() || synthesizesGlyph();
-}
-
 RenderBlockFlow* RenderListOutsideMarker::contentContainer() const
 {
-    // When the marker has generated content, its sole child is the anonymous
-    // inline-block box holding that content (created by RenderTreeBuilder::List).
     return dynamicDowncast<RenderBlockFlow>(firstChild());
 }
 
 LayoutRect RenderListOutsideMarker::localSelectionRect()
 {
     return LayoutRect(LayoutPoint(), borderBoxSize());
-}
-
-struct TextRunWithUnderlyingString {
-    TextRun textRun;
-    String underlyingString;
-    operator const TextRun&() const { return textRun; }
-};
-
-static auto textRunForContent(ListMarkerTextContent textContent, const Style::ComputedStyle& style) -> TextRunWithUnderlyingString
-{
-    ASSERT(!textContent.isEmpty());
-
-    auto textForRun = textContent.textWithSuffix;
-    auto textRun = RenderBlock::constructTextRun(textForRun, style);
-    return { WTF::move(textRun), WTF::move(textForRun) };
 }
 
 void RenderListOutsideMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
@@ -231,92 +149,24 @@ void RenderListOutsideMarker::paint(PaintInfo& paintInfo, const LayoutPoint& pai
     if (!paintInfo.rect.intersects(overflowRect))
         return;
 
-    if (CheckedPtr container = contentContainer()) {
-        if (paintInfo.phase == PaintPhase::Accessibility) {
-            paintInfo.accessibilityRegionContext()->takeBounds(*this, LayoutRect(boxOrigin, borderBoxSize()));
-            return;
-        }
-
-        if (paintInfo.phase == PaintPhase::Foreground && selectionState() != HighlightState::None) {
-            LayoutRect selectionRect = localSelectionRect();
-            selectionRect.moveBy(boxOrigin);
-            paintInfo.context().fillRect(snappedIntRect(selectionRect), m_listItem->selectionBackgroundColor());
-        }
-
-        // Paint the generated-content subtree as an atomic inline: paintAsInlineBlock fans out all
-        // sub-phases for Foreground and forwards Selection/EventRegion/TextClip to the child's paint().
-        container->paintAsInlineBlock(paintInfo, flipForWritingModeForChild(*container, boxOrigin));
+    CheckedPtr container = contentContainer();
+    if (!container)
         return;
-    }
-
-    if (paintInfo.phase != PaintPhase::Foreground && paintInfo.phase != PaintPhase::Accessibility)
-        return;
-
-    LayoutRect box(boxOrigin, borderBoxSize());
-
-    auto markerRect = relativeMarkerRect();
-    markerRect.moveBy(boxOrigin);
 
     if (paintInfo.phase == PaintPhase::Accessibility) {
-        paintInfo.accessibilityRegionContext()->takeBounds(*this, markerRect);
+        paintInfo.accessibilityRegionContext()->takeBounds(*this, LayoutRect(boxOrigin, borderBoxSize()));
         return;
     }
 
-    if (markerRect.isEmpty())
-        return;
-
-    GraphicsContext& context = paintInfo.context();
-
-    if (isImage()) {
-        if (RefPtr markerImage = protect(m_image)->image(this, markerRect.size(), context))
-            context.drawImage(*markerImage, markerRect, { imageOrientation() });
-        if (selectionState() != HighlightState::None) {
-            LayoutRect selectionRect = localSelectionRect();
-            selectionRect.moveBy(boxOrigin);
-            context.fillRect(snappedIntRect(selectionRect), m_listItem->selectionBackgroundColor());
-        }
-        return;
-    }
-
-    if (selectionState() != HighlightState::None) {
+    if (paintInfo.phase == PaintPhase::Foreground && selectionState() != HighlightState::None) {
         LayoutRect selectionRect = localSelectionRect();
         selectionRect.moveBy(boxOrigin);
-        context.fillRect(snappedIntRect(selectionRect), m_listItem->selectionBackgroundColor());
+        paintInfo.context().fillRect(snappedIntRect(selectionRect), m_listItem->selectionBackgroundColor());
     }
 
-    auto color = style().visitedDependentTextFillColorApplyingColorFilter();
-    context.setStrokeColor(color);
-    context.setStrokeStyle(StrokeStyle::SolidStroke);
-    context.setStrokeThickness(1.0f);
-    context.setFillColor(color);
-
-    if (m_textContent.isEmpty())
-        return;
-
-    GraphicsContextStateSaver stateSaver(context, false);
-    if (!writingMode().isHorizontal()) {
-        markerRect.moveBy(-boxOrigin);
-        markerRect = markerRect.transposedRect();
-        markerRect.moveBy(FloatPoint(box.x(), box.y() - logicalHeight()));
-        stateSaver.save();
-        context.translate(markerRect.x(), markerRect.maxY());
-        context.rotate(static_cast<float>(deg2rad(90.)));
-        context.translate(-markerRect.x(), -markerRect.maxY());
-    }
-
-    if (writingMode().isHorizontal() && !isExcludedMarker()) {
-        // This is required because RenderListOutsideMarker hand-draws the text, instead of running inline
-        // layout and paint on its (RenderText) subtree (LayoutUnit vs. float precision)
-        // An excluded marker has no inline box to correct against: the list item placed it directly.
-        // FIXME: The vertical path mispositions the marker line box separately (it ignores fallback-font
-        // metrics), so this is limited to horizontal writing modes for now. See webkit.org/b/319618.
-        if (auto markerInlineBox = InlineIterator::boxFor(*this))
-            markerRect.setY(paintOffset.y() + markerInlineBox->visualRectIgnoringBlockDirection().y());
-    }
-
-    auto textOrigin = FloatPoint { markerRect.x(), markerRect.y() + style().fontCascade().metricsOfPrimaryFont().ascent() };
-    textOrigin = roundPointToDevicePixels(LayoutPoint(textOrigin), protect(document())->deviceScaleFactor(), writingMode().isLogicalLeftInlineStart());
-    context.drawText(style().fontCascade(), textRunForContent(m_textContent, style()), textOrigin);
+    // Paint the generated-content subtree as an atomic inline: paintAsInlineBlock fans out all
+    // sub-phases for Foreground and forwards Selection/EventRegion/TextClip to the child's paint().
+    container->paintAsInlineBlock(paintInfo, flipForWritingModeForChild(*container, boxOrigin));
 }
 
 void RenderListOutsideMarker::layout()
@@ -324,20 +174,9 @@ void RenderListOutsideMarker::layout()
     StackStats::LayoutCheckPoint layoutCheckPoint;
     ASSERT(needsLayout());
 
-    if (CheckedPtr container = contentContainer()) {
-        updateInlineMargins();
+    updateInlineMargins();
+    if (CheckedPtr container = contentContainer())
         layoutContentContainer(*container);
-    } else if (isImage()) {
-        updateInlineMargins();
-        RefPtr image = m_image;
-        setBorderBoxWidth(image->imageSize(this, style().usedZoom()).width());
-        setBorderBoxHeight(image->imageSize(this, style().usedZoom()).height());
-        m_layoutBounds = { borderBoxHeight(), 0 };
-    } else {
-        setLogicalWidth(minContentLogicalWidthContribution());
-        setLogicalHeight(style().metricsOfPrimaryFont().intHeight());
-        m_layoutBounds = layoutBoundForTextContent(m_textContent.textWithSuffix);
-    }
 
     setMarginStart(0);
     setMarginEnd(0);
@@ -363,21 +202,28 @@ void RenderListOutsideMarker::layoutContentContainer(RenderBlockFlow& container)
 
     setLogicalWidth(container.logicalWidth());
 
-    // The inline formatting context aligns the marker box on the marker's primary-font baseline
-    // (like a text marker; see InlineLineBoxBuilder), then we paint the content box at the marker
-    // box origin. Offset the content box along the block axis so its own first-line baseline lands
-    // on that font baseline — otherwise the content's line-box half-leading shifts it off the list
-    // item's baseline. Logical setters keep this correct in vertical writing modes.
-    auto markerAscent = LayoutUnit { style().metricsOfPrimaryFont().ascent(BaselineAlignment::dominantBaseline(writingMode())) };
     auto contentBaseline = container.firstLineBaseline().value_or(container.logicalHeight());
-    container.setLogicalTop(markerAscent - contentBaseline);
 
-    if (textNeedsBidiResolution() || synthesizesGlyph()) {
-        setLogicalHeight(style().metricsOfPrimaryFont().intHeight());
-        m_layoutBounds = layoutBoundForTextContent(m_textContent.textWithSuffix);
+    if (CheckedPtr imageRenderer = isImage() ? dynamicDowncast<RenderBox>(container.firstChild()) : nullptr) {
+        container.setLogicalTop(-imageRenderer->logicalTop());
+        setLogicalHeight(imageRenderer->logicalHeight());
+        m_layoutBounds = { imageRenderer->logicalHeight(), 0 };
     } else {
-        setLogicalHeight(container.logicalHeight());
-        m_layoutBounds = { contentBaseline, container.logicalHeight() - contentBaseline };
+        // The inline formatting context aligns a text marker box on the marker's primary-font baseline
+        // (see InlineLineBoxBuilder), then we paint the content box at the marker box origin. Offset the
+        // content box along the block axis so its own first-line baseline lands on that font baseline —
+        // otherwise the content's line-box half-leading shifts it off the list item's baseline. Logical
+        // setters keep this correct in vertical writing modes.
+        auto markerAscent = LayoutUnit { style().metricsOfPrimaryFont().ascent(BaselineAlignment::dominantBaseline(writingMode())) };
+        container.setLogicalTop(markerAscent - contentBaseline);
+
+        if (hasContentProperty()) {
+            setLogicalHeight(container.logicalHeight());
+            m_layoutBounds = { contentBaseline, container.logicalHeight() - contentBaseline };
+        } else {
+            setLogicalHeight(style().metricsOfPrimaryFont().intHeight());
+            m_layoutBounds = layoutBoundForTextContent(m_textContent.textWithSuffix);
+        }
     }
 
     // The content box can extend outside the marker's border box (its baseline offset may be
@@ -432,8 +278,7 @@ void RenderListOutsideMarker::updateContent()
         // FIXME: This is a somewhat arbitrary width.
         LayoutUnit bulletWidth = style().metricsOfPrimaryFont().intAscent() / 2_lu;
         LayoutSize defaultBulletSize(bulletWidth, bulletWidth);
-        LayoutSize imageSize = calculateImageIntrinsicDimensions(m_image.get(), defaultBulletSize, ScaleByUsedZoom::No);
-        protect(m_image)->setContainerContextForRenderer(*this, imageSize, style().usedZoom());
+        setContentContainerImageSize(calculateImageIntrinsicDimensions(protect(m_image).get(), defaultBulletSize, ScaleByUsedZoom::Yes));
         m_textContent = {
             .textWithSuffix = emptyString(),
             .textWithoutSuffixLength = 0,
@@ -445,8 +290,25 @@ void RenderListOutsideMarker::updateContent()
 
     // The marker text is only known here (counter values resolve at layout), while the renderers
     // holding it were created from style. Push the text down so the inline formatting context has something to lay out.
-    if (textNeedsBidiResolution() || synthesizesGlyph())
-        updateContentContainerText();
+    updateContentContainerText();
+}
+
+void RenderListOutsideMarker::setContentContainerImageSize(LayoutSize imageSize)
+{
+    CheckedPtr container = contentContainer();
+    CheckedPtr imageRenderer = container ? dynamicDowncast<RenderImage>(container->firstChild()) : nullptr;
+    if (!imageRenderer)
+        return;
+
+    auto usedZoom = imageRenderer->style().usedZoomForLength();
+    auto logicalWidth = Style::PreferredSize { Style::PreferredSize::Fixed { imageSize.width() / usedZoom.value } };
+    auto logicalHeight = Style::PreferredSize { Style::PreferredSize::Fixed { imageSize.height() / usedZoom.value } };
+    if (imageRenderer->style().width() == logicalWidth && imageRenderer->style().height() == logicalHeight)
+        return;
+
+    imageRenderer->mutableStyle().setWidth(WTF::move(logicalWidth));
+    imageRenderer->mutableStyle().setHeight(WTF::move(logicalHeight));
+    imageRenderer->setNeedsLayout();
 }
 
 void RenderListOutsideMarker::updateContentContainerText()
@@ -458,10 +320,8 @@ void RenderListOutsideMarker::updateContentContainerText()
     }
 
     CheckedPtr textRenderer = dynamicDowncast<RenderText>(container->firstChild());
-    if (!textRenderer) {
-        ASSERT_NOT_REACHED();
+    if (!textRenderer)
         return;
-    }
 
     if (synthesizesGlyph()) {
         textRenderer->setText(m_textContent.textWithoutSuffix().toString());
@@ -475,39 +335,14 @@ void RenderListOutsideMarker::computeIntrinsicLogicalWidthContributions()
 {
     ASSERT(hasInvalidContentLogicalWidths());
 
-    if (CheckedPtr container = contentContainer()) {
-        // The marker is non-wrapping, so its min- and max-content widths are both the
-        // content's max-content width.
-        auto logicalWidth = container->maxContentLogicalWidthContribution();
-        m_minContentLogicalWidthContribution = logicalWidth;
-        m_maxContentLogicalWidthContribution = logicalWidth;
-        clearContentLogicalWidthsInvalidation();
-        updateInlineMargins();
-        return;
-    }
+    CheckedPtr container = contentContainer();
+    ASSERT(container);
 
-    if (isImage()) {
-        LayoutSize imageSize = LayoutSize(protect(m_image)->imageSize(this, style().usedZoom()));
-        m_maxContentLogicalWidthContribution = writingMode().isHorizontal() ? imageSize.width() : imageSize.height();
-        m_minContentLogicalWidthContribution = m_maxContentLogicalWidthContribution;
-        clearContentLogicalWidthsInvalidation();
-        updateInlineMargins();
-        return;
-    }
-
-    ASSERT(!hasContentProperty());
-
-    auto& font = style().fontCascade();
-
-    LayoutUnit logicalWidth;
-    if (!m_textContent.isEmpty())
-        logicalWidth = font.width(textRunForContent(m_textContent, style()));
-
+    // The marker is non-wrapping, so its min- and max-content widths are both the content's max-content width.
+    auto logicalWidth = container ? container->maxContentLogicalWidthContribution() : 0_lu;
     m_minContentLogicalWidthContribution = logicalWidth;
     m_maxContentLogicalWidthContribution = logicalWidth;
-
     clearContentLogicalWidthsInvalidation();
-
     updateInlineMargins();
 }
 
@@ -523,9 +358,6 @@ void RenderListOutsideMarker::updateInlineMargins()
         int offset = fontMetrics.intAscent() * 2 / 3;
         if (synthesizesGlyph())
             return { -offset - markerPadding - 1, offset + markerPadding + 1 - minContentLogicalWidthContribution() };
-
-        if (m_textContent.isEmpty() && !contentContainer())
-            return { };
 
         return { -minContentLogicalWidthContribution(), 0 };
     };
@@ -587,25 +419,6 @@ Node* RenderListOutsideMarker::nodeForHitTest() const
     return m_listItem ? m_listItem->element() : nullptr;
 }
 
-FloatRect RenderListOutsideMarker::relativeMarkerRect()
-{
-    if (isImage())
-        return { 0.f, 0.f, protect(m_image)->imageSize(this, style().usedZoom()).width(), protect(m_image)->imageSize(this, style().usedZoom()).height() };
-
-    if (m_textContent.isEmpty())
-        return { };
-
-    auto& font = style().fontCascade();
-    auto relativeRect = FloatRect { 0.f, 0.f, font.width(textRunForContent(m_textContent, style())), font.metricsOfPrimaryFont().height() };
-
-    if (!writingMode().isHorizontal()) {
-        relativeRect = relativeRect.transposedRect();
-        relativeRect.setX(borderBoxWidth() - relativeRect.x() - relativeRect.width());
-    }
-
-    return relativeRect;
-}
-
 LayoutRect RenderListOutsideMarker::selectionRectForRepaint(const RenderLayerModelObject*, bool)
 {
     ASSERT(!needsLayout());
@@ -618,11 +431,6 @@ static RefPtr<CSSRegisteredCounterStyle> counterStyleFor(const Style::ComputedSt
     if (!counterStyle)
         return nullptr;
     return document.counterStyleRegistry().resolvedCounterStyle(*counterStyle);
-}
-
-RefPtr<CSSRegisteredCounterStyle> RenderListOutsideMarker::counterStyle() const
-{
-    return counterStyleFor(style(), protect(document()));
 }
 
 bool listMarkerIsDisclosure(const Style::ComputedStyle& markerStyle, Document& document)

--- a/Source/WebCore/rendering/RenderListOutsideMarker.h
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.h
@@ -69,11 +69,9 @@ public:
 
     bool isImage() const final;
 
-    // True when the ::marker's `content` property generates the marker box contents
-    // (css-lists-3 §3.3). In that case the contents live in an anonymous inline-block
-    // child (contentContainer()) that this marker lays out and paints itself.
+    // True when the ::marker's `content` property generates the marker box contents (css-lists-3 §3.3),
+    // rather than list-style-image/type.
     bool hasContentProperty() const;
-    bool needsContentContainer() const;
 
     RenderBlockFlow* contentContainer() const;
 
@@ -95,7 +93,7 @@ private:
     void willBeDestroyed() final;
     ASCIILiteral renderName() const final { return "RenderListMarker"_s; }
     void computeIntrinsicLogicalWidthContributions() final;
-    bool canHaveChildren() const final { return needsContentContainer(); }
+    bool canHaveChildren() const final { return true; }
     bool canHaveGeneratedChildren() const final { return true; }
     void paint(PaintInfo&, const LayoutPoint&) final;
     void layout() final;
@@ -113,13 +111,11 @@ private:
     void updateInlineMargins();
     void updateContent();
     void updateContentContainerText();
+    void setContentContainerImageSize(LayoutSize);
     void layoutContentContainer(RenderBlockFlow&);
 
-    FloatRect relativeMarkerRect();
     LayoutRect NODELETE localSelectionRect();
 
-    RefPtr<CSSRegisteredCounterStyle> counterStyle() const;
-    bool textNeedsBidiResolution() const;
 
 private:
     ListMarkerTextContent m_textContent;

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -549,7 +549,7 @@ void write(TextStream& ts, const RenderObject& renderer, OptionSet<RenderAsTextF
         return;
     }
 
-    if (CheckedPtr listMarker = dynamicDowncast<RenderListOutsideMarker>(renderer); listMarker && listMarker->synthesizesGlyph())
+    if (is<RenderListOutsideMarker>(renderer))
         return;
 
     for (auto& child : childrenOfType<RenderObject>(downcast<RenderElement>(renderer))) {

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -135,23 +135,16 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
         m_builder.destroyAndCleanUpAnonymousWrappers(*markerRenderer, { });
 
     if (auto* markerRenderer = listItemRenderer.markerBox()) {
-        // Whether the marker box holds inline content depends on `content` and on list-style-type
-        // (only text markers with right-to-left content need it). The container also inherits
-        // unicode-bidi, so rebuild on that too, to carry the new value into it.
-        auto contentChanged = markerRenderer->style().content() != newStyle.content() || markerRenderer->style().unicodeBidi() != newStyle.unicodeBidi() || markerRenderer->style().listStyleType() != newStyle.listStyleType();
+        auto contentChanged = markerRenderer->style().content() != newStyle.content() || markerRenderer->style().unicodeBidi() != newStyle.unicodeBidi()
+            || markerRenderer->style().listStyleType() != newStyle.listStyleType() || markerRenderer->style().listStyleImage() != newStyle.listStyleImage();
         markerRenderer->setStyle(WTF::move(newStyle));
         // list-style-type, the counter style it resolves to and the writing mode all decide the marker's text.
         m_builder.addListItemNeedingMarkerUpdate(listItemRenderer);
 
-        // Recomputing this here rather than diffing the style properties it is made of also picks up
-        // what is not the marker's own style: its direction, and what the document's counter style
-        // registry currently resolves list-style-type to.
-        auto needsContentContainer = markerRenderer->needsContentContainer();
-        if (contentChanged || needsContentContainer != !!markerRenderer->contentContainer()) {
+        if (contentChanged) {
             if (auto* existingContainer = markerRenderer->contentContainer())
                 m_builder.destroy(*existingContainer);
-            if (needsContentContainer)
-                buildMarkerContentRenderers(*markerRenderer);
+            buildMarkerContentRenderers(*markerRenderer);
         } else if (auto* container = markerRenderer->contentContainer()) {
             // Content unchanged but other style changed: refresh the generated image/quote children
             // (RenderText/RenderCounter are handled by propagateStyleToAnonymousChildren on setStyle).
@@ -207,8 +200,7 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
     }
     m_builder.attach(*searchResult.parent, WTF::move(newMarkerRenderer), firstNonMarkerChild(*searchResult.parent));
 
-    if (listItemRenderer.markerBox()->needsContentContainer())
-        buildMarkerContentRenderers(*listItemRenderer.markerBox());
+    buildMarkerContentRenderers(*listItemRenderer.markerBox());
 }
 
 static CheckedRef<RenderBlock> parentForInlineMarker(RenderListItem& listItemRenderer, const RenderInline& marker)
@@ -253,7 +245,6 @@ void RenderTreeBuilder::List::buildInlineMarker(RenderListItem& listItemRenderer
 
 void RenderTreeBuilder::List::buildMarkerContentRenderers(RenderListOutsideMarker& marker)
 {
-    ASSERT(marker.needsContentContainer());
     ASSERT(!marker.contentContainer());
 
     // css-lists-3 §3.3 generates the marker contents "exactly as for ::before": an anonymous
@@ -266,6 +257,14 @@ void RenderTreeBuilder::List::buildMarkerContentRenderers(RenderListOutsideMarke
     m_builder.attach(marker, WTF::move(newContainer));
 
     if (!marker.hasContentProperty()) {
+        // css-lists-3 §3.3: a list-style-image draws in place of the counter style's text, as an image of its own.
+        if (RefPtr styleImage = marker.style().listStyleImage().tryStyleImage(); styleImage && !styleImage->errorOccurred()) {
+            auto imageRenderer = WebCore::createRenderer<RenderImage>(RenderObject::Type::Image, marker.document(), Style::ComputedStyle::createStyleInheritingFromPseudoStyle(marker.style()), styleImage.get());
+            imageRenderer->initializeStyle();
+            m_builder.attach(container.get(), WTF::move(imageRenderer));
+            return;
+        }
+
         // list-style-type text that needs renderers of its own, so inline layout can bidi-resolve it.
         // The text itself is only known once counter values resolve, so start empty and let
         // RenderListOutsideMarker::updateContent() fill it in at layout time.


### PR DESCRIPTION
#### c0a49688cb186d90984cc82b3b45259088e1cf77
<pre>
[list-marker] Give every outside list marker its content as renderers instead of hand-drawing the text and the image
<a href="https://bugs.webkit.org/show_bug.cgi?id=323502">https://bugs.webkit.org/show_bug.cgi?id=323502</a>
<a href="https://rdar.apple.com/problem/186741639">rdar://problem/186741639</a>

Reviewed by Antti Koivisto.

The outside marker already held its content as renderers when the ::marker had a content property, right to left
text or a synthesized glyph. Build them for the rest too, so one path measures, lays out and paints every marker.

The render tree dump leaves the marker&apos;s renderers out: its own line already carries the text.

* LayoutTests/TestExpectations:
* LayoutTests/platform/glib/fast/lists/008-expected.txt:
* LayoutTests/platform/glib/fast/lists/008-vertical-expected.txt:
* LayoutTests/platform/ios/fast/lists/008-expected.txt:
* LayoutTests/platform/ios/fast/lists/008-vertical-expected.txt:
* LayoutTests/platform/mac/fast/lists/008-expected.txt:
* LayoutTests/platform/mac/fast/lists/008-vertical-expected.txt:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.cpp:
(WebCore::Layout::LineBoxBuilder::constructInlineLevelBoxes):
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::isListMarkerImage):
(WebCore::LayoutIntegration::BoxTreeUpdater::createLayoutBox):
(WebCore::LayoutIntegration::BoxTreeUpdater::updateStyle):
(WebCore::LayoutIntegration::calculateListMarkerAttribute): Deleted.
* Source/WebCore/layout/layouttree/LayoutElementBox.cpp:
(WebCore::Layout::ElementBox::ElementBox):
* Source/WebCore/layout/layouttree/LayoutElementBox.h:
(WebCore::Layout::ElementBox::setIsListMarkerImage):
(WebCore::Layout::ElementBox::isListMarkerImage const):
(WebCore::Layout::ElementBox::setListMarkerAttributes): Deleted.
* Source/WebCore/rendering/RenderListOutsideMarker.cpp:
(WebCore::RenderListOutsideMarker::paint):
(WebCore::RenderListOutsideMarker::layout):
(WebCore::RenderListOutsideMarker::layoutContentContainer):
(WebCore::RenderListOutsideMarker::updateContent):
(WebCore::RenderListOutsideMarker::setContentContainerImageSize):
(WebCore::RenderListOutsideMarker::computeIntrinsicLogicalWidthContributions):
(WebCore::RenderListOutsideMarker::updateInlineMargins):
(WebCore::symbolsContainStrongDirectionalityText): Deleted.
(WebCore::counterStyleChainHasStrongDirectionalitySymbols): Deleted.
(WebCore::RenderListOutsideMarker::textNeedsBidiResolution): Deleted.
(WebCore::RenderListOutsideMarker::needsContentContainer): Deleted.
(WebCore::textRunForContent): Deleted.
(WebCore::RenderListOutsideMarker::relativeMarkerRect): Deleted.
(WebCore::RenderListOutsideMarker::counterStyle): Deleted.
* Source/WebCore/rendering/RenderListOutsideMarker.h:
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::write):
* Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp:
(WebCore::RenderTreeBuilder::List::updateItemMarker):
(WebCore::RenderTreeBuilder::List::buildMarkerContentRenderers):

Canonical link: <a href="https://commits.webkit.org/320626@main">https://commits.webkit.org/320626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77fd00bfebd28291e31a80fb301f90f3b0060b05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195724 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/db89b74d-f2ca-4ed5-babb-10563a1b465c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59039 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144888 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/da81d09d-a282-4b4d-9d32-e401927c8992) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165471 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125180 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7c75100e-6fa2-4d24-88dd-ca502a6477d7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47295 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45351 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157662 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45043 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6776 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197673 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58976 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154400 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41343 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59685 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154051 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48535 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132014 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128868 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58163 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20065 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57535 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57778 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57602 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->