### PR TITLE
Replace references to ComputedStyle's "lineHeight" with "textAutosizingAdjustedLineHeight"  and "computedLineHeight" with "usedLineHeight"

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -5483,10 +5483,10 @@
                 "normal"
             ],
             "codegen-properties": {
-                "animation-wrapper-requires-getter": "specifiedLineHeight",
-                "animation-wrapper-requires-setter": "setSpecifiedLineHeightFromAnimation",
+                "animation-wrapper-requires-setter": "setLineHeightFromAnimation",
                 "style-builder-custom": "All",
                 "style-extractor-custom": true,
+                "computed-style-name-for-methods": "SpecifiedLineHeight",
                 "computed-style-storage-path": ["m_inheritedData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::LineHeight",

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -2388,12 +2388,14 @@ Style::ComputedStyle HTMLInputElement::createInnerTextStyle(const Style::Compute
 
     auto shouldUseInitialLineHeight = [&] {
         // Do not allow line-height to be smaller than our default.
-        if (textBlockStyle.metricsOfPrimaryFont().intLineSpacing() > style.computedLineHeight())
+        if (textBlockStyle.metricsOfPrimaryFont().intLineSpacing() > style.usedLineHeight())
             return true;
         return isText() && !style.logicalHeight().isAuto() && !hasAutofillStrongPasswordButton();
     };
-    if (shouldUseInitialLineHeight())
-        textBlockStyle.setLineHeight(Style::ComputedStyle::initialLineHeight());
+    if (shouldUseInitialLineHeight()) {
+        textBlockStyle.setSpecifiedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
+        textBlockStyle.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
+    }
 
     return textBlockStyle;
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -79,7 +79,7 @@ InlineLayoutUnit InlineFormattingUtils::logicalTopForNextLine(const LineLayoutRe
                 return LayoutUnit { *nextLineLogicalTopCandidate };
             // We have to have a hint when intrusive floats prevented any inline content placement.
             ASSERT_NOT_REACHED();
-            return LayoutUnit { lineLogicalRect.top() + formattingContext().root().style().computedLineHeight() };
+            return LayoutUnit { lineLogicalRect.top() + formattingContext().root().style().usedLineHeight() };
         };
         auto floatConstraints = floatingContext.constraints(toLayoutUnit(lineLogicalRect.top()), nextLineLogicalTop(), FloatingContext::MayBeAboveLastFloat::Yes);
         if (floatConstraints.start && floatConstraints.end) {
@@ -192,7 +192,7 @@ InlineLayoutUnit InlineFormattingUtils::computedTextIndent(IsIntrinsicWidthMode 
 InlineLayoutUnit InlineFormattingUtils::initialLineHeight(bool isFirstLine) const
 {
     if (formattingContext().layoutState().inStandardsMode())
-        return isFirstLine ? formattingContext().root().firstLineStyle().computedLineHeight() : formattingContext().root().style().computedLineHeight();
+        return isFirstLine ? formattingContext().root().firstLineStyle().usedLineHeight() : formattingContext().root().style().usedLineHeight();
     return formattingContext().quirks().initialLineHeight();
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h
@@ -54,7 +54,7 @@ inline InlineLevelBox::InlineLevelBox(const Box& layoutBox, const WebCore::Style
     , m_isFirstWithinLayoutBox(positionWithinLayoutBox.contains(PositionWithinLayoutBox::First))
     , m_isLastWithinLayoutBox(positionWithinLayoutBox.contains(PositionWithinLayoutBox::Last))
     , m_type(type)
-    , m_style({ style.fontCascade().metricsOfPrimaryFont(), style.lineHeight(), style.textBoxTrim(), style.textBoxEdge(), style.lineFitEdge(), style.usedZoomForLength(), style.lineBoxContain(), InlineLayoutUnit(style.fontCascade().fontDescription().usedSize()), toInlineBoxLevelVerticalAlign(style, [this] { return preferredLineHeight(); }) })
+    , m_style({ style.fontCascade().metricsOfPrimaryFont(), style.textAutosizingAdjustedLineHeight(), style.textBoxTrim(), style.textBoxEdge(), style.lineFitEdge(), style.usedZoomForLength(), style.lineBoxContain(), InlineLayoutUnit(style.fontCascade().fontDescription().usedSize()), toInlineBoxLevelVerticalAlign(style, [this] { return preferredLineHeight(); }) })
 {
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -1239,7 +1239,7 @@ LineBuilder::RectAndFloatConstraints LineBuilder::adjustedLineRectWithCandidateI
         auto& inlineItem = run.inlineItem;
         if (inlineItem.isText()) {
             auto& styleToUse = isFirstFormattedLineCandidate() ? inlineItem.firstLineStyle() : inlineItem.style();
-            candidateContentHeight = std::max<InlineLayoutUnit>(candidateContentHeight, styleToUse.computedLineHeight());
+            candidateContentHeight = std::max<InlineLayoutUnit>(candidateContentHeight, styleToUse.usedLineHeight());
         } else if (inlineItem.isAtomicInlineBox() && lineBoxContain.contains(Style::WebkitLineBoxContainValue::Replaced))
             candidateContentHeight = std::max(candidateContentHeight, InlineLayoutUnit { formattingContext().geometryForBox(inlineItem.layoutBox()).marginBoxHeight() });
     }
@@ -1280,14 +1280,14 @@ std::optional<LineBuilder::InitialLetterOffsets> LineBuilder::adjustLineRectForI
     if (drop < letterHeight) {
         // Sunken/raised initial letter pushes contents of the first line down.
         auto numberOfSunkenLines = letterHeight - drop;
-        auto verticalGapForInlineContent = numberOfSunkenLines * rootStyle().computedLineHeight();
+        auto verticalGapForInlineContent = numberOfSunkenLines * rootStyle().usedLineHeight();
         clearGapBeforeFirstLine += verticalGapForInlineContent;
         // And we pull the initial letter up.
         initialLetterCapHeightOffset = -verticalGapForInlineContent + initialLetterCapHeightOffset.value_or(0_lu);
     } else if (drop > letterHeight) {
         // Initial letter is sunken below the first line.
         auto numberOfLinesAboveInitialLetter = drop - letterHeight;
-        sunkenBelowFirstLineOffset = numberOfLinesAboveInitialLetter * rootStyle().computedLineHeight();
+        sunkenBelowFirstLineOffset = numberOfLinesAboveInitialLetter * rootStyle().usedLineHeight();
     }
 
     m_lineLogicalRect.moveVertically(clearGapBeforeFirstLine);

--- a/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
@@ -122,9 +122,9 @@ std::optional<LayoutUnit> InlineQuirks::initialLetterAlignmentOffset(const Box& 
         return { };
     auto& primaryFontMetrics = lineBoxStyle.fontCascade().metricsOfPrimaryFont();
     auto lineHeight = [&]() -> InlineLayoutUnit {
-        if (lineBoxStyle.lineHeight().isNormal())
+        if (lineBoxStyle.textAutosizingAdjustedLineHeight().isNormal())
             return primaryFontMetrics.ascent(FontBaseline::Alphabetic) + primaryFontMetrics.descent(FontBaseline::Alphabetic);
-        return lineBoxStyle.computedLineHeight();
+        return lineBoxStyle.usedLineHeight();
     };
     auto& floatBoxGeometry = formattingContext().geometryForBox(floatBox);
     auto fontHeight = primaryFontMetrics.ascent() + primaryFontMetrics.descent();

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -486,7 +486,7 @@ static inline std::optional<Layout::BlockLayoutState::LineGrid> lineGrid(const R
         }
 
         auto columnWidth = lineGrid->style().fontCascade().primaryFont().maxCharWidth();
-        auto rowHeight = LayoutUnit::fromFloatCeil(lineGrid->style().computedLineHeight());
+        auto rowHeight = LayoutUnit::fromFloatCeil(lineGrid->style().usedLineHeight());
         auto topRowOffset = lineGrid->borderAndPaddingBefore();
 
         std::optional<LayoutSize> paginationOrigin;
@@ -1083,7 +1083,7 @@ static float baselineForEmptyContent(const RenderBlockFlow& rootRenderer)
     auto& fontMetrics = rootRenderer.style().metricsOfPrimaryFont();
     auto ascent = fontMetrics.ascent();
     auto descent = fontMetrics.descent();
-    auto baseline = ascent + (rootLayoutBox->firstLineStyle().computedLineHeight() - (ascent + descent)) / 2;
+    auto baseline = ascent + (rootLayoutBox->firstLineStyle().usedLineHeight() - (ascent + descent)) / 2;
     return rootRenderer.borderAndPaddingBefore() + baseline;
 }
 

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -399,7 +399,7 @@ String PrintContext::pageProperty(LocalFrame* frame, const String& propertyName,
         return autoAtom();
     }
     if (propertyName == "line-height"_s) {
-        return WTF::switchOn(style->lineHeight(),
+        return WTF::switchOn(style->textAutosizingAdjustedLineHeight(),
             [&](const CSS::Keyword::Normal&) -> String {
                 return "0"_s;
             },

--- a/Source/WebCore/rendering/CaretRectComputation.cpp
+++ b/Source/WebCore/rendering/CaretRectComputation.cpp
@@ -118,7 +118,7 @@ static LayoutRect computeCaretRectForEmptyElement(const RenderBoxModelObject& re
     }
     x = std::min(x, std::max<LayoutUnit>(maxX - caretWidth(), 0));
 
-    auto lineHeight = LayoutUnit::fromFloatCeil(currentStyle->computedLineHeight());
+    auto lineHeight = LayoutUnit::fromFloatCeil(currentStyle->usedLineHeight());
     auto height = std::min(lineHeight, LayoutUnit { currentStyle->metricsOfPrimaryFont().height() });
     auto y = renderer.borderAndPaddingBefore() + (lineHeight > height ? (lineHeight - height) / 2 : LayoutUnit { });
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3503,7 +3503,7 @@ static float lineHeightForEmptyContent(auto& style)
     auto& fontMetrics = style.metricsOfPrimaryFont();
     auto ascent = fontMetrics.ascent();
     auto fontHeight = fontMetrics.height();
-    return ascent + (style.computedLineHeight() - fontHeight) / 2.f;
+    return ascent + (style.usedLineHeight() - fontHeight) / 2.f;
 }
 
 std::optional<LayoutUnit> RenderBlockFlow::firstLineBaseline() const

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5092,7 +5092,7 @@ LayoutUnit RenderBox::lineHeight() const
         return false;
     };
     if (shouldUseLineHeightFromStyle())
-        return LayoutUnit::fromFloatCeil(firstLineStyle().computedLineHeight());
+        return LayoutUnit::fromFloatCeil(firstLineStyle().usedLineHeight());
 
     if (isBlockLevelReplacedOrAtomicInline())
         return marginBefore() + logicalHeight() + marginAfter();

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -148,7 +148,7 @@ bool RenderInline::mayAffectLayout() const
         || !WTF::holdsAlternative<CSS::Keyword::Baseline>(style().verticalAlign())
         || !style().textEmphasisStyle().isNone()
         || (checkFonts && (!parentStyle->fontCascade().metricsOfPrimaryFont().hasIdenticalAscentDescentAndLineGap(style().fontCascade().metricsOfPrimaryFont())
-        || parentStyle->lineHeight() != style().lineHeight()))
+        || parentStyle->textAutosizingAdjustedLineHeight() != style().textAutosizingAdjustedLineHeight()))
         || hasHardLineBreakChildOnly;
 
     if (!mayAffectLayout && checkFonts) {
@@ -157,7 +157,7 @@ bool RenderInline::mayAffectLayout() const
         auto& childStyle = firstLineStyle();
         mayAffectLayout = !parentStyle->fontCascade().metricsOfPrimaryFont().hasIdenticalAscentDescentAndLineGap(childStyle.fontCascade().metricsOfPrimaryFont())
             || !WTF::holdsAlternative<CSS::Keyword::Baseline>(childStyle.verticalAlign())
-            || parentStyle->lineHeight() != childStyle.lineHeight();
+            || parentStyle->textAutosizingAdjustedLineHeight() != childStyle.textAutosizingAdjustedLineHeight();
     }
     return mayAffectLayout;
 }

--- a/Source/WebCore/rendering/RenderLayoutState.cpp
+++ b/Source/WebCore/rendering/RenderLayoutState.cpp
@@ -210,7 +210,7 @@ void RenderLayoutState::computeLineGridPaginationOrigin(const RenderMultiColumnF
 
     // Shift to the next highest line grid multiple past the page logical top. Cache the delta
     // between this new value and the page logical top as the pagination origin.
-    auto lineBoxHeight = LayoutUnit::fromFloatCeil(m_lineGrid->style().computedLineHeight());
+    auto lineBoxHeight = LayoutUnit::fromFloatCeil(m_lineGrid->style().usedLineHeight());
     if (!roundToInt(lineBoxHeight))
         return;
     LayoutUnit remainder = roundToInt(pageLogicalTop - firstLineTop) % roundToInt(lineBoxHeight);

--- a/Source/WebCore/rendering/RenderListOutsideMarker.cpp
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.cpp
@@ -506,7 +506,7 @@ std::pair<float, float> RenderListOutsideMarker::layoutBoundForTextContent(Strin
     auto& metricsOfPrimaryFont = style.metricsOfPrimaryFont();
     auto primaryFontHeight = metricsOfPrimaryFont.height();
 
-    if (style.lineHeight().isNormal()) {
+    if (style.textAutosizingAdjustedLineHeight().isNormal()) {
         auto maxAscentAndDescent = ascentAndDescent(metricsOfPrimaryFont);
 
         for (Ref fallbackFont : Layout::TextUtil::fallbackFontsForText(text, style, Layout::TextUtil::IncludeHyphen::No)) {
@@ -524,7 +524,7 @@ std::pair<float, float> RenderListOutsideMarker::layoutBoundForTextContent(Strin
     }
 
     auto primaryFontAscentAndDescent = ascentAndDescent(metricsOfPrimaryFont);
-    auto halfLeading = (style.computedLineHeight() - (primaryFontAscentAndDescent.first + primaryFontAscentAndDescent.second)) / 2.f;
+    auto halfLeading = (style.usedLineHeight() - (primaryFontAscentAndDescent.first + primaryFontAscentAndDescent.second)) / 2.f;
     return { primaryFontAscentAndDescent.first + halfLeading, primaryFontAscentAndDescent.second + halfLeading };
 }
 

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -270,8 +270,8 @@ bool RenderTextControl::canScroll() const
 int RenderTextControl::innerLineHeight() const
 {
     if (auto innerTextElement = this->innerTextElement(); innerTextElement && innerTextElement->renderer())
-        return innerTextElement->renderer()->style().computedLineHeight();
-    return style().computedLineHeight();
+        return innerTextElement->renderer()->style().usedLineHeight();
+    return style().usedLineHeight();
 }
 #endif
 

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1498,7 +1498,9 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
     // Font
     if (auto controlFont = this->controlFont(appearance, fontCascade.get(), style.usedZoom())) {
         // If overriding the specified font with the theme font, also override the line height with the standard line height.
-        style.setLineHeight(Style::ComputedStyle::initialLineHeight());
+        style.setSpecifiedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
+        style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
+
         style.setFontDescription(WTF::move(controlFont.value()));
     }
 

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -272,7 +272,7 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
             continue;
 
         auto newParentStyle = cloneRenderStyleWithState(parentStyle);
-        newParentStyle.setLineHeight(lineHeightLength.isNormal() ? Style::LineHeight { lineHeightLength } : Style::LineHeight { Style::LineHeight::Length { static_cast<float>(lineHeight) } });
+        newParentStyle.setTextAutosizingAdjustedLineHeight(lineHeightLength.isNormal() ? Style::LineHeight { lineHeightLength } : Style::LineHeight { Style::LineHeight::Length { static_cast<float>(lineHeight) } });
         newParentStyle.setSpecifiedLineHeight(Style::LineHeight { lineHeightLength });
         newParentStyle.setFontDescription(WTF::move(fontDescription));
         parentRenderer->setStyle(WTF::move(newParentStyle));
@@ -337,11 +337,11 @@ void TextAutoSizingValue::reset()
 
         auto& parentStyle = parentRenderer->style();
         auto& originalLineHeight = parentStyle.specifiedLineHeight();
-        if (originalLineHeight == parentStyle.lineHeight())
+        if (originalLineHeight == parentStyle.textAutosizingAdjustedLineHeight())
             continue;
 
         auto newParentStyle = cloneRenderStyleWithState(parentStyle);
-        newParentStyle.setLineHeight(Style::LineHeight { originalLineHeight });
+        newParentStyle.setTextAutosizingAdjustedLineHeight(Style::LineHeight { originalLineHeight });
         newParentStyle.setFontDescription(WTF::move(fontDescription));
         parentRenderer->setStyle(WTF::move(newParentStyle));
     }

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -343,7 +343,8 @@ void RenderThemeAdwaita::adjustSearchFieldStyle(Style::ComputedStyle& style, con
 void RenderThemeAdwaita::adjustMenuListStyle(Style::ComputedStyle& style, const Element* element) const
 {
     RenderTheme::adjustMenuListStyle(style, element);
-    style.setLineHeight(Style::ComputedStyle::initialLineHeight());
+    style.setSpecifiedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
+    style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
 }
 
 void RenderThemeAdwaita::adjustMenuListButtonStyle(Style::ComputedStyle& style, const Element* element) const

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -3213,7 +3213,9 @@ static void adjustSelectListButtonStyleForVectorBasedControls(Style::ComputedSty
 #if PLATFORM(IOS_FAMILY)
     applyCommonButtonPaddingToStyleForVectorBasedControls(style);
 #endif
-    style.setLineHeight(CSS::Keyword::Normal { });
+
+    style.setSpecifiedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
+    style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
 }
 
 bool RenderThemeCocoa::adjustMenuListStyleForVectorBasedControls(Style::ComputedStyle& style, const Element* element) const
@@ -3233,8 +3235,10 @@ bool RenderThemeCocoa::adjustMenuListStyleForVectorBasedControls(Style::Computed
     style.setBoxShadow(CSS::Keyword::None  { });
 
     // Enforce "line-height: normal" as long as this element isn't a non-select element using `-webkit-appearance: menulist`.
-    if (element && is<HTMLSelectElement>(*element))
-        style.setLineHeight(CSS::Keyword::Normal { });
+    if (element && is<HTMLSelectElement>(*element)) {
+        style.setSpecifiedLineHeight(CSS::Keyword::Normal { });
+        style.setTextAutosizingAdjustedLineHeight(CSS::Keyword::Normal { });
+    }
 
     return true;
 }

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -471,7 +471,8 @@ static void adjustSelectListButtonStyle(Style::ComputedStyle& style)
     // Enforce "padding: 0 0.5em".
     applyCommonButtonPaddingToStyle(style);
 
-    style.setLineHeight(CSS::Keyword::Normal { });
+    style.setSpecifiedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
+    style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
 }
 
 class RenderThemeMeasureTextClient : public MeasureTextClient {

--- a/Source/WebCore/rendering/line/LineInlineHeaders.h
+++ b/Source/WebCore/rendering/line/LineInlineHeaders.h
@@ -45,7 +45,7 @@ inline bool requiresLineBoxForContent(const RenderInline& flow, const LineInfo& 
     if (flow.document().inNoQuirksMode()) {
         CheckedRef flowStyle = lineStyle(flow, lineInfo);
         CheckedRef parentStyle = lineStyle(*parent, lineInfo);
-        if (flowStyle->lineHeight() != parentStyle->lineHeight()
+        if (flowStyle->textAutosizingAdjustedLineHeight() != parentStyle->textAutosizingAdjustedLineHeight()
             || flowStyle->verticalAlign() != parentStyle->verticalAlign()
             || !parentStyle->fontCascade().metricsOfPrimaryFont().hasIdenticalAscentDescentAndLineGap(flowStyle->fontCascade().metricsOfPrimaryFont()))
         return true;

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1228,7 +1228,9 @@ static void setFontFromControlSize(Style::ComputedStyle& style, NSControlSize co
     fontDescription.setComputedSize([font pointSize]);
 
     // Reset line height
-    style.setLineHeight(Style::ComputedStyle::initialLineHeight());
+    style.setSpecifiedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
+    style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
+
     style.setFontDescription(WTF::move(fontDescription));
 }
 
@@ -1422,7 +1424,8 @@ void RenderThemeMac::adjustMenuListButtonStyle(Style::ComputedStyle& style, cons
 
     style.setMinHeight(18_css_px);
 
-    style.setLineHeight(Style::ComputedStyle::initialLineHeight());
+    style.setSpecifiedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
+    style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
 }
 
 std::span<const IntSize, 4> RenderThemeMac::menuListSizes() const

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -67,7 +67,7 @@ static std::optional<Style::ComputedStyle> styleForFirstLetter(const RenderEleme
         // Mathematically we can't rely on font-size, since font().height() doesn't necessarily match. For reliability, the best approach is simply to
         // compare the final measured cap-heights of the two fonts in order to get to the closest possible value.
         firstLetterStyle.setLineBoxContain({ Style::WebkitLineBoxContainValue::InitialLetter });
-        int lineHeight = paragraph->style().computedLineHeight();
+        int lineHeight = paragraph->style().usedLineHeight();
 
         // Set the font to be one line too big and then ratchet back to get to a precise fit. We can't just set the desired font size based off font height metrics
         // because many fonts bake ascent into the font metrics. Therefore we have to look at actual measured cap height values in order to know when we have a good fit.

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1430,7 +1430,7 @@ bool Adjuster::adjustForTextAutosizing(Style::ComputedStyle& style, AdjustmentFo
         style.setFontDescription(WTF::move(fontDescription));
     }
     if (auto newLineHeight = adjustment.newLineHeight)
-        style.setLineHeight(LineHeight::Fixed { *newLineHeight });
+        style.setTextAutosizingAdjustedLineHeight(LineHeight::Fixed { *newLineHeight });
     if (auto newStatus = adjustment.newStatus)
         style.setAutosizeStatus(*newStatus);
     return adjustment.newFontSize || adjustment.newLineHeight;

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -304,13 +304,13 @@ inline void BuilderCustom::applyValueLetterSpacing(BuilderState& builderState, C
 
 inline void BuilderCustom::applyInheritLineHeight(BuilderState& builderState)
 {
-    builderState.style().setLineHeight(forwardInheritedValue(builderState.parentStyle().lineHeight()));
+    builderState.style().setTextAutosizingAdjustedLineHeight(forwardInheritedValue(builderState.parentStyle().textAutosizingAdjustedLineHeight()));
     builderState.style().setSpecifiedLineHeight(forwardInheritedValue(builderState.parentStyle().specifiedLineHeight()));
 }
 
 inline void BuilderCustom::applyInitialLineHeight(BuilderState& builderState)
 {
-    builderState.style().setLineHeight(ComputedStyle::initialLineHeight());
+    builderState.style().setTextAutosizingAdjustedLineHeight(ComputedStyle::initialSpecifiedLineHeight());
     builderState.style().setSpecifiedLineHeight(ComputedStyle::initialSpecifiedLineHeight());
 }
 
@@ -365,7 +365,7 @@ inline void BuilderCustom::applyValueLineHeight(BuilderState& builderState, CSSV
 
     auto lineHeight = toStyleFromCSSValue<LineHeight>(builderState, value, 1.0f);
 
-    auto computedLineHeight = [&] -> LineHeight {
+    auto textAutosizingAdjustedLineHeight = [&] -> LineHeight {
         if (lineHeight.isNormal())
             return lineHeight;
 
@@ -376,7 +376,7 @@ inline void BuilderCustom::applyValueLineHeight(BuilderState& builderState, CSSV
         return toStyleFromCSSValue<LineHeight>(builderState, value, multiplier);
     }();
 
-    builderState.style().setLineHeight(WTF::move(computedLineHeight));
+    builderState.style().setTextAutosizingAdjustedLineHeight(WTF::move(textAutosizingAdjustedLineHeight));
     builderState.style().setSpecifiedLineHeight(WTF::move(lineHeight));
 }
 

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -472,7 +472,7 @@ public:
             return true;
 
         if (&a.inheritedData() != &b.inheritedData()) {
-            if (a.inheritedData().lineHeight != b.inheritedData().lineHeight
+            if (a.inheritedData().textAutosizingAdjustedLineHeight != b.inheritedData().textAutosizingAdjustedLineHeight
                 || a.inheritedData().specifiedLineHeight != b.inheritedData().specifiedLineHeight
                 || a.inheritedData().borderHorizontalSpacing != b.inheritedData().borderHorizontalSpacing
                 || a.inheritedData().borderVerticalSpacing != b.inheritedData().borderVerticalSpacing)

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -684,7 +684,7 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyWordSpacing> {
 template<> struct PropertyExtractorAdaptor<CSSPropertyLineHeight> {
     template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
     {
-        return WTF::switchOn(state.style.lineHeight(),
+        return WTF::switchOn(state.style.textAutosizingAdjustedLineHeight(),
             [&](const CSS::Keyword::Normal& keyword) {
                 return functor(keyword);
             },

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -319,7 +319,7 @@ static bool styleChangeAffectsRelativeUnits(const Style::ComputedStyle& style, c
     if (!existingStyle)
         return true;
     return !existingStyle->fontCascadeEqual(style)
-        || existingStyle->computedLineHeight() != style.computedLineHeight();
+        || existingStyle->usedLineHeight() != style.usedLineHeight();
 }
 
 auto TreeResolver::resolveElement(Element& element, const Style::ComputedStyle* existingStyle, ResolutionType resolutionType) -> std::pair<ElementUpdate, DescendantsToResolve>

--- a/Source/WebCore/style/computed/StyleComputedStyle+InitialInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyle+InitialInlines.h
@@ -46,10 +46,5 @@ inline PageSize ComputedStyle::initialPageSize()
     return CSS::Keyword::Auto { };
 }
 
-inline LineHeight ComputedStyle::initialSpecifiedLineHeight()
-{
-    return CSS::Keyword::Normal { };
-}
-
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -308,9 +308,12 @@ bool ComputedStyle::borderAndBackgroundEqual(const ComputedStyle& other) const
         && backgroundColor() == other.backgroundColor();
 }
 
-float ComputedStyle::computedLineHeight() const
+float ComputedStyle::usedLineHeight() const
 {
-    return evaluate<float>(lineHeight(), LineHeightEvaluationContext { usedFontSize(), metricsOfPrimaryFont().lineSpacing() }, usedZoomForLength());
+    return evaluate<float>(textAutosizingAdjustedLineHeight(), LineHeightEvaluationContext {
+        usedFontSize(),
+        metricsOfPrimaryFont().lineSpacing()
+    }, usedZoomForLength());
 }
 
 bool ComputedStyle::scrollSnapDataEquivalent(const ComputedStyle& other) const

--- a/Source/WebCore/style/computed/StyleComputedStyle.h
+++ b/Source/WebCore/style/computed/StyleComputedStyle.h
@@ -103,7 +103,6 @@ public:
 
     static inline PageSize initialPageSize();
     static constexpr ZIndex initialUsedZIndex();
-    static inline LineHeight initialSpecifiedLineHeight();
 
     // MARK: - Logical Values
 
@@ -138,7 +137,6 @@ public:
 
     // MARK: - Derived Values
 
-    WEBCORE_EXPORT float computedLineHeight() const;
     LayoutBoxExtent imageOutsets(const Style::BorderImage&, float deviceScaleFactor) const;
     LayoutBoxExtent imageOutsets(const Style::MaskBorder&, float deviceScaleFactor) const;
     LayoutBoxExtent borderImageOutsets(float deviceScaleFactor) const;
@@ -147,6 +145,7 @@ public:
 
     // MARK: - Used Values
 
+    WEBCORE_EXPORT float usedLineHeight() const;
     const WTF::String& hyphenString() const LIFETIME_BOUND;
     float usedStrokeWidth(const IntSize& viewportSize) const;
     WebCore::Color usedStrokeColor() const;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -269,26 +269,26 @@ float ComputedStyleBase::usedFontSize() const
     return fontDescription().usedSize();
 }
 
-const LineHeight& ComputedStyleBase::specifiedLineHeight() const
+const LineHeight& ComputedStyleBase::textAutosizingAdjustedLineHeight() const
 {
-    return m_inheritedData->specifiedLineHeight;
+    return m_inheritedData->textAutosizingAdjustedLineHeight;
 }
 
-void ComputedStyleBase::setSpecifiedLineHeight(LineHeight&& lineHeight)
+void ComputedStyleBase::setTextAutosizingAdjustedLineHeight(LineHeight&& lineHeight)
 {
-    SET_VAR(m_inheritedData, specifiedLineHeight, WTF::move(lineHeight));
+    SET_VAR(m_inheritedData, textAutosizingAdjustedLineHeight, WTF::move(lineHeight));
 }
 
-void ComputedStyleBase::setSpecifiedLineHeightFromAnimation(LineHeight&& lineHeight)
+void ComputedStyleBase::setLineHeightFromAnimation(LineHeight&& lineHeight)
 {
     bool specifiedLineHeightChanged = m_inheritedData->specifiedLineHeight != lineHeight;
-    bool lineHeightChanged = m_inheritedData->lineHeight != lineHeight;
-    if (specifiedLineHeightChanged || lineHeightChanged) {
+    bool textAutosizingAdjustedLineHeightChanged = m_inheritedData->textAutosizingAdjustedLineHeight != lineHeight;
+    if (specifiedLineHeightChanged || textAutosizingAdjustedLineHeightChanged) {
         auto& access = m_inheritedData.access();
         if (specifiedLineHeightChanged)
             access.specifiedLineHeight = lineHeight;
-        if (lineHeightChanged)
-            access.lineHeight = WTF::move(lineHeight);
+        if (textAutosizingAdjustedLineHeightChanged)
+            access.textAutosizingAdjustedLineHeight = WTF::move(lineHeight);
     }
 }
 

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -652,9 +652,10 @@ public:
     std::pair<FontOrientation, NonCJKGlyphOrientation> NODELETE fontAndGlyphOrientation();
     float NODELETE usedFontSize() const;
     inline WebkitLocale computedLocale() const;
-    const LineHeight& NODELETE specifiedLineHeight() const;
-    void setSpecifiedLineHeight(LineHeight&&);
-    void setSpecifiedLineHeightFromAnimation(LineHeight&&);
+
+    const LineHeight& NODELETE textAutosizingAdjustedLineHeight() const;
+    void setTextAutosizingAdjustedLineHeight(LineHeight&&);
+    void setLineHeightFromAnimation(LineHeight&&);
 
     void setLetterSpacingFromAnimation(LetterSpacing&&);
     void setWordSpacingFromAnimation(WordSpacing&&);

--- a/Source/WebCore/style/computed/data/StyleInheritedData.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedData.cpp
@@ -36,8 +36,8 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(InheritedData);
 InheritedData::InheritedData()
     : borderHorizontalSpacing(ComputedStyle::initialBorderHorizontalSpacing())
     , borderVerticalSpacing(ComputedStyle::initialBorderVerticalSpacing())
-    , lineHeight(ComputedStyle::initialLineHeight())
-    , specifiedLineHeight(ComputedStyle::initialLineHeight())
+    , specifiedLineHeight(ComputedStyle::initialSpecifiedLineHeight())
+    , textAutosizingAdjustedLineHeight(ComputedStyle::initialSpecifiedLineHeight())
     , fontData(FontData::create())
     , color(WebCore::Color::black)
     , visitedLinkColor(WebCore::Color::black)
@@ -48,8 +48,8 @@ inline InheritedData::InheritedData(const InheritedData& o)
     : RefCounted<InheritedData>()
     , borderHorizontalSpacing(o.borderHorizontalSpacing)
     , borderVerticalSpacing(o.borderVerticalSpacing)
-    , lineHeight(o.lineHeight)
     , specifiedLineHeight(o.specifiedLineHeight)
+    , textAutosizingAdjustedLineHeight(o.textAutosizingAdjustedLineHeight)
     , fontData(o.fontData)
     , color(o.color)
     , visitedLinkColor(o.visitedLinkColor)
@@ -79,8 +79,8 @@ bool InheritedData::fastPathInheritedEqual(const InheritedData& other) const
 
 bool InheritedData::nonFastPathInheritedEqual(const InheritedData& other) const
 {
-    return lineHeight == other.lineHeight
-        && specifiedLineHeight == other.specifiedLineHeight
+    return specifiedLineHeight == other.specifiedLineHeight
+        && textAutosizingAdjustedLineHeight == other.textAutosizingAdjustedLineHeight
         && fontData == other.fontData
         && borderHorizontalSpacing == other.borderHorizontalSpacing
         && borderVerticalSpacing == other.borderVerticalSpacing;
@@ -99,8 +99,8 @@ void InheritedData::dumpDifferences(TextStream& ts, const InheritedData& other) 
 
     LOG_IF_DIFFERENT(borderHorizontalSpacing);
     LOG_IF_DIFFERENT(borderVerticalSpacing);
-    LOG_IF_DIFFERENT(lineHeight);
     LOG_IF_DIFFERENT(specifiedLineHeight);
+    LOG_IF_DIFFERENT(textAutosizingAdjustedLineHeight);
     LOG_IF_DIFFERENT(color);
     LOG_IF_DIFFERENT(visitedLinkColor);
 }

--- a/Source/WebCore/style/computed/data/StyleInheritedData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedData.h
@@ -58,8 +58,8 @@ public:
     WebkitBorderSpacing borderHorizontalSpacing;
     WebkitBorderSpacing borderVerticalSpacing;
 
-    LineHeight lineHeight;
     LineHeight specifiedLineHeight;
+    LineHeight textAutosizingAdjustedLineHeight;
 
     DataRef<FontData> fontData;
     WebCore::Color color;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
@@ -580,7 +580,7 @@ static CursorContext cursorContext(const WebCore::HitTestResult& hitTestResult, 
 
     if (!lineContainsRequestPoint && cursorTypeIs(context.cursor, WebCore::Cursor::Type::IBeam)) {
         auto approximateLineRectInContentCoordinates = renderer->absoluteBoundingBoxRect();
-        approximateLineRectInContentCoordinates.setHeight(protect(renderer->style())->computedLineHeight());
+        approximateLineRectInContentCoordinates.setHeight(protect(renderer->style())->usedLineHeight());
         context.lineCaretExtent = view->contentsToRootView(approximateLineRectInContentCoordinates);
         if (!context.lineCaretExtent.contains(request.point) || !isEditable)
             context.lineCaretExtent.setY(request.point.y() - context.lineCaretExtent.height() / 2);

--- a/Source/WebKitLegacy/mac/DOM/DOMUIKitExtensions.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMUIKitExtensions.mm
@@ -228,7 +228,7 @@ static WebCore::Node* firstNodeAfter(const WebCore::BoundaryPoint& point)
 {  
     RenderObject* renderer = core(self)->renderer();
     if (is<RenderText>(renderer))
-        return downcast<RenderText>(*renderer).style().computedLineHeight();
+        return downcast<RenderText>(*renderer).style().usedLineHeight();
     
     return CGFLOAT_MAX;
 }

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -1384,7 +1384,7 @@ static WebFrameLoadType NODELETE toWebFrameLoadType(WebCore::FrameLoadType frame
 
     if (auto* textControlRenderer = dynamicDowncast<WebCore::RenderTextControl>(*renderer))
         return textControlRenderer->innerLineHeight();
-    return renderer->style().computedLineHeight();
+    return renderer->style().usedLineHeight();
 }
 
 - (void)updateLayout


### PR DESCRIPTION
#### 9b0f01ca9e14c8cf7b5485dadeaaeed687e2a851
<pre>
Replace references to ComputedStyle&apos;s &quot;lineHeight&quot; with &quot;textAutosizingAdjustedLineHeight&quot;  and &quot;computedLineHeight&quot; with &quot;usedLineHeight&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=323631">https://bugs.webkit.org/show_bug.cgi?id=323631</a>

Reviewed by Darin Adler.

Part 1 of <a href="https://bugs.webkit.org/show_bug.cgi?id=323630">https://bugs.webkit.org/show_bug.cgi?id=323630</a>

Style::ComputedStyle currently has three different line height accessors:
  - lineHeight()
  - specifiedLineHeight()
  - computedLineHeight()

None of these are clear and none of the prefixes align with their counterpart
CSS concept. Rather, what they actually represent is:

  - lineHeight()           -&gt; text autosizing adjusted computed style
  - specifiedLineHeight()  -&gt; computed style
  - computedLineHeight()   -&gt; zoom, percentage and keyword evaluated transform of
                              the &quot;text autosizing adjusted computed style&quot;.

As an initial step to fixing these names, we make the following renames:

  - lineHeight()           -&gt; textAutosizingAdjustedLineHeight()
  - computedLineHeight()   -&gt; usedLineHeight()

Whether we need to keep textAutosizingAdjustedLineHeight() long term is unclear.
It depends on whether the caching the transformation is necessary to maintain
performance, so that is something to handle at another time.

specifiedLineHeight() will be handled in a part 2.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/html/HTMLInputElement.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBoxInlines.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
* Source/WebCore/page/PrintContext.cpp:
* Source/WebCore/rendering/CaretRectComputation.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderInline.cpp:
* Source/WebCore/rendering/RenderLayoutState.cpp:
* Source/WebCore/rendering/RenderListOutsideMarker.cpp:
* Source/WebCore/rendering/RenderTextControl.cpp:
* Source/WebCore/rendering/RenderTheme.cpp:
* Source/WebCore/rendering/TextAutoSizing.cpp:
* Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
* Source/WebCore/rendering/line/LineInlineHeaders.h:
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
* Source/WebCore/style/StyleAdjuster.cpp:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleDifference.cpp:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
* Source/WebCore/style/computed/StyleComputedStyle+InitialInlines.h:
* Source/WebCore/style/computed/StyleComputedStyle.cpp:
* Source/WebCore/style/computed/StyleComputedStyle.h:
* Source/WebCore/style/computed/StyleComputedStyleBase.cpp:
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/computed/data/StyleInheritedData.cpp:
* Source/WebCore/style/computed/data/StyleInheritedData.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm:
* Source/WebKitLegacy/mac/DOM/DOMUIKitExtensions.mm:
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:

Canonical link: <a href="https://commits.webkit.org/320670@main">https://commits.webkit.org/320670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2995c8aeca6e1a8d0accf8dd5f3450e02a40c665

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53273 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195869 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150297 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59185 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145001 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165578 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125293 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47409 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45465 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157775 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45150 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6922 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197821 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59122 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154532 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41382 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59831 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154179 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48647 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129081 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58305 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20172 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57680 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57921 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57745 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->