### PR TITLE
[JSC] Array element clearing goes through libc memset and races the concurrent marker

### DIFF
--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -1291,7 +1291,9 @@ bool JSArray::setLength(JSGlobalObject* globalObject, unsigned newLength, bool t
         if (indexingType() == ArrayWithDouble) {
             for (unsigned i = butterfly->publicLength(); i-- > newLength;)
                 butterfly->contiguousDouble().at(this, i) = PNaN;
-        } else {
+        } else if (indexingType() == ArrayWithContiguous)
+            gcSafeZeroMemory(butterfly->contiguous().data() + newLength, lengthToClear * sizeof(JSValue));
+        else {
             for (unsigned i = butterfly->publicLength(); i-- > newLength;)
                 butterfly->contiguous().at(this, i).clear();
         }
@@ -1717,8 +1719,12 @@ bool JSArray::shiftCountWithAnyIndexingType(JSGlobalObject* globalObject, unsign
             }
         }
 
-        for (unsigned i = end; i < oldLength; ++i)
-            butterfly->contiguous().at(this, i).clear();
+        if (indexingType == ArrayWithContiguous)
+            gcSafeZeroMemory(butterfly->contiguous().data() + end, count * sizeof(JSValue));
+        else {
+            for (unsigned i = end; i < oldLength; ++i)
+                butterfly->contiguous().at(this, i).clear();
+        }
 
         butterfly->setPublicLength(oldLength - count);
 

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -3800,6 +3800,7 @@ bool JSObject::increaseVectorLength(VM& vm, unsigned newLength)
         // The cell was already big enough for the desired length!
         for (unsigned i = vectorLength; i < availableVectorLength; ++i)
             storage->m_vector[i].clear();
+        WTF::storeStoreFence();
         storage->setVectorLength(availableVectorLength);
         return true;
     }


### PR DESCRIPTION
#### ccdcb8a026c0cbb7edb053970add3df036bce380
<pre>
[JSC] Array element clearing goes through libc memset and races the concurrent marker
<a href="https://bugs.webkit.org/show_bug.cgi?id=323639">https://bugs.webkit.org/show_bug.cgi?id=323639</a>

Reviewed by Yusuke Suzuki.

JSArray::setLength, JSArray::shiftCountWithAnyIndexingType and the in-place
path of JSObject::increaseVectorLength clear vacated slots with a
WriteBarrier&lt;Unknown&gt;::clear() loop, which the compiler turns into a libc
memset call (bzero with Apple clang). The concurrent marker scans these slots
without locking, and libc does not guarantee store width: musl&apos;s memset
writes the edges of the range with 1-, 2- and 4-byte stores, so the marker
can read a half-zeroed JSValue and treat it as a JSCell*, crashing the marker
or corrupting mark bits. glibc and Apple&apos;s implementations happen to use
8-byte or wider stores, which hides the race.

Clear the slots with gcSafeZeroMemory() instead, like unshiftCountSlowCase
already does. In increaseVectorLength the cleared slots are published by the
following setVectorLength(), so also fence between the zeroing and the
publication. No test, because the tear is only observable with a libc whose
memset uses sub-8-byte stores.

* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::setLength):
(JSC::JSArray::shiftCountWithAnyIndexingType):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::increaseVectorLength):

Canonical link: <a href="https://commits.webkit.org/320794@main">https://commits.webkit.org/320794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22eeddd3cd398a7d1fb3c7597469a8bdb86eb8a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195968 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150370 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59293 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145077 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100583 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125372 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47489 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45533 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7268 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14161 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157849 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45229 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7031 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46907 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52204 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197930 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59228 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154615 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41467 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59935 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41834 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154268 "Found 2 new API test failures: TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/42949672974097MallocReadWrite, TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/42949672974097MallocReadOnly (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48731 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132282 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129189 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58405 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20251 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57781 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58021 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57846 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->