### PR TITLE
Cherry-pick 305413.1026@safari-7624.5.1.10-branch (1af72a6f5454). https://bugs.webkit.org/show_bug.cgi?id=313499

### DIFF
--- a/JSTests/stress/b3-ccmp-chain.js
+++ b/JSTests/stress/b3-ccmp-chain.js
@@ -1,0 +1,51 @@
+// Regression tests for B3 ccmp-chain lowering of nested boolean expressions on ARM64.
+
+let arr = [0, 1, 2, 3, 4, 5, 6, 7];
+
+function f(arr, i, a, b, c, d) {
+    if (i < 0)
+        return -2;
+    if ((i < arr.length) & (((((a == b) & (c == d)) | (a ^ c)) == 0))) {
+        return arr[i];
+    }
+    return -1;
+}
+noInline(f);
+for (let j = 0; j < testLoopCount; j++) {
+    let r1 = f(arr, j & 7, 5, 6, 5, 5);
+    if (r1 !== arr[j & 7])
+        throw new Error("T1 mismatch: f(arr, " + (j & 7) + ", 5, 6, 5, 5) got " + r1);
+    let r2 = f(arr, j & 7, 5, 5, 5, 5);
+    if (r2 !== -1)
+        throw new Error("T1 mismatch: f(arr, " + (j & 7) + ", 5, 5, 5, 5) got " + r2);
+}
+// T1
+if (f(arr, 0x7ffffff0, 5, 5, 5, -10) !== -1) throw new Error("T1 mismatch case 1");
+if (f(arr, 0x7ffffff0, 5, 5, 5, 10) !== -1) throw new Error("T1 mismatch case 2");
+if (f(arr, 5, 5, 6, 5, 5) !== arr[5]) throw new Error("T1 mismatch case 3");
+if (f(arr, 5, 5, 5, 5, 5) !== -1) throw new Error("T1 mismatch case 4");
+
+function f_legit_chain(a, b, c, d, e, g) {
+    if ((a == b) & (c < d) & (e != g))
+        return 1;
+    return 0;
+}
+noInline(f_legit_chain);
+let cases = [
+    [5, 5, 1, 2, 3, 4, 1],
+    [5, 5, 2, 1, 3, 4, 0],
+    [5, 6, 1, 2, 3, 4, 0],
+    [5, 5, 1, 2, 3, 3, 0],
+    [0, 0, 0, 1, 0, 0, 0],
+    [-1, -1, -3, -2, 1, 0, 1],
+];
+for (let j = 0; j < testLoopCount; j++) {
+    for (let [a, b, c, d, e, g] of cases)
+        f_legit_chain(a, b, c, d, e, g);
+}
+// T2
+for (let [a, b, c, d, e, g, exp] of cases) {
+    let got = f_legit_chain(a, b, c, d, e, g);
+    if (got !== exp)
+        throw new Error("T2 regression: f_legit_chain(" + [a, b, c, d, e, g] + ") got " + got + " expected " + exp);
+}

--- a/JSTests/stress/watchpoint-async-generator-code-deletion.js
+++ b/JSTests/stress/watchpoint-async-generator-code-deletion.js
@@ -1,0 +1,30 @@
+//@ runDefault("--useDollarVM=1", "--useConcurrentJIT=0")
+
+async function sleepAsync(secs) {
+    return new Promise(resolve => setTimeout(resolve, secs * 1000.0));
+}
+
+async function main() {
+    let x = 1;
+
+    $vm.deleteAllCodeWhenIdle();
+    await sleepAsync(0.0);
+
+    function opt() {
+        return x;
+    }
+
+    for (let i = 0; i < testLoopCount; i++) {
+        opt();
+    }
+
+    x = 2;
+
+    if (opt() !== 2)
+        throw new Error("Expected 2, got " + opt());
+}
+
+main().then(undefined, e => {
+    print(e);
+    $vm.abort();
+});

--- a/JSTests/stress/watchpoint-closure-not-affected.js
+++ b/JSTests/stress/watchpoint-closure-not-affected.js
@@ -1,0 +1,29 @@
+//@ runDefault("--useDollarVM=1", "--useConcurrentJIT=0")
+
+async function sleepAsync(secs) {
+    return new Promise(resolve => setTimeout(resolve, secs * 1000.0));
+}
+
+async function test() {
+    var obj = (function() {
+        let x = 1;
+        function opt() { return x; }
+        return { opt, set(v) { x = v; } };
+    })();
+
+    $vm.deleteAllCodeWhenIdle();
+    await sleepAsync(0.0);
+
+    for (let i = 0; i < 1000; i++)
+        obj.opt();
+
+    obj.set(2);
+
+    if (obj.opt() !== 2)
+        throw new Error("Expected 2, got " + obj.opt());
+}
+
+test().then(undefined, e => {
+    print(e);
+    $vm.abort();
+});

--- a/JSTests/wasm/stress/br-on-cast-fail-overlong-leb128.js
+++ b/JSTests/wasm/stress/br-on-cast-fail-overlong-leb128.js
@@ -1,0 +1,75 @@
+"use strict";
+// Canonical and overlong LEB128 encodings of a GC sub-opcode must produce
+// identical execution semantics. This test checks that for br_on_cast_fail
+// with FLAGS=0x03 - divergence means IPInt is reading the flags byte from a
+// position the encoding moved.
+
+function uleb(n) { const o=[]; do { let b=n&0x7f; n>>>=7; if(n) b|=0x80; o.push(b); } while(n); return o; }
+function section(id, b) { return [id, ...uleb(b.length), ...b]; }
+function str(s) { return [s.length, ...Array.from(s, c => c.charCodeAt(0))]; }
+
+function buildModule(brOnCastFail) {
+    const typeSec = [
+        0x03,
+        0x5f, 0x00,                          // type 0: (struct)
+        0x60, 0x00, 0x00,                    // type 1: () -> void
+        0x60, 0x00, 0x01, 0x7f,              // type 2: () -> i32
+    ];
+    const funcSec = [0x02, 0x01, 0x02];
+    // global 0: (mut (ref null any)) init = (struct.new_default 0)
+    const globalSec = [0x01, 0x63, 0x6e, 0x01, 0xfb, 0x01, 0x00, 0x0b];
+    const exportSec = [
+        0x02,
+        ...str("poison"),      0x00, 0x00,
+        ...str("is_poisoned"), 0x00, 0x01,
+    ];
+    const poisonBody = [
+        0x00,
+        0x02, 0x63, 0x6e,                    // block (result (ref null any))
+            0xd0, 0x6e,                      //   ref.null any
+            ...brOnCastFail,                     //   br_on_cast_fail 0  (FLAGS=0x03 in either encoding)
+            0x1a,                            //   drop  (drops the (ref null 0) cast result)
+            0xfb, 0x01, 0x00,                //   struct.new_default 0
+            0x0c, 0x00,                      //   br 0
+        0x0b,
+        0x24, 0x00,                          // global.set 0
+        0x0b,
+    ];
+    const checkBody = [
+        0x00,
+        0x23, 0x00,                          // global.get 0
+        0xd1,                                // ref.is_null
+        0x0b,
+    ];
+    const codeSec = [
+        0x02,
+        ...uleb(poisonBody.length), ...poisonBody,
+        ...uleb(checkBody.length),  ...checkBody,
+    ];
+    return new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        ...section(1, typeSec),
+        ...section(3, funcSec),
+        ...section(6, globalSec),
+        ...section(7, exportSec),
+        ...section(10, codeSec),
+    ]);
+}
+
+//                       prefix sub-op            flags label ht1   ht2
+const CANONICAL = [0xfb, 0x19,            0x03, 0x00, 0x6e, 0x00];
+const OVERLONG  = [0xfb, 0x99,0x80,0x00,  0x03, 0x00, 0x6e, 0x00];
+
+const a = new WebAssembly.Instance(new WebAssembly.Module(buildModule(CANONICAL)));
+const b = new WebAssembly.Instance(new WebAssembly.Module(buildModule(OVERLONG)));
+
+a.exports.poison();
+b.exports.poison();
+
+const rA = a.exports.is_poisoned();
+const rB = b.exports.is_poisoned();
+
+if (rA !== rB)
+    throw new Error("LEB encoding of GC sub-opcode affects br_on_cast_fail semantics: "
+                    + "canonical=" + rA + " overlong=" + rB
+                    + " — IPInt reads flags from PC at hardcoded offset");

--- a/JSTests/wasm/stress/br-on-cast-overlong-leb128.js
+++ b/JSTests/wasm/stress/br-on-cast-overlong-leb128.js
@@ -1,0 +1,75 @@
+"use strict";
+// Canonical and overlong LEB128 encodings of a GC sub-opcode must produce
+// identical execution semantics. This test checks that for br_on_cast with
+// FLAGS=0x03 - divergence means IPInt is reading the flags byte from a
+// position the encoding moved.
+
+function uleb(n) { const o=[]; do { let b=n&0x7f; n>>>=7; if(n) b|=0x80; o.push(b); } while(n); return o; }
+function section(id, b) { return [id, ...uleb(b.length), ...b]; }
+function str(s) { return [s.length, ...Array.from(s, c => c.charCodeAt(0))]; }
+
+function buildModule(brOnCast) {
+    const typeSec = [
+        0x03,
+        0x5f, 0x00,                          // type 0: (struct)
+        0x60, 0x00, 0x00,                    // type 1: () -> void
+        0x60, 0x00, 0x01, 0x7f,              // type 2: () -> i32
+    ];
+    const funcSec = [0x02, 0x01, 0x02];
+    // global 0: (mut (ref null 0)) init = (struct.new_default 0)
+    const globalSec = [0x01, 0x63, 0x00, 0x01, 0xfb, 0x01, 0x00, 0x0b];
+    const exportSec = [
+        0x02,
+        ...str("poison"),      0x00, 0x00,
+        ...str("is_poisoned"), 0x00, 0x01,
+    ];
+    const poisonBody = [
+        0x00,
+        0x02, 0x63, 0x00,                    // block (result (ref null 0))
+            0xd0, 0x6e,                      //   ref.null any
+            ...brOnCast,                     //   br_on_cast 0  (FLAGS=0x03 in either encoding)
+            0x1a,                            //   drop
+            0xfb, 0x01, 0x00,                //   struct.new_default 0  (only reached if cast missed)
+            0x0c, 0x00,                      //   br 0
+        0x0b,
+        0x24, 0x00,                          // global.set 0
+        0x0b,
+    ];
+    const checkBody = [
+        0x00,
+        0x23, 0x00,                          // global.get 0
+        0xd1,                                // ref.is_null
+        0x0b,
+    ];
+    const codeSec = [
+        0x02,
+        ...uleb(poisonBody.length), ...poisonBody,
+        ...uleb(checkBody.length),  ...checkBody,
+    ];
+    return new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        ...section(1, typeSec),
+        ...section(3, funcSec),
+        ...section(6, globalSec),
+        ...section(7, exportSec),
+        ...section(10, codeSec),
+    ]);
+}
+
+//                       prefix sub-op            flags label ht1   ht2
+const CANONICAL = [0xfb, 0x18,            0x03, 0x00, 0x6e, 0x00];
+const OVERLONG  = [0xfb, 0x98,0x80,0x00,  0x03, 0x00, 0x6e, 0x00];
+
+const a = new WebAssembly.Instance(new WebAssembly.Module(buildModule(CANONICAL)));
+const b = new WebAssembly.Instance(new WebAssembly.Module(buildModule(OVERLONG)));
+
+a.exports.poison();
+b.exports.poison();
+
+const rA = a.exports.is_poisoned();
+const rB = b.exports.is_poisoned();
+
+if (rA !== rB)
+    throw new Error("LEB encoding of GC sub-opcode affects br_on_cast semantics: "
+                    + "canonical=" + rA + " overlong=" + rB
+                    + " — IPInt reads flags from PC at hardcoded offset");

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -79,6 +79,7 @@
 #include "B3WasmAddressValue.h"
 #include <wtf/IndexMap.h>
 #include <wtf/IndexSet.h>
+#include <wtf/Scope.h>
 #include <wtf/StdLibExtras.h>
 
 #if !ASSERT_ENABLED
@@ -2229,6 +2230,7 @@ private:
     };
 
 #if CPU(ARM64)
+
     static bool isComparisonOpcode(B3::Opcode opcode)
     {
         switch (opcode) {
@@ -2277,11 +2279,19 @@ private:
         }
     }
 
-    CompareChainNode* findCompareChain(Value* value, SegmentedVector<CompareChainNode>& nodes, Vector<CompareChainNode*, 16>& logicalNodes, Vector<Value*, 16> usedValues)
+    CompareChainNode* findCompareChain(Value* value, SegmentedVector<CompareChainNode>& nodes, Vector<CompareChainNode*, 16>& logicalNodes, Vector<Value*, 16>& usedValues)
     {
         dataLogLnIf(B3LowerToAirInternal::verbose, "    findCompareChain: nodes.size()=", nodes.size(), ", value=", pointerDump(value));
         if (!value)
             return nullptr;
+
+        // Roll back logicalNodes/usedValues unless rollback.release() is reached.
+        size_t savedLogicalSize = logicalNodes.size();
+        size_t savedUsedSize = usedValues.size();
+        auto rollback = makeScopeExit([&] {
+            logicalNodes.shrink(savedLogicalSize);
+            usedValues.shrink(savedUsedSize);
+        });
 
         B3::Opcode opcode = value->opcode();
         dataLogLnIf(B3LowerToAirInternal::verbose, "    findCompareChain: opcode=", opcode);
@@ -2308,6 +2318,7 @@ private:
                     dataLogLnIf(B3LowerToAirInternal::verbose, "    findCompareChain: applying negation to chain");
                     negatedChain->markRequiresNegation();
                     usedValues.append(value);
+                    rollback.release();
                     return negatedChain;
                 }
             }
@@ -2318,6 +2329,7 @@ private:
             node->relCond = relationalConditionForOpcode(opcode);
             dataLogLnIf(B3LowerToAirInternal::verbose, "    findCompareChain: created comparison node");
             usedValues.append(value);
+            rollback.release();
             return node;
         }
 
@@ -2335,6 +2347,9 @@ private:
 
             // Negation handling: detect (chain) == 0 pattern
             // This optimizes patterns like !(a && b) which become (a && b) == 0
+            //
+            // FIXME: is this guard reachable? value's children must have the same type, child(0) must be integral,
+            // unclear whether the recursive call to findCompareChain can return int64
             if (value->type() != Int32 && value->child(1)->isInt(1)) {
                 dataLogLnIf(B3LowerToAirInternal::verbose, "    findCompareChain: detected == 0 pattern, checking for negation");
                 CompareChainNode* negatedChain = findCompareChain(value->child(0), nodes, logicalNodes, usedValues);
@@ -2342,9 +2357,11 @@ private:
                     dataLogLnIf(B3LowerToAirInternal::verbose, "    findCompareChain: applying negation to chain");
                     negatedChain->markRequiresNegation();
                     usedValues.append(value);
+                    rollback.release();
                     return negatedChain;
                 }
             }
+            return nullptr;
         }
 
         // Check if this is a BitAnd or BitOr
@@ -2378,7 +2395,6 @@ private:
             // We don't allow combining two logic operations
             if (!leftNode->isComparison() && !rightNode->isComparison()) {
                 dataLogLnIf(B3LowerToAirInternal::verbose, "    findCompareChain: both children are logic ops, rejecting");
-                logicalNodes.clear();
                 return nullptr;
             }
 
@@ -2398,6 +2414,7 @@ private:
             logicalNodes.append(node);
             usedValues.append(value);
             dataLogLnIf(B3LowerToAirInternal::verbose, "    findCompareChain: created logic op node (", (opcode == BitAnd ? "AND" : "OR"), ")");
+            rollback.release();
             return node;
         }
 

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1438,5 +1438,6 @@ void testCCmpNegatedAnd32(int32_t, int32_t);
 void testCCmpNegatedOr32(int32_t, int32_t);
 void testCCmpMixedWidth32And64(int32_t, int64_t, int32_t);
 void testCCmpMixedWidth64And32(int64_t, int32_t);
+void testCCmpChainRollback(int32_t, int32_t, int32_t, int32_t, int32_t, int32_t);
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -1019,6 +1019,13 @@ void run(const TestConfig* config)
     RUN(testCCmpMixedWidth64And32(5000, 9));        // second doesn't match
     RUN(testCCmpMixedWidth64And32(4999, 10));       // first doesn't match
 
+    RUN(testCCmpChainRollback(5, 8, 5, 5, 5, 10)); // in-bounds, expected 1
+    RUN(testCCmpChainRollback(5, 8, 1, 2, 3, 4)); // inner expr non-zero, expected 0
+    RUN(testCCmpChainRollback(5, 8, 5, 5, 5, 5)); // inner expr non-zero (both eq), expected 0
+    RUN(testCCmpChainRollback(-1, 8, 5, 5, 5, 10)); // signed i<len, expected 1
+    RUN(testCCmpChainRollback(200, 8, 5, 5, 5, 10)); // i>=len; pre-fix wrongly returns 1
+    RUN(testCCmpChainRollback(5, 8, 5, 5, 5, -10)); // c>d, expected 1
+
     RUN_UNARY(testSShrCompare32, int32OperandsMore());
     RUN_UNARY(testSShrCompare64, int64OperandsMore());
 

--- a/Source/JavaScriptCore/b3/testb3_8.cpp
+++ b/Source/JavaScriptCore/b3/testb3_8.cpp
@@ -2660,6 +2660,43 @@ void testCCmpMixedWidth64And32(int64_t a, int32_t b)
     CHECK_EQ(compileAndRun<int32_t>(proc, a, b), expected);
 }
 
+// Regression for findCompareChain rollback: pre-fix, BitOr's BitXor-child
+// failure leaked an inner logic node, dropping LessThan from the chain.
+void testCCmpChainRollback(int32_t i, int32_t len, int32_t a, int32_t b, int32_t c, int32_t d)
+{
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* thenCase = proc.addBlock();
+    BasicBlock* elseCase = proc.addBlock();
+    auto arguments = cCallArgumentValues<int32_t, int32_t, int32_t, int32_t, int32_t, int32_t>(proc, root);
+
+    Value* iLtLen = root->appendNew<Value>(proc, LessThan, Origin(), arguments[0], arguments[1]);
+    Value* eqAB = root->appendNew<Value>(proc, Equal, Origin(), arguments[2], arguments[3]);
+    Value* eqCD = root->appendNew<Value>(proc, Equal, Origin(), arguments[4], arguments[5]);
+    Value* innerAnd = root->appendNew<Value>(proc, BitAnd, Origin(), eqAB, eqCD);
+    Value* xorAC = root->appendNew<Value>(proc, BitXor, Origin(), arguments[2], arguments[4]);
+    Value* outerOr = root->appendNew<Value>(proc, BitOr, Origin(), innerAnd, xorAC);
+    Value* eqZero = root->appendNew<Value>(proc, Equal, Origin(),
+        outerOr, root->appendNew<Const32Value>(proc, Origin(), 0));
+    Value* condition = root->appendNew<Value>(proc, BitAnd, Origin(), iLtLen, eqZero);
+
+    root->appendNewControlValue(
+        proc, Branch, Origin(), condition,
+        FrequentedBlock(thenCase), FrequentedBlock(elseCase));
+
+    thenCase->appendNewControlValue(
+        proc, Return, Origin(),
+        thenCase->appendNew<Const32Value>(proc, Origin(), 1));
+
+    elseCase->appendNewControlValue(
+        proc, Return, Origin(),
+        elseCase->appendNew<Const32Value>(proc, Origin(), 0));
+
+    int zero = 0; // style checker complains about == 0
+    int32_t expected = (i < len && ((((a == b) & (c == d)) | (a ^ c)) == zero)) ? 1 : 0;
+    CHECK_EQ(compileAndRun<int32_t>(proc, i, len, a, b, c, d), expected);
+}
+
 #endif // ENABLE(B3_JIT)
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -617,16 +617,29 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
                 if (bytecode.m_var != UINT_MAX) {
                     SymbolTable* symbolTable = jsCast<SymbolTable*>(getConstant(bytecode.m_symbolTableOrScopeDepth.symbolTable()));
                     const Identifier& ident = identifier(bytecode.m_var);
-                    ConcurrentJSLocker locker(symbolTable->m_lock);
-                    auto iter = symbolTable->find(locker, ident.impl());
-                    ASSERT(iter != symbolTable->end(locker));
-                    if (bytecode.m_getPutInfo.initializationMode() == InitializationMode::ScopedArgumentInitialization) {
-                        ASSERT(bytecode.m_value.isArgument());
-                        unsigned argumentIndex = bytecode.m_value.toArgument() - 1;
-                        symbolTable->prepareToWatchScopedArgument(iter->value, argumentIndex);
-                    } else
-                        iter->value.prepareToWatch();
-                    metadata.m_watchpointSet = iter->value.watchpointSet();
+                    {
+                        ConcurrentJSLocker locker(symbolTable->m_lock);
+                        auto iter = symbolTable->find(locker, ident.impl());
+                        ASSERT(iter != symbolTable->end(locker));
+                        if (bytecode.m_getPutInfo.initializationMode() == InitializationMode::ScopedArgumentInitialization) {
+                            ASSERT(bytecode.m_value.isArgument());
+                            unsigned argumentIndex = bytecode.m_value.toArgument() - 1;
+                            symbolTable->prepareToWatchScopedArgument(iter->value, argumentIndex);
+                        } else
+                            iter->value.prepareToWatch();
+                        metadata.m_watchpointSet = iter->value.watchpointSet();
+                    }
+                    // Generator and async function bodies can resume on a new CodeBlock after the
+                    // original is cleared (e.g. by deleteAllCode). The new CodeBlock's constant pool
+                    // holds a fresh SymbolTable clone, but the suspended activation still references
+                    // the original. Firing the metadata WatchpointSet via touch() at runtime would
+                    // notify watchers of the wrong SymbolTable. Pre-invalidate here so DFG treats
+                    // these captured variables as non-constant, matching ClosureVar semantics.
+                    if (metadata.m_watchpointSet
+                        && ownerExecutable->isFunctionExecutable()
+                        && isGeneratorOrAsyncFunctionBodyParseMode(jsCast<FunctionExecutable*>(ownerExecutable)->parseMode())) {
+                        metadata.m_watchpointSet->invalidate(vm, PutToScopeFireDetail(this, ident));
+                    }
                 } else
                     metadata.m_watchpointSet = nullptr;
                 break;

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -3585,9 +3585,7 @@ end)
 ipintOp(_br_on_cast, macro()
     validateOpcodeConfig(a1)
     loadi IPInt::RefTestCastMetadata::toHeapType[MC], a1
-    # fb 18 FLAGS
-    loadb 2[PC], a2
-    rshifti 1, a2  # bit 1 = null2
+    loadb IPInt::RefTestCastMetadata::allowNull[MC], a2
     loadq [sp], a3
     operationCall(macro() cCall3(_ipint_extern_ref_test) end)
 
@@ -3603,9 +3601,7 @@ end)
 ipintOp(_br_on_cast_fail, macro()
     validateOpcodeConfig(a1)
     loadi IPInt::RefTestCastMetadata::toHeapType[MC], a1
-    loadb 2[PC], a2
-    # fb 19 FLAGS
-    rshifti 1, a2  # bit 1 = null2
+    loadb IPInt::RefTestCastMetadata::allowNull[MC], a2
     loadq [sp], a3
     operationCall(macro() cCall3(_ipint_extern_ref_test) end)
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -1367,20 +1367,22 @@ IPIntGenerator::ExpressionType IPIntGenerator::addSIMDConstant(v128_t)
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addRefTest(ExpressionType, bool, int32_t heapType, bool, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addRefTest(ExpressionType, bool allowNull, int32_t heapType, bool, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::RefTestCastMetadata>({
         heapType,
-        static_cast<uint8_t>(getCurrentInstructionLength())
+        static_cast<uint8_t>(getCurrentInstructionLength()),
+        static_cast<uint8_t>(allowNull),
     });
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addRefCast(ExpressionType, bool, int32_t heapType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addRefCast(ExpressionType, bool allowNull, int32_t heapType, ExpressionType&)
 {
     m_metadata->appendMetadata<IPInt::RefTestCastMetadata>({
         heapType,
-        static_cast<uint8_t>(getCurrentInstructionLength())
+        static_cast<uint8_t>(getCurrentInstructionLength()),
+        static_cast<uint8_t>(allowNull),
     });
     return { };
 }
@@ -2660,11 +2662,12 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addBranchCast(ControlType& block, ExpressionType, Stack&, bool, int32_t heapType, bool)
+[[nodiscard]] PartialResult IPIntGenerator::addBranchCast(ControlType& block, ExpressionType, Stack&, bool allowNull, int32_t heapType, bool)
 {
     m_metadata->appendMetadata<IPInt::RefTestCastMetadata>({
         heapType,
-        0
+        0,
+        static_cast<uint8_t>(allowNull),
     });
 
     IPIntLocation here = { curPC(), curMC() };

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
@@ -356,6 +356,7 @@ struct ArrayInitElemMetadata {
 struct RefTestCastMetadata {
     int32_t toHeapType;
     uint8_t length;
+    uint8_t allowNull;
 };
 
 #pragma pack()


### PR DESCRIPTION
#### 71731a79be7f75a85ab7f76e2e5b79bccbbaa6a4
<pre>
Cherry-pick 305413.1026@safari-7624.5.1.10-branch (1af72a6f5454). <a href="https://bugs.webkit.org/show_bug.cgi?id=313499">https://bugs.webkit.org/show_bug.cgi?id=313499</a>

    Pre-invalidate captured-variable WatchpointSets in generator and async function bodies
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313499">https://bugs.webkit.org/show_bug.cgi?id=313499</a>
    <a href="https://rdar.apple.com/173777534">rdar://173777534</a>

    Reviewed by Yusuke Suzuki.

    When deleteAllCode runs while an async generator is suspended, the generator
    body&apos;s CodeBlock is cleared and later re-created from re-parsed source. The
    new CodeBlock&apos;s constant pool gets a fresh SymbolTable clone with fresh
    WatchpointSets, but the suspended activation still references the original.
    A subsequent ResolvedClosureVar put_to_scope on the new CodeBlock fires
    touch() against the fresh clone&apos;s WatchpointSet, which the DFG is not
    watching, so DFG code that constant-folded the captured variable never
    deoptimizes and returns stale values.

    Treat ResolvedClosureVar writes inside suspendable bodies the same way
    ClosureVar writes are already treated: invalidate the WatchpointSet at
    link time. Sibling closures using ClosureVar already pay this cost;
    extending it to the declaring function eliminates the only remaining
    runtime path that relies on SymbolTable identity across re-link.

    Tests: JSTests/stress/watchpoint-async-generator-code-deletion.js
           JSTests/stress/watchpoint-closure-not-affected.js

    * JSTests/stress/watchpoint-async-generator-code-deletion.js: Added.
    (async sleepAsync):
    (async main.opt):
    (async main):
    * JSTests/stress/watchpoint-closure-not-affected.js: Added.
    (async sleepAsync):
    (async test.):
    (async test.obj):
    * Source/JavaScriptCore/bytecode/CodeBlock.cpp:
    (JSC::CodeBlock::finishCreation):

    Identifier: 305413.1026@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1161@webkitglib/2.52">https://commits.webkit.org/305877.1161@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 4185bc0d49f8bd79d0c2eebeed87a5ece28ca05d
<pre>
Cherry-pick 305413.1025@safari-7624.5-branch (5b76326e8fc9). <a href="https://bugs.webkit.org/show_bug.cgi?id=317349">https://bugs.webkit.org/show_bug.cgi?id=317349</a>

    IPInt br_on_cast/br_on_cast_fail must handle overlong LEB128 opcode
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317349">https://bugs.webkit.org/show_bug.cgi?id=317349</a>
    <a href="https://rdar.apple.com/178289134">rdar://178289134</a>

    Reviewed by Yusuke Suzuki.

    Currently IPInt implementations of br_on_cast/br_on_cast_fail assume
    flags are at a fixed offset in the instruction but overlong opcodes
    are legal and IPInt may use the wrong byte to load flags. This patch
    makes the validator cache allowNull in metadata so IPInt no longer
    loads from the instruction stream at all.

    Tests: JSTests/wasm/stress/br-on-cast-fail-overlong-leb128.js
           JSTests/wasm/stress/br-on-cast-overlong-leb128.js

    * JSTests/wasm/stress/br-on-cast-fail-overlong-leb128.js: Added.
    (uleb):
    (section):
    (str):
    * JSTests/wasm/stress/br-on-cast-overlong-leb128.js: Added.
    (uleb):
    (section):
    (str):
    * Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
    * Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
    (JSC::Wasm::IPIntGenerator::addRefTest):
    (JSC::Wasm::IPIntGenerator::addRefCast):
    (JSC::Wasm::IPIntGenerator::addBranchCast):
    * Source/JavaScriptCore/wasm/WasmIPIntGenerator.h:

    Identifier: 305413.1025@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1160@webkitglib/2.52">https://commits.webkit.org/305877.1160@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 48a4516616c36fdebf59645f93c14b0a3f9d0914
<pre>
Cherry-pick 305413.1024@safari-7624.5.1.10-branch (7e01f14f8eb7). <a href="https://bugs.webkit.org/show_bug.cgi?id=315389">https://bugs.webkit.org/show_bug.cgi?id=315389</a>

    Make B3 ccmp chain matcher use RAII
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315389">https://bugs.webkit.org/show_bug.cgi?id=315389</a>
    <a href="https://rdar.apple.com/176792415">rdar://176792415</a>

    Reviewed by Keith Miller.

    B3 ccmp chain matcher needs to roll back if a given pattern match fails
    part way through. RAII is a more principled and less error prone way to
    handle this.

    Test: JSTests/stress/b3-ccmp-chain.js

    * JSTests/stress/b3-ccmp-chain.js: Added.
    (f):
    (f_legit_chain):
    * Source/JavaScriptCore/b3/B3LowerToAir.cpp:
    * Source/JavaScriptCore/b3/testb3.h:
    * Source/JavaScriptCore/b3/testb3_1.cpp:
    (run):
    * Source/JavaScriptCore/b3/testb3_8.cpp:
    (testCCmpChainRollback):

    Identifier: 305413.1024@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1159@webkitglib/2.52">https://commits.webkit.org/305877.1159@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0268b0def0c550721916c59c9b1b2a8adb588d2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185426 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59338 "The change is no longer eligible for processing.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53155 "Build is in progress. Recent messages:") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195750 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150201 "The change is no longer eligible for processing.") 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60703 "Build is in progress. Recent messages:") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59065 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144911 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150201 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188381 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/60703 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/53155 "Build is in progress. Recent messages:") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125203 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/60703 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59065 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7108 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/53155 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/60703 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/53155 "Build is in progress. Recent messages:") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6801 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/46683 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/51994 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59065 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197698 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59002 "The change is no longer eligible for processing.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/53155 "Build is in progress. Recent messages:") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154439 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59711 "The change is no longer eligible for processing.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/53155 "Build is in progress. Recent messages:") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154075 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28156 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59711 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132046 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/128909 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58189 "The change is no longer eligible for processing.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/53155 "Build is in progress. Recent messages:") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57561 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57804 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57628 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->