### PR TITLE
Synchronous same-document history traversals coalesce instead of firing each popstate/hashchange

### DIFF
--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -258,6 +258,7 @@
     "web-platform-tests/network-error-logging": "skip",
     "web-platform-tests/notifications": "import",
     "web-platform-tests/old-tests": "skip",
+    "web-platform-tests/old-tests/submission/Microsoft/history": "import",
     "web-platform-tests/orientation-event": "skip",
     "web-platform-tests/orientation-sensor": "skip",
     "web-platform-tests/page-lifecycle": "import",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-cross-document-traversal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-cross-document-traversal-expected.txt
@@ -1,7 +1,4 @@
 
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT traversals in the same (back) direction: queued up Test timed out
-NOTRUN traversals in the same (forward) direction: queued up
+PASS traversals in the same (back) direction: queued up
+PASS traversals in the same (forward) direction: queued up
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-hashchange-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-hashchange-expected.txt
@@ -2,8 +2,8 @@
 
 Harness Error (TIMEOUT), message = null
 
-TIMEOUT same-document traversals in opposite directions: queued up Test timed out
-NOTRUN same-document traversals in opposite directions, second traversal invalid at queuing time: queued up
+PASS same-document traversals in opposite directions: queued up
+TIMEOUT same-document traversals in opposite directions, second traversal invalid at queuing time: queued up Test timed out
 NOTRUN same-document traversals in the same (back) direction: queue up
 NOTRUN same-document traversals in the same (forward) direction: queue up
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-pushstate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-pushstate-expected.txt
@@ -1,9 +1,6 @@
 
-
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT same-document traversals in opposite directions: queued up Test timed out
-NOTRUN same-document traversals in opposite directions, second traversal invalid at queuing time: queued up
-NOTRUN same-document traversals in the same (back) direction: queue up
-NOTRUN same-document traversals in the same (forward) direction: queue up
+PASS same-document traversals in opposite directions: queued up
+PASS same-document traversals in opposite directions, second traversal invalid at queuing time: queued up
+PASS same-document traversals in the same (back) direction: queue up
+PASS same-document traversals in the same (forward) direction: queue up
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/004-expected.txt
@@ -1,6 +1,6 @@
 
 PASS .go commands should be queued until the thread has ended
 PASS browser needs to support hashchange events for this testcase
-FAIL queued .go commands should all be executed when the queue is processed assert_equals: the wrong number of queued commands were executed expected 2 but got 1
-FAIL history position should be calculated when executing, not when calling the .go command assert_equals: expected "" but got "bar"
+PASS queued .go commands should all be executed when the queue is processed
+PASS history position should be calculated when executing, not when calling the .go command
 

--- a/LayoutTests/imported/w3c/web-platform-tests/old-tests/submission/Microsoft/history/history_000-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/old-tests/submission/Microsoft/history/history_000-expected.txt
@@ -1,0 +1,27 @@
+
+PASS onpopstate in window
+PASS history.pushState is present
+PASS history.replaceState is present
+PASS history.state is present
+PASS history.state is initialized to null
+PASS history.pushState increments history.length
+PASS history.pushState clears forward entries
+PASS history.pushState accepts a third parameter 'url' and uses it to alter location
+PASS history.pushState's url parameter can be an absolute url
+PASS history.pushState can modify location object in multiple frames
+PASS history.pushState throws DOMException with code SECURITY_ERR (18)
+PASS history.pushState throws DATA_CLONE_ERR(25) for bad state parameter
+PASS history.replaceState does not increment history.length
+PASS history.replaceState does not clear forward entries
+PASS history.replaceState accepts a third parameter 'url' and uses it to alter location
+PASS history.replaceState's url parameter can be an absolute url
+PASS history.replaceState can modify location object in multiple frames
+PASS history.replaceState throws DOMException with code SECURITY_ERR (18)
+PASS history.replaceState throws DATA_CLONE_ERR(25) for bad state parameter
+PASS PopStateEvent fires on Back navigation
+PASS PopStateEvent fires on Forward navigation
+PASS PopStateEvent receives state data on Back navigation
+PASS history.state is set by history.pushState
+PASS history.state is set by history.replaceState
+PASS history.state changes on navigation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/old-tests/submission/Microsoft/history/history_000.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/old-tests/submission/Microsoft/history/history_000.htm
@@ -1,0 +1,342 @@
+<!doctype html>
+<html>
+    <head>
+        <meta content="text/html; charset=utf-8" http-equiv="content-type" />
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="help" href="http://dev.w3.org/html5/spec/history.html" />
+        <title>HTML5 History Test Cases</title>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+    </head>
+<body>
+    <div id="log"></div>
+
+    <!-- Use this iframe to test url changes so that the base url does not change. Their document does not matter. -->
+    <iframe id="testframe1" style="display:none" src="/common/blank.html"></iframe>
+    <iframe id="testframe2" style="display:none" src="/common/blank.html"></iframe>
+
+    <script type="text/javascript">
+        var testCollection;
+        var testIndex = 0;
+        var testframe1 = document.getElementById("testframe1");
+        var testframe2 = document.getElementById("testframe2");
+
+        setup(function()
+        {
+            testCollection = [
+                function() {
+                     test(function() {
+                        assert_own_property(window, "onpopstate", "window has 'onpopstate' own property");
+                     }, "onpopstate in window");
+                },
+                function() {
+                     test(function() {
+                        assert_inherits(window.history, "pushState", "history inherits property 'pushState'");
+                        assert_equals(window.history.pushState.constructor, Function, "pushState is a function");
+                     }, "history.pushState is present");
+                 },
+                 function() {
+                     test(function() {
+                        assert_inherits(window.history, "replaceState", "history inherits property 'replaceState'");
+                        assert_equals(window.history.replaceState.constructor, Function, "replaceState is a function");
+                     }, "history.replaceState is present");
+                 },
+                 function() {
+                     test(function() {
+                        assert_inherits(window.history, "state", "history inherits property 'state'");
+                     }, "history.state is present");
+                },
+                function() {
+                     test(function() {
+                        assert_equals(window.history.state, null, "history.state initialized to null");
+                     }, "history.state is initialized to null");
+                },
+
+                function() {
+                    test(function() {
+                        var length = history.length;
+                        history.pushState(null,null);
+                        assert_equals(history.length, length+1, "history.length should be incremented by one");
+                    }, "history.pushState increments history.length");
+                },
+
+                function() {
+                    var t = async_test("history.pushState clears forward entries");
+                    t.step(function() {
+                        var length = history.length;
+                        //push some extra entries into the session history
+                        history.pushState(null,null);
+                        history.pushState(null, null);
+                        history.pushState(null, null);
+
+                        //there should now be three extra
+                        assert_equals(history.length, length+3, "Three additional travel entries add to history.length");
+
+                        let popstateCount = 0;
+                        onpopstate = t.step_func(function(e) {
+                          if (++popstateCount == 3) {
+                            onpopstate = null;
+                            //once the .back navigations have completed, push again and verify length is one more than starting value
+                            history.pushState(null, null);
+                            assert_equals(history.length, length+1, "History.length should now only be one more than original value");
+                            t.done();
+                          }
+                        });
+                        //travel back to the entry that the test started on
+                        history.back();
+                        history.back();
+                        history.back();
+                    });
+                },
+
+                function() {
+                    test(function() {
+                        testframe1.contentWindow.history.pushState(null,null, "test-pushstate-url");
+                        assert_equals(getPageName(testframe1.contentWindow.location.href), "test-pushstate-url", "iframe1 has the pushed url");
+                    }, "history.pushState accepts a third parameter 'url' and uses it to alter location");
+                },
+                function() {
+                    test(function() {
+                        var oldurl = testframe1.contentWindow.location.href.toString();
+                        var pagename = getPageName(oldurl);
+                        //form a new absolute url (with protocol, host, etc) with "absolute-page" as the name of the page
+                        var newurl = oldurl.replace(pagename, "absolute-page");
+
+                        testframe1.contentWindow.history.pushState(null,null, newurl);
+                        assert_equals(testframe1.contentWindow.location.href, newurl, "iframe1 has the pushed url correctly");
+                    }, "history.pushState's url parameter can be an absolute url");
+                },
+
+                function() {
+                    test(function() {
+                        testframe1.contentWindow.history.pushState(null,null, "multiple-pushstate-url1");
+                        testframe2.contentWindow.history.pushState(null,null, "multiple-pushstate-url2");
+
+                        assert_equals(getPageName(testframe1.contentWindow.location.href), "multiple-pushstate-url1", "iframe1 has the pushed url");
+                        assert_equals(getPageName(testframe2.contentWindow.location.href), "multiple-pushstate-url2", "iframe2 has the pushed url");
+                    }, "history.pushState can modify location object in multiple frames");
+                },
+
+                function() {
+                    test(function() {
+                        //trigger a security error by replacing the host of the current url with a fake one that is cross-domain
+                        var testurl = testframe1.contentWindow.location.href.toString().replace(testframe1.contentWindow.location.host, "fakelocation-push");
+                        assert_throws_dom("SECURITY_ERR", function() { history.pushState(null, null, testurl); }, "Security_Err 18 should be thrown");
+                    }, "history.pushState throws DOMException with code SECURITY_ERR (18)");
+                },
+
+                function() {
+                    test(function() {
+                        //trigger a data clone error by passing invalid SCA data into the function
+                        assert_throws_dom("DATA_CLONE_ERR", function() { history.pushState(document.body, null); }, "pushState should throw an exception DATA_CLONE_ERR with code 25");
+                    }, "history.pushState throws DATA_CLONE_ERR(25) for bad state parameter");
+                },
+
+                function() {
+                    test(function() {
+                        var length = history.length;
+                        history.replaceState(null,null);
+                        assert_equals(history.length, length, "history.length should not change");
+                    }, "history.replaceState does not increment history.length");
+                },
+
+                function() {
+                    var t = async_test("history.replaceState does not clear forward entries");
+                    t.step(function() {
+                        var length = history.length;
+                        //push some extra entries into the session history
+                        history.pushState(null,null);
+                        history.pushState(null, null);
+                        history.pushState(null, null);
+
+                        //there should now be three extra
+                        assert_equals(history.length, length+3, "Three additional travel entries add to history.length");
+
+                        let popstateCount = 0;
+                        onpopstate = t.step_func(function(e) {
+                          if (++popstateCount == 2) {
+                            onpopstate = null;
+                            //once the .back navigations have fired, replace and verify the length has not changed since the last check
+                            history.replaceState(null, null);
+                            assert_equals(history.length, length+3, "History.length should still be three more than original value");
+                            t.done();
+                          }
+                        });
+
+                        //travel back two entries to land in the middle
+                        history.back();
+                        history.back();
+                    });
+                },
+
+                function() {
+                    test(function() {
+                        testframe1.contentWindow.history.replaceState(null,null, "test-replaceState-url");
+                        assert_equals(getPageName(testframe1.contentWindow.location.href), "test-replaceState-url", "iframe1 has the pushed url");
+                    }, "history.replaceState accepts a third parameter 'url' and uses it to alter location");
+                },
+                function() {
+                    test(function() {
+                        var oldurl = testframe1.contentWindow.location.href.toString();
+                        var pagename = getPageName(oldurl);
+                        //form a new absolute url (with protocol, host, etc) with "absolute-page" as the name of the page
+                        var newurl = oldurl.replace(pagename, "absolute-page");
+
+                        testframe1.contentWindow.history.replaceState(null,null, newurl);
+                        assert_equals(testframe1.contentWindow.location.href, newurl, "iframe1 has the pushed url correctly");
+                    }, "history.replaceState's url parameter can be an absolute url");
+                },
+
+                function() {
+                    test(function() {
+                        testframe1.contentWindow.history.replaceState(null,null, "multiple-replaceState-url1");
+                        testframe2.contentWindow.history.replaceState(null,null, "multiple-replaceState-url2");
+
+                        assert_equals(getPageName(testframe1.contentWindow.location.href), "multiple-replaceState-url1", "iframe1 has the pushed url");
+                        assert_equals(getPageName(testframe2.contentWindow.location.href), "multiple-replaceState-url2", "iframe2 has the pushed url");
+                    }, "history.replaceState can modify location object in multiple frames");
+                },
+
+                function() {
+                    test(function() {
+                        //trigger a security error by replacing the host of the current url with a fake one that is cross-domain
+                        var testurl = testframe1.contentWindow.location.href.toString().replace(testframe1.contentWindow.location.host, "fakelocation-replace");
+                        assert_throws_dom("SECURITY_ERR", function() { history.replaceState(null, null, testurl); }, "Security_Err 18 should be thrown");
+                    }, "history.replaceState throws DOMException with code SECURITY_ERR (18)");
+                },
+
+                function() {
+                    test(function() {
+                        //trigger a data clone error by passing invalid SCA data into the function
+                        assert_throws_dom("DATA_CLONE_ERR", function() {history.replaceState(document.body, null);}, "replaceState should throw an exception DATA_CLONE_ERR with code 25");
+                    }, "history.replaceState throws DATA_CLONE_ERR(25) for bad state parameter");
+                },
+
+                function() {
+                    var t = async_test("PopStateEvent fires on Back navigation");
+                    t.step(function() {
+                        history.pushState(null, null);
+                        history.pushState(null, null);
+                        //prepare to end the test as soon as popstate fires
+                        onpopstate = function(e) {
+                            t.done();
+                        }
+                        //go back to fire the popstate event
+                        history.back();
+                    });
+                },
+
+                function() {
+                    var t = async_test("PopStateEvent fires on Forward navigation");
+                    t.step(function() {
+                        onpopstate = null;
+                        history.pushState(null, null);
+                        history.pushState(null, null);
+                        onpopstate = function(e) {
+                            //prepare to end the test as soon as popstate fires
+                            onpopstate = function(e) {
+                                t.done();
+                            };
+                            //go forward to fire the popstate event
+                            history.forward();
+                        };
+                        history.back();
+                    });
+                },
+
+                function() {
+                    var t = async_test("PopStateEvent receives state data on Back navigation");
+                    t.step(function() {
+                        history.pushState("popstate-data", null);
+                        history.pushState(null, null);
+                        //prepare the popstate event to validate the data
+                        onpopstate = t.step_func(function(e) {
+                            assert_equals(e.state, "popstate-data", "State data is passed to the event correctly");
+                            t.done();
+                        });
+                        //go back to fire the popstate event
+                        history.back();
+                    });
+                },
+
+                function() {
+                    test(function() {
+                        history.pushState("pushstate-data", null);
+                        //history.state should be set immediately
+                        assert_equals(history.state, "pushstate-data", "State data is set correctly");
+                    }, "history.state is set by history.pushState");
+                },
+
+                function() {
+                    test(function() {
+                        history.replaceState("replacestate-data", null);
+                        //history.state should be set immediately
+                        assert_equals(history.state, "replacestate-data", "State data is set correctly");
+                    }, "history.state is set by history.replaceState");
+                },
+
+                function() {
+                    var t = async_test("history.state changes on navigation");
+                    t.step(function() {
+                        history.pushState("state-back1", null);
+                        history.pushState("state-back2", null);
+                        //precondition
+                        assert_equals(history.state, "state-back2", "Verify that history.state is set to a second value");
+
+                        //set up the popstate event to verify that history.state was changed
+                        onpopstate = t.step_func(function(e) {
+                            assert_equals(e.state, "state-back1", "Verify that history.state reverted to the first value");
+                            t.done();
+                        });
+                        history.back();
+                    });
+                },
+            ];
+        }, {explicit_done:true, timeout:8000});
+
+        //used to get the name of a page within a path
+        //  to check correctness of url parameter
+        function getPageName(path) {
+            var path = path || location.pathname;
+            var segments = path.split('/');
+            return segments[segments.length-1];
+        }
+
+        //Callback for result_callback
+        //queues the next test in the array testCollection
+        //serves to make test execution sequential despite asynchronous behaviors
+        function testFinished(test) {
+            if(testIndex < testCollection.length - 1) {
+                //Run the function asynchronously so that the stack remains shallow
+                setTimeout(testCollection[++testIndex]);
+            } else {
+                //when the last test has run, explicitly end test suite
+                done();
+            }
+        }
+
+        add_result_callback(testFinished);
+
+        function startTestsWhenIframesLoaded() {
+          if (testframe1.contentWindow.document.readyState != 'complete' ||
+              testframe2.contentWindow.document.readyState != 'complete' ||
+              testframe1.contentDocument.location.href == 'about:blank' ||
+              testframe2.contentDocument.location.href == 'about:blank') {
+            return;
+          }
+          testframe1.removeEventListener('load', startTestsWhenIframesLoaded, false);
+          testframe2.removeEventListener('load', startTestsWhenIframesLoaded, false);
+
+          //start the first test
+          setTimeout(testCollection[testIndex]);
+        }
+
+        // add listeners to trigger the tests once the iframes are loaded,
+        // but also try to start it right away in case the load events have
+        // already fired and we missed them.
+        testframe1.addEventListener('load', startTestsWhenIframesLoaded, false);
+        testframe2.addEventListener('load', startTestsWhenIframesLoaded, false);
+        startTestsWhenIframesLoaded();
+     </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/old-tests/submission/Microsoft/history/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/old-tests/submission/Microsoft/history/w3c-import.log
@@ -1,0 +1,15 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/old-tests/submission/Microsoft/history/history_000.htm

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -105,7 +105,7 @@ public:
     enum class ShouldCancel : uint8_t { No, Yes };
     virtual ShouldCancel adjustForNewBackForwardEntry() { return ShouldCancel::No; }
 
-    enum class AccumulateResult : uint8_t { NotHandled, Accumulated, CancelPending };
+    enum class AccumulateResult : uint8_t { NotHandled, Accumulated, CancelPending, Enqueue };
     virtual AccumulateResult accumulateHistorySteps(Frame& /*frame*/, int /*additionalSteps*/) { return AccumulateResult::NotHandled; }
 
     double NODELETE delay() const { return m_delay; }
@@ -355,7 +355,15 @@ public:
         if (!localFrame)
             return false;
 
-        RefPtr historyItem = targetHistoryItem(*localFrame);
+        RefPtr page = localFrame->page();
+        if (!page)
+            return false;
+
+        // Evaluate same-document-ness for the originating frame, not the root. A subframe's
+        // traversal forwards to the top scheduler (so fire()/targetHistoryItem() resolve against
+        // the root), but whether an observable same-document event fires depends on the
+        // originating frame's own items, so look those up directly instead of the cached root item.
+        RefPtr historyItem = protect(page->backForward())->itemAtIndex(m_steps, localFrame->frameID());
         if (!historyItem)
             return false;
 
@@ -377,8 +385,11 @@ public:
         // history.go(0) is reload per spec, not a delta-traversal — fall through to normal scheduling.
         if (!additionalSteps)
             return AccumulateResult::NotHandled;
+        // A pending same-document traversal (hash/pushState) must fire its own popstate/hashchange
+        // before the next runs, so it can't coalesce into a net delta. Queue it instead of letting
+        // the schedule() path evict the pending navigation.
         if (isSameDocumentNavigation(frame))
-            return AccumulateResult::NotHandled;
+            return AccumulateResult::Enqueue;
         m_steps += additionalSteps;
         if (!m_steps)
             return AccumulateResult::CancelPending;
@@ -648,6 +659,7 @@ void NavigationScheduler::clear()
 {
     m_timer.stop();
     m_redirect = nullptr;
+    m_queuedHistorySteps.clear();
 }
 
 inline bool NavigationScheduler::shouldScheduleNavigation() const
@@ -856,6 +868,10 @@ void NavigationScheduler::scheduleHistoryNavigation(Frame& originatingFrame, int
         case ScheduledNavigation::AccumulateResult::CancelPending:
             cancel();
             return;
+        case ScheduledNavigation::AccumulateResult::Enqueue:
+            // Same-document pending traversal: keep it and queue this one so it fires after.
+            m_queuedHistorySteps.append(steps);
+            return;
         case ScheduledNavigation::AccumulateResult::NotHandled:
             break;
         }
@@ -919,6 +935,15 @@ void NavigationScheduler::timerFired()
     LOG(History, "NavigationScheduler %p timerFired - firing redirect %p", this, redirect.get());
 
     redirect->fire(frame);
+
+    // Per "traverse the history by a delta", each queued traversal computes its target index
+    // (currentStepIndex + delta) when it runs. Schedule the next step now that the current one's
+    // event has dispatched, so it resolves against the updated current entry.
+    if (m_redirect || m_queuedHistorySteps.isEmpty())
+        return;
+    if (!frame->page())
+        return;
+    scheduleHistoryNavigation(frame.get(), m_queuedHistorySteps.takeFirst());
 }
 
 void NavigationScheduler::schedule(std::unique_ptr<ScheduledNavigation> redirect)
@@ -981,6 +1006,10 @@ void NavigationScheduler::adjustPendingHistoryNavigationForNewBackForwardEntry()
             return;
         }
     }
+    // Creating a new same-document entry (pushState/replaceState/fragment) removes any tasks
+    // queued by the history traversal task source, so drop queued traversals along with adjusting
+    // the pending one.
+    m_queuedHistorySteps.clear();
     if (!m_redirect)
         return;
     if (m_redirect->adjustForNewBackForwardEntry() == ScheduledNavigation::ShouldCancel::Yes)
@@ -999,7 +1028,7 @@ void NavigationScheduler::cancel(NewLoadInProgress newLoadInProgress)
 
 bool NavigationScheduler::hasQueuedNavigation() const
 {
-    return m_redirect && !m_redirect->delay();
+    return (m_redirect && !m_redirect->delay()) || !m_queuedHistorySteps.isEmpty();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/NavigationScheduler.h
+++ b/Source/WebCore/loader/NavigationScheduler.h
@@ -36,6 +36,7 @@
 #include <WebCore/Timer.h>
 #include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/Deque.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakRef.h>
 
@@ -95,6 +96,7 @@ private:
     WeakRef<Frame> m_frame;
     Timer m_timer;
     std::unique_ptr<ScheduledNavigation> m_redirect;
+    Deque<int> m_queuedHistorySteps;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 379c7d7aafb1affdc037a50881bfdd9cec171f09
<pre>
Synchronous same-document history traversals coalesce instead of firing each popstate/hashchange
<a href="https://bugs.webkit.org/show_bug.cgi?id=323539">https://bugs.webkit.org/show_bug.cgi?id=323539</a>
<a href="https://rdar.apple.com/186777330">rdar://186777330</a>

Reviewed by NOBODY (OOPS!).

Bug 317077 added coalescing of synchronously-queued history.back()/forward()/go(n)
into a net delta to match HTML&apos;s &quot;traverse the history by a delta&quot; algorithm.
Same-document traversals (hash/pushState) must instead fire an event per traversal,
but several things broke that:

- The same-document case fell through to schedule(), which cancels the pending
  navigation, so a second synchronous traversal evicted the first and only one
  event fired.
- isSameDocumentNavigation() resolved the target against the root frame while
  comparing to the originating frame&apos;s current item, so a subframe&apos;s same-document
  traversal was misclassified as cross-document. back();forward() then coalesced to
  a net-zero delta and was cancelled outright, firing no event at all.
- Queued traversals were not removed when a new same-document entry was created,
  contrary to the history traversal task source being cleared by the URL and
  history update steps.

Queue same-document traversals behind the pending one and run them one at a time,
evaluate same-document-ness against the originating frame, resolve each queued
traversal&apos;s target when it fires (not when it is queued), and drop queued
traversals when a new same-document entry is created.

* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledNavigation::AccumulateResult): Add Enqueue.
(WebCore::ScheduledHistoryNavigation::isSameDocumentNavigation): Resolve the item
against the originating frame instead of the root.
(WebCore::ScheduledHistoryNavigation::accumulateHistorySteps): Return Enqueue for a
same-document pending traversal.
(WebCore::NavigationScheduler::clear): Clear the queue.
(WebCore::NavigationScheduler::scheduleHistoryNavigation): Handle Enqueue.
(WebCore::NavigationScheduler::timerFired): Run the next queued traversal after
firing the current one, so its target is resolved at fire time.
(WebCore::NavigationScheduler::adjustPendingHistoryNavigationForNewBackForwardEntry):
Drop queued traversals when a new same-document entry is created.
(WebCore::NavigationScheduler::hasQueuedNavigation): Account for the queue.
* Source/WebCore/loader/NavigationScheduler.h:

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-pushstate-expected.txt: Now passes.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-cross-document-traversal-expected.txt: Now pass
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/004-expected.txt: Now passes.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-traversal-same-document-traversal-pushstate-expected.txt: Partial Progression

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/972e0e100fa754629cd00e549d6fa20a243af2bd">https://github.com/web-platform-tests/wpt/commit/972e0e100fa754629cd00e549d6fa20a243af2bd</a>

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/old-tests/submission/Microsoft/history/history_000-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/old-tests/submission/Microsoft/history/history_000.htm: Added.
* LayoutTests/imported/w3c/web-platform-tests/old-tests/submission/Microsoft/history/w3c-import.log: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/379c7d7aafb1affdc037a50881bfdd9cec171f09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195558 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150069 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1414e638-8bb0-4e15-ab40-a866cc87d88f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187094 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144742 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100376 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/09d94600-d570-4a67-9c53-b675199bdd58) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125035 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0427285-13cc-4ad9-bc8a-3c28f3df461d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47160 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45220 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157527 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44909 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6613 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51800 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197508 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58808 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154253 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59517 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41513 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153904 "Found 1 new API test failure: TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/42949672974097MallocReadOnly (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48399 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131827 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128569 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/57996 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19929 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57367 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57610 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57434 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->