### PR TITLE
AX: Add a layout test for the bounds of a slider's accessibility value indicator

### DIFF
--- a/LayoutTests/accessibility/isolated-tree/mac/slider-value-indicator-bounds-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/slider-value-indicator-bounds-expected.txt
@@ -1,0 +1,20 @@
+This test ensures the value indicator of a slider reports the thumb's own box, and that the box tracks the slider's value.
+
+PASS: indicator().role === 'AXRole: AXValueIndicator'
+
+The indicator reports the thumb's box, which is a real box narrower than the slider.
+PASS: indicatorWidth() > 0 === true
+PASS: indicatorHeight() > 0 === true
+PASS: sliderWidth() > indicatorWidth() === true
+
+At the minimum value the thumb sits in the left half of the slider.
+PASS: indicatorOffsetInSlider() < sliderWidth() / 2 === true
+
+At the maximum value it sits in the right half, still within the slider.
+PASS: indicatorOffsetInSlider() > sliderWidth() / 2 === true
+PASS: indicatorOffsetInSlider() + indicatorWidth() <= sliderWidth() === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/isolated-tree/mac/slider-value-indicator-bounds.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/slider-value-indicator-bounds.html
@@ -1,0 +1,70 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<input type="range" id="slider" min="0" max="100" value="0" style="width: 300px;">
+
+<script>
+var output = "This test ensures the value indicator of a slider reports the thumb's own box, and that the box tracks the slider's value.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var slider = document.getElementById("slider");
+
+    function sliderElement() {
+        return accessibilityController.accessibleElementById("slider");
+    }
+
+    function indicator() {
+        return sliderElement().childAtIndex(0);
+    }
+
+    function indicatorWidth() {
+        return indicator().width;
+    }
+
+    function indicatorHeight() {
+        return indicator().height;
+    }
+
+    function sliderWidth() {
+        return sliderElement().width;
+    }
+
+    // Measured against the slider, not in absolute coordinates: the page's screen position is
+    // published a frame or two after load, so only the offset between the two boxes is stable.
+    function indicatorOffsetInSlider() {
+        var sliderAXObject = sliderElement();
+        return sliderAXObject.childAtIndex(0).x - sliderAXObject.x;
+    }
+
+    setTimeout(async function() {
+        // The rest only means anything if the first child really is the thumb.
+        output += expect("indicator().role", "'AXRole: AXValueIndicator'");
+
+        output += "\nThe indicator reports the thumb's box, which is a real box narrower than the slider.\n";
+        output += expect("indicatorWidth() > 0", "true");
+        output += expect("indicatorHeight() > 0", "true");
+        output += expect("sliderWidth() > indicatorWidth()", "true");
+
+        output += "\nAt the minimum value the thumb sits in the left half of the slider.\n";
+        output += await expectAsync("indicatorOffsetInSlider() < sliderWidth() / 2", "true");
+
+        slider.value = 100;
+
+        output += "\nAt the maximum value it sits in the right half, still within the slider.\n";
+        output += await expectAsync("indicatorOffsetInSlider() > sliderWidth() / 2", "true");
+        output += expect("indicatorOffsetInSlider() + indicatorWidth() <= sliderWidth()", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/slider-value-indicator-bounds-expected.txt
+++ b/LayoutTests/accessibility/mac/slider-value-indicator-bounds-expected.txt
@@ -1,0 +1,20 @@
+This test ensures the value indicator of a slider reports the thumb's own box, and that the box tracks the slider's value.
+
+PASS: indicator().role === 'AXRole: AXValueIndicator'
+
+The indicator reports the thumb's box, which is a real box narrower than the slider.
+PASS: indicatorWidth() > 0 === true
+PASS: indicatorHeight() > 0 === true
+PASS: sliderWidth() > indicatorWidth() === true
+
+At the minimum value the thumb sits in the left half of the slider.
+PASS: indicatorOffsetInSlider() < sliderWidth() / 2 === true
+
+At the maximum value it sits in the right half, still within the slider.
+PASS: indicatorOffsetInSlider() > sliderWidth() / 2 === true
+PASS: indicatorOffsetInSlider() + indicatorWidth() <= sliderWidth() === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/slider-value-indicator-bounds.html
+++ b/LayoutTests/accessibility/mac/slider-value-indicator-bounds.html
@@ -1,0 +1,70 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<input type="range" id="slider" min="0" max="100" value="0" style="width: 300px;">
+
+<script>
+var output = "This test ensures the value indicator of a slider reports the thumb's own box, and that the box tracks the slider's value.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var slider = document.getElementById("slider");
+
+    function sliderElement() {
+        return accessibilityController.accessibleElementById("slider");
+    }
+
+    function indicator() {
+        return sliderElement().childAtIndex(0);
+    }
+
+    function indicatorWidth() {
+        return indicator().width;
+    }
+
+    function indicatorHeight() {
+        return indicator().height;
+    }
+
+    function sliderWidth() {
+        return sliderElement().width;
+    }
+
+    // Measured against the slider, not in absolute coordinates: the page's screen position is
+    // published a frame or two after load, so only the offset between the two boxes is stable.
+    function indicatorOffsetInSlider() {
+        var sliderAXObject = sliderElement();
+        return sliderAXObject.childAtIndex(0).x - sliderAXObject.x;
+    }
+
+    setTimeout(async function() {
+        // The rest only means anything if the first child really is the thumb.
+        output += expect("indicator().role", "'AXRole: AXValueIndicator'");
+
+        output += "\nThe indicator reports the thumb's box, which is a real box narrower than the slider.\n";
+        output += expect("indicatorWidth() > 0", "true");
+        output += expect("indicatorHeight() > 0", "true");
+        output += expect("sliderWidth() > indicatorWidth()", "true");
+
+        output += "\nAt the minimum value the thumb sits in the left half of the slider.\n";
+        output += await expectAsync("indicatorOffsetInSlider() < sliderWidth() / 2", "true");
+
+        slider.value = 100;
+
+        output += "\nAt the maximum value it sits in the right half, still within the slider.\n";
+        output += await expectAsync("indicatorOffsetInSlider() > sliderWidth() / 2", "true");
+        output += expect("indicatorOffsetInSlider() + indicatorWidth() <= sliderWidth()", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### f33e68826cd74dab8ad670f66b75cd0ffc68b97a
<pre>
AX: Add a layout test for the bounds of a slider&apos;s accessibility value indicator
<a href="https://bugs.webkit.org/show_bug.cgi?id=323553">https://bugs.webkit.org/show_bug.cgi?id=323553</a>
<a href="https://rdar.apple.com/186798750">rdar://186798750</a>

Reviewed by Chris Fleizach.

No existing test verified the bounding box of the slider thumb. The new
test does that, and verifies it stays correct after a dynamic value
change (which moves the thumb).

* LayoutTests/accessibility/isolated-tree/mac/slider-value-indicator-bounds-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/slider-value-indicator-bounds.html: Added.
* LayoutTests/accessibility/mac/slider-value-indicator-bounds-expected.txt: Added.
* LayoutTests/accessibility/mac/slider-value-indicator-bounds.html: Added.

Canonical link: <a href="https://commits.webkit.org/320625@main">https://commits.webkit.org/320625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe5d2759b91f533a21351ca04792c53daaba509e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195583 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150085 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eae62313-94c3-4162-b98c-8334448e7c6e) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60534 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running checkout-pull-request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144764 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100388 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/be0210f8-24c7-455d-91cd-fa0d3384c400) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165360 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125057 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ea7651c8-16b0-4a41-82f8-10a57d82a9ce) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47181 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45244 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44930 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6638 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197533 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58834 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164866 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154275 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41340 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59543 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41534 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153926 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48422 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131856 "Build is in progress. Recent messages:") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128629 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58022 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19950 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57393 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57636 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57460 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->