### PR TITLE
[scroll-animations] WPT test `scroll-animations/css/animation-timeline-none.html` has a failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt
@@ -2,10 +2,10 @@
 PASS scroll-timeline-name is referenceable in animation-timeline on the declaring element itself
 PASS scroll-timeline-name is referenceable in animation-timeline on that element's descendants
 PASS scroll-timeline-name on an element which is not a scroll-container
-FAIL Change in scroll-timeline-name to match animation timeline updates animation. assert_equals: expected "none" but got "50px"
-FAIL Change in scroll-timeline-name to no longer match animation timeline updates animation. assert_equals: expected "none" but got "75px"
+PASS Change in scroll-timeline-name to match animation timeline updates animation.
+PASS Change in scroll-timeline-name to no longer match animation timeline updates animation.
 PASS Timeline lookup updates candidate when closer match available.
-FAIL Timeline lookup updates candidate when match becomes available. assert_equals: expected "none" but got "50px"
+PASS Timeline lookup updates candidate when match becomes available.
 PASS scroll-timeline-axis is block
 PASS scroll-timeline-axis is inline
 PASS scroll-timeline-axis is x

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Animation with animation-timeline:none holds current time at zero
-FAIL Animation with unknown timeline name produces no effect assert_equals: expected "0px" but got "100px"
+PASS Animation with unknown timeline name produces no effect
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt
@@ -5,8 +5,8 @@ PASS Switching pending animation from document to scroll timelines [immediate]
 PASS Switching pending animation from document to scroll timelines [scroll]
 PASS Changing computed value of animation-timeline changes effective timeline [immediate]
 PASS Changing computed value of animation-timeline changes effective timeline [scroll]
-FAIL Changing to/from unresolved timeline [immediate] assert_equals: expected "0px" but got "120px"
-FAIL Changing to/from unresolved timeline [scroll] assert_equals: expected "0px" but got "120px"
+FAIL Changing to/from unresolved timeline [immediate] assert_equals: expected "100px" but got "0px"
+FAIL Changing to/from unresolved timeline [scroll] assert_equals: expected "100px" but got "0px"
 PASS Reverse animation direction [immediate]
 PASS Reverse animation direction [scroll]
 PASS Change to timeline attachment while paused [immediate]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-in-container-query-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-in-container-query-expected.txt
@@ -1,3 +1,3 @@
 
-PASS Timeline appearing via container queries
+FAIL Timeline appearing via container queries assert_equals: expected "rgb(100, 100, 100)" but got "rgb(0, 0, 0)"
 

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -415,15 +415,7 @@ void StyleOriginatedTimelinesController::attachAnimation(CSSAnimation& animation
 
     if (!hasNamedTimeline) {
         ASSERT(allowsDeferral == AllowsDeferral::No);
-        // We don't have an active named timeline and yet we must set a timeline since
-        // we've already dealt with the deferral case before. There are two cases:
-        //     1. the name is within scope and we should create a placeholder inactive
-        //        scroll timeline, or,
-        //     2. the name is not within scope and the timeline is null.
-        if (relevantTimelineScopeElement)
-            protectedAnimation->setTimeline(&inactiveNamedTimeline(timelineName->name));
-        else
-            protectedAnimation->setTimeline(nullptr);
+        protectedAnimation->setTimeline(&inactiveNamedTimeline(timelineName->name));
     } else {
         auto& timelines = it->value;
         RefPtr timeline = determineTimelineForElement(timelines, *target, timelineName->scopeOrdinal, relevantTimelineScopeElement.get());
@@ -470,15 +462,27 @@ void StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope(
     // subtree—​for example, by siblings, cousins, or ancestors.
     switch (scope.type) {
     case Style::NameScope::Type::None: {
+        HashSet<Ref<ScrollTimeline>> namedTimelinesToUpdate;
         for (auto& entry : m_nameToTimelineMap) {
             for (auto& timeline : entry.value) {
                 if (timeline->timelineScopeDeclaredElement() == &styleable.element)
                     timeline->clearTimelineScopeDeclaredElement();
+                // Make sure to track this timeline to be updated in a separate
+                // step since updating timeline relationships could affect m_nameToTimelineMap.
+                namedTimelinesToUpdate.add(timeline.get());
             }
         }
         m_timelineScopeEntries.removeAllMatching([&](const std::pair<Style::NameScope, WeakStyleable> entry) {
             return entry.second == styleable;
         });
+        for (auto& timeline : namedTimelinesToUpdate) {
+            for (Ref animation : copyToVector(timeline->relevantAnimations())) {
+                if (RefPtr cssAnimation = dynamicDowncast<CSSAnimation>(animation)) {
+                    if (cssAnimation->owningElement())
+                        cssAnimation->syncStyleOriginatedTimeline();
+                }
+            }
+        }
         break;
     }
     case Style::NameScope::Type::All:


### PR DESCRIPTION
#### 92b2fb9f20fd5f3d4f83f36c472915ccb11dc03f
<pre>
[scroll-animations] WPT test `scroll-animations/css/animation-timeline-none.html` has a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=323616">https://bugs.webkit.org/show_bug.cgi?id=323616</a>
<a href="https://rdar.apple.com/186856274">rdar://186856274</a>

Reviewed by Simon Fraser.

More fallout from the spec change to make style-originated timelines match globally [0].

We must make sure in `StyleOriginatedTimelinesController::attachAnimation()` to always
yield an inactive style-originated timelines if we can&apos;t find the provided name set by
the `animation-timeline` property regardless of whether we have an element with a
`timeline-scope` property matching this name in the animation target&apos;s hierarchy.

This change caused a regression in the &apos;A timline scope in the ancestor chain&apos; (sic)
test in `scroll-animations/css/timeline-scope.html` which prompted the change in
`StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope()`
to update the timeline relationship for any animation associated with a timeline
which has a name that was contained in a `timeline-scope` property newly set to `none`.

Note that the regression in `scroll-animations/css/scroll-timeline-in-container-query.html`
is only temporary, this test has yet to be updated for the spec change in question [1].

[0] <a href="https://github.com/w3c/csswg-drafts/pull/13624">https://github.com/w3c/csswg-drafts/pull/13624</a>
[1] <a href="https://github.com/web-platform-tests/wpt/pull/62200">https://github.com/web-platform-tests/wpt/pull/62200</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-named-scroll-progress-timeline.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-in-container-query-expected.txt:
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::attachAnimation):
(WebCore::StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope):

Canonical link: <a href="https://commits.webkit.org/320629@main">https://commits.webkit.org/320629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cca4edb89b673872014a25f3c42ae9093a2633ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195728 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/801c86a2-86af-485b-922b-4f8a01b3db86) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144891 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/92dddfaf-f79b-4518-a487-24d499ddd734) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188359 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165475 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125183 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ff6d84a9-77bd-481f-999a-3ad177f11dee) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47298 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45354 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157665 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45047 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6780 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197677 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58980 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154403 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59689 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41652 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154055 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28149 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48538 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132020 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128873 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58167 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20069 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57539 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57782 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57606 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->