### PR TITLE
Cherry-pick 305413.1114@safari-7624.5.1.10-branch (2bc65ac3560e). https://bugs.webkit.org/show_bug.cgi?id=319112

### DIFF
--- a/JSTests/stress/uint32-array-result-int32-dfg.js
+++ b/JSTests/stress/uint32-array-result-int32-dfg.js
@@ -1,0 +1,41 @@
+//@ runDefault("--useConcurrentJIT=false", "--useFTLJIT=false", "--jitPolicyScale=0.1")
+// See rdar://176792844 for additional details on this test.
+
+let a = new Uint32Array(4);
+a[0] = 42;
+
+let dummy = [1, 2, 3]; dummy[0] = 1; dummy[0] = {};
+
+const sBodyArgs = ['a', 'idx', 'flag', 'intArr',
+"\n" +
+"    let i = idx;\n" +
+"    if (flag) i = 0.5;\n" +
+"    let v = a[i];\n" +
+"    let d = v - 0.5;\n" +
+"    intArr[0] = v;\n" +
+"    return d;\n"];
+
+let f1 = new Function(...sBodyArgs);
+noInline(f1);
+
+let intArr1 = [1, 2, 3]; intArr1[0] = 1;
+for (let k = 0; k < 100; k++)
+    f1(a, 0, false, intArr1);
+
+for (let k = 0; k < 110; k++)
+    f1(a, 100, false, intArr1);
+
+let evict = new Function('z', 'return z'); evict(0);
+
+let f2 = new Function(...sBodyArgs);
+noInline(f2);
+
+let intArr2 = [1, 2, 3]; intArr2[0] = 1;
+
+for (let k = 0; k < 100; k++)
+    f2(a, 0, false, intArr2);
+
+f2(a, 0, false, intArr2);
+
+if (intArr2[0] !== 42)
+    throw new Error("incorrect value " + intArr2[0]);

--- a/JSTests/stress/yarr-jit-non-bmp-backtrack-index-overflow.js
+++ b/JSTests/stress/yarr-jit-non-bmp-backtrack-index-overflow.js
@@ -1,0 +1,12 @@
+const re = /d\0e?|\u{10000}c/u;
+const subj = "\u{10000}d";
+const m = re.exec(subj);
+
+if (m !== null) {
+    throw new Error(
+        "expected null, got match=" + JSON.stringify(m[0]) +
+        " at index=" + m.index +
+        " (m.index + m[0].length = " + (m.index + m[0].length) +
+        " > subj.length = " + subj.length + ")"
+    );
+}

--- a/JSTests/stress/yarr-jit-non-bmp-backtrack-index-underflow.js
+++ b/JSTests/stress/yarr-jit-non-bmp-backtrack-index-underflow.js
@@ -1,0 +1,5 @@
+const re = /(?!\u{10000})a*|\u{10000}b/u;
+const subj = "\u{10000}cc";
+const m = re.exec(subj);
+if (m[0].length > subj.length)
+    throw new Error("m[0].length (" + m[0].length + ") > subj.length (" + subj.length + ")");

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -3388,8 +3388,13 @@ void SpeculativeJIT::setIntTypedArrayLoadResult(Node* node, JSValueRegs resultRe
 
     if (shouldBox) {
         if (isUInt32) {
-            convertUInt32ToDouble(resultReg, resultFPR);
-            boxDouble(resultFPR, resultRegs);
+            if (node->shouldSpeculateInt32() && canSpeculate) {
+                speculationCheck(ExitKind::Overflow, JSValueRegs(), nullptr, branch32(LessThan, resultReg, TrustedImm32(0)));
+                boxInt32(resultReg, resultRegs);
+            } else {
+                convertUInt32ToDouble(resultReg, resultFPR);
+                boxDouble(resultFPR, resultRegs);
+            }
         } else
             boxInt32(resultRegs.payloadGPR(), resultRegs);
         if (outOfBounds.isSet())

--- a/Source/JavaScriptCore/runtime/RegExpMatchesArray.h
+++ b/Source/JavaScriptCore/runtime/RegExpMatchesArray.h
@@ -76,7 +76,8 @@ ALWAYS_INLINE JSArray* createRegExpMatchesArray(
 
     result.start = position;
     result.end = subpatternResults[1];
-    
+    RELEASE_ASSERT(result.end >= result.start);
+
     JSArray* array;
     JSArray* indicesArray = nullptr;
 

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -3925,9 +3925,19 @@ class YarrGenerator final : public YarrJITInfo {
                             // already correctly incremented, if more than one then decrement as appropriate.
                             unsigned delta = alternative->m_minimumSize - beginOp->m_alternative->m_minimumSize;
                             ASSERT(delta);
+                            bool advancedIndexForNonBMP = false;
+#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
+                            if (m_useFirstNonBMPCharacterOptimization) {
+                                m_jit.add32(m_regs.firstCharacterAdditionalReadSize, m_regs.index);
+                                advancedIndexForNonBMP = true;
+                            }
+#endif
                             if (delta != 1)
                                 m_jit.sub32(MacroAssembler::Imm32(delta - 1), m_regs.index);
-                            m_jit.jump(beginOp->m_reentry);
+                            if (advancedIndexForNonBMP)
+                                checkInput().linkTo(beginOp->m_reentry, &m_jit);
+                            else
+                                m_jit.jump(beginOp->m_reentry);
                         } else {
                             // If the first alternative has minimum size 0xFFFFFFFFu, then there cannot
                             // be sufficent input available to handle this, so just fall through.


### PR DESCRIPTION
#### 4934ed9294e3ce3c69c68556caa21b99da7c6ceb
<pre>
Cherry-pick 305413.1114@safari-7624.5.1.10-branch (2bc65ac3560e). <a href="https://bugs.webkit.org/show_bug.cgi?id=319112">https://bugs.webkit.org/show_bug.cgi?id=319112</a>

    [JSC] DFG Uint32Array load should consider about Int32 speculation path
    <a href="https://bugs.webkit.org/show_bug.cgi?id=319112">https://bugs.webkit.org/show_bug.cgi?id=319112</a>
    <a href="https://rdar.apple.com/176792844">rdar://176792844</a>

    Reviewed by Mark Lam.

    DFG Uint32Array GetByVal may have Int32 result with speculation. But the
    current code is always using boxed-double for boxed result. We should
    use boxed-int32 when this speculation is set. The same thing is already
    done in FTL.

    Test: JSTests/stress/uint32-array-result-int32-dfg.js

    * JSTests/stress/uint32-array-result-int32-dfg.js: Added.
    * Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
    (JSC::DFG::SpeculativeJIT::setIntTypedArrayLoadResult):

    Identifier: 305413.1114@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1154@webkitglib/2.52">https://commits.webkit.org/305877.1154@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 27bad3866d55a66eb092caffcd4e1caebfc4eeff
<pre>
Cherry-pick 305413.1108@safari-7624.5.1.10-branch (30b9a27b47e8). <a href="https://bugs.webkit.org/show_bug.cgi?id=316996">https://bugs.webkit.org/show_bug.cgi?id=316996</a>

    [JSC] YarrJIT non-BMP backtrack trampoline (L&gt;F branch) does not add firstCharacterAdditionalReadSize to index, returns start &gt; end
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316996">https://bugs.webkit.org/show_bug.cgi?id=316996</a>
    <a href="https://rdar.apple.com/177699255">rdar://177699255</a>

    Reviewed by Yijia Huang.

    This patch fixes a mistake where firstCharacterAdditionalReadSize isn&apos;t added
    to the index register in YarrJIT during backtracking.

    Test: JSTests/stress/yarr-jit-non-bmp-backtrack-index-underflow.js

    * JSTests/stress/yarr-jit-non-bmp-backtrack-index-overflow.js: Added.
    * JSTests/stress/yarr-jit-non-bmp-backtrack-index-underflow.js: Added.
    * Source/JavaScriptCore/runtime/RegExpMatchesArray.h:
    (JSC::createRegExpMatchesArray):
    * Source/JavaScriptCore/yarr/YarrJIT.cpp:

    Identifier: 305413.1108@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1153@webkitglib/2.52">https://commits.webkit.org/305877.1153@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3387aedc41427db632d28bb72f4300d3f2cc2bcb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185381 "Passed style check") | [⏳ 🛠 ios](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/195705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150168 "The change is no longer eligible for processing.") 
| [⏳ 🧪 bindings](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/195705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150168 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188336 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/195705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [⏳ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/195705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [⏳ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/6758 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [⏳ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/197654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/197654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/197654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28145 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 tv](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [⏳ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | 
<!--EWS-Status-Bubble-End-->