### PR TITLE
AX: A disabled base-appearance select posts no AXPressDidFail

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/press-did-fail-notification-base-select-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/press-did-fail-notification-base-select-expected.txt
@@ -1,0 +1,10 @@
+This tests that pressing a disabled base-appearance select posts AXPressDidFail, and that the select still reports itself collapsed when the notification arrives.
+
+PASS: pressDidFailDeliveries() === 0
+PASS: pressDidFailDeliveries() === 1
+PASS: expandedAtDelivery === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/press-did-fail-notification-base-select.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/press-did-fail-notification-base-select.html
@@ -1,0 +1,59 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+select, select::picker(select) {
+    appearance: base-select;
+}
+</style>
+</head>
+<body>
+
+<select id="select" disabled>
+    <option>Alpha</option>
+    <option selected>Bravo</option>
+    <option>Charlie</option>
+</select>
+
+<script>
+var output = "This tests that pressing a disabled base-appearance select posts AXPressDidFail, and that the select still reports itself collapsed when the notification arrives.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var select = accessibilityController.accessibleElementById("select");
+    var pressDidFailCount = 0;
+    var pressListener = null;
+    var expandedAtDelivery = null;
+
+    function pressDidFailDeliveries() {
+        if (!pressListener) {
+            pressListener = function(element, notification, userInfo) {
+                if (notification != "AXPressDidFail")
+                    return;
+                pressDidFailCount++;
+                expandedAtDelivery = select.isExpanded;
+            };
+            accessibilityController.addNotificationListener(pressListener);
+        }
+        return pressDidFailCount;
+    }
+
+    output += expect("pressDidFailDeliveries()", "0");
+
+    setTimeout(async function() {
+        select.press();
+        output += await expectAsync("pressDidFailDeliveries()", "1");
+        output += expect("expandedAtDelivery", "false");
+
+        document.getElementById("select").style.display = "none";
+        accessibilityController.removeNotificationListener(pressListener);
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/press-did-fail-notification-base-select-expected.txt
+++ b/LayoutTests/accessibility/mac/press-did-fail-notification-base-select-expected.txt
@@ -1,0 +1,10 @@
+This tests that pressing a disabled base-appearance select posts AXPressDidFail, and that the select still reports itself collapsed when the notification arrives.
+
+PASS: pressDidFailDeliveries() === 0
+PASS: pressDidFailDeliveries() === 1
+PASS: expandedAtDelivery === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/press-did-fail-notification-base-select.html
+++ b/LayoutTests/accessibility/mac/press-did-fail-notification-base-select.html
@@ -1,0 +1,59 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+select, select::picker(select) {
+    appearance: base-select;
+}
+</style>
+</head>
+<body>
+
+<select id="select" disabled>
+    <option>Alpha</option>
+    <option selected>Bravo</option>
+    <option>Charlie</option>
+</select>
+
+<script>
+var output = "This tests that pressing a disabled base-appearance select posts AXPressDidFail, and that the select still reports itself collapsed when the notification arrives.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var select = accessibilityController.accessibleElementById("select");
+    var pressDidFailCount = 0;
+    var pressListener = null;
+    var expandedAtDelivery = null;
+
+    function pressDidFailDeliveries() {
+        if (!pressListener) {
+            pressListener = function(element, notification, userInfo) {
+                if (notification != "AXPressDidFail")
+                    return;
+                pressDidFailCount++;
+                expandedAtDelivery = select.isExpanded;
+            };
+            accessibilityController.addNotificationListener(pressListener);
+        }
+        return pressDidFailCount;
+    }
+
+    output += expect("pressDidFailDeliveries()", "0");
+
+    setTimeout(async function() {
+        select.press();
+        output += await expectAsync("pressDidFailDeliveries()", "1");
+        output += expect("expandedAtDelivery", "false");
+
+        document.getElementById("select").style.display = "none";
+        accessibilityController.removeNotificationListener(pressListener);
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1917,8 +1917,11 @@ bool AccessibilityRenderObject::press()
     if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(element()); selectElement && selectElement->usesBaseAppearancePicker()) {
         // Base-appearance selects need explicit picker toggling since they no longer use
         // AccessibilityMenuList which had its own press() override.
-        if (selectElement->isDisabledFormControl())
+        if (selectElement->isDisabledFormControl()) {
+            if (CheckedPtr cache = axObjectCache())
+                cache->postNotification(selectElement.get(), AXNotification::PressDidFail);
             return false;
+        }
         if (selectElement->popupIsVisible())
             selectElement->hidePickerPopoverElement();
         else


### PR DESCRIPTION
#### 32b085d39b37d9d45bc931b16076168ba5c466e9
<pre>
AX: A disabled base-appearance select posts no AXPressDidFail
<a href="https://bugs.webkit.org/show_bug.cgi?id=323529">https://bugs.webkit.org/show_bug.cgi?id=323529</a>
<a href="https://rdar.apple.com/186769876">rdar://186769876</a>

Reviewed by Dominic Mazzoni.

Pressing a disabled &lt;select&gt; is refused, and an assistive technology learns that from the
AXPressDidFail notification. AccessibilityMenuList::press() posts it, so the legacy menu-list
appearance is covered -- accessibility/mac/press-not-work-for-disabled-menu-list.html presses three
disabled selects and expects a notification each time.

A base-appearance select (appearance: base-select) is not an AccessibilityMenuList, though. It is served by
AccessibilityRenderObject::press(), which bails on isDisabledFormControl() with a bare
&quot;return false&quot; and posts nothing.

Post AXPressDidFail from that branch, matching what the menu-list override already does.

* LayoutTests/accessibility/isolated-tree/mac/press-did-fail-notification-base-select-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/press-did-fail-notification-base-select.html: Added.
* LayoutTests/accessibility/mac/press-did-fail-notification-base-select-expected.txt: Added.
* LayoutTests/accessibility/mac/press-did-fail-notification-base-select.html: Added.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::press):

Canonical link: <a href="https://commits.webkit.org/320659@main">https://commits.webkit.org/320659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c63821b8c50974c7b7b4439da802373afa697f2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195541 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150058 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1e4b4157-3db9-473a-bb57-0b058987eddb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144730 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100367 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/64c44269-7e7d-47bb-95c0-4e6d2a15b743) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125023 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/942be9fe-a495-43f2-b757-b597df0ad7dc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47144 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45205 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44892 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6597 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197492 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58791 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154238 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41375 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59500 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153894 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48385 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131820 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128540 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57979 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19911 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57350 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57593 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57417 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->