### PR TITLE
[GTK][WPE] white noise images for dma_buf atlas on i915 + Intel Arc

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
@@ -46,6 +46,7 @@
 
 #if USE(LIBDRM)
 #include <drm_fourcc.h>
+#include <xf86drm.h>
 #endif
 
 namespace WebCore {
@@ -122,6 +123,13 @@ static CPUMappingStrategy runCapabilityProbe()
         return CPUMappingStrategy::Unsupported;
     }
 
+    // CPUMappingStrategy::DmaBufFDMmap doesn't work for the combination of i915 driver and Intel Arc.
+    bool preferGBMBoMap = false;
+    if (drmVersion* version = drmGetVersion(gbm_device_get_fd(gbmDevice->device()))) {
+        preferGBMBoMap = equalSpans(unsafeSpan(version->name), "i915"_span);
+        drmFreeVersion(version);
+    }
+
     // mmap capability depends on the kernel dma-buf subsystem and the GBM backend, not on
     // buffer size, format, or modifier -- so the single-plane linear probe generalizes.
     static constexpr int probeSize = 16;
@@ -134,11 +142,13 @@ static CPUMappingStrategy runCapabilityProbe()
 
     auto strategy = CPUMappingStrategy::Unsupported;
 
-    if (auto* bo = createProbeBO()) {
-        UnixFileDescriptor fd { gbm_bo_get_fd_for_plane(bo, 0), UnixFileDescriptor::Adopt };
-        if (fd && probeReadWriteMappability(fd.value(), gbm_bo_get_stride_for_plane(bo, 0) * probeSize))
-            strategy = CPUMappingStrategy::DmaBufFDMmap;
-        gbm_bo_destroy(bo);
+    if (!preferGBMBoMap) {
+        if (auto* bo = createProbeBO()) {
+            UnixFileDescriptor fd { gbm_bo_get_fd_for_plane(bo, 0), UnixFileDescriptor::Adopt };
+            if (fd && probeReadWriteMappability(fd.value(), gbm_bo_get_stride_for_plane(bo, 0) * probeSize))
+                strategy = CPUMappingStrategy::DmaBufFDMmap;
+            gbm_bo_destroy(bo);
+        }
     }
 
     if (strategy == CPUMappingStrategy::Unsupported) {
@@ -484,6 +494,9 @@ MemoryMappedGPUBuffer::AccessScope::AccessScope(MemoryMappedGPUBuffer& buffer, A
 MemoryMappedGPUBuffer::AccessScope::~AccessScope()
 {
     m_buffer.performDMABufSyncSystemCall({ DMABufSyncFlag::End, m_mode == AccessScope::Mode::Read ? DMABufSyncFlag::Read : DMABufSyncFlag::Write });
+
+    if (m_mode == Mode::Write && cachedCPUMappingStrategy() == CPUMappingStrategy::GBMBoMap)
+        m_buffer.unmapIfNeeded();
 }
 
 std::unique_ptr<MemoryMappedGPUBuffer::AccessScope> MemoryMappedGPUBuffer::AccessScope::create(MemoryMappedGPUBuffer& buffer, AccessScope::Mode mode)


### PR DESCRIPTION
#### 3303c6f5ddfd9c91fc415d6b0dcc7e4166c7c016
<pre>
[GTK][WPE] white noise images for dma_buf atlas on i915 + Intel Arc
<a href="https://bugs.webkit.org/show_bug.cgi?id=311103">https://bugs.webkit.org/show_bug.cgi?id=311103</a>

Reviewed by Nikolas Zimmermann.

The combination of i915 driver and Intel Arc caused white noise for atlas image
uploading. Using xe driver work fine for the video card.

Using CPUMappingStrategy::GBMBoMap and unmapping in ~AccessScope() can work
around the issue for i915.

* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp:
(WebCore::runCapabilityProbe):
(WebCore::MemoryMappedGPUBuffer::AccessScope::~AccessScope):

Canonical link: <a href="https://commits.webkit.org/320811@main">https://commits.webkit.org/320811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a882c49873afcbc169dd38a6a8b3f2e743908b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195782 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150223 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59097 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144929 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100475 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165512 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125221 "Found 1 new API test failure: TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/42949672974097MallocReadOnly (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47337 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45392 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45084 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6833 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52026 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197730 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59034 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154452 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59743 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154101 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28237 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48577 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132085 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128964 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58221 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20106 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57593 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57836 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57660 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->