### PR TITLE
[cleanup] Drop RenderListOutsideMarker::m_image, the marker box's copy of the list-style-image its style already holds

### DIFF
--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -577,7 +577,7 @@ String RenderListItem::markerText(ListMarkerIncludeSuffix includeSuffix) const
     if (!marker)
         return { };
 
-    if (marker->style().content().isData() || listMarkerShowsImage(marker->style()))
+    if (marker->style().content().isData() || listMarkerImage(marker->style()))
         return { };
 
     auto textContent = listMarkerTextContent(marker->style(), const_cast<RenderListItem&>(*this));

--- a/Source/WebCore/rendering/RenderListOutsideMarker.cpp
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.cpp
@@ -78,8 +78,8 @@ RenderListOutsideMarker::~RenderListOutsideMarker() = default;
 
 void RenderListOutsideMarker::willBeDestroyed()
 {
-    if (m_image)
-        protect(m_image)->removeClient(*this);
+    if (RefPtr image = style().listStyleImage().tryStyleImage())
+        image->removeClient(*this);
     RenderBox::willBeDestroyed();
 }
 
@@ -107,12 +107,15 @@ void RenderListOutsideMarker::styleDidChange(Style::Difference diff, const Style
 
     propagateStyleToAnonymousChildren(StylePropagationType::AllChildren);
 
-    if (RefPtr newImage = style().listStyleImage().tryStyleImage(); m_image != newImage) {
-        if (m_image)
-            protect(m_image)->removeClient(*this);
-        m_image = WTF::move(newImage);
-        if (m_image)
-            protect(m_image)->addClient(*this);
+    // A marker that shows an image is the image's client, so that it hears about the image loading, and about it
+    // failing to load, which turns the marker into a text marker (see imageChanged).
+    RefPtr oldImage = oldStyle ? oldStyle->listStyleImage().tryStyleImage() : nullptr;
+    RefPtr newImage = style().listStyleImage().tryStyleImage();
+    if (oldImage != newImage) {
+        if (oldImage)
+            oldImage->removeClient(*this);
+        if (newImage)
+            newImage->addClient(*this);
     }
 }
 
@@ -120,7 +123,7 @@ bool RenderListOutsideMarker::isImage() const
 {
     // `content` supersedes list-style-image (css-lists-3 §3.3), so a marker with generated content
     // is never treated as an image marker (affects inline margins, baseline, and layout attributes).
-    return m_image && !protect(m_image)->errorOccurred() && !hasContentProperty();
+    return !hasContentProperty() && listMarkerImage(style());
 }
 
 bool RenderListOutsideMarker::hasContentProperty() const
@@ -239,7 +242,7 @@ void RenderListOutsideMarker::layoutContentContainer(RenderBlockFlow& container)
 void RenderListOutsideMarker::imageChanged(WrappedImagePtr o, const IntRect* rect)
 {
     if (parent()) {
-        RefPtr image = m_image;
+        RefPtr image = style().listStyleImage().tryStyleImage();
         if (image && o == image->data()) {
             if (image->errorOccurred()) {
                 // A failed image turns this into a text marker, and that text needs renderers the marker was not built with.
@@ -277,7 +280,7 @@ void RenderListOutsideMarker::updateContent()
         // FIXME: This is a somewhat arbitrary width.
         LayoutUnit bulletWidth = style().metricsOfPrimaryFont().intAscent() / 2_lu;
         LayoutSize defaultBulletSize(bulletWidth, bulletWidth);
-        setContentContainerImageSize(calculateImageIntrinsicDimensions(protect(m_image).get(), defaultBulletSize, ScaleByUsedZoom::Yes));
+        setContentContainerImageSize(calculateImageIntrinsicDimensions(listMarkerImage(style()).get(), defaultBulletSize, ScaleByUsedZoom::Yes));
         return;
     }
 
@@ -442,19 +445,19 @@ bool listMarkerIsDisclosure(const RenderElement* renderer)
     return listMarkerIsDisclosure(renderer->style(), protect(renderer->document()));
 }
 
-bool listMarkerShowsImage(const Style::ComputedStyle& markerStyle)
+RefPtr<Style::Image> listMarkerImage(const Style::ComputedStyle& markerStyle)
 {
-    // css-lists-3 §3.3: a non-normal `content` supersedes list-style-image, which in turn draws in place of the
-    // counter style's text unless it failed to load.
-    if (markerStyle.content().isData())
-        return false;
     RefPtr image = markerStyle.listStyleImage().tryStyleImage();
-    return image && !image->errorOccurred();
+    if (!image || image->errorOccurred())
+        return nullptr;
+    return image;
 }
 
 bool listMarkerSynthesizesGlyph(const Style::ComputedStyle& markerStyle)
 {
-    if (markerStyle.content().isData() || listMarkerShowsImage(markerStyle))
+    // css-lists-3 §3.3: a non-normal `content` supersedes list-style-type, and a list-style-image draws in place of
+    // the glyph unless it failed to load, so neither leaves us a glyph to draw.
+    if (markerStyle.content().isData() || listMarkerImage(markerStyle))
         return false;
 
     auto& listType = markerStyle.listStyleType();

--- a/Source/WebCore/rendering/RenderListOutsideMarker.h
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.h
@@ -110,10 +110,7 @@ private:
 
     LayoutRect NODELETE localSelectionRect();
 
-
 private:
-    RefPtr<Style::Image> m_image;
-
     SingleThreadWeakPtr<RenderListItem> m_listItem;
     std::pair<float, float> m_layoutBounds;
     std::optional<ExcludedPosition> m_excludedPosition;
@@ -123,7 +120,7 @@ private:
 constexpr int listMarkerImagePadding = 7;
 ListMarkerTextContent listMarkerTextContent(const Style::ComputedStyle& markerStyle, RenderListItem&);
 bool listMarkerSynthesizesGlyph(const Style::ComputedStyle& markerStyle);
-bool listMarkerShowsImage(const Style::ComputedStyle& markerStyle);
+RefPtr<Style::Image> listMarkerImage(const Style::ComputedStyle& markerStyle);
 bool listMarkerIsDisclosure(const Style::ComputedStyle& markerStyle, Document&);
 bool listMarkerIsDisclosure(const RenderElement*);
 void setListMarkerInlineMargins(Style::ComputedStyle& markerStyle, WritingMode listItemWritingMode, LayoutUnit marginStart, LayoutUnit marginEnd);


### PR DESCRIPTION
#### 3f39fb99f98226f668f7e04a1287564a606a1a5a
<pre>
[cleanup] Drop RenderListOutsideMarker::m_image, the marker box&apos;s copy of the list-style-image its style already holds
<a href="https://bugs.webkit.org/show_bug.cgi?id=323549">https://bugs.webkit.org/show_bug.cgi?id=323549</a>
<a href="https://rdar.apple.com/problem/186794793">rdar://problem/186794793</a>

Reviewed by Antti Koivisto.

The member held what style().listStyleImage() holds. Ask style for it: whether the marker shows an image, and
which image it resolves the size from, now go through listMarkerImage(), which is the name the two open-coded
copies of &quot;a list-style-image that loaded&quot; get. The marker is still the image&apos;s client so that it hears about
the image loading and about it failing to load, and that registration diffs the old style against the new one
the way RenderElement::updateFillImages does. It reads the style image unfiltered, since a marker whose image
failed has to hear about it to become a text marker.

* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::markerText const):
* Source/WebCore/rendering/RenderListOutsideMarker.cpp:
(WebCore::RenderListOutsideMarker::willBeDestroyed):
(WebCore::RenderListOutsideMarker::styleDidChange):
(WebCore::RenderListOutsideMarker::isImage const):
(WebCore::RenderListOutsideMarker::imageChanged):
(WebCore::RenderListOutsideMarker::updateContent):
(WebCore::listMarkerImage):
(WebCore::listMarkerSynthesizesGlyph):
(WebCore::listMarkerShowsImage): Deleted.
* Source/WebCore/rendering/RenderListOutsideMarker.h:

Canonical link: <a href="https://commits.webkit.org/320672@main">https://commits.webkit.org/320672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8d0d8538536f78767a5fc65a255fa0bea13be44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195756 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150206 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1384c2de-809c-4927-a13e-bddd5f222232) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59071 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144909 "Found 1 new test failure: fast/dom/lazy-image-loading-document-leak.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100458 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6cd53eb3-34c1-4c52-b9b4-96e267e8d9b4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125201 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/421e7a60-40ab-42a5-bf8f-c20a5390fd56) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47318 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45374 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157685 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45064 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6807 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197704 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59008 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154427 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41384 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59717 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154077 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48558 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132065 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128919 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58195 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20086 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57567 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57810 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57634 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->