### PR TITLE
IOSurfacePool does not try to take surfaces that were previously in use

### DIFF
--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp
@@ -124,33 +124,28 @@ void IOSurfacePool::didUseSurfaceOfSize(IntSize size)
 std::unique_ptr<IOSurface> IOSurfacePool::takeSurface(IntSize size, const ColorSpace& colorSpace, IOSurface::Format format, UseLosslessCompression useLosslessCompression)
 {
     Locker locker { m_lock };
-    CachedSurfaceMap::iterator mapIter = m_cachedSurfaces.find(size);
+    if (auto mapIter = m_cachedSurfaces.find(size); mapIter != m_cachedSurfaces.end()) {
+        for (auto surfaceIter = mapIter->value.begin(); surfaceIter != mapIter->value.end(); ++surfaceIter) {
+            if (!surfaceMatchesParameters(*surfaceIter->get(), size, colorSpace, format, useLosslessCompression))
+                continue;
 
-    if (mapIter == m_cachedSurfaces.end()) {
-        DUMP_POOL_STATISTICS(stream << "IOSurfacePool::takeSurface [" << m_poolIdentifier << "] - failed to find surface matching size " << size << " color space " << colorSpace << " format " << format << "\n" << poolStatistics());
-        return nullptr;
-    }
+            auto surface = WTF::move(*surfaceIter);
+            mapIter->value.remove(surfaceIter);
 
-    for (auto surfaceIter = mapIter->value.begin(); surfaceIter != mapIter->value.end(); ++surfaceIter) {
-        if (!surfaceMatchesParameters(*surfaceIter->get(), size, colorSpace, format, useLosslessCompression))
-            continue;
+            didUseSurfaceOfSize(size);
 
-        auto surface = WTF::move(*surfaceIter);
-        mapIter->value.remove(surfaceIter);
+            if (mapIter->value.isEmpty()) {
+                m_cachedSurfaces.remove(mapIter);
+                m_sizesInPruneOrder.removeLast();
+            }
 
-        didUseSurfaceOfSize(size);
+            didRemoveSurface(*surface, false);
 
-        if (mapIter->value.isEmpty()) {
-            m_cachedSurfaces.remove(mapIter);
-            m_sizesInPruneOrder.removeLast();
+            surface->setVolatile(false);
+
+            DUMP_POOL_STATISTICS(stream << "IOSurfacePool::takeSurface [" << m_poolIdentifier << "] - taking surface " << surface.get() << " with size " << size << " color space " << colorSpace << " format " << format << "\n" << poolStatistics());
+            return surface;
         }
-
-        didRemoveSurface(*surface, false);
-
-        surface->setVolatile(false);
-
-        DUMP_POOL_STATISTICS(stream << "IOSurfacePool::takeSurface [" << m_poolIdentifier << "] - taking surface " << surface.get() << " with size " << size << " color space " << colorSpace << " format " << format << "\n" << poolStatistics());
-        return surface;
     }
 
     // Some of the in-use surfaces may no longer actually be in-use, but we haven't moved them over yet.

--- a/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
+++ b/Source/WebCore/platform/graphics/cg/IOSurfacePool.h
@@ -57,7 +57,7 @@ public:
 
     WEBCORE_EXPORT ~IOSurfacePool();
 
-    std::unique_ptr<IOSurface> takeSurface(IntSize, const ColorSpace&, IOSurface::Format, UseLosslessCompression);
+    WEBCORE_EXPORT std::unique_ptr<IOSurface> takeSurface(IntSize, const ColorSpace&, IOSurface::Format, UseLosslessCompression);
     WEBCORE_EXPORT void addSurface(std::unique_ptr<IOSurface>&&);
 
     WEBCORE_EXPORT void discardAllSurfaces();

--- a/Tools/TestWebKitAPI/PlatformCocoa.cmake
+++ b/Tools/TestWebKitAPI/PlatformCocoa.cmake
@@ -180,6 +180,7 @@ list(APPEND TestWebCore_SOURCES
     Tests/WebCore/cocoa/CoreMediaUtilities.mm
     Tests/WebCore/cocoa/GraphicsContextCGTests.mm
     Tests/WebCore/cocoa/H264UtilitiesCocoaTests.mm
+    Tests/WebCore/cocoa/IOSurfacePoolTests.cpp
     Tests/WebCore/cocoa/IOSurfaceTests.mm
     Tests/WebCore/cocoa/ImageRotationSessionVT.cpp
     Tests/WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -740,6 +740,7 @@
 				WebCore/cocoa/GraphicsContextCGTests.mm,
 				WebCore/cocoa/H264UtilitiesCocoaTests.mm,
 				WebCore/cocoa/ImageRotationSessionVT.cpp,
+				WebCore/cocoa/IOSurfacePoolTests.cpp,
 				WebCore/cocoa/IOSurfaceTests.mm,
 				WebCore/cocoa/ISOBMFFTrackInfoParserTests.cpp,
 				WebCore/cocoa/MediaPlayerPrivateAVFoundationObjCTests.mm,

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfacePoolTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfacePoolTests.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if HAVE(IOSURFACE)
+
+#include "Test.h"
+#include <WebCore/ColorSpace.h>
+#include <WebCore/IOSurface.h>
+#include <WebCore/IOSurfacePool.h>
+#include <wtf/MachSendRight.h>
+
+namespace TestWebKitAPI {
+using namespace WebCore;
+
+TEST(IOSurfacePoolTest, TakeSurfaceFindsSurfaceThatIsNoLongerInUse)
+{
+    auto pool = IOSurfacePool::create();
+    IntSize size { 5, 5 };
+    auto colorSpace = ColorSpace::SRGB();
+
+    auto surface = IOSurface::create(nullptr, size, colorSpace);
+    ASSERT_NE(surface, nullptr);
+    IOSurfaceRef expected = surface->surface();
+
+    auto sendRight = surface->createSendRight();
+    EXPECT_TRUE(surface->isInUse());
+
+    pool->addSurface(WTF::move(surface));
+    EXPECT_EQ(pool->takeSurface(size, colorSpace, IOSurface::Format::BGRA, UseLosslessCompression::No), nullptr);
+    sendRight = { };
+    auto taken = pool->takeSurface(size, colorSpace, IOSurface::Format::BGRA, UseLosslessCompression::No);
+    ASSERT_NE(taken, nullptr);
+    EXPECT_EQ(taken->surface(), expected);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // HAVE(IOSURFACE)


### PR DESCRIPTION
#### ae38411fb04ec7370d4c9eae4fa77699f7858339
<pre>
IOSurfacePool does not try to take surfaces that were previously in use
<a href="https://bugs.webkit.org/show_bug.cgi?id=323620">https://bugs.webkit.org/show_bug.cgi?id=323620</a>
<a href="https://rdar.apple.com/186857165">rdar://186857165</a>

Reviewed by Matt Woodrow.

Frequent 2D context self drawing allocates intermediate buffers. These
do not clear CGIOSurfaceQueue immediately. During such loops, the
IOSurface IsInUse will flip for the earlier intermediate buffers
faster than IOSurfacePool in use surface collect callback runs.

If pool lookup fails, go through the in use list. The pool has quite
modest amount of entries anyway, in use or not, since the memory use
is 256mb.

Test: Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfacePoolTests.cpp

* Source/WebCore/platform/graphics/cg/IOSurfacePool.cpp:
(WebCore::IOSurfacePool::takeSurface):
* Source/WebCore/platform/graphics/cg/IOSurfacePool.h:
* Tools/TestWebKitAPI/PlatformCocoa.cmake:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfacePoolTests.cpp: Added.
(TestWebKitAPI::TEST(IOSurfacePoolTest, TakeSurfaceFindsSurfaceThatIsNoLongerInUse)):

Canonical link: <a href="https://commits.webkit.org/320628@main">https://commits.webkit.org/320628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4e5410f445a41d14c2ab3f69ba4b9b93f63027d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195726 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ec1e425-f99f-4557-bb02-b673af65acf1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187264 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144890 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/70f05f10-5635-465f-b64c-7e2fa4d5cec1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48569 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125182 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1c6d273c-bcf9-48c1-b4c7-a011278d4f30) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47297 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45353 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157664 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45048 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6778 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197675 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58978 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154402 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41344 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59687 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41653 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154053 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48539 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132018 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128870 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58165 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20070 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57537 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57780 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57604 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->