### PR TITLE
Cherry-pick 305413.999@safari-7624.5-branch (747321afe7db). https://bugs.webkit.org/show_bug.cgi?id=317270

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/dtls/dtls_transport.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/p2p/dtls/dtls_transport.cc
@@ -292,6 +292,17 @@ DtlsTransportInternalImpl::~DtlsTransportInternalImpl() {
   if (dtls_in_stun_) {
     CompleteDtlsInStun(/*success=*/false);
   }
+  if (ice_transport_) {
+    ice_transport()->ResetDtlsStunPiggybackCallbacks();
+    ice_transport()->DeregisterReceivedPacketCallback(this);
+#if WEBRTC_WEBKIT_BUILD
+    ice_transport()->UnsubscribeReceivingState(this);
+    ice_transport()->UnsubscribeWritableState(this);
+    ice_transport()->UnsubscribeReadyToSend(this);
+    ice_transport()->UnsubscribeNetworkRouteChanged(this);
+    ice_transport()->UnsubscribeSentPacket(this);
+#endif
+  }
 }
 
 void DtlsTransportInternalImpl::CompleteDtlsInStun(bool success) {

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.cpp
@@ -150,25 +150,18 @@ void LibWebRTCRtpTransformableFrame::setOptions(const RTCEncodedVideoFrameMetada
 
     if (newMetadata.frameId)
         rtcMetadata.SetFrameId(*newMetadata.frameId);
-    if (newMetadata.dependencies)
-        rtcMetadata.SetFrameDependencies(newMetadata.dependencies->span());
+    // FIXME: newMetadata.dependencies
     if (newMetadata.width)
         rtcMetadata.SetWidth(*newMetadata.width);
     if (newMetadata.height)
         rtcMetadata.SetHeight(*newMetadata.height);
-    if (newMetadata.spatialIndex)
-        rtcMetadata.SetSpatialIndex(*newMetadata.spatialIndex);
+    // FIXME: newMetadata.spatialIndex
     if (newMetadata.temporalIndex)
         rtcMetadata.SetTemporalIndex(*newMetadata.temporalIndex);
     if (newMetadata.synchronizationSource)
         rtcMetadata.SetSsrc(*newMetadata.synchronizationSource);
     // FIXME: newMetadata.payloadType
-    if (newMetadata.contributingSources) {
-        std::vector<uint32_t> csrcs(newMetadata.contributingSources->size());
-        for (auto& csrc : *newMetadata.contributingSources)
-            csrcs.push_back(csrc);
-        rtcMetadata.SetCsrcs(WTF::move(csrcs));
-    }
+    // FIXME: newMetadata.contributingSources
     if (newMetadata.rtpTimestamp)
         m_rtcFrame->SetRTPTimestamp(*newMetadata.rtpTimestamp);
     // FIXME: newMetadata.mimeType


### PR DESCRIPTION
#### 130cbb0bb5dcfd8bdd80fb0b7b865829cae97b7d
<pre>
Cherry-pick 305413.999@safari-7624.5-branch (747321afe7db). <a href="https://bugs.webkit.org/show_bug.cgi?id=317270">https://bugs.webkit.org/show_bug.cgi?id=317270</a>

    missing bounds check in RtpPacket::SetCsrcs for RTCEncodedVideoFrameMetadata.contributingSources
    <a href="https://rdar.apple.com/177147013">rdar://177147013</a>

    Reviewed by Eric Carlson.

    There is no use of updating csrcs, especially since this functionality is off by default.
    We remove updating csrcs from RTCEncodedVideoFrame constructor for now.
    We also remove dependencies and spatial index as they are not used either.

    * Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransformableFrame.cpp:
    (WebCore::LibWebRTCRtpTransformableFrame::setOptions):

    Identifier: 305413.999@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.213@webkitglib/2.54">https://commits.webkit.org/317695.213@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### dd9f9e1ef0cca9626cf5f18286abf56908ad99b3
<pre>
Cherry-pick 305413.996@safari-7624.5-branch (17b41f27a761). <a href="https://bugs.webkit.org/show_bug.cgi?id=317270">https://bugs.webkit.org/show_bug.cgi?id=317270</a>

    missing UnsubscribeReadyToSend/NetworkRouteChanged in LibWebRTC ~DtlsTransportInternalImpl causes use-after-free
    <a href="https://rdar.apple.com/177131722">rdar://177131722</a>

    Reviewed by Eric Carlson.

    We unregister all callbacks that were registered when connecting to the ICE transport.
    Test validated with a specific STUN server.

    * Source/ThirdParty/libwebrtc/Source/webrtc/p2p/dtls/dtls_transport.cc:

    Identifier: 305413.996@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.212@webkitglib/2.54">https://commits.webkit.org/317695.212@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50ca4a81a3de049c9dd130fe4f2857ddcaeafad1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185389 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59301 "Build is in progress. Recent messages:") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53118 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195713 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150173 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187251 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60666 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59028 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144879 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150173 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188344 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60666 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53118 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125171 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60666 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59028 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53118 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60666 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53118 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6766 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/51957 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59028 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197662 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/58965 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53118 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154391 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59674 "Build is in progress. Recent messages:") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53118 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154042 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28147 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/59674 "Build is in progress. Recent messages:") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132001 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/128856 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58152 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53118 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57524 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57767 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57591 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->