### PR TITLE
[cmake] run-webkit-tests picks the ASan build after an Xcode ASAN=YES build

### DIFF
--- a/Tools/Scripts/set-webkit-configuration
+++ b/Tools/Scripts/set-webkit-configuration
@@ -39,8 +39,10 @@ use webkitdirs;
 my $programName = basename($0);
 my $usage = <<EOF;
 Usage: $programName [options]
-  --[no-]asan                        Enable or disable clang address sanitizer
-  --[no-]tsan                        Enable or disable clang thread sanitizer
+  --[no-]asan                        Enable or disable clang address sanitizer for Xcode builds
+                                     (CMake builds select it per invocation, with --asan)
+  --[no-]tsan                        Enable or disable clang thread sanitizer for Xcode builds
+                                     (CMake builds select it per invocation, with --tsan)
   --[no-]ubsan                       Enable or disable clang undefined behavior sanitizer
   --[no-]libFuzzer                   Enable or disable clang libFuzzer
   --[no-]coverage                    Enable or disable LLVM Source-based Code Coverage
@@ -171,8 +173,9 @@ sub printCurrentSettings()
 {
     my $result = "Current settings:";
     $result .= " Configuration:" . configuration();
-    $result .= " ASan" if asanIsEnabled();
-    $result .= " TSan" if tsanIsEnabled();
+    # The persisted settings: asanIsEnabled() would hide them from CMake builds.
+    $result .= " ASan" if readSanitizerConfiguration("ASan");
+    $result .= " TSan" if readSanitizerConfiguration("TSan");
     $result .= " UBSan" if ubsanIsEnabled();
     $result .= " Fuzzilli" if fuzzilliIsEnabled();
     $result .= " LibFuzzer" if libFuzzerIsEnabled();

--- a/Tools/Scripts/webkit-build-directory
+++ b/Tools/Scripts/webkit-build-directory
@@ -57,6 +57,7 @@ Usage: $programName [options]
   --top-level           Show the top-level build directory
 
   --asan                Select the ASan (AddressSanitizer) build tree (with --cmake: WebKitBuild/cmake-mac/ASan)
+  --tsan                Select the TSan (ThreadSanitizer) build tree (with --cmake: WebKitBuild/cmake-mac/TSan)
   --gtk                 Find the build directory for the GTK+ port
   --win                 Find the build directory for Windows port
 

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -192,6 +192,7 @@ BEGIN {
        &shouldUseVcpkg
        &isWinCrossCompileFromLinux
        &winCrossCompileVcpkgRoot
+       &readSanitizerConfiguration
        &sourceDir
        &splitVersionString
        &tsanIsEnabled
@@ -248,6 +249,7 @@ my $didUserSpecifyArchitecture = 0;
 my %nativeArchitectureMap = ();
 my $asanIsEnabled;
 my $tsanIsEnabled;
+my $requestedSanitizer;
 my $ubsanIsEnabled;
 my $libFuzzerIsEnabled;
 my $coverageIsEnabled;
@@ -690,7 +692,7 @@ sub determineXcodeDestination
 sub readSanitizerConfiguration($)
 {
     my ($fileName) = @_;
-
+    determineBaseProductDir();
     if (open FILE, File::Spec->catfile($baseProductDir, $fileName)) {
         my $value = <FILE>;
         close FILE;
@@ -701,19 +703,50 @@ sub readSanitizerConfiguration($)
     return 0;
 }
 
+# "ASan", "TSan", or "".
+sub requestedSanitizer()
+{
+    return $requestedSanitizer if defined $requestedSanitizer;
+    my $asan = checkForArgumentAndRemoveFromARGV("--asan");
+    my $tsan = checkForArgumentAndRemoveFromARGV("--tsan");
+    die "Cannot enable both --asan and --tsan at the same time\n" if $asan && $tsan;
+    $requestedSanitizer = $asan ? "ASan" : ($tsan ? "TSan" : "");
+    return $requestedSanitizer;
+}
+
+# Sanitizer presets build into a configuration of their own (cmake-mac/ASan), so
+# a sanitizer is chosen per invocation here. The marker files are deliberately
+# not consulted: they toggle the sanitizer inside Xcode's Debug/Release tree, and
+# must not repoint the CMake tree.
+sub cmakeConfiguration()
+{
+    determineConfiguration();
+    return requestedSanitizer() || $configuration;
+}
+
+sub sanitizerIsEnabled($)
+{
+    my ($fileName) = @_;
+    return 1 if requestedSanitizer() eq $fileName;
+    return 0 unless readSanitizerConfiguration($fileName);
+    return 1 unless isAppleCocoaWebKit() && isCMakeBuild();
+    print STDERR "Ignoring the sticky $fileName setting: it applies to Xcode builds. Pass --" . lc($fileName) .
+        " for the CMake $fileName tree.\n";
+    return 0;
+}
+
 sub determineASanIsEnabled
 {
     return if defined $asanIsEnabled;
     determineBaseProductDir();
-    # Honor an explicit --asan (like --cmake) in addition to the marker file.
-    $asanIsEnabled = checkForArgumentAndRemoveFromARGV("--asan") || readSanitizerConfiguration("ASan");
+    $asanIsEnabled = sanitizerIsEnabled("ASan");
 }
 
 sub determineTSanIsEnabled
 {
     return if defined $tsanIsEnabled;
     determineBaseProductDir();
-    $tsanIsEnabled = checkForArgumentAndRemoveFromARGV("--tsan") || readSanitizerConfiguration("TSan");
+    $tsanIsEnabled = sanitizerIsEnabled("TSan");
 }
 
 sub determineUBSanIsEnabled
@@ -856,6 +889,7 @@ sub argumentsForConfiguration()
     push(@args, '--maccatalyst') if (defined $xcodeSDKPlatformName && $xcodeSDKPlatformName eq 'maccatalyst');
     push(@args, '--32-bit') if ($architecture eq "x86");
     push(@args, '--cmake') if (isAppleCocoaWebKit() && isCMakeBuild());
+    push(@args, '--' . lc(requestedSanitizer())) if requestedSanitizer();
     push(@args, '--gtk') if isGtk();
     push(@args, '--wpe') if isWPE();
     push(@args, '--jsc-only') if isJSCOnly();
@@ -1225,11 +1259,7 @@ sub determineConfigurationProductDir
     } elsif (isGtk() or isWPE() or isJSCOnly() or shouldBuildForCrossTarget() or inCrossTargetEnvironment()) {
         $configurationProductDir = "$baseProductDir/$portName/$configuration";
     } elsif (isAppleCocoaWebKit() && isCMakeBuild()) {
-        # Sanitizer presets build into a dedicated dir, e.g. cmake-mac/ASan.
-        my $cmakeConfiguration = $configuration;
-        $cmakeConfiguration = "ASan" if asanIsEnabled();
-        $cmakeConfiguration = "TSan" if tsanIsEnabled();
-        $configurationProductDir = File::Spec->catdir($baseProductDir, cmakeCocoaTreeName(), $cmakeConfiguration);
+        $configurationProductDir = File::Spec->catdir($baseProductDir, cmakeCocoaTreeName(), cmakeConfiguration());
     } else {
         $configurationProductDir = xcodeConfigurationProductDir();
     }
@@ -3214,14 +3244,9 @@ sub determineIsCMakeBuild()
         determineBaseProductDir();
         determineConfiguration();
 
-        # CMake sanitizer presets build into cmake-mac/ASan or cmake-mac/TSan, so
-        # resolve the tree the way determineConfigurationProductDir() does. Xcode
-        # toggles ASan within Debug/Release, so its path is unchanged.
-        my $cmakeConfiguration = $configuration;
-        $cmakeConfiguration = "ASan" if asanIsEnabled();
-        $cmakeConfiguration = "TSan" if tsanIsEnabled();
+        # Resolve the CMake tree the way determineConfigurationProductDir() does.
         my $cmakeTreeName = cmakeCocoaTreeName();
-        my $cmakeBuild = File::Spec->catdir($baseProductDir, $cmakeTreeName, $cmakeConfiguration);
+        my $cmakeBuild = File::Spec->catdir($baseProductDir, $cmakeTreeName, cmakeConfiguration());
         my $xcodeBuild = xcodeConfigurationProductDir();
 
         if (-f File::Spec->catfile($cmakeBuild, "CMakeCache.txt") && !-d $xcodeBuild) {
@@ -3241,7 +3266,7 @@ sub determineIsCMakeBuild()
             my $xcodeMtime = -f $xcodeMarker ? stat($xcodeMarker)->mtime : 0;
             if ($cmakeMtime > $xcodeMtime) {
                 $isCMakeBuild = 1;
-                print STDERR "Using last-built tree: $cmakeTreeName/$cmakeConfiguration (CMake)\n";
+                print STDERR "Using last-built tree: $cmakeTreeName/" . cmakeConfiguration() . " (CMake)\n";
             } elsif ($xcodeMtime && $cmakeMtime) {
                 print STDERR "Using last-built tree: " . basename($xcodeBuild) . " (Xcode)\n";
             }

--- a/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildLastBuiltASan.pl
+++ b/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildLastBuiltASan.pl
@@ -23,8 +23,8 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Unit test for webkitdirs::determineIsCMakeBuild last-built tiebreaker with a
-# sanitizer build: a CMake ASan build lands in cmake-mac/ASan, so when ASan is
-# enabled the tiebreaker must inspect that tree. Each scenario lives in its own
+# sanitizer build: a CMake ASan build lands in cmake-mac/ASan, so when --asan is
+# passed the tiebreaker must inspect that tree. Each scenario lives in its own
 # .pl file because determineIsCMakeBuild caches its answer in a script-global.
 use strict;
 use warnings;
@@ -45,13 +45,8 @@ use warnings qw(redefine prototype);
 my $configuration = "Debug";
 my $base = tempdir(CLEANUP => 1);
 
-# Enable ASan via the marker file that readSanitizerConfiguration() reads.
-open(my $asanFh, ">", File::Spec->catfile($base, "ASan")) or die "Could not create ASan marker: $!";
-print $asanFh "YES\n";
-close($asanFh);
-
-# The CMake ASan build lands in cmake-mac/ASan; Xcode toggles ASan within the
-# Debug tree. Both tree dirs must exist for the tiebreaker to run.
+# The CMake ASan build lands in cmake-mac/ASan. Both tree dirs must exist for
+# the tiebreaker to run.
 my $cmakeMarker = File::Spec->catfile($base, "cmake-mac", "ASan", ".ninja_log");
 my $xcodeMarker = File::Spec->catfile($base, "XCBuildData", "build.db");
 make_path(File::Spec->catdir($base, $configuration));
@@ -72,7 +67,7 @@ setBaseProductDir($base);
 setConfiguration($configuration);
 enableLastBuiltTiebreaker();
 
-@ARGV = ();
+@ARGV = ("--asan");
 webkitdirs::determineIsCMakeBuild();
 
-ok(isCMakeBuild(), "last-built tiebreaker inspects cmake-mac/ASan when ASan is enabled");
+ok(isCMakeBuild(), "last-built tiebreaker inspects cmake-mac/ASan when --asan is passed");

--- a/Tools/Scripts/webkitpy/port/config.py
+++ b/Tools/Scripts/webkitpy/port/config.py
@@ -57,6 +57,9 @@ class Config(object):
     # Shared across all Config instances: webkit-build-directory is a ~110ms
     # perl invocation whose result is invariant for given inputs within a run.
     _build_directories = {}
+    # Keyed like _build_directories: the tree scripts will actually use, which is
+    # how asan tells an Xcode build from a CMake one.
+    _default_product_directories = {}
 
     def __init__(self, executive, filesystem, port_implementation=None, use_cmake=False, use_xcode=False, asan=False):
         self._executive = executive
@@ -71,11 +74,16 @@ class Config(object):
     @classmethod
     def _clear_cache_for_testing(cls):
         cls._build_directories = {}
+        cls._default_product_directories = {}
+
+    def _cache_key(self, configuration, for_host):
+        port_impl = self._port_implementation if not for_host else None
+        return (port_impl, configuration or "", for_host, self._use_cmake, self._use_xcode, self._asan)
 
     def build_directory(self, configuration, for_host=False):
         """Returns the path to the build directory for the configuration."""
         port_impl = self._port_implementation if not for_host else None
-        cache_key = (port_impl, configuration or "", for_host, self._use_cmake, self._use_xcode, self._asan)
+        cache_key = self._cache_key(configuration, for_host)
         if self._build_directories.get(cache_key):
             return self._build_directories[cache_key]
 
@@ -100,12 +108,18 @@ class Config(object):
         # With no --configuration flag, webkit-build-directory also prints the
         # default-configuration dir on a second line; cache it for later hits.
         if len(parts) == 2:
+            self._default_product_directories[cache_key] = parts[1]
             default_configuration = parts[1][len(parts[0]):]
             if default_configuration.startswith("/"):
                 default_configuration = default_configuration[1:]
-            self._build_directories[(port_impl, default_configuration, for_host, self._use_cmake, self._use_xcode, self._asan)] = parts[1]
+            self._build_directories[self._cache_key(default_configuration, for_host)] = parts[1]
 
         return self._build_directories[cache_key]
+
+    def _default_product_directory(self):
+        """Returns the product directory for the default configuration, or None."""
+        self.build_directory(None)  # Populates _default_product_directories.
+        return self._default_product_directories.get(self._cache_key(None, False))
 
     def flag_for_configuration(self, configuration):
         if not configuration:
@@ -151,10 +165,19 @@ class Config(object):
     @property
     @memoized
     def asan(self):
-        # --asan forces asan on; otherwise fall back to the marker file.
         if self._asan:
             return True
         try:
+            # Mirrors webkitdirs.pm: the marker file toggles ASan inside Xcode's
+            # Debug/Release tree, so it says nothing about the CMake tree, which
+            # keeps sanitizer builds in a configuration of their own.
+            product_directory = self._default_product_directory()
+            if product_directory and self._is_cmake_product_directory(product_directory):
+                return self._filesystem.basename(product_directory) == "ASan"
             return self._filesystem.exists(self._filesystem.join(self.build_directory(None), "ASan"))
         except:
             return False
+
+    def _is_cmake_product_directory(self, product_directory):
+        # CMake presets build into WebKitBuild/cmake-<platform>/<Configuration>.
+        return self._filesystem.basename(self._filesystem.dirname(product_directory)).startswith("cmake-")

--- a/Tools/Scripts/webkitpy/port/config_unittest.py
+++ b/Tools/Scripts/webkitpy/port/config_unittest.py
@@ -232,3 +232,18 @@ class ConfigTest(unittest.TestCase):
         # An explicit --asan forces asan on even without the marker file.
         config = self.make_config(output='foo\nfoo/cmake-mac/ASan', files={}, asan=True)
         self.assertEqual(config.asan, True)
+
+    def test_asan_marker_is_ignored_for_the_cmake_tree(self):
+        # The ASan marker file `make ASAN=YES` leaves behind is a setting of the
+        # Xcode build; it must not make a CMake run report an ASan build.
+        files = {'foo/Configuration': 'Debug', 'foo/ASan': 'YES'}
+        config = self.make_config(output='foo\nfoo/cmake-mac/Debug', files=files, use_cmake=True)
+        self.assertEqual(config.asan, False)
+
+        # Same when the CMake tree came from webkitdirs.pm's last-built
+        # tiebreaker rather than from an explicit --cmake.
+        config = self.make_config(output='foo\nfoo/cmake-mac/Debug', files=files)
+        self.assertEqual(config.asan, False)
+
+        config = self.make_config(output='foo\nfoo/Debug', files=files, use_xcode=True)
+        self.assertEqual(config.asan, True)


### PR DESCRIPTION
#### 7ff776dfc2799c0faccd79bce8d0ad75d8246873
<pre>
[cmake] run-webkit-tests picks the ASan build after an Xcode ASAN=YES build
<a href="https://bugs.webkit.org/show_bug.cgi?id=323519">https://bugs.webkit.org/show_bug.cgi?id=323519</a>
<a href="https://rdar.apple.com/186761705">rdar://186761705</a>

Reviewed by NOBODY (OOPS!).

`make ASAN=YES` runs `set-webkit-configuration --asan`, which writes a sticky
WebKitBuild/ASan marker file. That marker is a setting of the Xcode build, which
toggles ASan inside its Debug/Release tree.

The marker was also being used to name the CMake product directory, so a later
`run-webkit-tests --cmake` silently resolved to WebKitBuild/cmake-mac/ASan and
reported an asan test configuration. Passing --debug did not help, because the
sanitizer dominated the directory name.

Give the Cocoa CMake tree a single source of truth: cmakeConfiguration(), which
is the sanitizer named by --asan/--tsan, or else Debug/Release, and never the
marker file. asanIsEnabled()/tsanIsEnabled() now agree with it, so the tree name
and the compile flags cannot diverge, and a marker that is being ignored prints a
note pointing at --asan.

webkitpy decides the same way, from the tree webkit-build-directory actually
resolved. That also covers the case where the last-built tiebreaker picks CMake
without an explicit --cmake.

* Tools/Scripts/set-webkit-configuration:
(printCurrentSettings):
* Tools/Scripts/webkit-build-directory:
* Tools/Scripts/webkitdirs.pm:
(readSanitizerConfiguration):
(requestedSanitizer):
(cmakeConfiguration):
(sanitizerIsEnabled):
(determineASanIsEnabled):
(determineTSanIsEnabled):
(argumentsForConfiguration):
(determineConfigurationProductDir):
(determineIsCMakeBuild):
* Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildLastBuiltASan.pl:
* Tools/Scripts/webkitpy/port/config.py:
(Config):
(Config._clear_cache_for_testing):
(Config._cache_key):
(Config.build_directory):
(Config._default_product_directory):
(Config.asan):
(Config._is_cmake_product_directory):
* Tools/Scripts/webkitpy/port/config_unittest.py:
(ConfigTest.test_asan):
(ConfigTest):
(ConfigTest.test_asan_marker_is_ignored_for_the_cmake_tree):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ff776dfc2799c0faccd79bce8d0ad75d8246873

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195513 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150041 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144705 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100360 "Exiting early after 60 failures. 60 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165297 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/124998 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/184513 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47118 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45181 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6911 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13799 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157485 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44867 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6569 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46443 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197465 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58761 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154213 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59470 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153864 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48359 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128480 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57949 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19886 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57320 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57563 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57387 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->