### PR TITLE
[IPC] Blob registry messages carrying a null URL crash the network process

### DIFF
--- a/LayoutTests/ipc/blob-registry-null-url-crash-expected.txt
+++ b/LayoutTests/ipc/blob-registry-null-url-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/blob-registry-null-url-crash.html
+++ b/LayoutTests/ipc/blob-registry-null-url-crash.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=true ] -->
+<title>Blob registry messages carrying a null URL must not crash the network process</title>
+<p>This test passes if WebKit does not crash.</p>
+<script>
+testRunner?.dumpAsText();
+testRunner?.waitUntilDone();
+</script>
+<script type="module">
+if (!window.IPC) {
+    testRunner?.notifyDone();
+} else {
+
+const { CoreIPC } = await import('./coreipc.js');
+const networking = CoreIPC.Networking.NetworkConnectionToWebProcess;
+const connection = 0;
+
+// A null String is not a valid key for the blob registry's maps.
+const nullURL = { string: null };
+const internalURL = () => ({ string: `blob:blobinternal:///${crypto.randomUUID()}` });
+const noTopOrigin = { };
+const policyContainer = {
+    contentSecurityPolicyResponseHeaders: { headers: [], httpStatusCode: 0 },
+    crossOriginEmbedderPolicy: { value: 0, reportOnlyValue: 0, reportingEndpoint: '', reportOnlyReportingEndpoint: '' },
+    crossOriginOpenerPolicy: { value: 0, reportOnlyValue: 0, reportingEndpoint: '', reportOnlyReportingEndpoint: '' },
+    referrerPolicy: 0,
+};
+
+// A lookup returns early while the registry's table is still null, so register a real blob first to
+// make sure the null keys below actually reach the hash function.
+const registeredBlobURL = URL.createObjectURL(new Blob([new Uint8Array([1, 2, 3])]));
+
+networking.RegisterInternalBlobURL(connection, { url: nullURL, blobParts: [], contentType: '' });
+networking.RegisterBlobURL(connection, { url: nullURL, srcURL: nullURL, policyContainer, topOrigin: noTopOrigin });
+networking.RegisterInternalBlobURLForSlice(connection, { url: nullURL, srcURL: nullURL, start: 0, end: 1, contentType: '' });
+networking.UnregisterBlobURL(connection, { url: nullURL, topOrigin: noTopOrigin });
+networking.RegisterBlobURLHandle(connection, { url: nullURL, topOrigin: noTopOrigin });
+networking.UnregisterBlobURLHandle(connection, { url: nullURL, topOrigin: noTopOrigin });
+
+networking.RegisterInternalBlobURL(connection, {
+    url: internalURL(),
+    blobParts: [{ m_dataOrURL: { variantType: 'URL', variant: nullURL } }],
+    contentType: 'application/octet-stream',
+});
+networking.RegisterBlobURL(connection, { url: internalURL(), srcURL: nullURL, policyContainer, topOrigin: noTopOrigin });
+networking.RegisterInternalBlobURLForSlice(connection, { url: internalURL(), srcURL: nullURL, start: 0, end: 1, contentType: '' });
+
+networking.BlobType(connection, { url: nullURL }, () => { });
+networking.BlobSize(connection, { url: nullURL }, () => { });
+
+// A null String in the blob URL vector, which reaches both BlobRegistryImpl::filesInBlob and
+// BlobRegistryImpl::populateBlobsForFileWriting.
+networking.WriteBlobsToTemporaryFilesForIndexedDB(connection, { blobURLs: [null, registeredBlobURL] }, () => {
+    URL.revokeObjectURL(registeredBlobURL);
+    testRunner?.notifyDone();
+});
+
+}
+</script>

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -196,7 +196,10 @@ void BlobRegistryImpl::registerInternalBlobURL(const URL& url, Vector<BlobPart>&
             break;
         }
         case BlobPart::Type::Blob: {
-            if (RefPtr blob = m_blobs.get(part.url().string()))
+            auto& partURLKey = part.url().string();
+            if (!m_blobs.isValidKey(partURLKey))
+                break;
+            if (RefPtr blob = m_blobs.get(partURLKey))
                 blobData->m_items.appendVector(blob->items());
             break;
         }
@@ -282,8 +285,10 @@ void BlobRegistryImpl::registerInternalBlobURLForSlice(const URL& url, const URL
 void BlobRegistryImpl::unregisterBlobURL(const URL& url, const std::optional<WebCore::SecurityOriginData>& topOrigin)
 {
     ASSERT(isMainThread());
-    ASSERT(BlobURL::isInternalURL(url) || topOrigin);
     auto& urlKey = url.string();
+    if (!m_blobs.isValidKey(urlKey))
+        return;
+    ASSERT(BlobURL::isInternalURL(url) || topOrigin);
     if (topOrigin && topOrigin != m_allowedBlobURLTopOrigins.get(urlKey)) {
         RELEASE_LOG_ERROR(Network, "BlobRegistryImpl::unregisterBlobURL: (%p) Rejecting unregistering blob URL with incorrect top origin.", this);
         return;
@@ -298,6 +303,8 @@ BlobData* BlobRegistryImpl::blobDataFromURL(const URL& url, const std::optional<
 {
     ASSERT(isMainThread());
     auto urlKey = url.stringWithoutFragmentIdentifier();
+    if (!m_blobs.isValidKey(urlKey))
+        return nullptr;
     if (topOrigin && topOrigin != m_allowedBlobURLTopOrigins.get(urlKey)) {
         RELEASE_LOG_ERROR(Network, "BlobRegistryImpl::blobDataFromURL: (%p) Requested blob URL with incorrect top origin.", this);
         return nullptr;
@@ -433,6 +440,8 @@ Vector<Ref<BlobDataFileReference>> BlobRegistryImpl::filesInBlob(const URL& url,
 
 void BlobRegistryImpl::addBlobData(const String& url, Ref<BlobData>&& blobData, const std::optional<WebCore::SecurityOriginData>& topOrigin)
 {
+    if (!m_blobs.isValidKey(url))
+        return;
     ASSERT(BlobURL::isInternalURL(URL { { }, url }) || topOrigin);
     auto addResult = m_blobs.set(url, WTF::move(blobData));
     if (!addResult.isNewEntry)
@@ -444,8 +453,10 @@ void BlobRegistryImpl::addBlobData(const String& url, Ref<BlobData>&& blobData, 
 
 void BlobRegistryImpl::registerBlobURLHandle(const URL& url, const std::optional<WebCore::SecurityOriginData>& topOrigin)
 {
-    ASSERT(BlobURL::isInternalURL(url) || topOrigin);
     auto urlKey = url.stringWithoutFragmentIdentifier();
+    if (!m_blobs.isValidKey(urlKey))
+        return;
+    ASSERT(BlobURL::isInternalURL(url) || topOrigin);
     if (!m_blobs.contains(urlKey))
         return;
     if (topOrigin && topOrigin != m_allowedBlobURLTopOrigins.get(urlKey)) {
@@ -457,8 +468,10 @@ void BlobRegistryImpl::registerBlobURLHandle(const URL& url, const std::optional
 
 void BlobRegistryImpl::unregisterBlobURLHandle(const URL& url, const std::optional<WebCore::SecurityOriginData>& topOrigin)
 {
-    ASSERT(BlobURL::isInternalURL(url) || topOrigin);
     auto urlKey = url.stringWithoutFragmentIdentifier();
+    if (!m_blobs.isValidKey(urlKey))
+        return;
+    ASSERT(BlobURL::isInternalURL(url) || topOrigin);
     if (topOrigin && topOrigin != m_allowedBlobURLTopOrigins.get(urlKey)) {
         RELEASE_LOG_ERROR(Network, "BlobRegistryImpl::unregisterBlobURLHandle: (%p) Rejecting unregistering blob URL handle with incorrect top origin", this);
         return;

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1175,6 +1175,7 @@ void NetworkConnectionToWebProcess::registerInternalFileBlobURL(const URL& url, 
 
 void NetworkConnectionToWebProcess::registerInternalBlobURL(const URL& url, Vector<BlobPart>&& blobParts, const String& contentType)
 {
+    MESSAGE_CHECK(!url.isEmpty());
     CheckedPtr session = networkSession();
     if (!session)
         return;
@@ -1185,6 +1186,7 @@ void NetworkConnectionToWebProcess::registerInternalBlobURL(const URL& url, Vect
 
 void NetworkConnectionToWebProcess::registerBlobURL(const URL& url, const URL& srcURL, PolicyContainer&& policyContainer, const std::optional<SecurityOriginData>& topOrigin)
 {
+    MESSAGE_CHECK(!url.isEmpty());
     CheckedPtr session = networkSession();
     if (!session)
         return;
@@ -1208,6 +1210,7 @@ void NetworkConnectionToWebProcess::registerInternalBlobURLOptionallyFileBacked(
 
 void NetworkConnectionToWebProcess::registerInternalBlobURLForSlice(const URL& url, const URL& srcURL, int64_t start, int64_t end, const String& contentType)
 {
+    MESSAGE_CHECK(!url.isEmpty());
     CheckedPtr session = networkSession();
     if (!session)
         return;
@@ -1218,6 +1221,7 @@ void NetworkConnectionToWebProcess::registerInternalBlobURLForSlice(const URL& u
 
 void NetworkConnectionToWebProcess::unregisterBlobURL(const URL& url, const std::optional<WebCore::SecurityOriginData>& topOrigin)
 {
+    MESSAGE_CHECK(!url.isEmpty());
     CheckedPtr session = networkSession();
     if (!session)
         return;
@@ -1228,6 +1232,7 @@ void NetworkConnectionToWebProcess::unregisterBlobURL(const URL& url, const std:
 
 void NetworkConnectionToWebProcess::registerBlobURLHandle(const URL& url, const std::optional<SecurityOriginData>& topOrigin)
 {
+    MESSAGE_CHECK(!url.isEmpty());
     CheckedPtr session = networkSession();
     if (!session)
         return;
@@ -1238,6 +1243,7 @@ void NetworkConnectionToWebProcess::registerBlobURLHandle(const URL& url, const 
 
 void NetworkConnectionToWebProcess::unregisterBlobURLHandle(const URL& url, const std::optional<SecurityOriginData>& topOrigin)
 {
+    MESSAGE_CHECK(!url.isEmpty());
     CheckedPtr session = networkSession();
     if (!session)
         return;


### PR DESCRIPTION
#### ad8eace7e8e7d59ba0b106f71c388c0c4e602940
<pre>
[IPC] Blob registry messages carrying a null URL crash the network process
<a href="https://bugs.webkit.org/show_bug.cgi?id=323525">https://bugs.webkit.org/show_bug.cgi?id=323525</a>
<a href="https://rdar.apple.com/185199578">rdar://185199578</a>

Reviewed by Sihui Liu.

A null String is HashTraits&lt;String&gt;::emptyValue() — the hash table&apos;s empty-bucket marker — so it can never legally be a key. And the key is hashed before the table is probed or validated: StringHash::hash and URLHash::hash both do an unconditional impl()-&gt;hash(), which faults at StringImpl + 0x10 (m_hashAndFlags) when the impl is null.

This commit rejects the null URL string before it ever reaches a hash operation:

- BlobRegistryImpl — the lookups (blobDataFromURL, registerBlobURLHandle, addBlobData, …) return the &quot;no such blob&quot; answer they&apos;d have given for an unregistered URL, so no caller behaviour changes for valid input.
- NetworkConnectionToWebProcess — the register/unregister messages bail before touching m_blobURLs / m_blobURLHandles, which are keyed by URL and hash the same way.

Nothing downstream needs the null case to work: a null URL can never match a registered blob, so &quot;reject early&quot; and &quot;look it up&quot; have the same result for every input a well-behaved web process can send.

Test: ipc/blob-registry-null-url-crash.html

* LayoutTests/ipc/blob-registry-null-url-crash-expected.txt: Added.
* LayoutTests/ipc/blob-registry-null-url-crash.html: Added.
* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::isValidBlobURLKey):
(WebCore::BlobRegistryImpl::registerInternalBlobURL):
(WebCore::BlobRegistryImpl::unregisterBlobURL):
(WebCore::BlobRegistryImpl::blobDataFromURL const):
(WebCore::BlobRegistryImpl::addBlobData):
(WebCore::BlobRegistryImpl::registerBlobURLHandle):
(WebCore::BlobRegistryImpl::unregisterBlobURLHandle):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::registerInternalBlobURL):
(WebKit::NetworkConnectionToWebProcess::registerBlobURL):
(WebKit::NetworkConnectionToWebProcess::registerInternalBlobURLForSlice):
(WebKit::NetworkConnectionToWebProcess::unregisterBlobURL):
(WebKit::NetworkConnectionToWebProcess::registerBlobURLHandle):
(WebKit::NetworkConnectionToWebProcess::unregisterBlobURLHandle):

Canonical link: <a href="https://commits.webkit.org/320859@main">https://commits.webkit.org/320859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/413e5d65c6d5eb361f8a53c613bd4d6ac2bfe7dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196419 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07b9e9ad-3c24-4796-9b8e-0cbaf52240c0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59743 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/17a67171-c168-4c25-aefd-2ca01fdee551) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189083 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/49114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125766 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/47847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/158201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45560 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7490 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/50288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198397 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59680 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165492 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/155004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41513 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60392 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/154641 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49080 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129806 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58831 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58224 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58453 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58283 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->