### PR TITLE
[WebDriver] pytest-timeout's SIGALRM can wedge the asyncio loop and hang the run

### DIFF
--- a/Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py
@@ -20,10 +20,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import asyncio
 import contextlib
 import errno
 import os
+import selectors
 import shutil
+import signal
 import sys
 import tempfile
 
@@ -107,7 +110,7 @@ class SubtestResultRecorder(object):
             self.record_skip(report)
 
     def _was_timeout(self, report):
-        return hasattr(report.longrepr, 'reprcrash') and report.longrepr.reprcrash.message.startswith('Failed: Timeout >')
+        return hasattr(report.longrepr, 'reprcrash') and report.longrepr.reprcrash.message.startswith('Failed: Timeout')
 
     def record_pass(self, report):
         expected = dict(report.user_properties).get("expectations", [])
@@ -179,6 +182,46 @@ class TestExpectationsMarker(object):
             item.user_properties.append(("expectations", expected))
 
 
+class TimeoutSignalHandler(object):
+    """Keep pytest-timeout's SIGALRM from firing inside asyncio's scheduler.
+
+    pytest-timeout raises from the signal handler wherever the alarm lands. Inside the
+    event loop's own scheduling code (e.g. while Future.set_result() is queueing the
+    wake-up of the awaiting task) that leaves the future done but the task never resumed,
+    and the loop runs forever. Defer the alarm until the loop is idle in the selector, from
+    where the exception propagates cleanly out of run_until_complete().
+    """
+
+    RETRY_INTERVAL = 0.005
+
+    @pytest.hookimpl(wrapper=True)
+    def pytest_timeout_set_timer(self, item, settings):
+        result = yield
+        if settings.method != 'signal':
+            return result
+        handler = signal.getsignal(signal.SIGALRM)
+        if callable(handler):
+            def deferring_handler(signum, frame):
+                __tracebackhide__ = True
+                if self._should_defer_timeout(frame):
+                    signal.setitimer(signal.ITIMER_REAL, self.RETRY_INTERVAL)
+                else:
+                    handler(signum, frame)
+            signal.signal(signal.SIGALRM, deferring_handler)
+        return result
+
+    @staticmethod
+    def _should_defer_timeout(frame):
+        # Raising timeout exceptions while the loop is running outside selector wait might
+        # corrupt internal state updates, leaving tasks hanging.
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return False
+        code = frame.f_code
+        return not (code.co_filename == selectors.__file__ and code.co_name == 'select')
+
+
 def collect(directory, args, ignore_param=None):
     collect_recorder = CollectRecorder(ignore_param)
     with open(os.devnull, 'w') as f:
@@ -210,7 +253,7 @@ def run(path, args, timeout, env, expectations, ignore_param=None, extra_plugins
                    '-p', 'no:cacheprovider']
             cmd.extend(args)
             cmd.append(path)
-            result = pytest.main(cmd, plugins=[harness_recorder, subtests_recorder, expectations_marker, *(extra_plugins or [])])
+            result = pytest.main(cmd, plugins=[harness_recorder, subtests_recorder, expectations_marker, TimeoutSignalHandler(), *(extra_plugins or [])])
 
             if result == ExitCode.INTERNAL_ERROR:
                 harness_recorder.outcome = ('ERROR', None)


### PR DESCRIPTION
#### 92641830324a1fd532b6782aaf82e52f6ffb6883
<pre>
[WebDriver] pytest-timeout&apos;s SIGALRM can wedge the asyncio loop and hang the run
<a href="https://bugs.webkit.org/show_bug.cgi?id=322171">https://bugs.webkit.org/show_bug.cgi?id=322171</a>

Reviewed by Carlos Alberto Lopez Perez.

pytest-timeout raises from its SIGALRM handler wherever the alarm lands. When
that is inside asyncio&apos;s scheduler, for instance while Future.set_result() is
queueing the wake-up of the task awaiting it, the future is marked done but the
wake-up is never scheduled. asyncio swallows the exception as &quot;Exception in
callback&quot;, the test task is parked for good, and the loop keeps servicing the
websockets keepalive until someone kills the bot. Every run of the BiDi tests
expected to time out goes through this path.

Wrap the handler pytest-timeout installs so that, while an event loop is
running, the alarm is only delivered from the selector the idle loop is blocked
in, where the exception propagates cleanly out of run_until_complete(). Anywhere
else inside the loop it is re-armed a few milliseconds later instead.

Also match the timeout message pytest-timeout 2.4.0 produces, which has been
making unexpected timeouts show up as failures since the bump.

* Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py:
(SubtestResultRecorder._was_timeout):
(TimeoutSignalHandler):
(TimeoutSignalHandler.pytest_timeout_set_timer):
(TimeoutSignalHandler._should_defer_timeout):
(run):

Canonical link: <a href="https://commits.webkit.org/320815@main">https://commits.webkit.org/320815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c91806b0b818d967d6715a38406da4620a82820

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53287 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195883 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150308 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145011 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100541 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48691 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125303 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/184893 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47418 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45475 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45162 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6937 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49871 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197837 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59137 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154546 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41482 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59846 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41767 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154193 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48657 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129095 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58318 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20184 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57694 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57935 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->