### PR TITLE
Cherry-pick 320490@main (f42e74f7147c). https://bugs.webkit.org/show_bug.cgi?id=323260

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -883,8 +883,6 @@ imported/w3c/web-platform-tests/css/css-backgrounds/background-size-043.html [ P
 imported/w3c/web-platform-tests/css/css-backgrounds/background-size-044.html [ Pass ]
 
 imported/w3c/web-platform-tests/css/css-animations/nested-scale-animations.html [ Pass ]
-imported/w3c/web-platform-tests/css/css-animations/transform-animation-under-large-scale.html [ Pass ]
-imported/w3c/web-platform-tests/css/css-transforms/3d-scene-with-iframe-001.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-transforms/transform3d-matrix3d-001.html [ Pass ]
 imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-combined-001.html [ Pass ]
 
@@ -1314,7 +1312,6 @@ imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-ro
 webkit.org/b/314309 imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-edge-behavior.html [ ImageOnlyFailure ]
 webkit.org/b/314310 imported/w3c/web-platform-tests/css/filter-effects/drop-shadow-currentcolor-dynamic-003.html [ ImageOnlyFailure ]
 webkit.org/b/314312 media/media-sources-selection.html [ ImageOnlyFailure ]
-webkit.org/b/314313 platform/glib/fast/layers/fractional-transforms.html [ ImageOnlyFailure ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Compositing tests

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
@@ -33,6 +33,7 @@
 #include "PlatformDisplay.h"
 #include "SkiaDamageRegion.h"
 #include "SkiaPaintingEngine.h"
+#include "SkiaUtilities.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
 #include <skia/gpu/ganesh/GrBackendSurface.h>
@@ -73,8 +74,11 @@ void SkiaBackingStore::processPendingTileUpdates()
     if (!m_hasPendingTileUpdates)
         return;
 
-    for (auto& tile : m_tiles.values())
+    m_hasPaddedTiles = false;
+    for (auto& tile : m_tiles.values()) {
         tile.processPendingUpdateIfNeeded();
+        m_hasPaddedTiles |= tile.isPadded();
+    }
 
     m_hasPendingTileUpdates = false;
 }
@@ -82,6 +86,17 @@ void SkiaBackingStore::processPendingTileUpdates()
 static inline bool allTileEdgesExposed(const FloatRect& totalRect, const FloatRect& tileRect)
 {
     return !tileRect.x() && !tileRect.y() && tileRect.width() + tileRect.x() >= totalRect.width() && tileRect.height() + tileRect.y() >= totalRect.height();
+}
+
+SkSamplingOptions SkiaBackingStore::samplingOptionsForMatrix(const SkMatrix& deviceMatrix) const
+{
+    if (!deviceMatrix.isScaleTranslate())
+        return SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone);
+
+    // Tiles are painted at m_scale device pixels per layer pixel, remove that scale before determining the sampling options.
+    auto matrix = deviceMatrix;
+    matrix.preScale(1 / m_scale, 1 / m_scale);
+    return SkiaUtilities::samplingOptionsForMatrix(matrix);
 }
 
 void SkiaBackingStore::paintToCanvas(SkCanvas& canvas, const SkPaint& paint, const SkiaDamageRegion* damageRegion)
@@ -96,7 +111,8 @@ void SkiaBackingStore::paintToCanvas(SkCanvas& canvas, const SkPaint& paint, con
     FloatRect layerRect = { { }, m_size };
 
     const auto ctm = canvas.getLocalToDeviceAs3x3();
-    const auto sampling = SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone);
+    const auto sampling = samplingOptionsForMatrix(ctm);
+    const auto constraint = requiresStrictSourceConstraint(sampling) ? SkCanvas::kStrict_SrcRectConstraint : SkCanvas::kFast_SrcRectConstraint;
     auto tilePaint = paint;
     for (auto& tile : m_tiles.values()) {
         if (canvas.quickReject(tile.rect()))
@@ -113,7 +129,7 @@ void SkiaBackingStore::paintToCanvas(SkCanvas& canvas, const SkPaint& paint, con
             continue;
 
         tilePaint.setAntiAlias(paint.isAntiAlias() && allTileEdgesExposed(layerRect, tile.rect()));
-        canvas.drawImageRect(image, tile.imageSourceRect(), tile.rect(), sampling, &tilePaint, SkCanvas::kFast_SrcRectConstraint);
+        canvas.drawImageRect(image, tile.imageSourceRect(), tile.rect(), sampling, &tilePaint, constraint);
     }
 }
 
@@ -314,6 +330,12 @@ SkRect SkiaBackingStore::Tile::imageSourceRect() const
     // one of m_surface or m_texture to be set, so this fallback is never taken in practice.
     ASSERT_NOT_REACHED();
     return SkRect::MakeEmpty();
+}
+
+bool SkiaBackingStore::Tile::isPadded() const
+{
+    // A surface snapshot is sized to the tile, so only a texture can be padded.
+    return m_texture && m_texture->size() != m_texture->allocatedSize();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
@@ -51,6 +51,9 @@ public:
     bool hasPendingTileUpdates() const { return m_hasPendingTileUpdates; }
     FloatSize size() const { return m_size; }
 
+    SkSamplingOptions samplingOptionsForMatrix(const SkMatrix&) const;
+    bool requiresStrictSourceConstraint(SkSamplingOptions sampling) const { return sampling.filter == SkFilterMode::kLinear && m_hasPaddedTiles; }
+
     void update(const FloatSize&, float scale, CoordinatedBackingStoreProxy::Update&&);
     void processPendingTileUpdates();
 
@@ -79,6 +82,7 @@ private:
 
         const FloatRect& rect() const LIFETIME_BOUND { return m_rect; }
         sk_sp<SkImage> image() const;
+        bool isPadded() const;
 
         // Logical region to sample from image() - smaller than the image for padded super-tiled textures.
         SkRect imageSourceRect() const;
@@ -105,6 +109,7 @@ private:
     FloatSize m_size;
     float m_scale { 1. };
     bool m_hasPendingTileUpdates { false };
+    bool m_hasPaddedTiles { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -809,7 +809,9 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
                 matrix.setScale(m_contentsTiling.size.width() / tileImage->width(), m_contentsTiling.size.height() / tileImage->height());
                 matrix.postTranslate(m_contentsRect.x() - m_contentsTiling.phase.width(), m_contentsRect.y() - m_contentsTiling.phase.height());
                 SkPaint paint = setupPaint();
-                paint.setShader(tileImage->makeShader(SkTileMode::kRepeat, SkTileMode::kRepeat, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), matrix));
+                // The shader matrix maps the tile image into layer space, so it needs to be taken into account here.
+                const auto sampling = SkiaUtilities::samplingOptionsForMatrix(SkMatrix::Concat(canvas.getLocalToDeviceAs3x3(), matrix));
+                paint.setShader(tileImage->makeShader(SkTileMode::kRepeat, SkTileMode::kRepeat, sampling, matrix));
                 drawRectRestricted(canvas, context.damageRegionOrNull(), SkRect(m_contentsRect), paint);
             }
         }
@@ -819,8 +821,10 @@ void SkiaCompositingLayer::paintContents(SkCanvas& canvas, PaintContext& context
                 if (rotationMatrix)
                     canvas.concat(*rotationMatrix);
                 SkPaint paint = setupPaint();
-                drawImageRectRestricted(canvas, context.damageRegionOrNull(), image.get(), SkRect::MakeSize(SkSize::Make(image->dimensions())), SkRect(imageRect),
-                    SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint);
+                const SkRect srcRect = SkRect::MakeSize(SkSize::Make(image->dimensions()));
+                const SkRect dstRect = SkRect(imageRect);
+                const auto sampling = SkiaUtilities::samplingOptionsForImageDraw(canvas.getLocalToDeviceAs3x3(), srcRect, dstRect);
+                drawImageRectRestricted(canvas, context.damageRegionOrNull(), image.get(), srcRect, dstRect, sampling, &paint);
             } else {
                 if (rotationMatrix)
                     transform.preConcat(*rotationMatrix);
@@ -1156,8 +1160,9 @@ void SkiaCompositingLayer::paintWithIntermediateSurface(SkCanvas& canvas, PaintC
     grContext->flushAndSubmit(surface.get(), GrSyncCpu::kNo);
 
     auto snapshot = surface->makeImageSnapshot();
-    const auto sampling = SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone);
 
+    // The surface is in device space, and both rects have the same size, so only the canvas matrix matters.
+    const auto sampling = SkiaUtilities::samplingOptionsForMatrix(canvas.getLocalToDeviceAs3x3());
     drawImageRectRestricted(canvas, context.damageRegionOrNull(), snapshot.get(), SkRect::MakeWH(surfaceRect.width(), surfaceRect.height()),
         SkRect::Make(surfaceRect), sampling, paint);
 }
@@ -1237,7 +1242,7 @@ void SkiaCompositingLayer::paintWithMaskAndBackdrop(SkCanvas& canvas, PaintConte
 
         if (shouldClipPath)
             canvas.clipPath(m_mask->m_clipPath->makeTransform(matrix), true);
-        else if (auto maskShader = maskImage->makeShader({ SkFilterMode::kLinear, SkMipmapMode::kNone }, &matrix))
+        else if (auto maskShader = maskImage->makeShader(SkiaUtilities::samplingOptionsForMatrix(SkMatrix::Concat(canvas.getLocalToDeviceAs3x3(), matrix)), &matrix))
             canvas.clipShader(maskShader);
     }
 

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp
@@ -32,6 +32,7 @@
 #include "FloatRect.h"
 #include "SkiaBackingStore.h"
 #include "SkiaDamageRegion.h"
+#include "SkiaUtilities.h"
 
 namespace WebCore {
 
@@ -52,32 +53,22 @@ void SkiaCompositingLayerImageSetBatch::updateSamplingOptions(SkCanvas& canvas, 
     m_samplingOptions = samplingOptions;
 }
 
-bool SkiaCompositingLayerImageSetBatch::imageRequiresLinearSampling(const SkCanvas& canvas, const sk_sp<SkImage>& image, const FloatRect& rect, const SkMatrix& ctm) const
-{
-    if (m_samplingOptions.filter == SkFilterMode::kLinear) {
-        // Linear is already the batch sampling options, so don't need change it to keep the batch.
-        return false;
-    }
-
-    // For axis aligned, not scaled and integer translated transforms, nearest and linear do the same,
-    // so we can keep nearest to avoid the sampling options switch that will cause a new batch.
-    auto matrix = canvas.getLocalToDeviceAs3x3() * ctm;
-    matrix.preConcat(SkMatrix::RectToRect(SkRect::MakeWH(image->width(), image->height()), SkRect(rect)));
-    if (!matrix.isScaleTranslate())
-        return true;
-
-    if (std::abs(matrix.getScaleX()) != 1 || std::abs(matrix.getScaleY()) != 1)
-        return true;
-
-    return !WTF::isIntegral(matrix.getTranslateX()) || !WTF::isIntegral(matrix.getTranslateY());
-}
-
 SkSamplingOptions SkiaCompositingLayerImageSetBatch::samplingOptionsForImage(const SkCanvas& canvas, const sk_sp<SkImage>& image, const FloatRect& rect, const SkMatrix& ctm) const
 {
-    if (!imageRequiresLinearSampling(canvas, image, rect, ctm))
+    if (m_samplingOptions.filter == SkFilterMode::kLinear)
         return m_samplingOptions;
 
-    return SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone);
+    const auto matrix = canvas.getLocalToDeviceAs3x3() * ctm;
+    return SkiaUtilities::samplingOptionsForImageDraw(matrix, SkRect::MakeWH(image->width(), image->height()), SkRect(rect));
+}
+
+SkSamplingOptions SkiaCompositingLayerImageSetBatch::samplingOptionsForBackingStore(const SkCanvas& canvas, const SkiaBackingStore& backingStore, const SkMatrix& ctm) const
+{
+    if (m_samplingOptions.filter == SkFilterMode::kLinear)
+        return m_samplingOptions;
+
+    const auto matrix = canvas.getLocalToDeviceAs3x3() * ctm;
+    return backingStore.samplingOptionsForMatrix(matrix);
 }
 
 size_t SkiaCompositingLayerImageSetBatch::matrixIndexForDraw(const SkMatrix& ctm)
@@ -91,7 +82,16 @@ size_t SkiaCompositingLayerImageSetBatch::matrixIndexForDraw(const SkMatrix& ctm
 void SkiaCompositingLayerImageSetBatch::addImageSet(SkCanvas& canvas, SkiaBackingStore& backingStore, const SkM44& transform, float opacity, bool enableAntialias, const SkiaDamageRegion* damageRegion, const SkPaint& fallbackPaint)
 {
     const auto ctm = transform.asM33();
-    const auto sampling = SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone);
+    const auto sampling = samplingOptionsForBackingStore(canvas, backingStore, ctm);
+
+    // A batch draws all of its entries with one constraint. A strict one would clamp every piece of a tile that
+    // the damage split, so the pieces would no longer join up. Draw this layer alone instead.
+    if (backingStore.requiresStrictSourceConstraint(sampling)) {
+        drawOutsideBatch(canvas, transform, damageRegion, [&](SkCanvas& canvas) {
+            backingStore.paintToCanvas(canvas, fallbackPaint, damageRegion);
+        });
+        return;
+    }
 
     if (!damageRegion) {
         updateSamplingOptions(canvas, sampling);
@@ -120,9 +120,10 @@ void SkiaCompositingLayerImageSetBatch::addImage(SkCanvas& canvas, const sk_sp<S
     const auto ctm = transform.asM33();
     const SkRect srcRectFull = SkRect::MakeWH(image->width(), image->height());
     const SkRect dstRectFull = SkRect(rect);
+    const auto sampling = samplingOptionsForImage(canvas, image, rect, ctm);
 
     if (!damageRegion) {
-        updateSamplingOptions(canvas, samplingOptionsForImage(canvas, image, rect, ctm));
+        updateSamplingOptions(canvas, sampling);
         const auto matrixIndex = matrixIndexForDraw(ctm);
         const unsigned aaFlags = enableAntialias ? SkCanvas::kAll_QuadAAFlags : SkCanvas::kNone_QuadAAFlags;
         m_imageSet.append(SkCanvas::ImageSetEntry(image, srcRectFull, dstRectFull, matrixIndex, opacity, aaFlags, false));
@@ -133,12 +134,12 @@ void SkiaCompositingLayerImageSetBatch::addImage(SkCanvas& canvas, const sk_sp<S
 
     SkMatrix inverse;
     const auto plan = planRestrictedDraw(canvas, transform, ctm, deviceRect, *damageRegion, inverse, [&](SkCanvas& canvas) {
-        canvas.drawImageRect(image, srcRectFull, dstRectFull, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &fallbackPaint, SkCanvas::kFast_SrcRectConstraint);
+        canvas.drawImageRect(image, srcRectFull, dstRectFull, sampling, &fallbackPaint, SkCanvas::kFast_SrcRectConstraint);
     });
     if (plan == RestrictedDraw::Done)
         return;
 
-    updateSamplingOptions(canvas, samplingOptionsForImage(canvas, image, rect, ctm));
+    updateSamplingOptions(canvas, sampling);
     const auto matrixIndex = matrixIndexForDraw(ctm);
 
     // Drawn whole, so it has no interior edges and antialiases like a draw with no damage.

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h
@@ -96,13 +96,9 @@ private:
         switch (damageRegion.planDraw(ctm, deviceRect, inverse)) {
         case SkiaDamageRegion::DrawDamageStrategy::Skip:
             return RestrictedDraw::Done;
-        case SkiaDamageRegion::DrawDamageStrategy::ClipToDamage: {
-            ScopedFlush autoFlush(canvas, *this, ScopedFlush::Mode::FlushBefore);
-            canvas.concat(transform);
-            damageRegion.clipCanvasInDeviceSpace(canvas);
-            fallbackDraw(canvas);
+        case SkiaDamageRegion::DrawDamageStrategy::ClipToDamage:
+            drawOutsideBatch(canvas, transform, &damageRegion, fallbackDraw);
             return RestrictedDraw::Done;
-        }
         case SkiaDamageRegion::DrawDamageStrategy::SplitByRect:
             break;
         }
@@ -110,9 +106,20 @@ private:
         return RestrictedDraw::Split;
     }
 
+    // Ends the batch and draws one layer on its own, under the layer transform and the damage clip.
+    template<typename FallbackDrawFunction>
+    void drawOutsideBatch(SkCanvas& canvas, const SkM44& transform, const SkiaDamageRegion* damageRegion, NOESCAPE const FallbackDrawFunction& fallbackDraw)
+    {
+        ScopedFlush autoFlush(canvas, *this, ScopedFlush::Mode::FlushBefore);
+        canvas.concat(transform);
+        if (damageRegion)
+            damageRegion->clipCanvasInDeviceSpace(canvas);
+        fallbackDraw(canvas);
+    }
+
     void updateSamplingOptions(SkCanvas&, SkSamplingOptions);
-    bool imageRequiresLinearSampling(const SkCanvas&, const sk_sp<SkImage>&, const FloatRect&, const SkMatrix&) const;
     SkSamplingOptions samplingOptionsForImage(const SkCanvas&, const sk_sp<SkImage>&, const FloatRect&, const SkMatrix&) const;
+    SkSamplingOptions samplingOptionsForBackingStore(const SkCanvas&, const SkiaBackingStore&, const SkMatrix&) const;
     size_t matrixIndexForDraw(const SkMatrix& ctm);
 
     Vector<SkCanvas::ImageSetEntry> m_imageSet;

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
@@ -32,11 +32,15 @@
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkBlendMode.h>
+#include <skia/core/SkMatrix.h>
+#include <skia/core/SkRect.h>
 #include <skia/core/SkRefCnt.h>
+#include <skia/core/SkSamplingOptions.h>
 #include <skia/gpu/ganesh/GrBackendSurface.h>
 #include <skia/gpu/ganesh/GrContextThreadSafeProxy.h>
 #include <skia/gpu/ganesh/GrDirectContext.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#include <wtf/MathExtras.h>
 
 class SkImage;
 class SkSurface;
@@ -51,6 +55,34 @@ enum class BlendMode : uint8_t;
 enum class CompositeOperator : uint8_t;
 
 namespace SkiaUtilities {
+
+inline SkSamplingOptions samplingOptionsForMatrix(const SkMatrix& matrix)
+{
+    auto mapsSourcePixelsOneToOne = [&] {
+        if (!matrix.isScaleTranslate())
+            return false;
+
+        // The scale needs a tolerance because it is computed by dividing. The translation does not: accepting
+        // a wrong one point samples an off grid draw, rejecting a wrong one only costs linear sampling.
+        constexpr float scaleTolerance = 1e-4f;
+        if (!WTF::areEssentiallyEqual(std::abs(matrix.getScaleX()), 1.0f, scaleTolerance) || !WTF::areEssentiallyEqual(std::abs(matrix.getScaleY()), 1.0f, scaleTolerance))
+            return false;
+
+        return WTF::isIntegral(matrix.getTranslateX()) && WTF::isIntegral(matrix.getTranslateY());
+    };
+
+    return mapsSourcePixelsOneToOne() ? SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone) : SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone);
+}
+
+inline SkSamplingOptions samplingOptionsForImageDraw(const SkMatrix& deviceMatrix, const SkRect& srcRect, const SkRect& dstRect)
+{
+    if (!deviceMatrix.isScaleTranslate())
+        return SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone);
+
+    auto matrix = deviceMatrix;
+    matrix.preConcat(SkMatrix::RectToRect(srcRect, dstRect));
+    return samplingOptionsForMatrix(matrix);
+}
 
 // Creates a GrBackendTexture from a BitmapTexture's GL texture.
 GrBackendTexture createBackendTexture(const BitmapTexture&);


### PR DESCRIPTION
#### fead9841406b8bf1fd40a0c10717ede6baee6098
<pre>
Cherry-pick 320490@main (f42e74f7147c). <a href="https://bugs.webkit.org/show_bug.cgi?id=323260">https://bugs.webkit.org/show_bug.cgi?id=323260</a>

    [GTK][WPE] Skia compositor: backing store tiles ignore the layer transform when picking sampling options
    <a href="https://bugs.webkit.org/show_bug.cgi?id=323260">https://bugs.webkit.org/show_bug.cgi?id=323260</a>

    Reviewed by Carlos Garcia Campos.

    Layer tiles are always drawn with SkFilterMode::kNearest. That is fine as long as
    each pixel of the tile ends up on exactly one screen pixel, at the same size and
    without any rotation. Once the layer is shifted by a fraction of a pixel, every
    screen pixel still takes its color from a single source pixel, rather than from a
    mix of the two it now falls inbetween. Edges lose their smoothness and visibly
    &quot;snap&quot; from one pixel to the next. TextureMapper does not have this problem,
    because its GL path always uses GL_LINEAR.

    The fix is to choose nearest or linear for each draw, depending on whether the
    transform still maps tile pixels 1:1 onto screen pixels. Layers whose content
    is a single image, already performed this test before they are drawn, so move
    that functionality into a shared place and use it for backing store tiles as well.
    Audit all other places that hardcoded linear vs. nearest and fast vs
    strict srcRect constraint.

    imported/w3c/web-platform-tests/css/css-animations/transform-animation-under-large-scale.html
    loses its glib specific [ Pass ] override and falls back to the generic ImageOnlyFailure of
    webkit.org/b/225407. The test scales a layer by 100 without re-rasterizing its contents at
    that scale, since GraphicsLayerCoordinated keeps the root relative scale factor updates
    turned off. Nearest sampling replicated each of the two content rows into a sharp block,
    which happened to match the reference. Linear sampling blurs the magnified tile, the same
    result all other ports produce.

    Linear sampling reaches past the source rect, which only matters for a tile whose
    texture is padded past its logical size (super-tiled textures) - keep
    that into account when deciding which sampling strategy to use.

    * LayoutTests/platform/glib/TestExpectations:
    * Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp:
    (WebCore::SkiaBackingStore::processPendingTileUpdates):
    (WebCore::SkiaBackingStore::samplingOptionsForMatrix const):
    (WebCore::SkiaBackingStore::paintToCanvas):
    (WebCore::SkiaBackingStore::Tile::isPadded const):
    * Source/WebCore/platform/graphics/skia/SkiaBackingStore.h:
    (WebCore::SkiaBackingStore::requiresStrictSourceConstraint const):
    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
    (WebCore::SkiaCompositingLayer::paintContents):
    (WebCore::SkiaCompositingLayer::paintWithIntermediateSurface):
    (WebCore::SkiaCompositingLayer::paintWithMaskAndBackdrop):
    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.cpp:
    (WebCore::SkiaCompositingLayerImageSetBatch::samplingOptionsForImage const):
    (WebCore::SkiaCompositingLayerImageSetBatch::samplingOptionsForBackingStore const):
    (WebCore::SkiaCompositingLayerImageSetBatch::addImageSet):
    (WebCore::SkiaCompositingLayerImageSetBatch::addImage):
    (WebCore::SkiaCompositingLayerImageSetBatch::imageRequiresLinearSampling const): Deleted.
    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayerImageSetBatch.h:
    (WebCore::SkiaCompositingLayerImageSetBatch::planRestrictedDraw):
    (WebCore::SkiaCompositingLayerImageSetBatch::drawOutsideBatch):
    * Source/WebCore/platform/graphics/skia/SkiaUtilities.h:
    (WebCore::SkiaUtilities::samplingOptionsForMatrix):
    (WebCore::SkiaUtilities::samplingOptionsForImageDraw):

    Canonical link: <a href="https://commits.webkit.org/320490@main">https://commits.webkit.org/320490@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.207@webkitglib/2.54">https://commits.webkit.org/317695.207@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/750443d8728b9720b3b6092cb0d43211558bb5eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185326 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59238 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53055 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195650 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150133 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187188 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60603 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58965 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144837 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150133 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188281 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60603 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53055 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125118 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60603 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58965 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53055 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60603 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53055 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6703 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/51894 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/58965 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197599 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/58902 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53055 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154336 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59611 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53055 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/153987 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28137 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59611 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/131931 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/128747 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58089 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53055 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57461 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57704 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57528 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->