### PR TITLE
Annotate Range's boundary points as owner-thread state

### DIFF
--- a/Source/WTF/wtf/ThreadAssertions.h
+++ b/Source/WTF/wtf/ThreadAssertions.h
@@ -216,6 +216,19 @@ ALWAYS_INLINE void releaseOwnerThreadAssertion(const LockType& lock) WTF_RELEASE
     UNUSED_PARAM(lock);
 }
 
+// Declares assertIsOwnerThread() and releaseOwnerThreadAssertion() members for a class whose state is
+// guarded by lock and owned by ownerThread, so call sites need not repeat both names. Because they are
+// members, a function that also touches a second instance's guarded state asserts on that instance:
+// sourceRange.assertIsOwnerThread() grants shared access to sourceRange's lock, not to this one's.
+#define WTF_DECLARE_OWNER_THREAD_ASSERTIONS(lock, ownerThread) \
+    void assertIsOwnerThread() const WTF_ASSERTS_ACQUIRED_SHARED_LOCK(lock) \
+    { \
+        WTF::assertIsOwnerThread(lock, ownerThread); \
+    } \
+    ALWAYS_INLINE void releaseOwnerThreadAssertion() const WTF_RELEASES_SHARED_LOCK(lock) WTF_IGNORES_THREAD_SAFETY_ANALYSIS \
+    { \
+    }
+
 // Type for globally named assertions for describing access requirements.
 // Can be used, for example, to require that a variable is accessed only in
 // a known named thread.

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -128,7 +128,9 @@ ExceptionOr<void> Range::setStart(Ref<Node>&& container, unsigned offset)
     if (childNode.hasException())
         return childNode.releaseException();
 
+    assertIsOwnerThread();
     bool shouldAlsoSetEnd = !is_lteq(treeOrder(BoundaryPoint(container.copyRef(), offset), makeBoundaryPoint(m_end)));
+    releaseOwnerThreadAssertion();
     {
         Locker locker { m_boundaryPointLock };
         m_start.set(WTF::move(container), offset, childNode.releaseReturnValue());
@@ -148,7 +150,9 @@ ExceptionOr<void> Range::setEnd(Ref<Node>&& container, unsigned offset)
     if (childNode.hasException())
         return childNode.releaseException();
 
+    assertIsOwnerThread();
     bool shouldAlsoSetStart = !is_lteq(treeOrder(makeBoundaryPoint(m_start), BoundaryPoint(container.copyRef(), offset)));
+    releaseOwnerThreadAssertion();
     {
         Locker locker { m_boundaryPointLock };
         m_end.set(WTF::move(container), offset, childNode.releaseReturnValue());
@@ -226,6 +230,7 @@ ExceptionOr<Range::CompareResults> Range::compareNode(Node& node) const
         return Exception { ExceptionCode::NotFoundError };
     }
 
+    assertIsOwnerThread();
     auto startOrdering = treeOrder(nodeRange->start, makeBoundaryPoint(m_start));
     auto endOrdering = treeOrder(nodeRange->end, makeBoundaryPoint(m_end));
     if (is_gteq(startOrdering) && is_lteq(endOrdering))
@@ -241,6 +246,8 @@ ExceptionOr<Range::CompareResults> Range::compareNode(Node& node) const
 
 ExceptionOr<short> Range::compareBoundaryPoints(unsigned short how, const Range& sourceRange) const
 {
+    assertIsOwnerThread();
+    sourceRange.assertIsOwnerThread();
     const RangeBoundaryPoint* thisPoint;
     const RangeBoundaryPoint* otherPoint;
     switch (how) {
@@ -321,6 +328,7 @@ static inline Node* NODELETE childOfCommonRootBeforeOffset(Node* container, unsi
 
 ExceptionOr<RefPtr<DocumentFragment>> Range::processContents(ActionType action)
 {
+    assertIsOwnerThread();
     RefPtr<DocumentFragment> fragment;
     if (action == Extract || action == Clone)
         fragment = DocumentFragment::create(protect(m_ownerDocument));
@@ -792,6 +800,7 @@ ExceptionOr<RefPtr<Node>> Range::checkNodeOffsetPair(Node& node, unsigned offset
 
 Ref<Range> Range::cloneRange() const
 {
+    assertIsOwnerThread();
     auto result = create(m_ownerDocument);
     result->setStart(protect(startContainer()), m_start.offset());
     result->setEnd(protect(endContainer()), m_end.offset());
@@ -912,6 +921,7 @@ ExceptionOr<void> Range::setStartBefore(Node& node)
 #if ENABLE(TREE_DEBUGGING)
 String Range::debugDescription() const
 {
+    assertIsOwnerThread();
     return makeString("from offset "_s, m_start.offset(), " of "_s, startContainer().debugDescription(), " to offset "_s, m_end.offset(), " of "_s, endContainer().debugDescription());
 }
 #endif
@@ -968,6 +978,7 @@ void Range::nodeWillBeRemoved(Node& node)
 
 bool Range::parentlessNodeMovedToNewDocumentAffectsRange(Node& node)
 {
+    assertIsOwnerThread();
     return node.isShadowIncludingInclusiveAncestorOf(&m_start.container());
 }
 

--- a/Source/WebCore/dom/Range.h
+++ b/Source/WebCore/dom/Range.h
@@ -29,6 +29,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/Lock.h>
 #include <wtf/Locker.h>
+#include <wtf/ThreadAssertions.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -50,11 +51,11 @@ public:
     WEBCORE_EXPORT static Ref<Range> create(Document&);
     WEBCORE_EXPORT ~Range();
 
-    Node& startContainer() const final { return m_start.container(); }
-    unsigned startOffset() const final { return m_start.offset(); }
-    Node& endContainer() const final { return m_end.container(); }
-    unsigned endOffset() const final { return m_end.offset(); }
-    bool collapsed() const final { return m_start == m_end; }
+    Node& startContainer() const final { assertIsOwnerThread(); return m_start.container(); }
+    unsigned startOffset() const final { assertIsOwnerThread(); return m_start.offset(); }
+    Node& endContainer() const final { assertIsOwnerThread(); return m_end.container(); }
+    unsigned endOffset() const final { assertIsOwnerThread(); return m_end.offset(); }
+    bool collapsed() const final { assertIsOwnerThread(); return m_start == m_end; }
     WEBCORE_EXPORT Node* commonAncestorContainer() const;
 
     void resetDidChangeForHighlight() { m_didChangeForHighlight = false; }
@@ -146,9 +147,12 @@ private:
     ExceptionOr<RefPtr<DocumentFragment>> processContents(ActionType);
 
     Ref<Document> m_ownerDocument;
-    RangeBoundaryPoint m_start;
-    RangeBoundaryPoint m_end;
+    // Only mutated on the main thread while holding m_boundaryPointLock, so main-thread reads use
+    // assertIsOwnerThread() instead of locking; the GC thread must lock even to read.
+    RangeBoundaryPoint m_start WTF_GUARDED_BY_LOCK(m_boundaryPointLock);
+    RangeBoundaryPoint m_end WTF_GUARDED_BY_LOCK(m_boundaryPointLock);
     mutable Lock m_boundaryPointLock;
+    WTF_DECLARE_OWNER_THREAD_ASSERTIONS(m_boundaryPointLock, mainThreadLike);
     bool m_isAssociatedWithSelection { false };
     bool m_didChangeForHighlight { false };
     bool m_isAssociatedWithHighlight { false };


### PR DESCRIPTION
#### 6f1389789211dc9bd677c8ef2fe152f12584b335
<pre>
Annotate Range&apos;s boundary points as owner-thread state
<a href="https://bugs.webkit.org/show_bug.cgi?id=323647">https://bugs.webkit.org/show_bug.cgi?id=323647</a>

Reviewed by Geoffrey Garen.

Range::m_start and m_end are mutated on the main thread under m_boundaryPointLock and read
on the GC threads by visitNodesInGCThread(), which locks. That reader is reached through
JSRange::visitAdditionalChildrenInGCThread(), so unlike isReachableFromOpaqueRoots() and
hasPendingActivity() it runs concurrently with the main thread rather than with the world
paused, and the lock it takes is load-bearing. The eleven mutation sites already took the
lock; nothing enforced that they did.

Guard both members with WTF_GUARDED_BY_LOCK() and assert on the main thread&apos;s unlocked read
paths. Most of those reads are not in Range.cpp but in the five inline accessors
startContainer(), startOffset(), endContainer(), endOffset() and collapsed(), which is
where the bulk of WebCore reaches the boundary points; annotating them is what makes the
guard hold for their callers. setStart() and setEnd() each read the opposite boundary point
to decide whether the range collapses before entering their critical section, so they are
the assert-then-lock case and call releaseOwnerThreadAssertion() before the Locker; they
are its first users. compareBoundaryPoints() reads a second Range&apos;s boundary points, and
shared access to one instance&apos;s lock grants nothing for another&apos;s, so it asserts on
sourceRange as well.

Also add WTF_DECLARE_OWNER_THREAD_ASSERTIONS(), which declares assertIsOwnerThread() and
releaseOwnerThreadAssertion() members for a class, so call sites name neither the lock nor
the owner thread and the choice of owner is stated once. Being members is what lets
compareBoundaryPoints() write sourceRange.assertIsOwnerThread() to grant access to that
object&apos;s lock. An RAII form was considered instead of the explicit release. It is worse
here: it does nothing for the common case of a function that only reads, and for
setStart()/setEnd() it forces the result variable out of its initializer and into an extra
scope, since leaving the assertion live to the end of the enclosing scope still reports the
Locker as acquiring a lock that is already held. Omitting the release is a build failure,
not a silent bug, so there is nothing for RAII to make safe.

No behaviour change is intended.

* Source/WTF/wtf/ThreadAssertions.h:
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::setStart):
(WebCore::Range::setEnd):
(WebCore::Range::compareNode const):
(WebCore::Range::compareBoundaryPoints const):
(WebCore::Range::processContents):
(WebCore::Range::cloneRange const):
(WebCore::Range::debugDescription const):
(WebCore::Range::parentlessNodeMovedToNewDocumentAffectsRange):
* Source/WebCore/dom/Range.h:

Canonical link: <a href="https://commits.webkit.org/320703@main">https://commits.webkit.org/320703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17c725eead28bc134408fcd333ea893a6f71ff05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195788 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150229 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/afd4a915-e5cb-4c4c-8e8e-7ae1b193c451) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144943 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100480 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1a9af27-a70b-442e-88fe-88095373cc9f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125235 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e1ccbb75-8579-4a3e-962a-bf099a54b048) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47347 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45400 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7140 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14027 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45095 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6839 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46721 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197736 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59040 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154458 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41407 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59749 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154107 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48586 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132092 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/128973 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58227 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20117 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57599 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57842 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57666 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->