### PR TITLE
NetworkRTCUDPSocketCocoa should not filter AF_UNSPEC remote addresses

### DIFF
--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
@@ -312,7 +312,9 @@ void NetworkRTCUDPSocketCocoaConnections::configureParameters(nw_parameters_t pa
 {
     auto protocolStack = adoptNS(nw_parameters_copy_default_protocol_stack(parameters));
     auto options = adoptNS(nw_protocol_stack_copy_internet_protocol(protocolStack.get()));
-    nw_ip_options_set_version(options.get(), version);
+
+    if (version != nw_ip_version_any)
+        nw_ip_options_set_version(options.get(), version);
 
     setNWParametersApplicationIdentifiers(parameters, m_sourceApplicationBundleIdentifier.data(), m_sourceApplicationAuditToken, m_attributedBundleIdentifier);
     setNWParametersTrackerOptions(parameters, m_shouldBypassRelay, m_isFirstParty, m_isKnownTracker);
@@ -392,7 +394,7 @@ auto NetworkRTCUDPSocketCocoaConnections::createNWConnection(const webrtc::Socke
         auto localEndpoint = adoptNS(nw_endpoint_create_host_with_numeric_port(hostAddress.c_str(), m_address.port()));
         nw_parameters_set_local_endpoint(parameters.get(), localEndpoint.get());
     }
-    configureParameters(parameters.get(), remoteAddress.family() == AF_INET ? nw_ip_version_4 : nw_ip_version_6);
+    configureParameters(parameters.get(), ipVersionFromFamily(remoteAddress.family()));
 
     if (m_trafficClass)
         nw_parameters_set_traffic_class(parameters.get(), *m_trafficClass);

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.h
@@ -42,6 +42,7 @@ void setNWParametersApplicationIdentifiers(nw_parameters_t, const char* sourceAp
 void setNWParametersTrackerOptions(nw_parameters_t, bool shouldBypassRelay, bool isFirstParty, bool isKnownTracker);
 bool isKnownTracker(const WebCore::RegistrableDomain&);
 std::optional<uint32_t> trafficClassFromDSCP(webrtc::DiffServCodePoint, bool enableServiceClass);
+nw_ip_version_t ipVersionFromFamily(int family);
 
 } // namespace WebKit
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.mm
@@ -113,6 +113,20 @@ std::optional<uint32_t> trafficClassFromDSCP(webrtc::DiffServCodePoint dscpValue
     return { };
 }
 
+nw_ip_version_t ipVersionFromFamily(int family)
+{
+    switch (family) {
+    case AF_INET:
+        return nw_ip_version_4;
+    case AF_INET6:
+        return nw_ip_version_6;
+    case AF_UNSPEC:
+        return nw_ip_version_any;
+    }
+    ASSERT_NOT_REACHED();
+    return nw_ip_version_any;
+}
+
 } // namespace WebKit
 
 #endif // USE(LIBWEBRTC)


### PR DESCRIPTION
#### 550f98d6dc5d18e6fe44f56c395e5602cc2f2b4a
<pre>
NetworkRTCUDPSocketCocoa should not filter AF_UNSPEC remote addresses
<a href="https://rdar.apple.com/186844205">rdar://186844205</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=323600">https://bugs.webkit.org/show_bug.cgi?id=323600</a>

Reviewed by Chris Dumez.

By providing nw_ip_options_set_version, we allow restricting to connecting to IPv4 or IPv6 addresses.
When being given an adress with an unresolved name, we do not know whether it will be IPv4 or IPv6.
In that case, we should not call nw_ip_options_set_version.
Otherwise, we risk resolving the address but failing to connect as the resolved address is not IPv6.

Before the PR, we would call nw_ip_options_set_version, reducing to IPv6 for both AF_INET6 and AF_UNSPEC.
We are now correctly restricting to IPv4 for AF_INET, to IPv6 for AF_INET6 and we do not restrict for AF_UNSPEC.

This cannot be tested right now that NetworkRTCUDPSocketCocoa only works on resolved IP addresses.
A follow-up patch may enable this code path.

* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
(WebKit::NetworkRTCUDPSocketCocoaConnections::configureParameters):
(WebKit::NetworkRTCUDPSocketCocoaConnections::createNWConnection):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUtilitiesCocoa.mm:
(WebKit::toNWIPVersion):

Canonical link: <a href="https://commits.webkit.org/320716@main">https://commits.webkit.org/320716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7080c7efaed434c1098829a822d18ff2dcd66f55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195685 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150155 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b93c0191-a0d5-4ba4-94e3-b44ca8d5e728) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59000 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144856 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100428 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9b1b5c61-4af7-44db-a3d7-86ba150e5273) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165445 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125149 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca275800-9151-4ae8-85d1-0deec13a1c59) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47266 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45324 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157633 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45016 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6738 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49708 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197634 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58937 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154367 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41416 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59646 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41621 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154017 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48506 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/131971 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128803 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58124 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20038 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57496 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57739 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57563 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->