### PR TITLE
[JSC] Add Toom-3 multiplication to `JSBigInt`

### DIFF
--- a/JSTests/microbenchmarks/bigint-mul-very-large.js
+++ b/JSTests/microbenchmarks/bigint-mul-very-large.js
@@ -1,0 +1,37 @@
+function test(xs, ys, count) {
+    let acc = 0n;
+    for (let i = 0; i < count; i++) {
+        const j = i & 7;
+        acc ^= xs[j] * ys[j];
+    }
+    return acc;
+}
+noInline(test);
+
+const DIGITS = 4000;
+
+const xs = [];
+const ys = [];
+let mix = 0x9e3779b97f4a7c15n;
+function combine(parts, begin, end) {
+    if (end - begin === 1)
+        return parts[begin];
+    const middle = (begin + end) >> 1;
+    return combine(parts, begin, middle) | (combine(parts, middle, end) << BigInt(64 * (middle - begin)));
+}
+function next() {
+    const parts = [];
+    for (let digit = 0; digit < DIGITS; digit++) {
+        mix = (mix * 6364136223846793005n + 1442695040888963407n) & 0xffffffffffffffffn;
+        parts.push(mix);
+    }
+    return combine(parts, 0, DIGITS) | (1n << BigInt(64 * DIGITS - 1));
+}
+for (let i = 0; i < 8; i++) {
+    xs.push(next());
+    ys.push(next());
+}
+
+let result = 0n;
+for (let i = 0; i < 10; i++)
+    result = test(xs, ys, 30);

--- a/JSTests/stress/bigint-multiply-toom3.js
+++ b/JSTests/stress/bigint-multiply-toom3.js
@@ -1,0 +1,88 @@
+//@ slow!
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error(`${message}: expected ${expected.toString(16).slice(0, 40)}... but got ${actual.toString(16).slice(0, 40)}...`);
+}
+
+function refMul(a, b) {
+    let result = 0n;
+    let shift = 0n;
+    while (b > 0n) {
+        const chunk = b & 0xffffffffn;
+        if (chunk)
+            result += (a * chunk) << shift;
+        b >>= 32n;
+        shift += 32n;
+    }
+    return result;
+}
+
+function combine(parts, begin, end) {
+    if (end - begin === 1)
+        return parts[begin];
+    const middle = (begin + end) >> 1;
+    return (combine(parts, begin, middle) << BigInt(64 * (end - middle))) | combine(parts, middle, end);
+}
+
+function makeOperand(digits, seed, shape) {
+    const parts = new Array(digits);
+    let mix = BigInt.asUintN(64, 0x9e3779b97f4a7c15n * BigInt(seed + 1));
+    for (let i = 0; i < digits; i++) {
+        mix = BigInt.asUintN(64, mix * 6364136223846793005n + 1442695040888963407n);
+        switch (shape) {
+        case "random":
+            parts[i] = mix;
+            break;
+        case "ones":
+            parts[i] = 0xffffffffffffffffn;
+            break;
+        case "sparse":
+            parts[i] = (i * 7 + seed) % 5 === 0 ? mix : 0n;
+            break;
+        case "halves":
+            parts[i] = i < digits / 2 ? 0n : mix;
+            break;
+        }
+    }
+    if (shape !== "ones")
+        parts[0] = (parts[0] & 0x0fffffffffffffffn) | 0x8000000000000000n;
+    return combine(parts, 0, digits);
+}
+
+function check(x, y, message) {
+    const p = x * y;
+    shouldBe(y * x, p, `${message} commutes`);
+    shouldBe(p / y, x, `${message} quotient`);
+    shouldBe(p % y, 0n, `${message} remainder`);
+    shouldBe((-x) * y, -p, `${message} sign`);
+    return p;
+}
+
+const shapes = ["random", "ones", "sparse", "halves"];
+
+for (const size of [480, 507, 508, 509, 510, 512, 700, 1000, 1525]) {
+    for (const shape of shapes) {
+        const x = makeOperand(size, size, shape);
+        const y = makeOperand(size, size * 3 + 1, shapes[(shapes.indexOf(shape) + 1) % shapes.length]);
+        const p = check(x, y, `${size} x ${size} ${shape}`);
+        if (shape === "random" && size < 800)
+            shouldBe(p, refMul(x, y), `${size} x ${size} reference`);
+        shouldBe((x + 1n) * (x + 1n) - x * x, 2n * x + 1n, `${size} square ${shape}`);
+    }
+}
+
+for (const [larger, smaller] of [[509, 508], [845, 508], [846, 508], [847, 508], [1016, 508], [1017, 508], [1524, 508], [1525, 508], [1500, 700], [2000, 700], [2000, 1000], [4000, 513], [4001, 600]]) {
+    for (const shape of shapes) {
+        const x = makeOperand(larger, larger + smaller, shape);
+        const y = makeOperand(smaller, larger * smaller, shapes[(shapes.indexOf(shape) + 2) % shapes.length]);
+        const p = check(x, y, `${larger} x ${smaller} ${shape}`);
+        if (shape === "random" && larger <= 1000)
+            shouldBe(p, refMul(x, y), `${larger} x ${smaller} reference`);
+    }
+}
+
+for (const size of [507, 508, 509, 1000]) {
+    const ones = (1n << BigInt(64 * size)) - 1n;
+    shouldBe(ones * ones, (ones << BigInt(64 * size)) - ones, `${size} all ones squared`);
+    shouldBe((ones + 2n) * ones, (ones << BigInt(64 * size)) + ones, `${size} power of two plus one times all ones`);
+}

--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -1382,6 +1382,301 @@ std::span<JSBigInt::Digit> JSBigInt::multiplyKaratsuba(std::span<const Digit> x,
     return z;
 }
 
+// Toom-3 multiplication, ported from V8 [1], which follows Wikipedia's description [2].
+//
+// [1]: https://source.chromium.org/chromium/chromium/src/+/main:v8/src/bigint/mul-toom.cc
+// [2]: https://en.wikipedia.org/wiki/Toom%E2%80%93Cook_multiplication
+static constexpr size_t toom3Threshold = 508;
+
+// Z := X + Y, zero-padding Z. Z may alias either operand.
+static void addZeroPadded(std::span<JSBigInt::Digit> z, std::span<const JSBigInt::Digit> x, std::span<const JSBigInt::Digit> y)
+{
+    using Digit = JSBigInt::Digit;
+    if (x.size() < y.size())
+        std::swap(x, y);
+    RELEASE_ASSERT(x.size() >= y.size());
+    RELEASE_ASSERT(z.size() >= x.size());
+    Digit carry = 0;
+    size_t i = 0;
+    for (; i < y.size(); i++) {
+        Digit newCarry = 0;
+        z[i] = JSBigInt::digitAdd3(x[i], y[i], carry, newCarry);
+        carry = newCarry;
+    }
+    for (; i < x.size(); i++) {
+        Digit newCarry = 0;
+        z[i] = JSBigInt::digitAdd(x[i], carry, newCarry);
+        carry = newCarry;
+    }
+    for (; i < z.size(); i++) {
+        z[i] = carry;
+        carry = 0;
+    }
+}
+
+// Z := X - Y for normalized X >= Y, zero-padding Z. Z may alias either operand.
+static void subZeroPadded(std::span<JSBigInt::Digit> z, std::span<const JSBigInt::Digit> x, std::span<const JSBigInt::Digit> y)
+{
+    using Digit = JSBigInt::Digit;
+    RELEASE_ASSERT(x.size() >= y.size());
+    RELEASE_ASSERT(z.size() >= x.size());
+    Digit borrow = 0;
+    size_t i = 0;
+    for (; i < y.size(); i++) {
+        Digit newBorrow = 0;
+        z[i] = JSBigInt::digitSub2(x[i], y[i], borrow, newBorrow);
+        borrow = newBorrow;
+    }
+    for (; i < x.size(); i++) {
+        Digit newBorrow = 0;
+        z[i] = JSBigInt::digitSub(x[i], borrow, newBorrow);
+        borrow = newBorrow;
+    }
+    ASSERT(!borrow);
+    for (; i < z.size(); i++)
+        z[i] = 0;
+}
+
+static bool lessThanNormalized(std::span<const JSBigInt::Digit> x, std::span<const JSBigInt::Digit> y)
+{
+    if (x.size() != y.size())
+        return x.size() < y.size();
+    for (size_t i = x.size(); i-- > 0;) {
+        if (x[i] != y[i])
+            return x[i] < y[i];
+    }
+    return false;
+}
+
+// Z := X + Y on sign-magnitude values, returning the sign of Z. Z may alias either operand.
+static bool addSigned(std::span<JSBigInt::Digit> z, std::span<const JSBigInt::Digit> x, bool xNegative, std::span<const JSBigInt::Digit> y, bool yNegative)
+{
+    if (xNegative == yNegative) {
+        addZeroPadded(z, x, y);
+        return xNegative;
+    }
+    x = normalize(x);
+    y = normalize(y);
+    if (!lessThanNormalized(x, y)) {
+        subZeroPadded(z, x, y);
+        return xNegative;
+    }
+    subZeroPadded(z, y, x);
+    return !xNegative;
+}
+
+// Z := X - Y on sign-magnitude values, returning the sign of Z. Z may alias either operand.
+static bool subtractSigned(std::span<JSBigInt::Digit> z, std::span<const JSBigInt::Digit> x, bool xNegative, std::span<const JSBigInt::Digit> y, bool yNegative)
+{
+    return addSigned(z, x, xNegative, y, !yNegative);
+}
+
+static void timesTwo(std::span<JSBigInt::Digit> x)
+{
+    JSBigInt::Digit carry = 0;
+    for (auto& digit : x) {
+        JSBigInt::Digit d = digit;
+        digit = (d << 1) | carry;
+        carry = d >> (JSBigInt::digitBits - 1);
+    }
+}
+
+static void divideByTwo(std::span<JSBigInt::Digit> x)
+{
+    JSBigInt::Digit carry = 0;
+    for (auto& xi : x | std::views::reverse) {
+        JSBigInt::Digit d = xi;
+        xi = (d >> 1) | carry;
+        carry = d << (JSBigInt::digitBits - 1);
+    }
+}
+
+static void divideByThree(std::span<JSBigInt::Digit> x)
+{
+    using Digit = JSBigInt::Digit;
+    constexpr unsigned halfDigitBits = JSBigInt::halfDigitBits;
+    constexpr Digit halfDigitMask = JSBigInt::halfDigitMask;
+    Digit remainder = 0;
+    for (auto& xi : x | std::views::reverse) {
+        Digit d = xi;
+        Digit upper = (remainder << halfDigitBits) | (d >> halfDigitBits);
+        Digit upperResult = upper / 3;
+        remainder = upper - 3 * upperResult;
+        Digit lower = (remainder << halfDigitBits) | (d & halfDigitMask);
+        Digit lowerResult = lower / 3;
+        remainder = lower - 3 * lowerResult;
+        xi = (upperResult << halfDigitBits) | lowerResult;
+    }
+}
+
+static size_t toom3ScratchLength(size_t longerOperandLength)
+{
+    size_t i = (longerOperandLength + 2) / 3;
+    size_t pLength = i + 1;
+    size_t rLength = 2 * pLength;
+    return 4 * rLength;
+}
+
+void JSBigInt::toom3Main(std::span<Digit> z, std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> scratch)
+{
+    ASSERT(z.size() >= x.size() + y.size());
+    ASSERT(scratch.size() >= toom3ScratchLength(std::max(x.size(), y.size())));
+    // Phase 1: Splitting.
+    size_t i = (std::max(x.size(), y.size()) + 2) / 3;
+    auto x0 = clampedSubspan(x, 0, i);
+    auto x1 = clampedSubspan(x, i, i);
+    auto x2 = clampedSubspan(x, 2 * i, i);
+    auto y0 = clampedSubspan(y, 0, i);
+    auto y1 = clampedSubspan(y, i, i);
+    auto y2 = clampedSubspan(y, 2 * i, i);
+
+    // Temporary storage.
+    size_t pLength = i + 1; // For all px, qx below.
+    size_t rLength = 2 * pLength; // For all r_x, Rx below.
+    // We will use the same variable names as the Wikipedia article, as much as C++ lets us: our
+    // "pm1" is their "p(-1)" etc. For consistency with other algorithms, we use X and Y where
+    // Wikipedia uses m and n.
+    // We will use and reuse the temporary storage as follows:
+    //
+    //   chunk                  | -------- time ----------->
+    //   [0 .. i]               |( po )( pm1 ) ( rm2  )
+    //   [i+1 .. rLength-1]     |( qo )( qm1 ) ( rm2  )
+    //   [rLength .. rLength+i] | (p1 ) ( pm2 ) (rinf)
+    //   [rLength+i+1 .. 2*rLength-1] | (q1 ) ( qm2 ) (rinf)
+    //   [2*rLength .. 3*rLength-1]   |      (   r1          )
+    //   [3*rLength .. 4*rLength-1]   |             (  rm1   )
+    //
+    // This requires interleaving phases 2 and 3 a bit: after computing r1 = p1 * q1, we can reuse
+    // p1's storage for pm2, and so on.
+    auto t = scratch.first(4 * rLength);
+    auto po = t.subspan(0, pLength);
+    auto qo = t.subspan(pLength, pLength);
+    auto p1 = t.subspan(rLength, pLength);
+    auto q1 = t.subspan(rLength + pLength, pLength);
+    auto r1 = t.subspan(2 * rLength, rLength);
+    auto rm1 = t.subspan(3 * rLength, rLength);
+
+    // We can also share the backing stores of Z, r0, R0.
+    auto r0 = z.first(rLength);
+
+    // Phase 2a: Evaluation, steps 0, 1, m1.
+    // po = X0 + X2
+    addZeroPadded(po, x0, x2);
+    // p0 = X0
+    // p1 = po + X1
+    addZeroPadded(p1, po, x1);
+    // pm1 = po - X1
+    auto pm1 = po;
+    bool pm1Sign = subtractSigned(pm1, po, /* poSign */ false, x1, /* x1Sign */ false);
+
+    // qo = Y0 + Y2
+    addZeroPadded(qo, y0, y2);
+    // q0 = Y0
+    // q1 = qo + Y1
+    addZeroPadded(q1, qo, y1);
+    // qm1 = qo - Y1
+    auto qm1 = qo;
+    bool qm1Sign = subtractSigned(qm1, qo, /* qoSign */ false, y1, /* y1Sign */ false);
+
+    // Phase 3a: Pointwise multiplication, steps 0, 1, m1.
+    multiplyZeroPadded(x0, y0, r0);
+    multiplyZeroPadded(p1, q1, r1);
+    multiplyZeroPadded(pm1, qm1, rm1);
+    bool rm1Sign = pm1Sign != qm1Sign;
+
+    // Phase 2b: Evaluation, steps m2 and inf.
+    // pm2 = (pm1 + X2) * 2 - X0
+    auto pm2 = p1;
+    bool pm2Sign = addSigned(pm2, pm1, pm1Sign, x2, /* x2Sign */ false);
+    timesTwo(pm2);
+    pm2Sign = subtractSigned(pm2, pm2, pm2Sign, x0, /* x0Sign */ false);
+    // pinf = X2
+
+    // qm2 = (qm1 + Y2) * 2 - Y0
+    auto qm2 = q1;
+    bool qm2Sign = addSigned(qm2, qm1, qm1Sign, y2, /* y2Sign */ false);
+    timesTwo(qm2);
+    qm2Sign = subtractSigned(qm2, qm2, qm2Sign, y0, /* y0Sign */ false);
+    // qinf = Y2
+
+    // Phase 3b: Pointwise multiplication, steps m2 and inf.
+    auto rm2 = t.first(rLength);
+    multiplyZeroPadded(pm2, qm2, rm2);
+    bool rm2Sign = pm2Sign != qm2Sign;
+
+    auto rinf = t.subspan(rLength, rLength);
+    multiplyZeroPadded(x2, y2, rinf);
+
+    // Phase 4: Interpolation.
+    auto R0 = r0;
+    auto R4 = rinf;
+    // R3 <- (rm2 - r1) / 3
+    auto R3 = rm2;
+    bool R3Sign = subtractSigned(R3, rm2, rm2Sign, r1, /* r1Sign */ false);
+    divideByThree(R3);
+    // R1 <- (r1 - rm1) / 2
+    auto R1 = r1;
+    bool R1Sign = subtractSigned(R1, r1, /* r1Sign */ false, rm1, rm1Sign);
+    divideByTwo(R1);
+    // R2 <- rm1 - r0
+    auto R2 = rm1;
+    bool R2Sign = subtractSigned(R2, rm1, rm1Sign, R0, /* R0Sign */ false);
+    // R3 <- (R2 - R3) / 2 + 2 * rinf
+    R3Sign = subtractSigned(R3, R2, R2Sign, R3, R3Sign);
+    divideByTwo(R3);
+    R3Sign = addSigned(R3, R3, R3Sign, rinf, /* rinfSign */ false);
+    R3Sign = addSigned(R3, R3, R3Sign, rinf, /* rinfSign */ false);
+    // R2 <- R2 + R1 - R4
+    R2Sign = addSigned(R2, R2, R2Sign, R1, R1Sign);
+    R2Sign = subtractSigned(R2, R2, R2Sign, R4, /* R4Sign */ false);
+    // R1 <- R1 - R3
+    R1Sign = subtractSigned(R1, R1, R1Sign, R3, R3Sign);
+
+    ASSERT(!R1Sign || normalize(R1).empty());
+    ASSERT(!R2Sign || normalize(R2).empty());
+    ASSERT(!R3Sign || normalize(R3).empty());
+
+    // Phase 5: Recomposition. R0 is already in place. Overflow can't happen.
+    zeroSpan(z.subspan(R0.size()));
+    inplaceAddAndPropagate(z.subspan(i), R1);
+    inplaceAddAndPropagate(z.subspan(2 * i), R2);
+    inplaceAddAndPropagate(z.subspan(3 * i), R3);
+    inplaceAddAndPropagate(z.subspan(4 * i), R4);
+}
+
+std::span<JSBigInt::Digit> JSBigInt::multiplyToom3(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result)
+{
+    ASSERT(x.size() >= y.size());
+    ASSERT(y.size() >= toom3Threshold);
+    RELEASE_ASSERT(result.size() >= x.size() + y.size());
+    auto z = result.first(x.size() + y.size());
+    // toom3Main splits both operands into thirds of the larger one, so a moderately longer x costs
+    // the same five products as a balanced pair and beats chunking x into y-sized pieces. Beyond
+    // that ratio the padding wastes more than the chunking does.
+    if (x.size() * 3 <= y.size() * 5) {
+        Vector<Digit> scratch(toom3ScratchLength(x.size()));
+        toom3Main(z, x, y, scratch.mutableSpan());
+        return z;
+    }
+    size_t k = y.size();
+    Vector<Digit> scratch(toom3ScratchLength(k));
+    toom3Main(z, x.first(k), y, scratch.mutableSpan());
+    if (k < x.size()) {
+        Vector<Digit> chunkProduct(2 * k);
+        auto product = chunkProduct.mutableSpan();
+        for (size_t i = k; i < x.size(); i += k) {
+            auto xi = clampedSubspan(x, i, k);
+            if (xi.size() < k) {
+                // The last chunk is shorter, so let the size dispatch pick its algorithm.
+                multiplyZeroPadded(xi, y, product);
+            } else
+                toom3Main(product, xi, y, scratch.mutableSpan());
+            inplaceAddAndPropagate(z.subspan(i), product);
+        }
+    }
+    return z;
+}
+
 ALWAYS_INLINE std::span<JSBigInt::Digit> JSBigInt::multiplyDigitsInto(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result)
 {
     ASSERT(!y.empty());
@@ -1416,6 +1711,8 @@ ALWAYS_INLINE std::span<JSBigInt::Digit> JSBigInt::multiplyDigitsInto(std::span<
     }
     if (y.size() == 1)
         return multiplySingle(x, y[0], result);
+    if (y.size() >= toom3Threshold)
+        return multiplyToom3(x, y, result);
     if (y.size() >= karatsubaThreshold)
         return multiplyKaratsuba(x, y, result);
     if (shouldUseComba(x.size(), y.size()))

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -549,6 +549,8 @@ private:
     static void karatsubaChunk(std::span<Digit> z, std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> scratch);
     static void karatsubaMain(std::span<Digit> z, std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> scratch, size_t n);
     static void karatsubaAbsoluteDifference(std::span<Digit> result, std::span<const Digit> x, std::span<const Digit> y, bool& negative);
+    static std::span<Digit> multiplyToom3(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result);
+    static void toom3Main(std::span<Digit> z, std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> scratch);
 
     static std::span<Digit> NODELETE divideSingle(std::span<Digit> q, Digit& remainder, std::span<const Digit>, Digit);
     static std::tuple<std::span<Digit>, std::span<Digit>> divideSchoolbook(std::span<Digit> q, std::span<Digit> r, std::span<const Digit>, std::span<const Digit>);


### PR DESCRIPTION
#### df94b6ccbb5363ad11e6a61a6741ddda0c119bd3
<pre>
[JSC] Add Toom-3 multiplication to `JSBigInt`
<a href="https://bugs.webkit.org/show_bug.cgi?id=323587">https://bugs.webkit.org/show_bug.cgi?id=323587</a>

Reviewed by Yusuke Suzuki.

Since 320495@main, JSBigInt multiplies large operands with Karatsuba, whose
O(n^1.58) cost still dominates at a few thousand digits: 4000 x 4000 digits
takes 1.08 ms. Add Toom-3 multiplication for products whose smaller operand has
at least 508 digits, which brings the growth to O(n^1.46). This is a port of
V8&apos;s implementation [1], which follows the description on Wikipedia [2].

Toom-3 replaces one product with five products of thirds, and Karatsuba
computes those. Karatsuba halves its operands until they are shorter than 44
digits, so the threshold follows from how often it halves a third. Up to 507
digits, a third has at most 169 digits and is halved twice. The five products
then take as many base-case digit products as Karatsuba does on the whole
operands, and the additions of Toom-3 make it slower. From 508 digits, a third
has at least 170 digits, which Karatsuba rounds up to 176 and halves three
times. That saves about a quarter of the digit products.

An x up to 5/3 the length of y goes to Toom-3 as is, and a longer x is
multiplied in y-sized chunks.

Time per product (us, 64-bit digits, Apple M4, best of 3 x 7 rounds):

digits          Before      After

480 x 480       34.519     34.486
507 x 507       39.201     39.058
508 x 508       39.174     37.668
600 x 600       51.274     48.453
700 x 700       62.320     62.429
1000 x 1000    117.663    111.336
2000 x 2000    355.545    294.577
4000 x 4000   1075.819    860.870
8000 x 8000   3236.771   2493.739
2000 x 508     156.399    152.821
2000 x 1000    235.766    222.031
10000 x 1000  1172.006   1105.562
12000 x 4000  3250.003   2548.486

                                   Baseline                  Patched

bigint-mul-very-large         330.2722+-1.1206     ^    263.5797+-1.2185        ^ definitely 1.2530x faster
bigint-mul-large              131.8938+-1.9921          131.1108+-1.3070
bigint-mul-large-unequal      280.3015+-2.7116          279.0286+-1.7460

[1]: <a href="https://source.chromium.org/chromium/chromium/src/+/main">https://source.chromium.org/chromium/chromium/src/+/main</a>:v8/src/bigint/mul-toom.cc
[2]: <a href="https://en.wikipedia.org/wiki/Toom%E2%80%93Cook_multiplication">https://en.wikipedia.org/wiki/Toom%E2%80%93Cook_multiplication</a>

Tests: JSTests/microbenchmarks/bigint-mul-very-large.js
       JSTests/stress/bigint-multiply-toom.js

Canonical link: <a href="https://commits.webkit.org/321013@main">https://commits.webkit.org/321013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97189e83c56cdd2100c615812470ed302077aa6c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196002 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150396 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145107 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100601 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165677 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125402 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47518 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45559 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7298 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14184 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157878 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45252 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7065 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46942 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49966 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197968 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59262 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154643 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41632 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59970 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41857 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154295 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48760 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132316 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129245 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58437 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20274 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57815 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58051 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57878 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->