### PR TITLE
AX: textRuns() unnecessarily recomputes the same elementRect() repeatedly, once per line, accruing samples on Speedometer

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1603,6 +1603,22 @@ AXTextRuns AccessibilityRenderObject::textRuns()
     float lineHeight = 0.0;
 
     bool isHorizontal = fontOrientation() == FontOrientation::Horizontal;
+
+    bool didComputeBoundsOffsets = false;
+    float containingBlockOffset = 0;
+    LayoutUnit elementRectOffset;
+    auto computeBoundsOffsetsIfNeeded = [&] {
+        if (didComputeBoundsOffsets)
+            return;
+        didComputeBoundsOffsets = true;
+
+        if (CheckedPtr containingBlock = renderText->containingBlock())
+            containingBlockOffset = isHorizontal ? containingBlock->absoluteBoundingBoxRect().x() : containingBlock->absoluteBoundingBoxRect().y();
+
+        LayoutRect rect = elementRect();
+        elementRectOffset = isHorizontal ? rect.x() : rect.y();
+    };
+
     // Appends text to the current lineString, collapsing whitespace as necessary (similar to how TextIterator::handleTextRun() does).
     auto appendToLineString = [&] (const InlineIterator::TextBoxIterator& textBox) {
         auto text = textBox->originalText();
@@ -1632,11 +1648,8 @@ AXTextRuns AccessibilityRenderObject::textRuns()
         // non-zero value indicates it was already set by an earlier text box.
         if (!didComputeDistanceFromBounds) {
             didComputeDistanceFromBounds = true;
-            float containingBlockOffset = 0;
-            if (CheckedPtr containingBlock = renderText->containingBlock())
-                containingBlockOffset = isHorizontal ? containingBlock->absoluteBoundingBoxRect().x() : containingBlock->absoluteBoundingBoxRect().y();
-
-            distanceFromBoundsInDirection = isHorizontal ? textRun.xPos() + lineBox->contentLogicalLeft() + containingBlockOffset - elementRect().x() : -textRun.xPos() + containingBlockOffset - elementRect().y();
+            computeBoundsOffsetsIfNeeded();
+            distanceFromBoundsInDirection = isHorizontal ? textRun.xPos() + lineBox->contentLogicalLeft() + containingBlockOffset - elementRectOffset : -textRun.xPos() + containingBlockOffset - elementRectOffset;
         }
 
         // Populate GlyphBuffer with all of the glyphs for the text runs, enabling us to measure character widths.


### PR DESCRIPTION
#### 60d1179d23a0bec425606c2c8da5d22f6a64ddc4
<pre>
AX: textRuns() unnecessarily recomputes the same elementRect() repeatedly, once per line, accruing samples on Speedometer
<a href="https://bugs.webkit.org/show_bug.cgi?id=323522">https://bugs.webkit.org/show_bug.cgi?id=323522</a>
<a href="https://rdar.apple.com/186765403">rdar://186765403</a>

Reviewed by Chris Fleizach.

AccessibilityRenderObject::textRuns() computes distanceFromBoundsInDirection for the
first text box on each line. Two of the three terms in it -- the containing block&apos;s
absolute position and this object&apos;s element rect -- are properties of the renderer, so
they&apos;re identical for every line, but both were computed inside the per-line branch.

Hoist them out and compute them at most once per textRuns() call. This is done lazily
rather than up front so renderers that turn out to have no text boxes don&apos;t pay for
them at all.

A profile of Speedometer 3.1 with VoiceOver enabled attributes 228 samples to these
two calls under textRuns() (190 elementRect, 38 absoluteBoundingBoxRect). A synthetic
isolated-tree build over deliberately wrap-heavy content (WebKitTestRunner with
--accessibility-isolated-tree, narrow column, ~1000 multi-line paragraphs) goes from a
median 224ms to 160ms, a 28% reduction, with non-overlapping run ranges.

* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):

Canonical link: <a href="https://commits.webkit.org/320591@main">https://commits.webkit.org/320591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b05b71af8b77411288b468bbdbccb3b8ab1d7fcc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195524 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b5918fec-0c16-4e43-a407-d6f2d150de6f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144715 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5f69970d-9fb4-4686-97cd-c39321cc5d9c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125008 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/47eae45a-bdc7-44b7-ab3b-8652ae3be5f6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47128 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45190 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157495 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44878 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6580 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49569 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197475 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58774 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154221 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41312 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59483 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153872 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48368 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131791 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128507 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57962 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19897 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57333 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57576 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57400 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->