### PR TITLE
Cherry-pick 305413.1119@safari-7624.5.1.10-branch (6b8717a224a0). https://bugs.webkit.org/show_bug.cgi?id=318500

### DIFF
--- a/LayoutTests/fast/canvas/canvas-filter-fillText-crash-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-filter-fillText-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash.
+
+

--- a/LayoutTests/fast/canvas/canvas-filter-fillText-crash.html
+++ b/LayoutTests/fast/canvas/canvas-filter-fillText-crash.html
@@ -1,0 +1,20 @@
+<!-- webkit-test-runner [ CanvasFiltersEnabled=true ] -->
+
+<!DOCTYPE html>
+
+<p>This test passes if it does not crash.</p>
+<canvas id="c" width="200" height="100"></canvas>
+
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+
+  const ctx = document.getElementById('c').getContext('2d');
+  ctx.font = '20px serif';
+
+  for (let i = 0; i < 15; ++i)
+    ctx.save();
+
+  ctx.filter = 'blur(5px)';
+  ctx.fillText('hello', 10, 50);
+</script>

--- a/LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash-expected.txt
+++ b/LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash.html
+++ b/LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script>
+  window.addEventListener("load", () => {
+    window.testRunner?.dumpAsText();
+
+    const audioData = new AudioData({
+      format: "f32",
+      sampleRate: 48000,
+      numberOfFrames: 1,
+      numberOfChannels: 2,
+      timestamp: 0,
+      data: new Float32Array([0.125, -0.125])
+    });
+    const copyDestination = new Int16Array(16);
+
+    let threw = false;
+    try {
+      audioData.copyTo(copyDestination, { format: "s16-planar", planeIndex: 0, frameOffset: 1 });
+    } catch (e) {
+      threw = e instanceof RangeError;
+    }
+
+    audioData.copyTo(copyDestination, { format: "s16-planar", planeIndex: 0, frameCount: 0 });
+    audioData.copyTo(copyDestination, { format: "s16-planar", planeIndex: 1, frameCount: 0 });
+
+    document.body.innerHTML = threw ? "PASS if no crash." : "FAIL: frameOffset == numberOfFrames did not throw RangeError.";
+  });
+</script>
+<body></body>

--- a/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash-expected.txt
+++ b/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash.html
+++ b/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true RemoteMediaSessionManagerEnabled=true ] -->
+<p>This test passes if it does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function done() { window.testRunner?.notifyDone(); }
+
+async function run() {
+    const { CoreIPC } = await import('./coreipc.js');
+
+    const pageID = IPC.pageID;
+
+    const state = {
+        pageIdentifier: pageID,
+        sessionIdentifier: 1234,
+        logIdentifier: 0,
+        mediaType: 0,
+        presentationType: 0,
+        displayType: 0,
+        state: 0,
+        stateToRestore: 0,
+        interruptionType: 0,
+        duration: { timeValue: 0, timeScale: 1, timeFlags: 0 },
+        groupIdentifier: { },
+        nowPlayingInfo: { },
+        shouldOverrideBackgroundLoadingRestriction: false,
+        isPlayingToWirelessPlaybackTarget: false,
+        isPlayingOnSecondScreen: false,
+        hasMediaStreamSource: false,
+        shouldOverridePauseDuringRouteChange: false,
+        isNowPlayingEligible: false,
+        canProduceAudio: false,
+        isSuspended: false,
+        isPlaying: false,
+        isAudible: false,
+        isEnded: false,
+        canReceiveRemoteControlCommands: false,
+        supportsSeeking: false,
+        hasPlayedAudiblySinceLastInterruption: false,
+        isLongEnoughForMainContent: false,
+        blockedBySystemInterruption: false,
+        activeAudioSessionRequired: false,
+        preparingToPlay: false,
+        isActiveNowPlayingSession: false,
+    };
+
+    // AddMediaSession creates the AudioHardwareListener; RemoveMediaSession (last
+    // session) clears MediaSessionManagerCocoa::m_audioHardwareListener while
+    // RemoteMediaSessionManagerProxy used to retain a stale listener proxy whose
+    // raw Client& dispatched into a manager with a null m_audioHardwareListener.
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.AddMediaSession(pageID, { session: state });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoveMediaSession(pageID, { session: state });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioOutputDeviceChanged(pageID, { bufferSizeMinimum: 128, bufferSizeMaximum: 4096 });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioHardwareDidBecomeActive(pageID, { });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioHardwareDidBecomeInactive(pageID, { });
+
+    // Let the async IPC drain before finishing.
+    await new Promise(resolve => setTimeout(resolve, 100));
+    done();
+}
+
+// The IPC testing API (window.IPC) is only present on debug/ASAN builds; on other
+// configurations this test must still finish, so guarantee notifyDone() on every path
+// and only import coreipc.js (which dereferences IPC at module scope) when IPC exists.
+if (!window.IPC || !IPC.messages.RemoteMediaSessionManagerProxy_AddMediaSession)
+    done();
+else
+    run().catch(done);
+</script>

--- a/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf-expected.txt
+++ b/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf.html
+++ b/LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true RemoteMediaSessionManagerEnabled=true ] -->
+<p>This test passes if it does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+const wait = ms => new Promise(r => setTimeout(r, ms));
+
+let finished = false;
+function finish() {
+    if (finished)
+        return;
+    finished = true;
+    window.testRunner?.notifyDone();
+}
+
+function makeState(pageID) {
+    return {
+        pageIdentifier: pageID, sessionIdentifier: 1234, logIdentifier: 0,
+        mediaType: 0, presentationType: 0, displayType: 0, state: 0, stateToRestore: 0,
+        interruptionType: 0, duration: { timeValue: 0, timeScale: 1, timeFlags: 0 },
+        groupIdentifier: { }, nowPlayingInfo: { },
+        shouldOverrideBackgroundLoadingRestriction: false, isPlayingToWirelessPlaybackTarget: false,
+        isPlayingOnSecondScreen: false, hasMediaStreamSource: false,
+        shouldOverridePauseDuringRouteChange: false, isNowPlayingEligible: false,
+        canProduceAudio: false, isSuspended: false, isPlaying: false, isAudible: false,
+        isEnded: false, canReceiveRemoteControlCommands: false, supportsSeeking: false,
+        hasPlayedAudiblySinceLastInterruption: false, isLongEnoughForMainContent: false,
+        blockedBySystemInterruption: false, activeAudioSessionRequired: false,
+        preparingToPlay: false, isActiveNowPlayingSession: false,
+    };
+}
+
+async function run() {
+    const { CoreIPC } = await import('./coreipc.js');
+
+    // With RemoteMediaSessionManagerEnabled=true each WebPageProxy creates its
+    // RemoteMediaSessionManagerProxy eagerly, so the last-opened page (B) owns
+    // the process-global AudioHardwareListener factory.
+    const winA = window.open("about:blank", "A");
+    const winB = window.open("about:blank", "B");
+    await wait(0);
+
+    if (!winA?.IPC || !winB?.IPC) {
+        finish();
+        return;
+    }
+    const pageA = winA.IPC.pageID;
+    const pageB = winB.IPC.pageID;
+
+    // A.AddMediaSession -> AudioHardwareListener::create(*A) -> B's factory ->
+    // B caches a listener whose raw Client& was A.
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.AddMediaSession(pageA, { session: makeState(pageA) });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoveMediaSession(pageA, { session: makeState(pageA) });
+
+    // Destroy A's WebPageProxy; B's listener used to keep a dangling Client& to A.
+    winA.close();
+    for (let i = 0; i < 8; ++i)
+        await wait(50);
+    if (window.GCController)
+        GCController.collect();
+    await wait(100);
+
+    // RemoteAudioOutputDeviceChanged on B used to dispatch on freed A.
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioOutputDeviceChanged(pageB, { bufferSizeMinimum: 128, bufferSizeMaximum: 4096 });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioHardwareDidBecomeActive(pageB, { });
+    CoreIPC.UI.RemoteMediaSessionManagerProxy.RemoteAudioHardwareDidBecomeInactive(pageB, { });
+
+    await wait(100);
+    finish();
+}
+
+// The IPC testing API (window.IPC) is only present on debug/ASAN builds; on other
+// configurations this test must still finish, so guarantee notifyDone() on every path
+// and only import coreipc.js (which dereferences IPC at module scope) when IPC exists.
+// The watchdog also finishes the test if an opened window never populates window.IPC.
+if (!window.IPC || !IPC.messages.RemoteMediaSessionManagerProxy_AddMediaSession)
+    finish();
+else {
+    setTimeout(finish, 8000);
+    run().catch(finish);
+}
+</script>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2887,18 +2887,17 @@ static bool canUseCachedShapedText(const TextRun& textRun)
 
 void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, double x, double y, bool fill, std::optional<double> maxWidth)
 {
-    auto& fontCascade = this->fontProxy()->fontCascade();
-    auto& fontMetrics = fontProxy()->metricsOfPrimaryFont();
-
     auto* cachedShapedText = [&]() -> TextShapingResultAndDisplayList* {
         if (!canUseCachedShapedText(textRun))
             return nullptr;
-        RefPtr fonts = fontCascade.fonts();
+
+        CheckedRef fontCascade = fontProxy()->fontCascade();
+        RefPtr fonts = fontCascade->fonts();
         ASSERT(fonts);
         return fonts->getOrCreateCachedShapedText(textRun, fontCascade, 0, std::nullopt, ForTextEmphasis::No);
     }();
 
-    float fontWidth = cachedShapedText ? cachedShapedText->textShapingResult.width : fontCascade.width(textRun);
+    float fontWidth = cachedShapedText ? cachedShapedText->textShapingResult.width : protect(fontProxy()->fontCascade())->width(textRun);
 
     bool useMaxWidth = maxWidth && maxWidth.value() < fontWidth;
     float width = useMaxWidth ? maxWidth.value() : fontWidth;
@@ -2906,22 +2905,26 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
     location += textOffset(width, textRun.direction());
 
     // The slop built in to this mask rect matches the heuristic used in FontCGWin.cpp for GDI text.
-    FloatRect textRect = FloatRect(location.x() - fontMetrics.intHeight() / 2, location.y() - fontMetrics.intAscent() - fontMetrics.intLineGap(),
-        width + fontMetrics.intHeight(), fontMetrics.intLineSpacing());
+    FloatRect textRect = [&] () {
+        const auto& fontMetrics = fontProxy()->metricsOfPrimaryFont();
+        return FloatRect(
+            location.x() - fontMetrics.intHeight() / 2,
+            location.y() - fontMetrics.intAscent() - fontMetrics.intLineGap(),
+            width + fontMetrics.intHeight(),
+            fontMetrics.intLineSpacing()
+        );
+    }();
     if (!fill)
         textRect = inflatedStrokeRect(textRect);
 
     auto targetSwitcher = CanvasFilterContextSwitcher::create(*this, textRect);
 
-    // FIXME: Need to refetch fontProxy. CanvasFilterContextSwitcher might have called save().
-    // https://bugs.webkit.org/show_bug.cgi?id=193077.
     auto* c = effectiveDrawingContext();
-    auto& fontProxy = *this->fontProxy();
 
     bool cachedDisplayListNeedsStateSave = false;
     // Any shadow could add display list items to draw glyphs a 2nd time with different context attributes.
     if (cachedShapedText && !cachedShapedText->displayList && !cachedShapedText->textShapingResult.glyphBuffer.isEmpty() && !c->dropShadow()) {
-        cachedShapedText->displayList = fontCascade.displayListForGlyphBuffer(*c, cachedShapedText->textShapingResult.glyphBuffer, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+        cachedShapedText->displayList = protect(fontProxy()->fontCascade())->displayListForGlyphBuffer(*c, cachedShapedText->textShapingResult.glyphBuffer, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
 
         if (cachedShapedText->displayList) {
             for (auto& item : cachedShapedText->displayList->items()) {
@@ -2950,11 +2953,11 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
                     }
                 } else {
                     FloatPoint startPoint = point + WebCore::size(glyphBuffer.initialAdvance());
-                    fontCascade.drawGlyphBuffer(context, glyphBuffer, startPoint, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+                    protect(fontProxy()->fontCascade())->drawGlyphBuffer(context, glyphBuffer, startPoint, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
                 }
             }
         } else
-            fontProxy.drawBidiText(context, textRun, point, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+            fontProxy()->drawBidiText(context, textRun, point, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
     };
 
 #if USE(CG)

--- a/Source/WebCore/platform/audio/AudioHardwareListener.h
+++ b/Source/WebCore/platform/audio/AudioHardwareListener.h
@@ -25,11 +25,12 @@
 
 #pragma once
 
-#include <wtf/AbstractRefCounted.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Ref.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
-    
+
 enum class AudioHardwareActivityType {
     Unknown,
     IsActive,
@@ -38,7 +39,7 @@ enum class AudioHardwareActivityType {
 
 class AudioHardwareListener : public AbstractRefCounted {
 public:
-    class Client {
+    class Client : public AbstractRefCountedAndCanMakeWeakPtr<Client> {
     public:
         virtual ~Client() = default;
         virtual void audioHardwareDidBecomeActive() = 0;
@@ -66,10 +67,12 @@ public:
 protected:
     WEBCORE_EXPORT AudioHardwareListener(Client&);
 
+    Client* client() const { return m_client.get(); }
     void setHardwareActivity(AudioHardwareActivityType activity) { m_activity = activity; }
     void setSupportedBufferSizes(BufferSizeRange sizes) { m_supportedBufferSizes = sizes; }
 
-    Client& m_client;
+private:
+    WeakPtr<Client> m_client;
     AudioHardwareActivityType m_activity { AudioHardwareActivityType::Unknown };
     BufferSizeRange m_supportedBufferSizes;
 };

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -744,8 +744,10 @@ void MediaSessionManagerCocoa::updateNowPlayingInfo()
 
 void MediaSessionManagerCocoa::audioOutputDeviceChanged()
 {
-    ASSERT(m_audioHardwareListener);
-    m_supportedAudioHardwareBufferSizes = m_audioHardwareListener->supportedBufferSizes();
+    RefPtr audioHardwareListener = m_audioHardwareListener;
+    if (!audioHardwareListener)
+        return;
+    m_supportedAudioHardwareBufferSizes = audioHardwareListener->supportedBufferSizes();
     m_defaultBufferSize = AudioSession::singleton().preferredBufferSize();
     AudioSession::singleton().audioOutputDeviceChanged();
     updateSessionState();

--- a/Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
@@ -235,6 +235,9 @@ static Variant<Vector<std::span<uint8_t>>, Vector<std::span<int16_t>>, Vector<st
 
 void PlatformRawAudioData::copyTo(std::span<uint8_t> destination, AudioSampleFormat destinationFormat, size_t planeIndex, std::optional<size_t> frameOffset, std::optional<size_t>, unsigned long copyElementCount)
 {
+    if (!copyElementCount)
+        return;
+
     // WebCodecsAudioDataAlgorithms's computeCopyElementCount ensures that all parameters are correct.
     auto& audioData = downcast<PlatformRawAudioDataCocoa>(*this);
 

--- a/Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp
+++ b/Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp
@@ -157,17 +157,21 @@ void AudioHardwareListenerMac::processIsRunningChanged()
     if (activity == hardwareActivity())
         return;
     setHardwareActivity(activity);
-    
+
+    RefPtr client = this->client();
+    if (!client)
+        return;
     if (hardwareActivity() == AudioHardwareActivityType::IsActive)
-        m_client.audioHardwareDidBecomeActive();
+        client->audioHardwareDidBecomeActive();
     else if (hardwareActivity() == AudioHardwareActivityType::IsInactive)
-        m_client.audioHardwareDidBecomeInactive();
+        client->audioHardwareDidBecomeInactive();
 }
 
 void AudioHardwareListenerMac::outputDeviceChanged()
 {
     setSupportedBufferSizes(currentDeviceSupportedBufferSizes());
-    m_client.audioOutputDeviceChanged();
+    if (RefPtr client = this->client())
+        client->audioOutputDeviceChanged();
 }
 
 }

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -883,7 +883,7 @@ RemoteMediaEngineConfigurationFactoryProxy& GPUConnectionToWebProcess::mediaEngi
 void GPUConnectionToWebProcess::createAudioHardwareListener(RemoteAudioHardwareListenerIdentifier identifier)
 {
     auto addResult = m_remoteAudioHardwareListenerMap.ensure(identifier, [&]() {
-        return makeUnique<RemoteAudioHardwareListenerProxy>(*this, WTF::move(identifier));
+        return RemoteAudioHardwareListenerProxy::create(*this, WTF::move(identifier));
     });
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
 }

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -435,7 +435,7 @@ private:
     HashMap<std::pair<WebPageProxyIdentifier, WebCore::PageIdentifier>, std::unique_ptr<LayerHostingContext>> m_visibilityPropagationContexts;
 #endif
 
-    using RemoteAudioHardwareListenerMap = HashMap<RemoteAudioHardwareListenerIdentifier, std::unique_ptr<RemoteAudioHardwareListenerProxy>>;
+    using RemoteAudioHardwareListenerMap = HashMap<RemoteAudioHardwareListenerIdentifier, Ref<RemoteAudioHardwareListenerProxy>>;
     RemoteAudioHardwareListenerMap m_remoteAudioHardwareListenerMap;
 
 #if USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioHardwareListenerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioHardwareListenerProxy.h
@@ -30,6 +30,7 @@
 #include "MessageReceiver.h"
 #include "RemoteAudioHardwareListenerIdentifier.h"
 #include <WebCore/AudioHardwareListener.h>
+#include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/UniqueRef.h>
@@ -43,13 +44,21 @@ namespace WebKit {
 
 class GPUConnectionToWebProcess;
 
-class RemoteAudioHardwareListenerProxy final : private WebCore::AudioHardwareListener::Client {
+class RemoteAudioHardwareListenerProxy final : public RefCounted<RemoteAudioHardwareListenerProxy>, private WebCore::AudioHardwareListener::Client {
     WTF_MAKE_TZONE_ALLOCATED(RemoteAudioHardwareListenerProxy);
 public:
-    RemoteAudioHardwareListenerProxy(GPUConnectionToWebProcess&, RemoteAudioHardwareListenerIdentifier&&);
+    static Ref<RemoteAudioHardwareListenerProxy> create(GPUConnectionToWebProcess& connection, RemoteAudioHardwareListenerIdentifier&& identifier)
+    {
+        return adoptRef(*new RemoteAudioHardwareListenerProxy(connection, WTF::move(identifier)));
+    }
     virtual ~RemoteAudioHardwareListenerProxy();
 
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
 private:
+    RemoteAudioHardwareListenerProxy(GPUConnectionToWebProcess&, RemoteAudioHardwareListenerIdentifier&&);
+
     // AudioHardwareListener::Client
     void audioHardwareDidBecomeActive() final;
     void audioHardwareDidBecomeInactive() final;

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp
@@ -65,19 +65,22 @@ public:
     void audioHardwareDidBecomeActive()
     {
         setHardwareActivity(WebCore::AudioHardwareActivityType::IsActive);
-        m_client.audioHardwareDidBecomeActive();
+        if (RefPtr client = this->client())
+            client->audioHardwareDidBecomeActive();
     }
 
     void audioHardwareDidBecomeInactive()
     {
         setHardwareActivity(WebCore::AudioHardwareActivityType::IsInactive);
-        m_client.audioHardwareDidBecomeInactive();
+        if (RefPtr client = this->client())
+            client->audioHardwareDidBecomeInactive();
     }
 
     void audioOutputDeviceChanged(uint64_t bufferSizeMinimum, uint64_t bufferSizeMaximum)
     {
         setSupportedBufferSizes({ bufferSizeMinimum, bufferSizeMaximum });
-        m_client.audioOutputDeviceChanged();
+        if (RefPtr client = this->client())
+            client->audioOutputDeviceChanged();
     }
 };
 #endif
@@ -100,8 +103,10 @@ RemoteMediaSessionManagerProxy::RemoteMediaSessionManagerProxy()
 #endif
 
 #if PLATFORM(COCOA)
-    WebCore::AudioHardwareListener::setCreationFunction([protectedThis = Ref { *this }] (WebCore::AudioHardwareListener::Client& client) {
-        return protectedThis->ensureAudioHardwareListenerProxy(client);
+    WebCore::AudioHardwareListener::setCreationFunction([weakThis = ThreadSafeWeakPtr { *this }] (WebCore::AudioHardwareListener::Client& client) -> Ref<WebCore::AudioHardwareListener> {
+        if (RefPtr protectedThis = weakThis.get())
+            return protectedThis->ensureAudioHardwareListenerProxy(client);
+        return RemoteMediaSessionManagerAudioHardwareListener::create(client);
     });
 #endif
 }
@@ -249,27 +254,33 @@ void RemoteMediaSessionManagerProxy::setPreferredBufferSize(size_t size)
 #if PLATFORM(COCOA)
 void RemoteMediaSessionManagerProxy::remoteAudioHardwareDidBecomeActive()
 {
-    if (m_audioHardwareListenerProxy)
-        Ref { *m_audioHardwareListenerProxy }->audioHardwareDidBecomeActive();
+    if (RefPtr listener = m_audioHardwareListenerProxy.get())
+        listener->audioHardwareDidBecomeActive();
 }
 
 void RemoteMediaSessionManagerProxy::remoteAudioHardwareDidBecomeInactive()
 {
-    if (m_audioHardwareListenerProxy)
-        Ref { *m_audioHardwareListenerProxy }->audioHardwareDidBecomeInactive();
+    if (RefPtr listener = m_audioHardwareListenerProxy.get())
+        listener->audioHardwareDidBecomeInactive();
 }
 
 void RemoteMediaSessionManagerProxy::remoteAudioOutputDeviceChanged(uint64_t bufferSizeMinimum, uint64_t bufferSizeMaximum)
 {
-    if (m_audioHardwareListenerProxy)
-        Ref { *m_audioHardwareListenerProxy }->audioOutputDeviceChanged(bufferSizeMinimum, bufferSizeMaximum);
+    if (RefPtr listener = m_audioHardwareListenerProxy.get())
+        listener->audioOutputDeviceChanged(bufferSizeMinimum, bufferSizeMaximum);
 }
 
 Ref<RemoteMediaSessionManagerAudioHardwareListener> RemoteMediaSessionManagerProxy::ensureAudioHardwareListenerProxy(WebCore::AudioHardwareListener::Client& client)
 {
-    if (!m_audioHardwareListenerProxy)
-        m_audioHardwareListenerProxy = RemoteMediaSessionManagerAudioHardwareListener::create(client);
-    return *m_audioHardwareListenerProxy;
+    if (&client == static_cast<WebCore::AudioHardwareListener::Client*>(this)) {
+        if (RefPtr existing = m_audioHardwareListenerProxy.get())
+            return existing.releaseNonNull();
+        auto listener = RemoteMediaSessionManagerAudioHardwareListener::create(client);
+        m_audioHardwareListenerProxy = listener.get();
+        return listener;
+    }
+
+    return RemoteMediaSessionManagerAudioHardwareListener::create(client);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
@@ -37,6 +37,7 @@
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -149,7 +150,7 @@ private:
     HashMap<WebCore::ProcessQualified<WebCore::MediaSessionIdentifier>, Ref<RemoteMediaSessionProxy>> m_sessionProxies;
 
 #if PLATFORM(COCOA)
-    RefPtr<RemoteMediaSessionManagerAudioHardwareListener> m_audioHardwareListenerProxy;
+    ThreadSafeWeakPtr<RemoteMediaSessionManagerAudioHardwareListener> m_audioHardwareListenerProxy;
 #endif
 
 #if USE(AUDIO_SESSION)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp
@@ -77,19 +77,22 @@ void RemoteAudioHardwareListener::gpuProcessConnectionDidClose(GPUProcessConnect
 void RemoteAudioHardwareListener::audioHardwareDidBecomeActive()
 {
     setHardwareActivity(AudioHardwareActivityType::IsActive);
-    m_client.audioHardwareDidBecomeActive();
+    if (RefPtr client = this->client())
+        client->audioHardwareDidBecomeActive();
 }
 
 void RemoteAudioHardwareListener::audioHardwareDidBecomeInactive()
 {
     setHardwareActivity(AudioHardwareActivityType::IsInactive);
-    m_client.audioHardwareDidBecomeInactive();
+    if (RefPtr client = this->client())
+        client->audioHardwareDidBecomeInactive();
 }
 
 void RemoteAudioHardwareListener::audioOutputDeviceChanged(uint64_t bufferSizeMinimum, uint64_t bufferSizeMaximum)
 {
     setSupportedBufferSizes({ bufferSizeMinimum, bufferSizeMaximum });
-    m_client.audioOutputDeviceChanged();
+    if (RefPtr client = this->client())
+        client->audioOutputDeviceChanged();
 }
 
 }


### PR DESCRIPTION
#### 93656e85b73070b5153aed02e2e8ecb245f4a0a7
<pre>
Cherry-pick 305413.1119@safari-7624.5.1.10-branch (6b8717a224a0). <a href="https://bugs.webkit.org/show_bug.cgi?id=318500">https://bugs.webkit.org/show_bug.cgi?id=318500</a>

    [WebCore] Memory underflow in PlatformRawAudioData::copyTo()
    <a href="https://rdar.apple.com/176473804">rdar://176473804</a>
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318500">https://bugs.webkit.org/show_bug.cgi?id=318500</a>

    Reviewed by Jean-Yves Avenard

    When PlatformRawAudioData::copyTo() is told to copy zero samples, just bail out early. This
    avoids a calculation where the number of samples has 1 subtracted from it, causing a math
    underflow.

    Cherry-pick <a href="https://commits.webkit.org/314451@main">https://commits.webkit.org/314451@main</a> for test to pass.

    Test: fast/webcodecs/audio-data-copy-to-zero-frames-crash.html

    * LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash-expected.txt: Added.
    * LayoutTests/fast/webcodecs/audio-data-copy-to-zero-frames-crash.html: Added.
    * LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any-expected.txt:
    * LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.js:
    (test):
    * LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-data-copyTo.any.worker-expected.txt:
    * Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp:
    (WebCore::computeCopyElementCount):
    * Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp:
    (WebCore::PlatformRawAudioData::copyTo):

    Identifier: 305413.1119@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.219@webkitglib/2.54">https://commits.webkit.org/317695.219@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 40326a5829115dd7204624cbc90aa9e0f042d816
<pre>
Cherry-pick 305413.1115@safari-7624.5-branch (ddf732bdf8b3). <a href="https://bugs.webkit.org/show_bug.cgi?id=319112">https://bugs.webkit.org/show_bug.cgi?id=319112</a>

    Hold AudioHardwareListener client weakly and stop caching listener proxies across clients
    <a href="https://rdar.apple.com/177436036">rdar://177436036</a>

    Reviewed by Jean-Yves Avenard.

    AudioHardwareListener stored its Client as a raw reference, while
    RemoteMediaSessionManagerProxy::ensureAudioHardwareListenerProxy()
    cached the first listener it created and reused it (with the original
    client) for every subsequent caller, in addition to holding it
    strongly via m_audioHardwareListenerProxy. Because each
    RemoteMediaSessionManagerProxy also overwrites the process-global
    AudioHardwareListener factory with a lambda capturing Ref{*this}, two
    WebPageProxy instances could end up with B&apos;s cached listener bound to
    A; closing A&apos;s page then made B&apos;s RemoteAudioOutputDeviceChanged
    dispatch a virtual call on a freed proxy (UI-process heap-use-after-
    free). Within a single page, removing the last media session cleared
    MediaSessionManagerCocoa::m_audioHardwareListener but left the
    strongly-held m_audioHardwareListenerProxy, so the same IPC message
    null-dereferenced m_audioHardwareListener in audioOutputDeviceChanged.

    Make AudioHardwareListener::Client an AbstractRefCountedAndCanMakeWeakPtr
    (matching NowPlayingManagerClient), store m_client as a WeakPtr, and
    upgrade to a protecting RefPtr before dispatching in every listener
    subclass. In RemoteMediaSessionManagerProxy, capture *this weakly in
    the creation lambda (also removing a leak of the last-constructed
    proxy), always create a fresh listener per call, only stash a
    ThreadSafeWeakPtr to it when the client is *this*, and dispatch IPC
    through that weak pointer so the listener&apos;s lifetime is governed
    solely by MediaSessionManagerCocoa::m_audioHardwareListener. Also
    guard MediaSessionManagerCocoa::audioOutputDeviceChanged() against a
    null m_audioHardwareListener for defense in depth, and make
    RemoteAudioHardwareListenerProxy ref-counted to satisfy the new Client
    contract.

    Tests: ipc/remote-media-session-manager-audio-hardware-listener-crash.html
           ipc/remote-media-session-manager-audio-hardware-listener-uaf.html

    * LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash-expected.txt: Added.
    * LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-crash.html: Added.
    * LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf-expected.txt: Added.
    * LayoutTests/ipc/remote-media-session-manager-audio-hardware-listener-uaf.html: Added.
    * Source/WebCore/platform/audio/AudioHardwareListener.h:
    (WebCore::AudioHardwareListener::client const):
    * Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
    (WebCore::MediaSessionManagerCocoa::audioOutputDeviceChanged):
    * Source/WebCore/platform/audio/mac/AudioHardwareListenerMac.cpp:
    (WebCore::AudioHardwareListenerMac::processIsRunningChanged):
    (WebCore::AudioHardwareListenerMac::outputDeviceChanged):
    * Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
    (WebKit::GPUConnectionToWebProcess::createAudioHardwareListener):
    * Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
    * Source/WebKit/GPUProcess/media/RemoteAudioHardwareListenerProxy.h:
    * Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp:
    (WebKit::RemoteMediaSessionManagerProxy::RemoteMediaSessionManagerProxy):
    (WebKit::RemoteMediaSessionManagerProxy::remoteAudioHardwareDidBecomeActive):
    (WebKit::RemoteMediaSessionManagerProxy::remoteAudioHardwareDidBecomeInactive):
    (WebKit::RemoteMediaSessionManagerProxy::remoteAudioOutputDeviceChanged):
    (WebKit::RemoteMediaSessionManagerProxy::ensureAudioHardwareListenerProxy):
    * Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h:
    * Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp:
    (WebKit::RemoteAudioHardwareListener::audioHardwareDidBecomeActive):
    (WebKit::RemoteAudioHardwareListener::audioHardwareDidBecomeInactive):
    (WebKit::RemoteAudioHardwareListener::audioOutputDeviceChanged):

    Identifier: 305413.1115@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.218@webkitglib/2.54">https://commits.webkit.org/317695.218@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 71a8d16813706ad8cb7ae83d32795b23049540d8
<pre>
Cherry-pick 320073@main (f0d5be8210e3). <a href="https://bugs.webkit.org/show_bug.cgi?id=316996">https://bugs.webkit.org/show_bug.cgi?id=316996</a>

    CanvasRenderingContext2DBase::drawTextUnchecked: don&apos;t re-use pointer returned by fontProxy()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318372">https://bugs.webkit.org/show_bug.cgi?id=318372</a>
    <a href="https://rdar.apple.com/175759731">rdar://175759731</a>

    Reviewed by Simon Fraser.

    CanvasRenderingContext2D::fontProxy() returns the pointer to State::font
    (a FontProxy) of the top State in the state stack. State stores the
    FontProxy by value, so the FontProxy goes away when the State is deallocated.
    This could happen when the state stack (a Vector&lt;State, 1&gt;) grows beyond
    the storage buffer: a new buffer is created, existing State objects are
    copied/moved to the new buffer and the old copies deallocated. Hence,
    pointers returned by fontProxy() aren&apos;t safe to be re-used, because
    between the time when the pointer is obtained and when it&apos;s used, some
    operations might&apos;ve manipulated the state stack and caused the FontProxy
    to go away.

    CanvasRenderingContext2DBase::drawTextUnchecked is one place where it happens:
    it (1) holds on to the font cascade from the FontProxy returned by fontProxy(),
    (2) creates a CanvasFilterContextSwitcher, whose constructor calls save() which
    manipulates the state stack, then (3) uses the saved font cascade from the
    FontProxy which might have been deallocated:

    void CanvasRenderingContext2DBase::drawTextUnchecked(...)
    {
        auto&amp; fontCascade = this-&gt;fontProxy()-&gt;fontCascade();       &lt;-- (1)

        [...]
        auto targetSwitcher = CanvasFilterContextSwitcher::create(*this, textRect);     &lt;-- (2)

        [...]
        auto drawText = [&amp;](...) {
            [...]
            fontCascade.drawGlyphBuffer(...);    &lt;-- (3)

    (actually, 317546@main indirectly fixes this by avoiding saving state when
    creating CanvasFilterContextSwitcher. But as explained above, re-using fontCascade
    is unsafe, so this patch still has merits, even though it&apos;s not fixing anything)

    Fix this by not holding onto pointers returned by fontProxy(). Instead, whenever
    the FontProxy is needed, call fontProxy() so we&apos;re guaranteed to have a pointer
    to a live FontProxy. Additionally, FontCascade can be made CheckedPtr, so wrap
    it in CheckedPtr/CheckedRef whenever possible.

    Future patches could improve on this by making FontProxy ref-counted, so the
    pointer returned by fontProxy() is guaranteed to be alive no matter how the
    State object storing it is copied/moved around.

    Test: fast/canvas/canvas-filter-fillText-crash.html

    * LayoutTests/fast/canvas/canvas-filter-fillText-crash-expected.txt: Added.
    * LayoutTests/fast/canvas/canvas-filter-fillText-crash.html: Added.
    * Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
    * Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
    (WebCore::CanvasRenderingContext2DBase::drawTextUnchecked):

    Originally-landed-as: 305413.1097@safari-7624.5-branch (1d58c6a24867). <a href="https://rdar.apple.com/175759731">rdar://175759731</a>
    Canonical link: <a href="https://commits.webkit.org/320073@main">https://commits.webkit.org/320073@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.217@webkitglib/2.54">https://commits.webkit.org/317695.217@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee6937231b50b4070052eae2d7a7c396c5ea507c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185441 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59353 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53170 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195765 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150211 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187303 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60718 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59080 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144918 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150211 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188396 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60718 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53170 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125210 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60718 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59080 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53170 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60718 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53170 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6816 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52009 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59080 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197713 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59017 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53170 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154436 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59726 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53170 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154086 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28152 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59726 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132063 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/128938 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58204 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53170 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57576 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57819 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57643 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->