### PR TITLE
AX: Add a layout test for accessibility text state across undo and redo

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/undo-redo-text-state-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/undo-redo-text-state-expected.txt
@@ -1,0 +1,24 @@
+This tests that a text control's accessible value, character count, and caret are already correct when the AXValueChanged notification for an undo or a redo is delivered.
+
+Typing at the end of the value, as one undoable insertion.
+PASS: characterCountAtDelivery === 11
+PASS: valueAtDelivery === 'AXValue: Hello world'
+PASS: caretAtDelivery === '{11, 0}'
+
+Undoing the insertion.
+PASS: characterCountAtDelivery === 5
+PASS: valueAtDelivery === 'AXValue: Hello'
+PASS: caretAtDelivery === '{5, 0}'
+
+Redoing the insertion.
+PASS: characterCountAtDelivery === 11
+PASS: valueAtDelivery === 'AXValue: Hello world'
+PASS: caretAtDelivery === '{11, 0}'
+
+The value the notification advertised is the one that persists.
+PASS: characterCount() === 11
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/undo-redo-text-state.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/undo-redo-text-state.html
@@ -1,0 +1,76 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<textarea id="target" style="width: 200px; height: 60px">Hello</textarea>
+
+<script>
+var output = "This tests that a text control's accessible value, character count, and caret are already correct when the AXValueChanged notification for an undo or a redo is delivered.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    // Sampled inside the notification handler, so these report what an assistive technology would
+    // read on being told the value changed, rather than what settles some time afterwards.
+    var valueAtDelivery = null;
+    var characterCountAtDelivery = null;
+    var caretAtDelivery = null;
+
+    function sampleStateAtDelivery() {
+        var element = accessibilityController.accessibleElementById("target");
+        valueAtDelivery = element.stringValue;
+        characterCountAtDelivery = element.numberOfCharacters;
+        caretAtDelivery = element.selectedTextRange;
+    }
+
+    function characterCount() {
+        return accessibilityController.accessibleElementById("target").numberOfCharacters;
+    }
+
+    async function waitForValueChanged(axTarget, command, argument) {
+        await waitForNotifications(axTarget, "AXValueChanged", 1,
+            () => { document.execCommand(command, false, argument); },
+            sampleStateAtDelivery);
+    }
+
+    setTimeout(async function() {
+        var target = document.getElementById("target");
+        target.focus();
+        target.setSelectionRange(5, 5);
+        var axTarget = accessibilityController.accessibleElementById("target");
+
+        output += "Typing at the end of the value, as one undoable insertion.\n";
+        await waitForValueChanged(axTarget, "insertText", " world");
+        output += expect("characterCountAtDelivery", "11");
+        output += expect("valueAtDelivery", "'AXValue: Hello world'");
+        output += expect("caretAtDelivery", "'{11, 0}'");
+
+        // Undo restores the selection the insertion started from, so the caret returns to where the
+        // typing began rather than staying at the end of the shortened value.
+        output += "\nUndoing the insertion.\n";
+        await waitForValueChanged(axTarget, "undo");
+        output += expect("characterCountAtDelivery", "5");
+        output += expect("valueAtDelivery", "'AXValue: Hello'");
+        output += expect("caretAtDelivery", "'{5, 0}'");
+
+        output += "\nRedoing the insertion.\n";
+        await waitForValueChanged(axTarget, "redo");
+        output += expect("characterCountAtDelivery", "11");
+        output += expect("valueAtDelivery", "'AXValue: Hello world'");
+        output += expect("caretAtDelivery", "'{11, 0}'");
+
+        output += "\nThe value the notification advertised is the one that persists.\n";
+        output += expect("characterCount()", "11");
+
+        document.getElementById("target").style.visibility = "hidden";
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/undo-redo-text-state-expected.txt
+++ b/LayoutTests/accessibility/mac/undo-redo-text-state-expected.txt
@@ -1,0 +1,24 @@
+This tests that a text control's accessible value, character count, and caret are already correct when the AXValueChanged notification for an undo or a redo is delivered.
+
+Typing at the end of the value, as one undoable insertion.
+PASS: characterCountAtDelivery === 11
+PASS: valueAtDelivery === 'AXValue: Hello world'
+PASS: caretAtDelivery === '{11, 0}'
+
+Undoing the insertion.
+PASS: characterCountAtDelivery === 5
+PASS: valueAtDelivery === 'AXValue: Hello'
+PASS: caretAtDelivery === '{5, 0}'
+
+Redoing the insertion.
+PASS: characterCountAtDelivery === 11
+PASS: valueAtDelivery === 'AXValue: Hello world'
+PASS: caretAtDelivery === '{11, 0}'
+
+The value the notification advertised is the one that persists.
+PASS: characterCount() === 11
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/undo-redo-text-state.html
+++ b/LayoutTests/accessibility/mac/undo-redo-text-state.html
@@ -1,0 +1,76 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<textarea id="target" style="width: 200px; height: 60px">Hello</textarea>
+
+<script>
+var output = "This tests that a text control's accessible value, character count, and caret are already correct when the AXValueChanged notification for an undo or a redo is delivered.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    // Sampled inside the notification handler, so these report what an assistive technology would
+    // read on being told the value changed, rather than what settles some time afterwards.
+    var valueAtDelivery = null;
+    var characterCountAtDelivery = null;
+    var caretAtDelivery = null;
+
+    function sampleStateAtDelivery() {
+        var element = accessibilityController.accessibleElementById("target");
+        valueAtDelivery = element.stringValue;
+        characterCountAtDelivery = element.numberOfCharacters;
+        caretAtDelivery = element.selectedTextRange;
+    }
+
+    function characterCount() {
+        return accessibilityController.accessibleElementById("target").numberOfCharacters;
+    }
+
+    async function waitForValueChanged(axTarget, command, argument) {
+        await waitForNotifications(axTarget, "AXValueChanged", 1,
+            () => { document.execCommand(command, false, argument); },
+            sampleStateAtDelivery);
+    }
+
+    setTimeout(async function() {
+        var target = document.getElementById("target");
+        target.focus();
+        target.setSelectionRange(5, 5);
+        var axTarget = accessibilityController.accessibleElementById("target");
+
+        output += "Typing at the end of the value, as one undoable insertion.\n";
+        await waitForValueChanged(axTarget, "insertText", " world");
+        output += expect("characterCountAtDelivery", "11");
+        output += expect("valueAtDelivery", "'AXValue: Hello world'");
+        output += expect("caretAtDelivery", "'{11, 0}'");
+
+        // Undo restores the selection the insertion started from, so the caret returns to where the
+        // typing began rather than staying at the end of the shortened value.
+        output += "\nUndoing the insertion.\n";
+        await waitForValueChanged(axTarget, "undo");
+        output += expect("characterCountAtDelivery", "5");
+        output += expect("valueAtDelivery", "'AXValue: Hello'");
+        output += expect("caretAtDelivery", "'{5, 0}'");
+
+        output += "\nRedoing the insertion.\n";
+        await waitForValueChanged(axTarget, "redo");
+        output += expect("characterCountAtDelivery", "11");
+        output += expect("valueAtDelivery", "'AXValue: Hello world'");
+        output += expect("caretAtDelivery", "'{11, 0}'");
+
+        output += "\nThe value the notification advertised is the one that persists.\n";
+        output += expect("characterCount()", "11");
+
+        document.getElementById("target").style.visibility = "hidden";
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### a09eb789c913720a2c19ef4bb516a0b7d6641729
<pre>
AX: Add a layout test for accessibility text state across undo and redo
<a href="https://bugs.webkit.org/show_bug.cgi?id=323532">https://bugs.webkit.org/show_bug.cgi?id=323532</a>
<a href="https://rdar.apple.com/186771075">rdar://186771075</a>

Reviewed by Chris Fleizach.

Undo and redo change a text control&apos;s value without any script touching it -- the edit is unapplied
by EditCommandComposition, not by an assignment the page makes. Editor::unappliedEditing() and
Editor::reappliedEditing() both end in respondToChangedContents(), which posts AXValueChanged via
AXObjectCache::onEditableTextValueChanged(). No accessibility test covered either command.

This test verifies that accessibility&apos;s notion of the field value, character count, and cursor
position is correct after undo and redo.

* LayoutTests/accessibility/isolated-tree/mac/undo-redo-text-state-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/undo-redo-text-state.html: Added.
* LayoutTests/accessibility/mac/undo-redo-text-state-expected.txt: Added.
* LayoutTests/accessibility/mac/undo-redo-text-state.html: Added.

Canonical link: <a href="https://commits.webkit.org/320679@main">https://commits.webkit.org/320679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7356f1970ad65e9e8a66779193a27aa4b5f10e85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185219 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195545 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150061 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d7fa1fbd-7731-4946-a736-3e8c8efd1a9d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187081 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144733 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100369 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c41de1cd-404d-4981-ad7f-5adff11c176b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125026 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd4765ea-f227-4043-a722-e757fc25b37e) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/184547 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47147 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45208 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6939 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13827 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157514 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44895 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6601 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46477 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51787 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197496 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/184622 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58795 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164831 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154241 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41389 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59504 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41499 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153892 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48387 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131813 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128545 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57983 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19914 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57354 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57597 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57421 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->