### PR TITLE
AX: setting-attributes-is-asynchronous.html fails in isolated tree mode because takeFocus() waits

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -11,7 +11,6 @@ accessibility/mac/frame-with-title.html [ Failure ]
 accessibility/mac/pseudo-element-text-markers.html [ Failure ]
 accessibility/mac/ruby-hierarchy-roles.html [ Failure Pass ]
 accessibility/mac/search-predicate-from-ignored-element.html [ Failure ]
-accessibility/mac/setting-attributes-is-asynchronous.html [ Failure ]
 accessibility/mac/attributed-string/attributed-string-has-completion-annotation.html [ Failure ]
 accessibility/isolated-tree/mac/attributed-string/attributed-string-has-completion-annotation.html [ Failure ]
 

--- a/LayoutTests/accessibility/isolated-tree/mac/setting-attributes-is-asynchronous-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/setting-attributes-is-asynchronous-expected.txt
@@ -1,0 +1,11 @@
+
+This tests makes sure that setting accessibility attributes happens asychronously, so that a caller won't hang if the result is an alert.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+This line should be printed first
+This line should be printed second.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/setting-attributes-is-asynchronous.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/setting-attributes-is-asynchronous.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+
+<input type="text" id="textfield" onfocus="debug('This line should be printed second.');  finishJSTest(); ">
+
+<div id="description"></div>
+<div id="console"></div>
+
+<script>
+
+description("This tests makes sure that setting accessibility attributes happens asychronously, so that a caller won't hang if the result is an alert.")
+
+if (window.testRunner && window.accessibilityController) {
+   window.jsTestIsAsync = true;
+   var textfield = accessibilityController.accessibleElementById("textfield");
+   textfield.takeFocus();
+   debug("This line should be printed first");
+} else
+   debug((window.testRunner ? "window.testRunner" : "window.accessibilityController") + " is not present");
+
+</script>
+</body>
+</html>

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -2309,7 +2309,11 @@ bool AccessibilityUIElementMac::isInTable() const
 
 void AccessibilityUIElementMac::takeFocus()
 {
-    setAttributeValue(m_element.get(), NSAccessibilityFocusedAttribute, @YES);
+    BEGIN_AX_OBJC_EXCEPTIONS
+    s_controller->executeOnAXThread([element = m_element] {
+        [element.get() accessibilitySetValue:@YES forAttribute:NSAccessibilityFocusedAttribute];
+    });
+    END_AX_OBJC_EXCEPTIONS
 }
 
 void AccessibilityUIElementMac::takeSelection()


### PR DESCRIPTION
#### 7468b6444dc1bb6669a9cd4476073d54ad1b52be
<pre>
AX: setting-attributes-is-asynchronous.html fails in isolated tree mode because takeFocus() waits
<a href="https://bugs.webkit.org/show_bug.cgi?id=323535">https://bugs.webkit.org/show_bug.cgi?id=323535</a>
<a href="https://rdar.apple.com/186773197">rdar://186773197</a>

Reviewed by Chris Fleizach and Dominic Mazzoni.

The test asserts that setting an accessibility attribute doesn&apos;t block the caller, by focusing a text
field and checking that the line printed after takeFocus() comes before the one its onfocus handler
prints. It got them the other way around in isolated tree mode.

takeFocus() went through setAttributeValue(), which dispatches with executeOnAXThreadAndWait() and
spins the main run loop until the accessibility thread is done. Focus was therefore taken, and the
handler had run, before takeFocus() returned.

Change AccessibilityUIElementMac::takeFocus to dispatch without waiting, similar to how every
other non-AXSync prefixed action works.

* LayoutTests/accessibility-isolated-tree/TestExpectations:
* LayoutTests/accessibility/isolated-tree/mac/setting-attributes-is-asynchronous-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/setting-attributes-is-asynchronous.html: Added.
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElementMac::takeFocus):

Canonical link: <a href="https://commits.webkit.org/320702@main">https://commits.webkit.org/320702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12d560aefbc5e54461ca0e0fd90b180f1a356e12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150311 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/96739049-f4c5-407a-ad68-3c8c29238ceb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59208 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145015 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100543 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37a04447-de17-434a-822b-87cc10e2beff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125309 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d68397e9-d922-4db5-b557-84f1a1d55047) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47422 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45479 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157788 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45163 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6945 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197845 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165099 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154550 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41406 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59853 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41768 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154199 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48664 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129102 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58324 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20185 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57701 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57941 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57766 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->