### PR TITLE
Cherry-pick 305413.1072@safari-7624.5.1.10-branch (34249048d66d). https://bugs.webkit.org/show_bug.cgi?id=318405

### DIFF
--- a/LayoutTests/fast/images/image-load-event-in-modal-dialog-crash-expected.txt
+++ b/LayoutTests/fast/images/image-load-event-in-modal-dialog-crash-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Window 'showModalDialog' function is deprecated and will be removed soon.
+CONSOLE MESSAGE: showModalDialog() is deprecated and will be removed. Please use the <dialog> element instead.
+PASS if no crash.

--- a/LayoutTests/fast/images/image-load-event-in-modal-dialog-crash.html
+++ b/LayoutTests/fast/images/image-load-event-in-modal-dialog-crash.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] --><!DOCTYPE html>
+<html>
+<body>
+<div id="host" style="display:none"></div>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+if (window.internals)
+    internals.setCanShowModalDialogOverride(true);
+
+var host = document.getElementById('host');
+var sr = host.attachShadow({mode: 'open'});
+sr.innerHTML = '<picture id="pic"><source srcset="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"><img></picture>';
+var pic = sr.getElementById('pic');
+
+pic.addEventListener('load', function listener() {
+    pic.removeEventListener('load', listener, true);
+    // Removing the <img> from its <picture> re-enters ImageLoader::updatedHasPendingEvent()
+    // and arms m_derefElementTimer.
+    pic.textContent = '';
+    // showModalDialog spins a nested run loop which fires m_derefElementTimer, dropping
+    // m_protectedElement while ImageLoader::dispatchPendingLoadEvent() is still on the stack.
+    showModalDialog('resources/self-closing-modal-dialog.html');
+
+    // The trailing updatedHasPendingEvent() (the crash point) runs after this handler
+    // returns, so finish on the next task rather than waiting a fixed delay.
+    setTimeout(function() {
+        document.write('PASS if no crash.');
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+}, /*capture*/ true);
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/images/resources/self-closing-modal-dialog.html
+++ b/LayoutTests/fast/images/resources/self-closing-modal-dialog.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script>
+setTimeout(function() {
+    if (window.testRunner)
+        testRunner.abortModal();
+    window.close();
+}, 10);
+</script>

--- a/LayoutTests/svg/animations/smil-seek-huge-repeat-count-crash-expected.txt
+++ b/LayoutTests/svg/animations/smil-seek-huge-repeat-count-crash-expected.txt
@@ -1,0 +1,3 @@
+Passes if it does not crash.
+
+

--- a/LayoutTests/svg/animations/smil-seek-huge-repeat-count-crash.html
+++ b/LayoutTests/svg/animations/smil-seek-huge-repeat-count-crash.html
@@ -1,0 +1,14 @@
+<body>
+    <p>Passes if it does not crash.</p>
+    <svg id="svg">
+        <rect width="100" height="100" fill="green">
+            <animate attributeName="x" from="0" to="10" dur="0.0001s" repeatCount="indefinite"/>
+        </rect>
+    </svg>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        svg.setCurrentTime(400000);
+    </script>
+</body>

--- a/LayoutTests/webaudio/mediaelementsource-clear-detached-frame-expected.txt
+++ b/LayoutTests/webaudio/mediaelementsource-clear-detached-frame-expected.txt
@@ -1,0 +1,10 @@
+Test that removing an iframe whose <audio> is connected as a MediaElementAudioSourceNode in the parent document does not crash, even if the audio render thread is mid-render when HTMLMediaElement::clearMediaPlayer() runs.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Did not crash after detaching iframe whose audio element is connected to a MediaElementAudioSourceNode.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webaudio/mediaelementsource-clear-detached-frame.html
+++ b/LayoutTests/webaudio/mediaelementsource-clear-detached-frame.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<head>
+    <script src="../resources/js-test.js"></script>
+    <script>
+        function runTest()
+        {
+            description("Test that removing an iframe whose &lt;audio&gt; is connected as a MediaElementAudioSourceNode in the parent document does not crash, even if the audio render thread is mid-render when HTMLMediaElement::clearMediaPlayer() runs.");
+            jsTestIsAsync = true;
+
+            const context = new AudioContext({ sampleRate: 44100 });
+
+            const frame = document.createElement("iframe");
+            frame.src = "resources/mediaelementsource-clear-detached-frame-iframe.html";
+            frame.onload = async function() {
+                const audio = frame.contentDocument.querySelector("audio");
+                const source = context.createMediaElementSource(audio);
+                source.connect(context.destination);
+                audio.play().catch(() => { });
+
+                await new Promise(resolve => setTimeout(resolve, 200));
+
+                frame.remove();
+
+                setTimeout(function() {
+                    testPassed("Did not crash after detaching iframe whose audio element is connected to a MediaElementAudioSourceNode.");
+                    finishJSTest();
+                }, 100);
+            };
+            document.body.appendChild(frame);
+        }
+    </script>
+</head>
+<body onload="runTest()">
+</body>

--- a/LayoutTests/webaudio/resources/mediaelementsource-clear-detached-frame-iframe.html
+++ b/LayoutTests/webaudio/resources/mediaelementsource-clear-detached-frame-iframe.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <audio src="media/24bit-22khz.wav" loop></audio>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6717,7 +6717,7 @@ void HTMLMediaElement::userCancelledLoad()
     updateActiveTextTrackCues(MediaTime::zeroTime());
 }
 
-void HTMLMediaElement::clearMediaPlayer()
+void HTMLMediaElement::clearMediaPlayer() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
     invalidateWatchtimeTimer();
     invalidateBufferingStopwatch();
@@ -6757,6 +6757,12 @@ void HTMLMediaElement::clearMediaPlayer()
     }
 
     if (RefPtr player = m_player) {
+#if ENABLE(WEB_AUDIO)
+        RefPtr audioSourceNode = m_audioSourceNode.get();
+        std::optional<Locker<Lock>> audioSourceNodeLocker;
+        if (audioSourceNode)
+            audioSourceNodeLocker.emplace(audioSourceNode->processLock());
+#endif
         player->invalidate();
         m_player = nullptr;
     }

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -676,7 +676,8 @@ void ImageLoader::dispatchPendingLoadEvent()
     if (!m_image)
         return;
     m_hasPendingLoadEvent = false;
-    if (element().document().hasLivingRenderTree())
+    Ref protectedElement = element();
+    if (protectedElement->document().hasLivingRenderTree())
         dispatchLoadEvent();
 
     // Only consider updating the protection ref-count of the Element immediately before returning
@@ -690,8 +691,9 @@ void ImageLoader::dispatchPendingErrorEvent()
         return;
     m_hasPendingErrorEvent = false;
     loadEventSender().cancelEvent(*this, eventNames().errorEvent);
-    if (element().document().hasLivingRenderTree())
-        protectedElement()->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
+    Ref protectedElement = element();
+    if (protectedElement->document().hasLivingRenderTree())
+        protectedElement->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
 
     // Only consider updating the protection ref-count of the Element immediately before returning
     // from this function as doing so might result in the destruction of this ImageLoader.

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -1066,12 +1066,13 @@ float SVGSMILElement::calculateAnimationPercentAndRepeat(SMILTime elapsed, unsig
     SMILTime activeTime = elapsed - m_intervalBegin;
     SMILTime repeatingDuration = this->repeatingDuration();
 
+    // Clamp the page-controlled repeat count to prevent overflow.
     if ((elapsed >= m_intervalEnd && !repeatingDuration.isIndefinite()) || activeTime > repeatingDuration) {
-        repeat = static_cast<unsigned>(repeatingDuration.value() / simpleDuration.value());
-        if (!fmod(repeatingDuration.value(), simpleDuration.value()))
+        repeat = clampTo<unsigned>(repeatingDuration.value() / simpleDuration.value());
+        if (repeat && !fmod(repeatingDuration.value(), simpleDuration.value()))
             --repeat;
     } else
-        repeat = static_cast<unsigned>(activeTime.value() / simpleDuration.value());
+        repeat = clampTo<unsigned>(activeTime.value() / simpleDuration.value());
 
     double percent;
     if (elapsed >= m_intervalEnd || activeTime > repeatingDuration) {
@@ -1204,16 +1205,9 @@ bool SVGSMILElement::progress(SMILTime elapsed, SVGSMILElement& firstAnimation, 
         if (m_activeState == Inactive || m_activeState == Frozen)
             smilEventSender().dispatchEventSoon(*this, eventNames().endEventEvent);
 
-        if (repeat) {
-            // We intentionally dispatch repeat - 1 events here because the first repeat
-            // event (for the initial loop) is sent elsewhere during continuous animation run.
-            // If repeat == 1, no events are dispatched here.
-            for (unsigned i = 0; i < repeat - 1; ++i)
-                smilEventSender().dispatchEventSoon(*this, eventNames().repeatEventEvent);
-
-            if (m_activeState == Inactive)
-                smilEventSender().dispatchEventSoon(*this, eventNames().repeatEventEvent);
-        }
+        // Coalesce the skipped repeat iterations into a single event instead of one per interval.
+        if (repeat > 1 || (repeat && m_activeState == Inactive))
+            smilEventSender().dispatchEventSoon(*this, eventNames().repeatEventEvent);
     }
 
     m_nextProgressTime = calculateNextProgressTime(elapsed);


### PR DESCRIPTION
#### c17624be28184aa80c2bcde10e85ecd38c544e57
<pre>
Cherry-pick 305413.1072@safari-7624.5.1.10-branch (34249048d66d). <a href="https://bugs.webkit.org/show_bug.cgi?id=318405">https://bugs.webkit.org/show_bug.cgi?id=318405</a>

    Clamp repeat count for SVG animation.
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318405">https://bugs.webkit.org/show_bug.cgi?id=318405</a>
    &lt;<a href="https://rdar.apple.com/176471329">rdar://176471329</a>&gt;

    Reviewed by Said Abou-Hallawa.

    This PR tightens the fix in 301404@main by clamping the repeat count to
    an upper bound to prevent overflow.

    Also coalesce the repeat events dispatched while seeking: rather than firing
    one repeatEvent per skipped interval, dispatch a single repeatEvent. SVG 1.1
    Animation defines a repeatEvent as raised each time the element repeats on a
    normally-advancing timeline; how many events a discontinuous seek replays for
    the intervals it skips is left to SMIL Animation&apos;s timing model, which does not
    require one event per skipped interval (see also the WPT seeking-events-* tests).

    * LayoutTests/svg/animations/smil-seek-huge-repeat-count-crash-expected.txt: Added.
    * LayoutTests/svg/animations/smil-seek-huge-repeat-count-crash.html: Added.
    * Source/WebCore/svg/animation/SVGSMILElement.cpp:
    (WebCore::SVGSMILElement::calculateAnimationPercentAndRepeat const):
    (WebCore::SVGSMILElement::progress):

    Identifier: 305413.1072@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1164@webkitglib/2.52">https://commits.webkit.org/305877.1164@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 7280d8374096d29d1a98724e5dbaa83d5a90d114
<pre>
Cherry-pick 305413.1065@safari-7624.5.1.10-branch (e186258f7967). <a href="https://bugs.webkit.org/show_bug.cgi?id=315989">https://bugs.webkit.org/show_bug.cgi?id=315989</a>

    Use-after-free in MediaElementAudioSourceNode::provideInput when iframe is detached
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315989">https://bugs.webkit.org/show_bug.cgi?id=315989</a>
    <a href="https://rdar.apple.com/175673159">rdar://175673159</a>

    Reviewed by Chris Dumez.

    HTMLMediaElement::clearMediaPlayer() resets m_player on the main thread without holding
    m_audioSourceNode-&gt;processLock(), but the audio render thread reads m_player via
    audioSourceProvider() inside MediaElementAudioSourceNode::process() while holding that lock.
    Because audioSourceProvider() returns a raw AudioSourceProvider* and drops its local
    RefPtr&lt;MediaPlayer&gt; on return, and MediaPlayer is DestructionThread::Main, the main thread can
    synchronously run ~MediaPlayer (destroying the RemoteAudioSourceProvider) while the render thread
    is still inside provideInput() with the now-dangling pointer.

    This is reachable from HTMLMediaElement::stop() (ActiveDOMObject stop on iframe detach) and
    userCancelledLoad().

    Match the contract already enforced by createMediaPlayer() and
    mediaPlayerWill/DidInitializeMediaEngine() by holding the audio node&apos;s processLock around
    player-&gt;invalidate() / m_player = nullptr in clearMediaPlayer(). process() acquires the same lock
    with tryLock(), so this cannot deadlock — the render thread will simply zero its output for one
    quantum while the main thread tears down.

    Test: webaudio/mediaelementsource-clear-detached-frame.html

    * LayoutTests/webaudio/mediaelementsource-clear-detached-frame-expected.txt: Added.
    * LayoutTests/webaudio/mediaelementsource-clear-detached-frame.html: Added.
    * LayoutTests/webaudio/resources/mediaelementsource-clear-detached-frame-iframe.html: Added.
    * Source/WebCore/html/HTMLMediaElement.cpp:
    (WebCore::HTMLMediaElement::clearMediaPlayer): Deleted.

    Identifier: 305413.1065@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1163@webkitglib/2.52">https://commits.webkit.org/305877.1163@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 5fea7e741ef8416c7f708c786038135e3718440c
<pre>
Cherry-pick 305413.1064@safari-7624.5.1.10-branch (fe774071a22a). <a href="https://bugs.webkit.org/show_bug.cgi?id=318348">https://bugs.webkit.org/show_bug.cgi?id=318348</a>

    [WebCore] Use-after-free in ImageLoader::dispatchPendingLoadEvent / dispatchPendingErrorEvent
    <a href="https://rdar.apple.com/177909775">rdar://177909775</a>

    Reviewed by Alan Baradlay.

    dispatchPendingLoadEvent() and dispatchPendingErrorEvent() dispatch author script and then
    touch `this` again via updatedHasPendingEvent(). The only thing keeping the element alive
    across the dispatch is a full-expression-scoped Ref plus the m_protectedElement member, and
    the 0s m_derefElementTimer can clear that member. A load handler can re-arm the timer by
    removing the &lt;img&gt; from its &lt;picture&gt; (selectImageSource(RelevantMutation::Yes) calls
    updatedHasPendingEvent()), then spin a nested run loop via showModalDialog(). The timer
    fires and drops m_protectedElement while the dispatch is still on the stack. When the
    dispatch returns the temporary Ref destructs as the last reference, ~HTMLImageElement frees
    the loader via its unique_ptr&lt;HTMLImageLoader&gt;, and the trailing updatedHasPendingEvent()
    runs on freed `this`.

    Hold a stack Ref to the element across the dispatch and the trailing updatedHasPendingEvent()
    in both functions. The loader is owned by the element, so keeping the element alive keeps
    this ImageLoader alive.

    Test: fast/images/image-load-event-in-modal-dialog-crash.html

    * LayoutTests/fast/images/image-load-event-in-modal-dialog-crash-expected.txt: Added.
    * LayoutTests/fast/images/image-load-event-in-modal-dialog-crash.html: Added.
    * LayoutTests/fast/images/resources/self-closing-modal-dialog.html: Added.
    * Source/WebCore/loader/ImageLoader.cpp:
    (WebCore::ImageLoader::dispatchPendingLoadEvent):
    (WebCore::ImageLoader::dispatchPendingErrorEvent):

    Identifier: 305413.1064@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1162@webkitglib/2.52">https://commits.webkit.org/305877.1162@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfc621a7c11e36e185bda4bbc5976a751dce7da0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185496 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59408 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53225 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195820 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150255 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187358 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60773 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59135 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144960 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150255 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188451 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60773 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53225 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125252 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60773 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59135 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53225 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60773 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53225 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6870 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52064 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59135 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197768 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59072 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53225 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154484 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59781 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53225 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154133 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28157 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59781 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132127 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129013 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58258 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53225 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57630 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57873 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57696 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->