### PR TITLE
A hung WebDriver command makes run-webdriver-tests hang forever

### DIFF
--- a/Tools/Scripts/webkitpy/webdriver_tests/webdriver_w3c_executor.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/webdriver_w3c_executor.py
@@ -23,6 +23,7 @@
 import logging
 import os
 import json
+import queue
 import sys
 
 import multiprocessing as mp
@@ -124,6 +125,9 @@ class WebKitDriverBrowser(WebDriverBrowser):
 
 
 class WebDriverW3CExecutor(WdspecExecutor):
+    RESULT_TIMEOUT_SECONDS = 300
+    TEARDOWN_TIMEOUT_SECONDS = 10
+
     def __init__(self, driver, server, env, timeout, expectations):
         WebKitDriverBrowser.test_env = env
         WebKitDriverBrowser.test_env.update(driver.browser_env())
@@ -140,11 +144,14 @@ class WebDriverW3CExecutor(WdspecExecutor):
 
         self._timeout = timeout
         self._expectations = expectations
-        self._test_queue = _mp_context.Queue()
-        self._result_queue = _mp_context.Queue()
+        self._test_queue = None
+        self._result_queue = None
+        self._process = None
 
     def setup(self):
         super(WebDriverW3CExecutor, self).setup(self.runner)
+        self._test_queue = _mp_context.Queue()
+        self._result_queue = _mp_context.Queue()
         self.browser.start(None)
         args = (self._test_queue,
                 self._result_queue,
@@ -161,8 +168,15 @@ class WebDriverW3CExecutor(WdspecExecutor):
     def teardown(self):
         self.protocol.teardown()
         self.browser.stop(force=True)
-        self._test_queue.put('TEARDOWN')
-        self._process = None
+        if self._process is not None:
+            self._test_queue.put('TEARDOWN')
+            self._process.join(self.TEARDOWN_TIMEOUT_SECONDS)
+            if self._process.is_alive():
+                self._process.terminate()
+                self._process.join(self.TEARDOWN_TIMEOUT_SECONDS)
+            self._process = None
+        self._test_queue = None
+        self._result_queue = None
 
     @staticmethod
     def _runner(test_queue, result_queue, host, port, capabilities, webdriver_binary, server_config, timeout, expectations):
@@ -195,4 +209,12 @@ class WebDriverW3CExecutor(WdspecExecutor):
 
     def run(self, test):
         self._test_queue.put(test)
-        return self._result_queue.get()
+        try:
+            return self._result_queue.get(timeout=self.RESULT_TIMEOUT_SECONDS)
+        except queue.Empty:
+            _log.error('No result for %s after %d seconds, terminating the test process'
+                       % (test, self.RESULT_TIMEOUT_SECONDS))
+            if self._process is not None:
+                self._process.terminate()
+                self._process.join(self.TEARDOWN_TIMEOUT_SECONDS)
+            return ('ERROR', 'no result after %d seconds' % self.RESULT_TIMEOUT_SECONDS), []


### PR DESCRIPTION
#### 52ff189c46229b8f81b3c2f5ab705ff49cda7780
<pre>
A hung WebDriver command makes run-webdriver-tests hang forever
<a href="https://bugs.webkit.org/show_bug.cgi?id=323608">https://bugs.webkit.org/show_bug.cgi?id=323608</a>

Reviewed by Carlos Alberto Lopez Perez.

The W3C runner hands each test file to a child process over a queue and then
waits for the result with self._result_queue.get(), which has no timeout. The
child runs the actual WebDriver commands, so if the browser never answers one
of them the child never posts a result and the parent waits for it forever.
Nothing prints in the meantime, so a wedged run is indistinguishable from a
slow one.

Bound that wait. When it expires the test process is wedged, so kill it and
report the file as an error.

teardown() had a related problem: it asked the test process to stop and
dropped its reference without waiting for it to go away, and both queues were
created once per executor and reused by every later process. An abandoned
process could therefore still take a test off the queue or push a result onto
it, and from then on every result was paired with the wrong test file, which
is hard to notice because the results still look plausible. Wait for the
process to exit, kill it if it does not, and give each test process its own
pair of queues.

* Tools/Scripts/webkitpy/webdriver_tests/webdriver_w3c_executor.py:
(WebDriverW3CExecutor.__init__):
(WebDriverW3CExecutor.setup):
(WebDriverW3CExecutor.teardown):
(WebDriverW3CExecutor.run):
(WebDriverW3CExecutor):
(do_delayed_imports):

Canonical link: <a href="https://commits.webkit.org/320921@main">https://commits.webkit.org/320921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f59c0a00f3e47a262bbbda4d0ef6d613252660fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196475 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150744 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188047 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59791 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145469 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100835 "3 flakes 15 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166003 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125801 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; run-api-tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/185514 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47878 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45859 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158232 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45595 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7545 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50322 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198453 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59736 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155038 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41560 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60447 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154681 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49116 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129859 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58875 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20574 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58276 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58495 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58337 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->