### PR TITLE
ASSERTION FAILED: layer.renderer().isStickilyPositioned() with -webkit-box-reflect on a position:sticky element

### DIFF
--- a/LayoutTests/compositing/reflections/assert-on-sticky-position-with-reflection-expected.txt
+++ b/LayoutTests/compositing/reflections/assert-on-sticky-position-with-reflection-expected.txt
@@ -1,0 +1,2 @@
+PASS if no assert in debug.
+

--- a/LayoutTests/compositing/reflections/assert-on-sticky-position-with-reflection.html
+++ b/LayoutTests/compositing/reflections/assert-on-sticky-position-with-reflection.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Reflected position:sticky renderer should not be asked sticky questions about the replica's layer</title>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<style>
+.sticky-reflected {
+    position: sticky;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    -webkit-box-reflect: above;
+}
+
+.scroller {
+    overflow: scroll;
+    width: 200px;
+    height: 200px;
+}
+
+.tall {
+    height: 400px;
+}
+</style>
+</head>
+<body>
+PASS if no assert in debug.
+
+<!-- Reflection created while resolving style for the first time. -->
+<div class="sticky-reflected"></div>
+
+<!-- Same, but with an enclosing overflow clip layer to exercise the other branch
+     of RenderLayerCompositor::isAsyncScrollableStickyLayer(). -->
+<div class="scroller">
+    <div class="sticky-reflected"></div>
+    <div class="tall"></div>
+</div>
+
+<div id="later" class="sticky-reflected" style="-webkit-box-reflect: none"></div>
+
+<script>
+// Reflection created from RenderLayer::styleChanged() on an already-sticky renderer.
+document.body.offsetTop;
+document.getElementById("later").style.webkitBoxReflect = "below";
+document.body.offsetTop;
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -4149,8 +4149,13 @@ bool RenderLayerCompositor::requiresCompositingForPosition(RenderLayerModelObjec
     if (!m_renderView.settings().acceleratedCompositingForFixedPositionEnabled())
         return false;
 
-    if (isSticky)
-        return isAsyncScrollableStickyLayer(layer);
+    if (isSticky) {
+        // rendererForCompositingTests() substitutes the reflected renderer for a RenderReplica, so `layer` can
+        // be the replica's layer while `renderer` is the sticky renderer being reflected. Ask about the sticky
+        // renderer's own layer; for every other caller this is the layer we were passed.
+        CheckedPtr stickyLayer = renderer.layer();
+        return stickyLayer && isAsyncScrollableStickyLayer(*stickyLayer);
+    }
 
     if (queryData.layoutUpToDate == LayoutUpToDate::No) {
         queryData.reevaluateAfterLayout = true;


### PR DESCRIPTION
#### 8ff57ddb452aaa28d0d425aea6dc22b5ee3fb2e3
<pre>
ASSERTION FAILED: layer.renderer().isStickilyPositioned() with -webkit-box-reflect on a position:sticky element
<a href="https://bugs.webkit.org/show_bug.cgi?id=323569">https://bugs.webkit.org/show_bug.cgi?id=323569</a>
<a href="https://rdar.apple.com/186812790">rdar://186812790</a>

Reviewed by Matt Woodrow.

rendererForCompositingTests() substitutes the reflected renderer for a
RenderReplica, so requiresCompositingForPosition() can read position:sticky off
the reflected element while `layer` is the replica&apos;s layer. It then passes that
layer to isAsyncScrollableStickyLayer(), whose ASSERT is about
layer.renderer().isStickilyPositioned() - and a RenderReplica is statically
positioned. In release builds the assert compiles out and the wrong layer is
walked, which can only produce a wrong compositing decision for the reflection.

Ask about the sticky renderer&apos;s own layer instead, matching what the other two
users of rendererForCompositingTests() already do: requiresCompositingLayer()
and reasonsForCompositing() both pass *renderer.layer() rather than the layer
they were given. For every other caller renderer.layer() == &amp;layer, so there is
no behavior change.

Test: compositing/reflections/assert-on-sticky-position-with-reflection.html

* LayoutTests/compositing/reflections/assert-on-sticky-position-with-reflection-expected.txt: Added.
* LayoutTests/compositing/reflections/assert-on-sticky-position-with-reflection.html: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::requiresCompositingForPosition const):

Canonical link: <a href="https://commits.webkit.org/320712@main">https://commits.webkit.org/320712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ef20a0965ad87919cae5e5f45674fb6b5381286

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195608 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150104 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ecd4c2f-3a61-42a4-a10c-b7060ceb1f09) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187144 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144785 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100402 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e1dc5570-55de-446f-8317-97c2f48d9223) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48472 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125078 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/10aa9270-0eae-4efa-9cae-8c96ad4d75c1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47200 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45262 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157567 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44948 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6662 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49642 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197557 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58858 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164884 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154298 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41411 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59567 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153949 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48441 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131884 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128682 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58045 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19968 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57417 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57660 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57484 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->