### PR TITLE
AX: In isolated tree mode, a list item whose first line is in a nested block loses its list marker

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/attributed-string-with-listitem-multiple-lines-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/attributed-string-with-listitem-multiple-lines-expected.txt
@@ -1,0 +1,14 @@
+This tests that when list item has text of multiple lines we only speak the list marker for the first line.
+
+1. First line
+second line
+2. Long long long long long long long long long long long long long long long long long long long long long long
+long long long long long long long long long long long long long
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+First line
+
+second line
+Long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long

--- a/LayoutTests/accessibility/isolated-tree/mac/attributed-string-with-listitem-multiple-lines.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/attributed-string-with-listitem-multiple-lines.html
@@ -1,0 +1,42 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<ol>
+<li id="item1"><p>First line</p>second line</li>
+<li id="item2"><p>Long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long</p></li>
+</ol>
+
+<script>
+let output = "This tests that when list item has text of multiple lines we only speak the list marker for the first line.\n\n";
+
+if (window.accessibilityController) {
+    var listItem1 = accessibilityController.accessibleElementById("item1");
+    var p1 = listItem1.childAtIndex(1);
+    var firstLineRange = p1.textMarkerRangeForElement(p1);
+    output += `${p1.stringForTextMarkerRange(firstLineRange)}\n`;
+
+    // Get second line.
+    var firstLineEnd = p1.endTextMarkerForTextMarkerRange(firstLineRange);
+    var secondLineRange = p1.lineTextMarkerRangeForTextMarker(p1.nextTextMarker(firstLineEnd));
+    output += `${p1.stringForTextMarkerRange(secondLineRange).trim()}\n`;
+
+    // Soft line break.
+    var listItem2 = accessibilityController.accessibleElementById("item2");
+    var item2Range = listItem2.textMarkerRangeForElement(listItem2);
+    var firstLineStart = listItem2.startTextMarkerForTextMarkerRange(item2Range);
+    firstLineRange = listItem2.lineTextMarkerRangeForTextMarker(firstLineStart);
+    output += `${listItem2.stringForTextMarkerRange(firstLineRange)}\n`;
+
+    firstLineEnd = listItem2.endTextMarkerForTextMarkerRange(firstLineRange);
+    secondLineRange = listItem2.lineTextMarkerRangeForTextMarker(listItem2.nextTextMarker(firstLineEnd));
+    output += `${listItem2.stringForTextMarkerRange(secondLineRange).trim()}\n`;
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -978,7 +978,6 @@ public:
     // True when this object's node is in the shadow tree of an <input> or <textarea>, as opposed to
     // an ARIA text control.
     virtual bool isInsideNativeTextControl() const = 0;
-    virtual AXTextRunLineID listMarkerLineID() const = 0;
     virtual String listMarkerText() const = 0;
     virtual FontOrientation fontOrientation() const = 0;
 #endif

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -1076,9 +1076,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::LinethroughColor:
         stream << "LinethroughColor";
         break;
-    case AXProperty::ListMarkerLineID:
-        stream << "ListMarkerLineID";
-        break;
     case AXProperty::ListMarkerText:
         stream << "ListMarkerText";
         break;

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -553,7 +553,7 @@ String listMarkerTextOnSameLine(const AXTextMarker& marker)
         if (RefPtr listMarker = findUnignoredDescendant(*listItemAncestor, /* includeSelf */ false, [] (const auto& descendant) {
             return descendant.role() == AccessibilityRole::ListMarker;
         })) {
-            auto lineID = listMarker->listMarkerLineID();
+            auto lineID = AXTextMarker { *listItemAncestor, 0 }.toTextRunMarker().lineID();
             if (lineID && lineID == marker.lineID())
                 return listMarker->listMarkerText();
         }

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -445,7 +445,6 @@ public:
     bool isReplacedElementForTextEmission() const final;
     bool isInUserAgentShadowTree() const final;
     bool isInsideNativeTextControl() const final;
-    AXTextRunLineID listMarkerLineID() const override { return { }; }
     String listMarkerText() const override { return { }; }
     FontOrientation fontOrientation() const final;
 #endif

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1771,12 +1771,6 @@ AXTextRuns AccessibilityRenderObject::textRuns()
     return { renderText->containingBlock(), WTF::move(runs), fullString.toString().isolatedCopy(), containsOnlyASCII };
 }
 
-AXTextRunLineID AccessibilityRenderObject::listMarkerLineID() const
-{
-    AX_ASSERT(role() == AccessibilityRole::ListMarker);
-    return { renderer() ? renderer()->containingBlock() : nullptr, 0 };
-}
-
 String AccessibilityRenderObject::listMarkerText() const
 {
     CheckedPtr marker = dynamicDowncast<RenderListOutsideMarker>(renderer());

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.h
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.h
@@ -120,7 +120,6 @@ public:
     String selectedText() const final;
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     AXTextRuns textRuns() final;
-    AXTextRunLineID listMarkerLineID() const final;
     String listMarkerText() const final;
 #endif
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -180,7 +180,6 @@ bool isDefaultValue(AXProperty property, AXPropertyValueVariant& value)
         [](std::unique_ptr<AXTextRuns>& typedValue) { return !typedValue || !typedValue->size(); },
         [](RetainPtr<CTFontRef>& typedValue) { return !typedValue; },
         [](FontOrientation typedValue) { return typedValue == FontOrientation::Horizontal; },
-        [](AXTextRunLineID typedValue) { return !typedValue; },
         [](WallTime& time) { return !time; },
         [](ElementName& name) { return name == ElementName::Unknown; },
         [](DateComponentsType& typedValue) { return typedValue == DateComponentsType::Invalid; },

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -112,7 +112,6 @@ public:
     bool isReplacedElementForTextEmission() const final { return boolAttributeValue(AXProperty::IsReplacedElementForTextEmission); }
     bool isInUserAgentShadowTree() const final { return boolAttributeValue(AXProperty::IsInUserAgentShadowTree); }
     bool isInsideNativeTextControl() const final { return boolAttributeValue(AXProperty::IsInsideNativeTextControl); }
-    AXTextRunLineID listMarkerLineID() const final { return propertyValue<AXTextRunLineID>(AXProperty::ListMarkerLineID); };
     String listMarkerText() const final { return stringAttributeValue(AXProperty::ListMarkerText); }
     FontOrientation fontOrientation() const final { return propertyValue<FontOrientation>(AXProperty::FontOrientation); }
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -2405,10 +2405,8 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
         case TextEmissionBehavior::None:
             break;
         }
-        if (object.role() == AccessibilityRole::ListMarker) {
+        if (object.role() == AccessibilityRole::ListMarker)
             setProperty(AXProperty::ListMarkerText, object.listMarkerText().isolatedCopy());
-            setProperty(AXProperty::ListMarkerLineID, object.listMarkerLineID());
-        }
 
         String language = object.language();
         if (!language.isEmpty())

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -247,7 +247,6 @@ enum class AXProperty : uint16_t {
     KeyShortcuts,
     Language,
     LinethroughColor,
-    ListMarkerLineID,
     ListMarkerText,
     LiveRegionAtomic,
     LocalizedActionVerb,
@@ -343,7 +342,6 @@ using AXPropertyValueVariant = Variant<std::nullptr_t, Markable<AXID>, String, b
     , RetainPtr<CTFontRef>
     , FontOrientation
     , std::unique_ptr<AXTextRuns>
-    , AXTextRunLineID
     , FrameIdentifier
 >;
 using AXPropertyVector = Vector<std::pair<AXProperty, AXPropertyValueVariant>>;


### PR DESCRIPTION
#### 5bf2f65bb5a72c248b63c93e9ced077d9853ec68
<pre>
AX: In isolated tree mode, a list item whose first line is in a nested block loses its list marker
<a href="https://bugs.webkit.org/show_bug.cgi?id=323518">https://bugs.webkit.org/show_bug.cgi?id=323518</a>
<a href="https://rdar.apple.com/186761205">rdar://186761205</a>

Reviewed by Chris Fleizach.

listMarkerTextOnSameLine decides whether a text marker sits on the line that shows the list marker by
comparing line IDs, and it named the marker&apos;s line with listMarkerLineID(), which is the block the
marker renderer is parented in rather than the line the marker is drawn on. Those agree only when the
list item&apos;s text is a direct child of the item&apos;s own block. An outside marker is a child of the
RenderListItem, but the item&apos;s first line can live in a nested block:

    &lt;ol&gt;&lt;li&gt;&lt;p&gt;First line&lt;/p&gt;second line&lt;/li&gt;&lt;/ol&gt;

There the text&apos;s containing block is the &lt;p&gt; and the marker&apos;s is the &lt;li&gt;, so the two line IDs never
matched and the marker was dropped entirely -- &quot;First line&quot; rather than &quot;1. First line&quot;.

Ask the line the list item&apos;s own text starts on using the existing cached data. This allows removal of
listMarkerLineID() and AXProperty::ListMarkerLineID.

Fixes accessibility/mac/attributed-string-with-listitem-multiple-lines.html in ITM.

* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::listMarkerTextOnSameLine):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::listMarkerLineID const): Deleted.
* Source/WebCore/accessibility/AccessibilityRenderObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::isDefaultValue):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::createIsolatedObjectData):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:

Canonical link: <a href="https://commits.webkit.org/320595@main">https://commits.webkit.org/320595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af3092d49dc1f358c721a0ea53057d98f6bcda09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195515 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b647f4f-2561-4982-8ae3-738811b269a1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144707 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/426ef24e-7962-4dc6-a304-b4fd17caacf2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125000 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cb3af84b-a4f4-4bfa-b5d2-cb821cfbefb9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47120 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45182 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157487 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44870 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6571 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51755 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197467 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58763 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154215 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41317 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59472 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41474 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153866 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48361 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131780 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128487 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57951 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19889 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57322 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57565 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57389 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->