### PR TITLE
CoreIPCSecTrust::createSecTrust() inserts nil into an NSMutableDictionary for an empty CoreIPCData

### DIFF
--- a/LayoutTests/ipc/cocoa/sectrust-null-data-crash-expected.txt
+++ b/LayoutTests/ipc/cocoa/sectrust-null-data-crash-expected.txt
@@ -1,0 +1,2 @@
+This test passes if WebKit does not crash.
+PASS

--- a/LayoutTests/ipc/cocoa/sectrust-null-data-crash.html
+++ b/LayoutTests/ipc/cocoa/sectrust-null-data-crash.html
@@ -1,0 +1,109 @@
+<!doctype html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=true ] -->
+<html>
+<head>
+<script>
+// CoreIPCSecTrust::createSecTrust() turns the decoded CoreIPCSecTrustData back into the
+// property list that SecTrustCreateFromPropertyListRepresentation() expects. A CoreIPCData
+// decoded from a disengaged std::optional<std::span<const uint8_t>> has no bytes, so its
+// toID() is nil, and inserting nil into an NSMutableDictionary raises an uncaught
+// NSInvalidArgumentException. Every field below is attacker controlled, so the receiving
+// process has to reject such a trust object instead of crashing.
+
+const nullData = { dataReference: { } };
+
+function secTrustData(overrides)
+{
+    return Object.assign({
+        result: 0,
+        anchorsOnly: false,
+        keychainsAllowed: false,
+        certificates: [],
+        chain: [],
+        details: [],
+        policies: [],
+        info: { },
+        verifyDate: { },
+        responses: { },
+        scts: { },
+        anchors: { },
+        trustedLogs: { },
+        exceptions: { },
+    }, overrides);
+}
+
+// Each entry puts a null CoreIPCData at a different spot in the trust data.
+const cases = [
+    { certificates: [nullData] },
+
+    { chain: [nullData] },
+
+    { policies: [{ alias: [
+        [{ m_string: 'policy' }, { alias: { variantType: 'WebKit::CoreIPCSecTrustData::PolicyOption', variant: { alias: [
+            [{ m_string: 'data' }, { alias: { variantType: 'WebKit::CoreIPCSecTrustData::PolicyArrayOfData', variant: { alias: [nullData] } } }],
+        ] } } }],
+    ] }] },
+
+    { info: { optionalValue: { alias: [
+        [{ m_string: 'revocation' }, { alias: { variantType: 'WebKit::CoreIPCSecTrustData::RevocationInfoArray', variant: { alias: [
+            { alias: [
+                [{ m_string: 'entry' }, { alias: [
+                    [{ m_string: 'value' }, { alias: { variantType: 'WebKit::CoreIPCData', variant: nullData } }],
+                ] }],
+            ] },
+        ] } } }],
+    ] } } },
+
+    { responses: { optionalValue: [nullData] } },
+
+    { scts: { optionalValue: [nullData] } },
+
+    { anchors: { optionalValue: [nullData] } },
+
+    { trustedLogs: { optionalValue: [nullData] } },
+
+    { exceptions: { optionalValue: [{ alias: [
+        [{ m_string: 'exception' }, { variantType: 'WebKit::CoreIPCData', variant: nullData }],
+    ] }] } },
+];
+
+async function runTest()
+{
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    if (!window.IPC) {
+        result.textContent = window.testRunner ? 'PASS' : 'This test requires IPC testing API';
+        return;
+    }
+
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    const { CoreIPC, IPCWireTap } = await import('../coreipc.js');
+
+    // Registering an outgoing message listener makes WebKit decode each message we send
+    // with the real argument coders, so CoreIPCSecTrust::createSecTrust() runs over this
+    // attacker controlled data exactly as it would in the receiving process.
+    const uiOutgoingTap = new IPCWireTap('UI', 'Outgoing');
+
+    for (const overrides of cases) {
+        CoreIPC.UI.WebInspectorUIProxy.ShowCertificate(IPC.pageID, { certificateInfo: { trust: { optionalValue: {
+            m_data: { optionalValue: secTrustData(overrides) },
+        } } } });
+    }
+
+    // The decoding above happens on a later run loop turn, so give it a chance to run
+    // before declaring the test finished.
+    setTimeout(() => {
+        result.textContent = 'PASS';
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 500);
+}
+</script>
+</head>
+<body onload="runTest()">
+This test passes if WebKit does not crash.
+<div id="result"></div>
+</body>
+</html>

--- a/LayoutTests/platform/ios-18/TestExpectations
+++ b/LayoutTests/platform/ios-18/TestExpectations
@@ -116,6 +116,10 @@ http/wpt/identity/ [ Skip ]
 # -- The above has different, expected behavior on iOS 26 than iOS 18 --
 # -- New failure expectations below this point only!! --
 
+# The IPC payload hardcodes the HAVE(WK_SECURE_CODING_SECTRUST) shape of WebKit::CoreIPCSecTrust,
+# which is only serialized that way on iOS 26 and later. iOS 18 sends a bare std::span instead.
+ipc/cocoa/sectrust-null-data-crash.html [ Skip ]
+
 
 
 

--- a/LayoutTests/platform/mac-sequoia/TestExpectations
+++ b/LayoutTests/platform/mac-sequoia/TestExpectations
@@ -48,6 +48,10 @@ accessibility/mac/intersection-with-selection-range.html [ Skip ]
 imported/w3c/web-platform-tests/webtransport [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-webtransport-blocked.sub.https.html [ Skip ]
 
+# The IPC payload hardcodes the HAVE(WK_SECURE_CODING_SECTRUST) shape of WebKit::CoreIPCSecTrust,
+# which is only serialized that way on macOS 26 and later. Sequoia sends a bare std::span instead.
+ipc/cocoa/sectrust-null-data-crash.html [ Skip ]
+
 
 
 

--- a/Source/WebKit/Shared/cf/CoreIPCSecTrust.mm
+++ b/Source/WebKit/Shared/cf/CoreIPCSecTrust.mm
@@ -640,6 +640,17 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     m_data = WTF::move(secTrustData);
 }
 
+static bool appendDataObject(NSMutableArray *array, const CoreIPCData& data, ASCIILiteral description)
+{
+    RetainPtr nsData = data.toID();
+    if (!nsData) {
+        RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust had a null value in %" PUBLIC_LOG_STRING, description.characters());
+        return false;
+    }
+    [array addObject:nsData.get()];
+    return true;
+}
+
 static RetainPtr<NSDictionary> createPolicyDictionary(const CoreIPCSecTrustData::PolicyOption& options)
 {
     RetainPtr<NSMutableDictionary> dict = adoptNS([[NSMutableDictionary alloc] initWithCapacity:options.size()]);
@@ -669,12 +680,8 @@ static RetainPtr<NSDictionary> createPolicyDictionary(const CoreIPCSecTrustData:
             [&] (const CoreIPCSecTrustData::PolicyArrayOfData& a) {
                 RetainPtr array = adoptNS([[NSMutableArray alloc] initWithCapacity:a.size()]);
                 for (const auto& d : a) {
-                    if (RetainPtr nsD = d.toID())
-                        [array addObject:d.toID().get()];
-                    else {
-                        RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrustData had an null value in policy dictionary");
-                        ASSERT_NOT_REACHED();
-                    }
+                    if (!appendDataObject(array, d, "policy dictionary"_s))
+                        return;
                 }
                 value = array;
             },
@@ -703,25 +710,24 @@ static RetainPtr<NSDictionary> createPolicyDictionary(const CoreIPCSecTrustData:
                 value = d;
             }
         );
+        if (!value)
+            return nullptr;
         [dict setObject:value.get() forKey:key.get()];
     }
     return dict;
 }
 
-static void addToDictFromOptionalDataHelper(const std::optional<Vector<CoreIPCData>>& opt, RetainPtr<NSMutableDictionary> dict, NSString* key)
+static bool addToDictFromOptionalDataHelper(const std::optional<Vector<CoreIPCData>>& opt, RetainPtr<NSMutableDictionary> dict, NSString* key)
 {
     if (!opt)
-        return;
+        return true;
     RetainPtr array = adoptNS([[NSMutableArray alloc] initWithCapacity:opt->size()]);
     for (const CoreIPCData& d : *opt) {
-        if (RetainPtr nsD = d.toID())
-            [array addObject:nsD.get()];
-        else {
-            RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrustData had an null value in data helper");
-            ASSERT_NOT_REACHED();
-        }
+        if (!appendDataObject(array, d, "data helper"_s))
+            return false;
     }
     [dict.get() setObject:array.get() forKey:key];
+    return true;
 }
 
 RetainPtr<SecTrustRef> CoreIPCSecTrust::createSecTrust() const
@@ -774,12 +780,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!m_data->certificates.isEmpty()) {
         RetainPtr certificates = adoptNS([[NSMutableArray alloc] initWithCapacity:m_data->certificates.size()]);
         for (const CoreIPCData& cert : m_data->certificates) {
-            if (RetainPtr nsCert = cert.toID())
-                [certificates addObject:nsCert.get()];
-            else {
-                RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrustData had an null value in certificates");
-                ASSERT_NOT_REACHED();
-            }
+            if (!appendDataObject(certificates, cert, "certificates"_s))
+                return { nullptr };
         }
         [dict setObject:certificates.get() forKey:@"certificates"];
     }
@@ -787,12 +789,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!m_data->chain.isEmpty()) {
         RetainPtr chain = adoptNS([[NSMutableArray alloc] initWithCapacity:m_data->chain.size()]);
         for (const CoreIPCData& cert : m_data->chain) {
-            if (RetainPtr nsCert = cert.toID())
-                [chain addObject:nsCert.get()];
-            else {
-                RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrustData had an null value in chain");
-                ASSERT_NOT_REACHED();
-            }
+            if (!appendDataObject(chain, cert, "chain"_s))
+                return { nullptr };
         }
         [dict setObject:chain.get() forKey:@"chain"];
     }
@@ -811,10 +809,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
                             value = s.toID();
                         },
                         [&] (const CoreIPCSecTrustData::PolicyOption& options) {
-                            RetainPtr<NSDictionary> d = createPolicyDictionary(options);
-                            value = d;
+                            value = createPolicyDictionary(options);
                         }
                     );
+                    if (!value)
+                        return { nullptr };
                     [policy setObject:value.get() forKey:key.get()];
                 }
                 [policies addObject:policy.get()];
@@ -874,6 +873,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
                                         subValue = d.toID();
                                     }
                                 );
+                                if (!subValue) {
+                                    RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust had a null value in 'info' revocation sub-dictionary");
+                                    return;
+                                }
                                 [subDict setObject:subValue.get() forKey:subPair.first.toID().get()];
                             }
                             [entryDict setObject:subDict.get() forKey:entryPair.first.toID().get()];
@@ -889,15 +892,21 @@ ALLOW_DEPRECATED_DECLARATIONS_END
                     value = subDict;
                 }
             );
+            if (!value)
+                return { nullptr };
             [info setObject:value.get() forKey:key.get()];
         }
         [dict setObject:info.get() forKey:@"info"];
     }
 
-    addToDictFromOptionalDataHelper(m_data->responses, dict, @"responses");
-    addToDictFromOptionalDataHelper(m_data->scts, dict, @"scts");
-    addToDictFromOptionalDataHelper(m_data->anchors, dict, @"anchors");
-    addToDictFromOptionalDataHelper(m_data->trustedLogs, dict, @"trustedLogs");
+    // Not short circuited, so every helper still runs and logs, as before.
+    bool addedOptionalData = true;
+    addedOptionalData &= addToDictFromOptionalDataHelper(m_data->responses, dict, @"responses");
+    addedOptionalData &= addToDictFromOptionalDataHelper(m_data->scts, dict, @"scts");
+    addedOptionalData &= addToDictFromOptionalDataHelper(m_data->anchors, dict, @"anchors");
+    addedOptionalData &= addToDictFromOptionalDataHelper(m_data->trustedLogs, dict, @"trustedLogs");
+    if (!addedOptionalData)
+        return { nullptr };
 
     if (m_data->exceptions) {
         RetainPtr exceptions = adoptNS([[NSMutableArray alloc] initWithCapacity:m_data->exceptions->size()]);
@@ -917,6 +926,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
                         value = n.toID();
                     }
                 );
+                if (!value) {
+                    RELEASE_LOG_ERROR(IPC, "CoreIPCSecTrust had a null value in 'exceptions'");
+                    return { nullptr };
+                }
                 [exception setObject:value.get() forKey:key.get()];
             }
             [exceptions addObject:exception.get()];


### PR DESCRIPTION
#### 8fa37140295aadfa570ade74c08137279bc16a73
<pre>
CoreIPCSecTrust::createSecTrust() inserts nil into an NSMutableDictionary for an empty CoreIPCData
<a href="https://bugs.webkit.org/show_bug.cgi?id=323638">https://bugs.webkit.org/show_bug.cgi?id=323638</a>
<a href="https://rdar.apple.com/185199834">rdar://185199834</a>

Reviewed by Abrar Rahman Protyasha.

CoreIPCData&apos;s dataReference is serialized as std::optional&lt;std::span&lt;const uint8_t&gt;&gt;, so a
malformed IPC message can decode a CoreIPCData whose m_cfData is null, making
CoreIPCData::toID() return nil. createSecTrust() inserted that nil into the SecTrust property
list dictionary, and -[NSMutableDictionary setObject:forKey:] raises
NSInvalidArgumentException, terminating the receiving process. Since a SecTrustRef is decoded
by calling createSecTrust() directly, any message carrying a WebCore::CertificateInfo lets a
compromised WebContent process take down the UI or Network process.

A null value has no representation in a SecTrust property list, so reject the whole trust
object instead of inserting nil or silently dropping the entry, which would build a property
list that does not match the wire data. All callers of createSecTrust() already handle a null
return; the generated coder returns it for a disengaged optional, and the existing
SecTrustCreateFromPropertyListRepresentation error path returns it too.

CoreIPCData is the only nil source here: CoreIPCString::toID() returns @&quot;&quot; for a null String,
and CoreIPCNumber and CoreIPCDate always produce an object, so guarding the dictionary values
and array elements built from a CoreIPCData covers every insertion. The encode side always
constructs CoreIPCData from a class-checked NSData, so no legitimate trust object can reach
the new early returns.

The four sites that already null-checked logged and continued with the element skipped; they
now reject too, and their ASSERT_NOT_REACHED() is dropped since this input is attacker
controlled and reaching it is not a WebKit bug.

Test: ipc/cocoa/sectrust-null-data-crash.html

* LayoutTests/ipc/cocoa/sectrust-null-data-crash-expected.txt: Added.
* LayoutTests/ipc/cocoa/sectrust-null-data-crash.html: Added.
* LayoutTests/platform/ios-18/TestExpectations:
* LayoutTests/platform/mac-sequoia/TestExpectations:
* Source/WebKit/Shared/cf/CoreIPCSecTrust.mm:
(WebKit::appendDataObject):
(WebKit::createPolicyDictionary):
(WebKit::addToDictFromOptionalDataHelper):
(WebKit::CoreIPCSecTrust::createSecTrust const):

Canonical link: <a href="https://commits.webkit.org/320749@main">https://commits.webkit.org/320749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f30bc911a9109988a87836b972b6390cf3b30f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196010 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150404 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9a1d72fd-91a9-4cee-97e1-5d9d20a7f161) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145112 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100608 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6bc12ec8-05fb-4a5e-a839-b1a2d1bb5008) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48801 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125407 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/58804aa0-6046-4b43-a90f-e938878b70ad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47527 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45565 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157887 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45255 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7073 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52238 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197976 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59270 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165191 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154650 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41437 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59978 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41860 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154302 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48764 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132326 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129262 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58445 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20277 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57823 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58059 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57886 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->