### PR TITLE
[scroll-animations] Null RefPtr deref in StyleOriginatedTimelinesController::attachAnimation logging

### DIFF
--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -427,7 +427,7 @@ void StyleOriginatedTimelinesController::attachAnimation(CSSAnimation& animation
     } else {
         auto& timelines = it->value;
         RefPtr timeline = determineTimelineForElement(timelines, *target, timelineName->scopeOrdinal, relevantTimelineScopeElement.get());
-        LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::attachAnimation: " << timelineName->name << " styleable: " << *target << " attaching to timeline of element: " << originatingElement(*timeline));
+        LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::attachAnimation: " << timelineName->name << " styleable: " << *target << " attaching to timeline of element: " << (timeline ? originatingElement(*timeline) : WeakStyleable()));
         // A deferred inactive timeline means there was a conflict with multiple timelines existing within
         // a parent element with a "timeline-scope" property. In that case, we must reconsider timeline attachment
         // once style resolution completes as further updates may occur that would yield a different timeline


### PR DESCRIPTION
#### 26c6e13373ed8fa7b82bd5b07219ba1577f7f658
<pre>
[scroll-animations] Null RefPtr deref in StyleOriginatedTimelinesController::attachAnimation logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=323552">https://bugs.webkit.org/show_bug.cgi?id=323552</a>
<a href="https://rdar.apple.com/186798549">rdar://186798549</a>

Reviewed by NOBODY (OOPS!).

The LOG_WITH_STREAM() in the hasNamedTimeline branch of attachAnimation() dereferenced the
RefPtr from determineTimelineForElement() unconditionally, but that RefPtr is nullable, as
the `timeline &amp;&amp;` check below already acknowledges. hasNamedTimeline is a bare-name map
lookup with no tree-scope test, while determineTimelineForElement() also requires
timelineIsInScopeForTarget(); since timelines register into the document&apos;s controller
regardless of declaring tree scope, a scroll-timeline-name declared only inside a shadow
tree satisfies the former yet matches nothing for a document-scope reference. `*timeline`
then trips ASSERT(m_ptr) in RefPtr::operator*() and ref()s null while constructing the
Ref&lt;ScrollTimeline&gt; argument. Only affects builds with logging compiled in, so no layout
test is possible. Log an empty WeakStyleable when no timeline matched.

* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::attachAnimation):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26c6e13373ed8fa7b82bd5b07219ba1577f7f658

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195582 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150084 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1d159675-1521-4d9f-99a3-97757a245352) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144763 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100387 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d9f33935-4540-4916-9c89-a98869e44c35) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165358 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125056 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7cafef62-08bc-4c23-8b3f-0bedc8f7fd2b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47179 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45242 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157546 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44928 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6637 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197532 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58833 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154274 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59542 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153925 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48421 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131855 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128625 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58021 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19948 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57392 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57635 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57459 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->