### PR TITLE
Validate WebCore::ActivityStateForCPUSampling when decoding WebProcessPool::ReportWebContentCPUTime

### DIFF
--- a/LayoutTests/ipc/report-web-content-cpu-time-invalid-activity-state-expected.txt
+++ b/LayoutTests/ipc/report-web-content-cpu-time-invalid-activity-state-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/report-web-content-cpu-time-invalid-activity-state.html
+++ b/LayoutTests/ipc/report-web-content-cpu-time-invalid-activity-state.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=true ] -->
+<p>This test passes if WebKit does not crash.</p>
+<script src="../resources/ipc.js"></script>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+async function test() {
+    if (!window.IPC)
+        return;
+
+    // WebCore::ActivityStateForCPUSampling only has values 0, 1 and 2. 255 used
+    // to reach the UI process unvalidated, where it collided with
+    // WTF::StrongEnumHashTraits<>::emptyValue() and tripped a RELEASE_ASSERT in
+    // the HashMap keyed on the enum. 254 is the deleted-value sentinel; 3 and 42
+    // are plain out-of-range values.
+    //
+    // The activity state is deliberately encoded as uint64_t rather than as the
+    // uint8_t the message now declares: that is the wire format this message had
+    // when the bug was reported, so it is what reproduces the crash on an
+    // unfixed build. Encoding a single byte would instead make the old decoder
+    // fail on a short message, which would make this pass for the wrong reason.
+    for (const activityState of [255, 254, 3, 42]) {
+        IPC.sendMessage('UI', 0, IPC.messages.WebProcessPool_ReportWebContentCPUTime.name,
+            [{ type: 'double', value: 1.5329279109640181e+25 }, // WTF::Seconds cpuTime
+             { type: 'uint64_t', value: BigInt(activityState) }]);
+    }
+
+    // Round-trip through the UI process on the same connection so the messages
+    // above have all been dispatched before the test finishes.
+    await asyncFlush('UI');
+}
+
+test().finally(() => window.testRunner?.notifyDone());
+</script>

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1200,6 +1200,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WTF::UUID': ['<wtf/UUID.h>'],
         'WallTime': ['<wtf/WallTime.h>'],
         'WebCore::AXDebugInfo': ['<WebCore/AXObjectCache.h>'],
+        'WebCore::ActivityStateForCPUSampling': ['<WebCore/ActivityState.h>'],
         'WebCore::AccessibilityMode': ['<WebCore/AXObjectCache.h>'],
         'WebCore::AccessibilityRemoteToken': ['<WebCore/AXObjectCache.h>'],
         'WebCore::AccessibilitySearchCriteriaIPC': ['<WebCore/AXSearchManager.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2652,6 +2652,13 @@ header: <WebCore/ModalContainerTypes.h>
     MediaIsMainContent,
 };
 
+header: <WebCore/ActivityState.h>
+enum class WebCore::ActivityStateForCPUSampling : uint8_t {
+    NonVisible,
+    VisibleNonActive,
+    VisibleAndActive
+};
+
 header: <WebCore/FocusDirection.h>
 enum class WebCore::FocusDirection : uint8_t {
     None,

--- a/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp
+++ b/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp
@@ -78,6 +78,8 @@ static inline String loggingKeyForActivityState(ActivityStateForCPUSampling stat
     case ActivityStateForCPUSampling::VisibleAndActive:
         return DiagnosticLoggingKeys::visibleAndActiveStateKey();
     }
+    RELEASE_ASSERT_NOT_REACHED();
+    return DiagnosticLoggingKeys::nonVisibleStateKey();
 }
 
 void PerActivityStateCPUUsageSampler::loggingTimerFired()

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2112,10 +2112,10 @@ void WebProcessPool::updateHiddenPageThrottlingAutoIncreaseLimit()
     sendToAllProcesses(Messages::WebProcess::SetHiddenPageDOMTimerThrottlingIncreaseLimit(m_hiddenPageDOMTimerThrottlingIncreaseLimit));
 }
 
-void WebProcessPool::reportWebContentCPUTime(Seconds cpuTime, uint64_t activityState)
+void WebProcessPool::reportWebContentCPUTime(Seconds cpuTime, WebCore::ActivityStateForCPUSampling activityState)
 {
 #if PLATFORM(MAC)
-    m_perActivityStateCPUUsageSampler->reportWebContentCPUTime(cpuTime, static_cast<WebCore::ActivityStateForCPUSampling>(activityState));
+    m_perActivityStateCPUUsageSampler->reportWebContentCPUTime(cpuTime, activityState);
 #else
     UNUSED_PARAM(cpuTime);
     UNUSED_PARAM(activityState);

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -102,6 +102,7 @@ class PageConfiguration;
 namespace WebCore {
 class RegistrableDomain;
 class Site;
+enum class ActivityStateForCPUSampling : uint8_t;
 enum class EventMakesGamepadsVisible : bool;
 enum class GamepadHapticEffectType : uint8_t;
 enum class ProcessSwapDisposition : uint8_t;
@@ -330,7 +331,7 @@ public:
     void setShouldMakeNextWebProcessLaunchFailForTesting(bool value) { m_shouldMakeNextWebProcessLaunchFailForTesting = value; }
     bool shouldMakeNextWebProcessLaunchFailForTesting() const { return m_shouldMakeNextWebProcessLaunchFailForTesting; }
 
-    void reportWebContentCPUTime(Seconds cpuTime, uint64_t activityState);
+    void reportWebContentCPUTime(Seconds cpuTime, WebCore::ActivityStateForCPUSampling);
 
     Ref<WebProcessProxy> processForSite(WebsiteDataStore&, WebProcessProxy::IsolatedProcessType, const std::optional<WebCore::Site>&, const std::optional<WebCore::Site>& mainFrameSite, WebProcessProxy::LockdownMode, EnhancedSecurity, const API::PageConfiguration&, WebCore::ProcessSwapDisposition); // Will return an existing one if limit is met or due to caching.
 

--- a/Source/WebKit/UIProcess/WebProcessPool.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessPool.messages.in
@@ -43,5 +43,5 @@ messages -> WebProcessPool {
     [EnabledBy=ModelElementEnabled && ModelProcessEnabled] StoppedPlayingModels()
 #endif
 
-    ReportWebContentCPUTime(Seconds cpuTime, uint64_t activityState)
+    ReportWebContentCPUTime(Seconds cpuTime, enum:uint8_t WebCore::ActivityStateForCPUSampling activityState)
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -492,7 +492,7 @@ void WebChromeClient::runModal()
 
 void WebChromeClient::reportProcessCPUTime(Seconds cpuTime, ActivityStateForCPUSampling activityState)
 {
-    WebProcess::singleton().send(Messages::WebProcessPool::ReportWebContentCPUTime(cpuTime, static_cast<uint64_t>(activityState)), 0);
+    WebProcess::singleton().send(Messages::WebProcessPool::ReportWebContentCPUTime(cpuTime, activityState), 0);
 }
 
 bool WebChromeClient::isPopup() const


### PR DESCRIPTION
#### a2ea9093812ea832e73fda46055da5d1d9056a55
<pre>
Validate WebCore::ActivityStateForCPUSampling when decoding WebProcessPool::ReportWebContentCPUTime
<a href="https://bugs.webkit.org/show_bug.cgi?id=323648">https://bugs.webkit.org/show_bug.cgi?id=323648</a>
<a href="https://rdar.apple.com/185199111">rdar://185199111</a>

Reviewed by Charlie Wolfe.

Declaring the argument as enum:uint8_t WebCore::ActivityStateForCPUSampling and
adding the enum to WebCoreArgumentCoders.serialization.in makes the serialization
generator emit isValidEnum&lt;WebCore::ActivityStateForCPUSampling&gt;(uint8_t), which
the generated decoder now runs before the handler is called. An out-of-range byte
therefore fails to decode: the message is dropped and the sending WebContent
process is terminated for sending an invalid message, instead of the UI process
aborting. Because the value handed to
PerActivityStateCPUUsageSampler::reportWebContentCPUTime is now guaranteed to be
one of the three enumerators, it can no longer equal StrongEnumHashTraits&apos;s empty
(255) or deleted (254) sentinel, making the RELEASE_ASSERT(isValidKey(value)) in
HashTable::add() unreachable. Narrowing the wire type from uint64_t to uint8_t
also removes the truncation that turned 767 into 255 in the first place, so no
wider value can fold onto a sentinel.

Test: ipc/report-web-content-cpu-time-invalid-activity-state.html

* LayoutTests/ipc/report-web-content-cpu-time-invalid-activity-state-expected.txt: Added.
* LayoutTests/ipc/report-web-content-cpu-time-invalid-activity-state.html: Added.
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp:
(WebKit::loggingKeyForActivityState):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::reportWebContentCPUTime):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessPool.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::reportProcessCPUTime):

Canonical link: <a href="https://commits.webkit.org/320752@main">https://commits.webkit.org/320752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7d1bdbae0d8054f4f67cc1b4eea6dfcc4c3706e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195972 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150374 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6735de38-3335-42b4-a1ea-8567129426b5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145084 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100587 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/23a43bdd-335b-49c7-b4fe-cf0c4bad322d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125379 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b84985b5-90b9-47ef-b99d-3c0a3d372d49) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/184993 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47496 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45538 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45233 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7035 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197935 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59232 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154619 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41439 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59939 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154272 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48736 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132289 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129193 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58409 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20255 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57785 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58025 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57850 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->