### PR TITLE
Allow annotating state that is read without locking on its owner thread

### DIFF
--- a/Source/WTF/wtf/ThreadAssertions.h
+++ b/Source/WTF/wtf/ThreadAssertions.h
@@ -29,6 +29,7 @@
 #include <cstdint>
 #include <utility>
 #include <wtf/Assertions.h>
+#include <wtf/CurrentThread.h>
 #include <wtf/ExportMacros.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/ThreadSafetyAnalysis.h>
@@ -168,6 +169,132 @@ inline ThreadLikeAssertion ThreadLike::createThreadLikeAssertion(uint32_t uid)
     return ThreadLikeAssertion { uid };
 }
 
+// Variant of ThreadLikeAssertion whose mutating check uses RELEASE_ASSERT, so that violations are
+// caught in release builds too. Consequently the owner is stored unconditionally, costing four bytes
+// even when assertions are disabled, and there is deliberately no destructor check: the garbage
+// collector is a legitimate accessor, so destruction from a GC thread must not be fatal.
+//
+// Only releaseAssertIsCurrentAndLatch(), used on the mutating paths, asserts in release builds. The
+// read side goes through assertIsOwnerThread(), which is only a security assertion, because readers
+// are typically far hotter than writers and must not pay for the check in shipping builds.
+//
+// The owner is latched on first use rather than at construction, for state whose owning thread is
+// not yet known when the object is created. Like ThreadLikeAssertion, a main thread owner is recorded
+// as mainThreadLike and rechecked through isMainThread(), so that the legacy iOS web thread is
+// handled without callers needing their own escape hatch.
+class WTF_CAPABILITY("is current") ThreadLikeReleaseAssertion {
+public:
+    ThreadLikeReleaseAssertion() = default;
+
+    bool isUnset() const { return !m_uid; }
+    bool isCurrent() const
+    {
+        if (m_uid == static_cast<uint32_t>(mainThreadLike))
+            return isMainThread();
+        return m_uid && m_uid == ThreadLike::currentSequence();
+    }
+
+private:
+    void latchToCurrentThread() { m_uid = isMainThread() ? static_cast<uint32_t>(mainThreadLike) : ThreadLike::currentSequence(); }
+
+    uint32_t m_uid { 0 };
+
+    friend void releaseAssertIsCurrentAndLatch(ThreadLikeReleaseAssertion&);
+};
+
+// Latches the owner thread on first call, and thereafter requires every access to come either from
+// that thread or from the garbage collector. Call this from the mutating paths.
+inline void releaseAssertIsCurrentAndLatch(ThreadLikeReleaseAssertion& ownerThread) WTF_ASSERTS_ACQUIRED_CAPABILITY(ownerThread)
+{
+    if (ownerThread.isUnset()) {
+        ASSERT_WITH_SECURITY_IMPLICATION(!currentThreadMayBeGCThread());
+        ownerThread.latchToCurrentThread();
+        return;
+    }
+    if (ownerThread.isCurrent()) [[likely]]
+        return;
+    RELEASE_ASSERT(currentThreadMayBeGCThread());
+}
+
+// Some state is mutated only on one thread, always while holding a lock, yet is read on that same
+// thread without taking the lock because doing so on every read would be too expensive. Threads
+// other than the owner must hold the lock even to read. Annotate such state with
+// WTF_GUARDED_BY_LOCK() as usual, and call assertIsOwnerThread() on the unlocked read path:
+//
+// struct MyClass {
+//     Element* element() const { assertIsOwnerThread(m_lock, mainThreadLike); return m_element.get(); }
+//     void setElement(Element* element) { Locker locker { m_lock }; m_element = element; }
+//     // Runs on another thread, so it must lock even though it only reads.
+//     void visit(Visitor& visitor) const { Locker locker { m_lock }; visitor.append(m_element); }
+// private:
+//     mutable Lock m_lock;
+//     RefPtr<Element> m_element WTF_GUARDED_BY_LOCK(m_lock);
+// };
+//
+// The owner may be given as mainThreadLike, as a ThreadLikeAssertion member for state owned by some
+// other thread or work queue, or as a ThreadLikeReleaseAssertion member when the owner should also be
+// checked in release builds.
+//
+// assertIsOwnerThread() grants only shared, read-only access, so thread safety analysis still
+// reports any write that does not hold the lock exclusively. That is what makes this preferable to
+// leaving the state unannotated: the "every write holds the lock" half of the invariant stays
+// machine-checked, reads from any other thread must still lock, and the unlocked reads become both
+// self-documenting and checked at run time.
+//
+// BlockDirectory has long used this idiom by hand, with assertIsMutatorOrMutatorIsStopped() granting
+// shared access to m_bitvectorLock; these helpers generalize it.
+//
+// A function that calls assertIsOwnerThread() and then takes the lock must release the assertion
+// first, by calling releaseOwnerThreadAssertion() below. Otherwise the assertion leaves the lock
+// marked as held for the remainder of the scope and the subsequent Locker is reported as acquiring
+// a lock that is already held.
+template<typename LockType>
+inline void assertIsOwnerThread(const LockType& lock, const ThreadLikeAssertion& ownerThread) WTF_ASSERTS_ACQUIRED_SHARED_LOCK(lock)
+{
+    UNUSED_PARAM(lock);
+    assertIsCurrent(ownerThread);
+}
+
+// Overloads for an owner latched by releaseAssertIsCurrentAndLatch(). Note that the capability is
+// granted unconditionally by calling these; the run-time check is only what catches a caller that
+// had no business taking the unlocked path. The garbage collector is therefore deliberately not
+// tolerated here, unlike on the mutating path: a GC thread reaching an unlocked read is exactly the
+// race these annotations exist to catch, and it must take the lock instead. An owner that has not
+// been latched yet is tolerated, because no mutation has happened and there is nothing to race with.
+//
+// This one is only a security assertion, not a release assertion: these reads sit on hot paths such
+// as event dispatch, and must not pay for an isMainThread() call in release builds. The release
+// assertion on the mutating path is what gives the shipping guarantee. Readers that are not hot
+// should prefer releaseAssertIsOwnerThread() below.
+template<typename LockType>
+inline void assertIsOwnerThread(const LockType& lock, const ThreadLikeReleaseAssertion& ownerThread) WTF_ASSERTS_ACQUIRED_SHARED_LOCK(lock)
+{
+    UNUSED_PARAM(lock);
+    UNUSED_PARAM(ownerThread);
+    ASSERT_WITH_SECURITY_IMPLICATION(ownerThread.isUnset() || ownerThread.isCurrent());
+}
+
+// As above, but checked in release builds too. Use this on read paths that are not hot enough for
+// the isMainThread() call to matter, so that they keep the same shipping guarantee as the mutating
+// paths. There is deliberately no equivalent taking a ThreadLikeAssertion: that type does not store
+// its owner when assertions are disabled, so it cannot be checked in release builds.
+template<typename LockType>
+inline void releaseAssertIsOwnerThread(const LockType& lock, const ThreadLikeReleaseAssertion& ownerThread) WTF_ASSERTS_ACQUIRED_SHARED_LOCK(lock)
+{
+    UNUSED_PARAM(lock);
+    RELEASE_ASSERT(ownerThread.isUnset() || ownerThread.isCurrent());
+}
+
+// Hands back the shared access granted by assertIsOwnerThread(), so that a function which starts
+// with an unlocked owner-thread read can go on to take the lock. Without this the analysis still
+// considers the lock held and reports the Locker as acquiring a lock that is already held. This
+// generates no code; it only moves the analysis state.
+template<typename LockType>
+ALWAYS_INLINE void releaseOwnerThreadAssertion(const LockType& lock) WTF_RELEASES_SHARED_LOCK(lock) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
+{
+    UNUSED_PARAM(lock);
+}
+
 // Type for globally named assertions for describing access requirements.
 // Can be used, for example, to require that a variable is accessed only in
 // a known named thread.
@@ -189,6 +316,7 @@ class WTF_CAPABILITY("is current") NamedAssertion { };
 using WTF::anyThreadLike;
 using WTF::AnyThreadLike;
 using WTF::assertIsCurrent;
+using WTF::assertIsOwnerThread;
 using WTF::currentThreadLike;
 using WTF::CurrentThreadLike;
 using WTF::mainThreadLike;
@@ -196,5 +324,9 @@ using WTF::MainThreadLike;
 using WTF::NamedAssertion;
 using WTF::noneThreadLike;
 using WTF::NoneThreadLike;
+using WTF::releaseAssertIsCurrentAndLatch;
+using WTF::releaseAssertIsOwnerThread;
+using WTF::releaseOwnerThreadAssertion;
 using WTF::ThreadLike;
 using WTF::ThreadLikeAssertion;
+using WTF::ThreadLikeReleaseAssertion;

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -186,7 +186,12 @@ void DOMAudioSession::stop()
 
 bool DOMAudioSession::virtualHasPendingActivity() const
 {
-    return hasEventListeners(eventNames().statechangeEvent);
+    return m_hasStateChangeEventListener;
+}
+
+void DOMAudioSession::eventListenersDidChange()
+{
+    m_hasStateChangeEventListener = hasEventListeners(eventNames().statechangeEvent);
 }
 
 void DOMAudioSession::beginAudioSessionInterruption()

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.h
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.h
@@ -79,6 +79,7 @@ private:
     // ActiveDOMObject
     void NODELETE stop() final;
     bool virtualHasPendingActivity() const final;
+    void eventListenersDidChange() final;
 
     // InterruptionObserver
     void beginAudioSessionInterruption() final;
@@ -89,6 +90,7 @@ private:
     State currentState() const;
 
     bool m_hasScheduleStateChangeEvent { false };
+    bool m_hasStateChangeEventListener { false };
     mutable std::optional<State> m_state;
 };
 

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
@@ -95,7 +95,15 @@ bool IDBDatabase::virtualHasPendingActivity() const
     if (!m_activeTransactions.isEmpty() || !m_committingTransactions.isEmpty() || !m_abortingTransactions.isEmpty())
         return true;
 
-    return hasEventListeners(m_eventNames.abortEvent) || hasEventListeners(m_eventNames.errorEvent) || hasEventListeners(m_eventNames.versionchangeEvent);
+    return m_hasRelevantEventListener;
+}
+
+void IDBDatabase::eventListenersDidChange()
+{
+    bool hasRelevantEventListener = hasEventListeners(m_eventNames.abortEvent)
+        || hasEventListeners(m_eventNames.errorEvent)
+        || hasEventListeners(m_eventNames.versionchangeEvent);
+    m_hasRelevantEventListener = hasRelevantEventListener;
 }
 
 const String IDBDatabase::name() const

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.h
@@ -122,6 +122,7 @@ private:
 
     // ActiveDOMObject.
     bool virtualHasPendingActivity() const final;
+    void eventListenersDidChange() final;
     void stop() final;
 
     void maybeCloseInServer();
@@ -130,6 +131,7 @@ private:
     IDBDatabaseInfo m_info;
     IDBDatabaseConnectionIdentifier m_databaseConnectionIdentifier;
 
+    bool m_hasRelevantEventListener { false };
     bool m_closePending { false };
     bool m_closedInServer { false };
 
@@ -138,7 +140,7 @@ private:
     HashMap<IDBResourceIdentifier, Ref<IDBTransaction>> m_committingTransactions;
     HashMap<IDBResourceIdentifier, Ref<IDBTransaction>> m_abortingTransactions;
     
-    const EventNames& m_eventNames; // Need to cache this so we can use it from GC threads.
+    const EventNames& m_eventNames;
     std::atomic<bool> m_isContextSuspended { false };
 };
 

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -476,7 +476,12 @@ void MediaDevices::scheduledEventTimerFired()
 
 bool MediaDevices::virtualHasPendingActivity() const
 {
-    return hasEventListeners(m_eventNames.devicechangeEvent);
+    return m_hasDeviceChangeEventListener;
+}
+
+void MediaDevices::eventListenersDidChange()
+{
+    m_hasDeviceChangeEventListener = hasEventListeners(m_eventNames.devicechangeEvent);
 }
 
 ScriptExecutionContext* MediaDevices::scriptExecutionContext() const

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -115,6 +115,7 @@ private:
     // ActiveDOMObject
     void stop() final;
     bool virtualHasPendingActivity() const final;
+    void eventListenersDidChange() final;
 
     // EventTarget.
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::MediaDevices; }
@@ -134,8 +135,9 @@ private:
 
     RunLoop::Timer m_scheduledEventTimer;
     Markable<UserMediaClient::DeviceChangeObserverToken> m_deviceChangeToken;
-    const EventNames& m_eventNames; // Need to cache this so we can use it from GC threads.
+    const EventNames& m_eventNames;
     bool m_listeningForDeviceChanges { false };
+    bool m_hasDeviceChangeEventListener { false };
 
     OptionSet<GestureAllowedRequest> m_requestTypesForCurrentGesture;
     WeakPtr<UserGestureToken> m_currentGestureToken;

--- a/Source/WebCore/bindings/js/JSTextTrackCueCustom.cpp
+++ b/Source/WebCore/bindings/js/JSTextTrackCueCustom.cpp
@@ -50,14 +50,16 @@ bool JSTextTrackCueOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> h
         return true;
     }
 
-    // If the cue is not associated with a track, it is not reachable.
-    if (!textTrackCue.track())
+    // If the cue is not associated with a track, it is not reachable. This runs on the parallel GC
+    // marking threads, so the test is done by TextTrackCue under m_trackLockForGC rather than
+    // through track(), which is only for the owner thread.
+    if (!textTrackCue.containsTrackAsOpaqueRootInGCThread(visitor))
         return false;
 
     if (reason) [[unlikely]]
         *reason = "TextTrack is an opaque root"_s;
 
-    SUPPRESS_UNCHECKED_ARG return containsWebCoreOpaqueRoot(visitor, textTrackCue.track());
+    return true;
 }
 
 template<typename Visitor>

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -183,6 +183,7 @@ CSSStyleSheet::~CSSStyleSheet()
 
 Node* CSSStyleSheet::ownerNode() const
 {
+    assertIsOwnerThread(m_opaqueRootLockForGC, mainThreadLike);
     return m_ownerNode.get();
 }
 
@@ -591,6 +592,7 @@ ExceptionOr<void> CSSStyleSheet::replaceSync(String&& text)
 
 bool CSSStyleSheet::isDetached() const
 {
+    assertIsOwnerThread(m_opaqueRootLockForGC, mainThreadLike);
     return !m_ownerNode
         && !m_ownerRule
         && m_adoptingTreeScopes.isEmptyIgnoringNullReferences();

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -192,7 +192,9 @@ private:
     WeakHashSet<ContainerNode, WeakPtrImplWithEventTargetData> m_adoptingTreeScopes;
 
     mutable Lock m_opaqueRootLockForGC;
-    CheckedPtr<Node> m_ownerNode;
+    // Only mutated on the main thread while holding m_opaqueRootLockForGC, so main-thread reads
+    // use assertIsOwnerThread() instead of locking; the GC thread must lock even to read.
+    CheckedPtr<Node> m_ownerNode WTF_GUARDED_BY_LOCK(m_opaqueRootLockForGC);
     CheckedPtr<CSSImportRule> m_ownerRule;
 
     TextPosition m_startPosition;

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -88,6 +88,7 @@ Attr::~Attr()
 
 ExceptionOr<void> Attr::setValue(const AtomString& value)
 {
+    assertIsOwnerThread(m_elementLockForGC, mainThreadLike);
     if (RefPtr element = m_element.get()) {
         auto verifiedValue = value;
         if (protect(document())->contextDocument().requiresTrustedTypes()) {
@@ -135,6 +136,7 @@ CSSStyleProperties* Attr::style()
 {
     // This is not part of the DOM API, and therefore not available to webpages. However, WebKit SPI
     // lets clients use this via the Objective-C and JavaScript bindings.
+    assertIsOwnerThread(m_elementLockForGC, mainThreadLike);
     RefPtr styledElement = dynamicDowncast<StyledElement>(m_element.get());
     if (!styledElement)
         return nullptr;
@@ -146,6 +148,7 @@ CSSStyleProperties* Attr::style()
 
 AtomString Attr::value() const
 {
+    assertIsOwnerThread(m_elementLockForGC, mainThreadLike);
     if (RefPtr element = m_element.get())
         return element->getAttributeForBindings(qualifiedName());
     return m_standaloneValue;
@@ -153,11 +156,11 @@ AtomString Attr::value() const
 
 void Attr::detachFromElementWithValue(const AtomString& value)
 {
-    ASSERT(m_element);
     ASSERT(m_standaloneValue.isNull());
     m_standaloneValue = value;
     {
         Locker locker { m_elementLockForGC };
+        ASSERT(m_element);
         m_element = nullptr;
     }
     setTreeScopeRecursively(Ref<Document> { document() });
@@ -165,9 +168,9 @@ void Attr::detachFromElementWithValue(const AtomString& value)
 
 void Attr::attachToElement(Element& element)
 {
-    ASSERT(!m_element);
     {
         Locker locker { m_elementLockForGC };
+        ASSERT(!m_element);
         m_element = &element;
     }
     m_standaloneValue = nullAtom();

--- a/Source/WebCore/dom/Attr.h
+++ b/Source/WebCore/dom/Attr.h
@@ -27,6 +27,7 @@
 #include <WebCore/Node.h>
 #include <WebCore/QualifiedName.h>
 #include <wtf/Lock.h>
+#include <wtf/ThreadAssertions.h>
 
 namespace WebCore {
 
@@ -44,7 +45,7 @@ public:
 
     String name() const { return qualifiedName().toString(); }
     bool specified() const { return true; }
-    Element* ownerElement() const { return m_element.get(); }
+    Element* ownerElement() const { assertIsOwnerThread(m_elementLockForGC, mainThreadLike); return m_element.get(); }
 
     WEBCORE_EXPORT AtomString value() const;
     WEBCORE_EXPORT ExceptionOr<void> setValue(const AtomString&);
@@ -78,7 +79,9 @@ private:
 
     // Attr wraps either an element/name, or a name/value pair (when it's a standalone Node.)
     // Note that m_name is always set, but m_element/m_standaloneValue may be null.
-    CheckedPtr<Element> m_element;
+    // m_element is only mutated on the main thread while holding m_elementLockForGC, so main-thread
+    // reads use assertIsOwnerThread() instead of locking; the GC thread must lock even to read.
+    CheckedPtr<Element> m_element WTF_GUARDED_BY_LOCK(m_elementLockForGC);
     QualifiedName m_name;
     AtomString m_standaloneValue;
     RefPtr<MutableStyleProperties> m_style;

--- a/Source/WebCore/dom/EventListenerMap.cpp
+++ b/Source/WebCore/dom/EventListenerMap.cpp
@@ -87,6 +87,7 @@ void EventListenerMap::clear()
 
 Vector<AtomString> EventListenerMap::eventTypes() const
 {
+    assertIsOwnerThreadForReading();
     return m_entries.map([](auto& entry) {
         return entry.first;
     });
@@ -107,7 +108,7 @@ void EventListenerMap::replacePreservingOptions(const AtomString& eventType, Eve
     releaseAssertOrSetThreadUID();
     Locker locker { m_lock };
 
-    auto* listeners = find(eventType);
+    auto* listeners = findForWriting(eventType);
     ASSERT(listeners);
     size_t index = findListener(*listeners, oldListener, useCapture);
     ASSERT(index != notFound);
@@ -122,7 +123,7 @@ bool EventListenerMap::add(const AtomString& eventType, Ref<EventListener>&& lis
     releaseAssertOrSetThreadUID();
     Locker locker { m_lock };
 
-    if (auto* listeners = find(eventType)) {
+    if (auto* listeners = findForWriting(eventType)) {
         if (findListener(*listeners, listener, options.capture) != notFound)
             return false; // Duplicate listener.
         listeners->append(RegisteredEventListener::create(WTF::move(listener), options));
@@ -161,7 +162,24 @@ bool EventListenerMap::remove(const AtomString& eventType, EventListener& listen
     return false;
 }
 
-EventListenerVector* EventListenerMap::find(const AtomString& eventType)
+bool EventListenerMap::isEmpty() const
+{
+    Locker locker { m_lock };
+    return m_entries.isEmpty();
+}
+
+const EventListenerVector* EventListenerMap::find(const AtomString& eventType) const
+{
+    assertIsOwnerThreadForReading();
+    for (auto& entry : m_entries) {
+        if (entry.first == eventType)
+            return &entry.second;
+    }
+
+    return nullptr;
+}
+
+EventListenerVector* EventListenerMap::findForWriting(const AtomString& eventType)
 {
     for (auto& entry : m_entries) {
         if (entry.first == eventType)
@@ -198,7 +216,7 @@ void EventListenerMap::removeFirstEventListenerCreatedFromMarkup(const AtomStrin
     }
 }
 
-static void copyListenersNotCreatedFromMarkupToTarget(const AtomString& eventType, EventListenerVector& listenerVector, EventTarget* target)
+static void copyListenersNotCreatedFromMarkupToTarget(const AtomString& eventType, const EventListenerVector& listenerVector, EventTarget* target)
 {
     for (auto& registeredListener : listenerVector) {
         // Event listeners created from markup have already been transfered to the shadow tree during cloning.
@@ -210,7 +228,8 @@ static void copyListenersNotCreatedFromMarkupToTarget(const AtomString& eventTyp
 
 void EventListenerMap::copyEventListenersNotCreatedFromMarkupToTarget(EventTarget* target)
 {
-    for (auto& entry : m_entries)
+    assertIsOwnerThreadForReading();
+    for (const auto& entry : m_entries)
         copyListenersNotCreatedFromMarkupToTarget(entry.first, entry.second, target);
 }
 

--- a/Source/WebCore/dom/EventListenerMap.h
+++ b/Source/WebCore/dom/EventListenerMap.h
@@ -40,11 +40,11 @@
 #include <wtf/Assertions.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/Compiler.h>
-#include <wtf/CurrentThread.h>
 #include <wtf/Forward.h>
 #include <wtf/Lock.h>
 #include <wtf/Locker.h>
 #include <wtf/Platform.h>
+#include <wtf/ThreadAssertions.h>
 #include <wtf/Vector.h>
 #include <wtf/text/AtomString.h>
 
@@ -62,7 +62,7 @@ class EventListenerMap {
 public:
     WEBCORE_EXPORT EventListenerMap();
 
-    bool isEmpty() const { return m_entries.isEmpty(); }
+    bool isEmpty() const;
     bool contains(const AtomString& eventType) const { return find(eventType); }
     bool NODELETE containsCapturing(const AtomString& eventType) const;
     bool NODELETE containsActive(const AtomString& eventType) const;
@@ -71,19 +71,22 @@ public:
     void clearEntriesForTearDown()
     {
         releaseAssertOrSetThreadUID();
+        Locker locker { m_lock };
         m_entries.clear();
     }
 
     void replacePreservingOptions(const AtomString& eventType, EventListener& oldListener, Ref<EventListener>&& newListener, bool useCapture = false);
     bool add(const AtomString& eventType, Ref<EventListener>&&, const RegisteredEventListener::Options&);
     bool remove(const AtomString& eventType, EventListener&, bool useCapture);
-    WEBCORE_EXPORT EventListenerVector* NODELETE find(const AtomString& eventType);
-    const EventListenerVector* find(const AtomString& eventType) const { return const_cast<EventListenerMap*>(this)->find(eventType); }
+    // Returns a pointer into m_entries, so it must be const: handing out a mutable pointer would let
+    // callers write to guarded state without thread safety analysis being able to check them.
+    WEBCORE_EXPORT const EventListenerVector* NODELETE find(const AtomString& eventType) const;
     Vector<AtomString> eventTypes() const;
 
     template<typename CallbackType>
     void enumerateEventListenerTypes(NOESCAPE const CallbackType& callback) const
     {
+        assertIsOwnerThreadForReading();
         for (auto& entry : m_entries) {
             uint32_t capturingCount = 0;
             uint32_t bubblingCount = 0;
@@ -100,6 +103,7 @@ public:
     template<typename CallbackType>
     bool containsMatchingEventListener(NOESCAPE const CallbackType& callback) const
     {
+        assertIsOwnerThreadForReading();
         for (auto& entry : m_entries) {
             if (callback(entry.first, m_entries))
                 return true;
@@ -111,28 +115,41 @@ public:
     void copyEventListenersNotCreatedFromMarkupToTarget(EventTarget*);
     
     template<typename Visitor> void visitJSEventListenersInGCThread(Visitor&);
-    Lock& lock() LIFETIME_BOUND { return m_lock; }
 
 private:
+    // 294937@main disabled these assertions when the web thread is enabled, after the release
+    // assertion failed in the field: on USE(WEB_THREAD), isMainThread() is false on the web thread
+    // whenever the web thread lock is momentarily dropped, so an owner latched in that window would
+    // reject later legitimate access from the UI thread. WebThreadIsEnabled() is not visible to WTF,
+    // so this bypass has to live here rather than in ThreadLikeReleaseAssertion.
+    void assertIsOwnerThreadForReading() const WTF_ASSERTS_ACQUIRED_SHARED_LOCK(m_lock)
+    {
+#if PLATFORM(IOS_FAMILY)
+        if (WebThreadIsEnabled())
+            return;
+#endif
+        assertIsOwnerThread(m_lock, m_ownerThread);
+    }
+
     void releaseAssertOrSetThreadUID()
     {
 #if PLATFORM(IOS_FAMILY)
         if (WebThreadIsEnabled())
             return;
 #endif
-        if (!m_threadUID) {
-            ASSERT(!currentThreadMayBeGCThread());
-            m_threadUID = currentThreadID();
-            return;
-        }
-        if (m_threadUID == currentThreadID()) [[likely]]
-            return;
-        RELEASE_ASSERT(currentThreadMayBeGCThread());
+        releaseAssertIsCurrentAndLatch(m_ownerThread);
     }
 
-    Vector<std::pair<AtomString, EventListenerVector>, 0, CrashOnOverflow, 4> m_entries;
-    Lock m_lock;
-    uint32_t m_threadUID { 0 };
+    // Mutating lookup, for callers that write through the result. Requires the lock, so that those
+    // writes are covered even though thread safety analysis cannot follow the returned pointer.
+    EventListenerVector* NODELETE findForWriting(const AtomString& eventType) WTF_REQUIRES_LOCK(m_lock);
+
+    // Only mutated on the owner thread while holding m_lock, so owner-thread reads use
+    // assertIsOwnerThread() instead of locking; the GC thread must lock even to read
+    // (see visitJSEventListenersInGCThread()).
+    Vector<std::pair<AtomString, EventListenerVector>, 0, CrashOnOverflow, 4> m_entries WTF_GUARDED_BY_LOCK(m_lock);
+    mutable Lock m_lock;
+    ThreadLikeReleaseAssertion m_ownerThread;
 };
 
 template<typename Visitor>

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -118,6 +118,9 @@ public:
     bool setAttributeEventListener(const AtomString& eventType, RefPtr<EventListener>&&, DOMWrapperWorld&);
     RefPtr<JSEventListener> attributeEventListener(const AtomString& eventType, DOMWrapperWorld&);
 
+    // hasEventListeners() locks and is safe from any thread. The eventType overload does not, and is
+    // owner thread only: GC thread callers such as virtualHasPendingActivity() must instead cache the
+    // answer in eventListenersDidChange(), as DOMAudioSession and MediaDevices do.
     inline bool hasEventListeners() const; // Defined in EventTargetInlines.h
     inline bool hasEventListeners(const AtomString& eventType) const; // Defined in EventTargetInlines.h
     bool hasAnyEventListeners(std::span<const AtomString> eventTypes) const;

--- a/Source/WebCore/dom/TreeWalker.cpp
+++ b/Source/WebCore/dom/TreeWalker.cpp
@@ -55,15 +55,14 @@ void TreeWalker::setCurrentNode(Node& node)
 
 inline Node* TreeWalker::setCurrent(Ref<Node>&& node)
 {
-    {
-        Locker locker { m_currentLock };
-        m_current = WTF::move(node);
-    }
+    Locker locker { m_currentLock };
+    m_current = WTF::move(node);
     return m_current.ptr();
 }
 
 ExceptionOr<Node*> TreeWalker::parentNode()
 {
+    assertIsOwnerThread(m_currentLock, mainThreadLike);
     RefPtr node = m_current.ptr();
     while (node != &root()) {
         node = node->parentNode();
@@ -82,6 +81,7 @@ ExceptionOr<Node*> TreeWalker::parentNode()
 
 ExceptionOr<Node*> TreeWalker::firstChild()
 {
+    assertIsOwnerThread(m_currentLock, mainThreadLike);
     for (RefPtr node = m_current->firstChild(); node; ) {
         auto filterResult = acceptNode(*node);
         if (filterResult.hasException())
@@ -115,6 +115,7 @@ ExceptionOr<Node*> TreeWalker::firstChild()
 
 ExceptionOr<Node*> TreeWalker::lastChild()
 {
+    assertIsOwnerThread(m_currentLock, mainThreadLike);
     for (RefPtr node = m_current->lastChild(); node; ) {
         auto filterResult = acceptNode(*node);
         if (filterResult.hasException())
@@ -148,6 +149,7 @@ ExceptionOr<Node*> TreeWalker::lastChild()
 
 template<TreeWalker::SiblingTraversalType type> ExceptionOr<Node*> TreeWalker::traverseSiblings()
 {
+    assertIsOwnerThread(m_currentLock, mainThreadLike);
     RefPtr node = m_current.ptr();
     if (node == &root())
         return nullptr;
@@ -191,6 +193,7 @@ ExceptionOr<Node*> TreeWalker::nextSibling()
 
 ExceptionOr<Node*> TreeWalker::previousNode()
 {
+    assertIsOwnerThread(m_currentLock, mainThreadLike);
     if (!filter()) {
         if (m_current.ptr() == &root())
             return nullptr;
@@ -247,6 +250,7 @@ ExceptionOr<Node*> TreeWalker::previousNode()
 
 ExceptionOr<Node*> TreeWalker::nextNode()
 {
+    assertIsOwnerThread(m_currentLock, mainThreadLike);
     if (!filter()) {
         for (RefPtr node = NodeTraversal::next(m_current, &root()); node; node = NodeTraversal::next(*node, &root())) {
             if (matchesWhatToShow(*node))

--- a/Source/WebCore/dom/TreeWalker.h
+++ b/Source/WebCore/dom/TreeWalker.h
@@ -30,6 +30,7 @@
 #include <wtf/Lock.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadAssertions.h>
 
 namespace WebCore {
 
@@ -44,8 +45,8 @@ public:
         return adoptRef(*new TreeWalker(rootNode, whatToShow, WTF::move(filter)));
     }                            
 
-    Node& currentNode() { return m_current.get(); }
-    const Node& currentNode() const { return m_current.get(); }
+    Node& currentNode() { assertIsOwnerThread(m_currentLock, mainThreadLike); return m_current.get(); }
+    const Node& currentNode() const { assertIsOwnerThread(m_currentLock, mainThreadLike); return m_current.get(); }
 
     WebCoreOpaqueRoot opaqueRootForCurrentNodeInGCThread() const;
 
@@ -68,7 +69,9 @@ private:
     Node* setCurrent(Ref<Node>&&);
 
     mutable Lock m_currentLock;
-    Ref<Node> m_current;
+    // Only mutated on the main thread while holding m_currentLock, so main-thread reads use
+    // assertIsOwnerThread() instead of locking; the GC thread must lock even to read.
+    Ref<Node> m_current WTF_GUARDED_BY_LOCK(m_currentLock);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLCollection.cpp
+++ b/Source/WebCore/html/HTMLCollection.cpp
@@ -162,6 +162,7 @@ void HTMLCollection::invalidateNamedElementCache(Document& document) const
 
 Element* HTMLCollection::namedItemSlow(const AtomString& name) const
 {
+    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
     // The pathological case. We need to walk the entire subtree.
     updateNamedElementCache();
     ASSERT(m_namedElementCache);
@@ -182,6 +183,7 @@ Element* HTMLCollection::namedItemSlow(const AtomString& name) const
 // Documented in https://dom.spec.whatwg.org/#interface-htmlcollection.
 const Vector<AtomString>& HTMLCollection::supportedPropertyNames()
 {
+    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
     updateNamedElementCache();
     ASSERT(m_namedElementCache);
 
@@ -190,6 +192,7 @@ const Vector<AtomString>& HTMLCollection::supportedPropertyNames()
 
 bool HTMLCollection::isSupportedPropertyName(const AtomString& name)
 {
+    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
     updateNamedElementCache();
     ASSERT(m_namedElementCache);
 
@@ -227,6 +230,7 @@ void HTMLCollection::updateNamedElementCache() const
 
 Vector<Ref<Element>> HTMLCollection::namedItems(const AtomString& name) const
 {
+    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
     // FIXME: This non-virtual function can't possibly be doing the correct thing for
     // any derived class that overrides the virtual namedItem function.
 

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -109,7 +109,10 @@ protected:
 
     const Ref<ContainerNode> m_ownerNode;
 
-    mutable std::unique_ptr<CollectionNamedElementCache> m_namedElementCache;
+    // Only mutated on the main thread while holding m_namedElementCacheAssignmentLock, so
+    // main-thread reads use assertIsOwnerThread() instead of locking; memoryCost() runs on the
+    // GC thread and must lock even to read.
+    mutable std::unique_ptr<CollectionNamedElementCache> m_namedElementCache WTF_GUARDED_BY_LOCK(m_namedElementCacheAssignmentLock);
 };
 
 inline size_t CollectionNamedElementCache::memoryCost() const

--- a/Source/WebCore/html/HTMLCollectionInlines.h
+++ b/Source/WebCore/html/HTMLCollectionInlines.h
@@ -111,16 +111,17 @@ inline void HTMLCollection::invalidateCache()
 
 inline bool HTMLCollection::hasNamedElementCache() const
 {
+    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
     return !!m_namedElementCache;
 }
 
 inline void HTMLCollection::setNamedItemCache(std::unique_ptr<CollectionNamedElementCache> cache) const
 {
     ASSERT(cache);
-    ASSERT(!m_namedElementCache);
     cache->didPopulate();
     {
         Locker locker { m_namedElementCacheAssignmentLock };
+        ASSERT(!m_namedElementCache);
         m_namedElementCache = WTF::move(cache);
     }
     document().collectionCachedIdNameMap(*this);
@@ -128,6 +129,7 @@ inline void HTMLCollection::setNamedItemCache(std::unique_ptr<CollectionNamedEle
 
 inline const CollectionNamedElementCache& HTMLCollection::namedItemCaches() const LIFETIME_BOUND
 {
+    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
     ASSERT(!!m_namedElementCache);
     return *m_namedElementCache;
 }

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -275,7 +275,16 @@ void TextTrackCue::didChange(bool affectOrder)
 
 TextTrack* TextTrackCue::track() const
 {
+    assertIsOwnerThread(m_trackLockForGC, mainThreadLike);
     return m_track.get();
+}
+
+bool TextTrackCue::containsTrackAsOpaqueRootInGCThread(JSC::AbstractSlotVisitor& visitor) const
+{
+    Locker locker { m_trackLockForGC };
+    if (!m_track)
+        return false;
+    SUPPRESS_UNCHECKED_ARG return containsWebCoreOpaqueRoot(visitor, m_track.get());
 }
 
 void TextTrackCue::setTrack(TextTrack* track)

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -41,6 +41,12 @@
 #include <wtf/Lock.h>
 #include <wtf/MediaTime.h>
 
+namespace JSC {
+
+class AbstractSlotVisitor;
+
+}
+
 namespace WebCore {
 
 class SpeechSynthesis;
@@ -81,6 +87,7 @@ public:
     void didMoveToNewDocument(Document&);
 
     TextTrack* NODELETE track() const;
+    bool containsTrackAsOpaqueRootInGCThread(JSC::AbstractSlotVisitor&) const;
     void setTrack(TextTrack*);
 
     template<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);
@@ -167,8 +174,10 @@ private:
     MediaTime m_endTime;
     int m_processingCueChanges { 0 };
 
-    Lock m_trackLockForGC;
-    CheckedPtr<TextTrack> m_track;
+    mutable Lock m_trackLockForGC;
+    // Only mutated on the main thread while holding m_trackLockForGC, so main-thread reads use
+    // assertIsOwnerThread() instead of locking; the GC thread must lock even to read.
+    CheckedPtr<TextTrack> m_track WTF_GUARDED_BY_LOCK(m_trackLockForGC);
 
     const RefPtr<DocumentFragment> m_cueNode;
     const RefPtr<TextTrackCueBox> m_displayTree;

--- a/Source/WebCore/xml/XSLStyleSheet.h
+++ b/Source/WebCore/xml/XSLStyleSheet.h
@@ -31,6 +31,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/Lock.h>
 #include <wtf/Ref.h>
+#include <wtf/ThreadAssertions.h>
 #include <wtf/TypeCasts.h>
 
 namespace WebCore {
@@ -91,7 +92,7 @@ public:
     String type() const override { return "text/xml"_s; }
     bool disabled() const override { return m_isDisabled; }
     void setDisabled(bool b) override { m_isDisabled = b; }
-    Node* ownerNode() const override { return m_ownerNode.get(); }
+    Node* ownerNode() const override { assertIsOwnerThread(m_opaqueRootLockForGC, mainThreadLike); return m_ownerNode.get(); }
     String href() const override { return m_originalURL; }
     String title() const override { return { }; }
 
@@ -110,7 +111,9 @@ private:
     void clearXSLStylesheetDocument();
 
     mutable Lock m_opaqueRootLockForGC;
-    CheckedPtr<Node> m_ownerNode;
+    // Only mutated on the main thread while holding m_opaqueRootLockForGC, so main-thread reads
+    // use assertIsOwnerThread() instead of locking; the GC thread must lock even to read.
+    CheckedPtr<Node> m_ownerNode WTF_GUARDED_BY_LOCK(m_opaqueRootLockForGC);
     String m_originalURL;
     URL m_finalURL;
     bool m_isDisabled { false };


### PR DESCRIPTION
#### 59ea2d4af9c3e54f4164f1fb4533dfd3e53d00ae
<pre>
Allow annotating state that is read without locking on its owner thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=323578">https://bugs.webkit.org/show_bug.cgi?id=323578</a>

Reviewed by NOBODY (OOPS!).

A recurring pattern could not be expressed with WTF_GUARDED_BY_LOCK() at all, and so
went entirely unchecked: state that is mutated on a single owner thread while holding
a lock, read on that same thread without locking because locking every read would be
too expensive, and read by one other thread -- usually the garbage collector -- which
does take the lock. Several such members already had a lock named for the purpose
(m_elementLockForGC, m_opaqueRootLockForGC, m_trackLockForGC) or a comment describing
the arrangement, but nothing enforced it.

Clang&apos;s guarded_by attribute distinguishes access modes: a write requires the
capability exclusively, while a read accepts it shared. That maps onto this pattern
exactly. assertIsOwnerThread(lock, owner) grants shared, read-only access and asserts
at run time that this really is the owner thread; taking the lock grants exclusive
access as before. Annotating these members therefore makes direct writes and
foreign-thread reads compiler-checked, and turns the owner-thread fast reads into
something self-documenting and checked at run time, which is better than the nothing
they had before.

Note that the capability is granted unconditionally by calling assertIsOwnerThread();
the run-time condition only catches a caller that had no business taking the unlocked
path. The garbage collector is deliberately not tolerated there -- a GC thread reaching
an unlocked read is exactly the race this is meant to catch, and it must take the lock
instead. An owner that has not been latched yet is tolerated, since no mutation has
happened and there is nothing to race with.

The owner may be given as mainThreadLike, as a ThreadLikeAssertion member for state
owned by another thread or work queue, or as a ThreadLikeReleaseAssertion member when
the mutating paths should also be checked in release builds. The last is a new variant
of ThreadLikeAssertion that latches its owner on first use rather than at construction
and tolerates the garbage collector, which legitimately drives destruction. It stores
its owner unconditionally, since the check is not compiled out, and deliberately has no
destructor check so that GC driven destruction is not fatal. Only its mutating entry
point asserts in release builds; the read side is a security assertion, because readers
such as EventListenerMap::find() sit on the event dispatch path and must not pay for an
isMainThread() call in shipping builds. releaseAssertIsOwnerThread() is provided for
readers that are not hot, though nothing uses it yet.

ThreadLikeReleaseAssertion generalizes the owner tracking that EventListenerMap grew in
<a href="https://commits.webkit.org/294451@main">294451@main</a>, which is now expressed in terms of it. The bypass added by <a href="https://commits.webkit.org/294937@main">294937@main</a> is
kept: on USE(WEB_THREAD), isMainThread() is false on the web thread whenever the web
thread lock is momentarily dropped, so an owner latched in that window would reject
later legitimate access from the UI thread. WebThreadIsEnabled() is not visible to WTF,
so that bypass stays in EventListenerMap.

The assertion marks the lock as held for the remainder of the scope, so a function that
asserts and then takes the lock would report the Locker as acquiring a lock that is
already held. releaseOwnerThreadAssertion() hands the shared access back for that case;
it generates no code and only moves the analysis state. Where the unlocked read merely
sat just outside an existing critical section it was simpler to move it inside: the
ASSERT()s in Attr::detachFromElementWithValue(), Attr::attachToElement() and
HTMLCollection::setNamedItemCache(), and the return value of TreeWalker::setCurrent().

Thread safety analysis cannot follow a pointer once it escapes, so EventListenerMap
needed one further change to make its guard meaningful: find() returned a mutable
EventListenerVector* into m_entries, which let callers write to guarded state
unchecked. It now returns a const pointer, which all four callers were already
compatible with, and the two internal mutators that do write through the result use a
new findForWriting() that requires the lock.

Adopting the annotations exposed one genuine race, fixed here:

- EventListenerMap::clearEntriesForTearDown() cleared m_entries without m_lock, racing
  visitJSEventListenersInGCThread() on the GC thread.

The GC threads reach listener state by two routes with different guarantees, and the
annotations cannot tell them apart, so two classes needed adapting rather than fixing:

- isReachableFromOpaqueRoots() and hasPendingActivity() run with the main thread paused, so
  the reads they perform are safe without a lock. visitChildren() and
  visitAdditionalChildren() do not, which is why those already lock. An owner-thread
  assertion cannot express &quot;safe because the world is stopped&quot;, so state read from the
  first route has to either take the lock or be cached.

- The generated isReachableFromOpaqueRoots() calls hasPendingActivity(), and thirteen
  virtualHasPendingActivity() implementations consult listener state. EventListenerMap::isEmpty()
  therefore takes m_lock, which costs nothing meaningful because none of its callers are on the
  event dispatch path. contains() cannot do the same, since EventHandler walks the element chain
  calling it once per mouse move, so the three implementations that ask about a specific event type
  (DOMAudioSession, MediaDevices, IDBDatabase) cache the answer in eventListenersDidChange()
  instead. That also saves them walking the entry vector on every GC visit, which is why
  AbortSignal, XMLHttpRequest, Notification, AudioScheduledSourceNode and fifteen others already
  do it; these three match them, including using a plain bool rather than an atomic, since the
  paused main thread means there is no concurrent writer.

- JSTextTrackCueOwner::isReachableFromOpaqueRoots() read TextTrackCue::m_track twice without
  m_trackLockForGC. Both reads were safe for the same reason, but they could disagree with each
  other, and m_track cannot carry WTF_GUARDED_BY_LOCK while they are unlocked. TextTrackCue now
  exposes containsTrackAsOpaqueRootInGCThread(), which holds the lock across a single test, as
  visitAdditionalChildrenInGCThread() already did for the same member.

* Source/WTF/wtf/ThreadAssertions.h:
(WTF::ThreadLikeReleaseAssertion):
(WTF::ThreadLikeReleaseAssertion::isUnset const):
(WTF::ThreadLikeReleaseAssertion::isCurrent const):
(WTF::ThreadLikeReleaseAssertion::latchToCurrentThread):
(WTF::releaseAssertIsCurrentAndLatch):
(WTF::assertIsOwnerThread):
(WTF::releaseAssertIsOwnerThread):
(WTF::releaseOwnerThreadAssertion):
* Source/WebCore/Modules/audiosession/DOMAudioSession.cpp:
(WebCore::DOMAudioSession::virtualHasPendingActivity const):
(WebCore::DOMAudioSession::eventListenersDidChange):
* Source/WebCore/Modules/audiosession/DOMAudioSession.h:
* Source/WebCore/Modules/indexeddb/IDBDatabase.cpp:
(WebCore::IDBDatabase::virtualHasPendingActivity const):
(WebCore::IDBDatabase::eventListenersDidChange):
* Source/WebCore/Modules/indexeddb/IDBDatabase.h:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::virtualHasPendingActivity const):
(WebCore::MediaDevices::eventListenersDidChange):
* Source/WebCore/Modules/mediastream/MediaDevices.h:
* Source/WebCore/bindings/js/JSTextTrackCueCustom.cpp:
(WebCore::JSTextTrackCueOwner::isReachableFromOpaqueRoots):
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::ownerNode const):
(WebCore::CSSStyleSheet::isDetached const):
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::setValue):
(WebCore::Attr::style):
(WebCore::Attr::value const):
(WebCore::Attr::detachFromElementWithValue):
(WebCore::Attr::attachToElement):
* Source/WebCore/dom/Attr.h:
(WebCore::Attr::ownerElement const):
* Source/WebCore/dom/EventListenerMap.cpp:
(WebCore::EventListenerMap::isEmpty const):
(WebCore::EventListenerMap::eventTypes const):
(WebCore::EventListenerMap::replacePreservingOptions):
(WebCore::EventListenerMap::add):
(WebCore::EventListenerMap::find const):
(WebCore::EventListenerMap::findForWriting):
(WebCore::EventListenerMap::copyEventListenersNotCreatedFromMarkupToTarget):
* Source/WebCore/dom/EventListenerMap.h:
(WebCore::EventListenerMap::clearEntriesForTearDown):
(WebCore::EventListenerMap::enumerateEventListenerTypes const):
(WebCore::EventListenerMap::containsMatchingEventListener const):
(WebCore::EventListenerMap::assertIsOwnerThreadForReading const):
(WebCore::EventListenerMap::releaseAssertOrSetThreadUID):
(WebCore::EventListenerMap::lock): Deleted.
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/dom/TreeWalker.cpp:
(WebCore::TreeWalker::setCurrent):
(WebCore::TreeWalker::parentNode):
(WebCore::TreeWalker::firstChild):
(WebCore::TreeWalker::lastChild):
(WebCore::TreeWalker::traverseSiblings):
(WebCore::TreeWalker::previousNode):
(WebCore::TreeWalker::nextNode):
* Source/WebCore/dom/TreeWalker.h:
(WebCore::TreeWalker::currentNode):
* Source/WebCore/html/HTMLCollection.cpp:
(WebCore::HTMLCollection::namedItemSlow const):
(WebCore::HTMLCollection::supportedPropertyNames):
(WebCore::HTMLCollection::isSupportedPropertyName):
(WebCore::HTMLCollection::namedItems const):
* Source/WebCore/html/HTMLCollection.h:
* Source/WebCore/html/HTMLCollectionInlines.h:
(WebCore::HTMLCollection::hasNamedElementCache const):
(WebCore::HTMLCollection::setNamedItemCache const):
(WebCore::HTMLCollection::namedItemCaches const):
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::TextTrackCue::track const):
(WebCore::TextTrackCue::containsTrackAsOpaqueRootInGCThread const):
* Source/WebCore/html/track/TextTrackCue.h:
* Source/WebCore/xml/XSLStyleSheet.h:
(WebCore::XSLStyleSheet::ownerNode const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59ea2d4af9c3e54f4164f1fb4533dfd3e53d00ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185347 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195671 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150146 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4b2474b5-e856-45c5-a2ca-5bb6ea8ab322) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187209 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144853 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100422 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1182c738-254b-46a2-a63e-63532240528d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125146 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d00de87f-f73e-49a9-b838-c53b9e1e2fda) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47255 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45314 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7052 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13937 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157622 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45005 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6724 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46605 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51915 "Found 9 new failures in dom/EventListenerMap.cpp, Modules/mediastream/RTCPeerConnection.cpp, accessibility/AccessibilitySVGObject.cpp, Modules/speech/SpeechRecognition.cpp, Modules/mediastream/MediaStream.cpp, Modules/mediastream/RTCIceTransport.cpp, Modules/mediastream/RTCDtlsTransport.cpp, Modules/mediastream/RTCSctpTransport.cpp, Modules/speech/SpeechSynthesisUtterance.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197620 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58923 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154361 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59632 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154008 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48497 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131954 "Found 8 new failures in Modules/mediastream/RTCPeerConnection.cpp, accessibility/AccessibilitySVGObject.cpp, Modules/speech/SpeechRecognition.cpp, Modules/mediastream/MediaStream.cpp, Modules/mediastream/RTCIceTransport.cpp, Modules/mediastream/RTCDtlsTransport.cpp, Modules/mediastream/RTCSctpTransport.cpp, Modules/speech/SpeechSynthesisUtterance.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128782 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58110 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20027 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57482 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57725 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57549 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->