### PR TITLE
[Site Isolation] Adopt the root compositing layer when swapping drawing areas

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -550,7 +550,28 @@ void RemoteLayerTreeDrawingArea::dispatchAfterEnsuringDrawing(IPC::AsyncReplyID 
 
 void RemoteLayerTreeDrawingArea::adoptLayersFromDrawingArea(DrawingArea& oldDrawingArea)
 {
-    m_remoteLayerTreeContext->adoptLayersFromContext(downcast<RemoteLayerTreeDrawingArea>(oldDrawingArea).m_remoteLayerTreeContext);
+    Ref oldArea = downcast<RemoteLayerTreeDrawingArea>(oldDrawingArea);
+    m_remoteLayerTreeContext->adoptLayersFromContext(oldArea->m_remoteLayerTreeContext);
+
+    // RenderLayerCompositor::setIsInWindow() bails out while m_rootLayerAttachment is set, so a page that already
+    // attached to the old drawing area never attaches to the new one; take the attachment over here.
+    for (auto& oldRootLayer : oldArea->m_rootLayers) {
+        auto* rootLayerInfo = rootLayerInfoWithFrameIdentifier(oldRootLayer.frameID);
+        if (!rootLayerInfo)
+            continue;
+        ASSERT(!rootLayerInfo->contentLayer);
+        rootLayerInfo->contentLayer = std::exchange(oldRootLayer.contentLayer, nullptr);
+
+        // Unlike the root layer, a view overlay can already be attached here: updatePreferences() runs
+        // first and DebugPageOverlays::settingsChanged() reaches the chrome client synchronously.
+        if (RefPtr viewOverlayRootLayer = std::exchange(oldRootLayer.viewOverlayRootLayer, nullptr))
+            rootLayerInfo->viewOverlayRootLayer = WTF::move(viewOverlayRootLayer);
+        // The size comes from mainFrameContentSizeChanged(), which a restore need not produce again.
+        rootLayerInfo->layer->setSize(oldRootLayer.layer->size());
+    }
+
+    updateRootLayers();
+    triggerRenderingUpdate();
 }
 
 void RemoteLayerTreeDrawingArea::scheduleRenderingUpdateTimerFired()

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -14299,7 +14299,7 @@ TEST(SiteIsolation, MultiProcessBFCacheIframeRendersAfterBackNavigation)
 {
     HTTPServer server({
         { "/main"_s, { "<iframe src='https://b.com/iframe'></iframe>"_s } },
-        { "/iframe"_s, { "<a id='link' href='https://b.com/destination' target='_top'>click me</a>"_s } },
+        { "/iframe"_s, { "<body style='margin:0'><div style='width:137px;height:59px;background:magenta;transform:translateZ(0)'></div><a id='link' href='https://b.com/destination' target='_top'>click me</a></body>"_s } },
         { "/destination"_s, { "<body>destination page</body>"_s } },
     }, HTTPServer::Protocol::HttpsProxy);
 
@@ -14338,8 +14338,11 @@ TEST(SiteIsolation, MultiProcessBFCacheIframeRendersAfterBackNavigation)
     TestWebKitAPI::Util::run(&done);
     EXPECT_FALSE(frozen);
 
-    NSString *layerTree = [webView _caLayerTreeAsText];
-    EXPECT_TRUE([layerTree containsString:@"(layer bounds"]);
+    // The iframe composites a 137x59 layer, a size nothing in a.com's process can produce, so those
+    // bounds appearing in the hosted CALayer tree detect b.com's contribution alone.
+    [webView waitForNextPresentationUpdate];
+    RetainPtr layerTree = [webView _caLayerTreeAsText];
+    EXPECT_TRUE([layerTree containsString:@"width: 137 height: 59"]) << [layerTree UTF8String];
 
     startCountingAnimationFrames(webView.get(), [webView firstChildFrame]);
     expectAnimationFrameCountToIncrease(webView.get(), [webView firstChildFrame]);


### PR DESCRIPTION
#### 2b001c8573b2c63a1341c7d58ee0d0e07c6d1d62
<pre>
[Site Isolation] Adopt the root compositing layer when swapping drawing areas
<a href="https://bugs.webkit.org/show_bug.cgi?id=323633">https://bugs.webkit.org/show_bug.cgi?id=323633</a>
<a href="https://rdar.apple.com/186864659">rdar://186864659</a>

Reviewed by Per Arne Vollan.

320565@main addressed a cross-origin iframe not rendering after a back navigation. On a multi-process back/forward cache
restore, committing the provisional page recreates the page&apos;s DrawingAreaProxy, RemotePageProxy::setDrawingArea()
re-sends CreateWebPage to each iframe process, and WebPage::reinitializeWebPage() swaps in a new drawing area. That
change froze the layer tree during the restore, on the premise that doing so defers the root compositing layer
attachment until the new drawing area is in place.

However, the premise does not hold. The freeze gates the drawing area&apos;s rendering update, not WebCore&apos;s compositing
update, and the attachment happens during the latter: the restore runs a compositing update, ensureRootLayer() attaches,
and the root layer lands on the outgoing drawing area. setIsInWindow() then bails out while m_rootLayerAttachment is
set, so the new drawing area never receives it. The layers are registered in the new context but unreachable from its
root layer, and recursiveBuildTransaction() walks down from the root, so nothing is committed.

The test added in 320565@main did not catch this because its iframe was a bare link. With nothing to composite,
usesCompositing() stays false, setIsInWindow() returns at its first gate, and the attachment is deferred past the swap.
Give that iframe a composited layer and it will always fail. Its assertion needs replacing as well: &quot;(layer bounds&quot;
appears for every layer in the dump, so it passed on the main frame&apos;s layers whether or not the iframe contributed
anything.

Rather than trying to keep the compositing update and the attachment from happening before the swap, make the attachment
transferable. adoptLayersFromDrawingArea() now takes the content layer and view overlay layer over from the outgoing
drawing area; a detach and re-attach would only add the rootLayerAttachmentChanged() side effects, since nothing about
the attachment has changed from WebCore&apos;s point of view. It also carries the root layer&apos;s size over, which comes from
mainFrameContentSizeChanged() and need not be produced again by a restore, and triggers a rendering update the way
setRootCompositingLayer() does after the same updateRootLayers().

The layer tree freeze from 320565@main is left in place even though it has no bearing on the attachment. Removing it
belongs in a separate change: a rare rAF-assertion failure in this test were only ever seen with the freeze removed, but
at roughly 2 in 100 runs against none in 80 the comparison is not conclusive either way. That looks like an unrelated
rendering-update scheduling problem and deserves its own investigation.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::adoptLayersFromDrawingArea):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, MultiProcessBFCacheIframeRendersAfterBackNavigation)):

Canonical link: <a href="https://commits.webkit.org/320658@main">https://commits.webkit.org/320658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f8c5abe64a4e8cf42abbee4f92e7b58bb6fb644

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150200 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5fc90558-7214-4061-9e33-b391592acf4f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187287 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59064 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144905 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100456 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bc93ae2b-d7e9-4d11-97c4-f02754f09042) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165490 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125197 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/feaba906-f48e-4029-83de-aef6b442dbf8) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/184753 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47314 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45370 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157681 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45062 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6800 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197697 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/184828 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59001 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154422 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41370 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59710 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41667 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154072 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48555 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132045 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128908 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58188 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20084 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57560 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57803 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57627 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->