### PR TITLE
Use RELEASE_ASSERT in assertIsCurrent(const RunLoop&) for extra thread safety

### DIFF
--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -413,15 +413,6 @@ private:
 
 inline void assertIsCurrent(const RunLoop& runLoop) WTF_ASSERTS_ACQUIRED_CAPABILITY(runLoop)
 {
-    UNUSED_PARAM(runLoop);
-    ASSERT_WITH_SECURITY_IMPLICATION(runLoop.isCurrent());
-}
-
-// Like assertIsCurrent(), but enforced in release builds too. Used by RunLoop::Timer::stop() and the
-// destructor, where running off the run loop's thread while the timer is active is a cross-thread
-// use-after-free, so it must crash even when debug assertions are disabled.
-inline void releaseAssertIsCurrent(const RunLoop& runLoop) WTF_ASSERTS_ACQUIRED_CAPABILITY(runLoop)
-{
     RELEASE_ASSERT(runLoop.isCurrent());
 }
 
@@ -432,5 +423,4 @@ WTF_EXPORT_PRIVATE void callOnRunLoop(RunLoop&, Function<void()>&&);
 using WTF::RunLoop;
 using WTF::RunLoopMode;
 using WTF::assertIsCurrent;
-using WTF::releaseAssertIsCurrent;
 using WTF::callOnRunLoop;

--- a/Source/WTF/wtf/cf/RunLoopCF.cpp
+++ b/Source/WTF/wtf/cf/RunLoopCF.cpp
@@ -154,7 +154,7 @@ void RunLoop::TimerBase::stop()
     // from another thread races with the in-flight callback and can leave it reading freed memory.
     // (Starting a timer cross-thread is safe and supported -- that is how dispatch()/dispatchAfter()
     // schedule work onto another run loop.)
-    releaseAssertIsCurrent(m_runLoop);
+    assertIsCurrent(m_runLoop);
     CFRunLoopTimerInvalidate(m_timer.get());
     m_timer = nullptr;
 }

--- a/Source/WTF/wtf/generic/RunLoopGeneric.cpp
+++ b/Source/WTF/wtf/generic/RunLoopGeneric.cpp
@@ -313,7 +313,7 @@ RunLoop::TimerBase::~TimerBase()
     // (Starting a timer cross-thread is safe and supported -- that is how dispatch()/dispatchAfter()
     // schedule work onto another run loop.)
     if (m_scheduledTask->isActive())
-        releaseAssertIsCurrent(m_runLoop);
+        assertIsCurrent(m_runLoop);
     Locker locker { m_runLoop->m_loopLock };
     stopWithLock();
 }
@@ -337,7 +337,7 @@ void RunLoop::TimerBase::stop()
 {
     Locker locker { m_runLoop->m_loopLock };
     if (m_scheduledTask->isActive())
-        releaseAssertIsCurrent(m_runLoop);
+        assertIsCurrent(m_runLoop);
     stopWithLock();
 }
 

--- a/Source/WTF/wtf/glib/RunLoopGLib.cpp
+++ b/Source/WTF/wtf/glib/RunLoopGLib.cpp
@@ -341,7 +341,7 @@ RunLoop::TimerBase::~TimerBase()
     // (Starting a timer cross-thread is safe and supported -- that is how dispatch()/dispatchAfter()
     // schedule work onto another run loop.)
     if (isActive())
-        releaseAssertIsCurrent(m_runLoop);
+        assertIsCurrent(m_runLoop);
     g_source_destroy(m_source.get());
 }
 
@@ -386,7 +386,7 @@ void RunLoop::TimerBase::start(Seconds interval, bool repeat)
 void RunLoop::TimerBase::stop()
 {
     if (isActive())
-        releaseAssertIsCurrent(m_runLoop);
+        assertIsCurrent(m_runLoop);
     g_source_set_ready_time(m_source.get(), -1);
     m_interval = { };
     m_isRepeating = false;

--- a/Source/WTF/wtf/win/RunLoopWin.cpp
+++ b/Source/WTF/wtf/win/RunLoopWin.cpp
@@ -271,7 +271,7 @@ void RunLoop::TimerBase::stop()
     // tearing it down from another thread races with the in-flight callback and risks a use-after-free.
     // (Starting a timer cross-thread is safe and supported -- that is how dispatch()/dispatchAfter()
     // schedule work onto another run loop.)
-    releaseAssertIsCurrent(m_runLoop);
+    assertIsCurrent(m_runLoop);
     m_isActive = false;
     m_nextFireDate = MonotonicTime::infinity();
 


### PR DESCRIPTION
#### 19cfe1ed983a6e886e86ff307e9fc9ee3053e525
<pre>
Use RELEASE_ASSERT in assertIsCurrent(const RunLoop&amp;) for extra thread safety
<a href="https://bugs.webkit.org/show_bug.cgi?id=323572">https://bugs.webkit.org/show_bug.cgi?id=323572</a>

Reviewed by Darin Adler.

Use RELEASE_ASSERT in assertIsCurrent(const RunLoop&amp;) for extra thread safety.
This tested as performance neutral on the benchmarks we track.

* Source/WTF/wtf/RunLoop.h:
(WTF::WTF_ASSERTS_ACQUIRED_CAPABILITY):
* Source/WTF/wtf/cf/RunLoopCF.cpp:
(WTF::RunLoop::TimerBase::stop):
* Source/WTF/wtf/generic/RunLoopGeneric.cpp:
(WTF::RunLoop::TimerBase::~TimerBase):
(WTF::RunLoop::TimerBase::stop):
* Source/WTF/wtf/glib/RunLoopGLib.cpp:
(WTF::RunLoop::TimerBase::~TimerBase):
(WTF::RunLoop::TimerBase::stop):
* Source/WTF/wtf/win/RunLoopWin.cpp:
(WTF::RunLoop::TimerBase::stop):

Canonical link: <a href="https://commits.webkit.org/320636@main">https://commits.webkit.org/320636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/748ec1936452eef4f4586cd6afa520d581afa4e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53016 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195613 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150109 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1237c08e-d8f9-46e8-8b8e-05c9c6d57719) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144794 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100405 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0d15542d-e0b5-4133-9a5e-61fc37203dd7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125087 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4a052df2-20b9-4d6f-8317-1d015717c540) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47205 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45268 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7000 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13887 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44955 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6667 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46545 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51855 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197562 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58863 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154304 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41351 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59572 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153955 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48447 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131889 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128691 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58050 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19975 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57422 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57665 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57489 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->