### PR TITLE
Error.stack carries multiple copies of the whole script when the script came from a data: URL

### DIFF
--- a/LayoutTests/js/dom/error-stack-data-url-truncation-expected.txt
+++ b/LayoutTests/js/dom/error-stack-data-url-truncation-expected.txt
@@ -1,0 +1,14 @@
+Tests that a data: URL over 1024 characters is cut down in a stack frame, that the cut avoids %XX escapes, and that short URLs and other schemes are left alone.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS plainLength is 1024
+PASS escapeAtEndLength is 1023
+PASS escapeStraddlingLength is 1022
+PASS shortLength is 500
+PASS ordinaryFrameSurvives is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/js/dom/error-stack-data-url-truncation.html
+++ b/LayoutTests/js/dom/error-stack-data-url-truncation.html
@@ -1,0 +1,84 @@
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+<script>
+description("Tests that a data: URL over 1024 characters is cut down in a stack frame, that the cut avoids %XX escapes, and that short URLs and other schemes are left alone.");
+
+window.jsTestIsAsync = true;
+
+const limit = 1024;
+
+// Makes a module whose data: URL is exactly totalLength characters.
+// percentAt puts a %20 escape at that index.
+function makeModuleURL(totalLength, percentAt)
+{
+    const prefix = "data:text/javascript,export%20function%20mk()%7Breturn%20new%20Error('t')%7D%3B%2F%2F";
+    let url = prefix;
+    while (url.length < totalLength) {
+        if (percentAt !== undefined && url.length === percentAt && totalLength - url.length >= 3) {
+            url += "%20";
+            continue;
+        }
+        if (percentAt !== undefined && url.length > percentAt - 3 && url.length < percentAt)
+            url += "a";
+        else
+            url += "abcdefghij".charAt(url.length % 10);
+    }
+    return url.substring(0, totalLength);
+}
+
+// A frame looks like fn@url:line:column. Pull out the url.
+function sourceURLOfDataFrame(stack)
+{
+    const frame = stack.split("\n").filter(function (each) { return each.indexOf("data:text/javascript,") !== -1; })[0];
+    if (!frame)
+        return null;
+    return frame.substring(frame.indexOf("data:text/javascript,")).replace(/:\d+:\d+$/, "");
+}
+
+async function urlLengthInStackFor(totalLength, percentAt)
+{
+    const module = await import(makeModuleURL(totalLength, percentAt));
+    const url = sourceURLOfDataFrame(module.mk().stack);
+    return url === null ? -1 : url.length;
+}
+
+// This file's own URL is not a data: URL, so it should stay whole.
+// Read it here: inside the async function below there is no caller frame.
+window.ordinaryFrameSurvives = new Error().stack.indexOf("error-stack-data-url-truncation.html") !== -1;
+
+async function runTests()
+{
+    try {
+        // Long data: URL, cut to 1024.
+        window.plainLength = await urlLengthInStackFor(5000);
+        shouldBe("plainLength", "1024");
+
+        // %20 starts at 1023, so cut before it.
+        window.escapeAtEndLength = await urlLengthInStackFor(5000, limit - 1);
+        shouldBe("escapeAtEndLength", "1023");
+
+        // %20 starts at 1022, so cut before it.
+        window.escapeStraddlingLength = await urlLengthInStackFor(5000, limit - 2);
+        shouldBe("escapeStraddlingLength", "1022");
+
+        // Under 1024, so unchanged.
+        window.shortLength = await urlLengthInStackFor(500);
+        shouldBe("shortLength", "500");
+
+        // Not a data: URL, so unchanged.
+        shouldBeTrue("ordinaryFrameSurvives");
+    } catch (exception) {
+        testFailed("threw " + exception);
+    }
+    finishJSTest();
+}
+
+runTests();
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/runtime/StackFrame.cpp
+++ b/Source/JavaScriptCore/runtime/StackFrame.cpp
@@ -260,10 +260,33 @@ LineColumn StackFrame::computeLineAndColumn() const
     return { };
 }
 
+// A `data:` URL is the whole script, so one frame can be tens of thousands of characters long.
+// Sentry caps its own stack lines at 1024, so use the same number.
+// FIXME: other schemes, and other places that print a source URL, are not capped.
+// https://bugs.webkit.org/show_bug.cgi?id=323716
+static constexpr unsigned maximumDataURLLengthInStackTrace = 1024;
+
+static StringView truncateLongDataURL(StringView sourceURL)
+{
+    if (sourceURL.length() <= maximumDataURLLengthInStackTrace)
+        return sourceURL;
+    if (!protocolIs(sourceURL, "data"_s))
+        return sourceURL;
+
+    // Don't cut in the middle of a %XX escape, or the URL won't decode.
+    unsigned length = maximumDataURLLengthInStackTrace;
+    size_t lastPercent = sourceURL.reverseFind('%', length - 1);
+    if (lastPercent != notFound && length - lastPercent < 3)
+        length = lastPercent;
+    return sourceURL.left(length);
+}
+
 String StackFrame::toString(VM& vm) const
 {
     String functionName = this->functionName(vm);
-    String sourceURL = this->sourceURLStripped(vm);
+    // sourceURL points into fullSourceURL, so keep fullSourceURL around.
+    String fullSourceURL = this->sourceURLStripped(vm);
+    auto sourceURL = truncateLongDataURL(fullSourceURL);
 
     if (sourceURL.isEmpty() || !hasLineAndColumnInfo())
         return makeString(functionName, '@', sourceURL);


### PR DESCRIPTION
#### b6afe0d39e0af9268c13fae37454f093df55bd7a
<pre>
Error.stack carries the whole script when the script came from a data: URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=323636">https://bugs.webkit.org/show_bug.cgi?id=323636</a>
<a href="https://rdar.apple.com/186614179">rdar://186614179</a>

Reviewed by Keith Miller, Abrar Rahman Protyasha, Yusuke Suzuki, and Darin Adler.

Reddit&apos;s startup script is a data: URL with the whole script inside it,
~65K of characters. A stack frame is one line of Error.stack with
multiple parts:

* the function name
* @
* where that function&apos;s code came from
*  :line:column.

That third part is the source URL. Normally it is short:
    mk@<a href="https://www.redditstatic.com/shreddit/bootstrap.js">https://www.redditstatic.com/shreddit/bootstrap.js</a>:1:38

But reddit does not load that script from a file. It pastes the script
into the page as a data: URL, a very long one.

When a tab loads in the background, reddit sends a report through Sentry
(version 6.12.0), which reads the stack to find the filename.

It tries three patterns on each line.
The first two only accept a line starting with &quot;at &quot;, which is what
Chrome writes, so JavaScriptCore&apos;s &quot;fn@url&quot; falls through to the third.

The 3rd pattern is trying to match for each individual character of
the long string something which looks like a filename. And it can&apos;t
find it. To go through the full it takes ~9 seconds or more. Sometimes
it tries multiple times.

Chrome matches on the first pattern which is under a millisecond.

Fix by truncating a data: URL to 1024 characters when writing the source
of a stack frame. We make sure to avoid percent escape so that the URL
stays parsable (%7B is {, cutting in the middle would make it not
decodable)

Sentry team for version 7.30.0 has done the same trick capping at 1024
characters to fix the same issue.

Ideally reddit would upgrade the Sentry version.

There is a new FIXME in the code for other schemes tracked in
<a href="https://webkit.org/b/323716">https://webkit.org/b/323716</a>

Test: js/dom/error-stack-data-url-truncation.html

* LayoutTests/js/dom/error-stack-data-url-truncation-expected.txt: Added.
* LayoutTests/js/dom/error-stack-data-url-truncation.html: Added.
* Source/JavaScriptCore/runtime/StackFrame.cpp:
(JSC::truncateLongDataURL):
(JSC::StackFrame::toString const):

Canonical link: <a href="https://commits.webkit.org/320770@main">https://commits.webkit.org/320770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adb18c8c53680513dc2ddc4fedba9c30cc2f565f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195996 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150392 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0e55cbee-1aa8-4764-8040-7feb9bac5baf) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145102 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100597 "Exiting early after 60 failures. 60 tests run. 61 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/468d848c-e737-4a41-af64-102aec4aa407) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48788 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125397 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e0d1878-7dce-4511-a9e0-a0d8626c2214) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47514 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45555 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7293 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14180 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157874 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45248 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7059 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46936 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197962 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59256 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154640 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41451 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59964 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154292 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48756 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132310 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129226 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58432 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20270 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57809 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58046 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57874 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->