### PR TITLE
Geolocation::Watchers should not maintain a redundant reverse notifier→id map

### DIFF
--- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008, 2009, 2010, 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Torch Mobile, Inc.
  * Copyright 2010, The Android Open Source Project
  *
@@ -88,11 +88,7 @@ static Ref<GeolocationPositionError> createGeolocationPositionError(GeolocationE
 bool Geolocation::Watchers::add(int id, Ref<GeoNotifier>&& notifier)
 {
     ASSERT(id > 0);
-
-    if (!m_idToNotifierMap.add(id, notifier).isNewEntry)
-        return false;
-    m_notifierToIdMap.set(WTF::move(notifier), id);
-    return true;
+    return m_idToNotifierMap.add(id, WTF::move(notifier)).isNewEntry;
 }
 
 GeoNotifier* Geolocation::Watchers::find(int id)
@@ -104,25 +100,28 @@ GeoNotifier* Geolocation::Watchers::find(int id)
 void Geolocation::Watchers::remove(int id)
 {
     ASSERT(id > 0);
-    if (RefPtr notifier = m_idToNotifierMap.take(id))
-        m_notifierToIdMap.remove(notifier.get());
+    m_idToNotifierMap.remove(id);
 }
 
 void Geolocation::Watchers::remove(GeoNotifier* notifier)
 {
-    if (auto identifier = m_notifierToIdMap.take(notifier))
-        m_idToNotifierMap.remove(identifier);
+    m_idToNotifierMap.removeIf([&](auto& entry) {
+        return entry.value.ptr() == notifier;
+    });
 }
 
 bool Geolocation::Watchers::contains(GeoNotifier* notifier) const
 {
-    return m_notifierToIdMap.contains(notifier);
+    for (auto& candidate : m_idToNotifierMap.values()) {
+        if (candidate.ptr() == notifier)
+            return true;
+    }
+    return false;
 }
 
 void Geolocation::Watchers::clear()
 {
     m_idToNotifierMap.clear();
-    m_notifierToIdMap.clear();
 }
 
 bool Geolocation::Watchers::isEmpty() const

--- a/Source/WebCore/Modules/geolocation/Geolocation.h
+++ b/Source/WebCore/Modules/geolocation/Geolocation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008, 2009, 2010, 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2026 Apple Inc. All rights reserved.
  * Copyright 2010, The Android Open Source Project
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,7 +39,6 @@
 #include <WebCore/ScriptWrappable.h>
 #include <WebCore/Timer.h>
 #include <wtf/CheckedRef.h>
-#include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/OrderedHashMap.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
@@ -116,9 +115,7 @@ private:
         void getNotifiersVector(GeoNotifierVector&) const;
     private:
         typedef OrderedHashMap<int, Ref<GeoNotifier>> IdToNotifierMap;
-        typedef HashMap<Ref<GeoNotifier>, int> NotifierToIdMap;
         IdToNotifierMap m_idToNotifierMap;
-        NotifierToIdMap m_notifierToIdMap;
     };
 
     bool hasListeners() const { return !m_oneShots.isEmpty() || !m_watchers.isEmpty(); }


### PR DESCRIPTION
#### e0c66a032d8428e0e2165e6db21e0ac6fceb65d9
<pre>
Geolocation::Watchers should not maintain a redundant reverse notifier→id map
<a href="https://bugs.webkit.org/show_bug.cgi?id=323589">https://bugs.webkit.org/show_bug.cgi?id=323589</a>
<a href="https://rdar.apple.com/186827644">rdar://186827644</a>

Reviewed by Chris Dumez.

Geolocation::Watchers kept two maps in sync by hand: an
OrderedHashMap&lt;int, Ref&lt;GeoNotifier&gt;&gt; for id→notifier lookup and a
HashMap&lt;Ref&lt;GeoNotifier&gt;, int&gt; whose only purpose was the reverse
notifier→id lookup used by remove(GeoNotifier*) and contains(GeoNotifier*).

The reverse map is unnecessary. The number of watchers on a document is
tiny (typically zero to a few), so the two by-notifier operations can
iterate the forward map instead of paying for a second hash map and the
manual bookkeeping to keep it consistent on every add/remove/clear.

Remove m_notifierToIdMap. remove(GeoNotifier*) now uses
OrderedHashMap::removeIf() and contains(GeoNotifier*) iterates values().

No behavior change.

* Source/WebCore/Modules/geolocation/Geolocation.cpp:
(WebCore::Geolocation::Watchers::add):
(WebCore::Geolocation::Watchers::remove):
(WebCore::Geolocation::Watchers::contains const):
(WebCore::Geolocation::Watchers::clear):
* Source/WebCore/Modules/geolocation/Geolocation.h:

Canonical link: <a href="https://commits.webkit.org/321026@main">https://commits.webkit.org/321026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/970d2a57e335ff71625dc2cc3509cd037a5cb088

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195639 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150128 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ee4e1bd-b250-4373-bf28-010147741a68) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58952 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144814 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100411 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/abb5d7b2-f478-4bd6-975b-fac913a72254) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165407 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125107 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e54ab2f-b594-4136-bfce-45936c7dd2bc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47230 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45292 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157597 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/44977 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6693 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51881 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197588 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58889 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154326 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41648 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59598 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153977 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48471 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131917 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128734 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58076 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/19998 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57448 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57691 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57515 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->