### PR TITLE
[cleanup] Drop RenderListOutsideMarker::m_textContent, the marker box's copy of text the list item already computes

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -4336,7 +4336,8 @@ String AccessibilityNodeObject::stringValue() const
             } else if (CheckedPtr renderListMarker = dynamicDowncast<RenderListOutsideMarker>(object->renderer())) {
                 // List markers have no DOM node. Flush any pending text run, then append marker text.
                 flushRun();
-                builder.append(renderListMarker->textContent());
+                if (CheckedPtr listItem = renderListMarker->listItem())
+                    builder.append(listItem->markerText());
             }
         }
         flushRun();

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -441,8 +441,10 @@ String AccessibilityRenderObject::textUnderElement(TextUnderElementMode mode) co
     if (auto* listMarker = dynamicDowncast<RenderListOutsideMarker>(*m_renderer)) {
         // A `content` marker has no text of its own; the child walk below reads the renderers holding it.
         if (!listMarker->hasContentProperty()) {
-            if (mode.includeListMarkers == IncludeListMarkerText::Yes)
-                return listMarker->textContent();
+            if (mode.includeListMarkers == IncludeListMarkerText::Yes) {
+                CheckedPtr listItem = listMarker->listItem();
+                return listItem ? listItem->markerText() : String();
+            }
             return { };
         }
     }
@@ -592,10 +594,13 @@ String AccessibilityRenderObject::stringValue() const
 #endif
 
     if (CheckedPtr renderListMarker = dynamicDowncast<RenderListOutsideMarker>(m_renderer.get())) {
+        CheckedPtr listItem = renderListMarker->listItem();
+        if (!listItem)
+            return { };
 #if USE(ATSPI)
-        return renderListMarker->textContent();
+        return listItem->markerText();
 #else
-        return renderListMarker->textContent(RenderListOutsideMarker::IncludeSuffix::No);
+        return listItem->markerText(ListMarkerIncludeSuffix::No);
 #endif
     }
 
@@ -1774,7 +1779,8 @@ AXTextRuns AccessibilityRenderObject::textRuns()
 String AccessibilityRenderObject::listMarkerText() const
 {
     CheckedPtr marker = dynamicDowncast<RenderListOutsideMarker>(renderer());
-    return marker ? marker->textContent() : String();
+    CheckedPtr listItem = marker ? marker->listItem() : nullptr;
+    return listItem ? listItem->markerText() : String();
 }
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -577,7 +577,7 @@ String RenderListItem::markerText(ListMarkerIncludeSuffix includeSuffix) const
     if (!marker)
         return { };
 
-    if (marker->style().content().isData())
+    if (marker->style().content().isData() || listMarkerShowsImage(marker->style()))
         return { };
 
     auto textContent = listMarkerTextContent(marker->style(), const_cast<RenderListItem&>(*this));

--- a/Source/WebCore/rendering/RenderListOutsideMarker.cpp
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.cpp
@@ -222,7 +222,7 @@ void RenderListOutsideMarker::layoutContentContainer(RenderBlockFlow& container)
             m_layoutBounds = { contentBaseline, container.logicalHeight() - contentBaseline };
         } else {
             setLogicalHeight(style().metricsOfPrimaryFont().intHeight());
-            m_layoutBounds = layoutBoundForTextContent(m_textContent.textWithSuffix);
+            m_layoutBounds = layoutBoundForTextContent(m_listItem->markerText());
         }
     }
 
@@ -270,7 +270,6 @@ void RenderListOutsideMarker::updateContent()
     if (hasContentProperty()) {
         // css-lists-3 §3.3: `content` (not normal) supersedes list-style-image/type. The generated
         // content lives in the anonymous inline-block contentContainer(); the marker has no text/image.
-        m_textContent = { };
         return;
     }
 
@@ -279,18 +278,12 @@ void RenderListOutsideMarker::updateContent()
         LayoutUnit bulletWidth = style().metricsOfPrimaryFont().intAscent() / 2_lu;
         LayoutSize defaultBulletSize(bulletWidth, bulletWidth);
         setContentContainerImageSize(calculateImageIntrinsicDimensions(protect(m_image).get(), defaultBulletSize, ScaleByUsedZoom::Yes));
-        m_textContent = {
-            .textWithSuffix = emptyString(),
-            .textWithoutSuffixLength = 0,
-        };
         return;
     }
 
-    m_textContent = listMarkerTextContent(style(), *m_listItem);
-
     // The marker text is only known here (counter values resolve at layout), while the renderers
     // holding it were created from style. Push the text down so the inline formatting context has something to lay out.
-    updateContentContainerText();
+    updateContentContainerText(listMarkerTextContent(style(), *m_listItem));
 }
 
 void RenderListOutsideMarker::setContentContainerImageSize(LayoutSize imageSize)
@@ -311,7 +304,7 @@ void RenderListOutsideMarker::setContentContainerImageSize(LayoutSize imageSize)
     imageRenderer->setNeedsLayout();
 }
 
-void RenderListOutsideMarker::updateContentContainerText()
+void RenderListOutsideMarker::updateContentContainerText(const ListMarkerTextContent& textContent)
 {
     CheckedPtr container = contentContainer();
     if (!container) {
@@ -324,11 +317,11 @@ void RenderListOutsideMarker::updateContentContainerText()
         return;
 
     if (synthesizesGlyph()) {
-        textRenderer->setText(m_textContent.textWithoutSuffix().toString());
+        textRenderer->setText(textContent.textWithoutSuffix().toString());
         return;
     }
 
-    textRenderer->setText(m_textContent.textWithSuffix);
+    textRenderer->setText(textContent.textWithSuffix);
 }
 
 void RenderListOutsideMarker::computeIntrinsicLogicalWidthContributions()
@@ -449,13 +442,19 @@ bool listMarkerIsDisclosure(const RenderElement* renderer)
     return listMarkerIsDisclosure(renderer->style(), protect(renderer->document()));
 }
 
-bool listMarkerSynthesizesGlyph(const Style::ComputedStyle& markerStyle)
+bool listMarkerShowsImage(const Style::ComputedStyle& markerStyle)
 {
-    // css-lists-3 §3.3: a non-normal `content` supersedes list-style-type, and a list-style-image draws in place of
-    // the glyph unless it failed to load, so neither leaves us a glyph to draw.
+    // css-lists-3 §3.3: a non-normal `content` supersedes list-style-image, which in turn draws in place of the
+    // counter style's text unless it failed to load.
     if (markerStyle.content().isData())
         return false;
-    if (RefPtr image = markerStyle.listStyleImage().tryStyleImage(); image && !image->errorOccurred())
+    RefPtr image = markerStyle.listStyleImage().tryStyleImage();
+    return image && !image->errorOccurred();
+}
+
+bool listMarkerSynthesizesGlyph(const Style::ComputedStyle& markerStyle)
+{
+    if (markerStyle.content().isData() || listMarkerShowsImage(markerStyle))
         return false;
 
     auto& listType = markerStyle.listStyleType();

--- a/Source/WebCore/rendering/RenderListOutsideMarker.h
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.h
@@ -56,12 +56,6 @@ public:
     RenderListOutsideMarker(RenderListItem&, Style::ComputedStyle&&);
     virtual ~RenderListOutsideMarker();
 
-    using IncludeSuffix = ListMarkerIncludeSuffix;
-    String textContent(IncludeSuffix includeSuffix = IncludeSuffix::Yes) const
-    {
-        return includeSuffix == IncludeSuffix::Yes ? m_textContent.textWithSuffix : m_textContent.textWithoutSuffix().toString();
-    }
-
     bool isDisclosureMarker() const;
     bool synthesizesGlyph() const;
 
@@ -110,7 +104,7 @@ private:
 
     void updateInlineMargins();
     void updateContent();
-    void updateContentContainerText();
+    void updateContentContainerText(const ListMarkerTextContent&);
     void setContentContainerImageSize(LayoutSize);
     void layoutContentContainer(RenderBlockFlow&);
 
@@ -118,7 +112,6 @@ private:
 
 
 private:
-    ListMarkerTextContent m_textContent;
     RefPtr<Style::Image> m_image;
 
     SingleThreadWeakPtr<RenderListItem> m_listItem;
@@ -130,6 +123,7 @@ private:
 constexpr int listMarkerImagePadding = 7;
 ListMarkerTextContent listMarkerTextContent(const Style::ComputedStyle& markerStyle, RenderListItem&);
 bool listMarkerSynthesizesGlyph(const Style::ComputedStyle& markerStyle);
+bool listMarkerShowsImage(const Style::ComputedStyle& markerStyle);
 bool listMarkerIsDisclosure(const Style::ComputedStyle& markerStyle, Document&);
 bool listMarkerIsDisclosure(const RenderElement*);
 void setListMarkerInlineMargins(Style::ComputedStyle& markerStyle, WritingMode listItemWritingMode, LayoutUnit marginStart, LayoutUnit marginEnd);

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -365,7 +365,8 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
         ts << " [r="_s << cell->rowIndex() << " c="_s << cell->col() << " rs="_s << cell->rowSpan() << " cs="_s << cell->colSpan() << ']';
 
     if (auto* listMarker = dynamicDowncast<RenderListOutsideMarker>(o)) {
-        auto text = listMarker->textContent(RenderListOutsideMarker::IncludeSuffix::No);
+        CheckedPtr listItem = listMarker->listItem();
+        auto text = listItem ? listItem->markerText(ListMarkerIncludeSuffix::No) : String();
         if (!text.isEmpty()) {
             if (text.length() != 1)
                 text = quoteAndEscapeNonPrintables(text);
@@ -921,7 +922,7 @@ String markerTextForListItem(Element* element)
     auto* renderer = dynamicDowncast<RenderListItem>(element->renderer());
     if (!renderer)
         return String();
-    return renderer->markerText(RenderListOutsideMarker::IncludeSuffix::No);
+    return renderer->markerText(ListMarkerIncludeSuffix::No);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### fa7a14d6070a68460b7203f520a518b843114af0
<pre>
[cleanup] Drop RenderListOutsideMarker::m_textContent, the marker box&apos;s copy of text the list item already computes
<a href="https://bugs.webkit.org/show_bug.cgi?id=323547">https://bugs.webkit.org/show_bug.cgi?id=323547</a>
<a href="https://rdar.apple.com/problem/186792207">rdar://problem/186792207</a>

Reviewed by Antti Koivisto.

The marker box kept the text it shows in a member, which the renderers holding that text have since become the
place for. Everything that read it goes through RenderListItem::markerText now, which computes the same text
from style, and answers for the inline marker shape too. It grew the one rule the member carried: a marker
showing an image says nothing. That rule was written out twice, so give it a name.

* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::stitchGroups const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textUnderElement const):
(WebCore::AccessibilityRenderObject::stringValue const):
(WebCore::AccessibilityRenderObject::listMarkerText const):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::markerText const):
* Source/WebCore/rendering/RenderListOutsideMarker.cpp:
(WebCore::RenderListOutsideMarker::layoutContentContainer):
(WebCore::RenderListOutsideMarker::updateContent):
(WebCore::RenderListOutsideMarker::updateContentContainerText):
(WebCore::listMarkerShowsImage):
(WebCore::listMarkerSynthesizesGlyph):
(WebCore::RenderListOutsideMarker::textContent const): Deleted.
* Source/WebCore/rendering/RenderListOutsideMarker.h:
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::RenderTreeAsText::writeRenderObject):
(WebCore::markerTextForListItem):

Canonical link: <a href="https://commits.webkit.org/320630@main">https://commits.webkit.org/320630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dd9aa3b84bd38d13827a995ee0d5791ba2719d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195738 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59053 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144897 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125189 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47305 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45361 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157672 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45054 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6789 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49749 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197686 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58990 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154410 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41346 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59699 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154062 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48547 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132031 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128886 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58177 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20076 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57549 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57792 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57616 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->