### PR TITLE
AX: In isolated tree mode, an image keeps a stale name when its figure gains or loses flow content

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/figure-caption-names-image-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/figure-caption-names-image-expected.txt
@@ -1,0 +1,17 @@
+This test verifies when an unlabeled image takes its accessible name from an ancestor figure's figcaption.
+
+PASS: descriptionOf('captionNamed') === 'AXDescription: A ripe apple'
+PASS: descriptionOf('flowContentSibling') === 'AXDescription: '
+PASS: descriptionOf('altNamed') === 'AXDescription: Alt text'
+
+Removing the paragraph, leaving the figcaption as the figure's only other child.
+PASS: descriptionOf('flowContentSibling') === 'AXDescription: A ripe pear'
+
+Adding a paragraph to the first figure.
+PASS: descriptionOf('captionNamed') === 'AXDescription: '
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/accessibility/isolated-tree/mac/figure-caption-names-image.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/figure-caption-names-image.html
@@ -1,0 +1,63 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="content">
+<figure id="appleFigure">
+    <img id="captionNamed" width="20" height="20" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">
+    <figcaption>A ripe apple</figcaption>
+</figure>
+
+<figure id="pearFigure">
+    <img id="flowContentSibling" width="20" height="20" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">
+    <p id="prose">Prose that is flow content.</p>
+    <figcaption>A ripe pear</figcaption>
+</figure>
+
+<figure>
+    <img id="altNamed" alt="Alt text" width="20" height="20" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">
+    <figcaption>A ripe plum</figcaption>
+</figure>
+</div>
+
+<script>
+var output = "This test verifies when an unlabeled image takes its accessible name from an ancestor figure's figcaption.\n\n";
+
+function descriptionOf(id)
+{
+    return accessibilityController.accessibleElementById(id).description;
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        // Per html-aam, an img with no alt and no title derives its name from the figcaption,
+        // but only when the figure holds nothing else that counts as flow content.
+        output += await expectAsync("descriptionOf('captionNamed')", "'AXDescription: A ripe apple'");
+        output += await expectAsync("descriptionOf('flowContentSibling')", "'AXDescription: '");
+        // An alt attribute names the image itself, so the figcaption is never consulted.
+        output += await expectAsync("descriptionOf('altNamed')", "'AXDescription: Alt text'");
+
+        output += "\nRemoving the paragraph, leaving the figcaption as the figure's only other child.\n";
+        document.getElementById("prose").remove();
+        output += await expectAsync("descriptionOf('flowContentSibling')", "'AXDescription: A ripe pear'");
+
+        output += "\nAdding a paragraph to the first figure.\n";
+        var paragraph = document.createElement("p");
+        paragraph.textContent = "Prose that is flow content.";
+        document.getElementById("appleFigure").appendChild(paragraph);
+        output += await expectAsync("descriptionOf('captionNamed')", "'AXDescription: '");
+
+        document.getElementById("content").style.visibility = "hidden";
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/figure-caption-names-image-expected.txt
+++ b/LayoutTests/accessibility/mac/figure-caption-names-image-expected.txt
@@ -1,0 +1,17 @@
+This test verifies when an unlabeled image takes its accessible name from an ancestor figure's figcaption.
+
+PASS: descriptionOf('captionNamed') === 'AXDescription: A ripe apple'
+PASS: descriptionOf('flowContentSibling') === 'AXDescription: '
+PASS: descriptionOf('altNamed') === 'AXDescription: Alt text'
+
+Removing the paragraph, leaving the figcaption as the figure's only other child.
+PASS: descriptionOf('flowContentSibling') === 'AXDescription: A ripe pear'
+
+Adding a paragraph to the first figure.
+PASS: descriptionOf('captionNamed') === 'AXDescription: '
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/accessibility/mac/figure-caption-names-image.html
+++ b/LayoutTests/accessibility/mac/figure-caption-names-image.html
@@ -1,0 +1,63 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="content">
+<figure id="appleFigure">
+    <img id="captionNamed" width="20" height="20" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">
+    <figcaption>A ripe apple</figcaption>
+</figure>
+
+<figure id="pearFigure">
+    <img id="flowContentSibling" width="20" height="20" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">
+    <p id="prose">Prose that is flow content.</p>
+    <figcaption>A ripe pear</figcaption>
+</figure>
+
+<figure>
+    <img id="altNamed" alt="Alt text" width="20" height="20" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">
+    <figcaption>A ripe plum</figcaption>
+</figure>
+</div>
+
+<script>
+var output = "This test verifies when an unlabeled image takes its accessible name from an ancestor figure's figcaption.\n\n";
+
+function descriptionOf(id)
+{
+    return accessibilityController.accessibleElementById(id).description;
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    setTimeout(async function() {
+        // Per html-aam, an img with no alt and no title derives its name from the figcaption,
+        // but only when the figure holds nothing else that counts as flow content.
+        output += await expectAsync("descriptionOf('captionNamed')", "'AXDescription: A ripe apple'");
+        output += await expectAsync("descriptionOf('flowContentSibling')", "'AXDescription: '");
+        // An alt attribute names the image itself, so the figcaption is never consulted.
+        output += await expectAsync("descriptionOf('altNamed')", "'AXDescription: Alt text'");
+
+        output += "\nRemoving the paragraph, leaving the figcaption as the figure's only other child.\n";
+        document.getElementById("prose").remove();
+        output += await expectAsync("descriptionOf('flowContentSibling')", "'AXDescription: A ripe pear'");
+
+        output += "\nAdding a paragraph to the first figure.\n";
+        var paragraph = document.createElement("p");
+        paragraph.textContent = "Prose that is flow content.";
+        document.getElementById("appleFigure").appendChild(paragraph);
+        output += await expectAsync("descriptionOf('captionNamed')", "'AXDescription: '");
+
+        document.getElementById("content").style.visibility = "hidden";
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -770,6 +770,9 @@ void AXIsolatedTree::updateNodeProperties(AccessibilityObject& axObject, const A
                 properties.append({ AXProperty::ExplicitOrientation, *orientation });
             break;
         }
+        case AXProperty::Description:
+            properties.append({ AXProperty::Description, axObject.description().isolatedCopy() });
+            break;
         case AXProperty::ExtendedDescription:
             properties.append({ AXProperty::ExtendedDescription, axObject.extendedDescription().isolatedCopy() });
             break;
@@ -1019,6 +1022,19 @@ void AXIsolatedTree::updateDependentProperties(AccessibilityObject& axObject)
     };
     updateRelatedObjects(axObject);
 
+    // An <img> with neither alt nor title takes its accessible name from an ancestor <figure>'s <figcaption>.
+    // If this is a <figure>, update image text underneath.
+    auto updateFigureCaptionedImages = [this] (AccessibilityObject& object) {
+        if (!object.isFigureElement())
+            return;
+
+        Accessibility::enumerateDescendantsIncludingIgnored<AXCoreObject>(object, false, [this, protectedThis = Ref { *this }] (auto& descendant) {
+            if (descendant.isImage())
+                queueNodeUpdate(descendant.objectID(), { { AXProperty::AccessibilityText, AXProperty::Description } });
+        });
+    };
+    updateFigureCaptionedImages(axObject);
+
     // When a row gains or loses cells, or a table changes rows in a row group, the column count of the table can change.
     bool updateTableAncestorColumns = axObject.isExposedTableRow() || isRowGroup(axObject.node());
     for (RefPtr ancestor = axObject.parentObject(); ancestor; ancestor = ancestor->parentObject()) {
@@ -1032,6 +1048,7 @@ void AXIsolatedTree::updateDependentProperties(AccessibilityObject& axObject)
         }
 
         updateRelatedObjects(*ancestor);
+        updateFigureCaptionedImages(*ancestor);
     }
 }
 


### PR DESCRIPTION
#### 5dc317e89095e74b91986953c624145aaf36d3fe
<pre>
AX: In isolated tree mode, an image keeps a stale name when its figure gains or loses flow content
<a href="https://bugs.webkit.org/show_bug.cgi?id=323520">https://bugs.webkit.org/show_bug.cgi?id=323520</a>
<a href="https://rdar.apple.com/186762993">rdar://186762993</a>

Reviewed by Chris Fleizach.

Per html-aam (w3c/aria#2224), an &lt;img&gt; with neither alt nor title derives its accessible
name from an ancestor &lt;figure&gt;&apos;s &lt;figcaption&gt;, but only while that figure holds no other
flow content. This accessible name is stored in AXProperty::{AccessibilityText, Description},
which wasn&apos;t updated the figure subtree changed. This is now fixed.

* LayoutTests/accessibility/isolated-tree/mac/figure-caption-names-image-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/figure-caption-names-image.html: Added.
* LayoutTests/accessibility/mac/figure-caption-names-image-expected.txt: Added.
* LayoutTests/accessibility/mac/figure-caption-names-image.html: Added.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):
(WebCore::AXIsolatedTree::updateDependentProperties):

Canonical link: <a href="https://commits.webkit.org/320586@main">https://commits.webkit.org/320586@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6abe66a4a8236726ae59993cfb9b352a95cd387

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195517 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/73845860-a760-4607-b1db-fa2e41a68288) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58828 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144709 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/25603d79-b422-446a-ad57-98a3ba3131b4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165301 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125002 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/65639349-b1d5-42cc-b3dd-3717aa2fada4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47121 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45184 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157488 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44871 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6573 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197469 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164807 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154217 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-animations/nested-scale-animations.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41306 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59474 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153868 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48363 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131782 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128491 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57953 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19890 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57324 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57567 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57391 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->