### PR TITLE
[CMake][Clang][GTK][WPE] -Werror is not used even if DEVELOPER_MODE_FATAL_WARNINGS is enabled

### DIFF
--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -7,7 +7,8 @@ function(WEBKIT_CHECK_COMPILER_FLAGS _compiler _result)
     foreach (_flag IN LISTS ARGN)
         # If an equals (=) character is present in a variable name, it will
         # not be cached correctly, and the check will be retried ad nauseam.
-        string(REPLACE "=" "__" _cachevar "${_compiler}_COMPILER_SUPPORTS_${_flag}")
+        # And, an minus (-) character causes a C macro name issue.
+        string(MAKE_C_IDENTIFIER "${_compiler}_COMPILER_SUPPORTS_${_flag}" _cachevar)
         if (CMAKE_${_compiler}_COMPILER_ID STREQUAL "AppleClang")
             set(${_cachevar} TRUE)
         elseif (${_compiler} STREQUAL CXX)
@@ -188,7 +189,8 @@ if (COMPILER_IS_GCC_OR_CLANG)
     endif ()
 
     WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-gsimple-template-names)
-    WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS("-mllvm -dwarf-linkage-names=Abstract")
+    # FIXME:
+    #WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS("-mllvm -dwarf-linkage-names=Abstract")
 
     # FIXME: Remove once the strict-aliasing violations exposed by 315506@main are fixed.
     # Enabling strict aliasing (the compiler default at -O2) miscompiles type-punning code
@@ -236,6 +238,9 @@ if (COMPILER_IS_GCC_OR_CLANG)
                                          -Wno-misleading-indentation
                                          -Wno-psabi
                                          -Wno-nullability-completeness)
+
+    # FIXME: ATOMICS_REQUIRE_LIBATOMIC check fails due to -Werror
+    WEBKIT_PREPEND_GLOBAL_CXX_FLAGS(-Wno-atomic-alignment)
 
     if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
         # FIXME: We should probably not be disabling -Wno-maybe-uninitialized?


### PR DESCRIPTION
#### b060b978b9eb2adc814dc7b599e29f0c171ef6d5
<pre>
[CMake][Clang][GTK][WPE] -Werror is not used even if DEVELOPER_MODE_FATAL_WARNINGS is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=323574">https://bugs.webkit.org/show_bug.cgi?id=323574</a>

Reviewed by NOBODY (OOPS!).

WEBKIT_CHECK_COMPILER_FLAGS() used a variable name
CXX_COMPILER_SUPPORTS_-Werror for the out variable of check_c_compiler_flag for
-Werror switch. This name is also used as a C macro name. It causes the
following warning.

&gt;        &lt;command line&gt;:1:31: error: ISO C99 requires whitespace after the macro name [-Werror,-Wc99-extensions]
&gt;            1 | #define CXX_COMPILER_SUPPORTS_-Werror 1
&gt;              |                               ^

Then, this warning was treated as an error due to -Werror switch. As the
result, CMake thought -Werror switch was not supported.

Replace minus characters as well as equal characters.

* Source/cmake/WebKitCompilerFlags.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b060b978b9eb2adc814dc7b599e29f0c171ef6d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195841 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150273 "Hash b060b978 for PR 73380 does not build (failure)") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59156 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145006 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/150273 "Hash b060b978 for PR 73380 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125298 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47378 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45441 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/7202 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; jscore-tests (cancelled)") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14064 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45132 "Passed tests") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6892 "Hash b060b978 for PR 73380 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46774 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49830 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197790 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59093 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154514 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59802 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154161 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48620 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129053 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58278 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20154 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57651 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57717 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->