### PR TITLE
[Linux] TestWebKitAPI/Tests/IPC/ConnectionTests.cpp : warning: format specifies type 'unsigned long long' but the argument has type 'uint64_t' (aka 'unsigned long')

### DIFF
--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -574,7 +574,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendAsync)
         for (uint64_t i = 100u; i < 160u; ++i) {
             b()->sendWithAsyncReply(MockTestMessageWithAsyncReply1 { }, [&, j = i] (uint64_t value) {
                 if (!value)
-                    WTFLogAlways("GOT: %llu", j);
+                    WTFLogAlways("GOT: %" PRIu64, j);
                 EXPECT_GE(value, 100u);
                 replies.add(value);
             }, i);
@@ -795,7 +795,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendAsyncOnTarget)
                 b()->sendWithAsyncReplyOnDispatcher(MockTestMessageWithAsyncReply1 { }, awq.queue(), [&, j = i, queue = awq.queue()] (uint64_t value) {
                     assertIsCurrent(queue);
                     if (!value)
-                        WTFLogAlways("GOT: %llu", j);
+                        WTFLogAlways("GOT: %" PRIu64, j);
                     EXPECT_GE(value, 100u);
                     replies.add(value);
                 }, i);
@@ -830,7 +830,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReply)
             b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, i)->then(runLoop,
                 [&, j = i] (uint64_t value) {
                     if (!value)
-                        WTFLogAlways("GOT: %llu", j);
+                        WTFLogAlways("GOT: %" PRIu64, j);
                     EXPECT_GE(value, 100u);
                     replies.add(value);
                 },
@@ -909,7 +909,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReplyOnMixAndMatchDispatche
                     EXPECT_TRUE(result);
                     auto value = *result;
                     if (!value)
-                        WTFLogAlways("GOT: %llu", j);
+                        WTFLogAlways("GOT: %" PRIu64, j);
                     EXPECT_GE(value, 100u);
                     replies.add(value);
                 });


### PR DESCRIPTION
#### 12f151735ba39bc84a1f4182c8d65596894ac0fb
<pre>
[Linux] TestWebKitAPI/Tests/IPC/ConnectionTests.cpp : warning: format specifies type &apos;unsigned long long&apos; but the argument has type &apos;uint64_t&apos; (aka &apos;unsigned long&apos;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=323580">https://bugs.webkit.org/show_bug.cgi?id=323580</a>

Reviewed by Carlos Garcia Campos.

Use PRIu64 for uint64_t.

* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/320609@main">https://commits.webkit.org/320609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bec514497a83f983cf88daafd27ac4ea2412e1d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185299 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195625 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58938 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144802 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48488 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165399 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125095 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47216 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45279 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157583 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44969 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6679 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197574 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58875 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154314 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59584 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153965 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28131 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48458 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128716 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58062 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19990 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57434 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57677 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57501 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->