### PR TITLE
[cleanup] Have RenderListOutsideMarker ask listMarkerSynthesizesGlyph() and a new shared listMarkerHasContent() instead of repeating both checks

### DIFF
--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -240,7 +240,7 @@ static bool markerTextSynthesizesGlyph(const RenderText& textRenderer)
     // The marker is this text's parent when it is an inline box, and its grandparent when a marker box holds the text in a content container of its own.
     for (CheckedPtr marker = textRenderer.parent(); marker; marker = marker->parent()) {
         if (marker->style().isListMarkerStyle())
-            return listMarkerSynthesizesGlyph(marker->style());
+            return listMarkerSynthesizesGlyph(marker->style(), protect(marker->document()));
         if (!marker->isAnonymous())
             return false;
     }

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -424,7 +424,7 @@ void RenderListItem::updateMarkerContent()
         return;
 
     auto textContent = listMarkerTextContent(marker->style(), *this);
-    if (!listMarkerSynthesizesGlyph(marker->style())) {
+    if (!listMarkerSynthesizesGlyph(marker->style(), protect(document()))) {
         textRenderer->setText(textContent.textWithSuffix);
         return;
     }
@@ -577,7 +577,7 @@ String RenderListItem::markerText(ListMarkerIncludeSuffix includeSuffix) const
     if (!marker)
         return { };
 
-    if (marker->style().content().isData() || listMarkerImage(marker->style()))
+    if (listMarkerHasContent(marker->style(), protect(document())) || listMarkerImage(marker->style()))
         return { };
 
     auto textContent = listMarkerTextContent(marker->style(), const_cast<RenderListItem&>(*this));

--- a/Source/WebCore/rendering/RenderListOutsideMarker.cpp
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.cpp
@@ -128,7 +128,7 @@ bool RenderListOutsideMarker::isImage() const
 
 bool RenderListOutsideMarker::hasContentProperty() const
 {
-    return document().settings().cssMarkerContentEnabled() && style().content().isData();
+    return listMarkerHasContent(style(), protect(document()));
 }
 
 RenderBlockFlow* RenderListOutsideMarker::contentContainer() const
@@ -453,11 +453,16 @@ RefPtr<Style::Image> listMarkerImage(const Style::ComputedStyle& markerStyle)
     return image;
 }
 
-bool listMarkerSynthesizesGlyph(const Style::ComputedStyle& markerStyle)
+bool listMarkerHasContent(const Style::ComputedStyle& markerStyle, Document& document)
+{
+    return document.settings().cssMarkerContentEnabled() && markerStyle.content().isData();
+}
+
+bool listMarkerSynthesizesGlyph(const Style::ComputedStyle& markerStyle, Document& document)
 {
     // css-lists-3 §3.3: a non-normal `content` supersedes list-style-type, and a list-style-image draws in place of
     // the glyph unless it failed to load, so neither leaves us a glyph to draw.
-    if (markerStyle.content().isData() || listMarkerImage(markerStyle))
+    if (listMarkerHasContent(markerStyle, document) || listMarkerImage(markerStyle))
         return false;
 
     auto& listType = markerStyle.listStyleType();
@@ -488,11 +493,7 @@ ListMarkerTextContent listMarkerTextContent(const Style::ComputedStyle& markerSt
 
 bool RenderListOutsideMarker::synthesizesGlyph() const
 {
-    // `content` supersedes list-style-type, so a content marker never draws in place of a glyph, and a list-style-image marker draws the image instead.
-    if (hasContentProperty() || isImage())
-        return false;
-    auto& listType = style().listStyleType();
-    return listType.isCircle() || listType.isDisc() || listType.isSquare();
+    return listMarkerSynthesizesGlyph(style(), protect(document()));
 }
 
 std::pair<float, float> RenderListOutsideMarker::layoutBoundForTextContent(String text) const

--- a/Source/WebCore/rendering/RenderListOutsideMarker.h
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.h
@@ -119,7 +119,8 @@ private:
 // The room an image marker keeps between itself and the content it labels.
 constexpr int listMarkerImagePadding = 7;
 ListMarkerTextContent listMarkerTextContent(const Style::ComputedStyle& markerStyle, RenderListItem&);
-bool listMarkerSynthesizesGlyph(const Style::ComputedStyle& markerStyle);
+bool listMarkerHasContent(const Style::ComputedStyle& markerStyle, Document&);
+bool listMarkerSynthesizesGlyph(const Style::ComputedStyle& markerStyle, Document&);
 RefPtr<Style::Image> listMarkerImage(const Style::ComputedStyle& markerStyle);
 bool listMarkerIsDisclosure(const Style::ComputedStyle& markerStyle, Document&);
 bool listMarkerIsDisclosure(const RenderElement*);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -101,7 +101,7 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
 
     auto newStyle = listItemRenderer.computeMarkerStyle();
     auto markerContentEnabled = listItemRenderer.document().settings().cssMarkerContentEnabled();
-    auto markerHasContent = markerContentEnabled && newStyle.content().isData();
+    auto markerHasContent = listMarkerHasContent(newStyle, listItemRenderer.document());
 
     // css-content-3: `content: none` on the ::marker suppresses the marker box entirely, regardless
     // of list-style-type/image. Otherwise (css-lists-3 §3.3) a non-normal `content` generates the


### PR DESCRIPTION
#### 259eb3eed9c4618c62b1cba4006fb0694f33ada9
<pre>
[cleanup] Have RenderListOutsideMarker ask listMarkerSynthesizesGlyph() and a new shared listMarkerHasContent() instead of repeating both checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=323551">https://bugs.webkit.org/show_bug.cgi?id=323551</a>
<a href="https://rdar.apple.com/problem/186795659">rdar://problem/186795659</a>

Reviewed by Antti Koivisto.

* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::markerTextSynthesizesGlyph):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::updateMarkerContent):
(WebCore::RenderListItem::markerText const):
* Source/WebCore/rendering/RenderListOutsideMarker.cpp:
(WebCore::RenderListOutsideMarker::hasContentProperty const):
(WebCore::listMarkerHasContent):
(WebCore::listMarkerSynthesizesGlyph):
(WebCore::RenderListOutsideMarker::synthesizesGlyph const):
* Source/WebCore/rendering/RenderListOutsideMarker.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp:
(WebCore::RenderTreeBuilder::List::updateItemMarker):

Canonical link: <a href="https://commits.webkit.org/320692@main">https://commits.webkit.org/320692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a53afa2aa0062497fe0288d9ba87c9dcc7c14dc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195944 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0e37b969-d7e9-4afb-a8f5-6af7b3b66008) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59266 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145054 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e5b0de2c-35c7-4150-a466-8c715de3e418) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165626 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125349 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5dd1b7b8-a457-4226-8fa4-af66e96c875c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47465 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157826 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45200 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7003 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52181 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197903 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59202 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154591 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41399 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59911 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41805 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154244 "Found 1 new API test failure: TestLoaderClient:/webkit/WebKitWebView/active-uri (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48709 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129166 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58382 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20222 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57757 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57998 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57823 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->