### PR TITLE
getImageData should return the requested color space even for fingerprinters

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2656,21 +2656,20 @@ ExceptionOr<Ref<ImageData>> CanvasRenderingContext2DBase::getImageData(int sx, i
     IntRect imageDataRect { sx, sy, sw, sh };
     auto outputImageDataPixelFormat = settings ? settings->pixelFormat : ImageDataPixelFormat::RgbaUnorm8;
     auto outputPixelFormat = toPixelFormat(outputImageDataPixelFormat);
+    auto computedColorSpace = ImageData::computeColorSpace(settings, m_settings.colorSpace);
 
     if (scriptContext && scriptContext->requiresScriptTrackingPrivacyProtection(ScriptTrackingPrivacyCategory::Canvas)) {
         RefPtr buffer = protect(canvasBase())->createImageForNoiseInjection();
         if (!buffer)
             return Exception { ExceptionCode::InvalidStateError };
 
-        auto format = PixelBufferFormat { AlphaPremultiplication::Unpremultiplied, outputPixelFormat, buffer->colorSpace() };
+        auto format = PixelBufferFormat { AlphaPremultiplication::Unpremultiplied, outputPixelFormat, toColorSpace(computedColorSpace, allowExtendedColorSpace(outputPixelFormat)) };
         RefPtr pixelBuffer = dynamicDowncast<ArrayPixelBuffer>(buffer->getPixelBuffer(format, imageDataRect));
         if (!pixelBuffer)
             return Exception { ExceptionCode::InvalidStateError };
 
         return { { ImageData::create(pixelBuffer.releaseNonNull(), outputImageDataPixelFormat) } };
     }
-
-    auto computedColorSpace = ImageData::computeColorSpace(settings, m_settings.colorSpace);
 
     if (outputImageDataPixelFormat == ImageDataPixelFormat::RgbaUnorm8) {
         if (auto imageData = makeImageDataIfContentsCached(imageDataRect, outputPixelFormat, computedColorSpace))

--- a/Tools/TestWebKitAPI/Resources/cocoa/canvas-fingerprinting.js
+++ b/Tools/TestWebKitAPI/Resources/cocoa/canvas-fingerprinting.js
@@ -149,3 +149,14 @@ async function fullCanvasHash(data) {
         data = fullTextCanvasImageData();
     return await digestMessage(data.data);
 }
+
+function getImageDataColorSpace(colorSpace) {
+    let canvas = document.createElement("canvas");
+    canvas.width = 10;
+    canvas.height = 10;
+    document.body.appendChild(canvas);
+    let ctx = canvas.getContext("2d", { colorSpace: colorSpace });
+    ctx.fillStyle = "green";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    return ctx.getImageData(0, 0, canvas.width, canvas.height, { colorSpace: colorSpace }).colorSpace;
+}

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScriptTrackingPrivacyTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScriptTrackingPrivacyTests.mm
@@ -368,6 +368,24 @@ TEST(ScriptTrackingPrivacyTests, Canvas2D)
         NSLog(@"FAIL: Expected hashes to be different: %@", [hashes firstObject]);
 }
 
+TEST(ScriptTrackingPrivacyTests, Canvas2DColorSpace)
+{
+    if (!supportsFingerprintingScriptRequests())
+        return;
+
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
+
+    RetainPtr webView = setUpWebViewForFingerprintingTests(@"test://top-domain.org/index.html", @{
+        @"test://top-domain.org/index.html" : simpleIndexHTML.createNSString().autorelease(),
+        @"test://top-domain.org/script.js" : getBundleResourceAsText(@"canvas-fingerprinting", @"js"),
+        @"test://pure.com/script.js" : @"window.colorSpaceForPureScript = getImageDataColorSpace('display-p3');",
+        @"test://tainted.example/script.js" : @"window.colorSpaceForTaintedScript = getImageDataColorSpace('display-p3');",
+    });
+
+    EXPECT_WK_STREQ("display-p3", [webView stringByEvaluatingJavaScript:@"window.colorSpaceForPureScript"]);
+    EXPECT_WK_STREQ("display-p3", [webView stringByEvaluatingJavaScript:@"window.colorSpaceForTaintedScript"]);
+}
+
 TEST(ScriptTrackingPrivacyTests, AudioSamples)
 {
     if (!supportsFingerprintingScriptRequests())


### PR DESCRIPTION
#### 587e3a7c563e482a45c3b186d9d5f093aadfb4a8
<pre>
getImageData should return the requested color space even for fingerprinters
<a href="https://bugs.webkit.org/show_bug.cgi?id=323637">https://bugs.webkit.org/show_bug.cgi?id=323637</a>
<a href="https://rdar.apple.com/183595301">rdar://183595301</a>

Reviewed by Mike Wyrzykowski.

The anti privacy tracking branch of getImageData() was always returning
an sRGB ImageData, which is against specs and therefore could be used as
a fingerprint datapoint.
Fixed by hoisting the existing ImageData::computeColorSpace() calculation
above the noise-injection branch and using it for the noise path&apos;s
PixelBufferFormat, matching what the normal (non-noise) path already
does.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::getImageData const):
* Tools/TestWebKitAPI/Resources/cocoa/canvas-fingerprinting.js:
(getImageDataColorSpace):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ScriptTrackingPrivacyTests.mm:
(TestWebKitAPI::(ScriptTrackingPrivacyTests, Canvas2DColorSpace)):

Canonical link: <a href="https://commits.webkit.org/320638@main">https://commits.webkit.org/320638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a06c7c4837c50d686d400539342febed0eb10c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195761 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150208 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/116940f8-c2b1-44bf-8d03-5620f04ea931) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187299 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144914 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100461 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b498757c-56ff-46d9-a2d5-f74bf81ad040) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165499 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125206 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b44ca848-d6e6-4e42-84ea-06930f6048b7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47324 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45379 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157691 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45071 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6812 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52005 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197709 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59013 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154433 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41353 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59722 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41676 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154083 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48564 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132059 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128930 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58200 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20093 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57572 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57815 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57639 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->