### PR TITLE
Skip resolving ::before and ::after styles for rules that cannot generate content

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-005-expected.txt
@@ -1,5 +1,5 @@
 
 PASS ::before pseudo element querying style() of originating element
 PASS ::before pseudo element not matching style()
-FAIL ::before pseudo element matching style() query after class change assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS ::before pseudo element matching style() query after class change
 

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -281,6 +281,8 @@ void ElementRuleCollector::collectMatchingRules(const MatchRequest& matchRequest
     } else {
         // If pseudo-element is not requested then just mark the bits that tell that this element has these.
         m_matchedPseudoElements.add(pseudoElementTypes & allPublicPseudoElementTypes);
+        auto requiringStyle = isHTMLElement ? ruleSet.universalHTMLPseudoElementTypesRequiringStyle() : ruleSet.universalPseudoElementTypesRequiringStyle();
+        m_matchedPseudoElementsRequiringStyle.add(requiringStyle & allPublicPseudoElementTypes);
     }
 }
 
@@ -634,6 +636,14 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
     }
 
     m_matchedPseudoElements.add(context.publicPseudoElements);
+    if (context.publicPseudoElements) {
+        auto requiringStyle = context.publicPseudoElements;
+        if (!ruleData.canGeneratePseudoElement()) {
+            requiringStyle.remove(PseudoElementType::Before);
+            requiringStyle.remove(PseudoElementType::After);
+        }
+        m_matchedPseudoElementsRequiringStyle.add(requiringStyle);
+    }
     m_styleRelations.appendVector(context.styleRelations);
 
     return selectorMatches;

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -73,6 +73,7 @@ public:
     void clearMatchedRules();
 
     EnumSet<PseudoElementType> matchedPseudoElements() const { return m_matchedPseudoElements; }
+    EnumSet<PseudoElementType> matchedPseudoElementsRequiringStyle() const { return m_matchedPseudoElementsRequiringStyle; }
     const Relations& styleRelations() const LIFETIME_BOUND { return m_styleRelations; }
 
     void addAuthorKeyframeRules(const StyleRuleKeyframe&);
@@ -139,6 +140,7 @@ private:
     Ref<MatchResult> m_result;
     Relations m_styleRelations;
     EnumSet<PseudoElementType> m_matchedPseudoElements;
+    EnumSet<PseudoElementType> m_matchedPseudoElementsRequiringStyle;
 };
 
 ALWAYS_INLINE void ElementRuleCollector::collectMatchingRulesForList(const RuleSet::RuleDataVector* rules, const MatchRequest& matchRequest)

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -31,14 +31,18 @@
 
 #include "CSSFontSelector.h"
 #include "CSSKeyframesRule.h"
+#include "CSSPrimitiveValue.h"
+#include "CSSPropertyNames.h"
 #include "CSSSelector.h"
 #include "CSSSelectorList.h"
+#include "CSSValueList.h"
 #include "CommonAtomStrings.h"
 #include "HTMLNames.h"
 #include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"
 #include "SelectorChecker.h"
 #include "SelectorFilter.h"
+#include "StylePropertiesInlines.h"
 #include "StyleResolver.h"
 #include "StyleRule.h"
 #include "StyleRuleImport.h"
@@ -125,6 +129,43 @@ static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector& se
     return PropertyAllowlist::None;
 }
 
+static bool isZeroTimeList(const CSSValue& value)
+{
+    if (auto* primitive = dynamicDowncast<CSSPrimitiveValue>(value))
+        return primitive->isZero().value_or(false);
+    if (auto* list = dynamicDowncast<CSSValueList>(value)) {
+        for (auto& item : *list) {
+            if (!isZeroTimeList(item))
+                return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+static bool canGeneratePseudoElement(const StyleProperties& properties)
+{
+    for (auto property : properties) {
+        switch (property.id()) {
+        case CSSPropertyContent:
+        case CSSPropertyAll:
+        case CSSPropertyAnimationName:
+        case CSSPropertyTransitionProperty:
+        case CSSPropertyTransitionTimingFunction:
+        case CSSPropertyTransitionBehavior:
+            return true;
+        case CSSPropertyTransitionDuration:
+        case CSSPropertyTransitionDelay:
+            if (!isZeroTimeList(*property.value()))
+                return true;
+            break;
+        default:
+            break;
+        }
+    }
+    return false;
+}
+
 RuleData::RuleData(const StyleRule& styleRule, unsigned selectorIndex, unsigned selectorListIndex, unsigned position, IsStartingStyle isStartingStyle)
     : m_styleRuleWithSelectorIndex(&styleRule, static_cast<uint16_t>(selectorIndex))
     , m_selectorListIndex(selectorListIndex)
@@ -133,6 +174,7 @@ RuleData::RuleData(const StyleRule& styleRule, unsigned selectorIndex, unsigned 
     , m_propertyAllowlist(std::to_underlying(determinePropertyAllowlist(selector())))
     , m_isStartingStyle(std::to_underlying(isStartingStyle))
     , m_isEnabled(true)
+    , m_canGeneratePseudoElement(m_canMatchPseudoElement && Style::canGeneratePseudoElement(styleRule.properties()))
     , m_position(position)
     , m_descendantSelectorIdentifierHashes(SelectorFilter::collectHashes(selector()))
 {

--- a/Source/WebCore/style/RuleData.h
+++ b/Source/WebCore/style/RuleData.h
@@ -62,6 +62,7 @@ public:
     unsigned selectorListIndex() const { return m_selectorListIndex; }
 
     bool canMatchPseudoElement() const { return m_canMatchPseudoElement; }
+    bool canGeneratePseudoElement() const { return m_canGeneratePseudoElement; }
     MatchBasedOnRuleHash matchBasedOnRuleHash() const { return static_cast<MatchBasedOnRuleHash>(m_matchBasedOnRuleHash); }
     unsigned linkMatchType() const { return m_linkMatchType; }
     void setLinkMatchType(unsigned value) { m_linkMatchType = value; }
@@ -84,6 +85,7 @@ private:
     unsigned m_propertyAllowlist : 3;
     unsigned m_isStartingStyle : 1;
     unsigned m_isEnabled : 1;
+    unsigned m_canGeneratePseudoElement : 1;
     // If we have more rules than 2^bitcount here we'll get confused about rule order.
     unsigned m_position : 21;
     SelectorFilter::Hashes m_descendantSelectorIdentifierHashes;

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -530,6 +530,11 @@ void RuleSet::addRuleToBucket(RuleData& ruleData)
         m_universalHTMLPseudoElementTypes.add(*stylePseudoElement);
         if (!isHTMLNamespace)
             m_universalPseudoElementTypes.add(*stylePseudoElement);
+        if (ruleData.canGeneratePseudoElement() || (*stylePseudoElement != PseudoElementType::Before && *stylePseudoElement != PseudoElementType::After)) {
+            m_universalHTMLPseudoElementTypesRequiringStyle.add(*stylePseudoElement);
+            if (!isHTMLNamespace)
+                m_universalPseudoElementTypesRequiringStyle.add(*stylePseudoElement);
+        }
         return true;
     };
 

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -124,6 +124,8 @@ public:
     EnumSet<PseudoElementType> universalHTMLPseudoElementTypes() const { return m_universalHTMLPseudoElementTypes; }
     // Pseudo element types applying to all elements.
     EnumSet<PseudoElementType> universalPseudoElementTypes() const { return m_universalPseudoElementTypes; }
+    EnumSet<PseudoElementType> universalHTMLPseudoElementTypesRequiringStyle() const { return m_universalHTMLPseudoElementTypesRequiringStyle; }
+    EnumSet<PseudoElementType> universalPseudoElementTypesRequiringStyle() const { return m_universalPseudoElementTypesRequiringStyle; }
 
     const Vector<StyleRulePage*>& pageRules() const LIFETIME_BOUND { return m_pageRules; }
 
@@ -236,6 +238,8 @@ private:
     RuleDataVector m_universalPseudoElementRules;
     EnumSet<PseudoElementType> m_universalHTMLPseudoElementTypes;
     EnumSet<PseudoElementType> m_universalPseudoElementTypes;
+    EnumSet<PseudoElementType> m_universalHTMLPseudoElementTypesRequiringStyle;
+    EnumSet<PseudoElementType> m_universalPseudoElementTypesRequiringStyle;
     Vector<StyleRulePage*> m_pageRules;
     RefPtr<StyleRuleViewTransition> m_viewTransitionRule;
     RuleFeatureSet m_features;

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -318,6 +318,9 @@ UnadjustedStyle Resolver::unadjustedStyleForElement(Element& element, const Reso
         matchedPseudoElements.add(state.parentStyle()->highlightPseudoElementTypes());
     if (matchedPseudoElements)
         style.setHasPseudoStyles(matchedPseudoElements);
+    auto pseudoElementsWithoutContent = matchedPseudoElements;
+    pseudoElementsWithoutContent.remove(collector.matchedPseudoElementsRequiringStyle());
+    style.setCanOmitPseudoElementStyles(pseudoElementsWithoutContent);
 
     auto elementStyleRelations = commitRelationsToRenderStyle(style, element, collector.styleRelations());
 

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -529,6 +529,9 @@ std::optional<ElementUpdate> TreeResolver::resolvePseudoElement(Element& element
     if (!elementUpdate.style->hasPseudoStyle(pseudoElementIdentifier.type))
         return resolveAncestorPseudoElement(element, pseudoElementIdentifier, elementUpdate);
 
+    if (elementUpdate.style->canOmitPseudoElementStyle(pseudoElementIdentifier.type) && !element.mayHaveKeyframeEffects())
+        return { };
+
     if ((pseudoElementIdentifier.type == PseudoElementType::FirstLine || pseudoElementIdentifier.type == PseudoElementType::FirstLetter) && !supportsFirstLineAndLetterPseudoElement(*elementUpdate.style))
         return { };
 

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -226,6 +226,8 @@ void ComputedStyle::copyContentFrom(const ComputedStyle& other)
 void ComputedStyle::copyPseudoElementBitsFrom(const ComputedStyle& other)
 {
     m_nonInheritedFlags.pseudoBits = other.m_nonInheritedFlags.pseudoBits;
+    m_nonInheritedFlags.canOmitBeforeStyle = other.m_nonInheritedFlags.canOmitBeforeStyle;
+    m_nonInheritedFlags.canOmitAfterStyle = other.m_nonInheritedFlags.canOmitAfterStyle;
 }
 
 bool ComputedStyle::operator==(const ComputedStyle& other) const

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
@@ -85,6 +85,8 @@ inline ComputedStyleBase::ComputedStyleBase(CreateDefaultStyleTag)
     m_nonInheritedFlags.isLink = false;
     m_nonInheritedFlags.pseudoElementType = 0;
     m_nonInheritedFlags.pseudoBits = 0;
+    m_nonInheritedFlags.canOmitBeforeStyle = false;
+    m_nonInheritedFlags.canOmitAfterStyle = false;
 
     static_assert((sizeof(InheritedFlags) <= 8), "InheritedFlags does not grow");
     static_assert((sizeof(NonInheritedFlags) <= 12), "NonInheritedFlags does not grow");

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -303,6 +303,12 @@ inline bool ComputedStyleBase::hasPseudoStyle(PseudoElementType pseudo) const
     return m_nonInheritedFlags.hasPseudoStyle(pseudo);
 }
 
+inline bool ComputedStyleBase::canOmitPseudoElementStyle(PseudoElementType pseudo) const
+{
+    return (pseudo == PseudoElementType::Before && m_nonInheritedFlags.canOmitBeforeStyle)
+        || (pseudo == PseudoElementType::After && m_nonInheritedFlags.canOmitAfterStyle);
+}
+
 inline bool ComputedStyleBase::hasAnyPublicPseudoStyles() const
 {
     return m_nonInheritedFlags.hasAnyPublicPseudoStyles();

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -235,6 +235,12 @@ inline void ComputedStyleBase::setHasPseudoStyles(EnumSet<PseudoElementType> set
     m_nonInheritedFlags.setHasPseudoStyles(set);
 }
 
+inline void ComputedStyleBase::setCanOmitPseudoElementStyles(EnumSet<PseudoElementType> set)
+{
+    m_nonInheritedFlags.canOmitBeforeStyle = set.contains(PseudoElementType::Before);
+    m_nonInheritedFlags.canOmitAfterStyle = set.contains(PseudoElementType::After);
+}
+
 inline void ComputedStyleBase::setPseudoElementIdentifier(std::optional<PseudoElementIdentifier>&& identifier)
 {
     if (identifier) {

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -468,6 +468,8 @@ void ComputedStyleBase::NonInheritedFlags::dumpDifferences(TextStream& ts, const
 
     LOG_IF_DIFFERENT_WITH_CAST(PseudoId, pseudoElementType);
     LOG_IF_DIFFERENT_WITH_CAST(unsigned, pseudoBits);
+    LOG_IF_DIFFERENT(canOmitBeforeStyle);
+    LOG_IF_DIFFERENT(canOmitAfterStyle);
 }
 
 void ComputedStyleBase::InheritedFlags::dumpDifferences(TextStream& ts, const InheritedFlags& other) const

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -599,6 +599,8 @@ public:
     inline bool hasPseudoStyle(PseudoElementType) const;
     inline EnumSet<PseudoElementType> highlightPseudoElementTypes() const;
     inline void setHasPseudoStyles(EnumSet<PseudoElementType>);
+    inline bool canOmitPseudoElementStyle(PseudoElementType) const;
+    inline void setCanOmitPseudoElementStyles(EnumSet<PseudoElementType>);
 
     Style::ComputedStyle* NODELETE pseudoElementStyle(const PseudoElementIdentifier&) const;
     Style::ComputedStyle* addPseudoElementStyle(std::unique_ptr<Style::ComputedStyle>);
@@ -784,6 +786,8 @@ public:
         PREFERRED_TYPE(bool) unsigned isLink : 1;
         PREFERRED_TYPE(PseudoElementType) unsigned pseudoElementType : PseudoElementTypeBits;
         unsigned pseudoBits : PublicPseudoIDBits;
+        PREFERRED_TYPE(bool) unsigned canOmitBeforeStyle : 1;
+        PREFERRED_TYPE(bool) unsigned canOmitAfterStyle : 1;
     };
 
     struct InheritedFlags {


### PR DESCRIPTION
#### ec1c4f8cad12e3dd85bbf1ddcdde28b7ae2b223d
<pre>
Skip resolving ::before and ::after styles for rules that cannot generate content
<a href="https://bugs.webkit.org/show_bug.cgi?id=323564">https://bugs.webkit.org/show_bug.cgi?id=323564</a>
<a href="https://rdar.apple.com/186807298">rdar://186807298</a>

Reviewed by NOBODY (OOPS!).

Rules like `*::before { box-sizing: border-box; }` match every element and force a full
::before/::after style resolution for each one, even though no pseudo-element renderer can ever come
out of them.

RuleData now records at rule-construction time whether a rule&apos;s declarations can generate a
pseudo-element: &apos;content&apos;, &apos;all&apos;, or animation/transition properties that could create or keep one
alive (zero-time durations and delays don&apos;t count). ElementRuleCollector accumulates that alongside
the matched pseudo-element bits, with RuleSet tracking it per universal-rule bucket, and the result
is stored on the computed style as canOmitBefore/AfterStyle.

TreeResolver skips resolving ::before/::after when every matching rule is non-generating and the
element has no keyframe effects.

~0.8% iOS SP3 improvement.

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/pseudo-elements-005-expected.txt:
This now happens to pass because deferred pseudo style resolution avoids querying the host’s stale
style during its update.

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRules):
(WebCore::Style::ElementRuleCollector::ruleMatches):
* Source/WebCore/style/ElementRuleCollector.h:
(WebCore::Style::ElementRuleCollector::matchedPseudoElementsRequiringStyle const):
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::isZeroTimeList):
(WebCore::Style::canGeneratePseudoElement):
(WebCore::Style::RuleData::RuleData):
* Source/WebCore/style/RuleData.h:
(WebCore::Style::RuleData::canGeneratePseudoElement const):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRuleToBucket):
* Source/WebCore/style/RuleSet.h:
(WebCore::Style::RuleSet::universalHTMLPseudoElementTypesRequiringStyle const):
(WebCore::Style::RuleSet::universalPseudoElementTypesRequiringStyle const):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::unadjustedStyleForElement):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolvePseudoElement):
* Source/WebCore/style/computed/StyleComputedStyle.cpp:
(WebCore::Style::ComputedStyle::copyPseudoElementBitsFrom):
* Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h:
(WebCore::Style::ComputedStyleBase::ComputedStyleBase):
* Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h:
(WebCore::Style::ComputedStyleBase::canOmitPseudoElementStyle const):
* Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h:
(WebCore::Style::ComputedStyleBase::setCanOmitPseudoElementStyles):
* Source/WebCore/style/computed/StyleComputedStyleBase.cpp:
(WebCore::Style::ComputedStyleBase::NonInheritedFlags::dumpDifferences const):
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec1c4f8cad12e3dd85bbf1ddcdde28b7ae2b223d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53015 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195612 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150108 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144789 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100403 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48478 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125082 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47206 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45266 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157573 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44954 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6666 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197561 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58862 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154302 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59571 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41558 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153953 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48446 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131888 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128693 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58049 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19974 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57421 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57664 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57488 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->