### PR TITLE
AX: In isolated tree mode, the insertion point line number is wrong when the caret is in a text control nested in a contenteditable

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -70,7 +70,6 @@ accessibility/mac/text-marker-for-index-2.html [ Failure ]
 accessibility/mac/text-marker-word-nav.html [ Failure ]
 accessibility/mac/selected-visible-position-range.html [ Failure ]
 accessibility/mac/text-marker-word-nav.html [ Timeout ]
-accessibility/textarea-insertion-point-line-number.html [ Failure ]
 
 # We compute the wrong line index relative to what is actually visually laid out.
 accessibility/mac/replaced-element-line-index-hang.html [ Failure ]

--- a/LayoutTests/accessibility/textarea-insertion-point-line-number.html
+++ b/LayoutTests/accessibility/textarea-insertion-point-line-number.html
@@ -40,22 +40,26 @@ if (window.accessibilityController) {
 
         // area2 is an empty textarea so the insertion point line number should be 0.
         area2AXUIElement = await waitForFocus("area2");
-        output += expect("area2AXUIElement.insertionPointLineNumber", "0");
+        output += await expectAsync("area2AXUIElement.insertionPointLineNumber", "0");
 
         // Set focus to the contenteditable-div element and set the insertion
         // point in each of the children lines.
         contenteditableAXUIElement = await waitForFocus("contenteditable-div");
 
-        var contenteditableLine1 = document.getElementById("contenteditable-line1");
-        window.getSelection().setBaseAndExtent(contenteditableLine1, 1, contenteditableLine1, 1);
+        async function selectAndWait(id) {
+            var node = document.getElementById(id);
+            await waitForNotification(null, "AXSelectedTextChanged", () => {
+                window.getSelection().setBaseAndExtent(node, 1, node, 1);
+            });
+        }
+
+        await selectAndWait("contenteditable-line1");
         output += expect("contenteditableAXUIElement.insertionPointLineNumber", "0");
 
-        var contenteditableLine2 = document.getElementById("contenteditable-line2");
-        window.getSelection().setBaseAndExtent(contenteditableLine2, 1, contenteditableLine2, 1);
+        await selectAndWait("contenteditable-line2");
         output += expect("contenteditableAXUIElement.insertionPointLineNumber", "1");
 
-        var contenteditableLine3 = document.getElementById("contenteditable-line3");
-        window.getSelection().setBaseAndExtent(contenteditableLine3, 1, contenteditableLine3, 1);
+        await selectAndWait("contenteditable-line3");
         output += expect("contenteditableAXUIElement.insertionPointLineNumber", "2");
 
         // Set focus to line 2 and get the insertion point line number relative

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -739,16 +739,18 @@ AXTextRunLineID AXTextMarker::lineID() const
     return runIndex != notFound ? runs->lineID(runIndex) : AXTextRunLineID();
 }
 
-int AXTextMarker::lineIndex() const
+int AXTextMarker::lineIndex(std::optional<AXID> rootID) const
 {
     if (!isValid())
         return -1;
     if (!isInTextRun())
-        return toTextRunMarker().lineIndex();
+        return toTextRunMarker().lineIndex(rootID);
 
     AXTextMarker startMarker;
     RefPtr object = isolatedObject();
-    if (object->isTextControl())
+    if (rootID)
+        startMarker = { treeID(), *rootID, 0 };
+    else if (object->isTextControl())
         startMarker = { *object, 0 };
     else if (RefPtr editableAncestor = object->editableAncestor())
         startMarker = { editableAncestor->treeID(), editableAncestor->objectID(), 0 };

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -342,8 +342,10 @@ public:
     AXTextMarker findLastBefore(std::optional<AXID>) const;
     AXTextMarker findLast() const { return findLastBefore(std::nullopt); }
     // The index of the line this text marker is on relative to the nearest editable ancestor (or start of the page if there are no editable ancestors).
+    // Pass |rootID| to count from the start of that object's text instead. This is required for computing
+    // the correct line index for nested text controls (e.g. a textarea inside a contenteditable).
     // Returns -1 if the line couldn't be computed (i.e. because `this` is invalid).
-    int lineIndex() const;
+    int lineIndex(std::optional<AXID> rootID = std::nullopt) const;
     // After resolving this marker to a text-run marker, what line does the offset point to?
     AXTextRunLineID lineID() const;
     // Returns the line number for the character index within the descendants of this marker's object.

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -1922,8 +1922,11 @@ int AXIsolatedObject::insertionPointLineNumber() const
             return AXTextMarker { *this, 0 }.toTextRunMarker(idOfNextSiblingIncludingIgnoredOrParent()).isValid() ? -1 : 0;
         }
         RefPtr selectionObject = selectedMarkerRange.start().isolatedObject();
-        if (selectionObject && isAncestorOfObject(*selectionObject))
-            return selectedMarkerRange.start().lineIndex();
+        if (selectionObject && isAncestorOfObject(*selectionObject)) {
+            // Count lines from this control, not from the selection's own editable ancestor, which is a
+            // nested control when one contains the selection (e.g. a <textarea> inside a contenteditable).
+            return selectedMarkerRange.start().lineIndex(objectID());
+        }
     }
     return -1;
 }


### PR DESCRIPTION
#### c1d6a750aaecddc7141e4becc6273adcd71baef3
<pre>
AX: In isolated tree mode, the insertion point line number is wrong when the caret is in a text control nested in a contenteditable
<a href="https://bugs.webkit.org/show_bug.cgi?id=323508">https://bugs.webkit.org/show_bug.cgi?id=323508</a>
<a href="https://rdar.apple.com/186747828">rdar://186747828</a>

Reviewed by Chris Fleizach.

AXInsertionPointLineNumber answers for the control it is asked of, so its line count has to start at
that control. The isolated tree instead let AXTextMarker::lineIndex pick a root, which is the marker&apos;s
nearest editable ancestor. When a text control holds the caret, that ancestor is the nested control
rather than the contenteditable being asked, so the count restarted inside it and reported line 0 for
a caret on the contenteditable&apos;s second line.

Let a caller name the root to count from, and have insertionPointLineNumber pass itself. Asking the
nested textarea directly still answers 0, which is what the last check in the test covers.

The test required some fixes too, as it did not accurately represent real AT behavior. It set the DOM
selection and read the insertion point in the same turn, and accessibility only learns about a selection
change from a notification, so in isolated tree mode all three reads saw the selection as it stood before
the first one -- the notification for the whole sequence arrives afterwards. Now we wait for the
notification as an AT would.

* LayoutTests/accessibility-isolated-tree/TestExpectations:
Mark accessibility/textarea-insertion-point-line-number.html as fixed.
* LayoutTests/accessibility/textarea-insertion-point-line-number.html:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::lineIndex const):
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::insertionPointLineNumber const):

Canonical link: <a href="https://commits.webkit.org/320572@main">https://commits.webkit.org/320572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/557604389e47899dd11903dd0979500068bc46ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195485 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd556e2d-55b0-480b-83d7-a05fd9e0ee8f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144684 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3bd2ac3f-7198-4203-b11b-6c36d72e15a4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124977 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cda558e0-de75-49ce-a833-a411e63ecfbc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47094 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45158 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157461 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44845 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6541 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197437 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58733 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164781 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154192 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41294 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59442 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153843 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48336 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131747 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128435 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57921 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19864 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57292 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57535 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57359 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->