### PR TITLE
[JSC] eval call should recognize tail-position

### DIFF
--- a/JSTests/stress/no-tail-call-in-generator-and-async-function-bodies.js
+++ b/JSTests/stress/no-tail-call-in-generator-and-async-function-bodies.js
@@ -1,0 +1,66 @@
+// A generator, async function, async generator, or async arrow body contains no tail positions
+// (https://tc39.es/ecma262/#sec-static-semantics-isintailposition, steps 4 to 7), so an ordinary
+// call under "return" must stay an ordinary call there.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}, expected ${String(expected)}`);
+}
+
+function drain(promise) {
+    var settled = false;
+    var result;
+    promise.then((value) => {
+        settled = true;
+        result = value;
+    });
+    drainMicrotasks();
+    shouldBe(settled, true);
+    return result;
+}
+
+// An async generator awaits whatever its body returns. A tail call would jump over that await and
+// hand the caller the promise itself.
+(function asyncGeneratorAwaitsReturnedCall() {
+    "use strict";
+    function f() { return Promise.resolve(42); }
+    var object = { f };
+
+    async function* plainCall() { return f(); }
+    async function* memberCall() { return object.f(); }
+    async function* spreadCall() { return f(...[]); }
+    async function* applyCall() { return f.apply(null, []); }
+
+    for (var generatorFunction of [plainCall, memberCall, spreadCall, applyCall]) {
+        for (var i = 0; i < testLoopCount; ++i) {
+            var result = drain(generatorFunction().next());
+            shouldBe(result.done, true);
+            shouldBe(result.value, 42);
+        }
+    }
+})();
+
+// The enclosing frame therefore stays on the stack, unlike an ordinary strict function's.
+(function bodiesKeepTheirFrame() {
+    "use strict";
+    function callerName() {
+        return new Error().stack.split("\n")[1].split("@")[0];
+    }
+
+    function* generatorBody() { return callerName(); }
+    shouldBe(generatorBody().next().value, "generatorBody");
+
+    async function asyncFunctionBody() { await 0; return callerName(); }
+    shouldBe(drain(asyncFunctionBody()), "asyncFunctionBody");
+
+    async function* asyncGeneratorBody() { return callerName(); }
+    shouldBe(drain(asyncGeneratorBody().next()).value, "asyncGeneratorBody");
+
+    // A resumed async arrow body carries no name of its own, so the point of this one is only
+    // that a frame is there at all: without it the caller would be drainMicrotasks.
+    var asyncArrowBody = async () => { await 0; return callerName(); };
+    shouldBe(drain(asyncArrowBody()), "");
+
+    function ordinaryStrictFunction() { return callerName(); }
+    shouldBe(ordinaryStrictFunction(), "bodiesKeepTheirFrame");
+})();

--- a/JSTests/stress/tail-call-eval-identifier-resolving-to-non-eval-function.js
+++ b/JSTests/stress/tail-call-eval-identifier-resolving-to-non-eval-function.js
@@ -1,0 +1,117 @@
+//@ defaultNoSamplingProfilerRun
+
+// A call whose callee is spelled "eval" is only a direct eval when the identifier
+// actually resolves to %eval%. Otherwise it is an ordinary call, so in a strict
+// function it must be a tail call.
+
+var iterations = 100000;
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}, expected ${String(expected)}`);
+}
+
+(function functionScope() {
+    var callCount = 0;
+    function f(n) {
+        "use strict";
+        if (n === 0) {
+            callCount += 1;
+            return "done";
+        }
+        return eval(n - 1);
+    }
+    var eval = f;
+    shouldBe(f(iterations), "done");
+    shouldBe(callCount, 1);
+})();
+
+(function functionScopeDynamic() {
+    var callCount = 0;
+    function f(n) {
+        "use strict";
+        if (n === 0) {
+            callCount += 1;
+            return "done";
+        }
+        return eval(n - 1);
+    }
+    eval("var eval = f;");
+    shouldBe(f(iterations), "done");
+    shouldBe(callCount, 1);
+})();
+
+(function withScope() {
+    var callCount = 0;
+    var f, scope = {};
+    with (scope) {
+        f = function (n) {
+            "use strict";
+            if (n === 0) {
+                callCount += 1;
+                return "done";
+            }
+            return eval(n - 1);
+        };
+    }
+    scope.eval = f;
+    shouldBe(f(iterations), "done");
+    shouldBe(callCount, 1);
+})();
+
+(function spreadArguments() {
+    var callCount = 0;
+    function f(n) {
+        "use strict";
+        if (n === 0) {
+            callCount += 1;
+            return "done";
+        }
+        return eval(...[n - 1]);
+    }
+    var eval = f;
+    shouldBe(f(iterations), "done");
+    shouldBe(callCount, 1);
+})();
+
+// A real direct eval in a tail position keeps direct eval semantics: it sees the
+// caller's bindings and its own declarations do not escape into the caller.
+(function realDirectEvalInTailPosition() {
+    "use strict";
+    var x = 42;
+    function f() {
+        "use strict";
+        var y = "inner";
+        return eval("[x, y, typeof z]");
+    }
+    shouldBe(f().join(), "42,inner,undefined");
+})();
+
+// An async generator body holds no tail positions, so "return eval(0)" must stay an ordinary
+// call whose result the body then awaits.
+(function asyncGeneratorScope() {
+    var eval = function () { return Promise.resolve(42); };
+    async function* g() {
+        "use strict";
+        return eval(0);
+    }
+    var result;
+    g().next().then((value) => { result = value; });
+    drainMicrotasks();
+    shouldBe(result.done, true);
+    shouldBe(result.value, 42);
+})();
+
+// Global scope, run last because it clobbers the global eval binding.
+var callCount = 0;
+function globalF(n) {
+    "use strict";
+    if (n === 0) {
+        callCount += 1;
+        return "done";
+    }
+    return eval(n - 1);
+}
+eval = globalF;
+shouldBe(globalF(iterations), "done");
+shouldBe(callCount, 1);

--- a/JSTests/test262/expectations-linux.yaml
+++ b/JSTests/test262/expectations-linux.yaml
@@ -112,14 +112,6 @@ test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-p
 test/language/expressions/assignment/fn-name-lhs-cover.js:
   default: 3
   strict mode: 3
-test/language/expressions/call/tco-non-eval-function-dynamic.js:
-  default: 3
-test/language/expressions/call/tco-non-eval-function.js:
-  default: 3
-test/language/expressions/call/tco-non-eval-global.js:
-  default: 3
-test/language/expressions/call/tco-non-eval-with.js:
-  default: 3
 test/language/expressions/delete/super-property-uninitialized-this.js:
   default: 3
   strict mode: 3

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -82,14 +82,6 @@ test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-p
 test/language/expressions/assignment/fn-name-lhs-cover.js:
   default: 3
   strict mode: 3
-test/language/expressions/call/tco-non-eval-function-dynamic.js:
-  default: 3
-test/language/expressions/call/tco-non-eval-function.js:
-  default: 3
-test/language/expressions/call/tco-non-eval-global.js:
-  default: 3
-test/language/expressions/call/tco-non-eval-with.js:
-  default: 3
 test/language/expressions/delete/super-property-uninitialized-this.js:
   default: 3
   strict mode: 3

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -448,7 +448,11 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
     // https://bugs.webkit.org/show_bug.cgi?id=148819
     //
     // Note that we intentionally enable tail call for naked constructors since it does not have special code for "return".
-    , m_allowTailCallOptimization(Options::useTailCalls() && !isConstructor() && constructorKind() == ConstructorKind::None && functionNode->isStrictMode())
+    //
+    // Generator, async function, and async generator bodies hold no tail positions at all
+    // (IsInTailPosition steps 4 to 7): their "return" is not a plain return. An async generator
+    // awaits the returned value, and a tail call would jump over that await.
+    , m_allowTailCallOptimization(Options::useTailCalls() && !isConstructor() && constructorKind() == ConstructorKind::None && functionNode->isStrictMode() && !isGeneratorOrAsyncFunctionBodyParseMode(parseMode()))
     , m_allowCallIgnoreResultOptimization(m_defaultAllowCallIgnoreResultOptimization)
     , m_needsToUpdateArrowFunctionContext(functionNode->usesArrowFunction() || functionNode->usesEval())
     , m_ecmaMode(ECMAMode::fromBool(functionNode->isStrictMode()))

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -379,6 +379,7 @@ namespace JSC {
         const CommonIdentifiers& propertyNames() const { return *m_vm.propertyNames; }
 
         bool isConstructor() const { return m_codeBlock->isConstructor(); }
+        bool allowsTailCallOptimization() const { return m_allowTailCallOptimization; }
         DerivedContextType derivedContextType() const { return m_derivedContextType; }
         bool usesArrowFunction() const { return m_scopeNode->usesArrowFunction(); }
         bool needsToUpdateArrowFunctionContext() const { return m_needsToUpdateArrowFunctionContext; }

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -1338,6 +1338,19 @@ RegisterID* EvalFunctionCallNode::emitBytecode(BytecodeGenerator& generator, Reg
         generator.emitLabel(notEvalFunction.get());
         generator.emitCallInTailPosition(returnValue.get(), func.get(), NoExpectedFunction, callArguments, divot(), divotStart(), divotEnd(), DebuggableCall::Yes);
         generator.emitLabel(done.get());
+    } else if (generator.allowsTailCallOptimization()) {
+        // A callee named "eval" is a direct eval only if it really is the built-in eval function.
+        // Otherwise this is an ordinary call, and an ordinary call in a tail position is a tail call.
+        Ref<Label> notEvalFunction = generator.newLabel();
+        Ref<Label> done = generator.newLabel();
+        generator.emitJumpIfNotEvalFunction(func.get(), notEvalFunction.get());
+
+        generator.emitCallDirectEval(returnValue.get(), func.get(), callArguments, divot(), divotStart(), divotEnd(), DebuggableCall::No);
+        generator.emitJump(done.get());
+
+        generator.emitLabel(notEvalFunction.get());
+        generator.emitCallInTailPosition(returnValue.get(), func.get(), NoExpectedFunction, callArguments, divot(), divotStart(), divotEnd(), DebuggableCall::Yes);
+        generator.emitLabel(done.get());
     } else
         generator.emitCallDirectEval(returnValue.get(), func.get(), callArguments, divot(), divotStart(), divotEnd(), DebuggableCall::No);
 


### PR DESCRIPTION
#### 4fa7b55ae4c6485fcdef946f98b692bff1a2fcc6
<pre>
[JSC] eval call should recognize tail-position
<a href="https://bugs.webkit.org/show_bug.cgi?id=323597">https://bugs.webkit.org/show_bug.cgi?id=323597</a>
<a href="https://rdar.apple.com/186840477">rdar://186840477</a>

Reviewed by Sosuke Suzuki.

This patch fixes TCO for function call named &quot;eval&quot;.
We follow to the pattern used in spread call case: performing CallDirectEval
only when the function is actually eval function. Otherwise, do a tail-call.

Doing so uncovered a separate bug in how we decide what a tail position is.
Generator, async function, and async generator bodies hold no tail positions
at all (IsInTailPosition steps 4 to 7), but BytecodeGenerator enabled TCO in
them anyway. An async generator awaits the value its body returns, so
op_tail_call jumped over that await and resolved the iterator result with the
promise itself; the other body modes dropped a frame that has to stay on the
stack. This is not specific to the new eval path, an ordinary call hits it too:

    async function* g() { &quot;use strict&quot;; return Promise.resolve(42); }
    g().next() // resolved with { value: &lt;promise&gt;, done: true }

So exclude those parse modes when computing m_allowTailCallOptimization.

Tests: JSTests/stress/no-tail-call-in-generator-and-async-function-bodies.js
       JSTests/stress/tail-call-eval-identifier-resolving-to-non-eval-function.js

* JSTests/stress/no-tail-call-in-generator-and-async-function-bodies.js: Added.
(shouldBe):
(drain):
(asyncGeneratorAwaitsReturnedCall.f):
(asyncGeneratorAwaitsReturnedCall.async plainCall):
(asyncGeneratorAwaitsReturnedCall.async memberCall):
(asyncGeneratorAwaitsReturnedCall.async spreadCall):
(asyncGeneratorAwaitsReturnedCall.async applyCall):
(asyncGeneratorAwaitsReturnedCall):
(bodiesKeepTheirFrame.callerName):
(bodiesKeepTheirFrame.generatorBody):
(bodiesKeepTheirFrame.async asyncFunctionBody):
(bodiesKeepTheirFrame.async asyncGeneratorBody):
(bodiesKeepTheirFrame.ordinaryStrictFunction):
(bodiesKeepTheirFrame):
* JSTests/stress/tail-call-eval-identifier-resolving-to-non-eval-function.js: Added.
(shouldBe):
(functionScope.f):
(functionScopeDynamic.f):
(functionScopeDynamic):
(withScope.with.f):
(withScope):
(spreadArguments.f):
(spreadArguments):
(realDirectEvalInTailPosition.f):
(realDirectEvalInTailPosition):
(asyncGeneratorScope.eval):
(asyncGeneratorScope.async g):
(asyncGeneratorScope):
(globalF):
* JSTests/test262/expectations-linux.yaml:
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::BytecodeGenerator):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::BytecodeGenerator::allowsTailCallOptimization const):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::EvalFunctionCallNode::emitBytecode):

Canonical link: <a href="https://commits.webkit.org/320687@main">https://commits.webkit.org/320687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22ba1ffdb61523a1feb0445b7298bdea41d8d9a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195814 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150251 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/32330a9b-c938-40da-928e-3e07c67d77d1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59129 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144954 "Found 1 new test failure: fast/dom/lazy-image-loading-document-leak.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100498 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9063d2e8-6409-4068-8e91-52e596687d21) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188445 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125246 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/81b7b93d-0b92-49af-bb36-7b67d8e8cbb9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47367 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45424 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7151 "Found 1 new JSC stress test failure: Too many failures: 2103 jsc tests failed (failure)") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14044 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157734 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45112 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6864 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46747 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52058 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197762 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59066 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154480 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59775 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154129 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28171 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48606 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132121 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129006 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58252 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20134 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57624 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57867 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57690 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->