### PR TITLE
[JSC] Use fast parh of `Array#copyWithIn` even if an array having a hole and indexed as `ArrayWithInt32`, `ArrayWithDouble`, and `ArrayWithContiguous`

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-copyWithin-contiguous-has-hole.js
+++ b/JSTests/microbenchmarks/array-prototype-copyWithin-contiguous-has-hole.js
@@ -5,7 +5,9 @@ noInline(test);
 
 const array = new Array(1024);
 for (let i = 0, l = array.length; i < l; ++i) {
-    array[i] = { i };
+    if (i % 3 !== 0) {
+        array[i] = { i };
+    }
 }
 
 for (let i = 0; i < testLoopCount; ++i) {

--- a/JSTests/microbenchmarks/array-prototype-copyWithin-double-has-hole.js
+++ b/JSTests/microbenchmarks/array-prototype-copyWithin-double-has-hole.js
@@ -5,7 +5,9 @@ noInline(test);
 
 const array = new Array(1024);
 for (let i = 0, l = array.length; i < l; ++i) {
-    array[i] = { i };
+    if (i % 3 !== 0) {
+        array[i] = i + 0.5;
+    }
 }
 
 for (let i = 0; i < testLoopCount; ++i) {

--- a/JSTests/microbenchmarks/array-prototype-copyWithin-double.js
+++ b/JSTests/microbenchmarks/array-prototype-copyWithin-double.js
@@ -3,10 +3,11 @@ function test(array, target, start, end) {
 }
 noInline(test);
 
-let array = new Array(1024);
-for (let j = 0; j < array.length; j++)
-    array[j] = j + 0.5;
+const array = new Array(1024);
+for (let i = 0, l = array.length; i < l; ++i) {
+    array[i] = i + 0.5;
+}
 
-for (let i = 0; i < 1e6; i++) {
-    array.copyWithin(i % 512, 256, 768);
+for (let i = 0; i < testLoopCount; ++i) {
+    test(array, i % 512, 256, 768);
 }

--- a/JSTests/microbenchmarks/array-prototype-copyWithin-int32-has-hole.js
+++ b/JSTests/microbenchmarks/array-prototype-copyWithin-int32-has-hole.js
@@ -5,7 +5,9 @@ noInline(test);
 
 const array = new Array(1024);
 for (let i = 0, l = array.length; i < l; ++i) {
-    array[i] = { i };
+    if (i % 3 !== 0) {
+        array[i] = i;
+    }
 }
 
 for (let i = 0; i < testLoopCount; ++i) {

--- a/JSTests/microbenchmarks/array-prototype-copyWithin-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-copyWithin-int32.js
@@ -3,10 +3,11 @@ function test(array, target, start, end) {
 }
 noInline(test);
 
-let array = new Array(1024);
-for (let j = 0; j < array.length; j++)
-    array[j] = j;
+const array = new Array(1024);
+for (let i = 0, l = array.length; i < l; ++i) {
+    array[i] = i;
+}
 
-for (let i = 0; i < 1e6; i++) {
-    array.copyWithin(i % 512, 256, 768);
+for (let i = 0; i < testLoopCount; ++i) {
+    test(array, i % 512, 256, 768);
 }

--- a/JSTests/stress/array-prototype-copyWithin-contiguous-array-proto-has-indexed-props.js
+++ b/JSTests/stress/array-prototype-copyWithin-contiguous-array-proto-has-indexed-props.js
@@ -1,0 +1,25 @@
+function compareArray(actual, expected) {
+    if (actual.length !== expected.length)
+        throw new Error(`Expected length ${expected.length} but got ${actual.length}`);
+    for (let i = 0, l = actual.length; i < l; ++i) {
+        if (Object.hasOwn(actual, i) !== Object.hasOwn(expected, i))
+            throw new Error(`${i}: Mismatch the owner of the property`);
+        if (actual[i] !== expected[i])
+            throw new Error(`${i}: Expected ${expected[i]} but got ${actual[i]}`);
+    }
+}
+
+Array.prototype[2] = "two";
+
+{
+    const arr = ["zero", "one", , "three"];
+    arr.copyWithin(0, 2)
+    compareArray(arr, ["two", "three", , "three"]);
+}
+
+{
+    const obj = { test: "three" };
+    const arr = [null, {}, , obj];
+    arr.copyWithin(0, 2)
+    compareArray(arr, ["two", obj, , obj]);
+}

--- a/JSTests/stress/array-prototype-copyWithin-contiguous.js
+++ b/JSTests/stress/array-prototype-copyWithin-contiguous.js
@@ -1,9 +1,11 @@
-function compareArray(a, b) {
-    if (a.length !== b.length)
-        throw new Error(`Expected length ${b.length} but got ${a.length}`);
-    for (let i = 0; i < a.length; i++) {
-        if (a[i] !== b[i])
-            throw new Error(`${i}: Expected ${b[i]} but got ${a[i]}`);
+function compareArray(actual, expected) {
+    if (actual.length !== expected.length)
+        throw new Error(`Expected length ${expected.length} but got ${actual.length}`);
+    for (let i = 0, l = actual.length; i < l; ++i) {
+        if (Object.hasOwn(actual, i) !== Object.hasOwn(expected, i))
+            throw new Error(`${i}: Mismatch the owner of the property`);
+        if (actual[i] !== expected[i])
+            throw new Error(`${i}: Expected ${expected[i]} but got ${actual[i]}`);
     }
 }
 
@@ -28,4 +30,42 @@ function compareArray(a, b) {
     let arr = [null, obj, "aaa", 42];
     arr.copyWithin(1, 2, 2); 
     compareArray(arr, [null, obj, "aaa", 42]);
+}
+
+{
+    // Have a hole on array by literal.
+    const obj = { test: 123 };
+    const arr = [null, , obj, , "aaa", , 42];
+    arr.copyWithin(2, 3);
+    compareArray(arr, [null, , , "aaa", , 42, 42]);
+}
+
+{
+    // Have a hole by array constructor.
+    const obj = { test: 123 };
+    const arr = new Array(7);
+    arr[0] = null;
+    arr[2] = obj;
+    arr[4] = "aaa";
+    arr[6] = 42;
+    arr.copyWithin(2, 3);
+    compareArray(arr, [null, , , "aaa", , 42, 42]);
+}
+
+{
+    // Have a hole by chainging Array#length
+    const arr = new Array(0);
+    arr.length = 5;
+    arr[2] = 2;
+    arr.copyWithin(2, 0);
+    compareArray(arr, [, , , , 2]);
+}
+
+{
+    // Have a hole by delete indexed prop
+    const obj = { test: 123 };
+    const arr = [null, obj, "aaa", 42];
+    delete arr[1];
+    arr.copyWithin(0, 1, 2);
+    compareArray(arr, [, , "aaa", 42]);
 }

--- a/JSTests/stress/array-prototype-copyWithin-double-array-proto-has-indexed-props.js
+++ b/JSTests/stress/array-prototype-copyWithin-double-array-proto-has-indexed-props.js
@@ -1,0 +1,18 @@
+function compareArray(actual, expected) {
+    if (actual.length !== expected.length)
+        throw new Error(`Expected length ${expected.length} but got ${actual.length}`);
+    for (let i = 0, l = actual.length; i < l; ++i) {
+        if (Object.hasOwn(actual, i) !== Object.hasOwn(expected, i))
+            throw new Error(`${i}: Mismatch the owner of the property`);
+        if (actual[i] !== expected[i])
+            throw new Error(`${i}: Expected ${expected[i]} but got ${actual[i]}`);
+    }
+}
+
+Array.prototype[2] = 2.2;
+
+{
+    const arr = [0.0, 1.1, , 3.3];
+    arr.copyWithin(0, 2)
+    compareArray(arr, [2.2, 3.3, , 3.3]);
+}

--- a/JSTests/stress/array-prototype-copyWithin-double.js
+++ b/JSTests/stress/array-prototype-copyWithin-double.js
@@ -1,9 +1,11 @@
-function compareArray(a, b) {
-    if (a.length !== b.length)
-        throw new Error(`Expected length ${b.length} but got ${a.length}`);
-    for (let i = 0; i < a.length; i++) {
-        if (a[i] !== b[i])
-            throw new Error(`${i}: Expected ${b[i]} but got ${a[i]}`);
+function compareArray(actual, expected) {
+    if (actual.length !== expected.length)
+        throw new Error(`Expected length ${expected.length} but got ${actual.length}`);
+    for (let i = 0, l = actual.length; i < l; ++i) {
+        if (Object.hasOwn(actual, i) !== Object.hasOwn(expected, i))
+            throw new Error(`${i}: Mismatch the owner of the property`);
+        if (actual[i] !== expected[i])
+            throw new Error(`${i}: Expected ${expected[i]} but got ${actual[i]}`);
     }
 }
 
@@ -23,4 +25,39 @@ function compareArray(a, b) {
     let arr = [1, 2, 3.3, 4.4];
     arr.copyWithin(0, 3, 2);
     compareArray(arr, [1, 2, 3.3, 4.4]);
+}
+
+{
+    // Have a hole on array by literal.
+    const arr = [0.0, , 2.2, , 4.4, , 6.6];
+    arr.copyWithin(2, 3);
+    compareArray(arr, [0.0, , , 4.4, , 6.6, 6.6]);
+}
+
+{
+    // Have a hole by array constructor.
+    const arr = new Array(7);
+    arr[0] = 0.0;
+    arr[2] = 2.2;
+    arr[4] = 4.4;
+    arr[6] = 6.6;
+    arr.copyWithin(2, 3);
+    compareArray(arr, [0.0, , , 4.4, , 6.6, 6.6]);
+}
+
+{
+    // Have a hole by chainging Array#length
+    const arr = new Array(0);
+    arr.length = 5;
+    arr[2] = 2.2;
+    arr.copyWithin(2, 0);
+    compareArray(arr, [, , , , 2.2]);
+}
+
+{
+    // Have a hole by delete indexed prop
+    const arr = [0.0, 1.1, 2.2];
+    delete arr[1];
+    arr.copyWithin(1, 1);
+    compareArray(arr, [0, , 2.2]);
 }

--- a/JSTests/stress/array-prototype-copyWithin-int32-array-proto-has-indexed-props.js
+++ b/JSTests/stress/array-prototype-copyWithin-int32-array-proto-has-indexed-props.js
@@ -1,0 +1,18 @@
+function compareArray(actual, expected) {
+    if (actual.length !== expected.length)
+        throw new Error(`Expected length ${expected.length} but got ${actual.length}`);
+    for (let i = 0, l = actual.length; i < l; ++i) {
+        if (Object.hasOwn(actual, i) !== Object.hasOwn(expected, i))
+            throw new Error(`${i}: Mismatch the owner of the property`);
+        if (actual[i] !== expected[i])
+            throw new Error(`${i}: Expected ${expected[i]} but got ${actual[i]}`);
+    }
+}
+
+Array.prototype[2] = 2;
+
+{
+    const arr = [0, 1, , 3];
+    arr.copyWithin(0, 2)
+    compareArray(arr, [2, 3, , 3]);
+}

--- a/JSTests/stress/array-prototype-copyWithin-int32.js
+++ b/JSTests/stress/array-prototype-copyWithin-int32.js
@@ -1,9 +1,11 @@
-function compareArray(a, b) {
-    if (a.length !== b.length)
-        throw new Error(`Expected length ${b.length} but got ${a.length}`);
-    for (let i = 0; i < a.length; i++) {
-        if (a[i] !== b[i])
-            throw new Error(`${i}: Expected ${b[i]} but got ${a[i]}`);
+function compareArray(actual, expected) {
+    if (actual.length !== expected.length)
+        throw new Error(`Expected length ${expected.length} but got ${actual.length}`);
+    for (let i = 0, l = actual.length; i < l; ++i) {
+        if (Object.hasOwn(actual, i) !== Object.hasOwn(expected, i))
+            throw new Error(`${i}: Mismatch the owner of the property`);
+        if (actual[i] !== expected[i])
+            throw new Error(`${i}: Expected ${expected[i]} but got ${actual[i]}`);
     }
 }
 
@@ -29,4 +31,39 @@ function compareArray(a, b) {
     let arr = [0, 1, 2, 3, 4, 5];
     arr.copyWithin(2, 3);
     compareArray(arr, [0, 1, 3, 4, 5, 5]);
+}
+
+{
+    // Have a hole on array by literal.
+    const arr = [0, , 2, , 4, , 6];
+    arr.copyWithin(2, 3);
+    compareArray(arr, [0, , , 4, , 6, 6]);
+}
+
+{
+    // Have a hole by array constructor.
+    const arr = new Array(7);
+    arr[0] = 0;
+    arr[2] = 2;
+    arr[4] = 4;
+    arr[6] = 6;
+    arr.copyWithin(2, 3);
+    compareArray(arr, [0, , , 4, , 6, 6]);
+}
+
+{
+    // Have a hole by chainging Array#length
+    const arr = new Array(0);
+    arr.length = 5;
+    arr[2] = 2;
+    arr.copyWithin(2, 0);
+    compareArray(arr, [, , , , 2]);
+}
+
+{
+    // Have a hole by delete indexed prop
+    const arr = [0, 1, 2];
+    delete arr[1];
+    arr.copyWithin(1, 1);
+    compareArray(arr, [0, , 2]);
 }

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -898,11 +898,11 @@ bool JSArray::fastCopyWithin(JSGlobalObject* globalObject, uint64_t from64, uint
     switch (type) {
     case ArrayWithInt32:
     case ArrayWithContiguous: {
-        auto data = this->butterfly()->contiguous().data();
+        Butterfly* butterfly = this->butterfly();
 
-        if (containsHole(data, length))
-            return false;
+        RELEASE_ASSERT(butterfly->vectorLength() >= length);
 
+        auto data = butterfly->contiguousInt32().data();
         std::span<WriteBarrier<Unknown>> destination { data + to, count };
         std::span<const WriteBarrier<Unknown>> source { data + from, count };
 
@@ -916,11 +916,11 @@ bool JSArray::fastCopyWithin(JSGlobalObject* globalObject, uint64_t from64, uint
         return true;
     }
     case ArrayWithDouble: {
-        auto data = this->butterfly()->contiguousDouble().data();
+        Butterfly* butterfly = this->butterfly();
 
-        if (containsHole(data, length))
-            return false;
+        RELEASE_ASSERT(butterfly->vectorLength() >= length);
 
+        auto data = butterfly->contiguousDouble().data();
         std::span<double> destination { data + to, count };
         std::span<double> source { data + from, count };
 


### PR DESCRIPTION
#### ae97aa471a12f25db388f1e95cc99f03a290d295
<pre>
[JSC] Use fast parh of `Array#copyWithIn` even if an array having a hole and indexed as `ArrayWithInt32`, `ArrayWithDouble`, and `ArrayWithContiguous`
<a href="https://bugs.webkit.org/show_bug.cgi?id=323593">https://bugs.webkit.org/show_bug.cgi?id=323593</a>

Reviewed by Yusuke Suzuki.

This change adds the support for array _having a hole_
to the fast path for [`Array#copyWithIn`][the spec] which was introduced in <a href="https://commits.webkit.org/291766@main">https://commits.webkit.org/291766@main</a>

Previously the fast path give up if the array has a hole conservatively.
We need to handle them as a part of the step 18c~18e in the spec.

However, we have a chance.

An array hole would be happen only in the following case.

- Initialized with a hole by constructor: `new Array(16)`
- Initialized with a hole by literal: `[, 1]`
- Extend `Array#length`: `var array = []; array.length = 100;`
- Delete an indexed property: `delete array[1]`

And an array hole is represnted as following internally for every cases:

- `JSC:ValueEmpty` : `ArrayWithInt32`, and `ArrayWithContiguous`.
- `JSC:PNaN`: `ArrayWithDouble`.

Thus we can use `memmoveSpan()`/`gcSafeMemmove()` for them.
This removes liner scan (`containsHole()`) from the fast path.

`ArrayWithArrayStorage` case also has the fast path but it does not follow this optimization.
It&apos;s an out of scope of this change.

[the spec]: <a href="https://tc39.es/ecma262/2026/#sec-array.prototype.copywithin">https://tc39.es/ecma262/2026/#sec-array.prototype.copywithin</a>

The benchmark result is here:

```
                                                  TipOfTree                  Patched

array-prototype-copyWithin-int32                1.2775+-0.0295     ^      0.6138+-0.0532        ^ definitely 2.0813x faster
array-prototype-copyWithin-double               1.4083+-0.0342     ^      0.6289+-0.0417        ^ definitely 2.2393x faster
array-prototype-copyWithin-contiguous-has-hole
                                               29.2703+-1.1639     ^      0.6603+-0.0382        ^ definitely 44.3303x faster
array-prototype-copyWithin-int32-has-hole
                                               29.2755+-1.1147     ^      0.6363+-0.0135        ^ definitely 46.0096x faster
array-prototype-copyWithin-contiguous           1.3071+-0.0339     ^      0.6790+-0.0131        ^ definitely 1.9251x faster
array-prototype-copyWithin-double-has-hole
                                               30.9277+-0.3593     ^      0.6198+-0.0284        ^ definitely 49.9035x faster

&lt;geometric&gt;                                     6.2959+-0.0561     ^      0.6390+-0.0070        ^ definitely 9.8531x faster
```

* JSTests/microbenchmarks/array-prototype-copyWithin-contiguous-has-hole.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-copyWithin-contiguous.js:
* JSTests/microbenchmarks/array-prototype-copyWithin-double-has-hole.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-copyWithin-double.js:
* JSTests/microbenchmarks/array-prototype-copyWithin-int32-has-hole.js: Added.
(test):
* JSTests/microbenchmarks/array-prototype-copyWithin-int32.js:
* JSTests/stress/array-prototype-copyWithin-contiguous-array-proto-has-indexed-props.js: Added.
(compareArray):
(2.compareArray):
* JSTests/stress/array-prototype-copyWithin-contiguous.js:
(compareArray):
* JSTests/stress/array-prototype-copyWithin-double-array-proto-has-indexed-props.js: Added.
(compareArray):
* JSTests/stress/array-prototype-copyWithin-double.js:
(compareArray):
* JSTests/stress/array-prototype-copyWithin-int32-array-proto-has-indexed-props.js: Added.
(compareArray):
* JSTests/stress/array-prototype-copyWithin-int32.js:
(compareArray):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastCopyWithin):

Canonical link: <a href="https://commits.webkit.org/320775@main">https://commits.webkit.org/320775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c58c1db4e34b961b336678395aac7b28047a3f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195842 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150274 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144977 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100514 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125269 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47385 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45443 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7174 "Found 1 new JSC stress test failure: Too many failures: 2103 jsc tests failed (failure)") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14059 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45127 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6893 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46775 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52086 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197791 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59094 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154506 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59803 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154153 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28224 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48630 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132154 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129054 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58279 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20149 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57652 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57895 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57718 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->