### PR TITLE
[GTK][WPE] SkiaGPUAtlas::uploadImages() should destory `writeScope` before signaling `m_uploadCondition`

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
@@ -109,12 +109,14 @@ void SkiaGPUAtlas::uploadImages()
 #if USE(GBM)
     if (auto* gpuBuffer = m_atlasTexture->memoryMappedGPUBuffer()) {
         RELEASE_ASSERT(gpuBuffer->isLinear() || gpuBuffer->isVivanteSuperTiled());
-        auto writeScope = makeGPUBufferWriteScope(*gpuBuffer);
-        RELEASE_ASSERT_WITH_MESSAGE(writeScope, "Failed to map GPU buffer for atlas upload");
+        {
+            auto writeScope = makeGPUBufferWriteScope(*gpuBuffer);
+            RELEASE_ASSERT_WITH_MESSAGE(writeScope, "Failed to map GPU buffer for atlas upload");
 
-        for (const auto& entry : m_layout->entries()) {
-            if (auto pixels = pixelDataInSRGB(entry.rasterImage))
-                gpuBuffer->updateContents(*writeScope, pixels->first, entry.atlasRect, pixels->second);
+            for (const auto& entry : m_layout->entries()) {
+                if (auto pixels = pixelDataInSRGB(entry.rasterImage))
+                    gpuBuffer->updateContents(*writeScope, pixels->first, entry.atlasRect, pixels->second);
+            }
         }
 
         m_uploadCondition->signal();


### PR DESCRIPTION
#### bfe5ce514044852459b0facd8a19761a53ab78a9
<pre>
[GTK][WPE] SkiaGPUAtlas::uploadImages() should destory `writeScope` before signaling `m_uploadCondition`
<a href="https://bugs.webkit.org/show_bug.cgi?id=323643">https://bugs.webkit.org/show_bug.cgi?id=323643</a>

Reviewed by Nikolas Zimmermann.

The type of `writeScope` is MemoryMappedGPUBuffer::AccessScope. The dtor
~AccessScope() actually syncs the buffer. We should do that before signaling
the condition variable.

* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp:
(WebCore::SkiaGPUAtlas::uploadImages):

Canonical link: <a href="https://commits.webkit.org/320810@main">https://commits.webkit.org/320810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3a522f91616275850ebff0a334505d6fcaff90d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53182 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195777 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150221 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187315 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59092 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144931 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100472 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125223 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47334 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45391 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157701 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45082 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6828 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197725 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59029 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154449 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59738 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154098 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28236 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48575 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132079 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128958 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58216 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20104 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57588 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57831 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57655 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->