### PR TITLE
Cherry-pick 320304@main (d4867a890432). https://bugs.webkit.org/show_bug.cgi?id=323060

### DIFF
--- a/LayoutTests/http/tests/cookies/resources/set-raw-cookie-in-third-party-iframe-frame.html
+++ b/LayoutTests/http/tests/cookies/resources/set-raw-cookie-in-third-party-iframe-frame.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+try {
+    internals.setCookie({
+        name: 'thirdpartyiframecookie',
+        value: 'value',
+        domain: 'localhost',
+        path: '/',
+        isSession: true,
+    });
+    parent.postMessage('PASS: setCookie from third-party iframe did not terminate the WebProcess', '*');
+} catch (e) {
+    parent.postMessage('FAIL: threw ' + e, '*');
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe-expected.txt
+++ b/LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe-expected.txt
@@ -1,0 +1,4 @@
+Test that internals.setCookie from a third-party iframe does not terminate the WebProcess.
+
+PASS: setCookie from third-party iframe did not terminate the WebProcess
+

--- a/LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe.html
+++ b/LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test that internals.setCookie from a third-party iframe does not terminate the WebProcess.</p>
+<pre id="out"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const log = s => document.getElementById('out').textContent += s + '\n';
+
+window.addEventListener('message', (event) => {
+    log(event.data);
+    testRunner?.notifyDone();
+});
+
+const iframe = document.createElement('iframe');
+iframe.src = 'http://localhost:8000/cookies/resources/set-raw-cookie-in-third-party-iframe-frame.html';
+document.body.appendChild(iframe);
+</script>
+</body>
+</html>

--- a/LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash-expected.txt
+++ b/LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if the NetworkProcess does not crash.

--- a/LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash.html
+++ b/LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash.html
@@ -1,0 +1,42 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if the NetworkProcess does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.onload = async () => {
+    if (!window.IPC)
+        return window.testRunner?.notifyDone();
+
+    const { CoreIPC } = await import('./coreipc.js');
+    const ownOrigin = location.origin + '/';
+
+    CoreIPC.Networking.NetworkConnectionToWebProcess.SetRawCookie(0, {
+        firstParty: { string: ownOrigin },
+        url:        { string: ownOrigin },
+        cookie: {
+            name:         'x',
+            value:        'y',
+            domain:       '127.0.0.1',
+            path:         '/',
+            partitionKey: '',
+            created:      0,
+            expires:      {},
+            httpOnly:     false,
+            secure:       false,
+            session:      true,
+            comment:      '',
+            commentURL:   { string: '' },
+            ports:        [],
+            sameSite:     0,
+        },
+        shouldPartitionCookie: 0,
+    });
+
+    setTimeout(() => {
+        window.testRunner?.notifyDone();
+    }, 500);
+};
+</script>

--- a/LayoutTests/ipc/set-raw-cookie-firstparty-message-check-expected.txt
+++ b/LayoutTests/ipc/set-raw-cookie-firstparty-message-check-expected.txt
@@ -1,0 +1,4 @@
+
+PASS SetRawCookie rejects cross-origin cookie.domain via MESSAGE_CHECK
+PASS SetRawCookie rejects cross-origin url via MESSAGE_CHECK
+

--- a/LayoutTests/ipc/set-raw-cookie-firstparty-message-check.html
+++ b/LayoutTests/ipc/set-raw-cookie-firstparty-message-check.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<title>Test that SetRawCookie validates cookie.domain and url against firstParty via MESSAGE_CHECK</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<body>
+<script>
+promise_test(async (t) => {
+    if (!window.IPC) {
+        done();
+        return;
+    }
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const ownOrigin = location.origin + '/';
+    const victimURL = 'http://victim-bank.test/';
+
+    function makeCookie(domain) {
+        return {
+            name:         'injected-by-poc',
+            value:        'session-fixation-payload',
+            domain:       domain,
+            path:         '/',
+            partitionKey: '',
+            created:      0,
+            expires:      {},
+            httpOnly:     true,
+            secure:       false,
+            session:      true,
+            comment:      '',
+            commentURL:   { string: '' },
+            ports:        [],
+            sameSite:     0,
+        };
+    }
+
+    // Drain any pending invalid-message string.
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {}, () => { });
+
+    // cookie.domain is cross-origin from firstParty -> MESSAGE_CHECK at
+    // NetworkConnectionToWebProcess::setRawCookie should fail.
+    CoreIPC.Networking.NetworkConnectionToWebProcess.SetRawCookie(0, {
+        firstParty: { string: ownOrigin },
+        url:        { string: ownOrigin },
+        cookie:     makeCookie('victim-bank.test'),
+        shouldPartitionCookie: 0,
+    });
+
+    let messageCheck = null;
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {},
+        reply => messageCheck = reply.error);
+
+    assert_true(!!messageCheck && messageCheck.includes('Message check failed'),
+        'SetRawCookie with cross-origin cookie.domain should trigger MESSAGE_CHECK, got: "' + messageCheck + '"');
+}, 'SetRawCookie rejects cross-origin cookie.domain via MESSAGE_CHECK');
+
+promise_test(async (t) => {
+    if (!window.IPC) {
+        done();
+        return;
+    }
+
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const ownOrigin = location.origin + '/';
+    const victimURL = 'http://victim-bank.test/';
+
+    function makeCookie(domain) {
+        return {
+            name:         'injected-by-poc',
+            value:        'session-fixation-payload',
+            domain:       domain,
+            path:         '/',
+            partitionKey: '',
+            created:      0,
+            expires:      {},
+            httpOnly:     true,
+            secure:       false,
+            session:      true,
+            comment:      '',
+            commentURL:   { string: '' },
+            ports:        [],
+            sameSite:     0,
+        };
+    }
+
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {}, () => { });
+
+    // url is cross-origin from firstParty -> MESSAGE_CHECK should fail.
+    CoreIPC.Networking.NetworkConnectionToWebProcess.SetRawCookie(0, {
+        firstParty: { string: ownOrigin },
+        url:        { string: victimURL },
+        cookie:     makeCookie(new URL(ownOrigin).host),
+        shouldPartitionCookie: 0,
+    });
+
+    let messageCheck = null;
+    CoreIPC.Networking.NetworkConnectionToWebProcess.TakeInvalidMessageStringForTesting(0, {},
+        reply => messageCheck = reply.error);
+
+    assert_true(!!messageCheck && messageCheck.includes('Message check failed'),
+        'SetRawCookie with cross-origin url should trigger MESSAGE_CHECK, got: "' + messageCheck + '"');
+}, 'SetRawCookie rejects cross-origin url via MESSAGE_CHECK');
+
+done();
+</script>
+</body>

--- a/Source/WebCore/loader/NavigationAction.h
+++ b/Source/WebCore/loader/NavigationAction.h
@@ -143,7 +143,7 @@ private:
     std::optional<PrivateClickMeasurement> m_privateClickMeasurement;
     std::function<bool()> m_pendingDispatchNavigateEvent;
 
-    NavigationType m_type;
+    NavigationType m_type { NavigationType::Other };
     std::optional<NavigationNavigationType> m_navigationAPIType;
 
     bool m_hasOpenedFrames { false };

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -978,8 +978,7 @@ void NetworkConnectionToWebProcess::setRawCookie(const URL& firstParty, const UR
 {
     auto allowCookieAccess = m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, firstParty);
     MESSAGE_CHECK(allowCookieAccess != NetworkProcess::AllowCookieAccess::Terminate);
-    MESSAGE_CHECK(RegistrableDomain::uncheckedCreateFromHost(cookie.domain).matches(firstParty));
-    MESSAGE_CHECK(RegistrableDomain(url).matches(firstParty));
+    MESSAGE_CHECK(RegistrableDomain::uncheckedCreateFromHost(cookie.domain).matches(url));
     if (allowCookieAccess != NetworkProcess::AllowCookieAccess::Allow)
         return;
 


### PR DESCRIPTION
#### 08279e6ba1d66e13f03863eac5af7b98cbd94d18
<pre>
Cherry-pick 320304@main (d4867a890432). <a href="https://bugs.webkit.org/show_bug.cgi?id=323060">https://bugs.webkit.org/show_bug.cgi?id=323060</a>

    Regression(314177@main) SetRawCookie&apos;s MESSAGE_CHECKs reject legitimate cookie writes from third-party iframes
    <a href="https://bugs.webkit.org/show_bug.cgi?id=323060">https://bugs.webkit.org/show_bug.cgi?id=323060</a>
    <a href="https://rdar.apple.com/177769847">rdar://177769847</a>

    Reviewed by Ben Nham.

    NetworkConnectionToWebProcess::setRawCookie validated cookie.domain and
    url against firstParty:
    ```
    MESSAGE_CHECK(RegistrableDomain::uncheckedCreateFromHost(cookie.domain).matches(firstParty));
    MESSAGE_CHECK(RegistrableDomain(url).matches(firstParty));
    ```

    This is too strict. WebCookieJar::setRawCookie passes
    document.firstPartyForCookies() as firstParty (the top-level page&apos;s URL)
    and document.cookieURL() as url (the document&apos;s own URL). For a
    third-party iframe these legitimately differ, so the checks terminate
    the WebProcess whenever Web Inspector or internals.setCookie is used in
    a cross-site iframe.

    Replace the two checks with an integrity check that cookie.domain&apos;s
    registrable domain matches url, mirroring the existing posture of
    setCookieFromDOMAsync which validates firstParty only and trusts the
    url/cookie pair. The new check still rejects a mismatched
    cookie.domain/url pair (the most useful invariant) without coupling
    either to the unrelated top-level firstParty.

    Tests: http/tests/cookies/set-raw-cookie-in-third-party-iframe.html
           ipc/set-raw-cookie-empty-commenturl-crash.html
           ipc/set-raw-cookie-firstparty-message-check.html

    * LayoutTests/http/tests/cookies/resources/set-raw-cookie-in-third-party-iframe-frame.html: Added.
    * LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe-expected.txt: Added.
    * LayoutTests/http/tests/cookies/set-raw-cookie-in-third-party-iframe.html: Added.
    Add test coverage for the overly strict checks.

    * LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash-expected.txt: Added.
    * LayoutTests/ipc/set-raw-cookie-empty-commenturl-crash.html: Added.
    * LayoutTests/ipc/set-raw-cookie-firstparty-message-check-expected.txt: Added.
    * LayoutTests/ipc/set-raw-cookie-firstparty-message-check.html: Added.
    Add test coverage for what 314177@main was trying to fix, to make sure
    that we don&apos;t regress it.

    * Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
    (WebKit::NetworkConnectionToWebProcess::setRawCookie):

    Canonical link: <a href="https://commits.webkit.org/320304@main">https://commits.webkit.org/320304@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1148@webkitglib/2.52">https://commits.webkit.org/305877.1148@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 289d3ee2940d5771e0c7af454283c92d0463c694
<pre>
Cherry-pick 320316@main (ba64b8f51316). <a href="https://bugs.webkit.org/show_bug.cgi?id=322905">https://bugs.webkit.org/show_bug.cgi?id=322905</a>

    NavigationAction::m_type is left uninitialized by the default constructor
    <a href="https://bugs.webkit.org/show_bug.cgi?id=322905">https://bugs.webkit.org/show_bug.cgi?id=322905</a>
    <a href="https://rdar.apple.com/186162338">rdar://186162338</a>

    Reviewed by Chris Dumez.

    NavigationAction&apos;s user-provided default constructor doesn&apos;t zero-fill
    members, and m_type is the only one without an in-class initializer, so
    it is left indeterminate. DocumentLoader default-constructs
    m_triggeringAction and its type() is read (via triggeringAction())
    before a real action is assigned, which is undefined behavior.

    Initialize m_type to NavigationType::Other, matching the other members.

    * Source/WebCore/loader/NavigationAction.h:

    Canonical link: <a href="https://commits.webkit.org/320316@main">https://commits.webkit.org/320316@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1147@webkitglib/2.52">https://commits.webkit.org/305877.1147@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b7dcca6787701c18450327096bf86a2e0cdb7aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185276 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59188 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53005 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195601 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150099 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187138 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60552 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58915 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144792 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150099 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188231 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60552 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53005 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125085 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60552 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58915 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53005 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60552 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53005 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6656 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/51844 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/58915 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197551 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/58852 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53005 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154293 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59561 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53005 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153944 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28127 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59561 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/131877 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/128662 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58040 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53005 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57411 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57654 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57478 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->