### PR TITLE
AX: Add a layout test for the AXDateTimeComponents attribute

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/datetime-components-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/datetime-components-expected.txt
@@ -1,0 +1,12 @@
+This test verifies the AXDateTimeComponents bitmask that each date and time input exposes.
+
+PASS: componentsFor('date') === 224
+PASS: componentsFor('time') === 14
+PASS: componentsFor('datetime-local') === 238
+PASS: componentsFor('month') === 192
+PASS: componentsFor('week') === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/datetime-components.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/datetime-components.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="content">
+<input id="date" type="date">
+<input id="time" type="time">
+<input id="datetime-local" type="datetime-local">
+<input id="month" type="month">
+<input id="week" type="week">
+</div>
+
+<script>
+var output = "This test verifies the AXDateTimeComponents bitmask that each date and time input exposes.\n\n";
+
+function componentsFor(id)
+{
+    return accessibilityController.accessibleElementById(id).numberAttributeValue("AXDateTimeComponents");
+}
+
+if (window.accessibilityController) {
+    // Days | Months | Years.
+    output += expect("componentsFor('date')", "224");
+    // Seconds | Minutes | Hours.
+    output += expect("componentsFor('time')", "14");
+    // Seconds | Minutes | Hours | Days | Months | Years.
+    output += expect("componentsFor('datetime-local')", "238");
+    // Months | Years.
+    output += expect("componentsFor('month')", "192");
+    // Week is the one date input that maps to no components, so VoiceOver is told nothing
+    // about which fields a week control presents.
+    output += expect("componentsFor('week')", "0");
+
+    document.getElementById("content").style.visibility = "hidden";
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/datetime-components-expected.txt
+++ b/LayoutTests/accessibility/mac/datetime-components-expected.txt
@@ -1,0 +1,12 @@
+This test verifies the AXDateTimeComponents bitmask that each date and time input exposes.
+
+PASS: componentsFor('date') === 224
+PASS: componentsFor('time') === 14
+PASS: componentsFor('datetime-local') === 238
+PASS: componentsFor('month') === 192
+PASS: componentsFor('week') === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/datetime-components.html
+++ b/LayoutTests/accessibility/mac/datetime-components.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="content">
+<input id="date" type="date">
+<input id="time" type="time">
+<input id="datetime-local" type="datetime-local">
+<input id="month" type="month">
+<input id="week" type="week">
+</div>
+
+<script>
+var output = "This test verifies the AXDateTimeComponents bitmask that each date and time input exposes.\n\n";
+
+function componentsFor(id)
+{
+    return accessibilityController.accessibleElementById(id).numberAttributeValue("AXDateTimeComponents");
+}
+
+if (window.accessibilityController) {
+    // Days | Months | Years.
+    output += expect("componentsFor('date')", "224");
+    // Seconds | Minutes | Hours.
+    output += expect("componentsFor('time')", "14");
+    // Seconds | Minutes | Hours | Days | Months | Years.
+    output += expect("componentsFor('datetime-local')", "238");
+    // Months | Years.
+    output += expect("componentsFor('month')", "192");
+    // Week is the one date input that maps to no components, so VoiceOver is told nothing
+    // about which fields a week control presents.
+    output += expect("componentsFor('week')", "0");
+
+    document.getElementById("content").style.visibility = "hidden";
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -201,6 +201,7 @@ static id attributeValue(id element, NSString *attribute)
         @"AXControllerFor",
         @"AXControllers",
         @"AXDRTSpeechAttribute",
+        @"AXDateTimeComponents",
         @"AXDateTimeComponentsType",
         @"AXDescribedBy",
         @"AXDescriptionFor",


### PR DESCRIPTION
#### bc9d065c862d6be3163c499b727219e970188cde
<pre>
AX: Add a layout test for the AXDateTimeComponents attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=323510">https://bugs.webkit.org/show_bug.cgi?id=323510</a>
<a href="https://rdar.apple.com/186749069">rdar://186749069</a>

Reviewed by Chris Fleizach.

AXDateTimeComponents is the attribute VoiceOver reads to decide which fields of a date
or time control it should present, and no layout test asserted it. This commit adds a test.

* LayoutTests/accessibility/isolated-tree/mac/datetime-components-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/datetime-components.html: Added.
* LayoutTests/accessibility/mac/datetime-components-expected.txt: Added.
* LayoutTests/accessibility/mac/datetime-components.html: Added.
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::attributeValue):

Canonical link: <a href="https://commits.webkit.org/320573@main">https://commits.webkit.org/320573@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3703f0c30ec8f1f01204c52992af679198932b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195491 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/166f2021-509c-4039-8353-817d7eaeefd8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58802 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144690 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/82dbfc67-fe5f-4b3a-9c86-0260fd8dda86) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48373 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165279 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124983 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d760b061-7b9d-4241-b9e7-4eec42dade79) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47101 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45163 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157468 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44849 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6547 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197443 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164785 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154197 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41298 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59448 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153848 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48342 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128443 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57927 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19868 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57298 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57541 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57365 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->