### PR TITLE
WebRTC remote audio is silent when the output device runs at a very high sample rate (e.g. 768 kHz USB DAC)

### DIFF
--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp
@@ -35,6 +35,9 @@
 #include "CoreAudioCaptureDevice.h"
 #include "CoreAudioCaptureDeviceManager.h"
 #include "Logging.h"
+#if USE(LIBWEBRTC)
+#include "LibWebRTCAudioFormat.h"
+#endif
 #include <Accelerate/Accelerate.h>
 #include <pal/cf/CoreAudioExtras.h>
 #include <pal/spi/cocoa/AudioToolboxSPI.h>
@@ -47,6 +50,17 @@
 #include <pal/cf/CoreMediaSoftLink.h>
 
 namespace WebCore {
+
+#if USE(LIBWEBRTC)
+static_assert(maxAudioRendererSampleRate == LibWebRTCAudioFormat::sampleRate, "AudioUnit input rate must be capped at the libwebrtc source rate");
+#endif
+
+double clampedAudioRendererSampleRate(double deviceSampleRate)
+{
+    if (deviceSampleRate > 0 && deviceSampleRate < maxAudioRendererSampleRate)
+        return deviceSampleRate;
+    return maxAudioRendererSampleRate;
+}
 
 class LocalAudioMediaStreamTrackRendererInternalUnit final : public AudioMediaStreamTrackRendererInternalUnit, public RefCounted<LocalAudioMediaStreamTrackRendererInternalUnit>  {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(LocalAudioMediaStreamTrackRendererInternalUnit);
@@ -232,7 +246,7 @@ void LocalAudioMediaStreamTrackRendererInternalUnit::createAudioUnitIfNeeded()
             return;
         }
 
-        outputDescription.mSampleRate = AudioSession::singleton().sampleRate();
+        outputDescription.mSampleRate = clampedAudioRendererSampleRate(AudioSession::singleton().sampleRate());
         m_outputDescription = outputDescription;
     }
     error = PAL::AudioUnitSetProperty(remoteIOUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &m_outputDescription->streamDescription(), sizeof(m_outputDescription->streamDescription()));

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h
@@ -62,6 +62,9 @@ public:
     virtual void deleteUnitForTesting() { }
 };
 
+constexpr double maxAudioRendererSampleRate = 48000;
+WEBCORE_EXPORT double clampedAudioRendererSampleRate(double deviceSampleRate);
+
 }
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Tools/TestWebKitAPI/PlatformCocoa.cmake
+++ b/Tools/TestWebKitAPI/PlatformCocoa.cmake
@@ -173,6 +173,7 @@ list(APPEND TestWebCore_SOURCES
     Tests/WebCore/YouTubePluginReplacement.cpp
 
     Tests/WebCore/cocoa/AttributedStringFontCache.mm
+    Tests/WebCore/cocoa/AudioMediaStreamTrackRendererInternalUnitCocoa.mm
     Tests/WebCore/cocoa/AudioStreamDescriptionCocoa.mm
     Tests/WebCore/cocoa/AudioVideoRendererAVFObjCTests.mm
     Tests/WebCore/cocoa/BifurcatedGraphicsContextTestsCG.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -730,6 +730,7 @@
 				WebCore/CBORValueTest.cpp,
 				WebCore/CBORWriterTest.cpp,
 				WebCore/cocoa/AttributedStringFontCache.mm,
+				WebCore/cocoa/AudioMediaStreamTrackRendererInternalUnitCocoa.mm,
 				WebCore/cocoa/AudioStreamDescriptionCocoa.mm,
 				WebCore/cocoa/AudioVideoRendererAVFObjCTests.mm,
 				WebCore/cocoa/AVFoundationSoftLinkTest.mm,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/AudioMediaStreamTrackRendererInternalUnitCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/AudioMediaStreamTrackRendererInternalUnitCocoa.mm
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
+
+#import "Helpers/Test.h"
+#import <WebCore/AudioMediaStreamTrackRendererInternalUnit.h>
+
+namespace TestWebKitAPI {
+
+TEST(AudioMediaStreamTrackRendererInternalUnit, ClampsHighDeviceSampleRate)
+{
+    EXPECT_EQ(WebCore::clampedAudioRendererSampleRate(768000), 48000.0);
+    EXPECT_EQ(WebCore::clampedAudioRendererSampleRate(384000), 48000.0);
+    EXPECT_EQ(WebCore::clampedAudioRendererSampleRate(96000), 48000.0);
+    EXPECT_EQ(WebCore::clampedAudioRendererSampleRate(48001), 48000.0);
+}
+
+TEST(AudioMediaStreamTrackRendererInternalUnit, PreservesSupportedDeviceSampleRate)
+{
+    EXPECT_EQ(WebCore::clampedAudioRendererSampleRate(48000), 48000.0);
+    EXPECT_EQ(WebCore::clampedAudioRendererSampleRate(44100), 44100.0);
+    EXPECT_EQ(WebCore::clampedAudioRendererSampleRate(22050), 22050.0);
+}
+
+TEST(AudioMediaStreamTrackRendererInternalUnit, FallsBackOnInvalidDeviceSampleRate)
+{
+    EXPECT_EQ(WebCore::clampedAudioRendererSampleRate(0), 48000.0);
+    EXPECT_EQ(WebCore::clampedAudioRendererSampleRate(-1), 48000.0);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)


### PR DESCRIPTION
#### bffdc0697fe76942cd9dc037dfc8ccbf1b5e22dd
<pre>
WebRTC remote audio is silent when the output device runs at a very high sample rate (e.g. 768 kHz USB DAC)
<a href="https://bugs.webkit.org/show_bug.cgi?id=308551">https://bugs.webkit.org/show_bug.cgi?id=308551</a>
<a href="https://rdar.apple.com/171619875">rdar://171619875</a>

Reviewed by NOBODY (OOPS!).

The remote-audio renderer configured its AudioUnit input scope (and, via
retrieveFormatDescription(), the AudioSampleDataSource output format) using the
output device&apos;s raw nominal sample rate. libwebrtc always delivers remote WebRTC
audio at a fixed 48 kHz, so when the default device runs at a very high rate such
as 768 kHz this forced a 16:1 resample. That conversion fails to initialize, the
AudioUnit is disposed, and remote participant audio is silent. Non-WebRTC audio
is unaffected because it does not go through this renderer.

Cap the AudioUnit input rate at the 48 kHz source rate and let CoreAudio&apos;s HAL
perform the final upsample to the device&apos;s native rate, which is the same path
non-WebRTC audio already uses successfully. Only the high end is clamped, so
devices running at or below 48 kHz keep the existing, well-tested conversion.

* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h:
(WebCore::clampedAudioRendererSampleRate): Declare helper and the
maxAudioRendererSampleRate invariant.
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp:
(WebCore::clampedAudioRendererSampleRate): Clamp the device rate to the libwebrtc
source rate, with a static_assert tying the cap to LibWebRTCAudioFormat::sampleRate.
(WebCore::LocalAudioMediaStreamTrackRendererInternalUnit::createAudioUnitIfNeeded):
Use the clamped rate for the AudioUnit input format.

Test: Tools/TestWebKitAPI/Tests/WebCore/cocoa/AudioMediaStreamTrackRendererInternalUnitCocoa.mm

* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp:
(WebCore::clampedAudioRendererSampleRate): Clamp the device rate to the libwebrtc
source rate, with a static_assert tying the cap to LibWebRTCAudioFormat::sampleRate.
(WebCore::LocalAudioMediaStreamTrackRendererInternalUnit::createAudioUnitIfNeeded):
Use the clamped rate for the AudioUnit input format.
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h:
(WebCore::clampedAudioRendererSampleRate): Declare helper and the maxAudioRendererSampleRate invariant.
* Tools/TestWebKitAPI/PlatformCocoa.cmake:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/AudioMediaStreamTrackRendererInternalUnitCocoa.mm: Added.
(TestWebKitAPI::TEST(AudioMediaStreamTrackRendererInternalUnit, ClampsHighDeviceSampleRate)):
(TestWebKitAPI::TEST(AudioMediaStreamTrackRendererInternalUnit, PreservesSupportedDeviceSampleRate)):
(TestWebKitAPI::TEST(AudioMediaStreamTrackRendererInternalUnit, FallsBackOnInvalidDeviceSampleRate)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bffdc0697fe76942cd9dc037dfc8ccbf1b5e22dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195635 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150125 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187171 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58948 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144811 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100409 "Exiting early after 60 failures. 60 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165406 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125104 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47227 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45289 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157594 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44976 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6689 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51877 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49669 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197584 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58885 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154323 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59594 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153974 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48468 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131944 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128729 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58072 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19997 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57444 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57687 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57511 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->