### PR TITLE
AX: Add a layout test for imperative slot assignment in the accessibility tree

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/slot-manual-assignment-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/slot-manual-assignment-expected.txt
@@ -1,0 +1,19 @@
+This tests that imperative slot assignment reparents a node in the accessibility tree, even though it mutates no DOM.
+
+A manual-assignment slot holds nothing until it is assigned, so the button is unslotted and unrendered.
+PASS: parentIdOf('alpha') === 'not in the accessibility tree'
+PASS: childCountOf('firstGroup') === 0
+
+Assigning the button to the first slot.
+PASS: parentIdOf('alpha') === 'firstGroup'
+PASS: childCountOf('firstGroup') === 1
+
+Assigning the same button to the second slot, which mutates no DOM.
+PASS: parentIdOf('alpha') === 'secondGroup'
+PASS: childCountOf('firstGroup') === 0
+PASS: childCountOf('secondGroup') === 1
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/slot-manual-assignment.html
+++ b/LayoutTests/accessibility/isolated-tree/slot-manual-assignment.html
@@ -1,0 +1,58 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="host">
+    <button id="alpha">Alpha</button>
+</div>
+
+<script>
+var output = "This tests that imperative slot assignment reparents a node in the accessibility tree, even though it mutates no DOM.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var shadowRoot = document.getElementById("host").attachShadow({ mode: "open", slotAssignment: "manual" });
+    shadowRoot.innerHTML = "<div role='group' aria-label='First' id='firstGroup'><slot id='firstSlot'></slot></div>"
+        + "<div role='group' aria-label='Second' id='secondGroup'><slot id='secondSlot'></slot></div>";
+    var firstSlot = shadowRoot.getElementById("firstSlot");
+    var secondSlot = shadowRoot.getElementById("secondSlot");
+
+    function parentIdOf(id) {
+        var element = accessibilityController.accessibleElementById(id);
+        return element ? element.parentElement().domIdentifier : "not in the accessibility tree";
+    }
+
+    function childCountOf(id) {
+        var element = accessibilityController.accessibleElementById(id);
+        return element ? element.childrenCount : -1;
+    }
+
+    setTimeout(async function() {
+        output += "A manual-assignment slot holds nothing until it is assigned, so the button is unslotted and unrendered.\n";
+        output += await expectAsync("parentIdOf('alpha')", "'not in the accessibility tree'");
+        output += expect("childCountOf('firstGroup')", "0");
+
+        output += "\nAssigning the button to the first slot.\n";
+        firstSlot.assign(document.getElementById("alpha"));
+        output += await expectAsync("parentIdOf('alpha')", "'firstGroup'");
+        output += expect("childCountOf('firstGroup')", "1");
+
+        output += "\nAssigning the same button to the second slot, which mutates no DOM.\n";
+        secondSlot.assign(document.getElementById("alpha"));
+        output += await expectAsync("parentIdOf('alpha')", "'secondGroup'");
+        output += expect("childCountOf('firstGroup')", "0");
+        output += expect("childCountOf('secondGroup')", "1");
+
+        document.getElementById("host").style.visibility = "hidden";
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/slot-manual-assignment-expected.txt
+++ b/LayoutTests/accessibility/slot-manual-assignment-expected.txt
@@ -1,0 +1,19 @@
+This tests that imperative slot assignment reparents a node in the accessibility tree, even though it mutates no DOM.
+
+A manual-assignment slot holds nothing until it is assigned, so the button is unslotted and unrendered.
+PASS: parentIdOf('alpha') === 'not in the accessibility tree'
+PASS: childCountOf('firstGroup') === 0
+
+Assigning the button to the first slot.
+PASS: parentIdOf('alpha') === 'firstGroup'
+PASS: childCountOf('firstGroup') === 1
+
+Assigning the same button to the second slot, which mutates no DOM.
+PASS: parentIdOf('alpha') === 'secondGroup'
+PASS: childCountOf('firstGroup') === 0
+PASS: childCountOf('secondGroup') === 1
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/slot-manual-assignment.html
+++ b/LayoutTests/accessibility/slot-manual-assignment.html
@@ -1,0 +1,58 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="host">
+    <button id="alpha">Alpha</button>
+</div>
+
+<script>
+var output = "This tests that imperative slot assignment reparents a node in the accessibility tree, even though it mutates no DOM.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var shadowRoot = document.getElementById("host").attachShadow({ mode: "open", slotAssignment: "manual" });
+    shadowRoot.innerHTML = "<div role='group' aria-label='First' id='firstGroup'><slot id='firstSlot'></slot></div>"
+        + "<div role='group' aria-label='Second' id='secondGroup'><slot id='secondSlot'></slot></div>";
+    var firstSlot = shadowRoot.getElementById("firstSlot");
+    var secondSlot = shadowRoot.getElementById("secondSlot");
+
+    function parentIdOf(id) {
+        var element = accessibilityController.accessibleElementById(id);
+        return element ? element.parentElement().domIdentifier : "not in the accessibility tree";
+    }
+
+    function childCountOf(id) {
+        var element = accessibilityController.accessibleElementById(id);
+        return element ? element.childrenCount : -1;
+    }
+
+    setTimeout(async function() {
+        output += "A manual-assignment slot holds nothing until it is assigned, so the button is unslotted and unrendered.\n";
+        output += await expectAsync("parentIdOf('alpha')", "'not in the accessibility tree'");
+        output += expect("childCountOf('firstGroup')", "0");
+
+        output += "\nAssigning the button to the first slot.\n";
+        firstSlot.assign(document.getElementById("alpha"));
+        output += await expectAsync("parentIdOf('alpha')", "'firstGroup'");
+        output += expect("childCountOf('firstGroup')", "1");
+
+        output += "\nAssigning the same button to the second slot, which mutates no DOM.\n";
+        secondSlot.assign(document.getElementById("alpha"));
+        output += await expectAsync("parentIdOf('alpha')", "'secondGroup'");
+        output += expect("childCountOf('firstGroup')", "0");
+        output += expect("childCountOf('secondGroup')", "1");
+
+        document.getElementById("host").style.visibility = "hidden";
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 13834c3c5a1c959e632403168043680baa667003
<pre>
AX: Add a layout test for imperative slot assignment in the accessibility tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=323531">https://bugs.webkit.org/show_bug.cgi?id=323531</a>
<a href="https://rdar.apple.com/186770569">rdar://186770569</a>

Reviewed by Dominic Mazzoni.

No existing test verified that the accessibility tree is correct after a
`slotAssignment: &quot;manual&quot;`, HTMLSlotElement::assign() slot re-assignment.

* LayoutTests/accessibility/isolated-tree/slot-manual-assignment-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/slot-manual-assignment.html: Added.
* LayoutTests/accessibility/slot-manual-assignment-expected.txt: Added.
* LayoutTests/accessibility/slot-manual-assignment.html: Added.

Canonical link: <a href="https://commits.webkit.org/320660@main">https://commits.webkit.org/320660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24cb5b06392c97af7760afd82d68fd4e4cc6cccd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195543 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150060 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3b303935-fef3-4e12-8d6b-bee7922964db) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144732 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100368 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1c74051-e5be-4678-8383-f1a9df67f104) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125025 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/aa72918b-088d-4945-9c56-df04268a4c39) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47146 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45206 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157513 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44893 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6599 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197494 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58793 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154240 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41376 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59502 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153891 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48389 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128542 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57981 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19912 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57352 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57595 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57419 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->