### PR TITLE
[WPE] WebDriver input is broken on WPEPlatform views with a scale factor

### DIFF
--- a/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
+++ b/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
@@ -48,15 +48,6 @@
 
 namespace WebKit {
 
-#if ENABLE(WEBDRIVER) && (ENABLE(WEBDRIVER_MOUSE_INTERACTIONS) || ENABLE(WEBDRIVER_TOUCH_INTERACTIONS) || ENABLE(WEBDRIVER_WHEEL_INTERACTIONS))
-static WebCore::IntPoint deviceScaleLocationInView(WebPageProxy& page, const WebCore::IntPoint& locationInView)
-{
-    WebCore::IntPoint deviceScaleLocationInView(locationInView);
-    deviceScaleLocationInView.scale(page.deviceScaleFactor());
-    return deviceScaleLocationInView;
-}
-#endif
-
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
 
 // Called by platform-indendent code to convert the current platform-dependent raw modifiers into generic WebEventModifiers,
@@ -183,10 +174,10 @@ void WebAutomationSession::platformSimulateMouseInteraction(WebPageProxy& page, 
 {
     UNUSED_PARAM(pointerType);
 
-    auto location = deviceScaleLocationInView(page, locationInView);
-
 #if USE(LIBWPE)
     if (page.viewBackend()) {
+        auto location = locationInView;
+        location.scale(page.deviceScaleFactor());
         platformSimulateMouseInteractionLibWPE(page, interaction, button, location, keyModifiers, pointerType, m_currentModifiers);
         return;
     }
@@ -199,25 +190,25 @@ void WebAutomationSession::platformSimulateMouseInteraction(WebPageProxy& page, 
 
     switch (interaction) {
     case MouseInteraction::Move:
-        doMotionEvent(page, location, state);
+        doMotionEvent(page, locationInView, state);
         break;
     case MouseInteraction::Down:
         m_currentModifiers |= modifier;
-        doMouseEvent(page, location, wpeButton, true, state | modifier);
+        doMouseEvent(page, locationInView, wpeButton, true, state | modifier);
         break;
     case MouseInteraction::Up:
         m_currentModifiers &= ~modifier;
-        doMouseEvent(page, location, wpeButton, false, state & ~modifier);
+        doMouseEvent(page, locationInView, wpeButton, false, state & ~modifier);
         break;
     case MouseInteraction::SingleClick:
-        doMouseEvent(page, location, wpeButton, true, state | modifier);
-        doMouseEvent(page, location, wpeButton, false, state);
+        doMouseEvent(page, locationInView, wpeButton, true, state | modifier);
+        doMouseEvent(page, locationInView, wpeButton, false, state);
         break;
     case MouseInteraction::DoubleClick:
-        doMouseEvent(page, location, wpeButton, true, state | modifier);
-        doMouseEvent(page, location, wpeButton, false, state);
-        doMouseEvent(page, location, wpeButton, true, state | modifier);
-        doMouseEvent(page, location, wpeButton, false, state);
+        doMouseEvent(page, locationInView, wpeButton, true, state | modifier);
+        doMouseEvent(page, locationInView, wpeButton, false, state);
+        doMouseEvent(page, locationInView, wpeButton, true, state | modifier);
+        doMouseEvent(page, locationInView, wpeButton, false, state);
         break;
     }
 #endif // ENABLE(WPE_PLATFORM)
@@ -483,10 +474,10 @@ void WebAutomationSession::platformSimulateKeySequence(WebPageProxy& page, const
 #if ENABLE(WEBDRIVER_WHEEL_INTERACTIONS)
 void WebAutomationSession::platformSimulateWheelInteraction(WebPageProxy& page, const WebCore::IntPoint& locationInView, const WebCore::IntSize& delta)
 {
-    auto location = deviceScaleLocationInView(page, locationInView);
-
 #if USE(LIBWPE)
     if (page.viewBackend()) {
+        auto location = locationInView;
+        location.scale(page.deviceScaleFactor());
         platformSimulateWheelInteractionLibWPE(page, location, delta);
         return;
     }
@@ -494,7 +485,7 @@ void WebAutomationSession::platformSimulateWheelInteraction(WebPageProxy& page, 
 
 #if ENABLE(WPE_PLATFORM)
     auto* view = page.wpeView();
-    GRefPtr<WPEEvent> event = adoptGRef(wpe_event_scroll_new(view, WPE_INPUT_SOURCE_MOUSE, 0, static_cast<WPEModifiers>(0), delta.width(), delta.height(), false, false, location.x(), location.y()));
+    GRefPtr<WPEEvent> event = adoptGRef(wpe_event_scroll_new(view, WPE_INPUT_SOURCE_MOUSE, 0, static_cast<WPEModifiers>(0), delta.width(), delta.height(), false, false, locationInView.x(), locationInView.y()));
     wpe_view_event(view, event.get());
 #endif
 }
@@ -512,25 +503,23 @@ void WebAutomationSession::platformSimulateTouchInteraction(WebPageProxy&page, T
     }
 #endif
 
-    auto location = deviceScaleLocationInView(page, locationInView);
-
 #if ENABLE(WPE_PLATFORM)
     GRefPtr<WPEEvent> event;
 
     switch (interaction) {
     case TouchInteraction::TouchDown:
         event = adoptGRef(wpe_event_touch_new(WPE_EVENT_TOUCH_DOWN, page.wpeView(), WPE_INPUT_SOURCE_TOUCHSCREEN, 0,
-            static_cast<WPEModifiers>(m_currentModifiers), 0, location.x(), location.y()));
+            static_cast<WPEModifiers>(m_currentModifiers), 0, locationInView.x(), locationInView.y()));
         break;
     case TouchInteraction::LiftUp:
         event = adoptGRef(wpe_event_touch_new(WPE_EVENT_TOUCH_UP, page.wpeView(), WPE_INPUT_SOURCE_TOUCHSCREEN, 0,
-            static_cast<WPEModifiers>(m_currentModifiers), 0, location.x(), location.y()));
+            static_cast<WPEModifiers>(m_currentModifiers), 0, locationInView.x(), locationInView.y()));
         break;
     case TouchInteraction::MoveTo:
         // TODO: Spread over intermediate points based on the duration, like iOS's WKTouchEventGenerator::moveToPoints
         // See https://bugs.webkit.org/show_bug.cgi?id=275031
         event = adoptGRef(wpe_event_touch_new(WPE_EVENT_TOUCH_MOVE, page.wpeView(), WPE_INPUT_SOURCE_TOUCHSCREEN, 0,
-            static_cast<WPEModifiers>(m_currentModifiers), 0, location.x(), location.y()));
+            static_cast<WPEModifiers>(m_currentModifiers), 0, locationInView.x(), locationInView.y()));
         break;
     }
 


### PR DESCRIPTION
#### ca658205d1c75d1f3b661ad59907374074252465
<pre>
[WPE] WebDriver input is broken on WPEPlatform views with a scale factor
<a href="https://bugs.webkit.org/show_bug.cgi?id=323603">https://bugs.webkit.org/show_bug.cgi?id=323603</a>

Reviewed by Carlos Garcia Campos.

deviceScaleLocationInView() converts the location WebDriver asks for into
device pixels before it is handed to the platform. That is what wpe
expects, but a WPEPlatform view and the events delivered to it use logical
coordinates: WPEViewWayland passes the surface local coordinates straight
through, and a view&apos;s size relates to its buffer as
wpe_view_get_width(view) * scale == wpe_buffer_get_width(buffer).

So on a WPEPlatform view every simulated pointer, wheel and touch location
is multiplied by the scale factor once too often. On a display with a scale
of 1 nothing changes, which is why this went unnoticed, but testing in
Android devices that do not use 1 we get problems. The command reports
success and the page never sees the click, because it landed outside the
element.

Keep the conversion for wpe, whose events really are in device pixels, at
the two call sites that dispatch to it, and pass the location through
unchanged everywhere else. deviceScaleLocationInView() has no callers left
and goes away with it, so a port built without wpe compiles none of this.

* Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp:
(WebKit::WebAutomationSession::platformSimulateMouseInteraction):
(WebKit::WebAutomationSession::platformSimulateWheelInteraction):
(WebKit::WebAutomationSession::platformSimulateTouchInteraction):
(WebKit::deviceScaleLocationInView): Deleted.

Canonical link: <a href="https://commits.webkit.org/320864@main">https://commits.webkit.org/320864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4db5c0705083a78b8929c2df0bac8550c178cae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150492 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145200 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100672 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125714 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47609 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45638 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157969 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45345 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7178 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52342 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198081 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59373 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154752 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41520 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60082 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154396 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48856 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132430 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129419 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58548 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20368 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57926 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58161 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57991 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->