### PR TITLE
[JSC] `RegExpTestInline` crashes when `deleteAllCode()` runs during a DFG/FTL compilation

### DIFF
--- a/JSTests/stress/regexp-test-inline-delete-all-code-race.js
+++ b/JSTests/stress/regexp-test-inline-delete-all-code-race.js
@@ -1,0 +1,45 @@
+//@ runDefault("--useDollarVM=1", "--thresholdForOptimizeAfterWarmUp=100")
+//@ runDefault("--useDollarVM=1", "--thresholdForOptimizeAfterWarmUp=100", "--thresholdForFTLOptimizeAfterWarmUp=100")
+
+// The DFG/FTL code generators for RegExpTestInline must not depend on the RegExp's
+// compilation state: deleteAllCode() can reset it on the main thread between strength
+// reduction and code generation of the same compilation plan. The varying warm-up
+// count is load-bearing: it sweeps the deleteAllCodeWhenIdle() timing across the
+// compilation window (a fixed count does not reproduce the race).
+//
+// Phase 1 (tick) races DFG plans: each turn compiles a fresh function and deletes all
+// code. Phase 2 (ftlTick) races FTL plans: a persistent function climbs the tiers
+// between deletes (a per-turn function never executes its DFG code, so it can never
+// request FTL), and deleting only every 5th turn leaves it time to get there.
+
+let iteration = 0;
+function tick() {
+    let f = new Function("s", "return /ab+c/.test(s);");
+    noInline(f);
+    let n = 100 + ((iteration * 37) % 400);
+    for (let i = 0; i < n; i++) {
+        if (!f("xxabbbcyy"))
+            throw new Error("expected match at iteration " + iteration);
+    }
+    $vm.deleteAllCodeWhenIdle();
+    if (++iteration < 400)
+        setTimeout(tick, 0);
+    else
+        setTimeout(ftlTick, 0);
+}
+
+let hot = function(s) { return /ab+c/.test(s); };
+noInline(hot);
+let ftlIteration = 0;
+function ftlTick() {
+    let n = 100 + ((ftlIteration * 37) % 400);
+    for (let i = 0; i < n; i++) {
+        if (!hot("xxabbbcyy"))
+            throw new Error("expected match at FTL iteration " + ftlIteration);
+    }
+    if (ftlIteration % 5 === 4)
+        $vm.deleteAllCodeWhenIdle();
+    if (++ftlIteration < 400)
+        setTimeout(ftlTick, 0);
+}
+setTimeout(tick, 0);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3051,7 +3051,7 @@ void SpeculativeJIT::compileRegExpTestInline(Node* node)
 {
     RegExp* regExp = uncheckedDowncast<RegExp>(node->cellOperand2()->value());
 
-    auto jitCodeBlock = regExp->getRegExpJITCodeBlock();
+    auto jitCodeBlock = regExp->getRegExpJITCodeBlockConcurrently();
     ASSERT(jitCodeBlock);
     auto inlineCodeStats8Bit = jitCodeBlock->get8BitInlineStats();
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -19822,7 +19822,7 @@ IGNORE_CLANG_WARNINGS_END
 
         ASSERT(!regExp->globalOrSticky());
 
-        auto jitCodeBlock = regExp->getRegExpJITCodeBlock();
+        auto jitCodeBlock = regExp->getRegExpJITCodeBlockConcurrently();
         ASSERT(jitCodeBlock);
         auto inlineCodeStats8Bit = jitCodeBlock->get8BitInlineStats();
 

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -192,6 +192,11 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         return m_regExpJITCode.get();
     }
+
+    Yarr::YarrCodeBlock* getRegExpJITCodeBlockConcurrently()
+    {
+        return m_regExpJITCode.get();
+    }
 #endif
 
     bool hasValidAtom() const { return !m_atom.isNull(); }


### PR DESCRIPTION
#### 111d7edcecd19a77402355eb24e46dc53866de55
<pre>
[JSC] `RegExpTestInline` crashes when `deleteAllCode()` runs during a DFG/FTL compilation
<a href="https://bugs.webkit.org/show_bug.cgi?id=323583">https://bugs.webkit.org/show_bug.cgi?id=323583</a>

Reviewed by Yusuke Suzuki.

DFGStrengthReductionPhase converts RegExpTest to RegExpTestInline after
checking regExp-&gt;getRegExpJITCodeBlock() on the compiler thread, but records
only the frozen RegExp* in the node. Code generation calls
getRegExpJITCodeBlock() again, and it returns nullptr once the RegExp has
left the JITCode state. The main thread can reset that state at any point
during the compilation: VM::deleteAllCode() clears every cached RegExp
before completing the in-flight JIT plans. When this lands between strength
reduction and code generation, the compiler thread crashes on the null
YarrCodeBlock. The race has existed since 244149@main introduced
RegExpTestInline.

Make code generation read the YarrCodeBlock through a new
getRegExpJITCodeBlockConcurrently() that does not consult the compilation
state. This is safe because deleteCode() only clears the compiled code refs:
it never resets m_regExpJITCode once allocated, and YarrCodeBlock::clear()
keeps the InlineStats. Code generation reads only stackSize() and
needsTemp2() from the stats, which are functions of the pattern alone
(unlike canInline() and codeSize(), which depend on the subject string
sampled for the Boyer-Moore lookahead), and it regenerates the matcher from
the pattern source via jitCompileInlinedTest, so the emitted code is correct
whatever the compilation state is.

Test: JSTests/stress/regexp-test-inline-delete-all-code-race.js

* JSTests/stress/regexp-test-inline-delete-all-code-race.js: Added.
(tick):
(let.hot):
(ftlTick):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileRegExpTestInline):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/RegExp.h:

Canonical link: <a href="https://commits.webkit.org/320684@main">https://commits.webkit.org/320684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77a47e3a3ad800aaf39e54c8e42756b71fa3b887

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150123 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144813 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100407 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48497 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165403 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125106 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47225 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45286 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7019 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13905 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157592 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44973 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6686 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46564 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51874 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197581 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58882 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154321 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41392 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59591 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153972 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48466 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131909 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128726 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58069 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19994 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57441 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57684 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57508 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->