### PR TITLE
Cherry-pick 305413.1033@safari-7624.5.1.10-branch (e4960726c71e). https://bugs.webkit.org/show_bug.cgi?id=317919

### DIFF
--- a/JSTests/stress/object-create-check-insertion.js
+++ b/JSTests/stress/object-create-check-insertion.js
@@ -1,0 +1,152 @@
+// Variant of rdar://178211104 for the ObjectCreate -> NewObject fold in
+// DFGConstantFoldingPhase.cpp.
+//
+// FixupPhase:    ObjectCreate child1 prediction = SpecObject -> fixEdge<ObjectUse>(child1)
+// CFA:           child1 proven = jsNull (heap watchpoint on G.k) -> ObjectUse ∩ {null} = ⊥
+//                -> block tail dead, merges nothing into loop header valuesAtHead
+// ConstantFold:  forNode(child1).m_value == null -> nullPrototypeObjectStructure()
+//                -> convertToNewObject() -> children.reset()  (ObjectUse edge GONE,
+//                no insertCheck) -> path resurrected after lower-index header was
+//                already folded against stale {ArrayWithContiguous}-only state.
+//
+// Payload: structure-check-free Contiguous element load on an ArrayWithDouble
+// butterfly -> raw bits 0x0000414141414141 returned as a JSCell*.
+
+// ---- knobs -------------------------------------------------------------
+const N_PROTO = 4;
+const N_HOLDER = 64;
+const TRAIN_GETKEY = 3000;
+const TRAIN_CALLER = 60;
+const TRAIN_GETK2 = 3000;
+const RAMP = 200000;
+
+// ---- helpers -----------------------------------------------------------
+function bitsToDouble(hi, lo) {
+    const buf = new ArrayBuffer(8);
+    const u32 = new Uint32Array(buf);
+    const f64 = new Float64Array(buf);
+    u32[0] = lo >>> 0;
+    u32[1] = hi >>> 0;
+    return f64[0];
+}
+
+function enforce(input)
+{
+    return String(input);
+}
+noInline(enforce);
+
+// Raw double whose bit pattern is 0x0000414141414141.
+// As a JSValue (top 15 bits zero, OtherTag bit clear) this is a JSCell* to 0x414141414141.
+const FAKE = bitsToDouble(0x00004141, 0x41414141);
+enforce("FAKE double = " + FAKE + "  (bits 0x0000414141414141)");
+
+// ---- the players -------------------------------------------------------
+const PROTOS = [];
+for (let i = 0; i < N_PROTO; i++) PROTOS.push({ ["p" + i]: i });
+
+const G = { k: PROTOS[0] };
+
+function getKey(holder) { return holder.k; }
+
+function getK2(x) { return x.k; }
+noInline(getK2);
+
+const INNER = { y: 1, z: 2 };
+
+function caller(o, p, skip, n) {
+    if (skip) return 0;
+    let obj = [INNER, INNER];        // ArrayWithContiguous (S1)
+    let result = 0;
+    let v = false;
+    for (let i = 0; i < n; i++) {
+        // Two non-array uses of `obj` so TypeCheckHoisting's vote ratio for loc(obj)
+        // drops below 1.0 (1 StructureCheck vote vs 2 Other votes) and the
+        // CheckStructure({Contiguous}) is NOT hoisted to the SetLocal in the
+        // else-branch (which would otherwise OSR-exit on the Double array).
+        v = (obj === o);
+        v = (obj === o) | v;
+        result = obj[0];             // payload: GetByVal, ArrayMode=Contiguous, CheckStructure elided
+        if (p) {
+            obj = [INNER, INNER];    // S1 again
+        } else {
+            obj = [FAKE, 1.1];       // ArrayWithDouble (S2) — only on the CFA-dead path
+            Object.create(getKey(G));// ObjectCreate(ObjectUse:getKey(G)); AI proto = null -> contradiction
+        }
+    }
+    return v ? 0 : result;
+}
+noInline(caller);
+
+// ---- training ----------------------------------------------------------
+
+// 1. make getKey's `holder.k` IC give up (megamorphic) with an Object-only value profile
+const holders = [];
+for (let i = 0; i < N_HOLDER; i++) {
+    const h = {};
+    h["u" + i] = i;
+    h.k = PROTOS[i % N_PROTO];
+    holders.push(h);
+}
+function trainGetKey() {
+    let acc = 0;
+    for (let i = 0; i < TRAIN_GETKEY; i++)
+        if (typeof getKey(holders[i % N_HOLDER]) === "object") acc++;
+    return acc;
+}
+noInline(trainGetKey);
+trainGetKey();
+
+// 2. warm caller in baseline:
+//    - p=true,  n=2 : payload sees only Contiguous arrays (both iterations)
+//    - p=false, n=1 : payload sees only Contiguous (iteration 0), then else branch
+//                     runs once (links getKey call IC so it's inlinable, runs
+//                     Object.create on an actual object), and the loop exits
+//                     BEFORE the Double array reaches the payload.
+const O = { a: 1 };
+function trainCaller() {
+    for (let i = 0; i < TRAIN_CALLER; i++) {
+        caller(O, true,  false, 2);
+        caller(O, false, false, 1);
+    }
+}
+noInline(trainCaller);
+trainCaller();
+
+// 3. flip G.k to null (Reflect.set: no put_by_id IC caches the replace ->
+//    the (StructureOf(G), "k") replacement watchpoint set is not pre-fired)
+Reflect.set(G, "k", null);
+
+// 4. create a still-valid (S_G,"k") replacement watchpoint AFTER the last write,
+//    so Graph::tryGetConstantProperty returns jsNull() at compile time
+function trainGetK2() {
+    let acc = 0;
+    for (let i = 0; i < TRAIN_GETK2; i++)
+        if (getK2(G) === null) acc++;
+    return acc;
+}
+noInline(trainGetK2);
+trainGetK2();
+
+// 5. tier caller up to DFG without touching any profile
+function ramp() {
+    for (let i = 0; i < RAMP; i++)
+        caller(O, true, true, 2);
+}
+noInline(ramp);
+ramp();
+
+// 6. trigger: resurrected path delivers an ArrayWithDouble into the payload,
+//    which was compiled as a check-free Contiguous element load.
+//    Iteration 0 reads INNER (Contiguous), iteration 1 reads FAKE bits as a cell.
+enforce("triggering...");
+const r = caller(O, false, false, 2);
+
+// `r` is now a JSValue whose raw bits are 0x0000414141414141: the JIT loaded
+// element 0 of an ArrayWithDouble through a structure-check-free Contiguous
+// GetByVal. Top 15 bits are zero and the OtherTag bit is clear, so the engine
+// treats it as a JSCell* to 0x414141414141. Any cell use dereferences it.
+enforce("caller returned a JSValue; using it as a cell -> deref 0x414141414141...");
+enforce("r.y = " + r.y);
+enforce(describe(r));
+enforce("*** if you see this, the fakeobj primitive did NOT trigger ***");

--- a/JSTests/wasm/stress/br-on-cast-fail-overlong-leb128.js
+++ b/JSTests/wasm/stress/br-on-cast-fail-overlong-leb128.js
@@ -1,0 +1,75 @@
+"use strict";
+// Canonical and overlong LEB128 encodings of a GC sub-opcode must produce
+// identical execution semantics. This test checks that for br_on_cast_fail
+// with FLAGS=0x03 - divergence means IPInt is reading the flags byte from a
+// position the encoding moved.
+
+function uleb(n) { const o=[]; do { let b=n&0x7f; n>>>=7; if(n) b|=0x80; o.push(b); } while(n); return o; }
+function section(id, b) { return [id, ...uleb(b.length), ...b]; }
+function str(s) { return [s.length, ...Array.from(s, c => c.charCodeAt(0))]; }
+
+function buildModule(brOnCastFail) {
+    const typeSec = [
+        0x03,
+        0x5f, 0x00,                          // type 0: (struct)
+        0x60, 0x00, 0x00,                    // type 1: () -> void
+        0x60, 0x00, 0x01, 0x7f,              // type 2: () -> i32
+    ];
+    const funcSec = [0x02, 0x01, 0x02];
+    // global 0: (mut (ref null any)) init = (struct.new_default 0)
+    const globalSec = [0x01, 0x63, 0x6e, 0x01, 0xfb, 0x01, 0x00, 0x0b];
+    const exportSec = [
+        0x02,
+        ...str("poison"),      0x00, 0x00,
+        ...str("is_poisoned"), 0x00, 0x01,
+    ];
+    const poisonBody = [
+        0x00,
+        0x02, 0x63, 0x6e,                    // block (result (ref null any))
+            0xd0, 0x6e,                      //   ref.null any
+            ...brOnCastFail,                     //   br_on_cast_fail 0  (FLAGS=0x03 in either encoding)
+            0x1a,                            //   drop  (drops the (ref null 0) cast result)
+            0xfb, 0x01, 0x00,                //   struct.new_default 0
+            0x0c, 0x00,                      //   br 0
+        0x0b,
+        0x24, 0x00,                          // global.set 0
+        0x0b,
+    ];
+    const checkBody = [
+        0x00,
+        0x23, 0x00,                          // global.get 0
+        0xd1,                                // ref.is_null
+        0x0b,
+    ];
+    const codeSec = [
+        0x02,
+        ...uleb(poisonBody.length), ...poisonBody,
+        ...uleb(checkBody.length),  ...checkBody,
+    ];
+    return new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        ...section(1, typeSec),
+        ...section(3, funcSec),
+        ...section(6, globalSec),
+        ...section(7, exportSec),
+        ...section(10, codeSec),
+    ]);
+}
+
+//                       prefix sub-op            flags label ht1   ht2
+const CANONICAL = [0xfb, 0x19,            0x03, 0x00, 0x6e, 0x00];
+const OVERLONG  = [0xfb, 0x99,0x80,0x00,  0x03, 0x00, 0x6e, 0x00];
+
+const a = new WebAssembly.Instance(new WebAssembly.Module(buildModule(CANONICAL)));
+const b = new WebAssembly.Instance(new WebAssembly.Module(buildModule(OVERLONG)));
+
+a.exports.poison();
+b.exports.poison();
+
+const rA = a.exports.is_poisoned();
+const rB = b.exports.is_poisoned();
+
+if (rA !== rB)
+    throw new Error("LEB encoding of GC sub-opcode affects br_on_cast_fail semantics: "
+                    + "canonical=" + rA + " overlong=" + rB
+                    + " — IPInt reads flags from PC at hardcoded offset");

--- a/JSTests/wasm/stress/br-on-cast-overlong-leb128.js
+++ b/JSTests/wasm/stress/br-on-cast-overlong-leb128.js
@@ -1,0 +1,75 @@
+"use strict";
+// Canonical and overlong LEB128 encodings of a GC sub-opcode must produce
+// identical execution semantics. This test checks that for br_on_cast with
+// FLAGS=0x03 - divergence means IPInt is reading the flags byte from a
+// position the encoding moved.
+
+function uleb(n) { const o=[]; do { let b=n&0x7f; n>>>=7; if(n) b|=0x80; o.push(b); } while(n); return o; }
+function section(id, b) { return [id, ...uleb(b.length), ...b]; }
+function str(s) { return [s.length, ...Array.from(s, c => c.charCodeAt(0))]; }
+
+function buildModule(brOnCast) {
+    const typeSec = [
+        0x03,
+        0x5f, 0x00,                          // type 0: (struct)
+        0x60, 0x00, 0x00,                    // type 1: () -> void
+        0x60, 0x00, 0x01, 0x7f,              // type 2: () -> i32
+    ];
+    const funcSec = [0x02, 0x01, 0x02];
+    // global 0: (mut (ref null 0)) init = (struct.new_default 0)
+    const globalSec = [0x01, 0x63, 0x00, 0x01, 0xfb, 0x01, 0x00, 0x0b];
+    const exportSec = [
+        0x02,
+        ...str("poison"),      0x00, 0x00,
+        ...str("is_poisoned"), 0x00, 0x01,
+    ];
+    const poisonBody = [
+        0x00,
+        0x02, 0x63, 0x00,                    // block (result (ref null 0))
+            0xd0, 0x6e,                      //   ref.null any
+            ...brOnCast,                     //   br_on_cast 0  (FLAGS=0x03 in either encoding)
+            0x1a,                            //   drop
+            0xfb, 0x01, 0x00,                //   struct.new_default 0  (only reached if cast missed)
+            0x0c, 0x00,                      //   br 0
+        0x0b,
+        0x24, 0x00,                          // global.set 0
+        0x0b,
+    ];
+    const checkBody = [
+        0x00,
+        0x23, 0x00,                          // global.get 0
+        0xd1,                                // ref.is_null
+        0x0b,
+    ];
+    const codeSec = [
+        0x02,
+        ...uleb(poisonBody.length), ...poisonBody,
+        ...uleb(checkBody.length),  ...checkBody,
+    ];
+    return new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        ...section(1, typeSec),
+        ...section(3, funcSec),
+        ...section(6, globalSec),
+        ...section(7, exportSec),
+        ...section(10, codeSec),
+    ]);
+}
+
+//                       prefix sub-op            flags label ht1   ht2
+const CANONICAL = [0xfb, 0x18,            0x03, 0x00, 0x6e, 0x00];
+const OVERLONG  = [0xfb, 0x98,0x80,0x00,  0x03, 0x00, 0x6e, 0x00];
+
+const a = new WebAssembly.Instance(new WebAssembly.Module(buildModule(CANONICAL)));
+const b = new WebAssembly.Instance(new WebAssembly.Module(buildModule(OVERLONG)));
+
+a.exports.poison();
+b.exports.poison();
+
+const rA = a.exports.is_poisoned();
+const rB = b.exports.is_poisoned();
+
+if (rA !== rB)
+    throw new Error("LEB encoding of GC sub-opcode affects br_on_cast semantics: "
+                    + "canonical=" + rA + " overlong=" + rB
+                    + " — IPInt reads flags from PC at hardcoded offset");

--- a/LayoutTests/fast/css/font-face-worker-serialization-thread-safety-expected.txt
+++ b/LayoutTests/fast/css/font-face-worker-serialization-thread-safety-expected.txt
@@ -1,0 +1,10 @@
+A worker serializing FontFace descriptors must not race the main thread on the process-global CSS serialization memoization map (CSSPrimitiveValue). Under ASan/TSan, the unfixed code reports a heap-use-after-free or double-free in HashTable::rehash; this test should run clean.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Did not crash during concurrent serialization.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/font-face-worker-serialization-thread-safety.html
+++ b/LayoutTests/fast/css/font-face-worker-serialization-thread-safety.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("A worker serializing FontFace descriptors must not race the main thread on the process-global CSS serialization memoization map (CSSPrimitiveValue). Under ASan/TSan, the unfixed code reports a heap-use-after-free or double-free in HashTable::rehash; this test should run clean.");
+
+jsTestIsAsync = true;
+
+// Each worker hammers customCSSText() off the main thread for ~800ms. It mixes two paths:
+//   - fractional percentages, which allocate a fresh heap CSSPrimitiveValue per value and, when
+//     overwritten, destroy it (map.add followed by map.remove) to churn the shared HashTable and
+//     provoke rehash() of the backing buffer.
+//   - integer percentages 0..255, which resolve to the shared StaticCSSValuePool objects that are
+//     also serialized on the main thread (the bit-field hazard).
+var workerSource = `
+    function pump() {
+        var deadline = performance.now() + 800;
+        while (performance.now() < deadline) {
+            var faces = [];
+            for (var i = 0; i < 256; ++i) {
+                var fractional = (i + 0.123456).toFixed(6) + "%";
+                var face = new FontFace("worker-" + i, "url(x)", { sizeAdjust: fractional });
+                face.sizeAdjust; // map.add(heap value)
+                faces.push(face);
+            }
+            for (var j = 0; j < faces.length; ++j) {
+                faces[j].sizeAdjust = (j + 0.654321).toFixed(6) + "%"; // destroys previous => map.remove
+                faces[j].sizeAdjust; // map.add(new heap value)
+            }
+            for (var k = 0; k < 256; ++k) {
+                // Shared static-pool objects, also touched on the main thread.
+                var shared = new FontFace("shared-" + k, "url(x)", { sizeAdjust: k + "%" });
+                shared.sizeAdjust;
+                shared.style;
+                shared.weight;
+                shared.width;
+            }
+        }
+        postMessage("done");
+    }
+    pump();
+`;
+
+var NUM_WORKERS = 4;
+var workersDone = 0;
+var blobURL = URL.createObjectURL(new Blob([workerSource], { type: "text/javascript" }));
+
+function onWorkerDone() {
+    if (++workersDone < NUM_WORKERS)
+        return;
+    testPassed("Did not crash during concurrent serialization.");
+    finishJSTest();
+}
+
+for (var w = 0; w < NUM_WORKERS; ++w) {
+    var worker = new Worker(blobURL);
+    worker.onmessage = onWorkerDone;
+}
+
+// Concurrently churn the shared map on the main thread: fractional percentages create and destroy
+// heap CSSPrimitiveValues, and integer percentages hit the same shared static-pool objects.
+var element = document.documentElement;
+var deadline = performance.now() + 800;
+while (performance.now() < deadline) {
+    for (var i = 0; i < 256; ++i) {
+        element.style.width = (i + 0.7777).toFixed(6) + "%"; // create heap value
+        element.style.getPropertyValue("width");             // map.add; next overwrite => map.remove
+    }
+    element.style.height = "100%";
+    for (var i = 0; i < 64; ++i)
+        element.style.getPropertyValue("height");            // shared static-pool object
+}
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/webanimations/threaded-animations/offset-path-shape-cache-thread-safety-crash-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/offset-path-shape-cache-thread-safety-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/webanimations/threaded-animations/offset-path-shape-cache-thread-safety-crash.html
+++ b/LayoutTests/webanimations/threaded-animations/offset-path-shape-cache-thread-safety-crash.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body { height: 5000px; }
+.mover {
+    position: absolute;
+    top: 50px; left: 50px;
+    width: 40px; height: 40px;
+    will-change: transform;
+    animation: move auto linear;
+    animation-timeline: scroll(root);
+}
+@keyframes move {
+    from { offset-distance: 0%; }
+    to   { offset-distance: 100%; }
+}
+/* Distinct polygon() values to churn the 4-slot cachedAcceleratedEffectPolygonPath() LRU. */
+#m0 { offset-path: polygon(0% 0%, 28% 12%, 53% 97%, 100% 5%, 19% 100%); }
+#m1 { offset-path: polygon(0% 0%, 53% 37%, 3% 72%, 75% 30%, 44% 100%); }
+#m2 { offset-path: polygon(0% 0%, 78% 62%, 28% 47%, 50% 55%, 69% 76%); }
+#m3 { offset-path: polygon(0% 0%, 100% 87%, 78% 22%, 25% 80%, 94% 51%); }
+#m4 { offset-path: polygon(0% 0%, 100% 100%, 100% 100%, 100% 100%, 100% 26%); }
+#m5 { offset-path: polygon(0% 0%, 100% 100%, 100% 100%, 100% 100%, 69% 1%); }
+</style>
+</head>
+<body>
+<div class="mover" id="m0"></div>
+<div class="mover" id="m1"></div>
+<div class="mover" id="m2"></div>
+<div class="mover" id="m3"></div>
+<div class="mover" id="m4"></div>
+<div class="mover" id="m5"></div>
+<script>
+// Two pages each have their own RemoteLayerTreeEventDispatcher (and so their
+// own m_animationLock); both can call updateAnimations() concurrently — one
+// from the main run loop (renderingUpdateComplete), one from the
+// ScrollingThread (didRefreshDisplay). Prior to the fix this raced on the
+// process-global TinyLRUCache in cachedAcceleratedEffectPolygonPath() and
+// crashed in the UIProcess.
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+let dir = 1;
+function pump()
+{
+    let y = scrollY + dir * 600;
+    if (y > 3800) { dir = -1; y = 3800; }
+    if (y < 10)   { dir =  1; y = 10; }
+    scrollTo({ top: y, behavior: "smooth" });
+}
+let scrollTimer = setInterval(pump, 60);
+pump();
+
+// Force periodic commits so renderingUpdateComplete() runs frequently on the
+// main run loop while didRefreshDisplay() runs on the ScrollingThread.
+let n = 0;
+let commitTimer = setInterval(() => { document.title = ++n; }, 33);
+
+let popup;
+addEventListener("load", () => {
+    setTimeout(() => {
+        popup = window.open("resources/offset-path-shape-cache-thread-safety-popup.html", "_blank", "width=900,height=700");
+    }, 200);
+    setTimeout(finish, 4000);
+});
+
+function finish()
+{
+    clearInterval(scrollTimer);
+    clearInterval(commitTimer);
+    if (popup)
+        popup.close();
+    document.body.innerText = "PASS if no crash.";
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/webanimations/threaded-animations/resources/offset-path-shape-cache-thread-safety-popup.html
+++ b/LayoutTests/webanimations/threaded-animations/resources/offset-path-shape-cache-thread-safety-popup.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body { height: 5000px; }
+.mover {
+    position: absolute;
+    top: 50px; left: 50px;
+    width: 40px; height: 40px;
+    will-change: transform;
+    animation: move auto linear;
+    animation-timeline: scroll(root);
+}
+@keyframes move {
+    from { offset-distance: 0%; }
+    to   { offset-distance: 100%; }
+}
+/* Distinct polygon() values from the opener to force LRU eviction churn. */
+#n0 { offset-path: polygon(0% 0%, 23% 2%, 5% 10%, 10% 48%, 94% 13%); }
+#n1 { offset-path: polygon(0% 0%, 48% 4%, 30% 35%, 35% 23%, 87% 38%); }
+#n2 { offset-path: polygon(0% 0%, 73% 7%, 55% 60%, 60% 73%, 77% 63%); }
+#n3 { offset-path: polygon(0% 0%, 98% 9%, 80% 85%, 85% 98%, 67% 88%); }
+#n4 { offset-path: polygon(0% 0%, 100% 12%, 100% 100%, 100% 100%, 57% 100%); }
+#n5 { offset-path: polygon(0% 0%, 100% 14%, 100% 100%, 100% 100%, 47% 100%); }
+</style>
+</head>
+<body>
+<div class="mover" id="n0"></div>
+<div class="mover" id="n1"></div>
+<div class="mover" id="n2"></div>
+<div class="mover" id="n3"></div>
+<div class="mover" id="n4"></div>
+<div class="mover" id="n5"></div>
+<script>
+let dir = 1;
+function pump()
+{
+    let y = scrollY + dir * 600;
+    if (y > 3800) { dir = -1; y = 3800; }
+    if (y < 10)   { dir =  1; y = 10; }
+    scrollTo({ top: y, behavior: "smooth" });
+}
+setInterval(pump, 60);
+pump();
+
+let n = 0;
+setInterval(() => { document.title = ++n; }, 33);
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1097,6 +1097,9 @@ private:
                     }
                     
                     if (structure) {
+                        m_interpreter.execute(indexInBlock); // Push CFA over this node after we get the state before.
+                        alreadyHandled = true; // Don't allow the default constant folder to do things to this.
+                        m_insertionSet.insertCheck(indexInBlock, node->origin, node->children);
                         node->convertToNewObject(m_graph.registerStructure(structure));
                         changed = true;
                         break;

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -3480,9 +3480,7 @@ end)
 ipintOp(_br_on_cast, macro()
     validateOpcodeConfig(a1)
     loadi IPInt::RefTestCastMetadata::toHeapType[MC], a1
-    # fb 18 FLAGS
-    loadb 2[PC], a2
-    rshifti 1, a2  # bit 1 = null2
+    loadb IPInt::RefTestCastMetadata::allowNull[MC], a2
     loadq [sp], a3
     operationCall(macro() cCall3(_ipint_extern_ref_test) end)
 
@@ -3498,9 +3496,7 @@ end)
 ipintOp(_br_on_cast_fail, macro()
     validateOpcodeConfig(a1)
     loadi IPInt::RefTestCastMetadata::toHeapType[MC], a1
-    loadb 2[PC], a2
-    # fb 19 FLAGS
-    rshifti 1, a2  # bit 1 = null2
+    loadb IPInt::RefTestCastMetadata::allowNull[MC], a2
     loadq [sp], a3
     operationCall(macro() cCall3(_ipint_extern_ref_test) end)
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -1306,20 +1306,22 @@ IPIntGenerator::ExpressionType IPIntGenerator::addSIMDConstant(v128_t)
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addRefTest(ExpressionType, bool, int32_t heapType, bool, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addRefTest(ExpressionType, bool allowNull, int32_t heapType, bool, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::RefTestCastMetadata>({
         heapType,
-        static_cast<uint8_t>(getCurrentInstructionLength())
+        static_cast<uint8_t>(getCurrentInstructionLength()),
+        static_cast<uint8_t>(allowNull),
     });
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addRefCast(ExpressionType, bool, int32_t heapType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addRefCast(ExpressionType, bool allowNull, int32_t heapType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::RefTestCastMetadata>({
         heapType,
-        static_cast<uint8_t>(getCurrentInstructionLength())
+        static_cast<uint8_t>(getCurrentInstructionLength()),
+        static_cast<uint8_t>(allowNull),
     });
     return { };
 }
@@ -2626,11 +2628,12 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addBranchCast(ControlType& block, ExpressionType, std::span<const TypedExpression>, bool, int32_t heapType, bool)
+[[nodiscard]] PartialResult IPIntGenerator::addBranchCast(ControlType& block, ExpressionType, std::span<const TypedExpression>, bool allowNull, int32_t heapType, bool)
 {
     m_metadata->appendMetadata<IPInt::RefTestCastMetadata>({
         heapType,
-        0
+        0,
+        static_cast<uint8_t>(allowNull),
     });
 
     IPIntLocation here = { curPC(), curMC() };

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
@@ -385,6 +385,7 @@ struct ArrayInitElemMetadata {
 struct RefTestCastMetadata {
     int32_t toHeapType;
     uint8_t length;
+    uint8_t allowNull;
 };
 
 #pragma pack()

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -44,7 +44,9 @@
 #include "StyleComputedStyle.h"
 #include "StyleLengthResolution.h"
 #include "StylePrimitiveNumericTypes+Rounding.h"
+#include <type_traits>
 #include <wtf/Hasher.h>
+#include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/MakeString.h>
@@ -166,6 +168,7 @@ CSSPrimitiveValue::~CSSPrimitiveValue()
         break;
     }
     if (m_hasCachedCSSText) {
+        ASSERT(isMainThread());
         ASSERT(serializedPrimitiveValues().contains(this));
         serializedPrimitiveValues().remove(this);
     }
@@ -350,11 +353,20 @@ String CSSPrimitiveValue::customCSSText(const CSS::SerializationContext& context
     case CSSUnitType::CSS_UNKNOWN:
         return String();
     default:
+        // The memoization map and m_hasCachedCSSText are not thread-safe, and worker threads can
+        // serialize FontFace descriptors concurrently with the main thread. Only memoize on the
+        // main thread; other threads serialize without touching the shared state.
+        if (!isMainThread())
+            return serializeInternal(context);
         auto& map = serializedPrimitiveValues();
         ASSERT(map.contains(this) == m_hasCachedCSSText);
         if (m_hasCachedCSSText)
             return map.get(this);
         String serializedValue = serializeInternal(context);
+        // m_hasCachedCSSText is written here without synchronization, so it must live in its own
+        // memory location (not a bit-field packed with concurrently-read members).
+        static_assert(std::is_member_object_pointer_v<decltype(&CSSPrimitiveValue::m_hasCachedCSSText)>,
+            "m_hasCachedCSSText must not be a bit-field");
         m_hasCachedCSSText = true;
         map.add(this, serializedValue);
         return serializedValue;

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -311,11 +311,12 @@ protected:
 
     // CSSPrimitiveValue:
     uint8_t m_primitiveUnitType : 7 { 0 }; // CSSUnitType
-    mutable uint8_t m_hasCachedCSSText : 1 { false };
     uint8_t m_isImplicitInitialValue : 1 { false };
 
     // CSSValueList and CSSValuePair:
     uint8_t m_valueSeparator : ValueSeparatorBits { 0 };
+
+    mutable uint8_t m_hasCachedCSSText { false };
 
 private:
     ClassType m_classType : ClassTypeBits;

--- a/Source/WebCore/platform/animation/values/shapes/AcceleratedEffectCircleFunction.cpp
+++ b/Source/WebCore/platform/animation/values/shapes/AcceleratedEffectCircleFunction.cpp
@@ -31,6 +31,7 @@
 #include "AcceleratedEffectAnimationUtilities.h"
 #include "GeometryUtilities.h"
 #include "Path.h"
+#include <wtf/Lock.h>
 #include <wtf/TinyLRUCache.h>
 
 namespace WebCore {
@@ -52,8 +53,13 @@ public:
     }
 };
 
-static const WebCore::Path& cachedAcceleratedEffectCirclePath(const FloatRect& rect)
+static WebCore::Path cachedAcceleratedEffectCirclePath(const FloatRect& rect)
 {
+    // This may be reached on the main run loop and the ScrollingThread concurrently
+    // (via RemoteLayerTreeEventDispatcher::updateAnimations), so the global cache
+    // must be guarded and the result copied out under the lock.
+    static Lock cacheLock;
+    Locker locker { cacheLock };
     static NeverDestroyed<TinyLRUCache<FloatRect, WebCore::Path, 4, AcceleratedEffectCirclePathPolicy>> cache;
     return cache.get().get(rect);
 }

--- a/Source/WebCore/platform/animation/values/shapes/AcceleratedEffectEllipseFunction.cpp
+++ b/Source/WebCore/platform/animation/values/shapes/AcceleratedEffectEllipseFunction.cpp
@@ -31,6 +31,7 @@
 #include "AcceleratedEffectAnimationUtilities.h"
 #include "GeometryUtilities.h"
 #include "Path.h"
+#include <wtf/Lock.h>
 #include <wtf/TinyLRUCache.h>
 
 namespace WebCore {
@@ -52,8 +53,13 @@ public:
     }
 };
 
-static const WebCore::Path& cachedAcceleratedEffectEllipsePath(const FloatRect& rect)
+static WebCore::Path cachedAcceleratedEffectEllipsePath(const FloatRect& rect)
 {
+    // This may be reached on the main run loop and the ScrollingThread concurrently
+    // (via RemoteLayerTreeEventDispatcher::updateAnimations), so the global cache
+    // must be guarded and the result copied out under the lock.
+    static Lock cacheLock;
+    Locker locker { cacheLock };
     static NeverDestroyed<TinyLRUCache<FloatRect, WebCore::Path, 4, AcceleratedEffectEllipsePathPolicy>> cache;
     return cache.get().get(rect);
 }

--- a/Source/WebCore/platform/animation/values/shapes/AcceleratedEffectInsetFunction.cpp
+++ b/Source/WebCore/platform/animation/values/shapes/AcceleratedEffectInsetFunction.cpp
@@ -30,6 +30,7 @@
 
 #include "AcceleratedEffectAnimationUtilities.h"
 #include "Path.h"
+#include <wtf/Lock.h>
 #include <wtf/TinyLRUCache.h>
 
 namespace WebCore {
@@ -51,8 +52,13 @@ public:
     }
 };
 
-static const WebCore::Path& cachedRoundedInsetPath(const FloatRoundedRect& rect)
+static WebCore::Path cachedRoundedInsetPath(const FloatRoundedRect& rect)
 {
+    // This may be reached on the main run loop and the ScrollingThread concurrently
+    // (via RemoteLayerTreeEventDispatcher::updateAnimations), so the global cache
+    // must be guarded and the result copied out under the lock.
+    static Lock cacheLock;
+    Locker locker { cacheLock };
     static NeverDestroyed<TinyLRUCache<FloatRoundedRect, WebCore::Path, 4, AcceleratedEffectInsetPathPolicy>> cache;
     return cache.get().get(rect);
 }

--- a/Source/WebCore/platform/animation/values/shapes/AcceleratedEffectPathFunction.cpp
+++ b/Source/WebCore/platform/animation/values/shapes/AcceleratedEffectPathFunction.cpp
@@ -33,6 +33,7 @@
 #include "GeometryUtilities.h"
 #include "Path.h"
 #include "SVGPathUtilities.h"
+#include <wtf/Lock.h>
 #include <wtf/TinyLRUCache.h>
 #include <wtf/ZippedRange.h>
 
@@ -79,8 +80,13 @@ struct AcceleratedEffectTransformedByteStreamPathPolicy : TinyLRUCachePolicy<Acc
     }
 };
 
-static const WebCore::Path& cachedAcceleratedEffectTransformedByteStreamPath(const SVGPathByteStream& stream, float zoom, const FloatPoint& offset)
+static WebCore::Path cachedAcceleratedEffectTransformedByteStreamPath(const SVGPathByteStream& stream, float zoom, const FloatPoint& offset)
 {
+    // This may be reached on the main run loop and the ScrollingThread concurrently
+    // (via RemoteLayerTreeEventDispatcher::updateAnimations), so the global cache
+    // must be guarded and the result copied out under the lock.
+    static Lock cacheLock;
+    Locker locker { cacheLock };
     static NeverDestroyed<TinyLRUCache<AcceleratedEffectSVGPathTransformedByteStream, WebCore::Path, 4, AcceleratedEffectTransformedByteStreamPathPolicy>> cache;
     return cache.get().get(AcceleratedEffectSVGPathTransformedByteStream { stream, zoom, offset });
 }

--- a/Source/WebCore/platform/animation/values/shapes/AcceleratedEffectPolygonFunction.cpp
+++ b/Source/WebCore/platform/animation/values/shapes/AcceleratedEffectPolygonFunction.cpp
@@ -30,6 +30,7 @@
 
 #include "AcceleratedEffectAnimationUtilities.h"
 #include "Path.h"
+#include <wtf/Lock.h>
 #include <wtf/TinyLRUCache.h>
 #include <wtf/ZippedRange.h>
 
@@ -55,8 +56,13 @@ public:
     }
 };
 
-static const WebCore::Path& cachedAcceleratedEffectPolygonPath(const Vector<FloatPoint>& points)
+static WebCore::Path cachedAcceleratedEffectPolygonPath(const Vector<FloatPoint>& points)
 {
+    // This may be reached on the main run loop and the ScrollingThread concurrently
+    // (via RemoteLayerTreeEventDispatcher::updateAnimations), so the global cache
+    // must be guarded and the result copied out under the lock.
+    static Lock cacheLock;
+    Locker locker { cacheLock };
     static NeverDestroyed<TinyLRUCache<Vector<FloatPoint>, WebCore::Path, 4, AcceleratedEffectPolygonPathPolicy>> cache;
     return cache.get().get(points);
 }


### PR DESCRIPTION
#### 9d899104d9b0ba8409f810a342d07c83b6116ba6
<pre>
Cherry-pick 305413.1033@safari-7624.5.1.10-branch (e4960726c71e). <a href="https://bugs.webkit.org/show_bug.cgi?id=317919">https://bugs.webkit.org/show_bug.cgi?id=317919</a>

    [threaded-animations] cross-thread UAF in UIProcess via unguarded static TinyLRUCache in AcceleratedEffect polygon path cache
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317919">https://bugs.webkit.org/show_bug.cgi?id=317919</a>
    <a href="https://rdar.apple.com/180233994">rdar://180233994</a>

    Reviewed by Chris Dumez.

    Values held by AcceleratedEffectValues may be accessed both from the main thread
    and the scrolling thread on macOS.

    Meanwhile, the `cachedAcceleratedEffectXXXPath()` family of functions use a process-global
    `static NeverDestroyed&lt;TinyLRUCache&lt;..., WebCore::Path, 4, ...&gt;&gt;` with no synchronization
    and return a `const Path&amp;` directly into a cache slot. TinyLRUCache::get() move-assigns
    slots whose `Path` value wraps `DataRef&lt;PathImpl&gt;`, a concurrent move-assignment
    tears the non-atomic pointer read/swap in `Ref::operator=(Ref&amp;&amp;)` and produces
    a stale refcounted pointer that is then deref&apos;d, yielding a use-after-free
    or double-free of `PathImpl`.

    We now guard each cache with a static Lock and return Path by value so the cache
    slot is copied out while the lock is held. `PathImpl` is `ThreadSafeRefCounted`
    so the by-value copy is just an atomic refcount bump. This matches the existing
    pattern used by `cachedCGColor()` and `UTIFromMIMEType()` for concurrently-accessed
    static `TinyLRUCache` instances.

    This fix was suggested by an LLM during bug analysis, I validated its approach.

    Test: webanimations/threaded-animations/offset-path-shape-cache-thread-safety-crash.html

    * LayoutTests/webanimations/threaded-animations/offset-path-shape-cache-thread-safety-crash-expected.txt: Added.
    * LayoutTests/webanimations/threaded-animations/offset-path-shape-cache-thread-safety-crash.html: Added.
    * LayoutTests/webanimations/threaded-animations/resources/offset-path-shape-cache-thread-safety-popup.html: Added.
    * Source/WebCore/platform/animation/values/shapes/AcceleratedEffectCircleFunction.cpp:
    (WebCore::cachedAcceleratedEffectCirclePath):
    * Source/WebCore/platform/animation/values/shapes/AcceleratedEffectEllipseFunction.cpp:
    (WebCore::cachedAcceleratedEffectEllipsePath):
    * Source/WebCore/platform/animation/values/shapes/AcceleratedEffectInsetFunction.cpp:
    (WebCore::cachedRoundedInsetPath):
    * Source/WebCore/platform/animation/values/shapes/AcceleratedEffectPathFunction.cpp:
    (WebCore::cachedAcceleratedEffectTransformedByteStreamPath):
    * Source/WebCore/platform/animation/values/shapes/AcceleratedEffectPolygonFunction.cpp:
    (WebCore::cachedAcceleratedEffectPolygonPath):

    Identifier: 305413.1033@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.211@webkitglib/2.54">https://commits.webkit.org/317695.211@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 9619a6b973814eac7c3a2ec638150b98c62262f5
<pre>
Cherry-pick 305413.1032@safari-7624.5-branch (bc1c6b94e762). <a href="https://bugs.webkit.org/show_bug.cgi?id=317654">https://bugs.webkit.org/show_bug.cgi?id=317654</a>

    [WebCore] Unsynchronized access to process-global serializedPrimitiveValues() HashMap in CSSPrimitiveValue::customCSSText from Worker thread
    <a href="https://rdar.apple.com/177596584">rdar://177596584</a>

    Reviewed by Alan Baradlay.

    FontFace is Exposed=(Window,Worker), so its descriptor getters serialize
    CSSPrimitiveValues off the main thread via customCSSText(), racing the main
    thread on the unsynchronized process-global serialization map and the
    m_hasCachedCSSText flag. A concurrent HashTable rehash can free the backing
    buffer while another thread holds a bucket pointer, producing a
    heap-use-after-free or double-free.

    Only memoize on the main thread; other threads serialize directly without
    touching the shared state. Move m_hasCachedCSSText out of the bit-field group so
    the main thread can set it without racing reads of the adjacent bits of a shared
    static value.

    Test: fast/css/font-face-worker-serialization-thread-safety.html
    * LayoutTests/fast/css/font-face-worker-serialization-thread-safety-expected.txt: Added.
    * LayoutTests/fast/css/font-face-worker-serialization-thread-safety.html: Added.
    * Source/WebCore/css/CSSPrimitiveValue.cpp:
    (WebCore::CSSPrimitiveValue::~CSSPrimitiveValue):
    (WebCore::CSSPrimitiveValue::customCSSText const):
    * Source/WebCore/css/CSSValue.h:

    Identifier: 305413.1032@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.210@webkitglib/2.54">https://commits.webkit.org/317695.210@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 91e956415ac3836874cdd9256495aff0bb1c55e9
<pre>
Cherry-pick 305413.1025@safari-7624.5-branch (5b76326e8fc9). <a href="https://bugs.webkit.org/show_bug.cgi?id=317349">https://bugs.webkit.org/show_bug.cgi?id=317349</a>

    IPInt br_on_cast/br_on_cast_fail must handle overlong LEB128 opcode
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317349">https://bugs.webkit.org/show_bug.cgi?id=317349</a>
    <a href="https://rdar.apple.com/178289134">rdar://178289134</a>

    Reviewed by Yusuke Suzuki.

    Currently IPInt implementations of br_on_cast/br_on_cast_fail assume
    flags are at a fixed offset in the instruction but overlong opcodes
    are legal and IPInt may use the wrong byte to load flags. This patch
    makes the validator cache allowNull in metadata so IPInt no longer
    loads from the instruction stream at all.

    Tests: JSTests/wasm/stress/br-on-cast-fail-overlong-leb128.js
           JSTests/wasm/stress/br-on-cast-overlong-leb128.js

    * JSTests/wasm/stress/br-on-cast-fail-overlong-leb128.js: Added.
    (uleb):
    (section):
    (str):
    * JSTests/wasm/stress/br-on-cast-overlong-leb128.js: Added.
    (uleb):
    (section):
    (str):
    * Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
    * Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
    (JSC::Wasm::IPIntGenerator::addRefTest):
    (JSC::Wasm::IPIntGenerator::addRefCast):
    (JSC::Wasm::IPIntGenerator::addBranchCast):
    * Source/JavaScriptCore/wasm/WasmIPIntGenerator.h:

    Identifier: 305413.1025@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.209@webkitglib/2.54">https://commits.webkit.org/317695.209@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 217e050243df05f627e58b21a20bb1e97a8e4bab
<pre>
Cherry-pick 305413.1017@safari-7624.5.1.10-branch (ac9e40a7195b). <a href="https://bugs.webkit.org/show_bug.cgi?id=317570">https://bugs.webkit.org/show_bug.cgi?id=317570</a>

    [JSC] ObjectCreate folding should emit checks
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317570">https://bugs.webkit.org/show_bug.cgi?id=317570</a>
    <a href="https://rdar.apple.com/178248992">rdar://178248992</a>

    Reviewed by Yijia Huang.

    When folding ObjectCreate(with-edge-checks), we are not emitting these
    checks and converting it to NewObject. As a result, we missed the edge
    filters and the subsequent code may rely on that. This patch correctly
    inserts these checks.

    Test: JSTests/stress/object-create-check-insertion.js

    * JSTests/stress/object-create-check-insertion.js: Added.
    (bitsToDouble):
    (enforce):
    (getKey):
    (getK2):
    (caller):
    (trainGetKey):
    (trainCaller):
    (trainGetK2):
    (ramp):
    * Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
    (JSC::DFG::ConstantFoldingPhase::foldConstants):

    Identifier: 305413.1017@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.208@webkitglib/2.54">https://commits.webkit.org/317695.208@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/260f365979f34d167e61fff1dc8ce1d28e523b52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185343 "2 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59255 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53072 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195667 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150143 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187205 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60620 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58982 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144847 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150143 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188298 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60620 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53072 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125140 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60620 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/58982 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7046 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53072 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60620 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53072 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6720 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/46601 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/51911 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/58982 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197616 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/58919 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53072 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154354 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59628 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53072 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154005 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28143 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59628 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/131950 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/128778 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58106 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53072 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57478 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57721 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57545 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->