### PR TITLE
AX: Typing crashes in debug builds when accessibility is enabled for a document with no AXObjectCache

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/typing-in-document-with-no-ax-object-cache-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/typing-in-document-with-no-ax-object-cache-expected.txt
@@ -1,0 +1,8 @@
+This tests that typing does not crash when accessibility is enabled after the document loaded, leaving the document without an AXObjectCache.
+
+PASS: input.value === 'a'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/typing-in-document-with-no-ax-object-cache.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/typing-in-document-with-no-ax-object-cache.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<input id="input">
+
+<script>
+var output = "This tests that typing does not crash when accessibility is enabled after the document loaded, leaving the document without an AXObjectCache.\n\n";
+
+var input = document.getElementById("input");
+
+function runTest() {
+    // Focus while accessibility is still off, so nothing on the focus path creates a cache.
+    input.focus();
+
+    // Turns accessibility but doesn't necessarily create an AXObjectCache.
+    accessibilityController.enableEnhancedAccessibility(true);
+
+    document.execCommand("InsertText", false, "a");
+    output += expect("input.value", "'a'");
+
+    debug(output);
+    finishJSTest();
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    // Waiting for load matters for reproducing the bug. Enabling accessibility any earlier lets
+    // Document::implicitClose() create the AXObjectCache this test needs to be missing.
+    window.addEventListener("load", runTest);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/typing-in-document-with-no-ax-object-cache-expected.txt
+++ b/LayoutTests/accessibility/mac/typing-in-document-with-no-ax-object-cache-expected.txt
@@ -1,0 +1,8 @@
+This tests that typing does not crash when accessibility is enabled after the document loaded, leaving the document without an AXObjectCache.
+
+PASS: input.value === 'a'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/typing-in-document-with-no-ax-object-cache.html
+++ b/LayoutTests/accessibility/mac/typing-in-document-with-no-ax-object-cache.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<input id="input">
+
+<script>
+var output = "This tests that typing does not crash when accessibility is enabled after the document loaded, leaving the document without an AXObjectCache.\n\n";
+
+var input = document.getElementById("input");
+
+function runTest() {
+    // Focus while accessibility is still off, so nothing on the focus path creates a cache.
+    input.focus();
+
+    // Turns accessibility but doesn't necessarily create an AXObjectCache.
+    accessibilityController.enableEnhancedAccessibility(true);
+
+    document.execCommand("InsertText", false, "a");
+    output += expect("input.value", "'a'");
+
+    debug(output);
+    finishJSTest();
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    // Waiting for load matters for reproducing the bug. Enabling accessibility any earlier lets
+    // Document::implicitClose() create the AXObjectCache this test needs to be missing.
+    window.addEventListener("load", runTest);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -992,7 +992,8 @@ int indexForVisiblePosition(const VisiblePosition& visiblePosition, RefPtr<Conta
     auto position = visiblePosition.deepEquivalent();
     Ref document = *position.document();
 
-    auto editableRoot = highestEditableRoot(position, AXObjectCache::accessibilityEnabled() ? HasEditableAXRole : ContentIsEditable);
+    bool useAccessibilityEditability = AXObjectCache::accessibilityEnabled() && document->existingAXObjectCache();
+    auto editableRoot = highestEditableRoot(position, useAccessibilityEditability ? HasEditableAXRole : ContentIsEditable);
     if (editableRoot && !document->inDesignMode())
         scope = editableRoot;
     else {


### PR DESCRIPTION
#### 9c91ee91b978756f6b4557170f8b15a966d90fe6
<pre>
AX: Typing crashes in debug builds when accessibility is enabled for a document with no AXObjectCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=323527">https://bugs.webkit.org/show_bug.cgi?id=323527</a>
<a href="https://rdar.apple.com/186768355">rdar://186768355</a>

Reviewed by Chris Fleizach.

imported/w3c/web-platform-tests/css/selectors/user-invalid.html crashes in debug builds on
ASSERT(node.document().existingAXObjectCache()) in isEditableToAccessibility(), reached from
the EditCommandComposition constructor by way of indexForVisiblePosition.

isEditableToAccessibility() has asserted since 2015 that a document whose editability is
being resolved through accessibility has an AXObjectCache to resolve it with. That held while
accessibility was turned on as a side effect of a client reaching into a page, because
reaching in created the cache. 320566@main made the mode process-wide -- broadcast to every
web process and seeded into WebPageCreationParameters -- so it is now routinely on for
documents an accessibility client hasn&apos;t yet talked to yet, and thus have no cache.

Fix this by also checking for the presence of an existingAXObjectCache before using accessibility editability.

* LayoutTests/accessibility/isolated-tree/mac/typing-in-document-with-no-ax-object-cache-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/typing-in-document-with-no-ax-object-cache.html: Added.
* LayoutTests/accessibility/mac/typing-in-document-with-no-ax-object-cache-expected.txt: Added.
* LayoutTests/accessibility/mac/typing-in-document-with-no-ax-object-cache.html: Added.
* Source/WebCore/editing/Editing.cpp:
(WebCore::indexForVisiblePosition):

Canonical link: <a href="https://commits.webkit.org/320589@main">https://commits.webkit.org/320589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b8336fc7a3329d7f0914c93f5cd7f810658888e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185213 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195539 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0db96f31-c879-4dee-9d1a-a62c65a987f4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144728 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a52878e7-9d6c-44b5-bc3d-9d3991b66c3e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48413 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165320 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125021 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a066f124-3a39-4441-bdae-f34715700b2b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47141 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45203 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157508 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44890 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6595 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197490 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164826 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154236 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41307 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59498 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41494 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153887 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48384 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131807 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128533 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57977 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19909 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57348 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57591 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57415 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->