### PR TITLE
Speed up FrameTree::containsRemoteFrame and related methods

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8595,7 +8595,7 @@ void Document::enforceSandboxFlags(SandboxFlags flags, SandboxFlagsSource source
     bool wasSandboxedOrigin = isSandboxed(SandboxFlag::Origin);
     SecurityContext::enforceSandboxFlags(flags, source);
 
-    if (RefPtr page = this->page(); page && page->hasRemoteFrames()) {
+    if (RefPtr page = this->page(); page && page->mainFrame().tree().containsRemoteFrame()) {
         bool sandboxedStateDidChange = wasSandboxedOrigin != isSandboxed(SandboxFlag::Origin);
         if (!sandboxedStateDidChange)
             return;
@@ -10554,7 +10554,7 @@ void Document::updateRemoteIntersectionObservers()
     if (!page)
         return;
 
-    ASSERT(page->hasRemoteFrames());
+    ASSERT(page->mainFrame().tree().containsRemoteFrame());
 
     RefPtr mainFrame = this->page()->mainFrame();
     if (!mainFrame)

--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -223,7 +223,7 @@ void Editor::writeSelectionToPasteboard(Pasteboard& pasteboard)
         if (!document->isTextDocument()) {
             content.dataInWebArchiveFormat = selectionInWebArchiveFormat();
             HashMap<FrameIdentifier, AttributedString> remoteFrameContent;
-            if (RefPtr page = document->page(); page && page->hasRemoteFrames()) {
+            if (RefPtr page = document->page(); page && page->mainFrame().tree().containsRemoteFrame()) {
                 LegacyWebArchive::ArchiveOptions options {
                     LegacyWebArchive::ShouldSaveScriptsFromMemoryCache::Yes,
                     LegacyWebArchive::ShouldArchiveSubframes::No

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -168,11 +168,6 @@ void Frame::detachFromPage()
         }
     }
 
-    if (m_frameType == FrameType::Remote) {
-        if (RefPtr page = m_page.get())
-            page->didDetachRemoteFrame();
-    }
-
     m_page = nullptr;
 }
 

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -53,6 +53,7 @@ FrameTree::~FrameTree()
         child->tree().detachFromParent();
         child->disconnectView();
     }
+    ASSERT(!m_remoteFrameDescendantCount);
 }
 
 void FrameTree::setSpecifiedName(const AtomString& specifiedName)
@@ -70,6 +71,45 @@ Frame* FrameTree::parent() const
     return m_parent.get();
 }
 
+unsigned FrameTree::remoteFrameCountIncludingSelf() const
+{
+    return m_remoteFrameDescendantCount + (is<RemoteFrame>(m_thisFrame.get()) ? 1 : 0);
+}
+
+void FrameTree::adjustRemoteFrameDescendantCountForSelfAndAncestors(int delta)
+{
+    if (!delta)
+        return;
+
+    for (RefPtr frame = m_thisFrame.ptr(); frame; frame = frame->tree().parent()) {
+        auto& count = frame->tree().m_remoteFrameDescendantCount;
+        count += delta;
+    }
+}
+
+#if ASSERT_ENABLED
+unsigned FrameTree::remoteFrameDescendantCountSlow() const
+{
+    unsigned count = 0;
+    for (RefPtr child = firstChild(); child; child = child->tree().nextSibling()) {
+        // There may a window between when a child tree clears its parent (detachFromParent) and
+        // when the parent removes the child (removeChild). Ignore these partially-detached nodes.
+        if (child->tree().parent() != m_thisFrame.ptr())
+            continue;
+        count += (is<RemoteFrame>(*child) ? 1 : 0) + child->tree().remoteFrameDescendantCountSlow();
+    }
+    return count;
+}
+#endif
+
+void FrameTree::detachFromParent()
+{
+    RefPtr parent = m_parent.get();
+    m_parent = nullptr;
+    if (parent)
+        parent->tree().adjustRemoteFrameDescendantCountForSelfAndAncestors(-remoteFrameCountIncludingSelf());
+}
+
 void FrameTree::appendChild(Frame& child)
 {
     ASSERT(child.page() == m_thisFrame->page());
@@ -85,11 +125,20 @@ void FrameTree::appendChild(Frame& child)
 
     m_scopedChildCount = invalidCount;
 
+    adjustRemoteFrameDescendantCountForSelfAndAncestors(child.tree().remoteFrameCountIncludingSelf());
+
     ASSERT(!m_lastChild->tree().m_nextSibling);
+    ASSERT(m_remoteFrameDescendantCount == remoteFrameDescendantCountSlow());
 }
 
 void FrameTree::removeChild(Frame& child)
 {
+    // We may have already called detachFromParent() on the child, which would cleared the parent
+    // on the child and already adjusted the descendant count.
+    ASSERT(!child.tree().parent() || child.tree().parent() == m_thisFrame.ptr());
+    if (child.tree().parent())
+        adjustRemoteFrameDescendantCountForSelfAndAncestors(-child.tree().remoteFrameCountIncludingSelf());
+
     WeakPtr<Frame>& newLocationForPrevious = m_lastChild == &child ? m_lastChild : child.tree().m_nextSibling->tree().m_previousSibling;
     RefPtr<Frame>& newLocationForNext = m_firstChild == &child ? m_firstChild : child.tree().m_previousSibling->tree().m_nextSibling;
 
@@ -98,6 +147,8 @@ void FrameTree::removeChild(Frame& child)
     newLocationForNext = WTF::move(child.tree().m_nextSibling);
 
     m_scopedChildCount = invalidCount;
+
+    ASSERT(m_remoteFrameDescendantCount == remoteFrameDescendantCountSlow());
 }
 
 void FrameTree::replaceChild(Frame& oldChild, Frame& newChild)
@@ -111,6 +162,7 @@ void FrameTree::replaceChild(Frame& oldChild, Frame& newChild)
     ASSERT(!newTree.firstChild());
     ASSERT(!newTree.lastChild());
     ASSERT(newTree.m_scopedChildCount == invalidCount);
+    ASSERT(!newTree.m_remoteFrameDescendantCount);
     ASSERT(newTree.m_thisFrame.ptr() == &newChild);
     ASSERT(is<LocalFrame>(oldChild) != is<LocalFrame>(newChild));
 
@@ -137,6 +189,9 @@ void FrameTree::replaceChild(Frame& oldChild, Frame& newChild)
         oldNextSibling->tree().m_previousSibling = &newChild;
     if (oldPreviousSibling)
         oldPreviousSibling->tree().m_nextSibling = &newChild;
+
+    adjustRemoteFrameDescendantCountForSelfAndAncestors(newTree.remoteFrameCountIncludingSelf());
+    ASSERT(m_remoteFrameDescendantCount == remoteFrameDescendantCountSlow());
 }
 
 static bool NODELETE inScope(Frame& frame, TreeScope& scope)
@@ -365,11 +420,7 @@ bool NODELETE FrameTree::isDescendantOf(const Frame* ancestor) const
 
 bool FrameTree::containsRemoteFrame() const
 {
-    for (RefPtr frame = m_thisFrame.ptr(); frame; frame = frame->tree().traverseNext(m_thisFrame.ptr())) {
-        if (is<RemoteFrame>(*frame))
-            return true;
-    }
-    return false;
+    return !!remoteFrameCountIncludingSelf();
 }
 
 bool FrameTree::containsLocalFrame() const
@@ -598,15 +649,6 @@ unsigned FrameTree::depth() const
     for (auto* parent = m_thisFrame.ptr(); parent; parent = parent->tree().parent())
         depth++;
     return depth;
-}
-
-bool FrameTree::hasRemoteFrameDescendant() const
-{
-    for (RefPtr frame = firstChild(); frame; frame = frame->tree().traverseNext(m_thisFrame.ptr())) {
-        if (is<RemoteFrame>(*frame))
-            return true;
-    }
-    return false;
 }
 
 AtomString FrameTree::uniqueName() const

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <WebCore/FrameIdentifier.h>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
@@ -75,7 +76,7 @@ public:
     Frame* NODELETE traverseNextInPostOrder(CanWrap) const;
 
     WEBCORE_EXPORT void appendChild(Frame&);
-    void detachFromParent() { m_parent = nullptr; }
+    WEBCORE_EXPORT void detachFromParent();
     WEBCORE_EXPORT void removeChild(Frame&);
     WEBCORE_EXPORT void replaceChild(Frame&, Frame&);
 
@@ -89,7 +90,7 @@ public:
     WEBCORE_EXPORT Frame& NODELETE top() const;
     unsigned NODELETE depth() const;
 
-    WEBCORE_EXPORT bool hasRemoteFrameDescendant() const;
+    bool hasRemoteFrameDescendant() const { return !!m_remoteFrameDescendantCount; }
 
     WEBCORE_EXPORT RefPtr<Frame> scopedChild(unsigned index) const;
     WEBCORE_EXPORT RefPtr<Frame> scopedChildByUniqueName(const AtomString&) const;
@@ -100,6 +101,12 @@ private:
     Frame* NODELETE deepFirstChild() const;
     Frame* NODELETE deepLastChild() const;
     Frame* NODELETE nextAncestorSibling(const Frame* stayWithin) const;
+
+    unsigned remoteFrameCountIncludingSelf() const;
+    void adjustRemoteFrameDescendantCountForSelfAndAncestors(int delta);
+#if ASSERT_ENABLED
+    unsigned remoteFrameDescendantCountSlow() const;
+#endif
 
     RefPtr<Frame> scopedChild(unsigned index, TreeScope*) const;
     RefPtr<Frame> scopedChild(NOESCAPE const Function<bool(const FrameTree&)>& isMatch, TreeScope*) const;
@@ -117,6 +124,7 @@ private:
     RefPtr<Frame> m_firstChild;
     WeakPtr<Frame> m_lastChild;
     mutable unsigned m_scopedChildCount { invalidCount };
+    Checked<unsigned> m_remoteFrameDescendantCount { 0 };
 };
 
 ASCIILiteral blankTargetFrameName();

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1606,7 +1606,7 @@ bool LocalDOMWindow::consumeTransientActivation()
             window->consumeLastActivationIfNecessary();
     }
 
-    if (RefPtr page = thisFrame ? thisFrame->page() : nullptr; page && page->hasRemoteFrames())
+    if (RefPtr page = thisFrame ? thisFrame->page() : nullptr; page && page->mainFrame().tree().containsRemoteFrame())
         thisFrame->loader().client().didConsumeUserActivation();
 
     return true;
@@ -1692,7 +1692,7 @@ void LocalDOMWindow::notifyActivated(MonotonicTime activationTime)
         updateActivationTimestampAndNotify(*descendantWindow, activationTime, closeWatcherEnabled);
     }
 
-    if (RefPtr page = frame->page(); page && page->hasRemoteFrames())
+    if (RefPtr page = frame->page(); page && page->mainFrame().tree().containsRemoteFrame())
         frame->loader().client().didNotifyUserActivation(activationTime);
 }
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3826,7 +3826,7 @@ void LocalFrameView::scrollPositionChanged(const ScrollPosition& oldPosition, co
     }
 
     if (oldPosition != newPosition) {
-        if (RefPtr page = m_frame->page(); page && page->hasRemoteFrames())
+        if (RefPtr page = m_frame->page(); page && page->mainFrame().tree().containsRemoteFrame())
             static_cast<Frame&>(m_frame).loaderClient().broadcastFrameScrollPositionToOtherProcesses(newPosition);
     }
 }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2261,28 +2261,11 @@ unsigned NODELETE Page::renderingUpdateCount() const
     return m_renderingUpdateCount;
 }
 
-bool Page::hasRemoteFrames() const
-{
-    ASSERT_IMPLIES(mainFrame().tree().containsRemoteFrame(), m_remoteFrameCount);
-    return !!m_remoteFrameCount;
-}
-
 void Page::syncLocalFrameInfoToRemote()
 {
-    ASSERT(hasRemoteFrames());
+    ASSERT(mainFrame().tree().containsRemoteFrame());
 
-    // Memoize FrameTree::containsRemoteFrame for the entire frame tree.
-    HashSet<FrameIdentifier> subtreeContainsRemoteFrame;
-    for (RefPtr frame = mainFrame(); frame; frame = frame->tree().traverseNext()) {
-        if (!is<RemoteFrame>(*frame))
-            continue;
-        for (RefPtr ancestor = frame; ancestor; ancestor = ancestor->tree().parent()) {
-            if (!subtreeContainsRemoteFrame.add(ancestor->frameID()).isNewEntry)
-                break;
-        }
-    }
-
-    forEachLocalFrame([&] (LocalFrame& frame) {
+    forEachLocalFrame([] (LocalFrame& frame) {
         RefPtr<LocalFrameView> frameView = frame.view();
 
         HashMap<FrameIdentifier, Ref<RemoteFrameLayoutInfo>> childrenFrameLayoutInfo;
@@ -2300,11 +2283,8 @@ void Page::syncLocalFrameInfoToRemote()
 #endif
 
         for (RefPtr child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
-            if (!subtreeContainsRemoteFrame.contains(child->frameID())) {
-                ASSERT(!child->tree().containsRemoteFrame());
+            if (!child->tree().containsRemoteFrame())
                 continue;
-            }
-            ASSERT(child->tree().containsRemoteFrame());
 
             auto absoluteToChildFrameOwnerLocalTransform = frameView->absoluteToChildFrameOwnerLocalTransform(*child);
             auto contentBoxLocation = frameView->childFrameOwnerContentBoxLocation(*child);
@@ -2671,7 +2651,7 @@ void Page::doAfterUpdateRendering()
 
     computeSampledPageTopColorIfNecessary();
 
-    if (hasRemoteFrames())
+    if (mainFrame().tree().containsRemoteFrame())
         syncLocalFrameInfoToRemote();
 }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -438,10 +438,6 @@ public:
     WEBCORE_EXPORT void setMainFrame(Ref<Frame>&&);
     WEBCORE_EXPORT const URL& NODELETE mainFrameURL() const LIFETIME_BOUND;
 
-    bool hasRemoteFrames() const;
-    void didAttachRemoteFrame() { ++m_remoteFrameCount; }
-    void didDetachRemoteFrame() { ASSERT(m_remoteFrameCount); --m_remoteFrameCount; }
-
     WEBCORE_EXPORT void didObserveFirstPartyUserGesture();
     SecurityOrigin& mainFrameOrigin() const;
     WEBCORE_EXPORT RefPtr<Frame> findFrameByPath(const Vector<uint64_t>& path) const;
@@ -1544,8 +1540,6 @@ private:
     HashSet<WeakRef<LocalFrame>> m_rootFrames;
     const UniqueRef<EditorClient> m_editorClient;
 
-    // Declared before m_mainFrame so a remote main frame can count itself as m_mainFrame is built.
-    unsigned m_remoteFrameCount { 0 };
     Ref<Frame> m_mainFrame;
     String m_mainFrameURLFragment;
 

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -66,8 +66,6 @@ RemoteFrame::RemoteFrame(Page& page, ClientCreator&& clientCreator, FrameIdentif
     , m_colorSchemePreference(ColorSchemePreference::NoPreference)
 {
     setView(RemoteFrameView::create(*this));
-
-    page.didAttachRemoteFrame();
 }
 
 RemoteFrame::~RemoteFrame()


### PR DESCRIPTION
#### 94f9b7905e3ce9a3d7497f26b563adcad6b7525f
<pre>
Speed up FrameTree::containsRemoteFrame and related methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=323516">https://bugs.webkit.org/show_bug.cgi?id=323516</a>
<a href="https://rdar.apple.com/186752700">rdar://186752700</a>

Reviewed by Alex Christensen.

We are starting to use FrameTree::containsRemoteFrame and related methods as part of various site
isolation patches. Make this a constant time operation instead of requiring a frame tree walk. We do
this by maintaining a remote frame descendant count for every FrameTree. This is updated every time
a frame is added or removed from the tree.

Also remove:

 - Page::hasRemoteFrames: callers can use FrameTree::containsRemoteFrame instead
 - The hasRemoteFrames memoization loop in Page::syncLocalFrameInfoToRemote

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::enforceSandboxFlags):
(WebCore::Document::updateRemoteIntersectionObservers):
* Source/WebCore/editing/cocoa/EditorCocoa.mm:
(WebCore::Editor::writeSelectionToPasteboard):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::detachFromPage):
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::remoteFrameCountIncludingSelf const):
(WebCore::FrameTree::adjustRemoteFrameDescendantCountForSelfAndAncestors):
(WebCore::FrameTree::remoteFrameDescendantCountSlow const):
(WebCore::FrameTree::detachFromParent):
(WebCore::FrameTree::appendChild):
(WebCore::FrameTree::removeChild):
(WebCore::FrameTree::replaceChild):
(WebCore::FrameTree::containsRemoteFrame const):
(WebCore::FrameTree::hasRemoteFrameDescendant const): Deleted.
* Source/WebCore/page/FrameTree.h:
(WebCore::FrameTree::hasRemoteFrameDescendant const):
(WebCore::FrameTree::detachFromParent): Deleted.
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::consumeTransientActivation):
(WebCore::LocalDOMWindow::notifyActivated):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollPositionChanged):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::syncLocalFrameInfoToRemote):
(WebCore::Page::doAfterUpdateRendering):
(WebCore::Page::hasRemoteFrames const): Deleted.
* Source/WebCore/page/Page.h:
(WebCore::Page::didAttachRemoteFrame): Deleted.
(WebCore::Page::didDetachRemoteFrame): Deleted.
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::m_colorSchemePreference):

Canonical link: <a href="https://commits.webkit.org/320880@main">https://commits.webkit.org/320880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e54e25446692432878dce955dece71b01f4d2360

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196207 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150562 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4614256b-83f9-43e7-87ff-4ea4c161d4b4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59530 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145280 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100716 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3a1e8dcf-907d-4ce9-9af6-f7a9b29c1276) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125589 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8279cb8-4d01-46c6-944c-1f287668c58a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47691 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45704 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45417 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7278 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52416 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198181 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59466 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154834 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41531 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60175 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154479 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48930 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129515 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58633 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20431 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58015 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58248 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58076 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->