### PR TITLE
AudioSampleDataSource does an extra full-quantum memcpy per render when mixing a source at less-than-unity gain

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.cpp
@@ -108,10 +108,10 @@ void AudioSampleBufferList::applyGain(float gain)
     applyGain(m_bufferList.get(), gain, m_internalFormat.format());
 }
 
-static void mixBuffers(WebAudioBufferList& destinationBuffer, const AudioBufferList& sourceBuffer, AudioStreamDescription::PCMFormat format, size_t frameCount)
+static void mixBuffers(AudioBufferList& destinationBuffer, const AudioBufferList& sourceBuffer, AudioStreamDescription::PCMFormat format, size_t frameCount)
 {
     auto sourceBufferSpan = span(sourceBuffer);
-    auto destinationBufferSpan = span(*destinationBuffer.list());
+    auto destinationBufferSpan = span(destinationBuffer);
     for (auto [source, destination] : zippedRange(sourceBufferSpan, destinationBufferSpan)) {
         switch (format) {
         case AudioStreamDescription::Int16: {
@@ -232,6 +232,17 @@ OSStatus AudioSampleBufferList::mixFrom(const AudioBufferList& source, size_t fr
         return kAudio_ParamError;
 
     mixBuffers(bufferList(), source, m_internalFormat.format(), frameCount);
+    return 0;
+}
+
+OSStatus AudioSampleBufferList::mixTo(AudioBufferList& buffer, size_t frameCount)
+{
+    if (frameCount > m_sampleCount)
+        return kAudio_ParamError;
+    if (buffer.mNumberBuffers > m_bufferList->bufferCount())
+        return kAudio_ParamError;
+
+    mixBuffers(buffer, bufferList(), m_internalFormat.format(), frameCount);
     return 0;
 }
 

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.h
@@ -56,6 +56,7 @@ public:
     OSStatus mixFrom(const AudioSampleBufferList&, size_t count = SIZE_MAX);
 
     OSStatus mixFrom(const AudioBufferList&, size_t count = SIZE_MAX);
+    OSStatus mixTo(AudioBufferList&, size_t count = SIZE_MAX);
     OSStatus copyTo(AudioBufferList&, size_t count = SIZE_MAX);
 
     const AudioStreamBasicDescription& streamDescription() const LIFETIME_BOUND { return m_internalFormat.streamDescription(); }

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm
@@ -269,8 +269,7 @@ bool AudioSampleDataSource::pullSamplesInternal(AudioBufferList& buffer, size_t 
         return false;
 
     scratchBuffer->applyGain(m_volume);
-    scratchBuffer->mixFrom(buffer, sampleCount);
-    if (scratchBuffer->copyTo(buffer, sampleCount))
+    if (scratchBuffer->mixTo(buffer, sampleCount))
         return false;
 
     return true;


### PR DESCRIPTION
#### 1957f6961aef9bdac7fd99296bad45f4d3d90534
<pre>
AudioSampleDataSource does an extra full-quantum memcpy per render when mixing a source at less-than-unity gain
<a href="https://bugs.webkit.org/show_bug.cgi?id=323573">https://bugs.webkit.org/show_bug.cgi?id=323573</a>
<a href="https://rdar.apple.com/186814894">rdar://186814894</a>

Reviewed by Chris Dumez.

In the Mix pull path, when a source&apos;s volume is below unity,
pullSamplesInternal() fetched the ring buffer into a scratch buffer,
applied gain, mixed the destination buffer into the scratch buffer, and
then copied the scratch buffer back over the destination:

    scratch  = ring          // fetch
    scratch *= volume        // applyGain
    scratch += buffer        // mixFrom
    buffer   = scratch        // copyTo  &lt;- extra full-quantum memcpy

That final copyTo is a redundant per-channel memcpy of the whole quantum,
paid on the real-time audio render thread on every callback for every
sub-unity-gain source. Because mixBuffers() is a commutative accumulate
(dest += src), the same result (buffer + ring*volume) can be produced by
mixing the gained scratch buffer directly into the destination:

    scratch  = ring          // fetch
    scratch *= volume        // applyGain
    buffer  += scratch        // mixTo

This drops one full-quantum memcpy per render. The unity-gain Mix path
already mixed in place via fetchModeForMixing and is unchanged.

Generalize the internal mixBuffers() helper to take a raw AudioBufferList&amp;
destination (existing callers pass WebAudioBufferList via its implicit
operator AudioBufferList&amp;), and add AudioSampleBufferList::mixTo(),
symmetric to copyTo(), that mixes the list&apos;s contents into a caller-owned
AudioBufferList.

* Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.cpp:
(WebCore::mixBuffers):
(WebCore::AudioSampleBufferList::mixTo):
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferList.h:
* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm:
(WebCore::AudioSampleDataSource::pullSamplesInternal):

Canonical link: <a href="https://commits.webkit.org/320600@main">https://commits.webkit.org/320600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43347803b322316de7466149c0fbac0bdc2f6652

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53017 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195614 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/62a8cdd6-a7ae-4205-9c2f-d8e03019e23a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144790 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/154e20e1-9e0b-4e01-ba78-1c90f117bed2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48475 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165383 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125083 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/383bbe76-9a31-4166-a6da-a9312e04c601) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47203 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45267 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157570 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44953 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6668 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51856 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197563 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58864 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154303 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41321 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59573 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41557 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153954 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48445 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131890 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128692 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58051 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19973 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57423 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57666 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57490 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->