### PR TITLE
Canvas 2D context is permanently poisoned after a transient backing-store allocation failure

### DIFF
--- a/LayoutTests/fast/canvas/canvas-transient-allocation-failure-recovery-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-transient-allocation-failure-recovery-expected.txt
@@ -1,0 +1,13 @@
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 1).
+PASS pixel[0] is 0
+PASS pixel[1] is 0
+PASS pixel[2] is 0
+PASS pixel[3] is 0
+PASS pixel[0] is 0
+PASS pixel[1] is 128
+PASS pixel[2] is 0
+PASS pixel[3] is 255
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/canvas-transient-allocation-failure-recovery.html
+++ b/LayoutTests/fast/canvas/canvas-transient-allocation-failure-recovery.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html><!-- webkit-test-runner [ runSingly=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+var canvas = document.createElement('canvas');
+canvas.width = 100;
+canvas.height = 100;
+var ctx = canvas.getContext("2d");
+
+if (window.internals)
+    internals.setMaxCanvasArea(1);
+
+ctx.fillRect(0, 0, 100, 100);
+
+var pixel = ctx.getImageData(50, 50, 1, 1).data;
+shouldBe("pixel[0]", "0");
+shouldBe("pixel[1]", "0");
+shouldBe("pixel[2]", "0");
+shouldBe("pixel[3]", "0");
+
+if (window.internals)
+    internals.setMaxCanvasArea(100 * 100);
+
+ctx.fillStyle = "green";
+ctx.fillRect(0, 0, 100, 100);
+
+pixel = ctx.getImageData(50, 50, 1, 1).data;
+shouldBe("pixel[0]", "0");
+shouldBe("pixel[1]", "128");
+shouldBe("pixel[2]", "0");
+shouldBe("pixel[3]", "255");
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -3360,10 +3360,10 @@ ImageBuffer* CanvasRenderingContext2DBase::buffer() const
 {
     if (m_hasCreatedImageBuffer)
         return m_buffer;
-    m_hasCreatedImageBuffer = true;
     RefPtr buffer = allocateImageBuffer();
     if (!buffer)
         return nullptr;
+    m_hasCreatedImageBuffer = true;
     auto& context = buffer->context();
     context.setShadowsIgnoreTransforms(true);
     context.setImageInterpolationQuality(defaultInterpolationQuality);


### PR DESCRIPTION
#### f2f5e1dff4dd0ccea5792e7395dce1dce3281db1
<pre>
Canvas 2D context is permanently poisoned after a transient backing-store allocation failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=323555">https://bugs.webkit.org/show_bug.cgi?id=323555</a>
<a href="https://rdar.apple.com/186799597">rdar://186799597</a>

Reviewed by Gerald Squelart.

CanvasRenderingContext2DBase::buffer() set m_hasCreatedImageBuffer to true
before checking whether allocateImageBuffer() actually succeeded. When
allocation failed transiently (memory pressure, area limit, no GPU buffer,
IPC failure), the flag was left true while m_buffer stayed null. Every
later buffer() call then hit the early `if (m_hasCreatedImageBuffer) return
m_buffer;` and returned null without ever retrying, so the context was
permanently dead until an actual canvas resize cleared the flag in
didUpdateCanvasSizeProperties() -- a plain reset() or `ctx.width =
ctx.width` self-assign does not.

The stale flag also made two readers wrong: isSurfaceBufferTransparentBlack()
returned false (so HTMLCanvasElement::paint() drew a nonexistent surface
instead of filling transparent black), and baseTransform()&apos;s
ASSERT(m_hasCreatedImageBuffer) passed with false confidence before
dereferencing buffer()-&gt;baseTransform() -- a release-mode null deref
reachable via fullCanvasCompositedDrawImage() -&gt;
calculateCompositingBufferRect(), which calls baseTransform() before any
drawing-context null check.

Set m_hasCreatedImageBuffer only after allocation succeeds, so a transient
failure leaves the context able to retry on the next draw.

Test: fast/canvas/canvas-transient-allocation-failure-recovery.html

* LayoutTests/fast/canvas/canvas-transient-allocation-failure-recovery-expected.txt: Added.
* LayoutTests/fast/canvas/canvas-transient-allocation-failure-recovery.html: Added.
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::buffer const):

Canonical link: <a href="https://commits.webkit.org/320605@main">https://commits.webkit.org/320605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd99effd77e0e3eccfd904a8be425ac5e5df2b85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195624 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144801 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125094 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47217 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45277 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44961 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6678 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197573 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154311 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41325 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59583 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153962 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48455 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131911 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128715 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58061 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19981 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57433 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57676 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57500 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->