### PR TITLE
[corner-shape] Some combinations of corner-shape with thick borders have incorrect rendering

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-inset-shadow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-inset-shadow.html
@@ -2,7 +2,7 @@
 <head>
 <link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shaping">
 <link rel="match" href="corner-shape-inset-shadow-ref.html">
-<meta name="fuzzy" content="maxDifference=0-255;totalPixels=0-360">
+<meta name="fuzzy" content="maxDifference=0-255;totalPixels=0-420">
 <style>
     .target {
         width: 200px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse001-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: scoop corners whose inner edges cover the padding box &mdash; reference</title>
+<style>
+    .target {
+        display: inline-block;
+        margin: 10px;
+        width: 150px;
+        height: 150px;
+        box-sizing: border-box;
+        background: green;
+        border-radius: 50%;
+        corner-shape: scoop;
+    }
+</style>
+</head>
+<div class=target></div>
+<div class=target></div>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse001-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: scoop corners whose inner edges cover the padding box &mdash; reference</title>
+<style>
+    .target {
+        display: inline-block;
+        margin: 10px;
+        width: 150px;
+        height: 150px;
+        box-sizing: border-box;
+        background: green;
+        border-radius: 50%;
+        corner-shape: scoop;
+    }
+</style>
+</head>
+<div class=target></div>
+<div class=target></div>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse001.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shape">
+<link rel="match" href="inner-corner-collapse001-ref.html">
+<meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-2500">
+<meta name="assert" content="Test that nothing is drawn inside the border when four scoop corners are thick enough that their inner edges cover the whole padding box. The three widths cover the inner edges crossing each other twice, meeting at the padding box edges, and missing the padding box altogether.">
+<style>
+    .target {
+        display: inline-block;
+        margin: 10px;
+        width: 150px;
+        height: 150px;
+        box-sizing: border-box;
+        border: 35px solid green;
+        border-radius: 50%;
+        corner-shape: scoop;
+    }
+</style>
+</head>
+<div class=target></div>
+<div class=target style="border-width: 50px"></div>
+<div class=target style="border-width: 60px"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse002-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: scoop corners leaving part of the padding box uncovered &mdash; reference</title>
+<style>
+    /* The border box is four quarter circles of radius 75 centered on the corners of the box; the
+       padding box is what's left of the box once the same circles, grown by the 20px border, are
+       taken out of it. */
+    .target {
+        margin: 10px;
+        width: 150px;
+        height: 150px;
+        background: green;
+        clip-path: path(evenodd, "M 75 0 A 75 75 0 0 0 150 75 A 75 75 0 0 0 75 150 A 75 75 0 0 0 0 75 A 75 75 0 0 0 75 0 Z M 75 58.31 A 95 95 0 0 0 91.69 75 A 95 95 0 0 0 75 91.69 A 95 95 0 0 0 58.31 75 A 95 95 0 0 0 75 58.31 Z");
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse002-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: scoop corners leaving part of the padding box uncovered &mdash; reference</title>
+<style>
+    /* The border box is four quarter circles of radius 75 centered on the corners of the box; the
+       padding box is what's left of the box once the same circles, grown by the 20px border, are
+       taken out of it. */
+    .target {
+        margin: 10px;
+        width: 150px;
+        height: 150px;
+        background: green;
+        clip-path: path(evenodd, "M 75 0 A 75 75 0 0 0 150 75 A 75 75 0 0 0 75 150 A 75 75 0 0 0 0 75 A 75 75 0 0 0 75 0 Z M 75 58.31 A 95 95 0 0 0 91.69 75 A 95 95 0 0 0 75 91.69 A 95 95 0 0 0 58.31 75 A 95 95 0 0 0 75 58.31 Z");
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse002.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shape">
+<link rel="match" href="inner-corner-collapse002-ref.html">
+<meta name="fuzzy" content="maxDifference=0-72; totalPixels=0-660">
+<meta name="assert" content="Test that the padding box is still drawn when four scoop corners are just thin enough to leave part of it uncovered.">
+<style>
+    .target {
+        margin: 10px;
+        width: 150px;
+        height: 150px;
+        box-sizing: border-box;
+        border: 20px solid green;
+        border-radius: 50%;
+        corner-shape: scoop;
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse003-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: a notch corner whose inner edge covers the padding box &mdash; reference</title>
+<style>
+    .target {
+        margin: 10px;
+        width: 150px;
+        height: 150px;
+        box-sizing: border-box;
+        background: green;
+        border-radius: 50%;
+        corner-shape: notch scoop bevel round;
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse003-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse003-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: a notch corner whose inner edge covers the padding box &mdash; reference</title>
+<style>
+    .target {
+        margin: 10px;
+        width: 150px;
+        height: 150px;
+        box-sizing: border-box;
+        background: green;
+        border-radius: 50%;
+        corner-shape: notch scoop bevel round;
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse003.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shape">
+<link rel="match" href="inner-corner-collapse003-ref.html">
+<meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-1500">
+<meta name="assert" content="Test that nothing is drawn inside the border when a notch corner is thick enough that its inner edge covers the whole padding box.">
+<style>
+    .target {
+        margin: 10px;
+        width: 150px;
+        height: 150px;
+        box-sizing: border-box;
+        border: 40px solid green;
+        border-radius: 50%;
+        corner-shape: notch scoop bevel round;
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection004-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection004-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: a notch corner whose inner edge meets the next corner's &mdash; reference</title>
+<style>
+    /* The two 275px radii don't fit along the 400px top edge, so they're both scaled down to 200px. The
+       border box then turns in to (200, 200) for the notch and runs straight out to (400, 200) for the
+       bevel. Inset by the 60px border, the notch turns in to (260, 260) and the bevel's edge becomes
+       x - y = 200 - 60 * sqrt(2), which the notch's edge runs into at (260, 144.85). */
+    .target {
+        margin: 20px;
+        width: 400px;
+        height: 400px;
+        background: green;
+        clip-path: path(evenodd, "M 200 0 L 400 200 L 400 400 L 0 400 L 0 200 L 200 200 Z M 260 144.853 L 340 224.853 L 340 340 L 60 340 L 60 260 L 260 260 Z");
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection004-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection004-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<head>
+<title>CSS Borders and Box Decorations 4: a notch corner whose inner edge meets the next corner's &mdash; reference</title>
+<style>
+    /* The two 275px radii don't fit along the 400px top edge, so they're both scaled down to 200px. The
+       border box then turns in to (200, 200) for the notch and runs straight out to (400, 200) for the
+       bevel. Inset by the 60px border, the notch turns in to (260, 260) and the bevel's edge becomes
+       x - y = 200 - 60 * sqrt(2), which the notch's edge runs into at (260, 144.85). */
+    .target {
+        margin: 20px;
+        width: 400px;
+        height: 400px;
+        background: green;
+        clip-path: path(evenodd, "M 200 0 L 400 200 L 400 400 L 0 400 L 0 200 L 200 200 Z M 260 144.853 L 340 224.853 L 340 340 L 60 340 L 60 260 L 260 260 Z");
+    }
+</style>
+</head>
+<div class=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection004.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<head>
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shape">
+<link rel="match" href="inner-corner-intersection004-ref.html">
+<meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-360">
+<meta name="assert" content="Test for rendering correctness when the inner edge of a notch corner intersects the inner edge of the adjacent corner.">
+<style>
+    .target {
+        margin: 20px;
+        width: 400px;
+        height: 400px;
+        box-sizing: border-box;
+        border: 60px solid green;
+
+        border-top-left-radius: 275px;
+        corner-top-left-shape: notch;
+
+        border-top-right-radius: 275px;
+        corner-top-right-shape: bevel;
+    }
+</style>
+</head>
+<div class=target></div>

--- a/Source/WebCore/platform/graphics/BezierUtilities.cpp
+++ b/Source/WebCore/platform/graphics/BezierUtilities.cpp
@@ -418,4 +418,9 @@ void trimMonotonicBezierCurvesAtIntersection(Vector<BezierSegment>& first, Vecto
     second = curvesFromIntersection(second, intersection.indexOnSecond, intersection.parameterOnSecond);
 }
 
+unsigned numberOfCrossingsWithSegment(const BezierSegment& curve, const FloatPoint& segmentStart, const FloatPoint& segmentEnd)
+{
+    return intersectBezierAndLine(curve, segmentStart, segmentEnd).size();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/BezierUtilities.h
+++ b/Source/WebCore/platform/graphics/BezierUtilities.h
@@ -54,6 +54,9 @@ WEBCORE_EXPORT std::optional<BezierCurvesIntersection> findMonotonicBezierCurves
 
 WEBCORE_EXPORT void trimMonotonicBezierCurvesAtIntersection(Vector<BezierSegment>& first, Vector<BezierSegment>& second, const BezierCurvesIntersection&);
 
+// How many times `curve` crosses the line segment from `segmentStart` to `segmentEnd`.
+WEBCORE_EXPORT unsigned numberOfCrossingsWithSegment(const BezierSegment& curve, const FloatPoint& segmentStart, const FloatPoint& segmentEnd);
+
 // `parameter` is the Bézier curve parameter t in [0, 1]: 0 is the start point, 1 is the end point (not arc length).
 FloatPoint pointOnBezierAtParameter(const BezierSegment& curve, double parameter);
 

--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.cpp
@@ -361,8 +361,19 @@ static BezierSegment shallowConcaveCornerBezier(const Corner& corner, const Floa
 
 using CornerCurves = Vector<BezierSegment, 2>;
 
+static BezierSegment straightBezierSegment(const FloatPoint& start, const FloatPoint& end)
+{
+    auto delta = end - start;
+    return { start, start + delta * (1.0f / 3.0f), start + delta * (2.0f / 3.0f), end };
+}
+
 static CornerCurves cornerCurveBeziers(const ResolvedCorner& corner)
 {
+    if (isNotch(corner.adjusted) || isSquare(corner.adjusted)) {
+        auto turningPoint = isNotch(corner.adjusted) ? corner.adjusted.center : corner.adjusted.outer;
+        return { straightBezierSegment(corner.adjusted.start, turningPoint), straightBezierSegment(turningPoint, corner.adjusted.end) };
+    }
+
     if (isShallowConcave(corner.adjusted) && corner.tangentVertex)
         return { shallowConcaveCornerBezier(corner.adjusted, *corner.tangentVertex) };
 
@@ -428,17 +439,87 @@ static FloatPoint sharpInnerCornerPoint(const FloatRect& innerRect, BoxCorner or
     return { };
 }
 
-static Vector<BezierSegment> trimmedSuperellipseCornerCurves(const ResolvedCorner& corner, const FloatRect& innerRect)
+static Vector<BezierSegment> curvesTrimmedToRect(const CornerCurves& curves, const FloatRect& innerRect)
 {
     Vector<BezierSegment> clippedCurves;
-    for (const auto& bezier : cornerCurveBeziers(corner)) {
+    for (const auto& bezier : curves) {
         for (const auto& curve : trimBezierToRect(bezier, innerRect))
             clippedCurves.append(curve);
     }
     return clippedCurves;
 }
 
-static void addSuperellipseCornerCurves(Path& path, const Vector<BezierSegment>& curves, const FloatPoint& sharpCornerPoint, bool& started)
+struct PreparedCorner {
+    ResolvedCorner resolved;
+    bool insetToTargetRect { false };
+    bool isElided { false };
+    // The whole corner curve, describing the area this corner removes from the target rect.
+    CornerCurves fullCurves;
+    // The part of that curve the contour draws: trimmed to the target rect, then to the neighboring corners.
+    Vector<BezierSegment> curves;
+};
+
+// A corner's curve, together with the two edges that meet at its vertex, encloses the area that the corner
+// removes from the target rect, so a point lies inside that area when the segment joining it to the vertex
+// crosses the curve an even number of times.
+static bool cornerRemovesPoint(const PreparedCorner& corner, const FloatPoint& point)
+{
+    const auto& adjusted = corner.resolved.adjusted;
+
+    if (isSquare(adjusted))
+        return false;
+
+    FloatRect cornerBox { adjusted.outer, FloatSize { } };
+    cornerBox.extend(adjusted.center);
+    if (!cornerBox.contains(point))
+        return false;
+
+    unsigned crossings = 0;
+    for (const auto& curve : corner.fullCurves)
+        crossings += numberOfCrossingsWithSegment(curve, point, adjusted.outer);
+    return !(crossings % 2);
+}
+
+static bool contourEnclosesArea(const Vector<PreparedCorner, 4>& corners, const FloatRect& targetRect)
+{
+    bool anyCornerIsConcave = false;
+    for (const auto& corner : corners) {
+        if (!corner.insetToTargetRect)
+            return true;
+        anyCornerIsConcave |= isConcave(corner.resolved.adjusted);
+    }
+
+    if (!anyCornerIsConcave)
+        return true;
+
+    auto isRemovedByAnyCorner = [&](const FloatPoint& point, const PreparedCorner* pointLiesOn) {
+        for (const auto& corner : corners) {
+            if (&corner != pointLiesOn && cornerRemovesPoint(corner, point))
+                return true;
+        }
+        return false;
+    };
+
+    for (const auto& corner : corners) {
+        if (corner.isElided)
+            continue;
+
+        if (corner.curves.isEmpty()) {
+            if (!isRemovedByAnyCorner(sharpInnerCornerPoint(targetRect, corner.resolved.adjusted.orientation), nullptr))
+                return true;
+            continue;
+        }
+
+        for (const auto& curve : corner.curves) {
+            if (!isRemovedByAnyCorner(pointOnBezierAtParameter(curve, 0.5), &corner))
+                return true;
+        }
+    }
+
+    return false;
+}
+
+static void addInsetCornerCurves(Path& path, const Vector<BezierSegment>& curves, const FloatPoint& sharpCornerPoint, bool& started)
 {
     auto lineOrMoveTo = [&](FloatPoint point) {
         if (!started) {
@@ -459,31 +540,10 @@ static void addSuperellipseCornerCurves(Path& path, const Vector<BezierSegment>&
     }
 }
 
-static void addClampedSharpCorner(Path& path, const ResolvedCorner& corner, const FloatRect& targetRect, bool& started)
-{
-    auto clampToTarget = [&](FloatPoint point) {
-        return FloatPoint {
-            std::clamp(point.x(), targetRect.x(), targetRect.maxX()),
-            std::clamp(point.y(), targetRect.y(), targetRect.maxY())
-        };
-    };
-    auto lineOrMoveTo = [&](FloatPoint point) {
-        if (!started) {
-            path.moveTo(point);
-            started = true;
-        } else
-            path.addLineTo(point);
-    };
-
-    lineOrMoveTo(clampToTarget(corner.miterStart));
-    path.addLineTo(clampToTarget(isNotch(corner.adjusted) ? corner.adjusted.center : corner.adjusted.outer));
-    path.addLineTo(clampToTarget(corner.miterEnd));
-}
-
 } // namespace
 
 // https://drafts.csswg.org/css-borders-4/#contour-path
-void borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, const FloatRect* targetRect, ContourStart contourStart)
+ContourResult borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, const FloatRect* targetRect, ContourStart contourStart)
 {
     bool started = false;
 
@@ -503,14 +563,6 @@ void borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, 
 
     static constexpr std::array<BoxCorner, 4> contourOrder { BoxCorner::TopRight, BoxCorner::BottomRight, BoxCorner::BottomLeft, BoxCorner::TopLeft };
 
-    struct PreparedCorner {
-        ResolvedCorner resolved;
-        bool insetToTargetRect { false };
-        bool usesCurves { false };
-        bool isSwallowed { false };
-        Vector<BezierSegment> curves;
-    };
-
     Vector<PreparedCorner, 4> corners;
     for (auto key : contourOrder) {
         const auto& input = cornerRects[key];
@@ -518,13 +570,15 @@ void borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, 
         auto resolved = resolveCorner(makeCorner(input), input.startInset, input.endInset);
         bool insetToTargetRect = targetRect && input.startInset >= 0.0 && input.endInset >= 0.0
             && !isEmpty(resolved.adjusted);
-        bool usesCurves = insetToTargetRect && std::isfinite(resolved.adjusted.curvature);
 
+        CornerCurves fullCurves;
         Vector<BezierSegment> curves;
-        if (usesCurves)
-            curves = trimmedSuperellipseCornerCurves(resolved, *targetRect);
+        if (insetToTargetRect) {
+            fullCurves = cornerCurveBeziers(resolved);
+            curves = curvesTrimmedToRect(fullCurves, *targetRect);
+        }
 
-        corners.append(PreparedCorner { WTF::move(resolved), insetToTargetRect, usesCurves, false, WTF::move(curves) });
+        corners.append(PreparedCorner { WTF::move(resolved), insetToTargetRect, false, WTF::move(fullCurves), WTF::move(curves) });
     }
 
     // Concave corners can intersect; trim them at the cusp. A corner's inset curve can also intersect with non-adjacent edges.
@@ -534,7 +588,7 @@ void borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, 
             auto& first = corners[index];
             auto& second = corners[(index + gap) % corners.size()];
 
-            if (!first.usesCurves || !second.usesCurves || first.isSwallowed || second.isSwallowed)
+            if (!first.insetToTargetRect || !second.insetToTargetRect || first.isElided || second.isElided)
                 continue;
 
             auto intersection = findMonotonicBezierCurvesIntersection(first.curves, second.curves);
@@ -550,22 +604,22 @@ void borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, 
             trimMonotonicBezierCurvesAtIntersection(first.curves, second.curves, *intersection);
 
             for (size_t between = 1; between < gap; ++between)
-                corners[(index + between) % corners.size()].isSwallowed = true;
+                corners[(index + between) % corners.size()].isElided = true;
         }
     }
 
+    if (targetRect && !contourEnclosesArea(corners, *targetRect))
+        return ContourResult::Empty;
+
     for (auto& prepared : corners) {
-        if (prepared.isSwallowed)
+        if (prepared.isElided)
             continue;
 
         const auto& corner = prepared.resolved;
         const auto& adjusted = corner.adjusted;
 
         if (prepared.insetToTargetRect) {
-            if (prepared.usesCurves)
-                addSuperellipseCornerCurves(path, prepared.curves, sharpInnerCornerPoint(*targetRect, adjusted.orientation), started);
-            else
-                addClampedSharpCorner(path, corner, *targetRect, started);
+            addInsetCornerCurves(path, prepared.curves, sharpInnerCornerPoint(*targetRect, adjusted.orientation), started);
             continue;
         }
 
@@ -583,6 +637,7 @@ void borderContourPath(Path& path, const RectCorners<CornerInput>& cornerRects, 
         path.addLineTo(corner.miterEnd);
     }
     path.closeSubpath();
+    return ContourResult::Contour;
 }
 
 static Vector<FloatPoint> normalizedInnerCornerHull(double curvature)

--- a/Source/WebCore/platform/graphics/CornerShapeUtilities.h
+++ b/Source/WebCore/platform/graphics/CornerShapeUtilities.h
@@ -43,9 +43,10 @@ struct CornerInput {
 };
 
 enum class ContourStart : bool { FirstCorner, TopEdge };
+enum class ContourResult : bool { Contour, Empty };
 
 // https://drafts.csswg.org/css-borders-4/#contour-path
-void borderContourPath(Path&, const RectCorners<CornerInput>&, const FloatRect* targetRect = nullptr, ContourStart = ContourStart::FirstCorner);
+ContourResult borderContourPath(Path&, const RectCorners<CornerInput>&, const FloatRect* targetRect = nullptr, ContourStart = ContourStart::FirstCorner);
 
 // https://drafts.csswg.org/css-borders-4/#corner-shape-constrain-radii
 double oppositeCornerScaleFactor(const RectCorners<CornerInput>&);

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -447,7 +447,7 @@ static bool cornersUseAlignedToCurveOffset(const RectCorners<float>& cornerCurva
 }
 
 // Offset the border-box reference curve to targetRect at constant thickness: outset corners miter out to the edges along their tangent, inset corners trim to the rect.
-static void addAlignedToCurveOffsetContour(Path& path, const FloatRoundedRect& referenceSnapped, const RectCorners<float>& cornerCurvatures, const FloatRect& targetRect)
+static ContourResult addAlignedToCurveOffsetContour(Path& path, const FloatRoundedRect& referenceSnapped, const RectCorners<float>& cornerCurvatures, const FloatRect& targetRect)
 {
     auto referenceRect = referenceSnapped.rect();
     double leftOffset = referenceRect.x() - targetRect.x();
@@ -458,7 +458,7 @@ static void addAlignedToCurveOffsetContour(Path& path, const FloatRoundedRect& r
     RectCorners<CornerInput> referenceCorners;
     buildCornerInputs(referenceSnapped, cornerCurvatures, -leftOffset, -topOffset, -rightOffset, -bottomOffset, referenceCorners);
 
-    borderContourPath(path, referenceCorners, &targetRect);
+    return borderContourPath(path, referenceCorners, &targetRect);
 }
 
 static void addOuterCornerShapeToPath(Path& path, const FloatRoundedRect& outerSnapped, const RectCorners<float>& cornerCurvatures, const std::optional<FloatRoundedRect>& offsetReferenceRect)
@@ -492,21 +492,23 @@ std::optional<Path> BorderShape::pathForShapedRect(const FloatRoundedRect& round
 Path BorderShape::pathForOuterCornerShape(const FloatRoundedRect& outerSnapped, const std::optional<FloatRoundedRect>& snappedOffsetReference) const
 {
     Path path;
-    bool useAlignedToCurve = snappedOffsetReference
-        && (cornersUseAlignedToCurveOffset(m_cornerCurvatures)
-            || cornersHaveConvexSuperellipse(m_cornerCurvatures));
+    bool useAlignedToCurve = snappedOffsetReference && (cornersUseAlignedToCurveOffset(m_cornerCurvatures) || cornersHaveConvexSuperellipse(m_cornerCurvatures));
     if (useAlignedToCurve) {
-        addAlignedToCurveOffsetContour(path, *snappedOffsetReference, m_cornerCurvatures, outerSnapped.rect());
+        if (addAlignedToCurveOffsetContour(path, *snappedOffsetReference, m_cornerCurvatures, outerSnapped.rect()) == ContourResult::Empty)
+            return path;
+
         if (!path.isEmpty())
             return path;
     }
+
     addOuterCornerShapeToPath(path, outerSnapped, m_cornerCurvatures, snappedOffsetReference);
     if (!path.isEmpty())
         return path;
+
     return pathForOuterRoundedRect(outerSnapped);
 }
 
-static void addInnerCornerShapeToPath(Path& path, const FloatRoundedRect& outerSnapped, const FloatRoundedRect& innerSnapped, const RectCorners<float>& cornerCurvatures, const std::optional<FloatRoundedRect>& offsetReferenceRect)
+static ContourResult addInnerCornerShapeToPath(Path& path, const FloatRoundedRect& outerSnapped, const FloatRoundedRect& innerSnapped, const RectCorners<float>& cornerCurvatures, const std::optional<FloatRoundedRect>& offsetReferenceRect)
 {
     auto outerRect = outerSnapped.rect();
     auto innerRect = innerSnapped.rect();
@@ -519,23 +521,27 @@ static void addInnerCornerShapeToPath(Path& path, const FloatRoundedRect& outerS
     RectCorners<CornerInput> cornerRects;
     buildCornerInputs(outerSnapped, cornerCurvatures, leftWidth, topWidth, rightWidth, bottomWidth, cornerRects);
     rebuildOffsetCornersFromReference(cornerRects, offsetReferenceRect, cornerCurvatures, innerRect);
-    borderContourPath(path, cornerRects, &innerRect);
+    return borderContourPath(path, cornerRects, &innerRect);
 }
 
 Path BorderShape::pathForInnerCornerShape(const FloatRoundedRect& outerSnapped, const FloatRoundedRect& innerSnapped, const std::optional<FloatRoundedRect>& snappedOffsetReference) const
 {
     Path path;
-    bool useAlignedToCurve = snappedOffsetReference
-        && (cornersUseAlignedToCurveOffset(m_cornerCurvatures)
-            || cornersHaveConvexSuperellipse(m_cornerCurvatures));
+    bool useAlignedToCurve = snappedOffsetReference && (cornersUseAlignedToCurveOffset(m_cornerCurvatures) || cornersHaveConvexSuperellipse(m_cornerCurvatures));
     if (useAlignedToCurve) {
-        addAlignedToCurveOffsetContour(path, *snappedOffsetReference, m_cornerCurvatures, innerSnapped.rect());
+        if (addAlignedToCurveOffsetContour(path, *snappedOffsetReference, m_cornerCurvatures, innerSnapped.rect()) == ContourResult::Empty)
+            return path;
+
         if (!path.isEmpty())
             return path;
     }
-    addInnerCornerShapeToPath(path, outerSnapped, innerSnapped, m_cornerCurvatures, snappedOffsetReference);
+
+    if (addInnerCornerShapeToPath(path, outerSnapped, innerSnapped, m_cornerCurvatures, snappedOffsetReference) == ContourResult::Empty)
+        return path;
+
     if (path.isEmpty())
         return pathForInnerRoundedRect(innerSnapped);
+
     return path;
 }
 
@@ -553,6 +559,7 @@ Path BorderShape::pathForInnerShape(float deviceScaleFactor) const
     auto innerSnapped = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     if (hasNonRoundCornerShape())
         return pathForInnerCornerShape(outerSnapped, innerSnapped, snappedOffsetReferenceRect(deviceScaleFactor));
+
     return pathForInnerRoundedRect(innerSnapped);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/BezierUtilitiesTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/BezierUtilitiesTests.cpp
@@ -380,4 +380,34 @@ TEST(BezierUtilities, FindMonotonicCurvesDoesNotModifyTheRuns)
     expectPointNear(second[0].start, 0, 10);
 }
 
+// Counting crossings tells a caller which side of a curve a point is on: the corner contour builder
+// walks from the point to the corner's vertex and treats an even count as "the corner removed this point".
+TEST(BezierUtilities, CountsCrossingsOfASegmentThatCutsTheCurve)
+{
+    auto curve = lineCurve({ 0, 10 }, { 20, 10 });
+
+    EXPECT_EQ(1u, numberOfCrossingsWithSegment(curve, { 10, 0 }, { 10, 20 }));
+    EXPECT_EQ(1u, numberOfCrossingsWithSegment(curve, { 10, 20 }, { 10, 0 }));
+}
+
+// Crossings past either end of the segment don't count, so a point can be tested against a nearby vertex.
+TEST(BezierUtilities, CountsNoCrossingsForASegmentStoppingShortOfTheCurve)
+{
+    auto curve = lineCurve({ 0, 10 }, { 20, 10 });
+
+    EXPECT_EQ(0u, numberOfCrossingsWithSegment(curve, { 10, 0 }, { 10, 9 }));
+    EXPECT_EQ(0u, numberOfCrossingsWithSegment(curve, { 10, 11 }, { 10, 20 }));
+    // Alongside the curve rather than across it.
+    EXPECT_EQ(0u, numberOfCrossingsWithSegment(curve, { 5, 0 }, { 15, 0 }));
+}
+
+// A curve that doubles back crosses the same segment twice, which is what keeps the even/odd test honest.
+TEST(BezierUtilities, CountsBothCrossingsOfACurveThatDoublesBack)
+{
+    BezierSegment archedCurve { { 0, 10 }, { 5, -10 }, { 15, -10 }, { 20, 10 } };
+
+    EXPECT_EQ(2u, numberOfCrossingsWithSegment(archedCurve, { -5, 5 }, { 25, 5 }));
+    EXPECT_EQ(0u, numberOfCrossingsWithSegment(archedCurve, { -5, 15 }, { 25, 15 }));
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 8faa195818613650b9227d51695bd6b48703b7ce
<pre>
[corner-shape] Some combinations of corner-shape with thick borders have incorrect rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=323565">https://bugs.webkit.org/show_bug.cgi?id=323565</a>
<a href="https://rdar.apple.com/186808871">rdar://186808871</a>

Reviewed by Abrar Rahman Protyasha.

The inside border edge can self-intersect with some combinations of border-width and concave
corner shapes; make sure these cases don&apos;t result in bad rendering by removing inner corners
when necessary, and computing when the entire inner shape disappears.

Tests: Tools/TestWebKitAPI/Tests/WebCore/BezierUtilitiesTests.cpp
       imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse001-ref.html
       imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse001.html
       imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse002-ref.html
       imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse002.html
       imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse003-ref.html
       imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse003.html
       imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection004-ref.html
       imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection004.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse002-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse003-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-collapse003.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection004-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection004-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/inner-corner-intersection004.html: Added.
* Source/WebCore/platform/graphics/BezierUtilities.cpp:
(WebCore::numberOfCrossingsWithSegment):
* Source/WebCore/platform/graphics/BezierUtilities.h:
* Source/WebCore/platform/graphics/CornerShapeUtilities.cpp:
(WebCore::borderContourPath):
* Source/WebCore/platform/graphics/CornerShapeUtilities.h:
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::addAlignedToCurveOffsetContour):
(WebCore::BorderShape::pathForOuterCornerShape const):
(WebCore::addInnerCornerShapeToPath):
(WebCore::BorderShape::pathForInnerCornerShape const):
(WebCore::BorderShape::pathForInnerShape const):
* Tools/TestWebKitAPI/Tests/WebCore/BezierUtilitiesTests.cpp:
(TestWebKitAPI::TEST(BezierUtilities, CountsCrossingsOfASegmentThatCutsTheCurve)):
(TestWebKitAPI::TEST(BezierUtilities, CountsNoCrossingsForASegmentStoppingShortOfTheCurve)):
(TestWebKitAPI::TEST(BezierUtilities, CountsBothCrossingsOfACurveThatDoublesBack)):
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-inset-shadow.html:

Canonical link: <a href="https://commits.webkit.org/320826@main">https://commits.webkit.org/320826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfd5c7646a46763d1652d471c602ab3e7dce090c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150586 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a6e28c0e-2423-4174-81c6-36b22d12f93b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187812 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59570 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145307 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100731 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eb97ad58-9fb8-487f-afb4-d0fb3b9edbdd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125619 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/939df41d-5544-41fa-a605-0ecc6e56d04b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47719 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45723 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7491 "Build is in progress. Recent messages:") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45442 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7319 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198222 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165377 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154864 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41491 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60217 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42042 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154510 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48959 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129563 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58669 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58055 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58285 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58113 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->