### PR TITLE
[JSC] C++ code should use truncateDoubleToInt64 for toInt32 too in x64

### DIFF
--- a/JSTests/stress/to-int32-out-of-int32-range-doubles-no-jit.js
+++ b/JSTests/stress/to-int32-out-of-int32-range-doubles-no-jit.js
@@ -1,0 +1,42 @@
+//@ runDefault("--useJIT=0")
+
+function shouldBe(actual, expected, input)
+{
+    if (actual !== expected)
+        throw new Error(`bad value for ${input}: ${actual}, expected ${expected}`);
+}
+
+// Reference ToInt32 through BigInt, independent of the conversion under test.
+function toInt32Reference(x)
+{
+    if (!Number.isFinite(x))
+        return 0;
+    return Number(BigInt.asIntN(32, BigInt(Math.trunc(x))));
+}
+
+const inputs = [
+    0, -0, 1, -1, 0.5, -0.5, 2147483647, -2147483648, 2147483648, -2147483649,
+    2147483647.9, -2147483648.9, 0xc66363a5, 0xffffffff, 0x100000000, 0x100000001,
+    4294967295.5, -4294967296, 2 ** 52 + 1, -(2 ** 52 + 1), 2 ** 53, 2 ** 53 + 2,
+    2 ** 62, -(2 ** 62), 2 ** 63 - 1024, -(2 ** 63 - 1024), 2 ** 63, -(2 ** 63),
+    2 ** 63 + 2048, -(2 ** 63 + 2048), 2 ** 64, 2 ** 84, 2 ** 85, 2 ** 100,
+    Number.MAX_VALUE, -Number.MAX_VALUE, Number.MIN_VALUE, Infinity, -Infinity, NaN,
+];
+
+const int32Array = new Int32Array(1);
+const uint32Array = new Uint32Array(1);
+
+for (const input of inputs) {
+    const expected = toInt32Reference(input);
+
+    shouldBe(input | 0, expected, input);
+    shouldBe(input ^ 0x5a5a5a5a, expected ^ 0x5a5a5a5a, input);
+    shouldBe(input >> 0, expected, input);
+    shouldBe(input >>> 0, expected >>> 0, input);
+
+    int32Array[0] = input;
+    shouldBe(int32Array[0], expected, input);
+
+    uint32Array[0] = input;
+    shouldBe(uint32Array[0], expected >>> 0, input);
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -2787,7 +2787,7 @@ void SpeculativeJIT::emitDoubleToInt32(FPRReg fpr, GPRReg gpr)
 #endif
     Jump notTruncatedToInteger = branchTruncateDoubleToInt32(fpr, gpr, BranchIfTruncateFailed);
     addSlowPathGenerator(slowPathCall(notTruncatedToInteger, this,
-        hasSensibleDoubleToInt() ? operationToInt32SensibleSlow : operationToInt32, NeedToSpill, ExceptionCheckRequirement::CheckNotNeeded, gpr, fpr));
+        operationToInt32, NeedToSpill, ExceptionCheckRequirement::CheckNotNeeded, gpr, fpr));
 }
 
 void SpeculativeJIT::compileValueToInt32(Node* node)

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -24696,23 +24696,16 @@ IGNORE_CLANG_WARNINGS_END
         }
 #endif
 
+#if CPU(X86_64)
         auto sensibleDoubleToInt32 = [&](LValue doubleValue) -> LValue {
             LBasicBlock slowPath = m_out.newBlock();
             LBasicBlock continuation = m_out.newBlock();
 
-#if CPU(X86_64)
             LValue fastResult64 = m_out.doubleToInt64(doubleValue);
             ValueFromBlock fastResult = m_out.anchor(m_out.castToInt32(fastResult64));
             m_out.branch(
                 m_out.equal(fastResult64, m_out.constInt64(std::numeric_limits<int64_t>::min())),
                 rarely(slowPath), usually(continuation));
-#else
-            LValue fastResultValue = m_out.doubleToInt32(doubleValue);
-            ValueFromBlock fastResult = m_out.anchor(fastResultValue);
-            m_out.branch(
-                m_out.equal(fastResultValue, m_out.constInt32(0x80000000)),
-                rarely(slowPath), usually(continuation));
-#endif
 
             LBasicBlock lastNext = m_out.appendTo(slowPath, continuation);
             ValueFromBlock slowResult = m_out.anchor(m_out.castToInt32(m_out.callWithoutSideEffects(Int64, operationToInt32SensibleSlow, doubleValue)));
@@ -24724,6 +24717,7 @@ IGNORE_CLANG_WARNINGS_END
 
         if (hasSensibleDoubleToInt())
             return sensibleDoubleToInt32(doubleValue);
+#endif
 
         auto doubleToInt32WithLimits = [&](LValue doubleValue, double low, double high, bool isSigned = true) {
             LBasicBlock greatEnough = m_out.newBlock();

--- a/Source/JavaScriptCore/runtime/MathCommon.cpp
+++ b/Source/JavaScriptCore/runtime/MathCommon.cpp
@@ -456,7 +456,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationToInt32, UCPUStrictInt32, (double val
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationToInt32SensibleSlow, UCPUStrictInt32, (double number))
 {
-    return toUCPUStrictInt32(toIntImpl<int32_t, ToIntMode::Int32AfterSensibleConversionAttempt>(number));
+    return toUCPUStrictInt32(toInt32AfterFailedTruncation(number));
 }
 
 extern "C" {

--- a/Source/JavaScriptCore/runtime/MathCommon.h
+++ b/Source/JavaScriptCore/runtime/MathCommon.h
@@ -29,7 +29,9 @@
 #include <JavaScriptCore/OperationResult.h>
 #include <climits>
 #include <cmath>
+#include <limits>
 #include <optional>
+#include <wtf/MathExtras.h>
 
 namespace JSC {
 
@@ -85,11 +87,7 @@ inline bool isNegativeZero(double value)
 //
 // The operation can be described as round towards zero, then select the 32 or 64 least
 // bits of the resulting value in 2s-complement representation.
-enum ToIntMode {
-    Generic,
-    Int32AfterSensibleConversionAttempt,
-};
-template<class Int, ToIntMode Mode = Generic>
+template<class Int>
 ALWAYS_INLINE Int toIntImpl(double number)
 {
     static_assert(std::is_same_v<Int, int32_t> || std::is_same_v<Int, int64_t>);
@@ -134,47 +132,36 @@ ALWAYS_INLINE Int toIntImpl(double number)
     // and exponent bits from the floatingpoint representation); mask these out.
     // Note that missingOne should be held as UInt since ((1 << intBitsMinusOne) - 1) causes
     // Int overflow.
-    if constexpr (Mode == ToIntMode::Int32AfterSensibleConversionAttempt) {
-        static_assert(intBitsMinusOne == 31);
-        if (exp == intBitsMinusOne) {
-            // This is an optimization for when toInt32() is called in the slow path
-            // of a JIT operation. Currently, this optimization is only applicable for
-            // x86 ports. This optimization offers 5% performance improvement in
-            // kraken-crypto-pbkdf2.
-            //
-            // On x86, the fast path does a sensible double-to-int32 conversion, by
-            // first attempting to truncate the double value to int32 using the
-            // cvttsd2si_rr instruction. According to Intel's manual, cvttsd2si performs
-            // the following truncate operation:
-            //
-            //     If src = NaN, +-Inf, or |(src)rz| > 0x7fffffff and (src)rz != 0x80000000,
-            //     then the result becomes 0x80000000. Otherwise, the operation succeeds.
-            //
-            // Note that the ()rz notation means rounding towards zero.
-            // We'll call the slow case function only when the above cvttsd2si fails. The
-            // JIT code checks for fast path failure by checking if result == 0x80000000.
-            // Hence, the slow path will only see the following possible set of numbers:
-            //
-            //     NaN, +-Inf, or |(src)rz| > 0x7fffffff.
-            //
-            // As a result, the exp of the double is always >= 31. We can take advantage
-            // of this by specifically checking for (exp == 31) and give the compiler a
-            // chance to constant fold the operations below.
-            const constexpr UInt missingOne = static_cast<UInt>(1U) << intBitsMinusOne;
-            result &= missingOne - 1;
-            result += missingOne;
-        }
-    } else {
-        if (exp < static_cast<int32_t>(intBits)) {
-            const UInt missingOne = static_cast<UInt>(1U) << exp;
-            result &= missingOne - 1;
-            result += missingOne;
-        }
+    if (exp < static_cast<int32_t>(intBits)) {
+        const UInt missingOne = static_cast<UInt>(1U) << exp;
+        result &= missingOne - 1;
+        result += missingOne;
     }
 
     // If the input value was negative (we could test either 'number' or 'bits',
     // but testing 'bits' is likely faster) invert the result appropriately.
     return static_cast<int64_t>(bits) < 0 ? -static_cast<Int>(result) : static_cast<Int>(result);
+}
+
+// ToInt32 for the inputs an x86_64 cvttsd2siq fast path rejects, which are exactly the ones
+// it maps to INT64_MIN: NaN, the infinities, and every |number| >= 2^63. Their exponent is at
+// least 63, so unlike toIntImpl this needs no rounding towards zero, and no restore of the
+// implicit leading mantissa bit, which at 2^63 or above cannot reach the low 32 bits.
+ALWAYS_INLINE int32_t toInt32AfterFailedTruncation(double number)
+{
+    uint64_t bits = std::bit_cast<uint64_t>(number);
+    int32_t exp = (static_cast<int32_t>(bits >> 52) & 0x7ff) - 0x3ff;
+    ASSERT(exp >= 63);
+
+    // Past a shift of 31 every mantissa bit weighs 2^32 or more, so nothing survives ToInt32.
+    // NaN and the infinities exit here too, on their all-ones exponent field. The unsigned
+    // comparison keeps a shift count out of range away from the shift below.
+    int32_t shift = exp - 52;
+    if (static_cast<uint32_t>(shift) > 31)
+        return 0;
+
+    uint32_t magnitude = static_cast<uint32_t>(bits << shift);
+    return static_cast<int64_t>(bits) < 0 ? -static_cast<int32_t>(magnitude) : static_cast<int32_t>(magnitude);
 }
 
 ALWAYS_INLINE int32_t toInt32(double number)
@@ -183,6 +170,14 @@ ALWAYS_INLINE int32_t toInt32(double number)
     int32_t result = 0;
     __asm__ ("fjcvtzs %w0, %d1" : "=r" (result) : "w" (number) : "cc");
     return result;
+#elif CPU(X86_64)
+    // ToInt32 is the low 32 bits of a truncation toward zero, which cvttsd2siq computes
+    // exactly for every |number| < 2^63. It reports NaN, the infinities, and everything
+    // of larger magnitude as INT64_MIN.
+    int64_t truncated = truncateDoubleToInt64(number);
+    if (truncated != std::numeric_limits<int64_t>::min()) [[likely]]
+        return static_cast<int32_t>(truncated);
+    return toInt32AfterFailedTruncation(number);
 #else
     return toIntImpl<int32_t>(number);
 #endif


### PR DESCRIPTION
#### 566279d48d565d6de872cf4d624c759879c7ab74
<pre>
[JSC] C++ code should use truncateDoubleToInt64 for toInt32 too in x64
<a href="https://bugs.webkit.org/show_bug.cgi?id=323591">https://bugs.webkit.org/show_bug.cgi?id=323591</a>
<a href="https://rdar.apple.com/186836512">rdar://186836512</a>

Reviewed by Sosuke Suzuki.

320602@main applied optimization in JIT for x64. But the same
optimization can be done in C++ as well. This patch applies it. Also we
clean up the code since sensible-conversion is only enabled on x64. Thus,

1. Remove sensible-conversion flag from toIntImpl.
2. Define specific function, toInt32AfterFailedTruncation
3. Use truncateDoubleToInt64 and toInt32AfterFailedTruncation in toInt32
   implementation in x64.
4. Clean up sensible-conversion code in DFG and FTL.

Test: JSTests/stress/to-int32-out-of-int32-range-doubles-no-jit.js

* JSTests/stress/to-int32-out-of-int32-range-doubles-no-jit.js: Added.
(shouldBe):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::emitDoubleToInt32):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/MathCommon.cpp:
(JSC::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/runtime/MathCommon.h:
(JSC::toIntImpl):
(JSC::toInt32AfterFailedTruncation):
(JSC::toInt32):

Canonical link: <a href="https://commits.webkit.org/320644@main">https://commits.webkit.org/320644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92951e3df9fe4256e14c2b68383b9eb1c59cd5d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195663 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150141 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144846 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100420 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125139 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47252 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45310 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7045 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13934 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157619 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45002 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6716 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46597 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51907 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197612 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58915 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154351 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59624 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41607 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154002 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28154 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48494 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131961 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128773 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58102 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20024 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57474 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57717 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57541 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->