### PR TITLE
[JSC] Extract `CheckInBounds` from `StringAt` and `StringCodePointAt`

### DIFF
--- a/JSTests/stress/string-index-dce-bounds-check.js
+++ b/JSTests/stress/string-index-dce-bounds-check.js
@@ -1,0 +1,59 @@
+//@ requireOptions("--useConcurrentJIT=0")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("FAIL: got " + actual + ", expected " + expected);
+}
+
+function codePointAtIsUndefined(string, index) {
+    return string.codePointAt(index) === undefined;
+}
+noInline(codePointAtIsUndefined);
+
+function atIsUndefined(string, index) {
+    return string.at(index) === undefined;
+}
+noInline(atIsUndefined);
+
+function charCodeAtIsNaN(string, index) {
+    var code = string.charCodeAt(index);
+    return code !== code;
+}
+noInline(charCodeAtIsNaN);
+
+function atNegative(string, index) {
+    return string.at(index);
+}
+noInline(atNegative);
+
+var str8Bit = "Hello, World!";
+var str16Bit = "こんにちは世界";
+
+for (var i = 0; i < testLoopCount; ++i) {
+    var index = i % str8Bit.length;
+    shouldBe(codePointAtIsUndefined(str8Bit, index), false);
+    shouldBe(atIsUndefined(str8Bit, index), false);
+    shouldBe(charCodeAtIsNaN(str8Bit, index), false);
+    index = i % str16Bit.length;
+    shouldBe(codePointAtIsUndefined(str16Bit, index), false);
+    shouldBe(atIsUndefined(str16Bit, index), false);
+    shouldBe(charCodeAtIsNaN(str16Bit, index), false);
+}
+
+for (var i = 0; i < 10; ++i) {
+    shouldBe(codePointAtIsUndefined(str8Bit, str8Bit.length), true);
+    shouldBe(atIsUndefined(str8Bit, str8Bit.length), true);
+    shouldBe(charCodeAtIsNaN(str8Bit, str8Bit.length), true);
+    shouldBe(codePointAtIsUndefined(str16Bit, str16Bit.length), true);
+    shouldBe(atIsUndefined(str16Bit, str16Bit.length), true);
+    shouldBe(charCodeAtIsNaN(str16Bit, str16Bit.length), true);
+}
+
+for (var i = 0; i < testLoopCount * 20; ++i) {
+    var index = -(i % str8Bit.length) - 1;
+    shouldBe(atNegative(str8Bit, index), str8Bit[str8Bit.length + index]);
+    index = -(i % str16Bit.length) - 1;
+    shouldBe(atNegative(str16Bit, index), str16Bit[str16Bit.length + index]);
+}
+shouldBe(atNegative(str8Bit, -str8Bit.length - 1), undefined);
+shouldBe(atNegative(str16Bit, -str16Bit.length - 1), undefined);

--- a/Source/JavaScriptCore/dfg/DFGSSALoweringPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSSALoweringPhase.cpp
@@ -91,7 +91,9 @@ private:
             break;
         }
 
-        case StringCharCodeAt: {
+        case StringAt:
+        case StringCharCodeAt:
+        case StringCodePointAt: {
             lowerStringBoundsCheck(m_graph.child(m_node, 0), m_graph.child(m_node, 1), m_graph.child(m_node, 2));
             break;
         }

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -12044,17 +12044,22 @@ IGNORE_CLANG_WARNINGS_END
         else
             stringLength = m_out.load32NonNegative(stringImpl, m_heaps.StringImpl_length);
 
-        LValue index = m_node->op() == StringAt ? m_out.select(m_out.lessThan(originalIndex, m_out.int32Zero), m_out.add(stringLength, originalIndex), originalIndex) : originalIndex;
+        bool boundsCheckLowered = m_node->op() == StringAt && m_node->arrayMode().isInBounds();
+        LValue index = m_node->op() == StringAt && !boundsCheckLowered ? m_out.select(m_out.lessThan(originalIndex, m_out.int32Zero), m_out.add(stringLength, originalIndex), originalIndex) : originalIndex;
 
         LBasicBlock fastPath = m_out.newBlock();
-        LBasicBlock slowPath = m_out.newBlock();
+        LBasicBlock slowPath = boundsCheckLowered ? nullptr : m_out.newBlock();
         LBasicBlock continuation = m_out.newBlock();
 
-        m_out.branch(
-            m_out.aboveOrEqual(index, stringLength),
-            rarely(slowPath), usually(fastPath));
+        if (boundsCheckLowered)
+            m_out.jump(fastPath);
+        else {
+            m_out.branch(
+                m_out.aboveOrEqual(index, stringLength),
+                rarely(slowPath), usually(fastPath));
+        }
 
-        LBasicBlock lastNext = m_out.appendTo(fastPath, slowPath);
+        LBasicBlock lastNext = m_out.appendTo(fastPath, slowPath ? slowPath : continuation);
 
         LBasicBlock is8Bit = m_out.newBlock();
         LBasicBlock is16Bit = m_out.newBlock();
@@ -12097,7 +12102,7 @@ IGNORE_CLANG_WARNINGS_END
             m_vmValue, char16BitValue)));
         m_out.jump(continuation);
 
-        m_out.appendTo(bitsContinuation, slowPath);
+        m_out.appendTo(bitsContinuation, slowPath ? slowPath : continuation);
 
         LValue character = m_out.phi(Int32, char8Bit, char16Bit);
 
@@ -12107,43 +12112,45 @@ IGNORE_CLANG_WARNINGS_END
             m_heaps.singleCharacterStrings, smallStrings, m_out.zeroExtPtr(character)))));
         m_out.jump(continuation);
 
-        m_out.appendTo(slowPath, continuation);
+        if (slowPath) {
+            m_out.appendTo(slowPath, continuation);
 
-        if (m_node->op() == StringCharAt) {
-            // String#charAt can accept out of range index and it always returns an empty string.
-            results.append(m_out.anchor(weakPointer(jsEmptyString(vm()))));
-        } else {
-            if (m_node->arrayMode().isInBounds()) {
-                speculate(OutOfBounds, noValue(), nullptr, m_out.booleanTrue);
-                results.append(m_out.anchor(m_out.intPtrZero));
+            if (m_node->op() == StringCharAt) {
+                // String#charAt can accept out of range index and it always returns an empty string.
+                results.append(m_out.anchor(weakPointer(jsEmptyString(vm()))));
             } else {
-                if (m_node->op() == StringAt) {
-                    // String#at can accept out of range index and it always returns undefined.
-                    results.append(m_out.anchor(m_out.constInt64(JSValue::encode(jsUndefined()))));
+                if (m_node->arrayMode().isInBounds()) {
+                    speculate(OutOfBounds, noValue(), nullptr, m_out.booleanTrue);
+                    results.append(m_out.anchor(m_out.intPtrZero));
                 } else {
-                    // FIXME: Revisit JSGlobalObject.
-                    // https://bugs.webkit.org/show_bug.cgi?id=203204
-                    JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
-                    if (m_graph.isWatchingStringPrototypeChainIsSaneWatchpoint(m_node)) {
-                        // FIXME: This could be captured using a Speculation mode that means
-                        // "out-of-bounds loads return a trivial value", something like
-                        // OutOfBoundsSaneChain.
-                        // https://bugs.webkit.org/show_bug.cgi?id=144668
-                        LBasicBlock negativeIndex = m_out.newBlock();
-
+                    if (m_node->op() == StringAt) {
+                        // String#at can accept out of range index and it always returns undefined.
                         results.append(m_out.anchor(m_out.constInt64(JSValue::encode(jsUndefined()))));
-                        m_out.branch(
-                            m_out.lessThan(index, m_out.int32Zero),
-                            rarely(negativeIndex), usually(continuation));
+                    } else {
+                        // FIXME: Revisit JSGlobalObject.
+                        // https://bugs.webkit.org/show_bug.cgi?id=203204
+                        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+                        if (m_graph.isWatchingStringPrototypeChainIsSaneWatchpoint(m_node)) {
+                            // FIXME: This could be captured using a Speculation mode that means
+                            // "out-of-bounds loads return a trivial value", something like
+                            // OutOfBoundsSaneChain.
+                            // https://bugs.webkit.org/show_bug.cgi?id=144668
+                            LBasicBlock negativeIndex = m_out.newBlock();
 
-                        m_out.appendTo(negativeIndex, continuation);
+                            results.append(m_out.anchor(m_out.constInt64(JSValue::encode(jsUndefined()))));
+                            m_out.branch(
+                                m_out.lessThan(index, m_out.int32Zero),
+                                rarely(negativeIndex), usually(continuation));
+
+                            m_out.appendTo(negativeIndex, continuation);
+                        }
+
+                        results.append(m_out.anchor(vmCall(Int64, operationGetByValStringInt, weakPointer(globalObject), base, index)));
                     }
-
-                    results.append(m_out.anchor(vmCall(Int64, operationGetByValStringInt, weakPointer(globalObject), base, index)));
                 }
             }
+            m_out.jump(continuation);
         }
-        m_out.jump(continuation);
 
         m_out.appendTo(continuation, lastNext);
         // We have to keep base alive since that keeps storage alive.
@@ -12223,7 +12230,8 @@ IGNORE_CLANG_WARNINGS_END
         else
             length = m_out.load32NonNegative(stringImpl, m_heaps.StringImpl_length);
 
-        speculate(Uncountable, noValue(), nullptr, m_out.aboveOrEqual(index, length));
+        if (!m_node->arrayMode().isInBounds())
+            speculate(Uncountable, noValue(), nullptr, m_out.aboveOrEqual(index, length));
 
         m_out.branch(
             m_out.testIsZero32(


### PR DESCRIPTION
#### 5d1761dffb0059dae2de405ab872b7bbd2798576
<pre>
[JSC] Extract `CheckInBounds` from `StringAt` and `StringCodePointAt`
<a href="https://bugs.webkit.org/show_bug.cgi?id=323640">https://bugs.webkit.org/show_bug.cgi?id=323640</a>

Reviewed by Yusuke Suzuki.

StringAt and StringCodePointAt speculate that the index is in bounds, and
the abstract interpreter types their result on the strength of that check,
so a user such as `string.codePointAt(index) === undefined` folds to a
constant. The node then has no users left, and MovHintRemoval + DCE in the
FTL pipeline remove it together with its bounds check, so out-of-bounds
indices keep returning the folded constant without exiting.

Extract the bounds check into a CheckInBounds node in SSA lowering, as
existing implementation for StringCharCodeAt. The check survives DCE on its own,
while an unused node stays removable. StringAt with an in-bounds array mode
now checks the index before it is normalized, so a negative index exits
with OutOfBounds and the next compile picks the out-of-bounds mode, which
handles negative indices inline without exiting.

Test: JSTests/stress/string-index-must-generate-dce.js

* JSTests/stress/string-index-dce-bounds-check.js: Added.
(shouldBe):
(codePointAtIsUndefined):
(atIsUndefined):
(charCodeAtIsNaN):
(atNegative):
* Source/JavaScriptCore/dfg/DFGSSALoweringPhase.cpp:
(JSC::DFG::SSALoweringPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileStringCharAtImpl):
(JSC::FTL::DFG::LowerDFGToB3::compileStringCodePointAt):

Canonical link: <a href="https://commits.webkit.org/321014@main">https://commits.webkit.org/321014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/791106ea2d3d2d9f43ddab485a834a5c77a85352

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195969 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150371 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145079 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100585 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188616 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165649 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125374 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47490 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45534 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7270 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14156 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157850 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45224 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7032 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46908 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49941 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197932 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59229 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154616 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41633 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59936 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41829 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154269 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48734 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132283 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129190 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58406 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20246 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57782 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58022 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57847 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->