### PR TITLE
[AppKit Gestures] For some tests, if they timeout, they may hang the entire test process if TestWebKitAPI is invoked directly

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift
@@ -98,7 +98,26 @@ public struct Future: Sendable, ~Copyable {
         case signaled
     }
 
-    private let state = Mutex<State>(.initial)
+    private final class Storage: Sendable {
+        let state = Mutex<State>(.initial)
+
+        func signal() {
+            let continuation = state.withLock { state -> CheckedContinuation<Void, Never>? in
+                defer {
+                    state = .signaled
+                }
+
+                if case .waiting(let continuation) = state {
+                    return continuation
+                }
+
+                return nil
+            }
+            continuation?.resume()
+        }
+    }
+
+    private let storage = Storage()
 
     /// Create a new Future.
     public init() {
@@ -106,40 +125,35 @@ public struct Future: Sendable, ~Copyable {
 
     /// Resolves the promise of this Future.
     public func signal() {
-        let continuation = state.withLock { state -> CheckedContinuation<Void, Never>? in
-            defer {
-                state = .signaled
-            }
-
-            if case .waiting(let continuation) = state {
-                return continuation
-            }
-
-            return nil
-        }
-        continuation?.resume()
+        storage.signal()
     }
 
-    /// Waits for the promise of this Future to be resolved.
+    /// Waits for the promise of this Future to be resolved, or for the current task to be cancelled.
     public func wait() async {
-        await withCheckedContinuation { continuation in
-            let resumeImmediately = state.withLock { state in
-                switch state {
-                case .signaled:
-                    return true
+        let storage = self.storage
 
-                case .initial:
-                    state = .waiting(continuation)
-                    return false
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                let resumeImmediately = storage.state.withLock { state in
+                    switch state {
+                    case .signaled:
+                        return true
 
-                case .waiting:
-                    preconditionFailure("Future only supports a single waiter")
+                    case .initial:
+                        state = .waiting(continuation)
+                        return false
+
+                    case .waiting:
+                        preconditionFailure("Future only supports a single waiter")
+                    }
+                }
+
+                if resumeImmediately {
+                    continuation.resume()
                 }
             }
-
-            if resumeImmediately {
-                continuation.resume()
-            }
+        } onCancel: {
+            storage.signal()
         }
     }
 }


### PR DESCRIPTION
#### ac7790c134a756f5d6779fba0f9f9e0b387b2236
<pre>
[AppKit Gestures] For some tests, if they timeout, they may hang the entire test process if TestWebKitAPI is invoked directly
<a href="https://bugs.webkit.org/show_bug.cgi?id=323542">https://bugs.webkit.org/show_bug.cgi?id=323542</a>
<a href="https://rdar.apple.com/186784001">rdar://186784001</a>

Reviewed by Abrar Rahman Protyasha.

Make `Future` support task cancellation so that timeouts work properly.

* Tools/TestWebKitAPI/Helpers/cocoa/Foundation+Extras.swift:
(Storage.signal):
(signal):
(wait):
(State.signal): Deleted.
(State.wait): Deleted.

Canonical link: <a href="https://commits.webkit.org/320657@main">https://commits.webkit.org/320657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44c927f46f1a4c798684fa556f1c0c71b7044b9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195568 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150075 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58881 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144752 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100380 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a6583215-58d2-4808-be00-b83e6eec20f5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165347 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125045 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/562a6db2-5239-4f60-8d33-f70104b751f0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47168 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45230 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157535 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44917 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6623 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197518 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58818 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154262 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41369 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59527 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153913 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48410 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128586 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58006 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19937 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57377 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57620 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57444 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->