### PR TITLE
Add layout test: Null pointer dereference in CachedRawResource::didAddClient()

### DIFF
--- a/LayoutTests/http/tests/xmlhttprequest/memory-cache-replay-client-destroyed-crash-expected.txt
+++ b/LayoutTests/http/tests/xmlhttprequest/memory-cache-replay-client-destroyed-crash-expected.txt
@@ -1,0 +1,6 @@
+Replays a memory-cached raw resource whose buffered data has more than one segment to a second client, and destroys that client from inside the first segment's callout. This test passes if the web process does not crash.
+
+PASS: response was buffered in more than one segment.
+PASS: second request was served from the memory cache.
+PASS: did not crash.
+

--- a/LayoutTests/http/tests/xmlhttprequest/memory-cache-replay-client-destroyed-crash.html
+++ b/LayoutTests/http/tests/xmlhttprequest/memory-cache-replay-client-destroyed-crash.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Replays a memory-cached raw resource whose buffered data has more than one
+segment to a second client, and destroys that client from inside the first
+segment's callout. This test passes if the web process does not crash.</p>
+<pre id="log"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function log(message)
+{
+    document.getElementById("log").appendChild(document.createTextNode(message + "\n"));
+}
+
+var url = "resources/cacheable-chunks.py";
+var segmentCount = 0;
+var firstNonce = null;
+
+var first = new XMLHttpRequest();
+first.open("GET", url, true);
+first.onreadystatechange = function () {
+    if (first.readyState === 3) {
+        ++segmentCount;
+        return;
+    }
+    if (first.readyState !== 4)
+        return;
+    firstNonce = first.responseText.split("\n")[0];
+    log(segmentCount > 1 ? "PASS: response was buffered in more than one segment."
+        : "FAIL: response arrived as a single chunk, so the replay only dispatches one segment.");
+    replayFromMemoryCache();
+};
+first.send();
+
+function replayFromMemoryCache()
+{
+    // The same URL is a memory cache hit. For raw resources CachedResource::addClientToSet()
+    // always defers the callbacks to a zero-delay timer, so the buffered segments are
+    // dispatched from CachedRawResource::didAddClient().
+    var second = new XMLHttpRequest();
+    second.open("GET", url, true);
+    second.onreadystatechange = function () {
+        if (second.readyState !== 3)
+            return;
+        var nonce = second.responseText.split("\n")[0];
+        log(nonce === firstNonce ? "PASS: second request was served from the memory cache."
+            : "FAIL: second request went back to the network, so didAddClient() did not replay the buffer.");
+        // Destroy the DocumentThreadableLoader while the remaining segments are still
+        // to be dispatched, which leaves didAddClient()'s client WeakPtr null.
+        second.abort();
+        second = null;
+        setTimeout(finish, 0);
+    };
+    second.send();
+}
+
+function finish()
+{
+    log("PASS: did not crash.");
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/xmlhttprequest/resources/cacheable-chunks.py
+++ b/LayoutTests/http/tests/xmlhttprequest/resources/cacheable-chunks.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import random
+import sys
+import time
+
+# A cacheable response whose body is written in several separately flushed
+# chunks, so that the FragmentedSharedBuffer kept by the CachedRawResource ends
+# up with more than one segment.
+sys.stdout.write(
+    'Content-Type: text/plain\r\n'
+    'Cache-Control: max-age=3600\r\n'
+    'Content-Type: application/x-no-buffering-please\r\n'
+    '\r\n'
+)
+sys.stdout.flush()
+
+# The nonce changes on every request, so a test can tell a memory cache hit
+# (same nonce as the first load) from a second trip to the network.
+sys.stdout.write('nonce=%d\n' % random.getrandbits(48))
+sys.stdout.flush()
+
+for i in range(3):
+    time.sleep(0.15)
+    sys.stdout.write('chunk %d\n' % i)
+    sys.stdout.flush()


### PR DESCRIPTION
#### 3c79df694fd3cc03adf59447e912269bb30a5a31
<pre>
Add layout test: Null pointer dereference in CachedRawResource::didAddClient()
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=309303">https://bugs.webkit.org/show_bug.cgi?id=309303</a>&gt;
&lt;<a href="https://rdar.apple.com/172095597">rdar://172095597</a>&gt;

Reviewed by NOBODY (OOPS!).

This is a null-pointer read (`EXC_BAD_ACCESS` at `0x0`) inside the
`FragmentedSharedBuffer::forEachSegmentAsSharedBuffer()` callback of
`CachedRawResource::didAddClient()`.  When a raw resource is replayed
out of the memory cache its buffered segments are dispatched one at a
time, and the client is only held as a `WeakPtr`.  A client that
destroys itself from inside one segment&apos;s `dataReceived()` callout
leaves that `WeakPtr` null, and the per-segment guard dereferenced the
null `WeakPtr` so the following segment did a virtual call through
`nullptr`.  The guard was corrected to `client &amp;&amp; hasClient(*client)`
in <a href="https://commits.webkit.org/308914@main">308914@main</a> (Bug 309303), but no test landed with it.

The test primes the memory cache with a response written in several
separately flushed chunks, so the `CachedRawResource` keeps a
`FragmentedSharedBuffer` with more than one segment.  It then requests
the same URL again: for raw resources `CachedResource::addClientToSet()`
always defers the client callbacks to a zero-delay timer, so the
buffered segments are dispatched from `CachedRawResource::didAddClient()`.
The second `XMLHttpRequest` aborts itself from its first
readystatechange callout, which destroys the `DocumentThreadableLoader`
while further segments are still pending, leaving the client `WeakPtr`
null.  The test asserts that the response was buffered in more than one
segment and that the second request was served from the memory cache,
so it fails loudly instead of silently passing if it ever stops
exercising the replay path.

Test: http/tests/xmlhttprequest/memory-cache-replay-client-destroyed-crash.html

* LayoutTests/http/tests/xmlhttprequest/memory-cache-replay-client-destroyed-crash-expected.txt: Add.
* LayoutTests/http/tests/xmlhttprequest/memory-cache-replay-client-destroyed-crash.html: Add.
* LayoutTests/http/tests/xmlhttprequest/resources/cacheable-chunks.py: Add.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c79df694fd3cc03adf59447e912269bb30a5a31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195497 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150032 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/695ebeda-aa54-4f99-9408-6f99748df783) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144694 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100357 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/700e1267-66ee-444d-a0b4-a00e999f139a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48377 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124987 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3d451b1d-8ab9-42ce-b750-bd74ba27c4cb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47105 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45167 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157472 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44853 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6553 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197449 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58745 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164789 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154202 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59454 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153853 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48347 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128453 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57933 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19872 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57304 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57547 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57371 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->