### PR TITLE
Cherry-pick 305413.1007@safari-7624.5.1.10-branch (d5c5da3f748b). https://bugs.webkit.org/show_bug.cgi?id=317295

### DIFF
--- a/JSTests/stress/operation-polymorphic-call-host-call-ic-reset.js
+++ b/JSTests/stress/operation-polymorphic-call-host-call-ic-reset.js
@@ -1,0 +1,33 @@
+//@ runDefault("--useConcurrentJIT=false", "--jitPolicyScale=0.1")
+var proto = {};
+
+function g1() { return 1; }
+function g2() { return 2; }
+function g3() { return 3; }
+
+proto.__defineGetter__("p", g1);
+
+var o = Object.create(proto);
+
+function getP(obj) {
+    return obj.p;
+}
+noInline(getP);
+
+for (var i = 0; i < 80; ++i)
+    getP(o);
+
+proto.__defineGetter__("p", g2);
+getP(o);
+proto.__defineGetter__("p", g3);
+getP(o);
+
+var evil = new Proxy(function() {}, {
+    apply: function(target, thisArg, args) {
+        delete proto.p;
+        return 0x42;
+    }
+});
+proto.__defineGetter__("p", evil);
+
+getP(o);

--- a/LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race-expected.txt
+++ b/LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Concurrent cache.put of opaque responses from main thread and Workers must not crash WebContent
+

--- a/LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race.html
+++ b/LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+</head>
+<body>
+<script>
+const NUM_WORKERS = 4;
+const PUTS_PER_THREAD = 30;
+const REMOTE = get_host_info().HTTP_REMOTE_ORIGIN + "/";
+
+const workerSrc = `
+const REMOTE = ${JSON.stringify(REMOTE)};
+const PUTS = ${PUTS_PER_THREAD};
+self.onmessage = async (e) => {
+    if (e.data !== "go")
+        return;
+    try {
+        const cache = await caches.open("opaque-response-race");
+        const responses = await Promise.all(
+            Array.from({length: PUTS}, (_, i) =>
+                fetch(REMOTE + "?w=" + i + "-" + Math.random(), { mode: "no-cors", cache: "no-store" })));
+        await Promise.all(responses.map((r, i) =>
+            cache.put("https://example.com/w-" + i + "-" + Math.random(), r).catch(() => {})));
+        postMessage("done");
+    } catch (err) {
+        postMessage("error:" + err);
+    }
+};
+`;
+
+promise_test(async t => {
+    await caches.delete("opaque-response-race");
+    const cache = await caches.open("opaque-response-race");
+
+    const url = URL.createObjectURL(new Blob([workerSrc], { type: "application/javascript" }));
+    t.add_cleanup(() => URL.revokeObjectURL(url));
+    const workers = [];
+    const workerDone = [];
+    for (let i = 0; i < NUM_WORKERS; i++) {
+        const w = new Worker(url);
+        workers.push(w);
+        workerDone.push(new Promise((resolve, reject) => {
+            w.onmessage = (e) => e.data === "done" ? resolve() : reject(new Error(e.data));
+            w.onerror = (e) => reject(new Error(e.message));
+        }));
+    }
+
+    for (const worker of workers)
+        worker.postMessage("go");
+
+    const mainResponses = await Promise.all(
+        Array.from({length: PUTS_PER_THREAD}, (_, i) =>
+            fetch(REMOTE + "?m=" + i + "-" + Math.random(), { mode: "no-cors", cache: "no-store" })));
+    const mainPuts = mainResponses.map((r, i) =>
+        cache.put("https://example.com/m-" + i + "-" + Math.random(), r).catch(() => {}));
+
+    await Promise.all([...mainPuts, ...workerDone]);
+
+    for (const worker of workers)
+        worker.terminate();
+    await caches.delete("opaque-response-race");
+}, "Concurrent cache.put of opaque responses from main thread and Workers must not crash WebContent");
+</script>
+</body>
+</html>

--- a/LayoutTests/ipc/set-fill-pattern-image-buffer-cross-backend-race-expected.txt
+++ b/LayoutTests/ipc/set-fill-pattern-image-buffer-cross-backend-race-expected.txt
@@ -1,0 +1,1 @@
+This test passes if the GPU process does not crash.

--- a/LayoutTests/ipc/set-fill-pattern-image-buffer-cross-backend-race.html
+++ b/LayoutTests/ipc/set-fill-pattern-image-buffer-cross-backend-race.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if the GPU process does not crash.</p>
+<script src="../resources/ipc.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+let CoreIPC;
+let currentIdentifier = 0x1000 + Math.floor(Math.random() * 0x1000000);
+function generateIdentifier() { return currentIdentifier++; }
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+function createRemoteRenderingBackend() {
+    const streamConnection = CoreIPC.newStreamConnection();
+    const renderingBackendIdentifier = generateIdentifier();
+    CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+        renderingBackendIdentifier: renderingBackendIdentifier,
+        connectionHandle: streamConnection
+    });
+    const remoteRenderingBackend = streamConnection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+    const didInitializeReply = streamConnection.connection.waitForMessage(
+        renderingBackendIdentifier, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, 1);
+    streamConnection.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
+    return { streamConnection, remoteRenderingBackend };
+}
+
+const COLORSPACE_SRGB = { serializableColorSpace: { alias: { optionalValue: { m_cgColorSpace: { alias: { variantType: 'WebCore::ColorSpace', variant: 19 } } } } } };
+
+function createRemoteImageBuffer(backend, w, h) {
+    const imageBufferIdentifier = generateIdentifier();
+    const graphicsContextIdentifier = generateIdentifier();
+    backend.remoteRenderingBackend.CreateImageBuffer({
+        logicalSize: { width: w, height: h },
+        renderingMode: 1,
+        renderingPurpose: 0,
+        resolutionScale: 1.0,
+        colorSpace: COLORSPACE_SRGB,
+        bufferFormat: { pixelFormat: 2, useLosslessCompression: 1 },
+        identifier: imageBufferIdentifier,
+        contextIdentifier: graphicsContextIdentifier
+    });
+    return {
+        remoteGraphicsContext: backend.streamConnection.newInterface("RemoteGraphicsContext", graphicsContextIdentifier),
+        imageBufferIdentifier, graphicsContextIdentifier
+    };
+}
+
+const RECT256 = { location: { x: 0, y: 0 }, size: { width: 256, height: 256 } };
+const RECT64 = { location: { x: 0, y: 0 }, size: { width: 64, height: 64 } };
+const IDENTITY = { span: [1.0, 0.0, 0.0, 1.0, 0.0, 0.0] };
+
+window.setTimeout(async () => {
+    if (!window.IPC)
+        return window.testRunner?.notifyDone();
+    try {
+        CoreIPC = (await import('./coreipc.js')).CoreIPC;
+        CoreIPC.typeInfo['WebCore::PlatformColorSpace'] = [{ type: 'std::optional<WebKit::CoreIPCCGColorSpace>', name: 'alias' }];
+
+        // Two RemoteRenderingBackend instances => two GPU process work-queue threads.
+        const A = createRemoteRenderingBackend();
+        const B = createRemoteRenderingBackend();
+
+        // Tile T owned by backend A.
+        const T = createRemoteImageBuffer(A, 256, 256);
+        T.remoteGraphicsContext.SetFillPackedColor({ color: { value: 0xff00ff00 } });
+        T.remoteGraphicsContext.FillRect({ rect: RECT256, requiresClipToRect: 0 });
+
+        // Create destination buffers on A whose base-state fill brush references T,
+        // serialize each into the per-connection shared resource cache, and adopt on B.
+        const N = 128;
+        const Dp = [];
+        for (let i = 0; i < N; i++) {
+            const D = createRemoteImageBuffer(A, 64, 64);
+            D.remoteGraphicsContext.SetFillPatternImageBuffer({
+                imageBufferIdentifier: T.imageBufferIdentifier,
+                pattern: { repeatX: true, repeatY: true, patternSpaceTransform: IDENTITY }
+            });
+            const sId = generateIdentifier();
+            A.remoteRenderingBackend.MoveToSerializedBuffer({
+                identifier: D.imageBufferIdentifier, serializedIdentifier: sId
+            });
+            const ibId = generateIdentifier();
+            const ctxId = generateIdentifier();
+            B.remoteRenderingBackend.MoveToImageBuffer({
+                identifier: sId, imageBufferIdentifier: ibId, contextIdentifier: ctxId
+            });
+            Dp.push(B.streamConnection.newInterface("RemoteGraphicsContext", ctxId));
+        }
+
+        // Race B's pattern fills (which would dereference T) against A's draws into T.
+        for (let iter = 0; iter < 8; iter++) {
+            for (let i = 0; i < N; i++) {
+                Dp[i].FillRect({ rect: RECT64, requiresClipToRect: 0 });
+                for (let k = 0; k < 8; k++) {
+                    T.remoteGraphicsContext.FillRect({ rect: RECT256, requiresClipToRect: 0 });
+                    T.remoteGraphicsContext.ClearRect({ rect: RECT256 });
+                }
+            }
+            await sleep(0);
+        }
+
+        A.streamConnection.connection.invalidate();
+        B.streamConnection.connection.invalidate();
+    } catch (e) { }
+    window.testRunner?.notifyDone();
+}, 10);
+</script>

--- a/Source/JavaScriptCore/bytecode/RepatchInlines.h
+++ b/Source/JavaScriptCore/bytecode/RepatchInlines.h
@@ -237,7 +237,8 @@ ALWAYS_INLINE void* virtualForWithFunction(VM& vm, JSCell* owner, CallFrame* cal
     JSValue calleeAsValue = calleeFrame->guaranteedJSValueCallee();
     calleeAsFunctionCell = getJSFunction(calleeAsValue);
     if (!calleeAsFunctionCell) [[unlikely]] {
-        if (is<InternalFunction>(calleeAsValue)) {
+        if (auto* internalFunction = dynamicDowncast<InternalFunction>(calleeAsValue)) {
+            calleeAsFunctionCell = internalFunction;
             CodePtr<JSEntryPtrTag> codePtr = vm.getCTIInternalFunctionTrampolineFor(kind);
             ASSERT(!!codePtr);
             return codePtr.taggedPtr();

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -2527,7 +2527,9 @@ JSC_DEFINE_JIT_OPERATION(operationPolymorphicCall, UCPURegister, (CallFrame* cal
     void* callTarget = virtualForWithFunction(vm, owner, calleeFrame, callLinkInfo, calleeAsFunctionCell);
     if (scope.exception()) [[unlikely]]
         OPERATION_RETURN(scope, std::bit_cast<UCPURegister>(vm.getCTIStub(CommonJITThunkID::ThrowExceptionFromCall).template retagged<JSEntryPtrTag>().code().taggedPtr()));
-    linkPolymorphicCall(vm, owner, calleeFrame, *callLinkInfo, CallVariant(calleeAsFunctionCell));
+    // A null cell means virtualForWithFunction did a host call that ran JS and may have freed *callLinkInfo; don't link.
+    if (calleeAsFunctionCell) [[likely]]
+        linkPolymorphicCall(vm, owner, calleeFrame, *callLinkInfo, CallVariant(calleeAsFunctionCell));
     // Keep owner alive explicitly. Now this function can be called from tail-call. This means that CallFrame for that owner already goes away, so we should keep it alive if we would like to use it.
     ensureStillAliveHere(owner);
     if (scope.exception()) [[unlikely]]

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -653,7 +653,9 @@ extern "C" UGPRPair SYSV_ABI llint_polymorphic_call(CallFrame* calleeFrame, Call
     void* callTarget = virtualForWithFunction(vm, owner, calleeFrame, callLinkInfo, calleeAsFunctionCell);
     if (scope.exception()) [[unlikely]]
         return encodeResult(callTarget, std::bit_cast<void*>(&vm));
-    linkPolymorphicCall(vm, owner, calleeFrame, *callLinkInfo, CallVariant(calleeAsFunctionCell));
+    // A null cell means virtualForWithFunction did a host call that ran JS and may have freed *callLinkInfo; don't link.
+    if (calleeAsFunctionCell) [[likely]]
+        linkPolymorphicCall(vm, owner, calleeFrame, *callLinkInfo, CallVariant(calleeAsFunctionCell));
     ensureStillAliveHere(owner);
     if (scope.exception()) [[unlikely]]
         return encodeResult(callTarget, std::bit_cast<void*>(&vm));

--- a/Source/WebCore/Modules/cache/CacheStorageConnection.cpp
+++ b/Source/WebCore/Modules/cache/CacheStorageConnection.cpp
@@ -64,15 +64,22 @@ uint64_t CacheStorageConnection::computeRecordBodySize(const FetchResponse& resp
         return computeRealBodySize(body);
     }
 
-    return m_opaqueResponseToSizeWithPaddingMap.ensure(response.opaqueLoadIdentifier(), [&] () {
-        uint64_t realSize = computeRealBodySize(body);
+    {
+        Locker lock { m_opaqueResponseToSizeWithPaddingMapLock };
+        auto iterator = m_opaqueResponseToSizeWithPaddingMap.find(response.opaqueLoadIdentifier());
+        if (iterator != m_opaqueResponseToSizeWithPaddingMap.end())
+            return iterator->value;
+    }
 
-        // Padding the size as per https://github.com/whatwg/storage/issues/31.
-        uint64_t sizeWithPadding = realSize + static_cast<uint64_t>(cryptographicallyRandomUnitInterval() * 128000);
-        sizeWithPadding = ((sizeWithPadding / 32000) + 1) * 32000;
+    // We compute the size outside of the lock as form data size computation may hop to main thread.
+    uint64_t realSize = computeRealBodySize(body);
 
-        return sizeWithPadding;
-    }).iterator->value;
+    // Padding the size as per https://github.com/whatwg/storage/issues/31.
+    uint64_t sizeWithPadding = realSize + static_cast<uint64_t>(cryptographicallyRandomUnitInterval() * 128000);
+    sizeWithPadding = ((sizeWithPadding / 32000) + 1) * 32000;
+
+    Locker lock { m_opaqueResponseToSizeWithPaddingMapLock };
+    return m_opaqueResponseToSizeWithPaddingMap.add(response.opaqueLoadIdentifier(), sizeWithPadding).iterator->value;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/cache/CacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/CacheStorageConnection.h
@@ -30,6 +30,7 @@
 #include <WebCore/RetrieveRecordsOptions.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/Lock.h>
 #include <wtf/NativePromise.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
@@ -70,10 +71,11 @@ public:
     virtual void updateQuotaBasedOnSpaceUsage(const ClientOrigin&) { }
 
 private:
-    uint64_t computeRealBodySize(const DOMCacheEngine::ResponseBody&);
+    uint64_t computeRealBodySize(const DOMCacheEngine::ResponseBody&) WTF_EXCLUDES_LOCK(m_opaqueResponseToSizeWithPaddingMapLock);
 
 protected:
-    HashMap<uint64_t, uint64_t> m_opaqueResponseToSizeWithPaddingMap;
+    Lock m_opaqueResponseToSizeWithPaddingMapLock;
+    HashMap<uint64_t, uint64_t> m_opaqueResponseToSizeWithPaddingMap WTF_GUARDED_BY_LOCK(m_opaqueResponseToSizeWithPaddingMapLock);
 };
 
 } // namespace WebCore

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -192,6 +192,8 @@ void RemoteRenderingBackend::moveToSerializedBuffer(RenderingResourceIdentifier 
     MESSAGE_CHECK(remoteImageBuffer, "Missing ImageBuffer");
     Ref imageBuffer = RemoteImageBuffer::sinkIntoImageBuffer(remoteImageBuffer.releaseNonNull());
     MESSAGE_CHECK(imageBuffer->hasOneRef(), "ImageBuffer in use");
+    // Avoid leaking cross-RemoteRenderingBackend state through context by releasing the context.
+    imageBuffer->releaseGraphicsContext();
     bool success = m_sharedResourceCache->addSerializedImageBuffer(serializedIdentifier, WTF::move(imageBuffer));
     MESSAGE_CHECK(success, "Duplicate SerializedImageBuffer");
 }


### PR DESCRIPTION
#### 4f518a958b8993e21dafe206f6f824a3173fc4ea
<pre>
Cherry-pick 305413.1007@safari-7624.5.1.10-branch (d5c5da3f748b). <a href="https://bugs.webkit.org/show_bug.cgi?id=317295">https://bugs.webkit.org/show_bug.cgi?id=317295</a>

    SerializedImageBuffer leaks cross-RemoteRenderingBackend data through GraphicsContext
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317295">https://bugs.webkit.org/show_bug.cgi?id=317295</a>
    <a href="https://rdar.apple.com/175520296">rdar://175520296</a>

    Reviewed by Dan Glastonbury.

    ImageBuffer context state might leak non-thread-safe
    cross-RemoteRenderingBackend instances through GraphicsContext state.

    Release the GraphicsContext when transfering the ImageBuffer to
    different RRB.

    * LayoutTests/ipc/set-fill-pattern-image-buffer-cross-backend-race-expected.txt: Added.
    * LayoutTests/ipc/set-fill-pattern-image-buffer-cross-backend-race.html: Added.
    * Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
    (WebKit::RemoteRenderingBackend::moveToSerializedBuffer):

    Identifier: 305413.1007@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.206@webkitglib/2.54">https://commits.webkit.org/317695.206@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 2bbb93aa5d88e18304cb746d71e436ad34a41e77
<pre>
Cherry-pick 305413.1001@safari-7624.5-branch (4c69ed8ad988). <a href="https://bugs.webkit.org/show_bug.cgi?id=317270">https://bugs.webkit.org/show_bug.cgi?id=317270</a>

    Unsynchronized cross-thread access to m_opaqueResponseToSizeWithPaddingMap in CacheStorageConnection::computeRecordBodySize
    <a href="https://rdar.apple.com/177953125">rdar://177953125</a>

    Reviewed by Chris Dumez.

    We add a lock and the related lock assertions to prevent unlocked access to the map.
    Given the potential locking that may happen for form data size computation, we make sure to compute the response real size outside of the lock.

    Test: http/wpt/cache-storage/cache-put-opaque-response-race.html

    * LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race-expected.txt: Added.
    * LayoutTests/http/wpt/cache-storage/cache-put-opaque-response-race.html: Added.
    * Source/WebCore/Modules/cache/CacheStorageConnection.cpp:
    (WebCore::CacheStorageConnection::computeRecordBodySize):
    * Source/WebCore/Modules/cache/CacheStorageConnection.h:

    Identifier: 305413.1001@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.205@webkitglib/2.54">https://commits.webkit.org/317695.205@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### d316b0131d5a0d6f0eb453f0ea380d37bae7b54e
<pre>
Cherry-pick 305413.992@safari-7624.5.1.10-branch (09ca909b6a83). <a href="https://bugs.webkit.org/show_bug.cgi?id=317142">https://bugs.webkit.org/show_bug.cgi?id=317142</a>

    [JSC] Do not attempt to link a CallLinkInfo after handleHostCall
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317142">https://bugs.webkit.org/show_bug.cgi?id=317142</a>
    <a href="https://rdar.apple.com/178282225">rdar://178282225</a>

    Reviewed by Yusuke Suzuki.

    handleHostCall performs the host call which may execute JS that
    fires a watchpoint invalidating the passed CallLinkInfo. So,
    it&apos;s not safe to modify *CallLinkInfo after the host call.

    So, make the callers of virtualForWithFunction skip the
    linkPolymorphicCall call in this case. This aligns the behavior
    of operationPolymorphicCall / llint_polymorphic_call with linkFor.

    However, to avoid the InternalFunction case potentially getting
    stuck in the polymorphic mode slow path, return the JSCell in this case.
    This is a slight change in behavior: before this change,
    InternalFunction would have caused the CallLinkInfo to downgrade
    to virtual mode. With this change, it can remain in polymorphic
    mode. This also aligns with linkFor behavior.

    Test: JSTests/stress/operation-polymorphic-call-host-call-ic-reset.js

    * JSTests/stress/operation-polymorphic-call-host-call-ic-reset.js: Added.
    (g2):
    (g3):
    (getP):
    (evil.new.Proxy):
    (evil.new.Proxy.apply):
    * Source/JavaScriptCore/bytecode/RepatchInlines.h:
    (JSC::virtualForWithFunction):
    * Source/JavaScriptCore/jit/JITOperations.cpp:
    (JSC::JSC_DEFINE_JIT_OPERATION):
    * Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
    (JSC::LLInt::llint_polymorphic_call):

    Identifier: 305413.992@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.204@webkitglib/2.54">https://commits.webkit.org/317695.204@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89eacb0fe01dacacce4578821aa511cdb164de17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185273 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59185 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53002 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195602 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150096 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187135 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60549 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58912 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144828 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150096 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188228 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60549 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53002 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125073 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60549 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58912 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6986 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53002 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60549 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53002 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6653 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/46531 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/51841 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/58912 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197548 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/58849 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53002 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154289 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59558 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53002 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153940 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28134 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59558 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/131874 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/128659 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58037 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53002 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57408 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57651 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57475 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->