### PR TITLE
[Win] memoryFootprint() crashes under WINE

### DIFF
--- a/Source/WTF/wtf/win/MemoryFootprintWin.cpp
+++ b/Source/WTF/wtf/win/MemoryFootprintWin.cpp
@@ -27,16 +27,74 @@
 #include <wtf/MemoryFootprint.h>
 
 #include <algorithm>
+#include <optional>
 #include <type_traits>
 #include <windows.h>
 #include <psapi.h>
 #include <wtf/MallocSpan.h>
 #include <wtf/MathExtras.h>
+#include <wtf/Vector.h>
 #include <wtf/win/Win32Handle.h>
 
 namespace WTF {
 
-size_t memoryFootprint()
+// Compute the size of the private working set with QueryWorkingSetEx over the committed
+// regions of the address space, in bounded batches with no retry loop.
+static std::optional<size_t> memoryFootprintFromWorkingSetEx()
+{
+    constexpr size_t batchSize = 16 * 1024;
+    Vector<PSAPI_WORKING_SET_EX_INFORMATION> batch;
+    batch.reserveInitialCapacity(batchSize);
+
+    size_t pageSize = 0;
+    size_t numberOfPrivateResidentPages = 0;
+    bool sawSuccessfulQuery = false;
+
+    auto flushBatch = [&] () -> bool {
+        if (batch.isEmpty())
+            return true;
+        // Wine only implements this query for the GetCurrentProcess() pseudo handle.
+        if (!QueryWorkingSetEx(GetCurrentProcess(), batch.mutableSpan().data(), batch.size() * sizeof(PSAPI_WORKING_SET_EX_INFORMATION)))
+            return false;
+        sawSuccessfulQuery = true;
+        for (auto& entry : batch) {
+            if (entry.VirtualAttributes.Valid && !entry.VirtualAttributes.Shared)
+                numberOfPrivateResidentPages++;
+        }
+        batch.shrink(0);
+        return true;
+    };
+
+    SYSTEM_INFO systemInfo;
+    GetSystemInfo(&systemInfo);
+    pageSize = systemInfo.dwPageSize;
+    if (!pageSize)
+        return std::nullopt;
+
+    MEMORY_BASIC_INFORMATION memoryInfo;
+    uintptr_t address = reinterpret_cast<uintptr_t>(systemInfo.lpMinimumApplicationAddress);
+    uintptr_t maximumAddress = reinterpret_cast<uintptr_t>(systemInfo.lpMaximumApplicationAddress);
+    while (address < maximumAddress && VirtualQuery(reinterpret_cast<LPCVOID>(address), &memoryInfo, sizeof(memoryInfo)) == sizeof(memoryInfo)) {
+        if (memoryInfo.State == MEM_COMMIT) {
+            uintptr_t regionEnd = reinterpret_cast<uintptr_t>(memoryInfo.BaseAddress) + memoryInfo.RegionSize;
+            for (uintptr_t page = reinterpret_cast<uintptr_t>(memoryInfo.BaseAddress); page < regionEnd; page += pageSize) {
+                batch.append({ reinterpret_cast<PVOID>(page), { } });
+                if (batch.size() == batchSize && !flushBatch())
+                    return std::nullopt;
+            }
+        }
+        uintptr_t next = reinterpret_cast<uintptr_t>(memoryInfo.BaseAddress) + memoryInfo.RegionSize;
+        if (next <= address)
+            break;
+        address = next;
+    }
+    if (!flushBatch() || !sawSuccessfulQuery)
+        return std::nullopt;
+
+    return numberOfPrivateResidentPages * pageSize;
+}
+
+static size_t memoryFootprintFromWorkingSetList()
 {
     // We would like to calculate size of private working set.
     // https://msdn.microsoft.com/en-us/library/windows/desktop/ms684891(v=vs.85).aspx
@@ -69,17 +127,24 @@ size_t memoryFootprint()
     if (QueryWorkingSet(process.get(), workingSetsOnStack, sizeOfBufferOnStack))
         return countSizeOfPrivateWorkingSet(*workingSetsOnStack);
 
+    // NumberOfEntries is only written on an ERROR_BAD_LENGTH failure.
+    if (GetLastError() != ERROR_BAD_LENGTH)
+        return 0;
+
     auto updateNumberOfEntries = [&] (size_t numberOfEntries) {
         // If working set increases between first QueryWorkingSet and second QueryWorkingSet, the second one can fail.
         // At that time, we should increase numberOfEntries.
         return std::max(minNumberOfEntries, numberOfEntries + numberOfEntries / 4 + 1);
     };
 
-    for (size_t numberOfEntries = updateNumberOfEntries(workingSetsOnStack->NumberOfEntries);;) {
+    constexpr const size_t maxNumberOfEntries = 16 * 1024 * 1024;
+    for (size_t numberOfEntries = updateNumberOfEntries(workingSetsOnStack->NumberOfEntries); numberOfEntries <= maxNumberOfEntries;) {
         size_t workingSetSizeInBytes = roundUpToMultipleOf(sizeof(PSAPI_WORKING_SET_INFORMATION), sizeof(PSAPI_WORKING_SET_INFORMATION) + sizeof(PSAPI_WORKING_SET_BLOCK) * numberOfEntries);
 
-        auto workingSets = MallocSpan<PSAPI_WORKING_SET_INFORMATION>::malloc(workingSetSizeInBytes);
+        auto workingSets = MallocSpan<PSAPI_WORKING_SET_INFORMATION>::tryMalloc(workingSetSizeInBytes);
         auto workingSetsSpan = workingSets.mutableSpan();
+        if (workingSetsSpan.empty())
+            return 0;
         if (QueryWorkingSet(process.get(), workingSetsSpan.data(), workingSetsSpan.size_bytes()))
             return countSizeOfPrivateWorkingSet(workingSetsSpan[0]);
 
@@ -87,6 +152,14 @@ size_t memoryFootprint()
             return 0;
         numberOfEntries = updateNumberOfEntries(workingSetsSpan[0].NumberOfEntries);
     }
+    return 0;
+}
+
+size_t memoryFootprint()
+{
+    if (auto footprint = memoryFootprintFromWorkingSetEx())
+        return *footprint;
+    return memoryFootprintFromWorkingSetList();
 }
 
 }


### PR DESCRIPTION
#### 3856a285807d08daf91e57de733118285a74501b
<pre>
[Win] memoryFootprint() crashes under WINE
<a href="https://bugs.webkit.org/show_bug.cgi?id=323559">https://bugs.webkit.org/show_bug.cgi?id=323559</a>

Reviewed by Don Olmstead.

Wine does not implement the working set list query: QueryWorkingSet fails
with ERROR_INVALID_PARAMETER without writing the buffer, so
memoryFootprint() sized its retry buffer from uninitialized stack memory
and the huge allocation crashed every WebKit process ~30s after launch.

Compute the private working set with QueryWorkingSetEx instead, walking
committed regions with VirtualQuery and querying page attributes in fixed
size batches: bounded memory, no retry loop, and it works under Wine. The
QueryWorkingSet path is kept as a hardened fallback (NumberOfEntries only
read after ERROR_BAD_LENGTH, capped retries, tryMalloc).

Verified under Wine: dirtying 64MB of private pages moves the reported
footprint by exactly 64MB, and the browser benchmarks run to completion.

* Source/WTF/wtf/win/MemoryFootprintWin.cpp:
(WTF::memoryFootprintFromWorkingSetEx): Added.
(WTF::memoryFootprintFromWorkingSetList): Renamed from memoryFootprint.
(WTF::memoryFootprint):

Canonical link: <a href="https://commits.webkit.org/320695@main">https://commits.webkit.org/320695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c2d0b9b30ba424228a20b09e09e667de9362da1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195599 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150097 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144777 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100397 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188229 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165372 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125070 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47194 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45256 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/6983 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13874 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157561 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44942 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6654 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46532 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51842 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197549 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58850 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154288 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59559 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41546 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153939 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28174 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48436 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131875 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128660 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58038 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19962 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57409 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57652 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57476 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->