### PR TITLE
[JSC] Make Air stack slot liveness sparse in instructions

### DIFF
--- a/Source/JavaScriptCore/b3/B3VariableLiveness.h
+++ b/Source/JavaScriptCore/b3/B3VariableLiveness.h
@@ -38,7 +38,7 @@
 namespace JSC { namespace B3 {
 
 struct VariableLivenessAdapter {
-    static constexpr const char* name = "VariableLiveness";
+    static constexpr ASCIILiteral name = "VariableLiveness"_s;
     typedef B3::CFG CFG;
     typedef Variable* Thing;
     
@@ -62,6 +62,38 @@ struct VariableLivenessAdapter {
     unsigned blockSize(BasicBlock* block)
     {
         return block->size();
+    }
+
+    // Any value boundary can be a Get or a Set, so all of them are visited and a group is just the
+    // boundary itself.
+    struct ActionGroup {
+        BasicBlock* block { nullptr };
+        unsigned boundary { 0 };
+    };
+
+    template<typename Func>
+    void forEachActionGroupDescending(BasicBlock* block, const Func& func)
+    {
+        for (unsigned boundary = block->size() + 1; boundary--;)
+            func(boundary, ActionGroup { block, boundary });
+    }
+
+    template<typename Func>
+    void forEachUseInGroup(ActionGroup group, const Func& func)
+    {
+        forEachUse(group.block, group.boundary, func);
+    }
+
+    template<typename Func>
+    void forEachDefInGroup(ActionGroup group, const Func& func)
+    {
+        forEachDef(group.block, group.boundary, func);
+    }
+
+    template<typename Func>
+    void forEachUseAtTail(BasicBlock* block, const Func& func)
+    {
+        forEachUse(block, block->size(), func);
     }
     
     template<typename Func>

--- a/Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp
@@ -29,15 +29,17 @@
 #if ENABLE(B3_JIT)
 
 #include "AirArgInlines.h"
+#include "AirCFG.h"
 #include "AirCode.h"
 #include "AirHandleCalleeSaves.h"
 #include "AirInstInlines.h"
-#include "AirLiveness.h"
 #include "AirPhaseScope.h"
 #include "AirStackAllocation.h"
 #include "AirStackAllocatorStats.h"
+#include "CompilerTimingScope.h"
+#include <wtf/ForbidHeapAllocation.h>
 #include <wtf/InterferenceGraph.h>
-#include <wtf/ListDump.h>
+#include <wtf/Liveness.h>
 
 namespace JSC { namespace B3 { namespace Air {
 
@@ -48,6 +50,273 @@ static constexpr bool verbose = false;
 static constexpr bool reportLargeMemoryUses = false;
 }
 
+// We will perform some spill coalescing. To make that effective, we need to be able to identify
+// coalescable moves and handle them specially in interference analysis.
+bool isCoalescableMove(Inst& inst, bool coalesceSpillSlots)
+{
+    if (!coalesceSpillSlots)
+        return false;
+
+    Width width;
+    switch (inst.kind.opcode) {
+    case Move:
+        width = pointerWidth();
+        break;
+    case Move32:
+    case MoveFloat:
+        width = Width32;
+        break;
+    case MoveDouble:
+        width = Width64;
+        break;
+    case MoveVector:
+        width = Width128;
+        break;
+    default:
+        return false;
+    }
+
+    if (inst.args().size() != 3)
+        return false;
+
+    for (unsigned i = 0; i < 2; ++i) {
+        Arg arg = inst.args()[i];
+        if (!arg.isStack())
+            return false;
+        StackSlot* slot = arg.stackSlot();
+        if (slot->kind() != StackSlotKind::Spill)
+            return false;
+        if (slot->byteSize() != bytesForWidth(width))
+            return false;
+    }
+
+    return true;
+}
+
+bool isUselessMove(Inst& inst, bool coalesceSpillSlots)
+{
+    return isCoalescableMove(inst, coalesceSpillSlots) && inst.args()[0] == inst.args()[1];
+}
+
+// The stack slot mentions, dead store candidates and coalescable move sites of a whole function,
+// collected in one forward walk over the instructions.
+//
+// A mention carries the instruction boundary it happens at, and they land in one flat array sorted by
+// boundary: an early action of instruction i belongs to boundary i and a late action to boundary
+// i + 1, so staging the late actions of i and appending them once i is decoded keeps it sorted.
+//
+// The kill candidates cannot be derived from the mentions: an instruction with no arguments at all
+// satisfies the predicate vacuously. The coalescable moves have to reach coalesceSlots in the order
+// the interference build reports them, because it sorts them with an unstable sort and a different
+// order would silently change which slots get coalesced.
+class StackSlotActions {
+    WTF_MAKE_NONCOPYABLE(StackSlotActions);
+    WTF_FORBID_HEAP_ALLOCATION;
+public:
+    enum ActionKind : uint8_t { UseAction, EarlyDefAction, LateDefAction };
+
+    struct Action {
+        uint32_t boundary { 0 };
+        uint32_t slotIndex { 0 };
+        ActionKind kind { UseAction };
+        bool isSpill { false };
+    };
+
+    struct MoveSite {
+        uint32_t instIndex { 0 };
+        uint32_t src { 0 };
+        uint32_t dst { 0 };
+    };
+
+    StackSlotActions(Code& code, bool coalesceSpillSlots)
+        : m_code(code)
+    {
+        CompilerTimingScope timingScope("Air"_s, "StackAllocator::actions"_s);
+
+        m_blockData.grow(code.size());
+
+        Vector<Action, 8> lateActions;
+        for (BasicBlock* block : code) {
+            BlockData& data = m_blockData[block->index()];
+            data.actionStart = m_actions.size();
+            data.killStart = m_killCandidates.size();
+            data.moveStart = m_moveSites.size();
+
+            unsigned blockSize = block->size();
+            for (unsigned instIndex = 0; instIndex < blockSize; ++instIndex) {
+                Inst& inst = block->at(instIndex);
+
+                // A dead store candidate has no effects beyond its arguments and defines only spill
+                // slots, late. That is the only kind of dead stack store this phase will see.
+                // Later, we will check whether this spill is alive or not. And if it is dead, we will remove this Inst.
+                bool isKillCandidate = !inst.hasNonArgEffects();
+                lateActions.shrink(0);
+                inst.forEachArg(
+                    [&](Arg& arg, Arg::Role role, Bank, Width) {
+                        bool isSpill = false;
+                        if (arg.isStack()) {
+                            StackSlot* slot = arg.stackSlot();
+                            uint32_t index = slot->index();
+                            isSpill = slot->kind() == StackSlotKind::Spill;
+                            if (Arg::isEarlyUse(role))
+                                m_actions.append({ instIndex, index, UseAction, isSpill });
+                            if (Arg::isEarlyDef(role))
+                                m_actions.append({ instIndex, index, EarlyDefAction, isSpill });
+                            if (Arg::isLateUse(role))
+                                lateActions.append({ instIndex + 1, index, UseAction, isSpill });
+                            if (Arg::isLateDef(role))
+                                lateActions.append({ instIndex + 1, index, LateDefAction, isSpill });
+                        }
+                        if (Arg::isEarlyDef(role))
+                            isKillCandidate = false;
+                        else if (Arg::isLateDef(role) && !isSpill)
+                            isKillCandidate = false;
+                    });
+                m_actions.appendVector(lateActions);
+
+                if (isKillCandidate)
+                    m_killCandidates.append(instIndex);
+
+                if (isCoalescableMove(inst, coalesceSpillSlots)) {
+                    m_moveSites.append({ instIndex, inst.args()[0].stackSlot()->index(), inst.args()[1].stackSlot()->index() });
+                    if (inst.args()[0] == inst.args()[1])
+                        m_sawUselessMove = true;
+                }
+            }
+
+            data.actionEnd = m_actions.size();
+            data.killEnd = m_killCandidates.size();
+            data.moveEnd = m_moveSites.size();
+        }
+    }
+
+    Code& code() const { return m_code; }
+    unsigned numIndices() const { return m_code.stackSlots().size(); }
+    bool sawUselessMove() const { return m_sawUselessMove; }
+
+    std::span<const Action> actionsFor(BasicBlock* block) const
+    {
+        const BlockData& data = m_blockData[block->index()];
+        return m_actions.subspan(data.actionStart, data.actionEnd - data.actionStart);
+    }
+
+    std::span<const uint32_t> killCandidatesFor(BasicBlock* block) const
+    {
+        const BlockData& data = m_blockData[block->index()];
+        return m_killCandidates.subspan(data.killStart, data.killEnd - data.killStart);
+    }
+
+    std::span<const MoveSite> moveSitesFor(BasicBlock* block) const
+    {
+        const BlockData& data = m_blockData[block->index()];
+        return m_moveSites.subspan(data.moveStart, data.moveEnd - data.moveStart);
+    }
+
+    // Boundary numbers restart at zero in every block, so `actions` has to be exactly one block's
+    // actions. The actions of one boundary are contiguous, so the last boundary is a suffix of the
+    // span, and taking it away leaves the boundary before it as the new suffix.
+    static std::span<const Action> consumeLastGroup(std::span<const Action>& actions)
+    {
+        ASSERT(!actions.empty());
+        uint32_t boundary = actions.back().boundary;
+        size_t start = actions.size();
+        while (start && actions[start - 1].boundary == boundary)
+            --start;
+        std::span<const Action> group = actions.subspan(start);
+        actions = actions.first(start);
+        return group;
+    }
+
+private:
+    struct BlockData {
+        uint32_t actionStart { 0 };
+        uint32_t actionEnd { 0 };
+        uint32_t killStart { 0 };
+        uint32_t killEnd { 0 };
+        uint32_t moveStart { 0 };
+        uint32_t moveEnd { 0 };
+    };
+
+    Code& m_code;
+    bool m_sawUselessMove { false };
+    Vector<Action> m_actions;
+    Vector<uint32_t> m_killCandidates;
+    Vector<MoveSite> m_moveSites;
+    Vector<BlockData> m_blockData;
+};
+
+// Boundaries with no mentions are simply absent, which is what keeps the fixpoint proportional to the
+// mentions rather than to the instructions.
+struct StackSlotLivenessAdapter {
+    WTF_FORBID_HEAP_ALLOCATION;
+public:
+    typedef Air::CFG CFG;
+    typedef StackSlot* Thing;
+    using ActionGroup = std::span<const StackSlotActions::Action>;
+
+    StackSlotLivenessAdapter(const StackSlotActions& actions)
+        : actions(actions)
+    {
+    }
+
+    void prepareToCompute() { }
+
+    unsigned numIndices() const { return actions.numIndices(); }
+    unsigned blockSize(BasicBlock* block) const { return block->size(); }
+    static unsigned valueToIndex(StackSlot* slot) { return slot->index(); }
+    StackSlot* indexToValue(unsigned index) const { return actions.code().stackSlots()[index]; }
+
+    template<typename Func>
+    void forEachActionGroupDescending(BasicBlock* block, const Func& func) const
+    {
+        auto blockActions = actions.actionsFor(block);
+        while (!blockActions.empty()) {
+            ActionGroup group = StackSlotActions::consumeLastGroup(blockActions);
+            func(group.front().boundary, group);
+        }
+    }
+
+    template<typename Func>
+    static void forEachUseInGroup(ActionGroup group, const Func& func)
+    {
+        for (const auto& action : group) {
+            if (action.kind == StackSlotActions::UseAction)
+                func(action.slotIndex);
+        }
+    }
+
+    template<typename Func>
+    static void forEachDefInGroup(ActionGroup group, const Func& func)
+    {
+        for (const auto& action : group) {
+            if (action.kind != StackSlotActions::UseAction)
+                func(action.slotIndex);
+        }
+    }
+
+    template<typename Func>
+    void forEachUseAtTail(BasicBlock* block, const Func& func) const
+    {
+        auto blockActions = actions.actionsFor(block);
+        if (blockActions.empty() || blockActions.back().boundary != block->size())
+            return;
+        forEachUseInGroup(StackSlotActions::consumeLastGroup(blockActions), func);
+    }
+
+    const StackSlotActions& actions;
+};
+
+class StackSlotLiveness final : public WTF::Liveness<StackSlotLivenessAdapter> {
+    WTF_FORBID_HEAP_ALLOCATION;
+public:
+    StackSlotLiveness(Code& code, const StackSlotActions& actions)
+        : WTF::Liveness<StackSlotLivenessAdapter>(code.cfg(), actions)
+    {
+        CompilerTimingScope timingScope("Air"_s, "StackAllocator::liveness"_s);
+        compute();
+    }
+};
+
 class StackAllocatorBase {
 protected:
     StackAllocatorBase(Code& code)
@@ -56,54 +325,6 @@ protected:
     {
         for (unsigned i = 0; i < m_remappedStackSlotIndices.size(); ++i)
             m_remappedStackSlotIndices[i] = i;
-    }
-
-    // We will perform some spill coalescing. To make that effective, we need to be able to identify
-    // coalescable moves and handle them specially in interference analysis.
-    bool NODELETE isCoalescableMove(Inst& inst) const
-    {
-        if (!Options::coalesceSpillSlots())
-            return false;
-
-        Width width;
-        switch (inst.kind.opcode) {
-        case Move:
-            width = pointerWidth();
-            break;
-        case Move32:
-        case MoveFloat:
-            width = Width32;
-            break;
-        case MoveDouble:
-            width = Width64;
-            break;
-        case MoveVector:
-            width = Width128;
-            break;
-        default:
-            return false;
-        }
-
-        if (inst.args().size() != 3)
-            return false;
-
-        for (unsigned i = 0; i < 2; ++i) {
-            Arg arg = inst.args()[i];
-            if (!arg.isStack())
-                return false;
-            StackSlot* slot = arg.stackSlot();
-            if (slot->kind() != StackSlotKind::Spill)
-                return false;
-            if (slot->byteSize() != bytesForWidth(width))
-                return false;
-        }
-
-        return true;
-    }
-
-    bool NODELETE isUselessMove(Inst& inst) const
-    {
-        return isCoalescableMove(inst) && inst.args()[0] == inst.args()[1];
     }
 
     unsigned NODELETE remap(unsigned slotIndex) const
@@ -138,16 +359,20 @@ public:
         : StackAllocatorBase(code)
         , m_interference()
         , m_coalescableMoves()
+        , m_stats(code.proc().name())
     {
         m_interference.setMaxIndex(m_code.stackSlots().size());
     }
 
     void run(const Vector<StackSlot*>& assignedEscapedStackSlots)
     {
-        StackSlotLiveness liveness(m_code);
+        bool coalesceSpillSlots = Options::coalesceSpillSlots();
 
+        StackSlotActions actions(m_code, coalesceSpillSlots);
+        StackSlotLiveness liveness(m_code, actions);
         buildInterferenceGraph(liveness);
-        coalesceSlots();
+
+        coalesceSlots(coalesceSpillSlots, actions.sawUselessMove());
         assignStackLocations(assignedEscapedStackSlots);
 
         updateFrameSizeBasedOnStackSlots(m_code);
@@ -159,90 +384,131 @@ private:
     {
         CompilerTimingScope timingScope("Air"_s, "StackAllocator::build"_s);
 
+        const StackSlotActions& actions = liveness.actions;
+        auto workset = liveness.makeWorkset();
+
         for (BasicBlock* block : m_code) {
-            StackSlotLiveness::LocalCalc localCalc(liveness, block);
+            auto blockActions = actions.actionsFor(block);
+            auto killCandidates = actions.killCandidatesFor(block);
+            auto moveSites = actions.moveSitesFor(block);
 
-            auto interfere = [&] (unsigned instIndex) {
-                if (AirAllocateStackByGraphColoringInternal::verbose)
-                    dataLog("Interfering: ", WTF::pointerListDump(localCalc.live()), "\n");
+            if (!blockActions.empty() || !killCandidates.empty() || !moveSites.empty()) {
+                liveness.copyLiveAtTailInto(workset, block);
 
-                Inst* prevInst = block->get(instIndex);
-                Inst* nextInst = block->get(instIndex + 1);
-                if (prevInst && isCoalescableMove(*prevInst)) {
-                    CoalescableMove move(prevInst->args()[0].stackSlot()->index(), prevInst->args()[1].stackSlot()->index(), block->frequency());
+                for (;;) {
+                    // Visit boundaries from the tail down, skipping any that mentions no stack slot
+                    // and holds neither a kill candidate nor a coalescable move: those cannot change
+                    // the live set or add an edge. Each of the three spans is trimmed from the back
+                    // as its last entry is consumed, so their last entries are always the next
+                    // candidates going backwards.
 
-                    m_coalescableMoves.append(move);
+                    // Compute the next changing boundary from all three different source. And moving the cursor to the closest one.
+                    int64_t actionBoundary = blockActions.empty() ? -1 : static_cast<int64_t>(blockActions.back().boundary);
+                    int64_t killBoundary = killCandidates.empty() ? -1 : static_cast<int64_t>(killCandidates.back()) + 1;
+                    int64_t moveBoundary = moveSites.empty() ? -1 : static_cast<int64_t>(moveSites.back().instIndex) + 1;
+                    int64_t boundary = std::max({ actionBoundary, killBoundary, moveBoundary });
+                    if (boundary < 0)
+                        break;
 
-                    for (StackSlot* otherSlot : localCalc.live()) {
-                        unsigned otherSlotIndex = otherSlot->index();
-                        if (otherSlotIndex != move.src)
-                            addEdge(move.dst, otherSlotIndex);
+                    std::span<const StackSlotActions::Action> group;
+                    if (actionBoundary == boundary) {
+                        group = StackSlotActions::consumeLastGroup(blockActions);
+
+                        // Completes the previous boundary's transfer. The uses at the tail boundary are
+                        // already part of liveAtTail, so re-adding them is a harmless no-op.
+                        for (const auto& action : group) {
+                            if (action.kind == StackSlotActions::UseAction)
+                                workset.add(action.slotIndex);
+                        }
                     }
 
-                    prevInst = nullptr;
+                    if (AirAllocateStackByGraphColoringInternal::verbose) {
+                        dataLog("Boundary ", boundary, " of block ", block->index(), ", live:");
+                        workset.forEachSetBit(
+                            [&] (unsigned slotIndex) {
+                                dataLog(" ", pointerDump(m_code.stackSlots()[slotIndex]));
+                            });
+                        if (boundary)
+                            dataLog(", after: ", block->at(boundary - 1));
+                        dataLogLn();
+                    }
+
+                    // Kill dead stores. For simplicity we say that a store is killable if it has only late
+                    // defs and those late defs are to things that are dead right now. We only do that
+                    // because that's the only kind of dead stack store we will see here.
+                    bool killedPreviousInst = false;
+                    if (killBoundary == boundary) {
+                        uint32_t candidateInstIndex = consumeLast(killCandidates);
+
+                        // All late defs at this boundary belong to the candidate, so the store is dead
+                        // exactly when none of them is live here.
+                        bool isDeadStore = true;
+                        for (const auto& action : group) {
+                            if (action.kind == StackSlotActions::LateDefAction && workset.contains(action.slotIndex)) {
+                                isDeadStore = false;
+                                break;
+                            }
+                        }
+                        if (isDeadStore) {
+                            dataLogLnIf(AirAllocateStackByGraphColoringInternal::verbose, "Killing dead store: ", block->at(candidateInstIndex));
+                            block->at(candidateInstIndex) = Inst();
+                            killedPreviousInst = true;
+                        }
+                    }
+
+                    // A coalescable move's destination does not interfere with its source, so it is
+                    // handled separately and its late def is left out of the loop below. A killed
+                    // store is gone, so it can no longer be coalesced.
+                    bool previousInstIsCoalescableMove = false;
+                    if (moveBoundary == boundary) {
+                        const auto& site = consumeLast(moveSites);
+                        if (!killedPreviousInst) {
+                            previousInstIsCoalescableMove = true;
+                            m_coalescableMoves.append(CoalescableMove(site.src, site.dst, block->frequency()));
+                            workset.forEachSetBit(
+                                [&](unsigned otherSlotIndex) {
+                                    if (otherSlotIndex != site.src)
+                                        addEdge(site.dst, otherSlotIndex);
+                                });
+                        }
+                    }
+
+                    for (const auto& action : group) {
+                        if (action.kind == StackSlotActions::UseAction || !action.isSpill)
+                            continue;
+                        // All late defs at this boundary belong to the previous instruction, so they
+                        // are exactly what a kill or a coalescable move suppresses.
+                        if (action.kind == StackSlotActions::LateDefAction && (killedPreviousInst || previousInstIsCoalescableMove))
+                            continue;
+                        uint32_t slotIndex = action.slotIndex;
+                        workset.forEachSetBit(
+                            [&](unsigned otherSlotIndex) {
+                                addEdge(slotIndex, otherSlotIndex);
+                            });
+                    }
+
+                    for (const auto& action : group) {
+                        if (action.kind != StackSlotActions::UseAction)
+                            workset.remove(action.slotIndex);
+                    }
                 }
-                Inst::forEachDef<Arg>(
-                    prevInst, nextInst,
-                    [&] (Arg& arg, Arg::Role, Bank, Width) {
-                        if (!arg.isStack())
-                            return;
-                        StackSlot* slot = arg.stackSlot();
-                        if (slot->kind() != StackSlotKind::Spill)
-                            return;
 
-                        for (StackSlot* otherSlot : localCalc.live())
-                            addEdge(slot, otherSlot);
-                    });
-            };
-
-            for (unsigned instIndex = block->size(); instIndex--;) {
-                if (AirAllocateStackByGraphColoringInternal::verbose)
-                    dataLog("Analyzing: ", block->at(instIndex), "\n");
-
-                // Kill dead stores. For simplicity we say that a store is killable if it has only late
-                // defs and those late defs are to things that are dead right now. We only do that
-                // because that's the only kind of dead stack store we will see here.
-                Inst& inst = block->at(instIndex);
-                if (!inst.hasNonArgEffects()) {
-                    bool ok = true;
-                    inst.forEachArg(
-                        [&] (Arg& arg, Arg::Role role, Bank, Width) {
-                            if (Arg::isEarlyDef(role)) {
-                                ok = false;
-                                return;
-                            }
-                            if (!Arg::isLateDef(role))
-                                return;
-                            if (!arg.isStack()) {
-                                ok = false;
-                                return;
-                            }
-                            StackSlot* slot = arg.stackSlot();
-                            if (slot->kind() != StackSlotKind::Spill) {
-                                ok = false;
-                                return;
-                            }
-
-                            if (localCalc.isLive(slot)) {
-                                ok = false;
-                                return;
-                            }
-                        });
-                    if (ok)
-                        inst = Inst();
-                }
-
-                interfere(instIndex);
-                localCalc.execute(instIndex);
+                ASSERT(blockActions.empty() && killCandidates.empty() && moveSites.empty());
             }
-            interfere(-1);
 
+            // Unconditional because fixObviousSpills, which runs immediately before this phase, leaves
+            // the instructions it deletes in the block for a later pass to drop.
             block->insts().removeAllMatching(
                 [&] (const Inst& inst) -> bool {
                     return !inst;
                 });
         }
 
+        reportInterferenceGraph();
+    }
+
+    void reportInterferenceGraph()
+    {
         if (AirAllocateStackByGraphColoringInternal::reportLargeMemoryUses && m_interference.memoryUse() > 1024) {
             dataLog("GraphColoringStackAllocator stackSlots, interferenceGraph(kB), coalescable moves(kB): ", m_code.stackSlots().size(), " : ");
             m_interference.dumpMemoryUseInKB();
@@ -260,19 +526,24 @@ private:
         }
     }
 
-    void coalesceSlots()
+    void coalesceSlots(bool coalesceSpillSlots, bool sawUselessMove)
     {
         CompilerTimingScope timingScope("Air"_s, "StackAllocator::coalesce"_s);
 
         if (m_stats.collectingStats()) {
+            m_stats.numBlocks = m_code.size();
             m_stats.numStackSlots = m_code.stackSlots().size();
             m_stats.stackSlotInterferenceSizeBytes = m_interference.memoryUse();
             m_stats.numStackSlotsCoalesceableMoves = m_coalescableMoves.size();
         }
 
         // Now try to coalesce some moves.
+        if (m_coalescableMoves.isEmpty() && !sawUselessMove)
+            return;
+
         std::ranges::sort(m_coalescableMoves, std::ranges::greater { }, &CoalescableMove::frequency);
 
+        bool anyRemapHappened = false;
         for (const CoalescableMove& move : m_coalescableMoves) {
             IndexType slotToKill = remap(move.src);
             IndexType slotToKeep = remap(move.dst);
@@ -283,11 +554,15 @@ private:
 
             m_stats.numStackSlotsCoalesced++;
             m_remappedStackSlotIndices[slotToKill] = slotToKeep;
+            anyRemapHappened = true;
 
             for (IndexType interferingSlot : m_interference[slotToKill])
                 addEdge(interferingSlot, slotToKeep);
             m_interference.mayClear(slotToKill);
         }
+
+        if (!anyRemapHappened && !sawUselessMove)
+            return;
 
         for (BasicBlock* block : m_code) {
             for (Inst& inst : *block) {
@@ -295,7 +570,7 @@ private:
                     if (arg.isStack())
                         arg = Arg::stack(remapStackSlot(arg.stackSlot()), arg.offset());
                 }
-                if (isUselessMove(inst))
+                if (isUselessMove(inst, coalesceSpillSlots))
                     inst = Inst();
             }
         }
@@ -308,7 +583,7 @@ private:
         // Now we assign stack locations. At its heart this algorithm is just first-fit. For each
         // StackSlot we just want to find the offsetFromFP that is least negative while ensuring no
         // overlap with other StackSlots that this overlaps with.
-        Vector<StackSlot*> otherSlots = assignedEscapedStackSlots;
+        Vector<StackSlot*> otherSlots;
         for (StackSlot* slot : m_code.stackSlots()) {
             if (isRemappedSlotIndex(slot->index()))
                 continue;
@@ -369,11 +644,6 @@ private:
         m_interference.add(u, v);
     }
 
-    void addEdge(StackSlot* u, StackSlot* v)
-    {
-        addEdge(u->index(), v->index());
-    }
-
     InterferenceGraph m_interference;
     Vector<CoalescableMove> m_coalescableMoves;
     AirStackAllocatorStats m_stats;
@@ -397,10 +667,15 @@ void allocateStackByGraphColoring(Code& code)
 {
     PhaseScope phaseScope(code, "allocateStackByGraphColoring"_s);
 
-    handleCalleeSaves(code);
+    {
+        CompilerTimingScope timingScope("Air"_s, "StackAllocator::calleeSaves"_s);
+        handleCalleeSaves(code);
+    }
 
-    Vector<StackSlot*> assignedEscapedStackSlots =
-        allocateAndGetEscapedStackSlotsWithoutChangingFrameSize(code);
+    Vector<StackSlot*> assignedEscapedStackSlots = [&] {
+        CompilerTimingScope timingScope("Air"_s, "StackAllocator::escapedSlots"_s);
+        return allocateAndGetEscapedStackSlotsWithoutChangingFrameSize(code);
+    }();
 
     if (!doTrivialStackAllocation(code)) {
         if (code.stackSlots().size() < WTF::maxSizeForSmallInterferenceGraph) {
@@ -421,4 +696,3 @@ void allocateStackByGraphColoring(Code& code)
 } } } // namespace JSC::B3::Air
 
 #endif // ENABLE(B3_JIT)
-

--- a/Source/JavaScriptCore/b3/air/AirLiveness.h
+++ b/Source/JavaScriptCore/b3/air/AirLiveness.h
@@ -44,7 +44,7 @@ public:
         : WTF::Liveness<Adapter>(code.cfg(), code)
     {
         SuperSamplerScope samplingScope(false);
-        CompilerTimingScope timingScope("Air"_s, "Liveness"_s);
+        CompilerTimingScope timingScope("Air"_s, Adapter::name);
         WTF::Liveness<Adapter>::compute();
     }
 };
@@ -57,7 +57,6 @@ using TmpLiveness = Liveness<TmpLivenessAdapter<bank, minimumTemperature>>;
 typedef Liveness<TmpLivenessAdapter<GP>> GPLiveness;
 typedef Liveness<TmpLivenessAdapter<FP>> FPLiveness;
 typedef Liveness<UnifiedTmpLivenessAdapter> UnifiedTmpLiveness;
-typedef Liveness<StackSlotLivenessAdapter> StackSlotLiveness;
 
 } } } // namespace JSC::B3::Air
 

--- a/Source/JavaScriptCore/b3/air/AirLivenessAdapter.h
+++ b/Source/JavaScriptCore/b3/air/AirLivenessAdapter.h
@@ -131,6 +131,38 @@ public:
         return block->size();
     }
 
+    // Nearly every instruction mentions a Tmp, so every boundary is worth visiting and a group is
+    // just the one record that holds both of that boundary's lists.
+    using ActionGroup = Actions*;
+
+    template<typename Func>
+    void forEachActionGroupDescending(BasicBlock* block, const Func& func)
+    {
+        ActionsForBoundary& actionsForBoundary = actions[block];
+        for (unsigned boundary = block->size() + 1; boundary--;)
+            func(boundary, &actionsForBoundary[boundary]);
+    }
+
+    template<typename Func>
+    static void forEachUseInGroup(ActionGroup group, const Func& func)
+    {
+        for (unsigned index : group->use)
+            func(index);
+    }
+
+    template<typename Func>
+    static void forEachDefInGroup(ActionGroup group, const Func& func)
+    {
+        for (unsigned index : group->def)
+            func(index);
+    }
+
+    template<typename Func>
+    void forEachUseAtTail(BasicBlock* block, const Func& func)
+    {
+        forEachUse(block, block->size(), func);
+    }
+
     template<typename Func>
     void forEachUse(BasicBlock* block, size_t instBoundaryIndex, const Func& func)
     {
@@ -155,7 +187,7 @@ struct TmpLivenessAdapter : LivenessAdapter<TmpLivenessAdapter<adapterBank, mini
 public:
     typedef LivenessAdapter<TmpLivenessAdapter<adapterBank, minimumTemperature>> Base;
 
-    static constexpr const char* name = "TmpLiveness";
+    static constexpr ASCIILiteral name = "TmpLiveness"_s;
     typedef Tmp Thing;
 
     TmpLivenessAdapter(Code& code)
@@ -186,7 +218,7 @@ struct UnifiedTmpLivenessAdapter : LivenessAdapter<UnifiedTmpLivenessAdapter> {
 public:
     typedef LivenessAdapter<UnifiedTmpLivenessAdapter> Base;
 
-    static constexpr const char* name = "UnifiedTmpLiveness";
+    static constexpr ASCIILiteral name = "UnifiedTmpLiveness"_s;
 
     typedef Tmp Thing;
 
@@ -204,27 +236,6 @@ public:
     static bool acceptsRole(Arg::Role) { return true; }
     unsigned valueToIndex(Tmp tmp) { return tmp.linearlyIndexed(code).index(); }
     Tmp indexToValue(unsigned index) { return Tmp::tmpForLinearIndex(code, index); }
-};
-
-struct StackSlotLivenessAdapter : LivenessAdapter<StackSlotLivenessAdapter> {
-    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(StackSlotLivenessAdapter);
-public:
-    static constexpr const char* name = "StackSlotLiveness";
-    typedef StackSlot* Thing;
-
-    StackSlotLivenessAdapter(Code& code)
-        : LivenessAdapter(code)
-    {
-    }
-
-    unsigned numIndices()
-    {
-        return code.stackSlots().size();
-    }
-    static bool acceptsBank(Bank) { return true; }
-    static bool acceptsRole(Arg::Role) { return true; }
-    static unsigned valueToIndex(StackSlot* stackSlot) { return stackSlot->index(); }
-    StackSlot* indexToValue(unsigned index) { return code.stackSlots()[index]; }
 };
 
 } } } // namespace JSC::B3::Air

--- a/Source/JavaScriptCore/b3/air/AirStackAllocatorStats.h
+++ b/Source/JavaScriptCore/b3/air/AirStackAllocatorStats.h
@@ -32,6 +32,7 @@
 namespace JSC { namespace B3 { namespace Air {
 
 #define FOR_EACH_STACK_ALLOCATOR_STAT(macro) \
+    macro(numBlocks)                         \
     macro(numStackSlots)                     \
     macro(stackSlotInterferenceSizeBytes)    \
     macro(numStackSlotsCoalesceableMoves)    \
@@ -40,7 +41,7 @@ namespace JSC { namespace B3 { namespace Air {
 
 class AirStackAllocatorStats {
 public:
-    AirStackAllocatorStats() = default;
+    AirStackAllocatorStats(const String& label = { }) { setLabel(label); }
 
     ASCIILiteral name() const { return "StackAlloc"_s; }
 

--- a/Source/WTF/wtf/Liveness.h
+++ b/Source/WTF/wtf/Liveness.h
@@ -62,26 +62,11 @@ private:
         return (numBits + wordBits - 1) / wordBits;
     }
 
+public:
+    // A live set that a client can walk backwards through a block itself, in index space rather than
+    // Thing space. Its representation follows whichever one the fixpoint used.
     class Workset {
     public:
-        void initialize(Storage storage, size_t wordsPerSet)
-        {
-            m_storage = storage;
-            if (storage == Storage::Dense)
-                m_dense.fill(0, wordsPerSet);
-            else
-                m_dense.clear();
-            m_sparse.clear();
-        }
-
-        void clear()
-        {
-            if (m_storage == Storage::Dense)
-                std::ranges::fill(m_dense, 0);
-            else
-                m_sparse.clear();
-        }
-
         bool add(unsigned bit)
         {
             if (m_storage == Storage::Dense) {
@@ -118,6 +103,39 @@ private:
             return m_sparse.contains(bit);
         }
 
+        template<typename Func>
+        void forEachSetBit(const Func& func) const
+        {
+            if (m_storage == Storage::Sparse) {
+                m_sparse.forEachSetBit(func);
+                return;
+            }
+            WTF::forEachSetBit(m_dense.span(), [&] (size_t bit) {
+                func(static_cast<unsigned>(bit));
+            });
+        }
+
+    private:
+        friend class Liveness;
+
+        void initialize(Storage storage, size_t wordsPerSet)
+        {
+            m_storage = storage;
+            if (storage == Storage::Dense)
+                m_dense.fill(0, wordsPerSet);
+            else
+                m_dense.clear();
+            m_sparse.clear();
+        }
+
+        void clear()
+        {
+            if (m_storage == Storage::Dense)
+                std::ranges::fill(m_dense, 0);
+            else
+                m_sparse.clear();
+        }
+
         void copyFromDense(std::span<const uint64_t> source)
         {
             ASSERT(m_storage == Storage::Dense);
@@ -135,12 +153,33 @@ private:
         std::span<const uint64_t> denseSpan() const LIFETIME_BOUND { return m_dense.span(); }
         const SparseBitVector<>& sparse() const LIFETIME_BOUND { return m_sparse; }
 
-    private:
         Vector<uint64_t> m_dense;
         SparseBitVector<> m_sparse;
         Storage m_storage { Storage::Dense };
     };
 
+    // Lets a client run its own backward walk over a block, for the passes that visit only some of
+    // the boundaries and so cannot use LocalCalc. Only valid once compute() has run, since the
+    // workset has to be built in whichever representation the fixpoint chose.
+    Workset makeWorkset()
+    {
+        ASSERT(m_computed);
+        Workset workset;
+        workset.initialize(m_storage, m_wordsPerSet);
+        return workset;
+    }
+
+    void copyLiveAtTailInto(Workset& workset, typename CFG::Node block)
+    {
+        ASSERT(m_computed);
+        ASSERT(workset.storage() == m_storage);
+        if (m_storage == Storage::Dense)
+            workset.copyFromDense(denseTailSlice(block->index()));
+        else
+            workset.copyFromSparse(sparseTail(block->index()));
+    }
+
+private:
     class Iterator {
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(Iterator);
     public:
@@ -253,7 +292,8 @@ public:
         Storage m_storage { Storage::Dense };
     };
 
-    // This calculator has to be run in reverse.
+    // This calculator has to be run in reverse. It needs forEachUse/forEachDef, so an adapter whose
+    // store cannot address an arbitrary boundary drives makeWorkset instead of this.
     class LocalCalc {
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(LocalCalc);
     public:
@@ -261,11 +301,7 @@ public:
             : m_liveness(liveness)
             , m_block(block)
         {
-            Workset& workset = liveness.m_workset;
-            if (liveness.m_storage == Storage::Dense)
-                workset.copyFromDense(liveness.denseTailSlice(block->index()));
-            else
-                workset.copyFromSparse(liveness.sparseTail(block->index()));
+            liveness.copyLiveAtTailInto(liveness.m_workset, block);
         }
 
         class Iterable {
@@ -462,28 +498,28 @@ protected:
             auto genSet = setFor(genMatrix, blockIndex);
             auto liveOutSet = setFor(liveOutMatrix, blockIndex);
 
-            // gen = transfer function applied to an empty live-out: the uses exposed at the head.
+            // gen = the transfer function applied to an empty live-out: the uses exposed at the head.
             // The fixpoint below works purely on gen/kill/liveOut, so this is the only place that
-            // walks instructions. This sweep reaches boundary blockSize down to 1 and then boundary
-            // 0, which is every boundary, so it collects kill as well.
+            // walks the block.
             m_workset.clear();
-            for (size_t instIndex = Adapter::blockSize(block); instIndex--;) {
-                Adapter::forEachDef(block, instIndex + 1, [&] (unsigned index) {
-                    m_workset.remove(index);
-                    setBit(killSet, index);
+            unsigned blockSize = Adapter::blockSize(block);
+            Adapter::forEachActionGroupDescending(block,
+                [&] (unsigned boundary, typename Adapter::ActionGroup group) {
+                    // The uses at the tail boundary are live-out rather than gen, and are seeded
+                    // below.
+                    if (boundary != blockSize)
+                        Adapter::forEachUseInGroup(group, [&] (unsigned index) { m_workset.add(index); });
+                    Adapter::forEachDefInGroup(group, [&] (unsigned index) {
+                        m_workset.remove(index);
+                        setBit(killSet, index);
+                    });
                 });
-                Adapter::forEachUse(block, instIndex, [&] (unsigned index) { m_workset.add(index); });
-            }
-            Adapter::forEachDef(block, 0, [&] (unsigned index) {
-                m_workset.remove(index);
-                setBit(killSet, index);
-            });
             std::span<const uint64_t> worksetSpan = m_workset.denseSpan();
             for (size_t i = 0; i < m_wordsPerSet; ++i)
                 genSet[i] = worksetSpan[i];
 
             // liveOut automatically contains the LateUse's of the terminal.
-            Adapter::forEachUse(block, Adapter::blockSize(block), [&] (unsigned index) {
+            Adapter::forEachUseAtTail(block, [&] (unsigned index) {
                 setBit(liveOutSet, index);
             });
 
@@ -539,6 +575,10 @@ protected:
                     worklist.append(predecessor->index());
             }
         }
+
+#if ASSERT_ENABLED
+        m_computed = true;
+#endif
     }
 
     // Sparse fallback for functions whose dense matrices would exceed the budget.
@@ -563,8 +603,8 @@ protected:
 
             // liveAtTail automatically contains the LateUse's of the terminal.
             auto& liveAtTail = sparseTail(blockIndex);
-            Adapter::forEachUse(
-                block, Adapter::blockSize(block),
+            Adapter::forEachUseAtTail(
+                block,
                 [&] (unsigned index) {
                     liveAtTail.set(index);
                 });
@@ -587,11 +627,13 @@ protected:
                 [&] (unsigned index) {
                     m_workset.add(index);
                 });
-            for (size_t instIndex = Adapter::blockSize(block); instIndex--;) {
-                Adapter::forEachDef(block, instIndex + 1, [&] (unsigned index) { m_workset.remove(index); });
-                Adapter::forEachUse(block, instIndex, [&] (unsigned index) { m_workset.add(index); });
-            }
-            Adapter::forEachDef(block, 0, [&] (unsigned index) { m_workset.remove(index); });
+            // The uses at the tail boundary are already in the tail set, so re-adding them here is a
+            // no-op and needs no special case.
+            Adapter::forEachActionGroupDescending(block,
+                [&] (unsigned, typename Adapter::ActionGroup group) {
+                    Adapter::forEachUseInGroup(group, [&] (unsigned index) { m_workset.add(index); });
+                    Adapter::forEachDefInGroup(group, [&] (unsigned index) { m_workset.remove(index); });
+                });
 
             auto& liveAtHead = sparseHead(blockIndex);
             delta.shrink(0);
@@ -614,6 +656,10 @@ protected:
                     worklist.append(predecessor->index());
             }
         }
+
+#if ASSERT_ENABLED
+        m_computed = true;
+#endif
     }
 
 private:
@@ -624,14 +670,9 @@ private:
 
     void forEachInDense(std::span<const uint64_t> set, const Invocable<void(const Thing&)> auto& func)
     {
-        for (size_t wordIndex = 0; wordIndex < m_wordsPerSet; ++wordIndex) {
-            uint64_t word = set[wordIndex];
-            while (word) {
-                unsigned bit = std::countr_zero(word);
-                word &= word - 1;
-                func(this->indexToValue(static_cast<unsigned>(wordIndex * wordBits + bit)));
-            }
-        }
+        WTF::forEachSetBit(set, [&] (size_t index) {
+            func(this->indexToValue(static_cast<unsigned>(index)));
+        });
     }
 
     void forEachInSparse(const SparseBitVector<>& set, const Invocable<void(const Thing&)> auto& func)
@@ -685,6 +726,9 @@ private:
     Vector<SparseBitVector<>> m_sparseStore;
     size_t m_wordsPerSet { 0 };
     Storage m_storage { Storage::Dense };
+#if ASSERT_ENABLED
+    bool m_computed { false };
+#endif
 };
 
 } // namespace WTF


### PR DESCRIPTION
#### 5e03b0c541d3895e5a12a6b032185901e5e4d738
<pre>
[JSC] Make Air stack slot liveness sparse in instructions
<a href="https://bugs.webkit.org/show_bug.cgi?id=323526">https://bugs.webkit.org/show_bug.cgi?id=323526</a>
<a href="https://rdar.apple.com/186767924">rdar://186767924</a>

Reviewed by Yijia Huang.

Normally Spill stack use is much limited even in very large program
compared to pure register / normal-stack / memory-location only instructions.
Even in very large function in sqlite3-wasm is having ~7% of
instructions using spill stack. However AirAllocateStackByGraphColoring
is walking over all Air instructions repeatedly while most of
instructions are meaningless since they do not have spills. In this
patch, we leverage this sparse characteristics to accelerate performance
of this phase. We first walk all Air instructions to collect actions,
kill-candidates, move-coalescable-sites in one forward pass. And we run
liveness analysis over this collected actions instead. This means that
overall graph size gets dramatically smaller (~10%) compared to
repeatedly scanning entire Air graph. Then, when building inference
graph, we step over spill action boundaries instead of instruction-index
step by step, this skips many non-interesting instructions automatically
and offers quick graph computation.

The analysis and achievement are exactly the same. And this is roughly
cutting 50% of time in this phase.

* Source/JavaScriptCore/b3/B3VariableLiveness.h:
(JSC::B3::VariableLivenessAdapter::forEachActionGroupDescending):
(JSC::B3::VariableLivenessAdapter::forEachUseInGroup):
(JSC::B3::VariableLivenessAdapter::forEachDefInGroup):
(JSC::B3::VariableLivenessAdapter::forEachUseAtTail):
* Source/JavaScriptCore/b3/air/AirAllocateStackByGraphColoring.cpp:
(JSC::B3::Air::allocateStackByGraphColoring):
* Source/JavaScriptCore/b3/air/AirLiveness.h:
(JSC::B3::Air::Liveness::Liveness):
* Source/JavaScriptCore/b3/air/AirLivenessAdapter.h:
(JSC::B3::Air::LivenessAdapter::forEachActionGroupDescending):
(JSC::B3::Air::LivenessAdapter::forEachUseInGroup):
(JSC::B3::Air::LivenessAdapter::forEachDefInGroup):
(JSC::B3::Air::LivenessAdapter::forEachUseAtTail):
(JSC::B3::Air::StackSlotLivenessAdapter::StackSlotLivenessAdapter): Deleted.
(JSC::B3::Air::StackSlotLivenessAdapter::numIndices): Deleted.
(JSC::B3::Air::StackSlotLivenessAdapter::acceptsBank): Deleted.
(JSC::B3::Air::StackSlotLivenessAdapter::acceptsRole): Deleted.
(JSC::B3::Air::StackSlotLivenessAdapter::valueToIndex): Deleted.
(JSC::B3::Air::StackSlotLivenessAdapter::indexToValue): Deleted.
* Source/JavaScriptCore/b3/air/AirStackAllocatorStats.h:
(JSC::B3::Air::AirStackAllocatorStats::AirStackAllocatorStats):
* Source/WTF/wtf/Liveness.h:
(WTF::Liveness::Workset::forEachSetBit const):
(WTF::Liveness::Workset::initialize):
(WTF::Liveness::Workset::clear):
(WTF::Liveness::makeWorkset):
(WTF::Liveness::copyLiveAtTailInto):
(WTF::Liveness::LocalCalc::LocalCalc):
(WTF::Liveness::computeDense):
(WTF::Liveness::computeSparse):
(WTF::Liveness::forEachInDense):

Canonical link: <a href="https://commits.webkit.org/320943@main">https://commits.webkit.org/320943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c17bbb0cca7a8486a6fffd7d46ed107bff185ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150774 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a1bd27bf-e0e8-4747-affb-486dd7cd823b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59825 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145499 "Found 1 new test failure: fast/dom/lazy-image-loading-document-leak.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100858 "4 flakes 14 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f611933d-2e8e-4e93-8268-2c877af2cd46) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189184 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125834 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c676291b-e316-41e3-b461-d96fa18c1f83) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47907 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45888 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7680 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14553 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158260 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45623 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7581 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47457 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52610 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198496 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59771 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155072 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60481 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42197 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154715 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28295 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49142 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132737 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129894 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58908 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20602 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58310 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58528 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58374 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->