### PR TITLE
Allow TURN UDP port to open a socket even if DNS resolution fails

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/turn_port.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/turn_port.cc
@@ -878,19 +878,32 @@ void TurnPort::ResolveTurnAddress(const SocketAddress& address) {
                    << address.ToSensitiveString();
   resolver_ = socket_factory()->CreateAsyncDnsResolver();
   auto callback = [this] {
+#if WEBRTC_WEBKIT_BUILD
+    // If DNS resolve is failed when trying to connect to the server,
+#else
     // If DNS resolve is failed when trying to connect to the server using TCP,
+#endif
     // one of the reason could be due to DNS queries blocked by firewall.
     // In such cases we will try to connect to the server with hostname,
     // assuming socket layer will resolve the hostname through a HTTP proxy (if
     // any).
     auto& result = resolver_->result();
     if (result.GetError() != 0 && (server_address_.proto == PROTO_TCP ||
+#if WEBRTC_WEBKIT_BUILD
+                                   server_address_.proto == PROTO_UDP ||
+#endif
                                    server_address_.proto == PROTO_TLS ||
                                    server_address_.proto == PROTO_DTLS)) {
       if (!CreateTurnClientSocket()) {
         OnAllocateError(STUN_ERROR_SERVER_NOT_REACHABLE,
                         "TURN host lookup received error.");
       }
+#if WEBRTC_WEBKIT_BUILD
+      if (server_address_.proto == PROTO_UDP) {
+        // Send request if UDP, for TCP & TLS, this will be sent by OnSocketConnect.
+        SendRequest(new TurnAllocateRequest(this), 0);
+      }
+#endif
       return;
     }
 


### PR DESCRIPTION
#### 1a1194af8bafdde54a6eef4a0ad088d6ce662f8a
<pre>
Allow TURN UDP port to open a socket even if DNS resolution fails
<a href="https://rdar.apple.com/186847964">rdar://186847964</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=323604">https://bugs.webkit.org/show_bug.cgi?id=323604</a>

Reviewed by Jean-Yves Avenard.

In case of DNS resolution failure, TURN TCP is able to try opening a socket to a host.
This exception is done in case a proxy forbids DNS/UDP. In that case, TCP can still succeed via a proxy.

With private relay, TURN UDP connections may succeed also even if local DNS resolution fails.
We apply the same principle as TURN TCP.

Manually tested by disabling DNS resolution for WebRTC.
A future patch will allow disabling this DNS resolution and we will add a test at that time.

* Source/ThirdParty/libwebrtc/Source/webrtc/p2p/base/turn_port.cc:

Canonical link: <a href="https://commits.webkit.org/320720@main">https://commits.webkit.org/320720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bb89eb713832e0387ebc4e95069d845e226bbe0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195695 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150162 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144866 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100433 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125158 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47273 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45333 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157640 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45026 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6748 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49718 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197644 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58947 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154376 "Found 1 new test failure: compositing/framesets/composited-frame-alignment.html (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41420 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59656 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154026 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48516 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128817 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58134 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20048 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57506 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57749 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57573 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->