### PR TITLE
[NewCodable] Add the ability to decode legacy Decodable types and Data

### DIFF
--- a/Source/WebKit/Shared/JavaScriptEvaluationGraphDecoder.swift
+++ b/Source/WebKit/Shared/JavaScriptEvaluationGraphDecoder.swift
@@ -262,19 +262,79 @@ struct JavaScriptEvaluationGraphDecoder<ID: Hashable & Sendable>: CommonDecoder,
 
     @_lifetime(self: copy self)
     mutating func decodeAny<V: CommonDecodingVisitor>(_ visitor: V) throws(CodingError.Decoding) -> V.DecodedValue {
-        fatalError("\(#function) is not implemented")
+        switch try codableValue() {
+        case .empty:
+            try visitor.visitNone()
+
+        case .bool(let value):
+            try visitor.visit(value)
+
+        case .number(let value):
+            if let integer = Int64(exactly: value) {
+                try visitor.visit(integer)
+            } else if let integer = UInt64(exactly: value) {
+                try visitor.visit(integer)
+            } else {
+                try visitor.visit(value)
+            }
+
+        case .string:
+            try decodeString(visitor)
+
+        case .seconds:
+            fatalError()
+
+        case .array:
+            try decodeArray { decoder throws(CodingError.Decoding) in
+                try visitor.visit(decoder: &decoder)
+            }
+
+        case .object:
+            try decodeStruct { decoder throws(CodingError.Decoding) in
+                try visitor.visit(decoder: &decoder)
+            }
+        }
     }
 
     @_lifetime(self: copy self)
     mutating func decodeBytes<V: DecodingBytesVisitor>(visitor: V) throws(CodingError.Decoding) -> V.DecodedValue {
-        fatalError("\(#function) is not implemented")
+        let value = try codableValue()
+
+        switch value {
+        case .string(let string):
+            guard let data = Data(base64Encoded: string) else {
+                throw CodingError.dataCorrupted(
+                    at: codingPath,
+                    debugDescription: "\(string) is not a valid base64 string."
+                )
+            }
+
+            return try visitor.visitBytes([UInt8](data))
+
+        case .array:
+            let bytes = try decodeArray { decoder throws(CodingError.Decoding) in
+                var bytes: [UInt8] = []
+                bytes.reserveCapacity(decoder.sizeHint ?? 0)
+
+                try decoder.decodeEachElement { elementDecoder throws(CodingError.Decoding) in
+                    bytes.append(try elementDecoder.decode(UInt8.self))
+                }
+
+                return bytes
+            }
+
+            return try visitor.visitBytes(bytes)
+
+        default:
+            throw CodingError.typeMismatch(
+                expectedTypeDescription: "base64 string or byte array",
+                actualValueDescription: "\(value)",
+                at: codingPath
+            )
+        }
     }
 
-    @_disfavoredOverload
-    @_lifetime(self: copy self)
-    mutating func decode<D: Decodable>(_: D.Type) throws(CodingError.Decoding) -> D {
-        fatalError("\(#function) is not implemented")
-    }
+    // Intentionally does not implement the `mutating func decode<D: Decodable>(_: D.Type) throws(CodingError.Decoding) -> D ` requirement; the default implementation is sound.
 }
 
 extension JavaScriptEvaluationGraphDecoder {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptEvaluationTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptEvaluationTests.swift
@@ -26,6 +26,7 @@
 @_spi(Experimental_NewCodable) import WebKit
 import Testing
 import NewCodable
+import struct FoundationEssentials.Data
 import struct Swift.String
 
 // MARK: Supporting types
@@ -69,6 +70,25 @@ private struct Team: Equatable {
 
 @CommonDecodable
 private struct Empty: Equatable {}
+
+private struct Profile: Decodable, Equatable {
+    let name: String
+    let age: Int
+    let tags: [String]
+}
+
+private struct CommonDecodableAdaptor<D: Decodable> {
+    let value: D
+}
+
+extension CommonDecodableAdaptor: CommonDecodable {
+    static func decode(from decoder: inout some (CommonDecoder & ~Escapable)) throws(CodingError.Decoding) -> Self {
+        CommonDecodableAdaptor(value: try decoder.decode(D.self))
+    }
+}
+
+extension CommonDecodableAdaptor: Equatable where D: Equatable {
+}
 
 // MARK: Tests
 
@@ -463,6 +483,51 @@ struct JavaScriptEvaluationTests {
             #"return { lead: { name: "Ada", age: 36 }, members: {}, scoresByName: {} };"#
         }
     }
+
+    @Test
+    func decodingData() async throws {
+        let data = Data([1, 2, 255])
+
+        // Bytes are either an array of numbers or the base64 string a script would produce for them.
+        try await testDecoding(data) { "return [1, 2, 255];" }
+        try await testDecoding(data) { "return btoa(String.fromCharCode(1, 2, 255));" }
+        try await testDecoding(Data()) { "return [];" }
+        try await testDecoding(Data()) { #"return "";"# }
+
+        // Every element has to be a byte, so one out of range or not integral is corrupt data
+        // rather than something to truncate.
+        await testDataCorrupted(decoding: Data.self) { "return [256];" }
+        await testDataCorrupted(decoding: Data.self) { "return [-1];" }
+        await testDataCorrupted(decoding: Data.self) { "return [1.5];" }
+        await testTypeMismatch(decoding: Data.self) { #"return ["1"];"# }
+
+        // A string is read as base64, so one which is not is corrupt data too.
+        await testDataCorrupted(decoding: Data.self) { #"return "not base64!";"# }
+
+        // Anything which is neither shape is a mismatch. A typed array is among them: it is
+        // not a JavaScript array, so it arrives keyed by index like any other object.
+        await testTypeMismatch(decoding: Data.self) { "return { 0: 1, 1: 2 };" }
+        await testTypeMismatch(decoding: Data.self) { "return 42;" }
+        await testTypeMismatch(decoding: Data.self) { "return null;" }
+    }
+
+    @Test
+    func decodingStandardDecodable() async throws {
+        typealias ProfileAdaptor = CommonDecodableAdaptor<Profile>
+
+        let box = ProfileAdaptor(value: Profile(name: "Ada", age: 36, tags: ["swift", "webkit"]))
+
+        try await testDecoding(box) {
+            #"return { name: "Ada", age: 36, tags: ["swift", "webkit"] };"#
+        }
+
+        // The standard decoding machinery classifies failures on this path, not the graph
+        // decoder, so only the fact that one is raised is checked here.
+        await testDecodingFailure(decoding: ProfileAdaptor.self) { #"return { name: "Ada", tags: [] };"# }
+        await testDecodingFailure(decoding: ProfileAdaptor.self) { #"return { name: "Ada", age: "36", tags: [] };"# }
+        await testDecodingFailure(decoding: ProfileAdaptor.self) { "return 42;" }
+        await testDecodingFailure(decoding: ProfileAdaptor.self) { "return null;" }
+    }
 }
 
 // MARK: Helpers
@@ -477,6 +542,7 @@ extension JavaScriptEvaluationTests {
         #expect(actual == expectedValue, sourceLocation: sourceLocation)
     }
 
+    @discardableResult
     private func testDecodingFailure<T: CommonDecodable>(
         decoding type: T.Type,
         sourceLocation: SourceLocation = #_sourceLocation,


### PR DESCRIPTION
#### df4d161570c606716592422d307db97e9bc9eda5
<pre>
[NewCodable] Add the ability to decode legacy Decodable types and Data
<a href="https://bugs.webkit.org/show_bug.cgi?id=323538">https://bugs.webkit.org/show_bug.cgi?id=323538</a>
<a href="https://rdar.apple.com/186776446">rdar://186776446</a>

Reviewed by Abrar Rahman Protyasha.

Test: Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptEvaluationTests.swift

* Source/WebKit/Shared/JavaScriptEvaluationGraphDecoder.swift:
(bytes):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/JavaScriptEvaluationTests.swift:
(CommonDecodableAdaptor.decode(from:)):
(JavaScriptEvaluationTests.decodingData):
(JavaScriptEvaluationTests.decodingStandardDecodable):

Canonical link: <a href="https://commits.webkit.org/320669@main">https://commits.webkit.org/320669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92503448c590a8c852e6e99529ba3badedbd7262

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52958 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195555 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150067 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f0ebd33-6ac1-4c5b-a28a-88fc66392ded) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187091 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144741 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100372 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6374c84e-d798-4c2e-8f0f-67b14684601b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188184 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48429 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165336 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125034 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8932b627-f906-46e6-be4a-e667e17a2ab3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47157 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45218 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157524 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44906 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6611 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197506 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58805 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154251 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41381 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59514 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41510 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153902 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48398 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131824 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128564 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57993 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19927 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57364 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57607 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57431 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->