### PR TITLE
AX: In isolated tree mode, removing a node from an aria-relevant="removals" live region announces nothing

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-removals-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-removals-expected.txt
@@ -1,0 +1,18 @@
+This tests that the notifications for aria-relevant=removals are correct.
+
+Received announcement request:
+AnnouncementKey: Mariners{
+    AXIsLiveRegionRemoval = 1;
+    AXLanguage = en;
+}
+AXPriorityKey: 10
+AXAnnouncementIsLiveRegionKey: true
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Giants
+Cubs
+Orioles
+Tigers

--- a/LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-removals.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-removals.html
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAriaLiveRegionManagementEnabled=true IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/accessibility-helper.js"></script>
+<meta http-equiv="content-language" content="en">
+<meta charset="utf-8" />
+</head>
+<body>
+
+<ul id="team-list" aria-live="polite" aria-relevant="removals" style="list-style-type: none;">
+    <li>Giants</li>
+    <li>Cubs</li>
+    <li>Orioles</li>
+    <li>Tigers</li>
+</ul>
+
+<script>
+var output = "This tests that the notifications for aria-relevant=removals are correct.\n\n";    
+var testFinished = false;
+
+function notificationCallback(object, notification, userInfo) {
+    if (notification == "AXAnnouncementRequested") {
+        output += `Received announcement request:\n`;
+        output += formatAnnouncementUserInfo(userInfo);
+        output += `\n`;
+        
+        testFinished = true;
+    }
+}
+
+if (accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.addNotificationListener(notificationCallback);
+    accessibilityController.accessibleElementById("team-list");
+
+    // Adding an element shouldn't speak anything when aria-relevant="removals" is set.
+    const newTeam = document.createElement("li");
+    newTeam.textContent = "Mariners";
+    document.getElementById("team-list").appendChild(newTeam);
+ 
+    setTimeout(async function() {
+        await waitFor(() => accessibilityController.accessibleElementById("team-list") != null);
+        // We should speak a remove notification for this item because of aria-relevant="removals".
+        document.getElementById("team-list").lastElementChild.remove();
+    
+        await waitFor(() => testFinished);
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -3617,22 +3617,26 @@ void AXObjectCache::postLiveRegionChangeNotification(AccessibilityObject& object
 void AXObjectCache::liveRegionChangedNotificationPostTimerFired()
 {
     m_liveRegionChangedPostTimer.stop();
+    processChangedLiveRegions();
+}
 
+void AXObjectCache::processChangedLiveRegions()
+{
     if (m_changedLiveRegions.isEmpty())
         return;
 
+    auto changedLiveRegions = std::exchange(m_changedLiveRegions, { });
+
 #if PLATFORM(COCOA)
     if (m_liveRegionManager) {
-        for (auto& object : m_changedLiveRegions)
+        for (auto& object : changedLiveRegions)
             m_liveRegionManager->handleLiveRegionChange(object.get());
-        m_changedLiveRegions.clear();
         return;
     }
 #endif
 
-    for (auto& object : m_changedLiveRegions)
+    for (auto& object : changedLiveRegions)
         postNotification(object.ptr(), protect(object->document()).get(), AXNotification::LiveRegionChanged);
-    m_changedLiveRegions.clear();
 }
 
 void AXObjectCache::onScrollbarUpdate(ScrollView& view)
@@ -5955,6 +5959,13 @@ void AXObjectCache::performDeferredCacheUpdate(ForceLayout forceLayout)
 #endif
 
     platformPerformDeferredCacheUpdate();
+
+#if PLATFORM(COCOA)
+    if (m_liveRegionManager && !m_changedLiveRegions.isEmpty()) {
+        m_liveRegionChangedPostTimer.stop();
+        processChangedLiveRegions();
+    }
+#endif
 }
 
 void AXObjectCache::handleDeferredPopoverToggle(AccessibilityObject& axPopover)

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -941,6 +941,7 @@ private:
     static Seconds announcementTranslationTimeout();
 
     void liveRegionChangedNotificationPostTimerFired();
+    void processChangedLiveRegions();
 
     void performCacheUpdateTimerFired() { performDeferredCacheUpdate(ForceLayout::No); }
 


### PR DESCRIPTION
#### 96cf89c2cbc71ab5f92161b3989b0fed6fb84e10
<pre>
AX: In isolated tree mode, removing a node from an aria-relevant=&quot;removals&quot; live region announces nothing
<a href="https://bugs.webkit.org/show_bug.cgi?id=323528">https://bugs.webkit.org/show_bug.cgi?id=323528</a>
<a href="https://rdar.apple.com/186769812">rdar://186769812</a>

Reviewed by Chris Fleizach.

AXLiveRegionManager announces a change by diffing a fresh snapshot of the region against the one it
stored last time, and it only takes that snapshot when the cache-update timer fires. A node added by
one deferred cache update and removed by the next never appears in any snapshot, so the two changes
cancel out and neither is announced. Adding a node to an aria-relevant=&quot;removals&quot; region and then
removing it is exactly that sequence, and it announced nothing at all.

The main thread doesn&apos;t hit this, because a client reading any attribute updates the backing store
first, which applies the pending change and lets the timer fire between the two mutations. Nothing
forces that in isolated tree mode, where reads are answered off the isolated tree, so both mutations
land in one cache update.

Diff each changed live region against the tree the cache update just produced, so a snapshot exists
for every state the accessibility tree actually took.

Makes live-region-removals.html pass in ITM.

* LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-removals-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/live-regions/live-region-removals.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::liveRegionChangedNotificationPostTimerFired):
(WebCore::AXObjectCache::processChangedLiveRegions):
(WebCore::AXObjectCache::performDeferredCacheUpdate):
* Source/WebCore/accessibility/AXObjectCache.h:

Canonical link: <a href="https://commits.webkit.org/320587@main">https://commits.webkit.org/320587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3df47796bde7b245ded96ef16eb8cfcdac61bcaa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195542 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7cdc3c23-3465-4c83-a3ae-9a577e9ced3b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58855 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144731 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f3fc2b2-6a69-4ddd-abf8-f0d43768a5d2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188171 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165324 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125024 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/894d569d-e8db-43ea-b979-1a6f6fbd9235) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47145 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45207 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44894 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6598 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51784 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197493 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58792 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164830 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154239 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41309 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59501 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41498 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153890 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48386 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131810 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128541 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57980 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19913 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57351 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57594 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57418 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->