### PR TITLE
[Skia] Use a reference instead of a pointer for SkData span() and mutableSpan() implementations

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
@@ -102,7 +102,7 @@ bool GraphicsContextGLImageExtractor::extractImage(AlphaPremultiplication source
             return false;
 
         m_pixelData = WTF::move(data);
-        m_imagePixelData = span(m_pixelData.get());
+        m_imagePixelData = span(*m_pixelData);
         m_imageSourceFormat = sourceFormat.value_or(DataFormat::RGBA8);
     } else {
         SkPixmap pixmap;

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp
@@ -157,7 +157,7 @@ void ImageBufferSkiaSurfaceBackend::putPixelBuffer(const PixelBufferSourceView& 
 
     // Fall back to converting, but only the part covered by sourceRectClipped/srcPixmap.
     auto data = SkData::MakeUninitialized(srcPixmap.computeByteSize());
-    ImageBufferBackend::putPixelBuffer(pixelBuffer, sourceRectClipped, IntPoint::zero(), destFormat, mutableSpan(data.get()));
+    ImageBufferBackend::putPixelBuffer(pixelBuffer, sourceRectClipped, IntPoint::zero(), destFormat, mutableSpan(*data));
     auto convertedSrcInfo = SkImageInfo::Make(srcPixmap.dimensions(), SkColorType::kBGRA_8888_SkColorType,
         SkAlphaType::kPremul_SkAlphaType, colorSpace().platformColorSpace());
     SkPixmap convertedSrcPixmap(convertedSrcInfo, data->writable_data(), convertedSrcInfo.minRowBytes64());

--- a/Source/WebCore/platform/graphics/skia/SkiaSpanExtras.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaSpanExtras.h
@@ -35,19 +35,20 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 
-inline std::span<const uint8_t> span(SkData* data)
+inline std::span<const uint8_t> span(SkData& data)
 {
-    return unsafeMakeSpan<const uint8_t>(data->bytes(), data->size());
+    return unsafeMakeSpan<const uint8_t>(data.bytes(), data.size());
 }
 
 inline std::span<const uint8_t> span(const sk_sp<SkData>& data)
 {
-    return span(data.get());
+    ASSERT(data);
+    return span(*data);
 }
 
-inline std::span<uint8_t> mutableSpan(SkData* data)
+inline std::span<uint8_t> mutableSpan(SkData& data)
 {
-    return unsafeMakeSpan(static_cast<uint8_t*>(data->writable_data()), data->size());
+    return unsafeMakeSpan(static_cast<uint8_t*>(data.writable_data()), data.size());
 }
 
 inline std::span<const uint8_t> span(const SkPixmap& pixmap)


### PR DESCRIPTION
#### 059ad1b28aea009c6b2124a11bb9999b2718b070
<pre>
[Skia] Use a reference instead of a pointer for SkData span() and mutableSpan() implementations
<a href="https://bugs.webkit.org/show_bug.cgi?id=323598">https://bugs.webkit.org/show_bug.cgi?id=323598</a>

Reviewed by NOBODY (OOPS!).

They always expect a non-null parameter, so better use a reference.

* Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp:
(WebCore::GraphicsContextGLImageExtractor::extractImage):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp:
(WebCore::ImageBufferSkiaSurfaceBackend::putPixelBuffer):
* Source/WebCore/platform/graphics/skia/SkiaSpanExtras.h:
(WebCore::span):
(WebCore::mutableSpan):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/059ad1b28aea009c6b2124a11bb9999b2718b070

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195680 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150153 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60633 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/58995 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144850 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100427 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165441 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125143 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47262 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45319 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157629 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45012 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6733 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197629 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58932 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154362 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59641 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41617 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154012 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48502 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131965 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128795 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58119 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20034 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57491 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57734 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57558 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->