### PR TITLE
TimeControlSupport keeps syncing the time labels while the media controls are faded

### DIFF
--- a/LayoutTests/media/modern-media-controls/time-control-support/time-control-support-disable-with-hidden-controls-expected.txt
+++ b/LayoutTests/media/modern-media-controls/time-control-support/time-control-support-disable-with-hidden-controls-expected.txt
@@ -1,0 +1,28 @@
+Testing TimeControlSupport stops syncing the time labels while the controls are not visible to the user.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Starting test.
+PASS controls.visible is true
+PASS controls.faded is false
+
+Now we wait for the controls to fade after a period of inactivity.
+PASS controls.faded became true
+
+Waiting for the media to advance while the controls are faded.
+
+The media advanced, but the faded time label should not have been re-synced.
+PASS media.currentTime > valueWhileFaded is true
+PASS controls.timeControl.elapsedTimeLabel.value is valueWhileFaded
+
+We pause the media so that controls can show again.
+
+Media paused, the elapsed time label should be re-synced now that controls are visible.
+PASS controls.faded is false
+PASS controls.timeControl.elapsedTimeLabel.value is media.currentTime
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/time-control-support/time-control-support-disable-with-hidden-controls.html
+++ b/LayoutTests/media/modern-media-controls/time-control-support/time-control-support-disable-with-hidden-controls.html
@@ -1,0 +1,84 @@
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/media-controls-loader.js" type="text/javascript"></script>
+<body>
+<video src="../../content/test.mp4" style="width: 320px; height: 240px;" autoplay controls></video>
+<div id="host"></div>
+<script type="text/javascript">
+
+window.jsTestIsAsync = true;
+
+description("Testing <code>TimeControlSupport</code> stops syncing the time labels while the controls are not visible to the user.");
+
+const container = document.querySelector("div#host");
+const media = document.querySelector("video");
+const mediaController = createControls(container, media, null);
+const controls = mediaController.controls;
+
+controls.autoHideController.autoHideDelay = 100;
+
+let valueWhileFaded;
+
+media.addEventListener("canplay", startTest);
+
+function startTest()
+{
+    debug("Starting test.");
+    shouldBeTrue("controls.visible");
+    shouldBeFalse("controls.faded");
+
+    debug("");
+    debug("Now we wait for the controls to fade after a period of inactivity.");
+    shouldBecomeEqual("controls.faded", "true", controlsDidFade);
+}
+
+function controlsDidFade()
+{
+    scheduler.flushScheduledLayoutCallbacks();
+    valueWhileFaded = controls.timeControl.elapsedTimeLabel.value;
+
+    debug("");
+    debug("Waiting for the media to advance while the controls are faded.");
+    media.addEventListener("timeupdate", checkFrozenWhileFaded);
+}
+
+function checkFrozenWhileFaded()
+{
+    // Wait until the media has genuinely advanced past the value shown when the controls faded.
+    if (media.currentTime <= valueWhileFaded)
+        return;
+
+    media.removeEventListener("timeupdate", checkFrozenWhileFaded);
+    scheduler.flushScheduledLayoutCallbacks();
+
+    debug("");
+    debug("The media advanced, but the faded time label should not have been re-synced.");
+    shouldBeTrue("media.currentTime > valueWhileFaded");
+    shouldBe("controls.timeControl.elapsedTimeLabel.value", "valueWhileFaded");
+
+    debug("");
+    debug("We pause the media so that controls can show again.");
+    media.addEventListener("pause", mediaDidPause);
+    media.pause();
+}
+
+function mediaDidPause()
+{
+    scheduler.flushScheduledLayoutCallbacks();
+
+    debug("");
+    debug("Media paused, the elapsed time label should be re-synced now that controls are visible.");
+    shouldBeFalse("controls.faded");
+    shouldBe("controls.timeControl.elapsedTimeLabel.value", "media.currentTime");
+    finishTest();
+}
+
+function finishTest()
+{
+    debug("");
+    container.remove();
+    media.remove();
+    finishJSTest();
+}
+
+</script>
+</body>

--- a/Source/WebCore/Modules/modern-media-controls/media/time-control-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/time-control-support.js
@@ -30,6 +30,9 @@ class TimeControlSupport extends MediaControllerSupport
 
     enable()
     {
+        if (!this._shouldBeEnabled())
+            return;
+
         super.enable();
 
         this.control.supportsSeeking = !this.mediaController.host || this.mediaController.host.supportsSeeking;
@@ -45,11 +48,27 @@ class TimeControlSupport extends MediaControllerSupport
         return ["timeupdate", "durationchange"];
     }
 
+    controlsUserVisibilityDidChange()
+    {
+        if (this._shouldBeEnabled())
+            this.enable();
+        else
+            this.disable();
+    }
+
     syncControl()
     {
         const media = this.mediaController.media;
         this.control.currentTime = media.currentTime;
         this.control.duration = media.duration;
+    }
+
+    // Private
+
+    _shouldBeEnabled()
+    {
+        const controls = this.mediaController.controls;
+        return controls.visible && !controls.faded;
     }
 
 }


### PR DESCRIPTION
#### f66d69a127d1e84cd90f5c4cac29fa3ab18e4561
<pre>
TimeControlSupport keeps syncing the time labels while the media controls are faded
<a href="https://bugs.webkit.org/show_bug.cgi?id=323570">https://bugs.webkit.org/show_bug.cgi?id=323570</a>
<a href="https://rdar.apple.com/186813252">rdar://186813252</a>

Reviewed by NOBODY (OOPS!).

The modern media controls fade out after a period of inactivity by setting
opacity to 0, not display:none, so the controls&apos; DOM stays live while hidden.
TimeControlSupport listens for &quot;timeupdate&quot;, which fires ~4Hz during playback,
and each event syncs the time labels and marks the TimeControl for layout. This
forces a style recalc and flexbox relayout of the controls&apos; shadow tree ~4Hz for
a video playing with faded controls (e.g. fullscreen) with nothing visible on
screen.

Stop listening for these events while the controls are not visible to the user,
mirroring AirplaySupport: override controlsUserVisibilityDidChange() to disable()
when the controls are hidden or faded, and gate enable() on the same condition.
enable() runs syncControl(), so the time labels are brought up to date the moment
the controls become visible again.

TimeControl is a container LayoutItem, not a button or slider, so nothing reads
its uiDelegate; disabling the support has no effect on user interaction.
StatusSupport and ScrubbingSupport are left unchanged.

Test: media/modern-media-controls/time-control-support/time-control-support-disable-with-hidden-controls.html

* LayoutTests/media/modern-media-controls/time-control-support/time-control-support-disable-with-hidden-controls-expected.txt: Added.
* LayoutTests/media/modern-media-controls/time-control-support/time-control-support-disable-with-hidden-controls.html: Added.
* Source/WebCore/Modules/modern-media-controls/media/time-control-support.js:
(TimeControlSupport.prototype.enable):
(TimeControlSupport.prototype.controlsUserVisibilityDidChange):
(TimeControlSupport.prototype._shouldBeEnabled):
(TimeControlSupport):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f66d69a127d1e84cd90f5c4cac29fa3ab18e4561

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195609 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150105 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/11e51413-fac1-43f1-ba2e-9f57f6270e8f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144787 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100401 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/180651e1-d05f-489d-bc17-80e89815047f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165379 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125080 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f20cd3df-075a-401b-8724-f140633286c0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47201 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45263 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157568 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44949 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6663 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51851 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197558 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164885 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154299 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59568 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153950 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48442 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131885 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128686 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58046 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19969 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57418 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57661 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57485 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->