### PR TITLE
[scroll-animations] Null WeakPtr deref when a named timeline outlives its originating element

### DIFF
--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -110,7 +110,8 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTreeOrder(const Vec
                 }
                 // Prefer the nearest timeline in hierarchy.
                 for (auto& matchedTimeline : matchedTimelines | std::views::reverse) {
-                    if (styleable.element.isComposedTreeDescendantOf(*originatingElement(matchedTimeline).element()))
+                    RefPtr matchedTimelineElement = originatingElement(matchedTimeline).element();
+                    if (matchedTimelineElement && styleable.element.isComposedTreeDescendantOf(*matchedTimelineElement))
                         return matchedTimeline.unsafePtr();
                 }
                 // Otherwise return the last of the matching timelines per https://github.com/w3c/csswg-drafts/issues/12581.
@@ -157,9 +158,11 @@ static bool timelineIsInScopeForTarget(const Ref<ScrollTimeline>& timeline, Elem
     if (!targetElement.isConnected())
         return false;
     RefPtr timelineOriginatingElement { originatingElement(timeline).element() };
-    ASSERT(timelineOriginatingElement);
+    if (!timelineOriginatingElement || !timelineOriginatingElement->isConnected())
+        return false;
     CheckedPtr scrollTimelineNameStyleScope = Style::Scope::forOrdinal(*timelineOriginatingElement, timeline->name().scopeOrdinal);
-    ASSERT(scrollTimelineNameStyleScope);
+    if (!scrollTimelineNameStyleScope)
+        return false;
     return Style::resolveTreeScopedReference(targetElement, { timeline->name().name, animationTimelineNameScopeOrdinal }, [&](const Style::Scope& scope, const Style::ScopedName&) {
         return scrollTimelineNameStyleScope == &scope;
     });


### PR DESCRIPTION
#### b42176cb83b968ed0577ff513ec0cc1971847d6f
<pre>
[scroll-animations] Null WeakPtr deref when a named timeline outlives its originating element
<a href="https://bugs.webkit.org/show_bug.cgi?id=323554">https://bugs.webkit.org/show_bug.cgi?id=323554</a>
<a href="https://rdar.apple.com/186799048">rdar://186799048</a>

Reviewed by NOBODY (OOPS!).

timelineIsInScopeForTarget() only ASSERT()ed originatingElement(timeline).element() before
dereferencing it, but that WeakPtr is nullable and the caller does not establish otherwise:
determineTimelineForElement()&apos;s pre-filter tests originatingStyleableIncludingTimelineScope(),
which returns the timeline-scope element rather than the originating one. A registration may
outlive its originating element, since Styleable::elementWasRemoved() unregisters named
timelines only via cancelStyleOriginatedAnimations(), which early-returns for a document in or
entering the back/forward cache. Should that happen, release builds would dereference null in
Style::Scope::forOrdinal(); no such crash has been observed in practice, so this is a defensive
fix rather than one for a reproduced failure. Also require the originating element to be
connected, since forOrdinal() reaches Scope::forNode()&apos;s ASSERT(node.isConnected()) while only
the target was checked.

Replace ASSERT(scrollTimelineNameStyleScope) with an early return too: forOrdinal() returns null
by design when the shadow root, host or assigned slot is gone, and resolveTreeScopedReference()
already treats that as &quot;not in scope&quot;, so release behaviour is unchanged.

Null-check the originating element in determineTreeOrder()&apos;s nearest-in-hierarchy loop as well,
matching the comparison above it. That one is likewise defensive, as determineTreeOrder()&apos;s only
caller now filters such timelines out.

No test: the null state would need a registration to survive into the back/forward cache and its
originating element to then be destroyed, which a layout test cannot construct.

* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::determineTreeOrder):
(WebCore::timelineIsInScopeForTarget):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b42176cb83b968ed0577ff513ec0cc1971847d6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/52988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195584 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150086 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187121 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58898 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144765 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100389 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165361 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125058 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47182 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45243 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44931 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6639 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197534 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58835 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154276 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59544 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41535 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153927 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48423 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131857 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128630 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58023 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19951 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57394 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57637 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57461 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->