### PR TITLE
SVGLength resolves 'ex' by rounding the font's x-height up to a whole pixel

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ex-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ex-expected.txt
@@ -1,0 +1,5 @@
+
+PASS ex unit in SVGLength
+PASS Convert back to ex from new user unit value
+PASS ex unit resolves against the fractional x-height
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ex.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ex.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<title>SVGLength with 'ex' unit</title>
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGLength">
+<link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGLength__value">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#ex_ref, text {
+  font-family:initial;
+  font-size:20px;
+}
+</style>
+<div id="ex_ref" style="height:10ex;"></div>
+<svg>
+  <text id="ex_test" x="10ex"/>
+</svg>
+<script>
+  let ex_ref = document.getElementById("ex_ref");
+  let ref_height = ex_ref.getBoundingClientRect().height;
+  let ex_test = document.getElementById("ex_test");
+  let ex_length = ex_test.x.baseVal[0];
+
+  test(() => {
+    assert_equals(ex_length.unitType, SVGLength.SVG_LENGTHTYPE_EXS);
+    assert_approx_equals(ex_length.value, ref_height, 0.1);
+  }, "ex unit in SVGLength");
+
+  test(() => {
+    ex_length.value = ref_height * 4;
+    assert_approx_equals(ex_length.valueInSpecifiedUnits, 40, 0.3);
+    ex_length.value = ref_height;
+    assert_approx_equals(ex_length.value, ref_height, 0.3);
+  }, "Convert back to ex from new user unit value");
+
+  test(() => {
+    let xHeight = ref_height / 10;
+    assert_not_equals(xHeight, Math.ceil(xHeight), "test font x-height must be fractional");
+    ex_test.setAttribute("x", "1ex");
+    // setAttribute rebuilds x.baseVal, so re-fetch the live SVGLength.
+    let ex_length_1 = ex_test.x.baseVal[0];
+    assert_approx_equals(ex_length_1.value, xHeight, 0.1);
+    assert_not_equals(ex_length_1.value, Math.ceil(xHeight));
+  }, "ex unit resolves against the fractional x-height");
+</script>

--- a/LayoutTests/platform/glib/svg/W3C-SVG-1.1/coords-units-03-b-expected.txt
+++ b/LayoutTests/platform/glib/svg/W3C-SVG-1.1/coords-units-03-b-expected.txt
@@ -39,7 +39,7 @@ layer at (0,0) size 480x360
           RenderSVGInlineText {#text} at (0,0) size 158x15
             chunk 1 text run 1 at (230.00,80.00) startOffset 0 endOffset 30 width 158.00: "Relative to font x-height (ex)"
         RenderSVGContainer {g} at (20,140) size 184x1
-          RenderSVGRect {rect} at (20,140) size 184x1 [fill={[type=SOLID] [color=#000000]}] [x=20.00] [y=80.00] [width=200.00] [height=1.00]
+          RenderSVGRect {rect} at (20,140) size 184x1 [fill={[type=SOLID] [color=#000000]}] [x=20.00] [y=80.00] [width=183.59] [height=1.00]
         RenderSVGText {text} at (20,86) size 94x15 contains 1 chunk(s)
           RenderSVGInlineText {#text} at (0,0) size 94x15
             chunk 1 text run 1 at (20.00,98.00) startOffset 0 endOffset 15 width 94.00: "41.67% = 200 px"

--- a/LayoutTests/platform/glib/svg/text/exs-display-none-expected.txt
+++ b/LayoutTests/platform/glib/svg/text/exs-display-none-expected.txt
@@ -1,14 +1,14 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x600
-  RenderSVGRoot {svg} at (50,52) size 572x83
-    RenderSVGContainer {g} at (50,52) size 572x83
-      RenderSVGText {text} at (50,52) size 572x83 contains 1 chunk(s)
+  RenderSVGRoot {svg} at (50,50) size 572x83
+    RenderSVGContainer {g} at (50,50) size 572x83
+      RenderSVGText {text} at (50,50) size 572x83 contains 1 chunk(s)
         RenderSVGTSpan {tspan} at (0,0) size 562x45
           RenderSVGInlineText {#text} at (0,0) size 562x45
-            chunk 1 text run 1 at (50.00,88.00) startOffset 0 endOffset 36 width 561.21: "Two lines of text should be visible."
+            chunk 1 text run 1 at (50.00,86.72) startOffset 0 endOffset 36 width 561.21: "Two lines of text should be visible."
         RenderSVGInlineText {#text} at (561,0) size 10x45
-          chunk 1 text run 1 at (611.21,88.00) startOffset 0 endOffset 1 width 10.00: " "
-        RenderSVGTSpan {tspan} at (0,38) size 562x45
-          RenderSVGInlineText {#text} at (0,38) size 562x45
-            chunk 1 text run 1 at (50.00,126.00) startOffset 0 endOffset 36 width 561.21: "Two lines of text should be visible."
+          chunk 1 text run 1 at (611.21,86.72) startOffset 0 endOffset 1 width 10.00: " "
+        RenderSVGTSpan {tspan} at (0,36) size 562x46
+          RenderSVGInlineText {#text} at (0,36) size 562x45
+            chunk 1 text run 1 at (50.00,123.44) startOffset 0 endOffset 36 width 561.21: "Two lines of text should be visible."

--- a/LayoutTests/platform/ios/svg/W3C-SVG-1.1/coords-units-03-b-expected.txt
+++ b/LayoutTests/platform/ios/svg/W3C-SVG-1.1/coords-units-03-b-expected.txt
@@ -39,7 +39,7 @@ layer at (0,0) size 480x360
           RenderSVGInlineText {#text} at (0,0) size 156x15
             chunk 1 text run 1 at (230.00,80.00) startOffset 0 endOffset 30 width 155.51: "Relative to font x-height (ex)"
         RenderSVGContainer {g} at (20,140) size 179x1
-          RenderSVGRect {rect} at (20,140) size 179x1 [fill={[type=SOLID] [color=#000000]}] [x=20.00] [y=80.00] [width=200.00] [height=1.00]
+          RenderSVGRect {rect} at (20,140) size 179x1 [fill={[type=SOLID] [color=#000000]}] [x=20.00] [y=80.00] [width=178.91] [height=1.00]
         RenderSVGText {text} at (20,86) size 92x15 contains 1 chunk(s)
           RenderSVGInlineText {#text} at (0,0) size 92x15
             chunk 1 text run 1 at (20.00,98.00) startOffset 0 endOffset 15 width 91.96: "41.67% = 200 px"

--- a/LayoutTests/platform/ios/svg/text/exs-display-none-expected.txt
+++ b/LayoutTests/platform/ios/svg/text/exs-display-none-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 800x600
       RenderSVGText {text} at (50,50) size 574x81 contains 1 chunk(s)
         RenderSVGTSpan {tspan} at (0,0) size 564x45
           RenderSVGInlineText {#text} at (0,0) size 564x45
-            chunk 1 text run 1 at (50.00,86.00) startOffset 0 endOffset 36 width 563.26: "Two lines of text should be visible."
+            chunk 1 text run 1 at (50.00,85.78) startOffset 0 endOffset 36 width 563.26: "Two lines of text should be visible."
         RenderSVGInlineText {#text} at (563,0) size 10x45
-          chunk 1 text run 1 at (613.26,86.00) startOffset 0 endOffset 1 width 10.00: " "
-        RenderSVGTSpan {tspan} at (0,36) size 564x45
-          RenderSVGInlineText {#text} at (0,36) size 564x45
-            chunk 1 text run 1 at (50.00,122.00) startOffset 0 endOffset 36 width 563.26: "Two lines of text should be visible."
+          chunk 1 text run 1 at (613.26,85.78) startOffset 0 endOffset 1 width 10.00: " "
+        RenderSVGTSpan {tspan} at (0,35) size 564x46
+          RenderSVGInlineText {#text} at (0,35) size 564x45
+            chunk 1 text run 1 at (50.00,121.56) startOffset 0 endOffset 36 width 563.26: "Two lines of text should be visible."

--- a/LayoutTests/platform/mac/svg/W3C-SVG-1.1/coords-units-03-b-expected.txt
+++ b/LayoutTests/platform/mac/svg/W3C-SVG-1.1/coords-units-03-b-expected.txt
@@ -39,7 +39,7 @@ layer at (0,0) size 480x360
           RenderSVGInlineText {#text} at (0,0) size 156x16
             chunk 1 text run 1 at (230.00,80.00) startOffset 0 endOffset 30 width 155.51: "Relative to font x-height (ex)"
         RenderSVGContainer {g} at (20,140) size 180x1
-          RenderSVGRect {rect} at (20,140) size 180x1 [fill={[type=SOLID] [color=#000000]}] [x=20.00] [y=80.00] [width=200.00] [height=1.00]
+          RenderSVGRect {rect} at (20,140) size 180x1 [fill={[type=SOLID] [color=#000000]}] [x=20.00] [y=80.00] [width=179.49] [height=1.00]
         RenderSVGText {text} at (20,86) size 92x16 contains 1 chunk(s)
           RenderSVGInlineText {#text} at (0,0) size 92x16
             chunk 1 text run 1 at (20.00,98.00) startOffset 0 endOffset 15 width 91.96: "41.67% = 200 px"

--- a/LayoutTests/platform/mac/svg/text/exs-display-none-expected.txt
+++ b/LayoutTests/platform/mac/svg/text/exs-display-none-expected.txt
@@ -1,14 +1,14 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x600
-  RenderSVGRoot {svg} at (50,50) size 574x82
-    RenderSVGContainer {g} at (50,50) size 574x82
-      RenderSVGText {text} at (50,50) size 574x82 contains 1 chunk(s)
+  RenderSVGRoot {svg} at (50,49) size 574x83
+    RenderSVGContainer {g} at (50,49) size 574x83
+      RenderSVGText {text} at (50,49) size 574x83 contains 1 chunk(s)
         RenderSVGTSpan {tspan} at (0,0) size 564x46
           RenderSVGInlineText {#text} at (0,0) size 564x46
-            chunk 1 text run 1 at (50.00,86.00) startOffset 0 endOffset 36 width 563.26: "Two lines of text should be visible."
+            chunk 1 text run 1 at (50.00,85.90) startOffset 0 endOffset 36 width 563.26: "Two lines of text should be visible."
         RenderSVGInlineText {#text} at (563,0) size 10x46
-          chunk 1 text run 1 at (613.26,86.00) startOffset 0 endOffset 1 width 10.00: " "
-        RenderSVGTSpan {tspan} at (0,36) size 564x46
-          RenderSVGInlineText {#text} at (0,36) size 564x46
-            chunk 1 text run 1 at (50.00,122.00) startOffset 0 endOffset 36 width 563.26: "Two lines of text should be visible."
+          chunk 1 text run 1 at (613.26,85.90) startOffset 0 endOffset 1 width 10.00: " "
+        RenderSVGTSpan {tspan} at (0,35) size 564x47
+          RenderSVGInlineText {#text} at (0,35) size 564x46
+            chunk 1 text run 1 at (50.00,121.80) startOffset 0 endOffset 36 width 563.26: "Two lines of text should be visible."

--- a/LayoutTests/svg/animations/svglength-animation-px-to-exs.html
+++ b/LayoutTests/svg/animations/svglength-animation-px-to-exs.html
@@ -20,6 +20,7 @@ rect.setAttribute("x", "0");
 rect.setAttribute("width", "100");
 rect.setAttribute("height", "100");
 rect.setAttribute("fill", "green");
+rect.setAttribute("font-family", "Ahem");
 rect.setAttribute("font-size", "10px");
 rect.setAttribute("onclick", "executeTest()");
 
@@ -29,7 +30,7 @@ animate.setAttribute("attributeName", "width");
 animate.setAttribute("begin", "click");
 animate.setAttribute("dur", "4s");
 animate.setAttribute("from", "100px");
-animate.setAttribute("to", "40ex");
+animate.setAttribute("to", "25ex");
 rect.appendChild(animate);
 rootSVGElement.appendChild(rect);
 

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -358,9 +358,7 @@ ExceptionOr<float> SVGLengthContext::convertValueFromUserUnitsToEXS(float value)
         return value / initialXHeightPx;
     }
 
-    // Use of ceil allows a pixel match to the W3Cs expected output of coords-units-03-b.svg
-    // if this causes problems in real world cases maybe it would be best to remove this
-    float xHeight = std::ceil(style->metricsOfPrimaryFont().xHeight().value_or(0));
+    float xHeight = style->metricsOfPrimaryFont().xHeight().value_or(0);
     if (!xHeight)
         return Exception { ExceptionCode::NotSupportedError };
 
@@ -378,9 +376,7 @@ ExceptionOr<float> SVGLengthContext::convertValueFromEXSToUserUnits(float value)
         return value * initialXHeightPx;
     }
 
-    // Use of ceil allows a pixel match to the W3Cs expected output of coords-units-03-b.svg
-    // if this causes problems in real world cases maybe it would be best to remove this
-    return value * std::ceil(style->metricsOfPrimaryFont().xHeight().value_or(0));
+    return value * style->metricsOfPrimaryFont().xHeight().value_or(0);
 }
 
 std::optional<FloatSize> SVGLengthContext::viewportSize() const


### PR DESCRIPTION
#### dedced319ff7e3e3a4b6ec83c4467d023ae53d37
<pre>
SVGLength resolves &apos;ex&apos; by rounding the font&apos;s x-height up to a whole pixel
<a href="https://bugs.webkit.org/show_bug.cgi?id=322716">https://bugs.webkit.org/show_bug.cgi?id=322716</a>
<a href="https://rdar.apple.com/185984854">rdar://185984854</a>

Reviewed by Sam Weinig.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

SVGLengthContext resolved the &apos;ex&apos; unit by applying std::ceil() to the
primary font&apos;s x-height before multiplying, so the SVG DOM
(baseVal.value / valueInSpecifiedUnits) disagreed with getComputedStyle
for the same element: e.g. Helvetica at 20px (x-height ~10.459px) gave
x=&quot;2ex&quot; as 22 (2 x ceil(10.459)) via the DOM but 20.898438px via
getComputedStyle. Per spec, &apos;ex&apos; resolves against the computed font
x-height with no rounding:
<a href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGLength__value">https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGLength__value</a>

The ceil() dated back to SVG 1.1; SVG 2 does not mandate any such
rounding.

The ceil() carried a comment noting it existed solely to get a pixel
match against the W3C SVG 1.1 expected output of coords-units-03-b.svg,
and that it might be best to remove it if it ever caused problems in
real-world cases. That is now the case: WebKit is the only engine still
applying this rounding, Firefox and Chrome both dropped it, and SVG 2
says nothing about rounding &apos;ex&apos;. We therefore knowingly deviate from
the SVG 1.1 test (rebaselining coords-units-03-b) in favor of interop
with other browsers and conformance to SVG 2.

Remove the ceil() in both conversion directions.

Test: imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ex.html

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ex-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-ex.html: Added.
  Re-fetch x.baseVal[0] after setAttribute() so the fractional-x-height
  subtest reads the live SVGLength instead of a detached wrapper.
* LayoutTests/platform/mac/svg/W3C-SVG-1.1/coords-units-03-b-expected.txt: Rebaselined.
* LayoutTests/platform/mac/svg/text/exs-display-none-expected.txt: Ditto.
* LayoutTests/platform/ios/svg/W3C-SVG-1.1/coords-units-03-b-expected.txt: Ditto.
* LayoutTests/platform/ios/svg/text/exs-display-none-expected.txt: Ditto.
* LayoutTests/platform/glib/svg/W3C-SVG-1.1/coords-units-03-b-expected.txt: Ditto.
* LayoutTests/platform/glib/svg/text/exs-display-none-expected.txt: Ditto.
* LayoutTests/svg/animations/svglength-animation-px-to-exs.html: Updated.
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::convertValueFromUserUnitsToEXS const):
(WebCore::SVGLengthContext::convertValueFromEXSToUserUnits const):

Canonical link: <a href="https://commits.webkit.org/320606@main">https://commits.webkit.org/320606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70b555be08c721fc5569e63f3b0c8f6564822a5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195643 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/18b5a9f3-0180-4b39-bf69-25e9855fb23b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60601 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58956 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144819 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ed28cc74-39f8-47e3-ad21-a15fea2b12f4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48508 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165410 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125112 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9977538a-7188-49a5-840b-ada31a9e96a2) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/184645 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47236 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45295 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157603 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44980 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6697 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46575 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197592 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/184720 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164916 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154330 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41329 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59602 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153981 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48475 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131921 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128738 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58080 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20002 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57452 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57695 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57519 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->