### PR TITLE
Minor ComputedStyle Data Cleanup

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -4004,7 +4004,8 @@
                 "aliases": [
                     "-webkit-box-sizing"
                 ],
-                "computed-style-storage-path": ["m_nonInheritedData", "boxData"],
+                "computed-style-storage-path": ["m_nonInheritedFlags"],
+                "computed-style-storage-container": "struct",
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "BoxSizing",
                 "parser-grammar": "<<values>>"

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -425,9 +425,6 @@ public:
                 if (a.nonInheritedData().boxData->verticalAlign != b.nonInheritedData().boxData->verticalAlign)
                     return true;
 
-                if (a.nonInheritedData().boxData->boxSizing != b.nonInheritedData().boxData->boxSizing)
-                    return true;
-
                 if (a.nonInheritedData().boxData->hasAutoUsedZIndex != b.nonInheritedData().boxData->hasAutoUsedZIndex)
                     return true;
             }
@@ -493,6 +490,7 @@ public:
             || a.inheritedFlags().rtlOrdering != b.inheritedFlags().rtlOrdering
             || a.nonInheritedFlags().position != b.nonInheritedFlags().position
             || a.nonInheritedFlags().floating != b.nonInheritedFlags().floating
+            || a.nonInheritedFlags().boxSizing != b.nonInheritedFlags().boxSizing
             || a.nonInheritedFlags().originalDisplay != b.nonInheritedFlags().originalDisplay)
             return true;
 

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -195,6 +195,7 @@ void ComputedStyle::fastPathInheritFrom(const ComputedStyle& inheritParent)
     // FIXME: Use this mechanism for other properties too, like variables.
     m_inheritedFlags.visibility = inheritParent.m_inheritedFlags.visibility;
     m_inheritedFlags.hasExplicitlySetColor = inheritParent.m_inheritedFlags.hasExplicitlySetColor;
+    m_inheritedFlags.colorIsCurrentColorForHighlight = inheritParent.m_inheritedFlags.colorIsCurrentColorForHighlight;
 
     if (m_inheritedData.ptr() != inheritParent.m_inheritedData.ptr()) {
         if (m_inheritedData->nonFastPathInheritedEqual(*inheritParent.m_inheritedData)) {
@@ -260,6 +261,8 @@ bool ComputedStyle::fastPathInheritedEqual(const ComputedStyle& other) const
         return false;
     if (m_inheritedFlags.hasExplicitlySetColor != other.m_inheritedFlags.hasExplicitlySetColor)
         return false;
+    if (m_inheritedFlags.colorIsCurrentColorForHighlight != other.m_inheritedFlags.colorIsCurrentColorForHighlight)
+        return false;
     if (m_inheritedData.ptr() == other.m_inheritedData.ptr())
         return true;
     return m_inheritedData->fastPathInheritedEqual(*other.m_inheritedData);
@@ -270,6 +273,7 @@ bool ComputedStyle::nonFastPathInheritedEqual(const ComputedStyle& other) const
     auto withoutFastPathFlags = [](auto flags) {
         flags.visibility = { };
         flags.hasExplicitlySetColor = { };
+        flags.colorIsCurrentColorForHighlight = { };
         return flags;
     };
     if (withoutFastPathFlags(m_inheritedFlags) != withoutFastPathFlags(other.m_inheritedFlags))

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
@@ -62,6 +62,7 @@ inline ComputedStyleBase::ComputedStyleBase(CreateDefaultStyleTag)
     m_inheritedFlags.printColorAdjust = static_cast<unsigned>(ComputedStyle::initialPrintColorAdjust());
     m_inheritedFlags.pointerEvents = static_cast<unsigned>(ComputedStyle::initialPointerEvents());
     m_inheritedFlags.insideLink = static_cast<unsigned>(InsideLink::NotInside);
+    m_inheritedFlags.colorIsCurrentColorForHighlight = 0;
     m_inheritedFlags.isZoomed = 0;
 #if ENABLE(TEXT_AUTOSIZING)
     m_inheritedFlags.autosizeStatus = 0;
@@ -71,10 +72,11 @@ inline ComputedStyleBase::ComputedStyleBase(CreateDefaultStyleTag)
     m_nonInheritedFlags.originalDisplay = ComputedStyle::initialDisplay().toRaw();
     m_nonInheritedFlags.overflowX = static_cast<unsigned>(ComputedStyle::initialOverflowX());
     m_nonInheritedFlags.overflowY = static_cast<unsigned>(ComputedStyle::initialOverflowY());
-    m_nonInheritedFlags.clear = static_cast<unsigned>(ComputedStyle::initialClear());
     m_nonInheritedFlags.position = static_cast<unsigned>(ComputedStyle::initialPosition());
-    m_nonInheritedFlags.unicodeBidi = static_cast<unsigned>(ComputedStyle::initialUnicodeBidi());
     m_nonInheritedFlags.floating = static_cast<unsigned>(ComputedStyle::initialFloating());
+    m_nonInheritedFlags.clear = static_cast<unsigned>(ComputedStyle::initialClear());
+    m_nonInheritedFlags.boxSizing = static_cast<unsigned>(ComputedStyle::initialBoxSizing());
+    m_nonInheritedFlags.unicodeBidi = static_cast<unsigned>(ComputedStyle::initialUnicodeBidi());
     m_nonInheritedFlags.textDecorationLine = ComputedStyle::initialTextDecorationLine().toRaw();
     m_nonInheritedFlags.usesViewportUnits = false;
     m_nonInheritedFlags.isContainerDependent = false;
@@ -119,10 +121,11 @@ inline void ComputedStyleBase::NonInheritedFlags::copyNonInheritedFrom(const Non
     originalDisplay = other.originalDisplay;
     overflowX = other.overflowX;
     overflowY = other.overflowY;
-    clear = other.clear;
     position = other.position;
-    unicodeBidi = other.unicodeBidi;
     floating = other.floating;
+    clear = other.clear;
+    boxSizing = other.boxSizing;
+    unicodeBidi = other.unicodeBidi;
     textDecorationLine = other.textDecorationLine;
     usesViewportUnits = other.usesViewportUnits;
     isContainerDependent = other.isContainerDependent;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -56,11 +56,11 @@
 namespace WebCore {
 namespace Style {
 
-static_assert(PublicPseudoIDBits == allPublicPseudoElementTypes.size());
-static_assert(!(static_cast<unsigned>(maxTextTransformValue) >> TextTransformBits));
+static_assert(ComputedStyleBase::PublicPseudoIDBits == allPublicPseudoElementTypes.size());
+static_assert(!(static_cast<unsigned>(maxTextTransformValue) >> ComputedStyleBase::TextTransformBits));
 
 // Value zero is used to indicate no pseudo-element.
-static_assert(!((std::to_underlying(PseudoElementType::HighestEnumValue) + 1) >> PseudoElementTypeBits));
+static_assert(!((std::to_underlying(PseudoElementType::HighestEnumValue) + 1) >> ComputedStyleBase::PseudoElementTypeBits));
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ComputedStyleBase);
 
@@ -467,6 +467,7 @@ void ComputedStyleBase::NonInheritedFlags::dumpDifferences(TextStream& ts, const
     LOG_IF_DIFFERENT_WITH_CAST(PositionType, position);
     LOG_IF_DIFFERENT_WITH_CAST(UnicodeBidi, unicodeBidi);
     LOG_IF_DIFFERENT_WITH_CAST(Float, floating);
+    LOG_IF_DIFFERENT_WITH_CAST(BoxSizing, boxSizing);
 
     LOG_IF_DIFFERENT(usesViewportUnits);
     LOG_IF_DIFFERENT(isContainerDependent);
@@ -500,6 +501,8 @@ void ComputedStyleBase::InheritedFlags::dumpDifferences(TextStream& ts, const In
     LOG_IF_DIFFERENT_WITH_FROM_RAW(TextTransform, textTransform);
     LOG_IF_DIFFERENT_WITH_FROM_RAW(TextDecorationLine, textDecorationLineInEffect);
 
+    LOG_IF_DIFFERENT_WITH_CAST(bool, isZoomed);
+
     LOG_IF_DIFFERENT_WITH_CAST(PointerEvents, pointerEvents);
     LOG_IF_DIFFERENT_WITH_CAST(Visibility, visibility);
     LOG_IF_DIFFERENT_WITH_CAST(CursorType, cursorType);
@@ -512,11 +515,14 @@ void ComputedStyleBase::InheritedFlags::dumpDifferences(TextStream& ts, const In
     LOG_IF_DIFFERENT_WITH_CAST(EmptyCell, emptyCells);
     LOG_IF_DIFFERENT_WITH_CAST(BorderCollapse, borderCollapse);
     LOG_IF_DIFFERENT_WITH_CAST(CaptionSide, captionSide);
+
     LOG_IF_DIFFERENT_WITH_CAST(BoxDirection, boxDirection);
     LOG_IF_DIFFERENT_WITH_CAST(Order, rtlOrdering);
+
     LOG_IF_DIFFERENT_WITH_CAST(bool, hasExplicitlySetColor);
     LOG_IF_DIFFERENT_WITH_CAST(PrintColorAdjust, printColorAdjust);
     LOG_IF_DIFFERENT_WITH_CAST(InsideLink, insideLink);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, colorIsCurrentColorForHighlight);
 
 #if ENABLE(TEXT_AUTOSIZING)
     LOG_IF_DIFFERENT_WITH_CAST(unsigned, autosizeStatus);

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -451,11 +451,6 @@ using WebkitBoxFlex = Number<CSS::All, float>;
 using WebkitBoxFlexGroup = Integer<CSS::Nonnegative>;
 using WebkitBoxOrdinalGroup = Integer<CSS::Positive>;
 
-constexpr auto PublicPseudoIDBits = 19;
-constexpr auto TextDecorationLineBits = 5;
-constexpr auto TextTransformBits = 6;
-constexpr auto PseudoElementTypeBits = 5;
-
 using PseudoElementStyles = HashMap<PseudoElementIdentifier, std::unique_ptr<ComputedStyle>>;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(ComputedStyleBase);
@@ -752,6 +747,11 @@ public:
     inline const PageSize& pageSize() const LIFETIME_BOUND;
     inline void setPageSize(PageSize&&);
 
+    static constexpr auto PseudoElementTypeBits = 5;
+    static constexpr auto PublicPseudoIDBits = 19;
+    static constexpr auto TextTransformBits = 6;
+    static constexpr auto TextDecorationLineBits = 5;
+
     struct NonInheritedFlags {
         bool operator==(const NonInheritedFlags&) const = default;
 
@@ -765,14 +765,17 @@ public:
         void dumpDifferences(TextStream&, const NonInheritedFlags&) const;
 #endif
 
+        // If you add more style bits here, update ComputedStyleBase::NonInheritedFlags::copyNonInheritedFrom().
         PREFERRED_TYPE(Style::DisplayType) unsigned display : 5;
         PREFERRED_TYPE(Style::DisplayType) unsigned originalDisplay : 5;
         PREFERRED_TYPE(Overflow) unsigned overflowX : 3;
         PREFERRED_TYPE(Overflow) unsigned overflowY : 3;
-        PREFERRED_TYPE(Clear) unsigned clear : 3;
         PREFERRED_TYPE(PositionType) unsigned position : 3;
-        PREFERRED_TYPE(UnicodeBidi) unsigned unicodeBidi : 3;
         PREFERRED_TYPE(Float) unsigned floating : 3;
+        PREFERRED_TYPE(Clear) unsigned clear : 3;
+        PREFERRED_TYPE(BoxSizing) unsigned boxSizing : 1;
+        PREFERRED_TYPE(UnicodeBidi) unsigned unicodeBidi : 3;
+        unsigned textDecorationLine : TextDecorationLineBits; // Text decorations defined *only* by this element. PREFERRED_TYPE elided to avoid header inclusion.
 
         PREFERRED_TYPE(bool) unsigned usesViewportUnits : 1;
         PREFERRED_TYPE(bool) unsigned isContainerDependent : 1;
@@ -780,15 +783,12 @@ public:
         PREFERRED_TYPE(bool) unsigned hasExplicitlyInheritedProperties : 1; // Explicitly inherits a non-inherited property.
         PREFERRED_TYPE(bool) unsigned disallowsFastPathInheritance : 1;
 
-        // Non-property related state bits.
+        // Non-property related state bits. These do not get copied by copyNonInheritedFrom().
         PREFERRED_TYPE(bool) unsigned firstChildState : 1;
         PREFERRED_TYPE(bool) unsigned lastChildState : 1;
         PREFERRED_TYPE(bool) unsigned isLink : 1;
         PREFERRED_TYPE(PseudoElementType) unsigned pseudoElementType : PseudoElementTypeBits;
         unsigned pseudoBits : PublicPseudoIDBits;
-        unsigned textDecorationLine : TextDecorationLineBits; // Text decorations defined *only* by this element. PREFERRED_TYPE elided to avoid header inclusion.
-
-        // If you add more style bits here, you will also need to update ComputedStyleBase::NonInheritedFlags::copyNonInheritedFrom().
     };
 
     struct InheritedFlags {
@@ -801,16 +801,21 @@ public:
         // Writing Mode = 8 bits (can be packed into 6 if needed)
         WritingMode writingMode;
 
-        // Text Formatting = 19 bits aligned onto 2 bytes + 4 trailing bits
+        // Pay attention to field alignment here to make sure this stays compact.
+        // See also static_assert in ComputedStyleBase::ComputedStyleBase(CreateDefaultStyleTag).
+
+        // Text Formatting = 21 bits
         PREFERRED_TYPE(WhiteSpaceCollapse) unsigned char whiteSpaceCollapse : 3;
         PREFERRED_TYPE(TextWrapMode) unsigned char textWrapMode : 1;
         PREFERRED_TYPE(TextAlign) unsigned char textAlign : 4;
         PREFERRED_TYPE(TextWrapStyle) unsigned char textWrapStyle : 2;
         unsigned char textTransform : TextTransformBits; // PREFERRED_TYPE elided to avoid header inclusion.
-        unsigned char : 1; // byte alignment
         unsigned char textDecorationLineInEffect : TextDecorationLineBits; // PREFERRED_TYPE elided to avoid header inclusion.
 
-        // Cursors and Visibility = 13 bits aligned onto 4 bits + 1 byte + 1 bit
+        // Zoom = 1 bit
+        PREFERRED_TYPE(bool) unsigned char isZoomed : 1;
+
+        // Cursors and Visibility = 13 bits
         PREFERRED_TYPE(PointerEvents) unsigned char pointerEvents : 4;
         PREFERRED_TYPE(Visibility) unsigned char visibility : 2;
         PREFERRED_TYPE(CursorType) unsigned char cursorType : 6;
@@ -828,17 +833,22 @@ public:
         PREFERRED_TYPE(BoxDirection) unsigned char boxDirection : 1;
         PREFERRED_TYPE(WebCore::Order) unsigned char rtlOrdering : 1;
 
-        // Color Stuff = 4 bits
+        // Color Stuff = 5 bits
         PREFERRED_TYPE(bool) unsigned char hasExplicitlySetColor : 1;
         PREFERRED_TYPE(PrintColorAdjust) unsigned char printColorAdjust : 1;
         PREFERRED_TYPE(InsideLink) unsigned char insideLink : 2;
-
-        PREFERRED_TYPE(bool) unsigned char isZoomed : 1;
+        // Whether color came from the currentcolor keyword. A highlight pseudo-element resolves
+        // currentcolor against its originating element, so the chain inherits the keyword rather than
+        // the color it resolved to. Highlight styles always set this, so it doesn't depend on being
+        // inherited with the color. https://drafts.csswg.org/css-pseudo-4/#highlight-cascade
+        // FIXME: A value that merely references currentcolor, like color-mix(in oklab, teal,
+        // currentcolor), is not covered. See BuilderCustom::applyHighlightInheritColor().
+        PREFERRED_TYPE(bool) unsigned char colorIsCurrentColorForHighlight : 1;
 
 #if ENABLE(TEXT_AUTOSIZING)
         unsigned autosizeStatus : 5;
 #endif
-        // Total = 63 bits (fits in 8 bytes)
+        // Total = 60 bits (fits in 8 bytes)
     };
 
 protected:

--- a/Source/WebCore/style/computed/data/StyleBoxData.cpp
+++ b/Source/WebCore/style/computed/data/StyleBoxData.cpp
@@ -51,7 +51,6 @@ BoxData::BoxData()
     , verticalAlign(ComputedStyle::initialVerticalAlign())
     , hasAutoSpecifiedZIndex(static_cast<uint8_t>(ComputedStyle::initialSpecifiedZIndex().m_isAuto))
     , hasAutoUsedZIndex(static_cast<uint8_t>(ComputedStyle::initialUsedZIndex().m_isAuto))
-    , boxSizing(static_cast<uint8_t>(BoxSizing::ContentBox))
     , boxDecorationBreak(static_cast<uint8_t>(BoxDecorationBreak::Slice))
     , baselineSource(static_cast<uint8_t>(ComputedStyle::initialBaselineSource()))
     , specifiedZIndexValue(ComputedStyle::initialSpecifiedZIndex().m_value)
@@ -70,7 +69,6 @@ inline BoxData::BoxData(const BoxData& o)
     , verticalAlign(o.verticalAlign)
     , hasAutoSpecifiedZIndex(o.hasAutoSpecifiedZIndex)
     , hasAutoUsedZIndex(o.hasAutoUsedZIndex)
-    , boxSizing(o.boxSizing)
     , boxDecorationBreak(o.boxDecorationBreak)
     , baselineSource(o.baselineSource)
     , specifiedZIndexValue(o.specifiedZIndexValue)
@@ -94,7 +92,6 @@ bool BoxData::operator==(const BoxData& o) const
         && verticalAlign == o.verticalAlign
         && usedZIndexValue == o.usedZIndexValue
         && hasAutoUsedZIndex == o.hasAutoUsedZIndex
-        && boxSizing == o.boxSizing
         && boxDecorationBreak == o.boxDecorationBreak
         && baselineSource == o.baselineSource
         && specifiedZIndexValue == o.specifiedZIndexValue
@@ -118,7 +115,6 @@ void BoxData::dumpDifferences(TextStream& ts, const BoxData& other) const
     LOG_IF_DIFFERENT_WITH_CAST(bool, hasAutoSpecifiedZIndex);
     LOG_IF_DIFFERENT_WITH_CAST(bool, hasAutoUsedZIndex);
 
-    LOG_IF_DIFFERENT_WITH_CAST(BoxSizing, boxSizing);
     LOG_IF_DIFFERENT_WITH_CAST(BoxDecorationBreak, boxDecorationBreak);
     LOG_IF_DIFFERENT_WITH_CAST(BaselineSource, baselineSource);
 

--- a/Source/WebCore/style/computed/data/StyleBoxData.h
+++ b/Source/WebCore/style/computed/data/StyleBoxData.h
@@ -63,7 +63,6 @@ public:
 
     PREFERRED_TYPE(bool) uint8_t hasAutoSpecifiedZIndex : 1;
     PREFERRED_TYPE(bool) uint8_t hasAutoUsedZIndex : 1;
-    PREFERRED_TYPE(BoxSizing) uint8_t boxSizing : 1;
     PREFERRED_TYPE(BoxDecorationBreak) uint8_t boxDecorationBreak : 1;
     PREFERRED_TYPE(BaselineSource) uint8_t baselineSource : 2;
 

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp
@@ -35,21 +35,24 @@ using namespace CSS::Literals;
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(NonInheritedRareData);
 
 NonInheritedRareData::NonInheritedRareData()
-    : containIntrinsicWidth(ComputedStyle::initialContainIntrinsicWidth())
-    , containIntrinsicHeight(ComputedStyle::initialContainIntrinsicHeight())
-    , lineClamp(ComputedStyle::initialLineClamp())
+    : touchAction(ComputedStyle::initialTouchAction())
     , zoom(ComputedStyle::initialZoom())
-    , maxLines(ComputedStyle::initialMaxLines())
-    , touchAction(ComputedStyle::initialTouchAction())
     , initialLetter(ComputedStyle::initialInitialLetter())
+    , lineClamp(ComputedStyle::initialLineClamp())
+    , maxLines(ComputedStyle::initialMaxLines())
     , marquee(MarqueeData::create())
     , backdropFilter(BackdropFilterData::create())
     , grid(GridData::create())
     , gridItem(GridItemData::create())
     , maskBorder(MaskBorderData::create())
     , clip(ComputedStyle::initialClip())
+    , clipPath(ComputedStyle::initialClipPath())
+    , overflowClipMargin(ComputedStyle::initialOverflowClipMargin())
     , scrollMargin(0_css_px)
     , scrollPadding(CSS::Keyword::Auto { })
+    , scrollSnapType(ComputedStyle::initialScrollSnapType())
+    , scrollSnapAlign(ComputedStyle::initialScrollSnapAlign())
+    , scrollbarGutter(ComputedStyle::initialScrollbarGutter())
     , counterIncrement(ComputedStyle::initialCounterIncrement())
     , counterReset(ComputedStyle::initialCounterReset())
     , counterSet(ComputedStyle::initialCounterSet())
@@ -60,20 +63,22 @@ NonInheritedRareData::NonInheritedRareData()
     , shapeOutside(ComputedStyle::initialShapeOutside())
     , shapeMargin(ComputedStyle::initialShapeMargin())
     , shapeImageThreshold(ComputedStyle::initialShapeImageThreshold())
-    , perspective(ComputedStyle::initialPerspective())
-    , perspectiveOrigin({ ComputedStyle::initialPerspectiveOriginX(), ComputedStyle::initialPerspectiveOriginY() })
-    , clipPath(ComputedStyle::initialClipPath())
     , customProperties(CustomPropertyData::create())
     // customPaintWatchedProperties
     , rotate(ComputedStyle::initialRotate())
     , scale(ComputedStyle::initialScale())
     , translate(ComputedStyle::initialTranslate())
+    , perspective(ComputedStyle::initialPerspective())
+    , perspectiveOrigin({ ComputedStyle::initialPerspectiveOriginX(), ComputedStyle::initialPerspectiveOriginY() })
 #if ENABLE(SPATIAL_PORTAL)
     , portalTransform(ComputedStyle::initialPortalTransform())
 #else
     , portalTransform(CSS::Keyword::Auto { })
 #endif
+    , containerType(ComputedStyle::initialContainerType())
     , containerNames(ComputedStyle::initialContainerNames())
+    , containIntrinsicWidth(ComputedStyle::initialContainIntrinsicWidth())
+    , containIntrinsicHeight(ComputedStyle::initialContainIntrinsicHeight())
     , linkParameters(ComputedStyle::initialLinkParameters())
     , viewTransitionClasses(ComputedStyle::initialViewTransitionClasses())
     , viewTransitionName(ComputedStyle::initialViewTransitionName())
@@ -92,10 +97,6 @@ NonInheritedRareData::NonInheritedRareData()
     , timelineScope(ComputedStyle::initialTimelineScope())
     , triggerScope(ComputedStyle::initialTriggerScope())
     , timelineTriggers { CSS::Keyword::None { } }
-    , scrollbarGutter(ComputedStyle::initialScrollbarGutter())
-    , containerType(ComputedStyle::initialContainerType())
-    , scrollSnapType(ComputedStyle::initialScrollSnapType())
-    , scrollSnapAlign(ComputedStyle::initialScrollSnapAlign())
     , pseudoElementNameArgument(nullAtom())
     , anchorNames(ComputedStyle::initialAnchorNames())
     , anchorScope(ComputedStyle::initialAnchorScope())
@@ -103,24 +104,28 @@ NonInheritedRareData::NonInheritedRareData()
     , positionArea(ComputedStyle::initialPositionArea())
     , positionTryFallbacks(ComputedStyle::initialPositionTryFallbacks())
     , usedPositionOptionIndex()
-    , overflowClipMargin(ComputedStyle::initialOverflowClipMargin())
     , blockStepSize(ComputedStyle::initialBlockStepSize())
     , blockStepAlign(static_cast<unsigned>(ComputedStyle::initialBlockStepAlign()))
     , blockStepInsert(static_cast<unsigned>(ComputedStyle::initialBlockStepInsert()))
     , blockStepRound(static_cast<unsigned>(ComputedStyle::initialBlockStepRound()))
-    , spatial(static_cast<unsigned>(SpatialType::None))
-    , portalAction(static_cast<unsigned>(PortalActionType::None))
     , overscrollBehaviorX(static_cast<unsigned>(ComputedStyle::initialOverscrollBehaviorX()))
     , overscrollBehaviorY(static_cast<unsigned>(ComputedStyle::initialOverscrollBehaviorY()))
+    , scrollbarWidth(static_cast<unsigned>(ComputedStyle::initialScrollbarWidth()))
+    , scrollBehavior(static_cast<unsigned>(ComputedStyle::initialScrollBehavior()))
+    , overflowAnchor(static_cast<unsigned>(ComputedStyle::initialOverflowAnchor()))
+    , scrollSnapStop(static_cast<unsigned>(ComputedStyle::initialScrollSnapStop()))
+    , overflowContinue(static_cast<unsigned>(ComputedStyle::initialOverflowContinue()))
+    , contentVisibility(static_cast<unsigned>(ComputedStyle::initialContentVisibility()))
+    , spatial(static_cast<unsigned>(SpatialType::None))
+    , portalAction(static_cast<unsigned>(PortalActionType::None))
     , transformStyle3D(static_cast<unsigned>(ComputedStyle::initialTransformStyle3D()))
     , transformStyleForcedToFlat(false)
     , backfaceVisibility(static_cast<unsigned>(ComputedStyle::initialBackfaceVisibility()))
-    , scrollBehavior(static_cast<unsigned>(ComputedStyle::initialScrollBehavior()))
+    , effectiveBlendMode(static_cast<unsigned>(ComputedStyle::initialBlendMode()))
     , textDecorationStyle(static_cast<unsigned>(ComputedStyle::initialTextDecorationStyle()))
     , textGroupAlign(static_cast<unsigned>(ComputedStyle::initialTextGroupAlign()))
-    , contentVisibility(static_cast<unsigned>(ComputedStyle::initialContentVisibility()))
-    , effectiveBlendMode(static_cast<unsigned>(ComputedStyle::initialBlendMode()))
     , isolation(static_cast<unsigned>(ComputedStyle::initialIsolation()))
+    , contain(ComputedStyle::initialContain().toRaw())
     , inputSecurity(static_cast<unsigned>(ComputedStyle::initialInputSecurity()))
 #if ENABLE(APPLE_PAY)
     , applePayButtonStyle(static_cast<unsigned>(ComputedStyle::initialApplePayButtonStyle()))
@@ -129,46 +134,44 @@ NonInheritedRareData::NonInheritedRareData()
     , breakBefore(static_cast<unsigned>(ComputedStyle::initialBreakBefore()))
     , breakAfter(static_cast<unsigned>(ComputedStyle::initialBreakAfter()))
     , breakInside(static_cast<unsigned>(ComputedStyle::initialBreakInside()))
+    , marginTrim(ComputedStyle::initialMarginTrim().toRaw())
     , textBoxTrim(static_cast<unsigned>(ComputedStyle::initialTextBoxTrim()))
-    , overflowAnchor(static_cast<unsigned>(ComputedStyle::initialOverflowAnchor()))
-    , positionTryOrder(static_cast<unsigned>(ComputedStyle::initialPositionTryOrder()))
-    , positionVisibility(ComputedStyle::initialPositionVisibility().toRaw())
-    , fieldSizing(static_cast<unsigned>(ComputedStyle::initialFieldSizing()))
     , wrapInside(static_cast<unsigned>(ComputedStyle::initialWrapInside()))
-    , nativeAppearanceDisabled(static_cast<unsigned>(false))
+    , whiteSpaceTrim(ComputedStyle::initialWhiteSpaceTrim().toRaw())
 #if HAVE(CORE_MATERIAL)
     , appleVisualEffect(static_cast<unsigned>(ComputedStyle::initialAppleVisualEffect()))
 #endif
-    , scrollbarWidth(static_cast<unsigned>(ComputedStyle::initialScrollbarWidth()))
+    , fieldSizing(static_cast<unsigned>(ComputedStyle::initialFieldSizing()))
+    , nativeAppearanceDisabled(static_cast<unsigned>(false))
+    , positionTryOrder(static_cast<unsigned>(ComputedStyle::initialPositionTryOrder()))
+    , positionVisibility(ComputedStyle::initialPositionVisibility().toRaw())
     , usesAnchorFunctions(false)
     , anchorFunctionScrollCompensatedAxes(0)
     , isPopoverInvoker(false)
     , useSVGZoomRulesForLength(false)
-    , marginTrim(ComputedStyle::initialMarginTrim().toRaw())
-    , contain(ComputedStyle::initialContain().toRaw())
-    , overflowContinue(static_cast<unsigned>(ComputedStyle::initialOverflowContinue()))
-    , scrollSnapStop(static_cast<unsigned>(ComputedStyle::initialScrollSnapStop()))
-    , whiteSpaceTrim(ComputedStyle::initialWhiteSpaceTrim().toRaw())
 {
 }
 
 inline NonInheritedRareData::NonInheritedRareData(const NonInheritedRareData& o)
     : RefCounted<NonInheritedRareData>()
-    , containIntrinsicWidth(o.containIntrinsicWidth)
-    , containIntrinsicHeight(o.containIntrinsicHeight)
-    , lineClamp(o.lineClamp)
-    , zoom(o.zoom)
-    , maxLines(o.maxLines)
     , touchAction(o.touchAction)
+    , zoom(o.zoom)
     , initialLetter(o.initialLetter)
+    , lineClamp(o.lineClamp)
+    , maxLines(o.maxLines)
     , marquee(o.marquee)
     , backdropFilter(o.backdropFilter)
     , grid(o.grid)
     , gridItem(o.gridItem)
     , maskBorder(o.maskBorder)
     , clip(o.clip)
+    , clipPath(o.clipPath)
+    , overflowClipMargin(o.overflowClipMargin)
     , scrollMargin(o.scrollMargin)
     , scrollPadding(o.scrollPadding)
+    , scrollSnapType(o.scrollSnapType)
+    , scrollSnapAlign(o.scrollSnapAlign)
+    , scrollbarGutter(o.scrollbarGutter)
     , counterIncrement(o.counterIncrement)
     , counterReset(o.counterReset)
     , counterSet(o.counterSet)
@@ -179,16 +182,18 @@ inline NonInheritedRareData::NonInheritedRareData(const NonInheritedRareData& o)
     , shapeOutside(o.shapeOutside)
     , shapeMargin(o.shapeMargin)
     , shapeImageThreshold(o.shapeImageThreshold)
-    , perspective(o.perspective)
-    , perspectiveOrigin(o.perspectiveOrigin)
-    , clipPath(o.clipPath)
     , customProperties(o.customProperties)
     , customPaintWatchedProperties(o.customPaintWatchedProperties)
     , rotate(o.rotate)
     , scale(o.scale)
     , translate(o.translate)
+    , perspective(o.perspective)
+    , perspectiveOrigin(o.perspectiveOrigin)
     , portalTransform(o.portalTransform)
+    , containerType(o.containerType)
     , containerNames(o.containerNames)
+    , containIntrinsicWidth(o.containIntrinsicWidth)
+    , containIntrinsicHeight(o.containIntrinsicHeight)
     , linkParameters(o.linkParameters)
     , viewTransitionClasses(o.viewTransitionClasses)
     , viewTransitionName(o.viewTransitionName)
@@ -207,10 +212,6 @@ inline NonInheritedRareData::NonInheritedRareData(const NonInheritedRareData& o)
     , timelineScope(o.timelineScope)
     , triggerScope(o.triggerScope)
     , timelineTriggers(o.timelineTriggers)
-    , scrollbarGutter(o.scrollbarGutter)
-    , containerType(o.containerType)
-    , scrollSnapType(o.scrollSnapType)
-    , scrollSnapAlign(o.scrollSnapAlign)
     , pseudoElementNameArgument(o.pseudoElementNameArgument)
     , anchorNames(o.anchorNames)
     , anchorScope(o.anchorScope)
@@ -218,24 +219,28 @@ inline NonInheritedRareData::NonInheritedRareData(const NonInheritedRareData& o)
     , positionArea(o.positionArea)
     , positionTryFallbacks(o.positionTryFallbacks)
     , usedPositionOptionIndex(o.usedPositionOptionIndex)
-    , overflowClipMargin(o.overflowClipMargin)
     , blockStepSize(o.blockStepSize)
     , blockStepAlign(o.blockStepAlign)
     , blockStepInsert(o.blockStepInsert)
     , blockStepRound(o.blockStepRound)
-    , spatial(o.spatial)
-    , portalAction(o.portalAction)
     , overscrollBehaviorX(o.overscrollBehaviorX)
     , overscrollBehaviorY(o.overscrollBehaviorY)
+    , scrollbarWidth(o.scrollbarWidth)
+    , scrollBehavior(o.scrollBehavior)
+    , overflowAnchor(o.overflowAnchor)
+    , scrollSnapStop(o.scrollSnapStop)
+    , overflowContinue(o.overflowContinue)
+    , contentVisibility(o.contentVisibility)
+    , spatial(o.spatial)
+    , portalAction(o.portalAction)
     , transformStyle3D(o.transformStyle3D)
     , transformStyleForcedToFlat(o.transformStyleForcedToFlat)
     , backfaceVisibility(o.backfaceVisibility)
-    , scrollBehavior(o.scrollBehavior)
+    , effectiveBlendMode(o.effectiveBlendMode)
     , textDecorationStyle(o.textDecorationStyle)
     , textGroupAlign(o.textGroupAlign)
-    , contentVisibility(o.contentVisibility)
-    , effectiveBlendMode(o.effectiveBlendMode)
     , isolation(o.isolation)
+    , contain(o.contain)
     , inputSecurity(o.inputSecurity)
 #if ENABLE(APPLE_PAY)
     , applePayButtonStyle(o.applePayButtonStyle)
@@ -244,26 +249,21 @@ inline NonInheritedRareData::NonInheritedRareData(const NonInheritedRareData& o)
     , breakBefore(o.breakBefore)
     , breakAfter(o.breakAfter)
     , breakInside(o.breakInside)
+    , marginTrim(o.marginTrim)
     , textBoxTrim(o.textBoxTrim)
-    , overflowAnchor(o.overflowAnchor)
-    , positionTryOrder(o.positionTryOrder)
-    , positionVisibility(o.positionVisibility)
-    , fieldSizing(o.fieldSizing)
     , wrapInside(o.wrapInside)
-    , nativeAppearanceDisabled(o.nativeAppearanceDisabled)
+    , whiteSpaceTrim(o.whiteSpaceTrim)
 #if HAVE(CORE_MATERIAL)
     , appleVisualEffect(o.appleVisualEffect)
 #endif
-    , scrollbarWidth(o.scrollbarWidth)
+    , fieldSizing(o.fieldSizing)
+    , nativeAppearanceDisabled(o.nativeAppearanceDisabled)
+    , positionTryOrder(o.positionTryOrder)
+    , positionVisibility(o.positionVisibility)
     , usesAnchorFunctions(o.usesAnchorFunctions)
     , anchorFunctionScrollCompensatedAxes(o.anchorFunctionScrollCompensatedAxes)
     , isPopoverInvoker(o.isPopoverInvoker)
     , useSVGZoomRulesForLength(o.useSVGZoomRulesForLength)
-    , marginTrim(o.marginTrim)
-    , contain(o.contain)
-    , overflowContinue(o.overflowContinue)
-    , scrollSnapStop(o.scrollSnapStop)
-    , whiteSpaceTrim(o.whiteSpaceTrim)
 {
 }
 
@@ -276,21 +276,24 @@ NonInheritedRareData::~NonInheritedRareData() = default;
 
 bool NonInheritedRareData::operator==(const NonInheritedRareData& o) const
 {
-    return containIntrinsicWidth == o.containIntrinsicWidth
-        && containIntrinsicHeight == o.containIntrinsicHeight
-        && lineClamp == o.lineClamp
+    return touchAction == o.touchAction
         && zoom == o.zoom
-        && maxLines == o.maxLines
-        && touchAction == o.touchAction
         && initialLetter == o.initialLetter
+        && lineClamp == o.lineClamp
+        && maxLines == o.maxLines
         && marquee == o.marquee
         && backdropFilter == o.backdropFilter
         && grid == o.grid
         && gridItem == o.gridItem
         && maskBorder == o.maskBorder
         && clip == o.clip
+        && clipPath == o.clipPath
+        && overflowClipMargin == o.overflowClipMargin
         && scrollMargin == o.scrollMargin
         && scrollPadding == o.scrollPadding
+        && scrollSnapType == o.scrollSnapType
+        && scrollSnapAlign == o.scrollSnapAlign
+        && scrollbarGutter == o.scrollbarGutter
         && counterIncrement == o.counterIncrement
         && counterReset == o.counterReset
         && counterSet == o.counterSet
@@ -301,18 +304,21 @@ bool NonInheritedRareData::operator==(const NonInheritedRareData& o) const
         && shapeOutside == o.shapeOutside
         && shapeMargin == o.shapeMargin
         && shapeImageThreshold == o.shapeImageThreshold
-        && perspective == o.perspective
-        && perspectiveOrigin == o.perspectiveOrigin
-        && clipPath == o.clipPath
-        && textDecorationColor == o.textDecorationColor
         && customProperties == o.customProperties
         && customPaintWatchedProperties == o.customPaintWatchedProperties
         && rotate == o.rotate
         && scale == o.scale
         && translate == o.translate
+        && perspective == o.perspective
+        && perspectiveOrigin == o.perspectiveOrigin
         && portalTransform == o.portalTransform
+        && containerType == o.containerType
         && containerNames == o.containerNames
+        && containIntrinsicWidth == o.containIntrinsicWidth
+        && containIntrinsicHeight == o.containIntrinsicHeight
         && linkParameters == o.linkParameters
+        && viewTransitionClasses == o.viewTransitionClasses
+        && viewTransitionName == o.viewTransitionName
         && columnGap == o.columnGap
         && rowGap == o.rowGap
         && offsetPath == o.offsetPath
@@ -320,17 +326,14 @@ bool NonInheritedRareData::operator==(const NonInheritedRareData& o) const
         && offsetPosition == o.offsetPosition
         && offsetAnchor == o.offsetAnchor
         && offsetRotate == o.offsetRotate
-        && textDecorationThickness == o.textDecorationThickness
+        && textDecorationColor == o.textDecorationColor
         && textDecorationInset == o.textDecorationInset
+        && textDecorationThickness == o.textDecorationThickness
         && scrollTimelines == o.scrollTimelines
         && viewTimelines == o.viewTimelines
         && timelineScope == o.timelineScope
         && triggerScope == o.triggerScope
         && timelineTriggers == o.timelineTriggers
-        && scrollbarGutter == o.scrollbarGutter
-        && containerType == o.containerType
-        && scrollSnapType == o.scrollSnapType
-        && scrollSnapAlign == o.scrollSnapAlign
         && pseudoElementNameArgument == o.pseudoElementNameArgument
         && anchorNames == o.anchorNames
         && anchorScope == o.anchorScope
@@ -338,54 +341,51 @@ bool NonInheritedRareData::operator==(const NonInheritedRareData& o) const
         && positionArea == o.positionArea
         && positionTryFallbacks == o.positionTryFallbacks
         && usedPositionOptionIndex == o.usedPositionOptionIndex
-        && overflowClipMargin == o.overflowClipMargin
         && blockStepSize == o.blockStepSize
         && blockStepAlign == o.blockStepAlign
         && blockStepInsert == o.blockStepInsert
         && blockStepRound == o.blockStepRound
-        && spatial == o.spatial
-        && portalAction == o.portalAction
         && overscrollBehaviorX == o.overscrollBehaviorX
         && overscrollBehaviorY == o.overscrollBehaviorY
+        && scrollbarWidth == o.scrollbarWidth
+        && scrollBehavior == o.scrollBehavior
+        && overflowAnchor == o.overflowAnchor
+        && scrollSnapStop == o.scrollSnapStop
+        && overflowContinue == o.overflowContinue
+        && contentVisibility == o.contentVisibility
+        && spatial == o.spatial
+        && portalAction == o.portalAction
         && transformStyle3D == o.transformStyle3D
         && transformStyleForcedToFlat == o.transformStyleForcedToFlat
         && backfaceVisibility == o.backfaceVisibility
-        && scrollBehavior == o.scrollBehavior
+        && effectiveBlendMode == o.effectiveBlendMode
         && textDecorationStyle == o.textDecorationStyle
         && textGroupAlign == o.textGroupAlign
-        && effectiveBlendMode == o.effectiveBlendMode
         && isolation == o.isolation
+        && contain == o.contain
         && inputSecurity == o.inputSecurity
 #if ENABLE(APPLE_PAY)
         && applePayButtonStyle == o.applePayButtonStyle
         && applePayButtonType == o.applePayButtonType
 #endif
-        && contentVisibility == o.contentVisibility
-        && breakAfter == o.breakAfter
         && breakBefore == o.breakBefore
+        && breakAfter == o.breakAfter
         && breakInside == o.breakInside
+        && marginTrim == o.marginTrim
         && textBoxTrim == o.textBoxTrim
-        && overflowAnchor == o.overflowAnchor
-        && viewTransitionClasses == o.viewTransitionClasses
-        && viewTransitionName == o.viewTransitionName
-        && positionTryOrder == o.positionTryOrder
-        && positionVisibility == o.positionVisibility
-        && fieldSizing == o.fieldSizing
         && wrapInside == o.wrapInside
-        && nativeAppearanceDisabled == o.nativeAppearanceDisabled
+        && whiteSpaceTrim == o.whiteSpaceTrim
 #if HAVE(CORE_MATERIAL)
         && appleVisualEffect == o.appleVisualEffect
 #endif
-        && scrollbarWidth == o.scrollbarWidth
+        && fieldSizing == o.fieldSizing
+        && nativeAppearanceDisabled == o.nativeAppearanceDisabled
+        && positionTryOrder == o.positionTryOrder
+        && positionVisibility == o.positionVisibility
         && usesAnchorFunctions == o.usesAnchorFunctions
         && anchorFunctionScrollCompensatedAxes == o.anchorFunctionScrollCompensatedAxes
         && isPopoverInvoker == o.isPopoverInvoker
-        && useSVGZoomRulesForLength == o.useSVGZoomRulesForLength
-        && marginTrim == o.marginTrim
-        && contain == o.contain
-        && overflowContinue == o.overflowContinue
-        && scrollSnapStop == o.scrollSnapStop
-        && whiteSpaceTrim == o.whiteSpaceTrim;
+        && useSVGZoomRulesForLength == o.useSVGZoomRulesForLength;
 }
 
 Contain NonInheritedRareData::usedContain() const
@@ -403,28 +403,29 @@ Contain NonInheritedRareData::usedContain() const
 #if !LOG_DISABLED
 void NonInheritedRareData::dumpDifferences(TextStream& ts, const NonInheritedRareData& other) const
 {
+    LOG_IF_DIFFERENT(touchAction);
+
+    LOG_IF_DIFFERENT(zoom);
+
+    LOG_IF_DIFFERENT(initialLetter);
+    LOG_IF_DIFFERENT(lineClamp);
+    LOG_IF_DIFFERENT(maxLines);
+
     marquee->dumpDifferences(ts, other.marquee);
     backdropFilter->dumpDifferences(ts, other.backdropFilter);
     grid->dumpDifferences(ts, other.grid);
     gridItem->dumpDifferences(ts, other.gridItem);
     maskBorder->dumpDifferences(ts, other.maskBorder);
 
-    LOG_IF_DIFFERENT(containIntrinsicWidth);
-    LOG_IF_DIFFERENT(containIntrinsicHeight);
-
-    LOG_IF_DIFFERENT(lineClamp);
-
-    LOG_IF_DIFFERENT(zoom);
-
-    LOG_IF_DIFFERENT(maxLines);
-
-    LOG_IF_DIFFERENT(touchAction);
-
-    LOG_IF_DIFFERENT(initialLetter);
-
     LOG_IF_DIFFERENT(clip);
+    LOG_IF_DIFFERENT(clipPath);
+    LOG_IF_DIFFERENT(overflowClipMargin);
+
     LOG_IF_DIFFERENT(scrollMargin);
     LOG_IF_DIFFERENT(scrollPadding);
+    LOG_IF_DIFFERENT(scrollSnapType);
+    LOG_IF_DIFFERENT(scrollSnapAlign);
+    LOG_IF_DIFFERENT(scrollbarGutter);
 
     LOG_IF_DIFFERENT(counterIncrement);
     LOG_IF_DIFFERENT(counterReset);
@@ -440,22 +441,21 @@ void NonInheritedRareData::dumpDifferences(TextStream& ts, const NonInheritedRar
     LOG_IF_DIFFERENT(shapeMargin);
     LOG_IF_DIFFERENT(shapeImageThreshold);
 
-    LOG_IF_DIFFERENT(perspective);
-    LOG_IF_DIFFERENT(perspectiveOrigin);
-
-    LOG_IF_DIFFERENT(clipPath);
-
-    LOG_IF_DIFFERENT(textDecorationColor);
-
     customProperties->dumpDifferences(ts, other.customProperties);
     LOG_IF_DIFFERENT(customPaintWatchedProperties);
 
     LOG_IF_DIFFERENT(rotate);
     LOG_IF_DIFFERENT(scale);
     LOG_IF_DIFFERENT(translate);
+    LOG_IF_DIFFERENT(perspective);
+    LOG_IF_DIFFERENT(perspectiveOrigin);
     LOG_IF_DIFFERENT(portalTransform);
 
+    LOG_IF_DIFFERENT(containerType);
     LOG_IF_DIFFERENT(containerNames);
+    LOG_IF_DIFFERENT(containIntrinsicWidth);
+    LOG_IF_DIFFERENT(containIntrinsicHeight);
+
     LOG_IF_DIFFERENT(linkParameters);
 
     LOG_IF_DIFFERENT(viewTransitionClasses);
@@ -470,21 +470,16 @@ void NonInheritedRareData::dumpDifferences(TextStream& ts, const NonInheritedRar
     LOG_IF_DIFFERENT(offsetAnchor);
     LOG_IF_DIFFERENT(offsetRotate);
 
-    LOG_IF_DIFFERENT(textDecorationThickness);
+    LOG_IF_DIFFERENT(textDecorationColor);
     LOG_IF_DIFFERENT(textDecorationInset);
+    LOG_IF_DIFFERENT(textDecorationThickness);
 
     LOG_IF_DIFFERENT(scrollTimelines);
     LOG_IF_DIFFERENT(viewTimelines);
-
     LOG_IF_DIFFERENT(timelineScope);
+
     LOG_IF_DIFFERENT(triggerScope);
     LOG_IF_DIFFERENT(timelineTriggers);
-
-    LOG_IF_DIFFERENT(scrollbarGutter);
-    LOG_IF_DIFFERENT(containerType);
-
-    LOG_IF_DIFFERENT(scrollSnapType);
-    LOG_IF_DIFFERENT(scrollSnapAlign);
 
     LOG_IF_DIFFERENT(pseudoElementNameArgument);
 
@@ -494,33 +489,36 @@ void NonInheritedRareData::dumpDifferences(TextStream& ts, const NonInheritedRar
     LOG_IF_DIFFERENT(positionArea);
     LOG_IF_DIFFERENT(positionTryFallbacks);
     LOG_IF_DIFFERENT(usedPositionOptionIndex);
-    LOG_IF_DIFFERENT(positionVisibility);
-
-    LOG_IF_DIFFERENT(overflowClipMargin);
 
     LOG_IF_DIFFERENT(blockStepSize);
 
     LOG_IF_DIFFERENT_WITH_CAST(BlockStepAlign, blockStepAlign);
     LOG_IF_DIFFERENT_WITH_CAST(BlockStepInsert, blockStepInsert);
     LOG_IF_DIFFERENT_WITH_CAST(BlockStepRound, blockStepRound);
-    LOG_IF_DIFFERENT_WITH_CAST(SpatialType, spatial);
-    LOG_IF_DIFFERENT_WITH_CAST(PortalActionType, portalAction);
 
     LOG_IF_DIFFERENT_WITH_CAST(OverscrollBehavior, overscrollBehaviorX);
     LOG_IF_DIFFERENT_WITH_CAST(OverscrollBehavior, overscrollBehaviorY);
+    LOG_IF_DIFFERENT_WITH_CAST(ScrollbarWidth, scrollbarWidth);
+    LOG_IF_DIFFERENT_WITH_CAST(ScrollBehavior, scrollBehavior);
+    LOG_IF_DIFFERENT_WITH_CAST(OverflowAnchor, overflowAnchor);
+    LOG_IF_DIFFERENT_WITH_CAST(ScrollSnapStop, scrollSnapStop);
+    LOG_IF_DIFFERENT_WITH_CAST(OverflowContinue, overflowContinue);
+    LOG_IF_DIFFERENT_WITH_CAST(ContentVisibility, contentVisibility);
+
+    LOG_IF_DIFFERENT_WITH_CAST(SpatialType, spatial);
+    LOG_IF_DIFFERENT_WITH_CAST(PortalActionType, portalAction);
 
     LOG_IF_DIFFERENT_WITH_CAST(TransformStyle3D, transformStyle3D);
     LOG_IF_DIFFERENT_WITH_CAST(bool, transformStyleForcedToFlat);
     LOG_IF_DIFFERENT_WITH_CAST(BackfaceVisibility, backfaceVisibility);
 
-    LOG_IF_DIFFERENT_WITH_CAST(ScrollBehavior, scrollBehavior);
+    LOG_IF_DIFFERENT_WITH_CAST(BlendMode, effectiveBlendMode);
+
     LOG_IF_DIFFERENT_WITH_CAST(TextDecorationStyle, textDecorationStyle);
     LOG_IF_DIFFERENT_WITH_CAST(TextGroupAlign, textGroupAlign);
 
-    LOG_IF_DIFFERENT_WITH_CAST(ContentVisibility, contentVisibility);
-    LOG_IF_DIFFERENT_WITH_CAST(BlendMode, effectiveBlendMode);
-
     LOG_IF_DIFFERENT_WITH_CAST(Isolation, isolation);
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(Contain, contain);
 
     LOG_IF_DIFFERENT_WITH_CAST(InputSecurity, inputSecurity);
 
@@ -532,32 +530,26 @@ void NonInheritedRareData::dumpDifferences(TextStream& ts, const NonInheritedRar
     LOG_IF_DIFFERENT_WITH_CAST(BreakBetween, breakBefore);
     LOG_IF_DIFFERENT_WITH_CAST(BreakBetween, breakAfter);
     LOG_IF_DIFFERENT_WITH_CAST(BreakInside, breakInside);
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(MarginTrim, marginTrim);
 
     LOG_IF_DIFFERENT_WITH_CAST(TextBoxTrim, textBoxTrim);
-    LOG_IF_DIFFERENT_WITH_CAST(OverflowAnchor, overflowAnchor);
-    LOG_IF_DIFFERENT_WITH_CAST(PositionTryOrder, positionTryOrder);
-    LOG_IF_DIFFERENT_WITH_CAST(FieldSizing, fieldSizing);
     LOG_IF_DIFFERENT_WITH_CAST(WrapInside, wrapInside);
-
-    LOG_IF_DIFFERENT_WITH_CAST(bool, nativeAppearanceDisabled);
+    LOG_IF_DIFFERENT_WITH_FROM_RAW(WhiteSpaceTrim, whiteSpaceTrim);
 
 #if HAVE(CORE_MATERIAL)
     LOG_IF_DIFFERENT_WITH_CAST(AppleVisualEffect, appleVisualEffect);
 #endif
 
-    LOG_IF_DIFFERENT_WITH_CAST(ScrollbarWidth, scrollbarWidth);
+    LOG_IF_DIFFERENT_WITH_CAST(FieldSizing, fieldSizing);
+    LOG_IF_DIFFERENT_WITH_CAST(bool, nativeAppearanceDisabled);
 
+    LOG_IF_DIFFERENT_WITH_CAST(PositionTryOrder, positionTryOrder);
+    LOG_IF_DIFFERENT(positionVisibility);
     LOG_IF_DIFFERENT_WITH_CAST(bool, usesAnchorFunctions);
     LOG_IF_DIFFERENT_WITH_CAST(bool, anchorFunctionScrollCompensatedAxes);
     LOG_IF_DIFFERENT_WITH_CAST(bool, isPopoverInvoker);
+
     LOG_IF_DIFFERENT_WITH_CAST(bool, useSVGZoomRulesForLength);
-
-    LOG_IF_DIFFERENT_WITH_FROM_RAW(MarginTrim, marginTrim);
-    LOG_IF_DIFFERENT_WITH_FROM_RAW(Contain, contain);
-
-    LOG_IF_DIFFERENT_WITH_CAST(OverflowContinue, overflowContinue);
-    LOG_IF_DIFFERENT_WITH_CAST(ScrollSnapStop, scrollSnapStop);
-    LOG_IF_DIFFERENT_WITH_FROM_RAW(WhiteSpaceTrim, whiteSpaceTrim);
 }
 #endif // !LOG_DISABLED
 

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
@@ -120,18 +120,13 @@ public:
 
     Contain usedContain() const;
 
-    ContainIntrinsicSize containIntrinsicWidth;
-    ContainIntrinsicSize containIntrinsicHeight;
-
-    WebkitLineClamp lineClamp;
+    TouchAction touchAction;
 
     Zoom zoom;
 
-    MaximumLines maxLines;
-
-    TouchAction touchAction;
-
     WebkitInitialLetter initialLetter;
+    WebkitLineClamp lineClamp;
+    MaximumLines maxLines;
 
     DataRef<MarqueeData> marquee;
     DataRef<BackdropFilterData> backdropFilter;
@@ -140,9 +135,14 @@ public:
     DataRef<MaskBorderData> maskBorder;
 
     Clip clip;
+    ClipPath clipPath;
+    OverflowClipMargin overflowClipMargin;
 
     ScrollMarginBox scrollMargin;
     ScrollPaddingBox scrollPadding;
+    ScrollSnapType scrollSnapType;
+    ScrollSnapAlign scrollSnapAlign;
+    ScrollbarGutter scrollbarGutter;
 
     CounterIncrement counterIncrement;
     CounterReset counterReset;
@@ -159,20 +159,20 @@ public:
     ShapeMargin shapeMargin;
     ShapeImageThreshold shapeImageThreshold;
 
-    Perspective perspective;
-    PerspectiveOrigin perspectiveOrigin;
-
-    ClipPath clipPath;
-
     DataRef<CustomPropertyData> customProperties;
     HashSet<AtomString> customPaintWatchedProperties;
 
     Rotate rotate;
     Scale scale;
     Translate translate;
+    Perspective perspective;
+    PerspectiveOrigin perspectiveOrigin;
     PortalTransform portalTransform;
 
+    Style::ContainerType containerType;
     ContainerNames containerNames;
+    ContainIntrinsicSize containIntrinsicWidth;
+    ContainIntrinsicSize containIntrinsicHeight;
 
     LinkParameters linkParameters;
 
@@ -194,17 +194,10 @@ public:
 
     ScrollTimelines scrollTimelines;
     ViewTimelines viewTimelines;
-
     NameScope timelineScope;
 
     NameScope triggerScope;
     TimelineTriggers timelineTriggers;
-
-    ScrollbarGutter scrollbarGutter;
-    Style::ContainerType containerType;
-
-    ScrollSnapType scrollSnapType;
-    ScrollSnapAlign scrollSnapAlign;
 
     AtomString pseudoElementNameArgument;
 
@@ -215,28 +208,36 @@ public:
     PositionTryFallbacks positionTryFallbacks;
     std::optional<size_t> usedPositionOptionIndex;
 
-    OverflowClipMargin overflowClipMargin;
-
     BlockStepSize blockStepSize;
+
     PREFERRED_TYPE(BlockStepAlign) unsigned blockStepAlign : 2;
     PREFERRED_TYPE(BlockStepInsert) unsigned blockStepInsert : 2;
     PREFERRED_TYPE(BlockStepRound) unsigned blockStepRound : 2;
-    PREFERRED_TYPE(SpatialType) unsigned spatial : 1;
-    PREFERRED_TYPE(PortalActionType) unsigned portalAction : 1;
 
     PREFERRED_TYPE(OverscrollBehavior) unsigned overscrollBehaviorX : 2;
     PREFERRED_TYPE(OverscrollBehavior) unsigned overscrollBehaviorY : 2;
+    PREFERRED_TYPE(ScrollbarWidth) unsigned scrollbarWidth : 2;
+    PREFERRED_TYPE(ScrollBehavior) unsigned scrollBehavior : 1;
+    PREFERRED_TYPE(OverflowAnchor) unsigned overflowAnchor : 1;
+    PREFERRED_TYPE(ScrollSnapStop) unsigned scrollSnapStop : 1;
+    PREFERRED_TYPE(OverflowContinue) unsigned overflowContinue : 2;
+    PREFERRED_TYPE(ContentVisibility) unsigned contentVisibility : 2;
+
+    PREFERRED_TYPE(SpatialType) unsigned spatial : 1;
+    PREFERRED_TYPE(PortalActionType) unsigned portalAction : 1;
 
     PREFERRED_TYPE(TransformStyle3D) unsigned transformStyle3D : 2;
     PREFERRED_TYPE(bool) unsigned transformStyleForcedToFlat : 1; // The used value for transform-style is forced to flat by a grouping property.
     PREFERRED_TYPE(BackfaceVisibility) unsigned backfaceVisibility : 1;
 
-    PREFERRED_TYPE(ScrollBehavior) unsigned scrollBehavior : 1;
+    PREFERRED_TYPE(BlendMode) unsigned effectiveBlendMode: 5;
+
     PREFERRED_TYPE(TextDecorationStyle) unsigned textDecorationStyle : 3;
     PREFERRED_TYPE(TextGroupAlign) unsigned textGroupAlign : 3;
-    PREFERRED_TYPE(ContentVisibility) unsigned contentVisibility : 2;
-    PREFERRED_TYPE(BlendMode) unsigned effectiveBlendMode: 5;
+
     PREFERRED_TYPE(Isolation) unsigned isolation : 1;
+    PREFERRED_TYPE(Contain) unsigned contain : 5;
+
     PREFERRED_TYPE(InputSecurity) unsigned inputSecurity : 1;
 #if ENABLE(APPLE_PAY)
     PREFERRED_TYPE(ApplePayButtonStyle) unsigned applePayButtonStyle : 2;
@@ -245,26 +246,25 @@ public:
     PREFERRED_TYPE(BreakBetween) unsigned breakBefore : 4;
     PREFERRED_TYPE(BreakBetween) unsigned breakAfter : 4;
     PREFERRED_TYPE(BreakInside) unsigned breakInside : 3;
+    PREFERRED_TYPE(MarginTrim) unsigned marginTrim : 2;
+
     PREFERRED_TYPE(TextBoxTrim) unsigned textBoxTrim : 2;
-    PREFERRED_TYPE(OverflowAnchor) unsigned overflowAnchor : 1;
-    PREFERRED_TYPE(PositionTryOrder) unsigned positionTryOrder : 3;
-    PREFERRED_TYPE(PositionVisibility) unsigned positionVisibility : 5;
-    PREFERRED_TYPE(FieldSizing) unsigned fieldSizing : 1;
     PREFERRED_TYPE(WrapInside) unsigned wrapInside : 1;
-    PREFERRED_TYPE(bool) unsigned nativeAppearanceDisabled : 1;
+    PREFERRED_TYPE(WhiteSpaceTrim) unsigned whiteSpaceTrim : 3;
+
 #if HAVE(CORE_MATERIAL)
     PREFERRED_TYPE(AppleVisualEffect) unsigned appleVisualEffect : 5;
 #endif
-    PREFERRED_TYPE(ScrollbarWidth) unsigned scrollbarWidth : 2;
+    PREFERRED_TYPE(FieldSizing) unsigned fieldSizing : 1;
+    PREFERRED_TYPE(bool) unsigned nativeAppearanceDisabled : 1;
+
+    PREFERRED_TYPE(PositionTryOrder) unsigned positionTryOrder : 3;
+    PREFERRED_TYPE(PositionVisibility) unsigned positionVisibility : 5;
     PREFERRED_TYPE(bool) unsigned usesAnchorFunctions : 1;
     PREFERRED_TYPE(EnumSet<BoxAxis>) unsigned anchorFunctionScrollCompensatedAxes : 2;
     PREFERRED_TYPE(bool) unsigned isPopoverInvoker : 1;
+
     PREFERRED_TYPE(bool) unsigned useSVGZoomRulesForLength : 1;
-    PREFERRED_TYPE(MarginTrim) unsigned marginTrim : 2;
-    PREFERRED_TYPE(Contain) unsigned contain : 5;
-    PREFERRED_TYPE(OverflowContinue) unsigned overflowContinue : 2;
-    PREFERRED_TYPE(ScrollSnapStop) unsigned scrollSnapStop : 1;
-    PREFERRED_TYPE(WhiteSpaceTrim) unsigned whiteSpaceTrim : 3;
 
 private:
     NonInheritedRareData();


### PR DESCRIPTION
#### 103384db3c0cb572819ce530629f04f83b4b1a8d
<pre>
Minor ComputedStyle Data Cleanup
<a href="https://bugs.webkit.org/show_bug.cgi?id=322438">https://bugs.webkit.org/show_bug.cgi?id=322438</a>
<a href="https://rdar.apple.com/185720364">rdar://185720364</a>

Reviewed by NOBODY (OOPS!).

Some minor clean-up of our style data storage:
- Move box-sizing inline (from BoxData), since it&apos;s often set on every element.
- Reorder NonInheritedFlags and NonInheritedRareData thematically.
- Update some comments and move static bit counts closer to where they&apos;re used.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/StyleDifference.cpp:
* Source/WebCore/style/computed/StyleComputedStyle.cpp:
(WebCore::Style::ComputedStyle::fastPathInheritFrom):
(WebCore::Style::ComputedStyle::fastPathInheritedEqual const):
(WebCore::Style::ComputedStyle::nonFastPathInheritedEqual const):
* Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h:
(WebCore::Style::ComputedStyleBase::ComputedStyleBase):
(WebCore::Style::ComputedStyleBase::NonInheritedFlags::copyNonInheritedFrom):
* Source/WebCore/style/computed/StyleComputedStyleBase.cpp:
(WebCore::Style::ComputedStyleBase::NonInheritedFlags::dumpDifferences const):
(WebCore::Style::ComputedStyleBase::InheritedFlags::dumpDifferences const):
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/computed/data/StyleBoxData.cpp:
(WebCore::Style::BoxData::BoxData):
(WebCore::Style::BoxData::operator== const):
(WebCore::Style::BoxData::dumpDifferences const):
* Source/WebCore/style/computed/data/StyleBoxData.h:
* Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp:
(WebCore::Style::NonInheritedRareData::NonInheritedRareData):
(WebCore::Style::perspectiveOrigin):
(WebCore::Style::useSVGZoomRulesForLength):
(WebCore::Style::NonInheritedRareData::operator== const):
(WebCore::Style::NonInheritedRareData::dumpDifferences const):
(WebCore::Style::whiteSpaceTrim): Deleted.
* Source/WebCore/style/computed/data/StyleNonInheritedRareData.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/103384db3c0cb572819ce530629f04f83b4b1a8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59085 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/52902 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/195501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187035 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58812 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/195501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/188128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/195501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [⏳ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/195501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/44859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/6557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/51741 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/197453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/58749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/164795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/197453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/197453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131765 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/128458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/57937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/19878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57551 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57375 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->