### PR TITLE
Update WebGL texture test expectations

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5131,7 +5131,6 @@ webgl/1.0.x/conformance/textures/misc/texture-corner-case-videos.html [ Failure 
 webgl/2.0.y/conformance/textures/misc/texture-corner-case-videos.html [ Failure ]
 
 # WebGL tests to be investigated and categorized.
-webkit.org/b/292182 webgl/1.0.x/conformance/textures/image_bitmap_from_video/tex-2d-luminance-luminance-unsigned_byte.html [ Pass Timeout ]
 webkit.org/b/292182 [ x86_64 ] webgl/1.0.x/conformance/textures/misc/copytexsubimage2d-large-partial-copy-corruption.html [ Failure Pass ]
 webkit.org/b/292182 webgl/1.0.x/conformance/textures/misc/texture-video-transparent.html [ Failure Pass ]
 webkit.org/b/292182 [ x86_64 ] webgl/2.0.y/conformance/textures/misc/copytexsubimage2d-large-partial-copy-corruption.html [ Failure Pass ]
@@ -5836,10 +5835,6 @@ imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal
 imported/w3c/web-platform-tests/css/css-highlight-api/custom-highlight-universal-painting-003.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/highlight-image-currentcolor.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/highlight-image-stacked.html [ ImageOnlyFailure ]
-
-http/tests/webgl/1.0.x/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html [ Skip ]
-http/tests/webgl/2.0.y/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html [ Skip ]
-http/tests/webgl/2.0.y/conformance2/textures/misc/origin-clean-conformance-offscreencanvas.html [ Skip ]
 
 # These are only enabled on Cocoa WK2 ports
 webanimations/multiple-transform-properties-and-multiple-transform-properties-animation-with-delay-on-forced-layer.html [ Skip ]

--- a/LayoutTests/http/tests/webgl/1.0.x/conformance/textures/misc/origin-clean-conformance-offscreencanvas-expected.txt
+++ b/LayoutTests/http/tests/webgl/1.0.x/conformance/textures/misc/origin-clean-conformance-offscreencanvas-expected.txt
@@ -1,11 +1,5 @@
 CONSOLE MESSAGE: [loadCrossOriginImage]
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: null is not an object (evaluating 'gl.createTexture')
-FAIL: Timed out waiting for notifyDone to be called
-
 This test runs the WebGL Test listed below in an iframe and reports PASS or FAIL.
 
 Test: ../../../../resources/webgl_test_files/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html
-
-[ 1: PASS ] img was loaded
-[ 2: PASS ] img domain (localhost:8000) and page domain (0.1:8000) are not the same.
-[ 3: FAIL ] Unable to fetch WebGL rendering context for Canvas
+[ PASS ] All tests passed

--- a/LayoutTests/http/tests/webgl/2.0.y/conformance/textures/misc/origin-clean-conformance-offscreencanvas-expected.txt
+++ b/LayoutTests/http/tests/webgl/2.0.y/conformance/textures/misc/origin-clean-conformance-offscreencanvas-expected.txt
@@ -1,11 +1,5 @@
 CONSOLE MESSAGE: [loadCrossOriginImage]
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: null is not an object (evaluating 'gl.createTexture')
-FAIL: Timed out waiting for notifyDone to be called
-
 This test runs the WebGL Test listed below in an iframe and reports PASS or FAIL.
 
 Test: ../../../../resources/webgl_test_files/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html?webglVersion=2
-
-[ 1: PASS ] img was loaded
-[ 2: PASS ] img domain (localhost:8000) and page domain (0.1:8000) are not the same.
-[ 3: FAIL ] Unable to fetch WebGL rendering context for Canvas
+[ PASS ] All tests passed

--- a/LayoutTests/http/tests/webgl/2.0.y/conformance2/textures/misc/origin-clean-conformance-offscreencanvas-expected.txt
+++ b/LayoutTests/http/tests/webgl/2.0.y/conformance2/textures/misc/origin-clean-conformance-offscreencanvas-expected.txt
@@ -1,11 +1,5 @@
 CONSOLE MESSAGE: [loadCrossOriginImage]
-CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: null is not an object (evaluating 'gl.createTexture')
-FAIL: Timed out waiting for notifyDone to be called
-
 This test runs the WebGL Test listed below in an iframe and reports PASS or FAIL.
 
 Test: ../../../../resources/webgl_test_files/conformance2/textures/misc/origin-clean-conformance-offscreencanvas.html?webglVersion=2
-
-[ 1: PASS ] img was loaded
-[ 2: PASS ] img domain (localhost:8000) and page domain (0.1:8000) are not the same.
-[ 3: FAIL ] Unable to fetch WebGL rendering context for Canvas
+[ PASS ] All tests passed

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -391,19 +391,6 @@ http/tests/resourceLoadStatistics/switch-session-on-navigation-to-prevalent-with
 http/tests/websocket/tests/hybi/interleaved-fragments.html [ Pass Failure Timeout ]
 http/tests/websocket/tests/hybi/send-object-tostring-check.html [ Pass Failure Timeout ]
 
-# rdar://77084155 (REGRESSION: [ MacOS WK2 ] WebGL textures tests are consistently timing out)
-webgl/2.0.y/conformance/textures/image_bitmap_from_video/tex-2d-rgb-rgb-unsigned_byte.html [ Skip ]
-webgl/2.0.y/conformance/textures/image_bitmap_from_video/tex-2d-rgb-rgb-unsigned_short_5_6_5.html [ Skip ]
-webgl/2.0.y/conformance/textures/image_bitmap_from_video/tex-2d-rgba-rgba-unsigned_byte.html [ Skip ]
-webgl/2.0.y/conformance/textures/image_bitmap_from_video/tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html [ Skip ]
-webgl/2.0.y/conformance/textures/image_bitmap_from_video/tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html [ Skip ]
-webgl/2.0.y/conformance/textures/misc/texture-upload-size.html [ Skip ]
-webgl/2.0.y/conformance/textures/video/tex-2d-rgb-rgb-unsigned_byte.html [ Skip ]
-webgl/2.0.y/conformance/textures/video/tex-2d-rgb-rgb-unsigned_short_5_6_5.html [ Skip ]
-webgl/2.0.y/conformance/textures/video/tex-2d-rgba-rgba-unsigned_byte.html [ Skip ]
-webgl/2.0.y/conformance/textures/video/tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html [ Skip ]
-webgl/2.0.y/conformance/textures/video/tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html [ Skip ]
-
 # fast/events/controlclick-no-onclick.html fails or times out on Mac WK2
 webkit.org/b/105948 fast/events/controlclick-no-onclick.html [ Skip ]
 
@@ -1849,10 +1836,6 @@ webkit.org/b/295743 [ Debug ] media/video-display-aspect-ratio.html [ Pass Failu
 
 # FIXME: Needs bug.
 http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-unfiltered-link-decoration-before-short-deletion.html [ Failure ]
-
-webkit.org/b/295756 webgl/1.0.x/conformance/rendering/texture-switch-performance.html [ Pass Failure ]
-webkit.org/b/295756 webgl/2.0.y/conformance/rendering/texture-switch-performance.html [ Pass Failure ]
-webkit.org/b/295756 webgl/2.0.y/conformance2/rendering/texture-switch-performance.html [ Pass Failure ]
 
 webkit.org/b/295814 [ arm64 ] scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe.html [ Pass Timeout ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1605,9 +1605,6 @@ webkit.org/b/230411 http/tests/media/hls/video-controller-getStartDate.html [ Pa
 # HLS stream fails to become ready to play on headless bots
 http/tests/media/hls/hls-limit-play-rate.html
 
-# rdar://65641438 ([WebGL2] tex-srgb-mipmap test fails on macOS Intel + iOS (but passes on macOS Apple Silicon) (214392))
-[ arm64 ] webgl/2.0.y/conformance2/textures/misc/tex-srgb-mipmap.html [ Failure ]
-
 [ x86_64 ] imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-opacity.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-saturate.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-boundary.html [ ImageOnlyFailure ]
@@ -1673,8 +1670,6 @@ webkit.org/b/222692 inspector/page/empty-or-missing-resources.html [ Pass Timeou
 
 # webkit.org/b/223043 the following tests have issues only on Apple Silicon
 webrtc/h264-baseline.html  [ Failure Timeout ]
-
-webkit.org/b/223259 [ arm64 ] webgl/2.0.y/conformance2/textures/misc/tex-mipmap-levels.html [ Failure ]
 
 webkit.org/b/223271 [ Debug ] imported/w3c/web-platform-tests/xhr/event-upload-progress.any.worker.html [ Pass Failure ]
 


### PR DESCRIPTION
#### d4a16a979d443be4cdc35d0762efc1049cf8022f
<pre>
Update WebGL texture test expectations
<a href="https://bugs.webkit.org/show_bug.cgi?id=322241">https://bugs.webkit.org/show_bug.cgi?id=322241</a>
<a href="https://rdar.apple.com/185470917">rdar://185470917</a>

Reviewed by Dan Glastonbury.

Update WebGL layout test expectations for various texture-related tests.

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/webgl/1.0.x/conformance/textures/misc/origin-clean-conformance-offscreencanvas-expected.txt:
* LayoutTests/http/tests/webgl/2.0.y/conformance/textures/misc/origin-clean-conformance-offscreencanvas-expected.txt:
* LayoutTests/http/tests/webgl/2.0.y/conformance2/textures/misc/origin-clean-conformance-offscreencanvas-expected.txt:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/320882@main">https://commits.webkit.org/320882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1de4dd598f8e08497f147f1982317fe35db799e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196410 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150703 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ee79bcb3-ef0f-49bc-a70d-659b31f13b32) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59734 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145429 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100806 "1 flakes 13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/60479f38-381e-44b6-ad97-994f9e0237bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49116 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165962 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125755 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a9ae0d5-704b-481e-8d9e-dde6b7e768fa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47849 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45823 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158203 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45550 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7481 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198388 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59671 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165482 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154995 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41535 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60383 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154632 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49070 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129797 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58822 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58215 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58444 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58274 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->