### PR TITLE
[JSC] Fill Wasm GC arrays of references with gcSafeMemfill

### DIFF
--- a/JSTests/wasm/gc/bulk-array-element-types.js
+++ b/JSTests/wasm/gc/bulk-array-element-types.js
@@ -310,3 +310,22 @@ for (const [offset, size] of [[1, -1], [-1, 1], [-1, -1], [0, 9], [8, 1], [9, 0]
         assert.throws(() => m.copySrc(size), WebAssembly.RuntimeError, "access to a null reference");
     }
 }
+
+{
+    for (const length of [1, 9, 32]) {
+        const m = instantiate(`
+            (module
+               (type $arr (array (mut anyref)))
+               (type $box (struct (field i32)))
+               (global $a (ref $arr) (array.new_default $arr (i32.const ${length})))
+               (func (export "fill") (param i32)
+                 (array.fill $arr (global.get $a) (i32.const 0) (struct.new $box (local.get 0)) (i32.const ${length})))
+               (func (export "get") (param i32) (result i32)
+                 (struct.get $box 0 (ref.cast (ref $box) (array.get $arr (global.get $a) (local.get 0))))))
+        `).exports;
+
+        m.fill(9);
+        for (let i = 0; i < length; ++i)
+            assert.eq(m.get(i), 9);
+    }
+}

--- a/Source/JavaScriptCore/heap/GCMemoryOperations.h
+++ b/Source/JavaScriptCore/heap/GCMemoryOperations.h
@@ -272,7 +272,7 @@ ALWAYS_INLINE void gcSafeZeroMemory(T* dst, size_t bytes)
         "movi v0.16b, #0\t\n"
 
 #if !OS(WINDOWS)
-        // On Windows ARM64, LLVM has a bug (llvm/llvm-project#47432) that causes a
+        // On Windows ARM64, LLVM has a bug (https://github.com/llvm/llvm-project/issues/47432) that causes a
         // fatal error "Failed to evaluate function length in SEH unwind info" when
         // inline assembly contains alignment directives like .p2align.
         ".p2align 4\t\n"
@@ -303,6 +303,87 @@ ALWAYS_INLINE void gcSafeZeroMemory(T* dst, size_t bytes)
     size_t count = bytes / 8;
     for (size_t i = 0; i < count; ++i)
         std::bit_cast<volatile uint64_t*>(dst)[i] = 0;
+#endif
+}
+
+template<typename T>
+ALWAYS_INLINE void gcSafeMemfill(T* dst, T value, size_t bytes)
+{
+    static_assert(sizeof(T) == sizeof(JSValue));
+    RELEASE_ASSERT(!(bytes % sizeof(JSValue)));
+    uint64_t word = std::bit_cast<uint64_t>(value);
+#if CPU(X86_64)
+    size_t alignedBytes = (bytes / 64) * 64;
+    size_t offset = 0;
+    __asm__ volatile(
+        "movq %q[word], %%xmm0\t\n"
+        "movlhps %%xmm0, %%xmm0\t\n"
+
+        ".balign 32\t\n"
+        "1:\t\n"
+        "cmpq %q[offset], %q[alignedBytes]\t\n"
+        "je 2f\t\n"
+        "movups %%xmm0, (%q[dst], %q[offset], 1)\t\n"
+        "movups %%xmm0, 16(%q[dst], %q[offset], 1)\t\n"
+        "movups %%xmm0, 32(%q[dst], %q[offset], 1)\t\n"
+        "movups %%xmm0, 48(%q[dst], %q[offset], 1)\t\n"
+        "addq $64, %q[offset]\t\n"
+        "jmp 1b\t\n"
+
+        "2:\t\n"
+        "cmpq %q[offset], %q[bytes]\t\n"
+        "je 3f\t\n"
+        "movq %%xmm0, (%q[dst], %q[offset], 1)\t\n"
+        "addq $8, %q[offset]\t\n"
+        "jmp 2b\t\n"
+
+        "3:\t\n"
+
+        : [offset] "+r" (offset)
+        : [alignedBytes] "r" (alignedBytes), [bytes] "r" (bytes), [dst] "r" (dst), [word] "r" (word)
+        : "xmm0", "memory", "cc"
+    );
+#elif CPU(ARM64)
+            uint64_t alignedBytes = (static_cast<uint64_t>(bytes) / 64) * 64;
+            uint64_t dstPtr = static_cast<uint64_t>(std::bit_cast<uintptr_t>(dst));
+            uint64_t end = dstPtr + bytes;
+            uint64_t alignedEnd = dstPtr + alignedBytes;
+
+            __asm__ volatile(
+        "dup v0.2d, %x[word]\t\n"
+
+#if !OS(WINDOWS)
+        // On Windows ARM64, LLVM has a bug (https://github.com/llvm/llvm-project/issues/47432) that causes a
+        // fatal error "Failed to evaluate function length in SEH unwind info" when
+        // inline assembly contains alignment directives like .p2align.
+        ".p2align 4\t\n"
+#endif
+        "1:\t\n"
+        "cmp %x[dstPtr], %x[alignedEnd]\t\n"
+        "b.eq 2f\t\n"
+
+        "stnp q0, q0, [%x[dstPtr]]\t\n"
+        "stnp q0, q0, [%x[dstPtr], #0x20]\t\n"
+        "add %x[dstPtr], %x[dstPtr], #0x40\t\n"
+        "b 1b\t\n"
+
+        "2:\t\n"
+        "cmp %x[dstPtr], %x[end]\t\n"
+        "b.eq 3f\t\n"
+
+        "str d0, [%x[dstPtr]], #0x8\t\n"
+        "b 2b\t\n"
+
+        "3:\t\n"
+
+        : [dstPtr] "+r" (dstPtr)
+        : [end] "r" (end), [alignedEnd] "r" (alignedEnd), [word] "r" (word)
+        : "v0", "memory", "cc"
+            );
+#else
+            size_t count = bytes / 8;
+            for (size_t i = 0; i < count; ++i)
+                std::bit_cast<volatile uint64_t*>(dst)[i] = word;
 #endif
 }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp
@@ -31,6 +31,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "GCMemoryOperations.h"
 #include "JSCInlines.h"
 #include "JSWebAssemblyArrayInlines.h"
 #include "JSWebAssemblyInstance.h"
@@ -69,8 +70,7 @@ void JSWebAssemblyArray::fill(VM& vm, uint32_t offset, uint64_t value, uint32_t 
 {
     // Handle ref types separately to ensure write barriers are in effect.
     if (elementsAreRefTypes()) {
-        for (size_t i = 0; i < size; ++i)
-            setWithoutWriteBarrier(offset + i, value);
+        gcSafeMemfill(span<uint64_t>().subspan(offset, size).data(), value, static_cast<size_t>(size) * sizeof(uint64_t));
         vm.writeBarrier(this);
         return;
     }


### PR DESCRIPTION
#### 0d81375a0f4ef33aeda284e2e941fd6e47613c19
<pre>
[JSC] Fill Wasm GC arrays of references with gcSafeMemfill
<a href="https://bugs.webkit.org/show_bug.cgi?id=323628">https://bugs.webkit.org/show_bug.cgi?id=323628</a>

Reviewed by Yusuke Suzuki.

JSWebAssemblyArray::fill of ref elements stored encoded JSValues one
at a time. Concurrent GC needs whole 8-byte writes. Add gcSafeMemfill
next to gcSafeZeroMemory and use it for that path, then one write
barrier, matching array.copy.

* Source/JavaScriptCore/heap/GCMemoryOperations.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp:
* JSTests/wasm/gc/bulk-array-element-types.js:

Canonical link: <a href="https://commits.webkit.org/320819@main">https://commits.webkit.org/320819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/172b1ae49371eb8b7602424842d610484a73662f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196046 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150436 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59371 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145150 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100637 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48833 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165716 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125445 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47559 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45596 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7340 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14225 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157919 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45293 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7109 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46986 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52274 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198012 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59306 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154686 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41484 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60014 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154338 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48801 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132362 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129321 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58481 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20316 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57859 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58095 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57922 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->