### PR TITLE
TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestResources.cpp : warning: releasing lock 's_serverLock' that was not held [-Wthread-safety-analysis]

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestResources.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestResources.cpp
@@ -718,7 +718,7 @@ public:
     unsigned m_resourcesToStartPending;
 };
 
-static void testWebViewSyncRequestOnMaxConns(SyncRequestOnMaxConnsTest* test, gconstpointer)
+static void testWebViewSyncRequestOnMaxConns(SyncRequestOnMaxConnsTest* test, gconstpointer) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
     s_serverLock.lock();
     test->loadURI(kServer->getURIForPath("/sync-request-on-max-conns-0").data());
@@ -730,7 +730,7 @@ static void testWebViewSyncRequestOnMaxConns(SyncRequestOnMaxConnsTest* test, gc
     }
 
     // By default sync XHRs have a 10 seconds timeout, we don't want to wait all that so use our own timeout.
-    guint timeoutSourceID = g_timeout_add(1000, [] (gpointer) -> gboolean {
+    guint timeoutSourceID = g_timeout_add(1000, [] (gpointer) WTF_IGNORES_THREAD_SAFETY_ANALYSIS -> gboolean {
         g_assert_not_reached();
         s_serverLock.unlock();
         return G_SOURCE_REMOVE;
@@ -739,7 +739,7 @@ static void testWebViewSyncRequestOnMaxConns(SyncRequestOnMaxConnsTest* test, gc
     struct UnlockServerSourceContext {
         guint unlockServerSourceID;
     } context = {
-        g_idle_add_full(G_PRIORITY_DEFAULT, [](gpointer userData) -> gboolean {
+        g_idle_add_full(G_PRIORITY_DEFAULT, [](gpointer userData) WTF_IGNORES_THREAD_SAFETY_ANALYSIS -> gboolean {
             auto& context = *static_cast<UnlockServerSourceContext*>(userData);
             context.unlockServerSourceID = 0;
             s_serverLock.unlock();


### PR DESCRIPTION
#### 2e4a326aeb925c5b7168a40aa4a6ccc64ac862e8
<pre>
TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestResources.cpp : warning: releasing lock &apos;s_serverLock&apos; that was not held [-Wthread-safety-analysis]
<a href="https://bugs.webkit.org/show_bug.cgi?id=323581">https://bugs.webkit.org/show_bug.cgi?id=323581</a>

Reviewed by Carlos Garcia Campos.

Added WTF_IGNORES_THREAD_SAFETY_ANALYSIS to suppress the warnings.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestResources.cpp:
(testWebViewSyncRequestOnMaxConns):

Canonical link: <a href="https://commits.webkit.org/320608@main">https://commits.webkit.org/320608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b08240d4ce7094ec77fc918513c48ebb27f11039

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195627 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144804 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125097 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47220 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45282 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44967 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6681 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197576 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58877 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154316 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59586 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153967 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28130 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48460 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128718 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58064 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19987 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57436 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57679 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57503 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->