### PR TITLE
RenderLayer::backgroundIsKnownToBeOpaqueInRect should account for clip-path and mask

### DIFF
--- a/LayoutTests/compositing/masks/clip-path-with-opaque-child-background-expected.html
+++ b/LayoutTests/compositing/masks/clip-path-with-opaque-child-background-expected.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+  .c {
+      position: relative;
+      will-change: transform;
+  }
+  .clip {
+      width: 200px;
+      height: 200px;
+      clip-path: circle();
+  }
+  .blue {
+      width: 100%;
+      height: 100%;
+      background: blue;
+  }
+</style>
+
+You should see a blue circle without a black square.
+
+<div class="c">
+  <div class="clip">
+    <div class="blue"></div>
+  </div>
+</div>

--- a/LayoutTests/compositing/masks/clip-path-with-opaque-child-background.html
+++ b/LayoutTests/compositing/masks/clip-path-with-opaque-child-background.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<style>
+  .c {
+      position: relative;
+      will-change: transform;
+  }
+  .clip {
+      width: 200px;
+      height: 200px;
+      clip-path: circle();
+  }
+  .blue {
+      width: 100%;
+      height: 100%;
+      background: blue;
+      position: absolute;
+  }
+</style>
+
+You should see a blue circle without a black square.
+
+<div class="c">
+  <div class="clip">
+    <div class="blue"></div>
+  </div>
+</div>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5886,7 +5886,7 @@ bool RenderLayer::backgroundIsKnownToBeOpaqueInRect(const LayoutRect& localRect)
     
     // We can't consult child layers if we clip, since they might cover
     // parts of the rect that are clipped out.
-    if (renderer().hasNonVisibleOverflow())
+    if (renderer().hasNonVisibleOverflow() || renderer().hasClipPath() || renderer().hasMask())
         return false;
     
     return listBackgroundIsKnownToBeOpaqueInRect(positiveZOrderLayers(), localRect)


### PR DESCRIPTION
#### 56c34b19052f1b17a93edb6d8decbbaaef1df934
<pre>
RenderLayer::backgroundIsKnownToBeOpaqueInRect should account for clip-path and mask
<a href="https://bugs.webkit.org/show_bug.cgi?id=322885">https://bugs.webkit.org/show_bug.cgi?id=322885</a>

Reviewed by Simon Fraser.

A layer with clip-path or mask can render a non-rectangular area even
when its children fully cover the layer&apos;s bounds, so it should not be
treated as opaque based solely on its children&apos;s opacity.

* LayoutTests/compositing/masks/clip-path-with-opaque-child-background-expected.html: Added.
* LayoutTests/compositing/masks/clip-path-with-opaque-child-background.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::backgroundIsKnownToBeOpaqueInRect):
(WebCore::RenderLayer::calculateClipRects const):

Canonical link: <a href="https://commits.webkit.org/320634@main">https://commits.webkit.org/320634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4de97ec71f5cb0efd11e3cc1464376ce287f116

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195552 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150066 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187088 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60502 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58865 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144736 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100373 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165334 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125029 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47155 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45216 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157522 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44904 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6608 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197503 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164840 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154248 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59511 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41508 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153900 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28151 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48393 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131821 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128559 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57990 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19923 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57361 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57604 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57428 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->