### PR TITLE
[ShapeDetection] BarcodeDetector/TextDetector copy each result String instead of moving it

### DIFF
--- a/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.cpp
+++ b/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.cpp
@@ -115,8 +115,8 @@ void BarcodeDetector::detect(ScriptExecutionContext& scriptExecutionContext, Ima
         }
 
         backing->detect(image.releaseNonNull(), [promise = WTF::move(promise)](Vector<ShapeDetection::DetectedBarcode>&& detectedBarcodes) mutable {
-            promise.resolve(detectedBarcodes.map([](const auto& detectedBarcode) {
-                return convertFromBacking(detectedBarcode);
+            promise.resolve(WTF::map(WTF::move(detectedBarcodes), [](ShapeDetection::DetectedBarcode&& detectedBarcode) {
+                return convertFromBacking(WTF::move(detectedBarcode));
             }));
         });
     });

--- a/Source/WebCore/Modules/ShapeDetection/DetectedBarcode.h
+++ b/Source/WebCore/Modules/ShapeDetection/DetectedBarcode.h
@@ -59,11 +59,11 @@ struct DetectedBarcode {
     Vector<Point2D> cornerPoints;
 };
 
-inline DetectedBarcode convertFromBacking(const ShapeDetection::DetectedBarcode& detectedBarcode)
+inline DetectedBarcode convertFromBacking(ShapeDetection::DetectedBarcode&& detectedBarcode)
 {
     return {
         DOMRectReadOnly::create(detectedBarcode.boundingBox.x(), detectedBarcode.boundingBox.y(), detectedBarcode.boundingBox.width(), detectedBarcode.boundingBox.height()),
-        detectedBarcode.rawValue,
+        WTF::move(detectedBarcode.rawValue),
         convertFromBacking(detectedBarcode.format),
         detectedBarcode.cornerPoints.map([] (const auto& cornerPoint) {
             return Point2D { cornerPoint.x(), cornerPoint.y() };

--- a/Source/WebCore/Modules/ShapeDetection/DetectedText.h
+++ b/Source/WebCore/Modules/ShapeDetection/DetectedText.h
@@ -58,11 +58,11 @@ struct DetectedText {
     Vector<Point2D> cornerPoints;
 };
 
-inline DetectedText convertFromBacking(const ShapeDetection::DetectedText& detectedText)
+inline DetectedText convertFromBacking(ShapeDetection::DetectedText&& detectedText)
 {
     return {
         DOMRectReadOnly::create(detectedText.boundingBox.x(), detectedText.boundingBox.y(), detectedText.boundingBox.width(), detectedText.boundingBox.height()),
-        detectedText.rawValue,
+        WTF::move(detectedText.rawValue),
         detectedText.cornerPoints.map([] (const auto& cornerPoint) {
             return Point2D { cornerPoint.x(), cornerPoint.y() };
         }),

--- a/Source/WebCore/Modules/ShapeDetection/TextDetector.cpp
+++ b/Source/WebCore/Modules/ShapeDetection/TextDetector.cpp
@@ -87,8 +87,8 @@ void TextDetector::detect(ScriptExecutionContext& scriptExecutionContext, ImageB
         }
 
         backing->detect(*image, [promise = WTF::move(promise)](Vector<ShapeDetection::DetectedText>&& detectedText) mutable {
-            promise.resolve(detectedText.map([](const auto& detectedText) {
-                return convertFromBacking(detectedText);
+            promise.resolve(WTF::map(WTF::move(detectedText), [](ShapeDetection::DetectedText&& detectedText) {
+                return convertFromBacking(WTF::move(detectedText));
             }));
         });
     });


### PR DESCRIPTION
#### 1ff4e5710003c2817eabf8eac9218787f47eda7d
<pre>
[ShapeDetection] BarcodeDetector/TextDetector copy each result String instead of moving it
<a href="https://bugs.webkit.org/show_bug.cgi?id=323577">https://bugs.webkit.org/show_bug.cgi?id=323577</a>
<a href="https://rdar.apple.com/186820008">rdar://186820008</a>

Reviewed by Chris Dumez.

detect() owns the Vector of results from the backing detector, but
Vector::map() invokes its functor with const T&amp;, and convertFromBacking()
copied rawValue out of the const reference. Convert with
WTF::map(WTF::move(...)) and add an rvalue convertFromBacking() overload
that moves rawValue. Other members are type conversions that allocate
regardless. FaceDetector is unchanged (no movable String).

No change in behavior.

* Source/WebCore/Modules/ShapeDetection/BarcodeDetector.cpp:
(WebCore::BarcodeDetector::detect):
* Source/WebCore/Modules/ShapeDetection/DetectedBarcode.h:
(WebCore::convertFromBacking):
* Source/WebCore/Modules/ShapeDetection/DetectedText.h:
(WebCore::convertFromBacking):
* Source/WebCore/Modules/ShapeDetection/TextDetector.cpp:
(WebCore::TextDetector::detect):

Canonical link: <a href="https://commits.webkit.org/320604@main">https://commits.webkit.org/320604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/517295006e68c3accb5e0255fa46c2cf34ff344a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195618 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0ba48301-cdbf-4d56-9a26-43ec01afa842) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144796 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c8e1c724-831e-497f-a6c3-efa909a30808) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125089 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/52aac5f6-4114-47e0-85b0-eae4f7185eec) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47210 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45272 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157577 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44960 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6672 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197567 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58868 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154307 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41324 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59577 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153958 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48451 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131895 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128699 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58055 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19980 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57427 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57670 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57494 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->