### PR TITLE
[WebGPU][WGSL] Array value constructor named through a type alias emits invalid MSL, silently producing wrong compute results

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -973,15 +973,19 @@ void RewriteGlobalVariables::packArrayResource(AST::Variable& global, const Type
     );
     packedType.m_inferredType = packedElementType;
 
-    auto& arrayTypeName = downcast<AST::ArrayTypeExpression>(*global.maybeTypeName());
+    auto& typeName = *global.maybeTypeName();
+    auto* maybeArrayTypeName = dynamicDowncast<AST::ArrayTypeExpression>(typeName);
     auto& packedArrayTypeName = m_shaderModule.astBuilder().construct<AST::ArrayTypeExpression>(
-        arrayTypeName.span(),
+        typeName.span(),
         &packedType,
-        arrayTypeName.maybeElementCount()
+        maybeArrayTypeName ? maybeArrayTypeName->maybeElementCount() : nullptr
     );
     packedArrayTypeName.m_inferredType = packedArrayType;
 
-    m_shaderModule.replace(arrayTypeName, packedArrayTypeName);
+    if (maybeArrayTypeName)
+        m_shaderModule.replace(*maybeArrayTypeName, packedArrayTypeName);
+    else
+        m_shaderModule.replace(downcast<AST::IdentifierExpression>(typeName), packedArrayTypeName);
     updateReference(global, packedArrayTypeName);
     m_shaderModule.replace(&global.role(), AST::VariableRole::PackedResource);
 }

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -2363,9 +2363,9 @@ void FunctionDefinitionWriter::visit(const Type* type, AST::CallExpression& call
         }
     }
 
-    auto isArray = is<AST::ArrayTypeExpression>(call.target());
-    auto isStruct = !isArray && std::holds_alternative<Types::Struct>(*call.target().inferredType());
-    if (call.isConstructor() && (isArray || isStruct)) {
+    auto isArray = call.isConstructor() && std::holds_alternative<Types::Array>(*type);
+    auto isStruct = call.isConstructor() && !isArray && std::holds_alternative<Types::Struct>(*call.target().inferredType());
+    if (isArray || isStruct) {
         visit(type);
         m_body.append('(');
         const Type* arrayElementType = nullptr;

--- a/Tools/TestWebKitAPI/Tests/WGSL/shaders/array-alias-constructor.wgsl
+++ b/Tools/TestWebKitAPI/Tests/WGSL/shaders/array-alias-constructor.wgsl
@@ -1,7 +1,17 @@
 alias A = array<i32, 4>;
 
+@group(0) @binding(0) var<storage, read_write> x: array<i32>;
+
+fn f(a: i32) -> A
+{
+    return A(a, a + 1, a + 2, a + 3);
+}
+
 @compute @workgroup_size(1)
 fn main()
 {
     let a: A = A();
+    let b: A = A(x[0], x[0] + 1, x[0] + 2, x[0] + 3);
+    let c: A = f(x[0]);
+    x[0] = a[0] + b[0] + c[0];
 }

--- a/Tools/TestWebKitAPI/Tests/WGSL/shaders/array-vec3.wgsl
+++ b/Tools/TestWebKitAPI/Tests/WGSL/shaders/array-vec3.wgsl
@@ -1,4 +1,9 @@
+alias Aliased = array<vec3f, 1>;
+alias AliasedRuntimeSized = array<vec3f>;
+
 @group(0) @binding(0) var<storage, read_write> un: array<vec3f, 1>;
+@group(0) @binding(1) var<storage, read_write> aliased: Aliased;
+@group(0) @binding(2) var<storage, read_write> aliasedRuntimeSized: AliasedRuntimeSized;
 
 @compute @workgroup_size(1)
 fn main() {
@@ -26,5 +31,19 @@ fn main() {
     let y = v[1];
     v.x = x;
     v[1] = y;
+  }
+
+  {
+    let x = aliased[0].x;
+    aliased[0].x = x;
+    aliased[0] = un[0];
+    var v = aliased[0];
+    v[1] = x;
+  }
+
+  {
+    let x = aliasedRuntimeSized[0].x;
+    aliasedRuntimeSized[0].x = x;
+    aliasedRuntimeSized[0] = aliased[0];
   }
 }


### PR DESCRIPTION
#### 5f7bc716873fa5f84176a2d38ff00567f49c40c7
<pre>
[WebGPU][WGSL] Array value constructor named through a type alias emits invalid MSL, silently producing wrong compute results
<a href="https://bugs.webkit.org/show_bug.cgi?id=323543">https://bugs.webkit.org/show_bug.cgi?id=323543</a>
<a href="https://rdar.apple.com/186803296">rdar://186803296</a>

Reviewed by Dan Glastonbury.

Ensure arrays via type aliases are correctly handled to
avoid miscompilations.

Tests: Tools/TestWebKitAPI/Tests/WGSL/shaders/array-alias-constructor.wgsl
       Tools/TestWebKitAPI/Tests/WGSL/shaders/array-vec3.wgsl

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::packArrayResource):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Tools/TestWebKitAPI/Tests/WGSL/shaders/array-alias-constructor.wgsl:
* Tools/TestWebKitAPI/Tests/WGSL/shaders/array-vec3.wgsl:

Canonical link: <a href="https://commits.webkit.org/320690@main">https://commits.webkit.org/320690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8362bd160a8a563c7a31c1c4545ca08c3ec0385

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195607 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150103 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d09816ee-b086-438e-9527-18fad030840e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187143 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58920 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144783 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100400 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/067e72e7-758a-403b-ab18-4a52b167a0ef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125076 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/85257a6e-53a5-44a2-a6c7-3392da2b5936) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47198 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45261 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157565 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44945 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6661 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51849 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49641 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197556 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58857 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154297 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41398 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59566 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41549 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153948 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48437 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131883 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128676 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58044 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19965 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57416 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57659 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57483 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->