### PR TITLE
[JSC] `RegExp.escape` should not narrow supplementary code points to 16 bits

### DIFF
--- a/JSTests/stress/regexp-escape-supplementary.js
+++ b/JSTests/stress/regexp-escape-supplementary.js
@@ -1,0 +1,32 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+// Supplementary code points whose low 16 bits spell a syntax character, a
+// punctuator, a control character or whitespace must pass through unchanged.
+shouldBe(RegExp.escape("\u{2002A}"), "\u{2002A}"); // low 16 bits: '*'
+shouldBe(RegExp.escape("\u{20009}"), "\u{20009}"); // low 16 bits: '\t'
+shouldBe(RegExp.escape("\u{2002C}"), "\u{2002C}"); // low 16 bits: ','
+shouldBe(RegExp.escape("\u{20020}"), "\u{20020}"); // low 16 bits: ' '
+shouldBe(RegExp.escape("\u{12000}"), "\u{12000}"); // low 16 bits: U+2000 (EN QUAD)
+shouldBe(RegExp.escape("\u{1D800}"), "\u{1D800}"); // low 16 bits: lead surrogate
+shouldBe(RegExp.escape("\u{1FEFF}"), "\u{1FEFF}"); // low 16 bits: U+FEFF (BOM)
+for (const s of ["\u{2002A}", "\u{20009}", "\u{2002C}", "\u{20020}", "\u{12000}", "\u{1D800}", "\u{1FEFF}", "\u{1F600}"]) {
+    for (const flags of ["", "u", "v"])
+        shouldBe(new RegExp(RegExp.escape(s), flags).test(s), true);
+}
+
+// Every BMP code unit RegExp.escape rewrites, combined with every plane.
+const escapedCodeUnits = [..."^$\\.*+?()[]{}|/,-=<>#&!%:;@~'`\"\t\n\v\f\r       　﻿"].map((c) => c.charCodeAt(0));
+for (let codeUnit = 0x2000; codeUnit <= 0x200a; codeUnit++)
+    escapedCodeUnits.push(codeUnit);
+escapedCodeUnits.push(0xd800, 0xd83d, 0xdbff, 0xdc00, 0xde00, 0xdfff);
+for (const codeUnit of escapedCodeUnits)
+    shouldBe(RegExp.escape("_" + String.fromCharCode(codeUnit)) !== "_" + String.fromCharCode(codeUnit), true);
+for (let plane = 1; plane <= 16; plane++) {
+    for (const codeUnit of escapedCodeUnits) {
+        const s = String.fromCodePoint((plane << 16) | codeUnit);
+        shouldBe(RegExp.escape(s), s);
+    }
+}

--- a/Source/JavaScriptCore/runtime/RegExpConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpConstructor.cpp
@@ -131,8 +131,10 @@ JSC_DEFINE_HOST_FUNCTION(regExpConstructorEscape, (JSGlobalObject* globalObject,
             continue;
         }
 
-        if (StringView("^$\\.*+?()[]{}|/"_s).contains(codePoint)) {
-            builder.append('\\', codePoint);
+        bool isASCIICodePoint = isASCII(codePoint);
+
+        if (isASCIICodePoint && StringView("^$\\.*+?()[]{}|/"_s).contains(static_cast<char16_t>(codePoint))) {
+            builder.append('\\', static_cast<char16_t>(codePoint));
             continue;
         }
 
@@ -156,15 +158,12 @@ JSC_DEFINE_HOST_FUNCTION(regExpConstructorEscape, (JSGlobalObject* globalObject,
             break;
         }
 
-        if (StringView(",-=<>#&!%:;@~'`\""_s).contains(codePoint) || isStrWhiteSpace(codePoint) || U16_IS_SURROGATE(codePoint)) {
+        if ((isASCIICodePoint && StringView(",-=<>#&!%:;@~'`\""_s).contains(static_cast<char16_t>(codePoint)))
+            || (U_IS_BMP(codePoint) && (isStrWhiteSpace(static_cast<char16_t>(codePoint)) || U16_IS_SURROGATE(codePoint)))) {
             if (isLatin1(codePoint))
                 builder.append('\\', 'x', pad('0', 2, toStringWithRadix(codePoint, 16)));
-            else if (U_IS_BMP(codePoint))
+            else
                 builder.append('\\', 'u', pad('0', 4, toStringWithRadix(codePoint, 16)));
-            else {
-                builder.append('\\', 'u', pad('0', 4, toStringWithRadix(U16_LEAD(codePoint), 16)));
-                builder.append('\\', 'u', pad('0', 4, toStringWithRadix(U16_TRAIL(codePoint), 16)));
-            }
             continue;
         }
 


### PR DESCRIPTION
#### b44e00d2f037003c48d578eced64caddf9036dfa
<pre>
[JSC] `RegExp.escape` should not narrow supplementary code points to 16 bits
<a href="https://bugs.webkit.org/show_bug.cgi?id=323642">https://bugs.webkit.org/show_bug.cgi?id=323642</a>

Reviewed by Yusuke Suzuki.

regExpConstructorEscape reads a whole code point with U16_NEXT but then
classifies it through StringView::contains(char16_t) and isStrWhiteSpace,
which truncate it to its low 16 bits. A supplementary code point whose low
16 bits spell a syntax character, a punctuator, a control character or
whitespace is escaped even though the spec leaves it alone: U+2002A (low 16
bits &quot;*&quot;) becomes &quot;\&quot; followed by U+2002A, and U+20009 (low 16 bits &quot;\t&quot;)
becomes &quot;\ud840\udc09&quot;. With the u or v flag the escaped string then never
matches the input. 56 low-16-bit values in each of the 16 supplementary
planes are affected.

Run the punctuator checks only for ASCII code points and the whitespace and
surrogate checks only for BMP code points, so that a supplementary code
point passes through unchanged. The branch that emitted a surrogate pair
escape is dead after this: nothing in the escape set is supplementary.

Tests: JSTests/stress/regexp-escape-supplementary.js

* JSTests/stress/regexp-escape-supplementary.js: Added.
(shouldBe):
* Source/JavaScriptCore/runtime/RegExpConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/320682@main">https://commits.webkit.org/320682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc5e75761ab915a1967da3bcd68094d3bc00794a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195774 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150218 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59089 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144925 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100468 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165508 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125217 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47332 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45388 "Passed tests") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7122 "Found 1 new JSC stress test failure: Too many failures: 2104 jsc tests failed (failure)") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14012 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157699 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45080 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6825 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46707 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52018 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197722 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59026 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154445 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41391 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59735 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154094 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48571 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132075 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128952 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58213 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20102 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57585 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57828 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57652 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->