### PR TITLE
[list-marker] The outside list marker resolves its content during layout instead of when it changes

### DIFF
--- a/Source/WebCore/rendering/RenderListOutsideMarker.cpp
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.cpp
@@ -325,10 +325,10 @@ void RenderListOutsideMarker::layout()
     ASSERT(needsLayout());
 
     if (CheckedPtr container = contentContainer()) {
-        updateInlineMarginsAndContent();
+        updateInlineMargins();
         layoutContentContainer(*container);
     } else if (isImage()) {
-        updateInlineMarginsAndContent();
+        updateInlineMargins();
         RefPtr image = m_image;
         setBorderBoxWidth(image->imageSize(this, style().usedZoom()).width());
         setBorderBoxHeight(image->imageSize(this, style().usedZoom()).height());
@@ -402,10 +402,11 @@ void RenderListOutsideMarker::imageChanged(WrappedImagePtr o, const IntRect* rec
                     element = pseudoElement->hostElement();
                 if (element)
                     element->invalidateStyleAndRenderersForSubtree();
-            }
-            if (borderBoxWidth() != image->imageSize(this, style().usedZoom()).width() || borderBoxHeight() != image->imageSize(this, style().usedZoom()).height() || image->errorOccurred())
                 setNeedsLayoutAndInvalidateContentLogicalWidths();
-            else
+            } else if (borderBoxSize() != LayoutSize(image->imageSize(this, style().usedZoom()))) {
+                updateInlineMarginsAndContent();
+                setNeedsLayoutAndInvalidateContentLogicalWidths();
+            } else
                 repaint();
         }
     }
@@ -414,9 +415,7 @@ void RenderListOutsideMarker::imageChanged(WrappedImagePtr o, const IntRect* rec
 
 void RenderListOutsideMarker::updateInlineMarginsAndContent()
 {
-    // FIXME: It's messy to use the preferredLogicalWidths dirty bit for this optimization, also unclear if this is premature optimization.
-    if (hasInvalidContentLogicalWidths())
-        updateContent();
+    updateContent();
     updateInlineMargins();
 }
 
@@ -475,7 +474,6 @@ void RenderListOutsideMarker::updateContentContainerText()
 void RenderListOutsideMarker::computeIntrinsicLogicalWidthContributions()
 {
     ASSERT(hasInvalidContentLogicalWidths());
-    updateContent();
 
     if (CheckedPtr container = contentContainer()) {
         // The marker is non-wrapping, so its min- and max-content widths are both the


### PR DESCRIPTION
#### 221348147d70038b32775a76ce4a7ba964126503
<pre>
[list-marker] The outside list marker resolves its content during layout instead of when it changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=323530">https://bugs.webkit.org/show_bug.cgi?id=323530</a>
<a href="https://rdar.apple.com/problem/186770171">rdar://problem/186770171</a>

Reviewed by Antti Koivisto.

The marker resolved what it shows -- its text, and the size it measures its image at -- off the preferred
width dirty bit, so it ran
during layout and during the preferred width pass. Both are the wrong time: setting the text there marks the
renderers holding it dirty from inside layout, and the width pass leaves whatever it marks for someone else
to lay out. Everything that changes what the marker shows already tells the marker about it
(RenderTreeBuilder::updateListMarkerContents, RenderListItem::updateValueAndMarkerContent), so resolve it
there, and add the one caller that was missing: an image that reports a size once it decodes.

* Source/WebCore/rendering/RenderListOutsideMarker.cpp:
(WebCore::RenderListOutsideMarker::layout):
(WebCore::RenderListOutsideMarker::imageChanged):
(WebCore::RenderListOutsideMarker::updateInlineMarginsAndContent):
(WebCore::RenderListOutsideMarker::computeIntrinsicLogicalWidthContributions):

Canonical link: <a href="https://commits.webkit.org/320624@main">https://commits.webkit.org/320624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7376f042009716a0a4576c76cab1e29d3b2d4d9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53112 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195707 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0448a31c-5662-4957-bc5a-f142368cb99b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144874 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a955afb8-1c35-4617-953e-f48f50816323) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165462 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125166 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/149cefec-4d6e-4fa9-bac0-bad00246fe9c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47284 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45341 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157651 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45033 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6760 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197656 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58959 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154386 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41339 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59668 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154037 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48524 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131995 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128845 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58146 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20055 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57518 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57761 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57585 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->