### PR TITLE
[corner-shape] Add some more shape-outside/corner-shape tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-content-box-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-content-box-expected.txt
@@ -1,0 +1,9 @@
+
+PASS corner-shape: notch with shape-outside: content-box
+PASS corner-shape: bevel with shape-outside: content-box
+PASS corner-shape: round with shape-outside: content-box
+PASS corner-shape: square with shape-outside: content-box
+PASS corner-shape: scoop with shape-outside: content-box
+PASS corner-shape: superellipse(1.5) with shape-outside: content-box
+PASS corner-shape: superellipse(-.8) with shape-outside: content-box
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-content-box.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-content-box.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<title>shape-outside: content-box with corner-shape</title>
+<link rel="help" href="https://drafts.csswg.org/css-shapes-1/#shapes-from-box-values">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shape">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+body {
+  margin: 0;
+}
+.container {
+  width: 320px;
+  line-height: 0;
+}
+
+/* Thin border and padding relative to the radius, so that the content-box keeps a corner large enough
+   for each corner-shape to carve a different amount out of it. */
+.shape {
+  float: left;
+  shape-outside: content-box;
+  border-radius: 70px;
+  box-sizing: content-box;
+  height: 160px;
+  width: 160px;
+  padding: 10px;
+  border: 10px solid lightgreen;
+  margin: 20px;
+  background-color: orange;
+}
+
+.box {
+  display: inline-block;
+  width: 100px;
+  background-color: blue;
+}
+
+.longbox {
+  display: inline-block;
+  width: 320px;
+  background-color: blue;
+}
+</style>
+
+<main class="container">
+  <div class="shape"></div>
+  <div class="longbox" style="height: 20px;"></div> <!-- Above the content-box -->
+  <div class="box" style="height: 44px;"></div> <!-- Box at the corner -->
+  <div class="box" style="height: 56px;"></div>
+  <div class="box" style="height: 56px;"></div>
+  <div class="box" style="height: 44px;"></div> <!-- Box at the corner -->
+  <div class="longbox" style="height: 20px;"></div> <!-- Below the content-box -->
+</main>
+
+<script>
+function shape_outside_corner_shape_test(corner_shape, expected) {
+  test(() => {
+    const shape = document.querySelector(".shape");
+    shape.style.setProperty("corner-shape", corner_shape);
+    const actual = Array.from(document.querySelectorAll(".container .box")).map(b => b.getBoundingClientRect().x);
+    assert_array_approx_equals(actual, expected, 2);
+  }, `corner-shape: ${corner_shape} with shape-outside: content-box`);
+}
+
+shape_outside_corner_shape_test("notch", [130, 200, 200, 130]);
+shape_outside_corner_shape_test("bevel", [166, 200, 200, 166]);
+shape_outside_corner_shape_test("round", [193, 200, 200, 193]);
+shape_outside_corner_shape_test("square", [200, 200, 200, 200]);
+shape_outside_corner_shape_test("scoop", [141, 200, 200, 141]);
+shape_outside_corner_shape_test("superellipse(1.5)", [197, 200, 200, 197]);
+shape_outside_corner_shape_test("superellipse(-.8)", [145, 200, 200, 145]);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-corners-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-corners-expected.txt
@@ -1,0 +1,7 @@
+
+PASS corner-shape: square scoop bevel notch with shape-outside
+PASS corner-shape: notch round square bevel with shape-outside
+PASS corner-shape: bevel square notch round with shape-outside
+PASS corner-shape: round notch scoop square with shape-outside
+PASS corner-shape: scoop bevel round notch with shape-outside
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-corners.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-corners.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<title>shape-outside with a different corner-shape per corner</title>
+<link rel="help" href="https://drafts.csswg.org/css-shapes-1/#shapes-from-box-values">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shape">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+body {
+  margin: 0;
+}
+.container {
+  width: 200px;
+  line-height: 0;
+}
+
+.shape {
+  float: left;
+  shape-outside: border-box;
+  border-radius: 48%;
+  box-sizing: content-box;
+  height: 40px;
+  width: 40px;
+  padding: 20px;
+  border: 20px solid lightgreen;
+  margin: 20px;
+  background-color: orange;
+}
+
+.box {
+  display: inline-block;
+  width: 60px;
+  background-color: blue;
+}
+
+.longbox {
+  display: inline-block;
+  width: 200px;
+  height: 20px;
+  background-color: blue;
+}
+</style>
+
+<main class="container">
+  <div class="shape"></div>
+  <div class="longbox"></div>
+  <div class="box" style="height: 24px;"></div>
+  <div class="box" style="height: 36px;"></div>
+  <div class="box" style="height: 36px;"></div>
+  <div class="box" style="height: 24px;"></div>
+  <div class="longbox"></div>
+</main>
+
+<script>
+function shape_outside_corner_shape_test(corner_shape, expected) {
+  test(() => {
+    const shape = document.querySelector(".shape");
+    shape.style.setProperty("corner-shape", corner_shape);
+    const actual = Array.from(document.querySelectorAll(".container .box")).map(b => b.getBoundingClientRect().x);
+    assert_array_approx_equals(actual, expected, 2);
+  }, `corner-shape: ${corner_shape} with shape-outside`);
+}
+
+shape_outside_corner_shape_test("square scoop bevel notch", [88, 140, 140, 106]);
+shape_outside_corner_shape_test("notch round square bevel", [129, 140, 140, 140]);
+shape_outside_corner_shape_test("bevel square notch round", [140, 140, 140, 82]);
+shape_outside_corner_shape_test("round notch scoop square", [82, 140, 140, 88]);
+shape_outside_corner_shape_test("scoop bevel round notch", [106, 140, 140, 129]);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-margin-box-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-margin-box-expected.txt
@@ -1,0 +1,9 @@
+
+PASS corner-shape: notch with shape-outside: margin-box
+PASS corner-shape: bevel with shape-outside: margin-box
+PASS corner-shape: round with shape-outside: margin-box
+PASS corner-shape: square with shape-outside: margin-box
+PASS corner-shape: scoop with shape-outside: margin-box
+PASS corner-shape: superellipse(1.5) with shape-outside: margin-box
+PASS corner-shape: superellipse(-.8) with shape-outside: margin-box
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-margin-box.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-margin-box.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<title>shape-outside: margin-box with corner-shape</title>
+<link rel="help" href="https://drafts.csswg.org/css-shapes-1/#shapes-from-box-values">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shape">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+body {
+  margin: 0;
+}
+.container {
+  width: 240px;
+  line-height: 0;
+}
+
+.shape {
+  float: left;
+  shape-outside: margin-box;
+  border-radius: 48%;
+  box-sizing: content-box;
+  height: 40px;
+  width: 40px;
+  padding: 20px;
+  border: 20px solid lightgreen;
+  margin: 20px;
+  background-color: orange;
+}
+
+.box {
+  display: inline-block;
+  width: 80px;
+  background-color: blue;
+}
+
+.longbox {
+  display: inline-block;
+  width: 240px;
+  height: 20px;
+  background-color: blue;
+}
+</style>
+
+<main class="container">
+  <div class="shape"></div>
+  <div class="box" style="height: 24px;"></div>
+  <div class="box" style="height: 56px;"></div>
+  <div class="box" style="height: 56px;"></div>
+  <div class="box" style="height: 24px;"></div>
+  <div class="longbox"></div>
+</main>
+
+<script>
+function shape_outside_corner_shape_test(corner_shape, expected) {
+  test(() => {
+    const shape = document.querySelector(".shape");
+    shape.style.setProperty("corner-shape", corner_shape);
+    const actual = Array.from(document.querySelectorAll(".container .box")).map(b => b.getBoundingClientRect().x);
+    assert_array_approx_equals(actual, expected, 2);
+  }, `corner-shape: ${corner_shape} with shape-outside: margin-box`);
+}
+
+shape_outside_corner_shape_test("notch", [82, 160, 160, 82]);
+shape_outside_corner_shape_test("bevel", [106, 160, 160, 106]);
+shape_outside_corner_shape_test("round", [138, 160, 160, 138]);
+shape_outside_corner_shape_test("square", [160, 160, 160, 160]);
+shape_outside_corner_shape_test("scoop", [86, 160, 160, 86]);
+shape_outside_corner_shape_test("superellipse(1.5)", [149, 160, 160, 149]);
+shape_outside_corner_shape_test("superellipse(-.8)", [89, 160, 160, 89]);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-padding-box-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-padding-box-expected.txt
@@ -1,0 +1,9 @@
+
+PASS corner-shape: notch with shape-outside: padding-box
+PASS corner-shape: bevel with shape-outside: padding-box
+PASS corner-shape: round with shape-outside: padding-box
+PASS corner-shape: square with shape-outside: padding-box
+PASS corner-shape: scoop with shape-outside: padding-box
+PASS corner-shape: superellipse(1.5) with shape-outside: padding-box
+PASS corner-shape: superellipse(-.8) with shape-outside: padding-box
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-padding-box.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-padding-box.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<title>shape-outside: padding-box with corner-shape</title>
+<link rel="help" href="https://drafts.csswg.org/css-shapes-1/#shapes-from-box-values">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shape">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+body {
+  margin: 0;
+}
+.container {
+  width: 320px;
+  line-height: 0;
+}
+
+/* Thin border and padding relative to the radius, so that the padding-box keeps a corner large enough
+   for each corner-shape to carve a different amount out of it. */
+.shape {
+  float: left;
+  shape-outside: padding-box;
+  border-radius: 70px;
+  box-sizing: content-box;
+  height: 160px;
+  width: 160px;
+  padding: 10px;
+  border: 10px solid lightgreen;
+  margin: 20px;
+  background-color: orange;
+}
+
+.box {
+  display: inline-block;
+  width: 100px;
+  background-color: blue;
+}
+
+.longbox {
+  display: inline-block;
+  width: 320px;
+  background-color: blue;
+}
+</style>
+
+<main class="container">
+  <div class="shape"></div>
+  <div class="longbox" style="height: 20px;"></div> <!-- Above the padding-box -->
+  <div class="box" style="height: 44px;"></div> <!-- Box at the corner -->
+  <div class="box" style="height: 56px;"></div>
+  <div class="box" style="height: 56px;"></div>
+  <div class="box" style="height: 44px;"></div> <!-- Box at the corner -->
+  <div class="longbox" style="height: 20px;"></div> <!-- Below the padding-box -->
+</main>
+
+<script>
+function shape_outside_corner_shape_test(corner_shape, expected) {
+  test(() => {
+    const shape = document.querySelector(".shape");
+    shape.style.setProperty("corner-shape", corner_shape);
+    const actual = Array.from(document.querySelectorAll(".container .box")).map(b => b.getBoundingClientRect().x);
+    assert_array_approx_equals(actual, expected, 2);
+  }, `corner-shape: ${corner_shape} with shape-outside: padding-box`);
+}
+
+shape_outside_corner_shape_test("notch", [140, 210, 210, 140]);
+shape_outside_corner_shape_test("bevel", [180, 210, 210, 180]);
+shape_outside_corner_shape_test("round", [204, 210, 210, 204]);
+shape_outside_corner_shape_test("square", [210, 210, 210, 210]);
+shape_outside_corner_shape_test("scoop", [153, 210, 210, 153]);
+shape_outside_corner_shape_test("superellipse(1.5)", [208, 210, 210, 208]);
+shape_outside_corner_shape_test("superellipse(-.8)", [157, 210, 210, 157]);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-shape-margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-shape-margin-expected.txt
@@ -1,0 +1,9 @@
+
+PASS corner-shape: notch with shape-margin
+PASS corner-shape: bevel with shape-margin
+PASS corner-shape: round with shape-margin
+PASS corner-shape: square with shape-margin
+PASS corner-shape: scoop with shape-margin
+PASS corner-shape: superellipse(1.5) with shape-margin
+PASS corner-shape: superellipse(-.8) with shape-margin
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-shape-margin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-shape-margin.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<title>shape-margin with corner-shape</title>
+<link rel="help" href="https://drafts.csswg.org/css-shapes-1/#shape-margin-property">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shape">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+body {
+  margin: 0;
+}
+.container {
+  width: 210px;
+  line-height: 0;
+}
+
+.shape {
+  float: left;
+  shape-outside: border-box;
+  shape-margin: 10px;
+  border-radius: 48%;
+  box-sizing: content-box;
+  height: 40px;
+  width: 40px;
+  padding: 20px;
+  border: 20px solid lightgreen;
+  margin: 20px;
+  background-color: orange;
+}
+
+.box {
+  display: inline-block;
+  width: 60px;
+  background-color: blue;
+}
+
+.longbox {
+  display: inline-block;
+  width: 210px;
+  height: 20px;
+  background-color: blue;
+}
+</style>
+
+<main class="container">
+  <div class="shape"></div>
+  <div class="longbox" style="height: 10px;"></div>
+  <div class="box" style="height: 24px;"></div>
+  <div class="box" style="height: 46px;"></div>
+  <div class="box" style="height: 46px;"></div>
+  <div class="box" style="height: 24px;"></div>
+  <div class="longbox"></div>
+</main>
+
+<script>
+function shape_outside_corner_shape_test(corner_shape, expected) {
+  test(() => {
+    const shape = document.querySelector(".shape");
+    shape.style.setProperty("corner-shape", corner_shape);
+    const actual = Array.from(document.querySelectorAll(".container .box")).map(b => b.getBoundingClientRect().x);
+    assert_array_approx_equals(actual, expected, 2);
+  }, `corner-shape: ${corner_shape} with shape-margin`);
+}
+
+shape_outside_corner_shape_test("notch", [92, 150, 150, 92]);
+shape_outside_corner_shape_test("bevel", [111, 150, 150, 111]);
+shape_outside_corner_shape_test("round", [134, 150, 150, 134]);
+shape_outside_corner_shape_test("square", [150, 150, 150, 150]);
+shape_outside_corner_shape_test("scoop", [95, 150, 150, 95]);
+shape_outside_corner_shape_test("superellipse(1.5)", [141, 150, 150, 141]);
+shape_outside_corner_shape_test("superellipse(-.8)", [96, 150, 150, 96]);
+</script>


### PR DESCRIPTION
#### b36f7a6cf350bc0d696ff32df642f58fba711556
<pre>
[corner-shape] Add some more shape-outside/corner-shape tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=323566">https://bugs.webkit.org/show_bug.cgi?id=323566</a>
<a href="https://rdar.apple.com/186809547">rdar://186809547</a>

Reviewed by Dan Glastonbury.

Add more shape-outside/corner-shape tests (which test the code landed in 320552@main).

Based on work by Lilly Le (@cupidsity).

* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-content-box-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-content-box.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-corners-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-corners.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-margin-box-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-margin-box.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-padding-box-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-padding-box.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-shape-margin-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shape-outside-shape-margin.html: Added.

Canonical link: <a href="https://commits.webkit.org/320633@main">https://commits.webkit.org/320633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1130a6e54ee5db4917459a349bc4b9f5b839e7a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195596 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150094 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58910 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144776 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100396 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48464 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165374 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125069 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47192 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45254 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157559 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44944 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6651 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197546 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164880 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154287 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41349 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59556 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41548 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153938 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48433 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128657 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58035 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19964 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57406 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57649 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57473 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->