### PR TITLE
Allow annotating state that is read without locking on its owner thread

### DIFF
--- a/Source/WTF/wtf/ThreadAssertions.h
+++ b/Source/WTF/wtf/ThreadAssertions.h
@@ -168,6 +168,54 @@ inline ThreadLikeAssertion ThreadLike::createThreadLikeAssertion(uint32_t uid)
     return ThreadLikeAssertion { uid };
 }
 
+// Some state is mutated only on one thread, always while holding a lock, yet is read on that same
+// thread without taking the lock because doing so on every read would be too expensive. Threads
+// other than the owner must hold the lock even to read. Annotate such state with
+// WTF_GUARDED_BY_LOCK() as usual, and call assertIsOwnerThread() on the unlocked read path:
+//
+// struct MyClass {
+//     Element* element() const { assertIsOwnerThread(m_lock, mainThreadLike); return m_element.get(); }
+//     void setElement(Element* element) { Locker locker { m_lock }; m_element = element; }
+//     // Runs on another thread, so it must lock even though it only reads.
+//     void visit(Visitor& visitor) const { Locker locker { m_lock }; visitor.append(m_element); }
+// private:
+//     mutable Lock m_lock;
+//     RefPtr<Element> m_element WTF_GUARDED_BY_LOCK(m_lock);
+// };
+//
+// The owner may be given as mainThreadLike, or as a ThreadLikeAssertion member for state owned by
+// some other thread or work queue.
+//
+// assertIsOwnerThread() grants only shared, read-only access, so thread safety analysis still
+// reports any write that does not hold the lock exclusively. That is what makes this preferable to
+// leaving the state unannotated: the "every write holds the lock" half of the invariant stays
+// machine-checked, reads from any other thread must still lock, and the unlocked reads become both
+// self-documenting and checked at run time.
+//
+// BlockDirectory has long used this idiom by hand, with assertIsMutatorOrMutatorIsStopped() granting
+// shared access to m_bitvectorLock; these helpers generalize it.
+//
+// A function that calls assertIsOwnerThread() and then takes the lock must release the assertion
+// first, by calling releaseOwnerThreadAssertion() below. Otherwise the assertion leaves the lock
+// marked as held for the remainder of the scope and the subsequent Locker is reported as acquiring
+// a lock that is already held.
+template<typename LockType>
+inline void assertIsOwnerThread(const LockType& lock, const ThreadLikeAssertion& ownerThread) WTF_ASSERTS_ACQUIRED_SHARED_LOCK(lock)
+{
+    UNUSED_PARAM(lock);
+    assertIsCurrent(ownerThread);
+}
+
+// Hands back the shared access granted by assertIsOwnerThread(), so that a function which starts
+// with an unlocked owner-thread read can go on to take the lock. Without this the analysis still
+// considers the lock held and reports the Locker as acquiring a lock that is already held. This
+// generates no code; it only moves the analysis state.
+template<typename LockType>
+ALWAYS_INLINE void releaseOwnerThreadAssertion(const LockType& lock) WTF_RELEASES_SHARED_LOCK(lock) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
+{
+    UNUSED_PARAM(lock);
+}
+
 // Type for globally named assertions for describing access requirements.
 // Can be used, for example, to require that a variable is accessed only in
 // a known named thread.
@@ -189,6 +237,7 @@ class WTF_CAPABILITY("is current") NamedAssertion { };
 using WTF::anyThreadLike;
 using WTF::AnyThreadLike;
 using WTF::assertIsCurrent;
+using WTF::assertIsOwnerThread;
 using WTF::currentThreadLike;
 using WTF::CurrentThreadLike;
 using WTF::mainThreadLike;
@@ -196,5 +245,6 @@ using WTF::MainThreadLike;
 using WTF::NamedAssertion;
 using WTF::noneThreadLike;
 using WTF::NoneThreadLike;
+using WTF::releaseOwnerThreadAssertion;
 using WTF::ThreadLike;
 using WTF::ThreadLikeAssertion;

--- a/Source/WebCore/bindings/js/JSTextTrackCueCustom.cpp
+++ b/Source/WebCore/bindings/js/JSTextTrackCueCustom.cpp
@@ -50,14 +50,16 @@ bool JSTextTrackCueOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> h
         return true;
     }
 
-    // If the cue is not associated with a track, it is not reachable.
-    if (!textTrackCue.track())
+    // If the cue is not associated with a track, it is not reachable. This runs on the parallel GC
+    // marking threads, so the test is done by TextTrackCue under m_trackLockForGC rather than
+    // through track(), which is only for the owner thread.
+    if (!textTrackCue.containsTrackAsOpaqueRootInGCThread(visitor))
         return false;
 
     if (reason) [[unlikely]]
         *reason = "TextTrack is an opaque root"_s;
 
-    SUPPRESS_UNCHECKED_ARG return containsWebCoreOpaqueRoot(visitor, textTrackCue.track());
+    return true;
 }
 
 template<typename Visitor>

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -183,6 +183,7 @@ CSSStyleSheet::~CSSStyleSheet()
 
 Node* CSSStyleSheet::ownerNode() const
 {
+    assertIsOwnerThread(m_opaqueRootLockForGC, mainThreadLike);
     return m_ownerNode.get();
 }
 
@@ -591,6 +592,7 @@ ExceptionOr<void> CSSStyleSheet::replaceSync(String&& text)
 
 bool CSSStyleSheet::isDetached() const
 {
+    assertIsOwnerThread(m_opaqueRootLockForGC, mainThreadLike);
     return !m_ownerNode
         && !m_ownerRule
         && m_adoptingTreeScopes.isEmptyIgnoringNullReferences();

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -192,7 +192,9 @@ private:
     WeakHashSet<ContainerNode, WeakPtrImplWithEventTargetData> m_adoptingTreeScopes;
 
     mutable Lock m_opaqueRootLockForGC;
-    CheckedPtr<Node> m_ownerNode;
+    // Only mutated on the main thread while holding m_opaqueRootLockForGC, so main-thread reads
+    // use assertIsOwnerThread() instead of locking; the GC thread must lock even to read.
+    CheckedPtr<Node> m_ownerNode WTF_GUARDED_BY_LOCK(m_opaqueRootLockForGC);
     CheckedPtr<CSSImportRule> m_ownerRule;
 
     TextPosition m_startPosition;

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -88,6 +88,7 @@ Attr::~Attr()
 
 ExceptionOr<void> Attr::setValue(const AtomString& value)
 {
+    assertIsOwnerThread(m_elementLockForGC, mainThreadLike);
     if (RefPtr element = m_element.get()) {
         auto verifiedValue = value;
         if (protect(document())->contextDocument().requiresTrustedTypes()) {
@@ -135,6 +136,7 @@ CSSStyleProperties* Attr::style()
 {
     // This is not part of the DOM API, and therefore not available to webpages. However, WebKit SPI
     // lets clients use this via the Objective-C and JavaScript bindings.
+    assertIsOwnerThread(m_elementLockForGC, mainThreadLike);
     RefPtr styledElement = dynamicDowncast<StyledElement>(m_element.get());
     if (!styledElement)
         return nullptr;
@@ -146,6 +148,7 @@ CSSStyleProperties* Attr::style()
 
 AtomString Attr::value() const
 {
+    assertIsOwnerThread(m_elementLockForGC, mainThreadLike);
     if (RefPtr element = m_element.get())
         return element->getAttributeForBindings(qualifiedName());
     return m_standaloneValue;
@@ -153,11 +156,11 @@ AtomString Attr::value() const
 
 void Attr::detachFromElementWithValue(const AtomString& value)
 {
-    ASSERT(m_element);
     ASSERT(m_standaloneValue.isNull());
     m_standaloneValue = value;
     {
         Locker locker { m_elementLockForGC };
+        ASSERT(m_element);
         m_element = nullptr;
     }
     setTreeScopeRecursively(Ref<Document> { document() });
@@ -165,9 +168,9 @@ void Attr::detachFromElementWithValue(const AtomString& value)
 
 void Attr::attachToElement(Element& element)
 {
-    ASSERT(!m_element);
     {
         Locker locker { m_elementLockForGC };
+        ASSERT(!m_element);
         m_element = &element;
     }
     m_standaloneValue = nullAtom();

--- a/Source/WebCore/dom/Attr.h
+++ b/Source/WebCore/dom/Attr.h
@@ -27,6 +27,7 @@
 #include <WebCore/Node.h>
 #include <WebCore/QualifiedName.h>
 #include <wtf/Lock.h>
+#include <wtf/ThreadAssertions.h>
 
 namespace WebCore {
 
@@ -44,7 +45,7 @@ public:
 
     String name() const { return qualifiedName().toString(); }
     bool specified() const { return true; }
-    Element* ownerElement() const { return m_element.get(); }
+    Element* ownerElement() const { assertIsOwnerThread(m_elementLockForGC, mainThreadLike); return m_element.get(); }
 
     WEBCORE_EXPORT AtomString value() const;
     WEBCORE_EXPORT ExceptionOr<void> setValue(const AtomString&);
@@ -78,7 +79,9 @@ private:
 
     // Attr wraps either an element/name, or a name/value pair (when it's a standalone Node.)
     // Note that m_name is always set, but m_element/m_standaloneValue may be null.
-    CheckedPtr<Element> m_element;
+    // m_element is only mutated on the main thread while holding m_elementLockForGC, so main-thread
+    // reads use assertIsOwnerThread() instead of locking; the GC thread must lock even to read.
+    CheckedPtr<Element> m_element WTF_GUARDED_BY_LOCK(m_elementLockForGC);
     QualifiedName m_name;
     AtomString m_standaloneValue;
     RefPtr<MutableStyleProperties> m_style;

--- a/Source/WebCore/dom/TreeWalker.cpp
+++ b/Source/WebCore/dom/TreeWalker.cpp
@@ -55,15 +55,14 @@ void TreeWalker::setCurrentNode(Node& node)
 
 inline Node* TreeWalker::setCurrent(Ref<Node>&& node)
 {
-    {
-        Locker locker { m_currentLock };
-        m_current = WTF::move(node);
-    }
+    Locker locker { m_currentLock };
+    m_current = WTF::move(node);
     return m_current.ptr();
 }
 
 ExceptionOr<Node*> TreeWalker::parentNode()
 {
+    assertIsOwnerThread(m_currentLock, mainThreadLike);
     RefPtr node = m_current.ptr();
     while (node != &root()) {
         node = node->parentNode();
@@ -82,6 +81,7 @@ ExceptionOr<Node*> TreeWalker::parentNode()
 
 ExceptionOr<Node*> TreeWalker::firstChild()
 {
+    assertIsOwnerThread(m_currentLock, mainThreadLike);
     for (RefPtr node = m_current->firstChild(); node; ) {
         auto filterResult = acceptNode(*node);
         if (filterResult.hasException())
@@ -115,6 +115,7 @@ ExceptionOr<Node*> TreeWalker::firstChild()
 
 ExceptionOr<Node*> TreeWalker::lastChild()
 {
+    assertIsOwnerThread(m_currentLock, mainThreadLike);
     for (RefPtr node = m_current->lastChild(); node; ) {
         auto filterResult = acceptNode(*node);
         if (filterResult.hasException())
@@ -148,6 +149,7 @@ ExceptionOr<Node*> TreeWalker::lastChild()
 
 template<TreeWalker::SiblingTraversalType type> ExceptionOr<Node*> TreeWalker::traverseSiblings()
 {
+    assertIsOwnerThread(m_currentLock, mainThreadLike);
     RefPtr node = m_current.ptr();
     if (node == &root())
         return nullptr;
@@ -191,6 +193,7 @@ ExceptionOr<Node*> TreeWalker::nextSibling()
 
 ExceptionOr<Node*> TreeWalker::previousNode()
 {
+    assertIsOwnerThread(m_currentLock, mainThreadLike);
     if (!filter()) {
         if (m_current.ptr() == &root())
             return nullptr;
@@ -247,6 +250,7 @@ ExceptionOr<Node*> TreeWalker::previousNode()
 
 ExceptionOr<Node*> TreeWalker::nextNode()
 {
+    assertIsOwnerThread(m_currentLock, mainThreadLike);
     if (!filter()) {
         for (RefPtr node = NodeTraversal::next(m_current, &root()); node; node = NodeTraversal::next(*node, &root())) {
             if (matchesWhatToShow(*node))

--- a/Source/WebCore/dom/TreeWalker.h
+++ b/Source/WebCore/dom/TreeWalker.h
@@ -30,6 +30,7 @@
 #include <wtf/Lock.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadAssertions.h>
 
 namespace WebCore {
 
@@ -44,8 +45,8 @@ public:
         return adoptRef(*new TreeWalker(rootNode, whatToShow, WTF::move(filter)));
     }                            
 
-    Node& currentNode() { return m_current.get(); }
-    const Node& currentNode() const { return m_current.get(); }
+    Node& currentNode() { assertIsOwnerThread(m_currentLock, mainThreadLike); return m_current.get(); }
+    const Node& currentNode() const { assertIsOwnerThread(m_currentLock, mainThreadLike); return m_current.get(); }
 
     WebCoreOpaqueRoot opaqueRootForCurrentNodeInGCThread() const;
 
@@ -68,7 +69,9 @@ private:
     Node* setCurrent(Ref<Node>&&);
 
     mutable Lock m_currentLock;
-    Ref<Node> m_current;
+    // Only mutated on the main thread while holding m_currentLock, so main-thread reads use
+    // assertIsOwnerThread() instead of locking; the GC thread must lock even to read.
+    Ref<Node> m_current WTF_GUARDED_BY_LOCK(m_currentLock);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLCollection.cpp
+++ b/Source/WebCore/html/HTMLCollection.cpp
@@ -162,6 +162,7 @@ void HTMLCollection::invalidateNamedElementCache(Document& document) const
 
 Element* HTMLCollection::namedItemSlow(const AtomString& name) const
 {
+    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
     // The pathological case. We need to walk the entire subtree.
     updateNamedElementCache();
     ASSERT(m_namedElementCache);
@@ -182,6 +183,7 @@ Element* HTMLCollection::namedItemSlow(const AtomString& name) const
 // Documented in https://dom.spec.whatwg.org/#interface-htmlcollection.
 const Vector<AtomString>& HTMLCollection::supportedPropertyNames()
 {
+    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
     updateNamedElementCache();
     ASSERT(m_namedElementCache);
 
@@ -190,6 +192,7 @@ const Vector<AtomString>& HTMLCollection::supportedPropertyNames()
 
 bool HTMLCollection::isSupportedPropertyName(const AtomString& name)
 {
+    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
     updateNamedElementCache();
     ASSERT(m_namedElementCache);
 
@@ -227,6 +230,7 @@ void HTMLCollection::updateNamedElementCache() const
 
 Vector<Ref<Element>> HTMLCollection::namedItems(const AtomString& name) const
 {
+    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
     // FIXME: This non-virtual function can't possibly be doing the correct thing for
     // any derived class that overrides the virtual namedItem function.
 

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -109,7 +109,10 @@ protected:
 
     const Ref<ContainerNode> m_ownerNode;
 
-    mutable std::unique_ptr<CollectionNamedElementCache> m_namedElementCache;
+    // Only mutated on the main thread while holding m_namedElementCacheAssignmentLock, so
+    // main-thread reads use assertIsOwnerThread() instead of locking; memoryCost() runs on the
+    // GC thread and must lock even to read.
+    mutable std::unique_ptr<CollectionNamedElementCache> m_namedElementCache WTF_GUARDED_BY_LOCK(m_namedElementCacheAssignmentLock);
 };
 
 inline size_t CollectionNamedElementCache::memoryCost() const

--- a/Source/WebCore/html/HTMLCollectionInlines.h
+++ b/Source/WebCore/html/HTMLCollectionInlines.h
@@ -111,16 +111,17 @@ inline void HTMLCollection::invalidateCache()
 
 inline bool HTMLCollection::hasNamedElementCache() const
 {
+    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
     return !!m_namedElementCache;
 }
 
 inline void HTMLCollection::setNamedItemCache(std::unique_ptr<CollectionNamedElementCache> cache) const
 {
     ASSERT(cache);
-    ASSERT(!m_namedElementCache);
     cache->didPopulate();
     {
         Locker locker { m_namedElementCacheAssignmentLock };
+        ASSERT(!m_namedElementCache);
         m_namedElementCache = WTF::move(cache);
     }
     document().collectionCachedIdNameMap(*this);
@@ -128,6 +129,7 @@ inline void HTMLCollection::setNamedItemCache(std::unique_ptr<CollectionNamedEle
 
 inline const CollectionNamedElementCache& HTMLCollection::namedItemCaches() const LIFETIME_BOUND
 {
+    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
     ASSERT(!!m_namedElementCache);
     return *m_namedElementCache;
 }

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -275,7 +275,16 @@ void TextTrackCue::didChange(bool affectOrder)
 
 TextTrack* TextTrackCue::track() const
 {
+    assertIsOwnerThread(m_trackLockForGC, mainThreadLike);
     return m_track.get();
+}
+
+bool TextTrackCue::containsTrackAsOpaqueRootInGCThread(JSC::AbstractSlotVisitor& visitor) const
+{
+    Locker locker { m_trackLockForGC };
+    if (!m_track)
+        return false;
+    SUPPRESS_UNCHECKED_ARG return containsWebCoreOpaqueRoot(visitor, m_track.get());
 }
 
 void TextTrackCue::setTrack(TextTrack* track)

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -41,6 +41,12 @@
 #include <wtf/Lock.h>
 #include <wtf/MediaTime.h>
 
+namespace JSC {
+
+class AbstractSlotVisitor;
+
+}
+
 namespace WebCore {
 
 class SpeechSynthesis;
@@ -81,6 +87,7 @@ public:
     void didMoveToNewDocument(Document&);
 
     TextTrack* NODELETE track() const;
+    bool containsTrackAsOpaqueRootInGCThread(JSC::AbstractSlotVisitor&) const;
     void setTrack(TextTrack*);
 
     template<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);
@@ -167,8 +174,10 @@ private:
     MediaTime m_endTime;
     int m_processingCueChanges { 0 };
 
-    Lock m_trackLockForGC;
-    CheckedPtr<TextTrack> m_track;
+    mutable Lock m_trackLockForGC;
+    // Only mutated on the main thread while holding m_trackLockForGC, so main-thread reads use
+    // assertIsOwnerThread() instead of locking; the GC thread must lock even to read.
+    CheckedPtr<TextTrack> m_track WTF_GUARDED_BY_LOCK(m_trackLockForGC);
 
     const RefPtr<DocumentFragment> m_cueNode;
     const RefPtr<TextTrackCueBox> m_displayTree;

--- a/Source/WebCore/xml/XSLStyleSheet.h
+++ b/Source/WebCore/xml/XSLStyleSheet.h
@@ -31,6 +31,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/Lock.h>
 #include <wtf/Ref.h>
+#include <wtf/ThreadAssertions.h>
 #include <wtf/TypeCasts.h>
 
 namespace WebCore {
@@ -91,7 +92,7 @@ public:
     String type() const override { return "text/xml"_s; }
     bool disabled() const override { return m_isDisabled; }
     void setDisabled(bool b) override { m_isDisabled = b; }
-    Node* ownerNode() const override { return m_ownerNode.get(); }
+    Node* ownerNode() const override { assertIsOwnerThread(m_opaqueRootLockForGC, mainThreadLike); return m_ownerNode.get(); }
     String href() const override { return m_originalURL; }
     String title() const override { return { }; }
 
@@ -110,7 +111,9 @@ private:
     void clearXSLStylesheetDocument();
 
     mutable Lock m_opaqueRootLockForGC;
-    CheckedPtr<Node> m_ownerNode;
+    // Only mutated on the main thread while holding m_opaqueRootLockForGC, so main-thread reads
+    // use assertIsOwnerThread() instead of locking; the GC thread must lock even to read.
+    CheckedPtr<Node> m_ownerNode WTF_GUARDED_BY_LOCK(m_opaqueRootLockForGC);
     String m_originalURL;
     URL m_finalURL;
     bool m_isDisabled { false };


### PR DESCRIPTION
#### b982ebd3147d60c781c65bff005b603999b57100
<pre>
Allow annotating state that is read without locking on its owner thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=323596">https://bugs.webkit.org/show_bug.cgi?id=323596</a>

Reviewed by Geoffrey Garen.

A recurring pattern could not be expressed with WTF_GUARDED_BY_LOCK() at all, and so
went entirely unchecked: state that is mutated on a single owner thread while holding
a lock, read on that same thread without locking because locking every read would be
too expensive, and read by one other thread -- usually the garbage collector -- which
does take the lock. Several such members already had a lock named for the purpose
(m_elementLockForGC, m_opaqueRootLockForGC, m_trackLockForGC) or a comment describing
the arrangement, but nothing enforced it.

Clang&apos;s guarded_by attribute distinguishes access modes: a write requires the
capability exclusively, while a read accepts it shared. That maps onto this pattern
exactly. assertIsOwnerThread(lock, owner) grants shared, read-only access and asserts
at run time that this really is the owner thread; taking the lock grants exclusive
access as before. Annotating these members therefore makes direct writes and
foreign-thread reads compiler-checked, and turns the owner-thread fast reads into
something self-documenting and checked at run time, which is better than the nothing
they had before.

Note that the capability is granted unconditionally by calling assertIsOwnerThread();
the run-time condition only catches a caller that had no business taking the unlocked
path. The assertion also marks the lock as held for the remainder of the scope, so a
function that asserts and then takes the lock would report the Locker as acquiring a
lock that is already held. releaseOwnerThreadAssertion() hands the shared access back
for that case; it generates no code and only moves the analysis state. Where the
unlocked read merely sat just outside an existing critical section it was simpler to
move it inside: the ASSERT()s in Attr::detachFromElementWithValue(),
Attr::attachToElement() and HTMLCollection::setNamedItemCache(), and the return value
of TreeWalker::setCurrent().

Adopted for Attr::m_element, TreeWalker::m_current, CSSStyleSheet::m_ownerNode,
XSLStyleSheet::m_ownerNode, HTMLCollection::m_namedElementCache and
TextTrackCue::m_track. All six are owned by the main thread, which for these classes
is the same as the context thread, since Document::isContextThread() is isMainThread().

TextTrackCue needed one adaptation. JSTextTrackCueOwner::isReachableFromOpaqueRoots()
read m_track twice without m_trackLockForGC. Those reads were not racy:
isReachableFromOpaqueRoots() and hasPendingActivity() run with the main thread paused,
which is why they may read without locking, whereas visitChildren() and
visitAdditionalChildren() do not and therefore already lock. An owner-thread assertion
cannot express &quot;safe because the world is stopped&quot;, and the two reads could disagree
with each other, so TextTrackCue now exposes containsTrackAsOpaqueRootInGCThread(),
which holds the lock across a single test, as visitAdditionalChildrenInGCThread()
already did for the same member.

No behaviour change is intended: this patch fixes no bugs, it only makes existing
invariants checkable.

* Source/WTF/wtf/ThreadAssertions.h:
(WTF::assertIsOwnerThread):
(WTF::releaseOwnerThreadAssertion):
* Source/WebCore/bindings/js/JSTextTrackCueCustom.cpp:
(WebCore::JSTextTrackCueOwner::isReachableFromOpaqueRoots):
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::ownerNode const):
(WebCore::CSSStyleSheet::isDetached const):
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::setValue):
(WebCore::Attr::style):
(WebCore::Attr::value const):
(WebCore::Attr::detachFromElementWithValue):
(WebCore::Attr::attachToElement):
* Source/WebCore/dom/Attr.h:
(WebCore::Attr::ownerElement const):
* Source/WebCore/dom/TreeWalker.cpp:
(WebCore::TreeWalker::setCurrent):
(WebCore::TreeWalker::parentNode):
(WebCore::TreeWalker::firstChild):
(WebCore::TreeWalker::lastChild):
(WebCore::TreeWalker::traverseSiblings):
(WebCore::TreeWalker::previousNode):
(WebCore::TreeWalker::nextNode):
* Source/WebCore/dom/TreeWalker.h:
(WebCore::TreeWalker::currentNode):
* Source/WebCore/html/HTMLCollection.cpp:
(WebCore::HTMLCollection::namedItemSlow const):
(WebCore::HTMLCollection::supportedPropertyNames):
(WebCore::HTMLCollection::isSupportedPropertyName):
(WebCore::HTMLCollection::namedItems const):
* Source/WebCore/html/HTMLCollection.h:
* Source/WebCore/html/HTMLCollectionInlines.h:
(WebCore::HTMLCollection::hasNamedElementCache const):
(WebCore::HTMLCollection::setNamedItemCache const):
(WebCore::HTMLCollection::namedItemCaches const):
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::TextTrackCue::track const):
(WebCore::TextTrackCue::containsTrackAsOpaqueRootInGCThread const):
* Source/WebCore/html/track/TextTrackCue.h:
* Source/WebCore/xml/XSLStyleSheet.h:
(WebCore::XSLStyleSheet::ownerNode const):

Canonical link: <a href="https://commits.webkit.org/320637@main">https://commits.webkit.org/320637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4355f05fb4e8b08bde17c0b34dfd95addae5e7f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185350 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195674 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150148 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187212 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58989 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144855 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100423 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165435 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125148 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47257 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45315 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7054 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/13938 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157624 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45006 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6727 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46608 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51918 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49699 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197623 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58926 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154360 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41352 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59635 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154011 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48498 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131957 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128788 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58113 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20028 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57485 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57728 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57552 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->