### PR TITLE
REGRESSION(320449@main) Broken Win-Build-EWS

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/ProcessDidTerminate.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/ProcessDidTerminate.cpp
@@ -32,7 +32,11 @@
 #include "Helpers/Test.h"
 #include <WebKit/WKPagePrivate.h>
 #include <WebKit/WKRetainPtr.h>
+#if OS(WINDOWS)
+#include <windows.h>
+#else
 #include <signal.h>
+#endif
 
 namespace TestWebKitAPI {
 
@@ -74,6 +78,19 @@ static void webProcessCrashed(WKPageRef page, WKProcessTerminationReason reason,
     EXPECT_EQ(kWKProcessTerminationReasonCrash, reason);
 
     crashHandlerCalled = true;
+}
+
+static void killWebProcess(WKPageRef page)
+{
+    auto processIdentifier = WKPageGetProcessIdentifier(page);
+#if OS(WINDOWS)
+    HANDLE process = OpenProcess(PROCESS_TERMINATE, FALSE, processIdentifier);
+    ASSERT_TRUE(process);
+    TerminateProcess(process, 1);
+    CloseHandle(process);
+#else
+    kill(processIdentifier, SIGKILL);
+#endif
 }
 
 TEST(WebKit, ProcessDidTerminateRequestedByClient)
@@ -120,7 +137,7 @@ TEST(WebKit, ProcessDidTerminateWithReasonCrash)
     Util::run(&loadBeforeCrash);
 
     // Simulate a crash by killing the WebProcess.
-    kill(WKPageGetProcessIdentifier(webView.page()), SIGKILL);
+    killWebProcess(webView.page());
 
     Util::run(&crashHandlerCalled);
 }


### PR DESCRIPTION
#### 22b00f16abbf061110bda15d4d1fb01bfd0b8bae
<pre>
REGRESSION(320449@main) Broken Win-Build-EWS
<a href="https://bugs.webkit.org/show_bug.cgi?id=323449">https://bugs.webkit.org/show_bug.cgi?id=323449</a>
<a href="https://rdar.apple.com/186678844">rdar://186678844</a>

Unreviewed build fix.

ProcessDidTerminate.cpp uses kill(pid, SIGKILL), which doesn&apos;t exist on
Windows. Use OpenProcess/TerminateProcess there instead.

* Tools/TestWebKitAPI/Tests/WebKit/WKPage/ProcessDidTerminate.cpp:
(TestWebKitAPI::killWebProcess):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/320583@main">https://commits.webkit.org/320583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/987994b5da79cefafa42f0aeaea366ff1a64e65f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195575 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144758 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165353 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125051 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47173 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45236 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44923 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6630 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197525 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58825 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154268 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59534 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41527 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153919 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28125 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48415 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128605 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58013 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19943 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57384 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57627 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->