### PR TITLE
[WebDriver] Add Cookie drops the cookie when the request has no sameSite attribute

### DIFF
--- a/Source/WebDriver/Session.cpp
+++ b/Source/WebDriver/Session.cpp
@@ -2757,7 +2757,7 @@ static Ref<JSON::Object> builtAutomationCookie(const Session::Cookie& cookie)
     cookieObject->setBoolean("httpOnly"_s, cookie.httpOnly.value_or(false));
     cookieObject->setBoolean("session"_s, !cookie.expiry);
     cookieObject->setDouble("expires"_s, cookie.expiry.value_or(0));
-    cookieObject->setString("sameSite"_s, cookie.sameSite.value_or("None"_s));
+    cookieObject->setString("sameSite"_s, cookie.sameSite.value_or("Lax"_s));
     return cookieObject;
 }
 

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -388,22 +388,6 @@
             }
         }
     },
-    "imported/selenium/py/test/selenium/webdriver/common/cookie_tests.py": {
-        "subtests": {
-            "test_add_cookie": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-            },
-            "test_get_all_cookies": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-            },
-            "test_should_not_delete_cookies_with_asimilar_name": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-            },
-            "test_delete_cookie_raises_value_error_for_empty_name": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-            }
-        }
-    },
 
     "imported/selenium/py/test/selenium/webdriver/common/element_attribute_tests.py": {
         "subtests": {
@@ -668,56 +652,11 @@
                 }
             }
 
-
-        }
-    },
-
-    "imported/w3c/webdriver/tests/classic/add_cookie/user_prompts.py": {
-        "subtests": {
-            "test_accept[alert-None]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-            },
-            "test_accept[confirm-True]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-            },
-            "test_accept[prompt-]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-            },
-            "test_dismiss[alert-None]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-            },
-            "test_dismiss[confirm-False]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-            },
-            "test_dismiss[prompt-None]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-            }
         }
     },
 
     "imported/w3c/webdriver/tests/classic/add_cookie/add.py": {
         "subtests": {
-            "test_add_cookie_with_expiry_in_the_future": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-            },
-            "test_add_cookie_for_ip": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-            },
-            "test_add_cookie_with_valid_samesite_flag[None]": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-            },
-            "test_add_domain_cookie": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-            },
-            "test_add_session_cookie": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-            },
-            "test_add_session_cookie_with_leading_dot_character_in_domain": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-            },
-            "test_add_non_session_cookie": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-            },
             "test_cookie_unsupported_scheme[about]": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/230616"}}
             },
@@ -775,14 +714,6 @@
                 "expected": {"wpe": {"status": ["PASS"], "bug": "webkit.org/b/212950"}}
             }
         }
-    },
-
-    "imported/w3c/webdriver/tests/classic/delete_all_cookies/user_prompts.py": {
-        "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
-    },
-
-    "imported/w3c/webdriver/tests/classic/delete_cookie/user_prompts.py": {
-        "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
     },
 
     "imported/w3c/webdriver/tests/classic/forward/forward.py": {
@@ -2051,10 +1982,6 @@
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/182330"}}
             }
         }
-    },
-
-    "imported/w3c/webdriver/tests/classic/get_named_cookie/user_prompts.py": {
-        "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/279079"}}
     },
 
     "imported/w3c/webdriver/tests/classic/element_clear/clear.py": {


### PR DESCRIPTION
#### d5be61fee14a830023a971b2621e47051a9e78ef
<pre>
[WebDriver] Add Cookie drops the cookie when the request has no sameSite attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=323634">https://bugs.webkit.org/show_bug.cgi?id=323634</a>

Reviewed by Carlos Garcia Campos.

The sameSite field is optional in the Add Cookie command, but the sameSite
member of the Automation protocol Cookie type is mandatory, so the driver has
to fill it in when the client omits it, and it filled it in with None. That
is not the same thing as having no SameSite attribute: a cookie with
SameSite=None is only accepted when it is also Secure, and libsoup enforces
that when the cookie is added to the jar, whatever the origin is. The jar
quietly discards the cookie, the command still answers success, and the
cookie is then in neither the page nor the network session.

A cookie set by a page without a SameSite attribute behaves as Lax, which is
also libsoup&apos;s own default for a cookie parsed without the attribute, so use
Lax as the default here too instead of None.

This is what bug 279079 was tracking: 70 of its subtests pass now, in
add_cookie, in the user prompt tests of add_cookie, delete_cookie,
delete_all_cookies and get_named_cookie, which all add a cookie before
checking the prompt, and in the imported selenium cookie tests. The remaining
expectation of that bug,
add_cookie/add.py::test_add_cookie_with_valid_samesite_flag[None], passes
without this change as well and is removed as an outdated expectation.

* Source/WebDriver/Session.cpp:
(WebDriver::builtAutomationCookie):
* WebDriverTests/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/320916@main">https://commits.webkit.org/320916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a4ed9e4bb88b67cbeaa71c46d5689a51b88bd6b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195755 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150205 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144908 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100457 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165493 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125200 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47316 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45373 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157683 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45065 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6806 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/51999 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197703 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59007 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154426 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41555 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59716 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41670 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154076 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48559 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132051 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128916 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58194 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20087 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57566 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57809 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57633 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->