### PR TITLE
Add worker layout test: Race on RemoteVideoDecoderCallbacks::m_timestampToDuration leads to use-after-free

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/videoDecoder-concurrent-decode-output-in-worker-no-crash-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/videoDecoder-concurrent-decode-output-in-worker-no-crash-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Concurrent VideoDecoder.decode() in a worker and output delivery should not race on the timestamp-to-duration map
+

--- a/LayoutTests/http/wpt/webcodecs/videoDecoder-concurrent-decode-output-in-worker-no-crash.html
+++ b/LayoutTests/http/wpt/webcodecs/videoDecoder-concurrent-decode-output-in-worker-no-crash.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</head>
+<body>
+<script>
+promise_test(async (t) => {
+    const worker = new Worker("videoDecoder-concurrent-decode-output-in-worker-no-crash.js");
+    t.add_cleanup(() => worker.terminate());
+    // The decodes are driven from a message event handler so that VideoDecoder.decode()
+    // runs on the worker thread, as in the crash this test covers.
+    const result = await new Promise((resolve, reject) => {
+        worker.onmessage = event => resolve(event.data);
+        worker.onerror = event => reject(new Error(event.message));
+        worker.postMessage("start");
+    });
+    assert_equals(result, "PASS", result);
+}, "Concurrent VideoDecoder.decode() in a worker and output delivery should not race on the timestamp-to-duration map");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/webcodecs/videoDecoder-concurrent-decode-output-in-worker-no-crash.js
+++ b/LayoutTests/http/wpt/webcodecs/videoDecoder-concurrent-decode-output-in-worker-no-crash.js
@@ -1,0 +1,53 @@
+onmessage = async () => {
+    try {
+        let resolveChunk;
+        const haveChunk = new Promise(r => resolveChunk = r);
+        let keyChunkData;
+        let decoderConfig;
+
+        const encoder = new VideoEncoder({
+            output(chunk, metadata) {
+                if (metadata.decoderConfig)
+                    decoderConfig = metadata.decoderConfig;
+                const buffer = new Uint8Array(chunk.byteLength);
+                chunk.copyTo(buffer);
+                keyChunkData = buffer;
+                resolveChunk();
+            },
+            error(e) { }
+        });
+        encoder.configure({ codec: "avc1.42001E", width: 64, height: 64, bitrate: 100000, framerate: 30, avc: { format: "annexb" } });
+        const canvas = new OffscreenCanvas(64, 64);
+        canvas.getContext("2d").fillRect(0, 0, 64, 64);
+        const frame = new VideoFrame(canvas, { timestamp: 0 });
+        encoder.encode(frame, { keyFrame: true });
+        frame.close();
+        await encoder.flush();
+        await haveChunk;
+        encoder.close();
+
+        const decoder = new VideoDecoder({
+            output(frame) { frame.close(); },
+            error(e) { }
+        });
+        decoder.configure(decoderConfig || { codec: "avc1.42001E" });
+
+        // Submit many decodes carrying a duration so that addDuration() runs on this
+        // worker thread while completedDecoding() drains on the LibWebRTCCodecs work queue.
+        for (let i = 0; i < 2000; ++i) {
+            decoder.decode(new EncodedVideoChunk({
+                type: "key",
+                timestamp: i,
+                duration: 1,
+                data: keyChunkData
+            }));
+            if (decoder.decodeQueueSize > 64)
+                await new Promise(r => setTimeout(r, 0));
+        }
+        await decoder.flush().catch(() => { });
+        decoder.close();
+        postMessage("PASS");
+    } catch (e) {
+        postMessage("FAIL: " + e);
+    }
+};


### PR DESCRIPTION
#### 8f83741b5630805f70f2f9763a853d6a5026a470
<pre>
Add worker layout test: Race on RemoteVideoDecoderCallbacks::m_timestampToDuration leads to use-after-free
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=321480">https://bugs.webkit.org/show_bug.cgi?id=321480</a>&gt;
&lt;<a href="https://rdar.apple.com/177096608">rdar://177096608</a>&gt;

Reviewed by NOBODY (OOPS!).

Add a worker-thread variant of the existing WebCodecs `VideoDecoder`
concurrent-decode regression test.  The underlying data race on
`RemoteVideoDecoderCallbacks::m_timestampToDuration` was already fixed
by adding `m_timestampToDurationLock` (<a href="https://commits.webkit.org/319863@main">319863@main</a>):
`RemoteVideoDecoderCallbacks::addDuration()` runs on the thread that
called `VideoDecoder.decode()`, while
`RemoteVideoDecoderCallbacks::notifyDecodingResult()` mutates the same
`std::unordered_map` on the LibWebRTCCodecs work queue.

Test: http/wpt/webcodecs/videoDecoder-concurrent-decode-output-in-worker-no-crash.html

* LayoutTests/http/wpt/webcodecs/videoDecoder-concurrent-decode-output-in-worker-no-crash-expected.txt: Add.
* LayoutTests/http/wpt/webcodecs/videoDecoder-concurrent-decode-output-in-worker-no-crash.html: Add.
* LayoutTests/http/wpt/webcodecs/videoDecoder-concurrent-decode-output-in-worker-no-crash.js: Add.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f83741b5630805f70f2f9763a853d6a5026a470

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195745 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150196 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/da4400a8-1379-41fd-a37d-3dbd33a19687) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187283 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59060 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144902 "Found 1 new test failure: fast/dom/lazy-image-loading-document-leak.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100453 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/591abef7-5541-478a-9c98-1c6d7d5c8e71) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125194 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6abda999-9e97-4e37-a449-c44e872b5529) 
| [⏳ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47310 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45367 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157677 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45059 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6796 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51989 "Build is in progress. Recent messages:") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197693 "Built successfully") | | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/58997 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/164995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154417 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59706 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154068 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48552 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128899 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58184 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20081 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57556 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57799 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57623 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->