### PR TITLE
[JSC] Folding `Shl` into `WasmAddress` index form can use a locked value's `Tmp`

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -651,14 +651,15 @@ private:
         case WasmAddress: {
             WasmAddressValue* wasmAddress = address->as<WasmAddressValue>();
             Value* pointer = wasmAddress->child(0);
-            // Why don't we need to check m_locked here? WasmAddressValue is purely used for address computation,
+            // Why don't we need to check m_locked for the WasmAddressValue itself? It is purely used for address computation,
             // which is different from the other operations. And we already know that numUses(address) is below the threshold.
             // If we ensure that all use of WasmAddress gets indexArg form, we do not need to have WasmAddressValue's instruction actually.
             if (!Arg::isValidIndexForm(1, offset, width))
                 return fallback();
 
             Tmp base = Tmp(wasmAddress->pinnedGPR());
-            if (std::optional<unsigned> scale = scaleForShl(pointer, offset, width))
+            std::optional<unsigned> scale = scaleForShl(pointer, offset, width);
+            if (scale && !m_locked.contains(pointer->child(0)))
                 return indexArg(base, pointer->child(0), *scale, offset);
 
             return indexArg(base, pointer, 1, offset);

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1282,6 +1282,7 @@ void testWasmBoundsCheck(unsigned offset);
 void testWasmAddress();
 void testWasmAddressZeroExtendScaledIndex();
 void testWasmAddressZeroExtend32BitShiftWraps();
+void testWasmAddressScaledIndexWithLockedShlChild();
 void testFastTLSLoad();
 void testFastTLSStore();
 void testDoubleLiteralComparison(double, double);

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -1173,6 +1173,7 @@ void run(const TestConfig* config)
     RUN(testWasmAddress());
     RUN(testWasmAddressZeroExtendScaledIndex());
     RUN(testWasmAddressZeroExtend32BitShiftWraps());
+    RUN(testWasmAddressScaledIndexWithLockedShlChild());
     RUN(testWasmAddressWithOffset());
     
     RUN(testFastTLSLoad());

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -1977,6 +1977,42 @@ void testWasmAddressZeroExtend32BitShiftWraps()
     CHECK_EQ(invoke<int32_t>(*code, static_cast<int32_t>(0x40000000), 0, values), 11);
 }
 
+void testWasmAddressScaledIndexWithLockedShlChild()
+{
+    Procedure proc;
+    GPRReg pinnedGPR = GPRInfo::argumentGPR2;
+    proc.pinRegister(pinnedGPR);
+
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* loadBlock = proc.addBlock();
+    BasicBlock* bailBlock = proc.addBlock();
+
+    auto arguments = cCallArgumentValues<uint64_t, uint64_t, int32_t*>(proc, root);
+    Value* masked = root->appendNew<Value>(
+        proc, BitAnd, Origin(), arguments[0],
+        root->appendNew<Const64Value>(proc, Origin(), 7));
+    Value* pointer = root->appendNew<Value>(
+        proc, Shl, Origin(), masked,
+        root->appendNew<Const32Value>(proc, Origin(), 2));
+    root->appendNewControlValue(proc, Branch, Origin(), arguments[1], FrequentedBlock(loadBlock), FrequentedBlock(bailBlock));
+
+    loadBlock->appendNewControlValue(
+        proc, Return, Origin(),
+        loadBlock->appendNew<MemoryValue>(
+            proc, Load, Int32, Origin(),
+            loadBlock->appendNew<WasmAddressValue>(proc, Origin(), pointer, pinnedGPR), 0));
+
+    bailBlock->appendNewControlValue(
+        proc, Return, Origin(),
+        bailBlock->appendNew<Const32Value>(proc, Origin(), -1));
+
+    auto code = compileProc(proc);
+    int32_t values[] = { 11, 22, 33, 44, 55, 66, 77, 88 };
+    for (uint64_t i = 0; i < 8; ++i)
+        CHECK_EQ(invoke<int32_t>(*code, 0x100 + i, 1, values), values[i]);
+    CHECK_EQ(invoke<int32_t>(*code, 0x100, 0, values), -1);
+}
+
 void testWasmAddressWithOffset()
 {
     Procedure proc;


### PR DESCRIPTION
#### 10d4d20f5b6c1db2127d5fb7fd0fae533a092b57
<pre>
[JSC] Folding `Shl` into `WasmAddress` index form can use a locked value&apos;s `Tmp`
<a href="https://bugs.webkit.org/show_bug.cgi?id=323582">https://bugs.webkit.org/show_bug.cgi?id=323582</a>

Reviewed by Keith Miller.

Since 320441@main the WasmAddress case of effectiveAddr() folds a
pointer-width Shl into the index scale, but unlike the sibling Add and Shl
cases it does not check m_locked. Blocks are lowered in pre-order, so a Shl
sitting in an earlier block than the memory access is lowered first, and on
ARM64 a Shl whose child is a single-use BitAnd or ZExt32(Trunc) commits that
child internally into a UBFIZ. The fold then asks tmp() for the locked child
and gets a Tmp no instruction defines, so the access runs on base plus an
undefined index register while the bounds check still tests the correct
pointer.

Skip the fold when the Shl&apos;s child is locked, matching the Add case; the
address then falls back to the Shl&apos;s own Tmp with scale 1.

Tests: Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_7.cpp

* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testWasmAddressScaledIndexWithLockedShlChild):

Canonical link: <a href="https://commits.webkit.org/320618@main">https://commits.webkit.org/320618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09335c5f6ee9a93978ed717657d28f2e65035ea6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185302 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195628 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144806 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48491 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125099 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47219 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45281 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7012 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13900 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44968 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6682 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46560 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197577 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58878 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154317 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41337 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59587 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41572 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153968 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48461 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131905 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128719 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58065 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19988 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57437 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57680 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->