### PR TITLE
RenderTreeBuilder::FormControls::updatePseudoElement attaches a ::picker-icon renderer to a RenderTableCol

### DIFF
--- a/LayoutTests/fast/forms/select/base/picker-icon-table-column-crash-expected.txt
+++ b/LayoutTests/fast/forms/select/base/picker-icon-table-column-crash-expected.txt
@@ -1,0 +1,11 @@
+A base-appearance select whose display turns it into a table column must not get a ::picker-icon renderer attached to its RenderTableCol.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getComputedStyle(document.getElementById("column")).display is "table-column"
+PASS getComputedStyle(document.getElementById("columnGroup")).display is "table-column-group"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/select/base/picker-icon-table-column-crash.html
+++ b/LayoutTests/fast/forms/select/base/picker-icon-table-column-crash.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<style>
+select, ::picker(select) {
+    appearance: base-select;
+}
+</style>
+</head>
+<body>
+<select id="column" style="display: table-column"><option>One</option></select>
+<select id="columnGroup" style="display: table-column-group"><option>Two</option></select>
+<script>
+description("A base-appearance select whose display turns it into a table column must not get a ::picker-icon renderer attached to its RenderTableCol.");
+
+document.body.offsetHeight;
+
+shouldBeEqualToString('getComputedStyle(document.getElementById("column")).display', 'table-column');
+shouldBeEqualToString('getComputedStyle(document.getElementById("columnGroup")).display', 'table-column-group');
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
@@ -143,11 +143,17 @@ void RenderTreeBuilder::FormControls::updatePseudoElement(PseudoElementType type
         existingPseudoElement = nullptr;
     }
 
+    if (!renderer.canHaveChildren())
+        return;
+
     Ref document = renderer.document();
     auto pseudoElementStyle = Style::ComputedStyle::clone(*pseudoStyle);
 
     RenderPtr<RenderBlockFlow> pseudoElement = createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, document, WTF::move(pseudoElementStyle));
     pseudoElement->initializeStyle();
+
+    if (!renderer.isChildAllowed(*pseudoElement, pseudoElement->style()))
+        return;
 
     if (pseudoElement->style().content().isData())
         RenderTreeUpdater::GeneratedContent::createContentRenderers(m_builder, *pseudoElement, pseudoElement->style(), type);


### PR DESCRIPTION
#### 2bbc270ed64cf3f873a6e01455c305fa040e6b19
<pre>
RenderTreeBuilder::FormControls::updatePseudoElement attaches a ::picker-icon renderer to a RenderTableCol
<a href="https://bugs.webkit.org/show_bug.cgi?id=323585">https://bugs.webkit.org/show_bug.cgi?id=323585</a>
<a href="https://rdar.apple.com/185183091">rdar://185183091</a>

Reviewed by Tim Nguyen.

RenderTreeBuilder::FormControls::updatePseudoElement() attaches the ::picker-icon and
::checkmark renderers to the form control&apos;s renderer without consulting
canHaveChildren() or isChildAllowed(), unlike every other renderer creation path. A
&lt;select&gt; with appearance: base-select and display: table-column therefore gets an
anonymous RenderBlockFlow under its RenderTableCol, breaking the invariant that
nextColumn() relies on when it hard-casts firstChild() with downcast&lt;RenderTableCol&gt;().
Check both before attaching, which leaves firstChild() null so nextColumn() falls
through to its already type-filtered sibling walk. Both are needed: table-column is
rejected by canHaveChildren(), table-column-group by isChildAllowed(). The checks sit
after the existing-renderer teardown, and before createContentRenderers() and
setPseudoElementRenderer(), so nothing stale is kept and the discarded renderer is a
leaf with no pointer published to the parent. Not a regression from 307421@main: the
unguarded attach predates it in updateCheckmark() and is still reachable via
::checkmark with an author rule, but select::picker-icon applies to every base
appearance menulist &lt;select&gt;, so plain markup now reaches it.

Test: fast/forms/select/base/picker-icon-table-column-crash.html

* LayoutTests/fast/forms/select/base/picker-icon-table-column-crash-expected.txt: Added.
* LayoutTests/fast/forms/select/base/picker-icon-table-column-crash.html: Added.
* Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp:
(WebCore::RenderTreeBuilder::FormControls::updatePseudoElement):

Canonical link: <a href="https://commits.webkit.org/320996@main">https://commits.webkit.org/320996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c145f820896c7fb48bb5531fb3998002c58ecd9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196865 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/151037 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145765 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/101016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49456 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126157 "Passed tests") | | ⏳ 🛠 vision-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/185926 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48184 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46117 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158529 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45871 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7940 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50621 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198856 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/186000 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155366 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41618 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60826 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42421 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155000 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49411 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133000 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130337 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59238 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20852 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58653 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58868 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58760 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->