### PR TITLE
[JSC][Wasm] Hold the restore-frame copy end in the existing scratch

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -4487,6 +4487,7 @@ void BBQJIT::emitTailCall(FunctionSpaceIndex functionIndexSpace, const RTT& sign
     // Save the old Frame Pointer for later and make sure the return address gets saved to its canonical location.
     emitRestoreCalleeSaves();
     auto preserved = callingConvention.argumentGPRs();
+    preserved.add(wasmScratchGPR, IgnoreVectors);
     if constexpr (isARM64E())
         preserved.add(callingConvention.prologueScratchGPRs[0], IgnoreVectors);
     ScratchScope<1, 0> scratches(*this, WTF::move(preserved));
@@ -4509,7 +4510,7 @@ void BBQJIT::emitTailCall(FunctionSpaceIndex functionIndexSpace, const RTT& sign
         m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, targetInstOffset), wasmScratchGPR);
 
         // We can trash wasmBaseMemoryPointer and wasmBoundsCheckingSizeRegister since we won't use them during argument setup and we'll restore them for our callee anyway.
-        emitRestoreInstanceFrameIfNeeded(m_jit, GPRInfo::wasmContextInstancePointer, callerStackSize, m_frameSize, topSourceOffsetFromFP, wasmScratchGPR, wasmBaseMemoryPointer);
+        emitRestoreInstanceFrameIfNeeded(m_jit, GPRInfo::wasmContextInstancePointer, callerStackSize, m_frameSize, topSourceOffsetFromFP, wasmScratchGPR, wasmBaseMemoryPointer, wasmBoundsCheckingSizeRegister, callerFramePointer);
     }
 
 #if CPU(X86_64)
@@ -4747,20 +4748,42 @@ void BBQJIT::emitIndirectTailCall(const char* opcode, const Value& callee, GPRRe
 
     emitRestoreCalleeSaves();
 
+#if CPU(ARM64)
+    auto restoreFramePreserved = callingConvention.argumentGPRs();
+    restoreFramePreserved.add(importableFunction, IgnoreVectors);
+    restoreFramePreserved.add(wasmScratchGPR, IgnoreVectors);
+    if constexpr (isARM64E())
+        restoreFramePreserved.add(callingConvention.prologueScratchGPRs[0], IgnoreVectors);
+    ScratchScope<1, 0> restoreFrameScratches(*this, WTF::move(restoreFramePreserved));
+    GPRReg callerFramePointer = restoreFrameScratches.gpr(0);
+    restoreFrameScratches.unbindPreserved();
+#endif
+
     {
-        int32_t topSource = -static_cast<int32_t>(m_frameSize);
-        for (unsigned i = 0; i < arguments.size(); i++) {
-            if (!arguments[i].value().isConst()) {
-                Location loc = locationOf(arguments[i]);
-                if (loc.isStack())
-                    topSource = std::max(topSource, loc.asStackOffset() + static_cast<int32_t>(sizeof(Register)));
+        auto computeTopSourceOffsetFromFP = [&] {
+            int32_t topSource = -static_cast<int32_t>(m_frameSize);
+            for (unsigned i = 0; i < arguments.size(); i++) {
+                if (!arguments[i].value().isConst()) {
+                    Location loc = locationOf(arguments[i]);
+                    if (loc.isStack())
+                        topSource = std::max(topSource, loc.asStackOffset() + static_cast<int32_t>(sizeof(Register)));
+                }
             }
-        }
-        Checked<int32_t> topSourceOffsetFromFP = static_cast<int32_t>(roundUpToMultipleOf<stackAlignmentBytes()>(topSource));
+            return static_cast<int32_t>(roundUpToMultipleOf<stackAlignmentBytes()>(topSource));
+        };
 
         m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfTargetInstance()), wasmScratchGPR);
         Jump isSameInstance = m_jit.branchPtr(RelationalCondition::Equal, wasmScratchGPR, GPRInfo::wasmContextInstancePointer);
-        emitRestoreInstanceFrameIfNeeded(m_jit, GPRInfo::wasmContextInstancePointer, callerStackSize, m_frameSize, topSourceOffsetFromFP, wasmScratchGPR, wasmBaseMemoryPointer);
+#if CPU(ARM64)
+        emitRestoreInstanceFrameIfNeeded(m_jit, GPRInfo::wasmContextInstancePointer, callerStackSize, m_frameSize, computeTopSourceOffsetFromFP(), wasmScratchGPR, wasmBaseMemoryPointer, wasmBoundsCheckingSizeRegister, callerFramePointer);
+#else
+        {
+            RegisterSet pairPreserved;
+            pairPreserved.add(importableFunction, IgnoreVectors);
+            ScratchScope<1, 0> pairDest(*this, WTF::move(pairPreserved));
+            emitRestoreInstanceFrameIfNeeded(m_jit, GPRInfo::wasmContextInstancePointer, callerStackSize, m_frameSize, computeTopSourceOffsetFromFP(), wasmScratchGPR, wasmBaseMemoryPointer, wasmBoundsCheckingSizeRegister, pairDest.gpr(0));
+        }
+#endif
         m_jit.loadPtr(CCallHelpers::Address(importableFunction, WasmToWasmImportableFunction::offsetOfTargetInstance()), GPRInfo::wasmContextInstancePointer);
         loadWebAssemblyGlobalState(wasmBaseMemoryPointer, wasmBoundsCheckingSizeRegister);
         isSameInstance.link(m_jit);
@@ -4788,13 +4811,6 @@ void BBQJIT::emitIndirectTailCall(const char* opcode, const Value& callee, GPRRe
     resolvedArguments.append(Value::pinned(pointerType(), Location::fromStack(sizeof(Register))));
     parameterLocations.append(Location::fromStack(tailCallStackOffsetFromFP + Checked<int>(sizeof(Register))));
 #elif CPU(ARM64)
-    auto preserved = callingConvention.argumentGPRs();
-    preserved.add(importableFunction, IgnoreVectors);
-    if constexpr (isARM64E())
-        preserved.add(callingConvention.prologueScratchGPRs[0], IgnoreVectors);
-    ScratchScope<1, 0> scratches(*this, WTF::move(preserved));
-    GPRReg callerFramePointer = scratches.gpr(0);
-    scratches.unbindPreserved();
     m_jit.loadPairPtr(MacroAssembler::framePointerRegister, callerFramePointer, MacroAssembler::linkRegister);
 #else
     UNREACHABLE_FOR_PLATFORM();

--- a/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
+++ b/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
@@ -234,7 +234,7 @@ static inline void prepareForTailCall(CCallHelpers& jit, const B3::StackmapGener
 // FIXME: In OMG and BBQ, emit restore frame creation on an out-of-line slow path
 // so the common case (same instance || restore frame exists) doesn't have to jump over
 // this code.
-inline void emitRestoreInstanceFrameIfNeeded(CCallHelpers& jit, GPRReg currentInstanceReg, Checked<int32_t> callerStackSize, Checked<int32_t> frameSize, Checked<int32_t> topSourceOffsetFromFP, GPRReg scratch1, GPRReg scratch2)
+inline void emitRestoreInstanceFrameIfNeeded(CCallHelpers& jit, GPRReg currentInstanceReg, Checked<int32_t> callerStackSize, Checked<int32_t> frameSize, Checked<int32_t> topSourceOffsetFromFP, GPRReg scratch1, GPRReg scratch2, GPRReg pairDest0, GPRReg pairDest1)
 {
 #if CPU(ARM64E)
     auto* restoreFrameReturnAddress = untagCodePtr<NativeToJITGatePtrTag>(g_jscConfig.llint.gateMap[static_cast<unsigned>(Gate::wasmRestoreFrame)]);
@@ -242,7 +242,11 @@ inline void emitRestoreInstanceFrameIfNeeded(CCallHelpers& jit, GPRReg currentIn
     auto* restoreFrameReturnAddress = untagCodePtr<CFunctionPtrTag>(wasm_restore_frame_return);
 #endif
     ASSERT(restoreFrameReturnAddress);
-    ASSERT(noOverlap(currentInstanceReg, scratch1, scratch2));
+#if CPU(ARM64)
+    ASSERT(noOverlap(currentInstanceReg, scratch1, scratch2, pairDest0, pairDest1, CCallHelpers::dataTempRegister, CCallHelpers::memoryTempRegister));
+#else
+    ASSERT(noOverlap(currentInstanceReg, scratch1, scratch2, pairDest0, pairDest1));
+#endif
     ASSERT(topSourceOffsetFromFP <= callerStackSize);
     ASSERT(isMultipleOf(stackAlignmentBytes(), topSourceOffsetFromFP));
     static constexpr unsigned restoreFrameSize = RestoreFrameCallee::restoreFrameSizeInBytes;
@@ -273,23 +277,23 @@ inline void emitRestoreInstanceFrameIfNeeded(CCallHelpers& jit, GPRReg currentIn
         });
 
         JIT_COMMENT(jit, "Copy loop start");
+        jit.addPtr(CCallHelpers::TrustedImm32(topSourceOffsetFromFP), GPRInfo::callFrameRegister, scratch2);
         auto loop = jit.label();
         {
-            auto scratch3 = jit.scratchRegister();
             DisallowMacroScratchRegisterUsage disallowScratch(jit);
 #if CPU(ARM64)
-            jit.loadPair64(CCallHelpers::PostIndexAddress(scratch1, 16), scratch2, scratch3);
-            jit.storePair64(scratch2, scratch3, CCallHelpers::Address(scratch1, -static_cast<int32_t>(restoreFrameSize) - 16));
+            constexpr int32_t pairStoreOffset = -static_cast<int32_t>(restoreFrameSize) - 16;
+            ASSERT(ARM64Assembler::isValidSTPImm<64>(pairStoreOffset));
+            jit.loadPair64(CCallHelpers::PostIndexAddress(scratch1, 16), pairDest0, pairDest1);
+            jit.storePair64(pairDest0, pairDest1, CCallHelpers::Address(scratch1, pairStoreOffset));
 #else
-            jit.loadPair64(scratch1, scratch2, scratch3);
-            jit.storePair64(scratch2, scratch3, CCallHelpers::Address(scratch1, -restoreFrameSize));
+            jit.loadPair64(scratch1, pairDest0, pairDest1);
+            jit.storePair64(pairDest0, pairDest1, CCallHelpers::Address(scratch1, -restoreFrameSize));
 #endif
         }
 #if !CPU(ARM64)
         jit.addPtr(CCallHelpers::TrustedImm32(16), scratch1);
 #endif
-        // FIXME: It'd be nice to use the address scratch on ARM64 to hold the end point.
-        jit.addPtr(CCallHelpers::TrustedImm32(topSourceOffsetFromFP), GPRInfo::callFrameRegister, scratch2);
         jit.branchPtr(CCallHelpers::Below, scratch1, scratch2).linkTo(loop, &jit);
     }
 

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -2074,17 +2074,21 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
         patchpoint->append(calleeInstance, ValueRep::SomeRegister);
         // Cross-instance setup below reloads pinned registers before the tail-call shuffle consumes late inputs.
         patchpoint->clobberLate(RegisterSet::wasmPinnedRegisters());
-        // emitRestoreInstanceFrameIfNeeded needs two scratches. wasmBaseMemoryPointer is
-        // always pinned so B3 won't allocate it. wasmBoundsCheckingSizeRegister
-        // is only pinned in BoundsChecking mode, so in Signaling mode we need B3 to give us a
-        // scratch that avoids the inputs.
-        if (m_mode == MemoryMode::Signaling)
-            patchpoint->numGPScratchRegisters = 1;
+        // wasmBaseMemoryPointer is always pinned. wasmBoundsCheckingSizeRegister is only
+        // pinned in BoundsChecking, so Signaling needs B3 scratches for the end and both pair dests.
+        patchpoint->numGPScratchRegisters = m_mode == MemoryMode::Signaling ? 3 : 2;
         patchArgsIndex += m_proc.resultCount(patchpoint->type());
         Checked<int32_t> callerStackSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(wasmCallerInfoAsCallee.headerAndArgumentStackSizeInBytes);
         patchpoint->setGenerator([prepareForCall = prepareForCall, patchArgsIndex, callerStackSize = static_cast<int32_t>(callerStackSize), mode = m_mode](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
             GPRReg calleeInstanceGPR = params[patchArgsIndex + 1].gpr();
-            GPRReg scratch2 = mode == MemoryMode::Signaling ? params.gpScratch(0) : GPRInfo::wasmBoundsCheckingSizeRegister;
+            unsigned destScratch = 0;
+            GPRReg end = GPRInfo::wasmBoundsCheckingSizeRegister;
+            if (mode == MemoryMode::Signaling) {
+                end = params.gpScratch(0);
+                destScratch = 1;
+            }
+            GPRReg pairDest0 = params.gpScratch(destScratch);
+            GPRReg pairDest1 = params.gpScratch(destScratch + 1);
             auto sameInstance = jit.branchPtr(CCallHelpers::Equal, calleeInstanceGPR, GPRInfo::wasmContextInstancePointer);
             {
                 AllowMacroScratchRegisterUsage allowScratch(jit);
@@ -2096,7 +2100,7 @@ auto OMGIRGenerator::emitIndirectCall(Value* calleeInstance, Value* calleeCode, 
                 for (const auto& entry : params.code().calleeSaveRegisterAtOffsetList())
                     topSource = std::max<int32_t>(topSource, entry.offset() + entry.byteSize());
                 Checked<int32_t> topSourceOffsetFromFP = static_cast<int32_t>(roundUpToMultipleOf<stackAlignmentBytes()>(topSource));
-                emitRestoreInstanceFrameIfNeeded(jit, GPRInfo::wasmContextInstancePointer, callerStackSize, params.code().frameSize(), topSourceOffsetFromFP, GPRInfo::wasmBaseMemoryPointer, scratch2);
+                emitRestoreInstanceFrameIfNeeded(jit, GPRInfo::wasmContextInstancePointer, callerStackSize, params.code().frameSize(), topSourceOffsetFromFP, GPRInfo::wasmBaseMemoryPointer, end, pairDest0, pairDest1);
                 jit.move(calleeInstanceGPR, GPRInfo::wasmContextInstancePointer);
                 jit.loadPairPtr(GPRInfo::wasmContextInstancePointer, CCallHelpers::TrustedImm32(JSWebAssemblyInstance::offsetOfCachedMemoryBaseSizePair(0)), GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister);
                 jit.cageConditionally(Gigacage::Primitive, GPRInfo::wasmBaseMemoryPointer, GPRInfo::wasmBoundsCheckingSizeRegister, calleeInstanceGPR);
@@ -6519,12 +6523,10 @@ auto OMGIRGenerator::emitDirectCall(unsigned callProfileIndex, FunctionSpaceInde
             // We pessimistically assume we could be calling to something that is bounds checking.
             // FIXME: We shouldn't have to do this: https://bugs.webkit.org/show_bug.cgi?id=172181
             patchpoint->clobberLate(RegisterSet::wasmPinnedRegisters());
-            // emitRestoreInstanceFrameIfNeeded needs two scratches. wasmBaseMemoryPointer is
-            // always pinned so B3 won't allocate it. wasmBoundsCheckingSizeRegister
-            // is only pinned in BoundsChecking mode, so in Signaling mode we need B3 to give us a
-            // scratch that avoids the inputs.
-            if (isTailCallRootCaller && m_mode == MemoryMode::Signaling)
-                patchpoint->numGPScratchRegisters = 1;
+            // wasmBaseMemoryPointer is always pinned. wasmBoundsCheckingSizeRegister is only
+            // pinned in BoundsChecking, so Signaling needs B3 scratches for the end and both pair dests.
+            if (isTailCallRootCaller)
+                patchpoint->numGPScratchRegisters = m_mode == MemoryMode::Signaling ? 3 : 2;
             patchArgsIndex += m_proc.resultCount(patchpoint->type());
             patchpoint->setGenerator([this, patchArgsIndex, handle, isTailCallRootCaller, tailCallStackOffsetFromFP, prepareForCall, signature = Ref<const RTT>(signature), wasmCalleeInfo, callerStackSize = static_cast<int32_t>(WTF::roundUpToMultipleOf<stackAlignmentBytes()>(wasmCallerInfoAsCallee.headerAndArgumentStackSizeInBytes)), mode = m_mode](CCallHelpers& jit, const B3::StackmapGenerationParams& params) {
                 AllowMacroScratchRegisterUsage allowScratch(jit);
@@ -6537,8 +6539,15 @@ auto OMGIRGenerator::emitDirectCall(unsigned callProfileIndex, FunctionSpaceInde
                     for (const auto& entry : params.code().calleeSaveRegisterAtOffsetList())
                         topSource = std::max<int32_t>(topSource, entry.offset() + entry.byteSize());
                     Checked<int32_t> topSourceOffsetFromFP = static_cast<int32_t>(roundUpToMultipleOf<stackAlignmentBytes()>(topSource));
-                    GPRReg scratch2 = mode == MemoryMode::Signaling ? params.gpScratch(0) : GPRInfo::wasmBoundsCheckingSizeRegister;
-                    emitRestoreInstanceFrameIfNeeded(jit, GPRInfo::wasmContextInstancePointer, callerStackSize, params.code().frameSize(), topSourceOffsetFromFP, GPRInfo::wasmBaseMemoryPointer, scratch2);
+                    unsigned destScratch = 0;
+                    GPRReg end = GPRInfo::wasmBoundsCheckingSizeRegister;
+                    if (mode == MemoryMode::Signaling) {
+                        end = params.gpScratch(0);
+                        destScratch = 1;
+                    }
+                    GPRReg pairDest0 = params.gpScratch(destScratch);
+                    GPRReg pairDest1 = params.gpScratch(destScratch + 1);
+                    emitRestoreInstanceFrameIfNeeded(jit, GPRInfo::wasmContextInstancePointer, callerStackSize, params.code().frameSize(), topSourceOffsetFromFP, GPRInfo::wasmBaseMemoryPointer, end, pairDest0, pairDest1);
                     // Import stub sets up the pinned registers for us so we don't have to do anything here.
                 }
                 if (prepareForCall)


### PR DESCRIPTION
#### bad56771438ebc6d3a4335b7b273b2264a8d61cb
<pre>
[JSC][Wasm] Hold the restore-frame copy end in the existing scratch
<a href="https://bugs.webkit.org/show_bug.cgi?id=323613">https://bugs.webkit.org/show_bug.cgi?id=323613</a>

Reviewed by NOBODY (OOPS!).

The wasm-to-wasm restore-frame copy loop recomputes
cfr + topSourceOffsetFromFP every 16-byte iteration because scratch2
is a load dest. Compute that end once into scratch2 and use two
caller scratches as the pair dests.

* Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h:
(emitRestoreInstanceFrameIfNeeded):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(BBQJIT::emitTailCall):
(BBQJIT::emitIndirectTailCall):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bad56771438ebc6d3a4335b7b273b2264a8d61cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196027 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150419 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145130 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100623 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125425 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47542 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45582 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7320 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14209 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45277 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7090 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46967 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49991 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197993 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59287 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154668 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59995 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154320 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48785 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132365 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129286 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58462 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20300 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57840 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58076 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57903 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->