### PR TITLE
[JSC] Atomics.isLockFree should use ToIntegerOrInfinity

### DIFF
--- a/JSTests/stress/atomics-is-lock-free-integer.js
+++ b/JSTests/stress/atomics-is-lock-free-integer.js
@@ -1,0 +1,48 @@
+function toIntegerOrInfinity(value) {
+    let number = Number(value);
+    if (isNaN(number))
+        return 0;
+    return Math.trunc(number) + 0;
+}
+
+function expected(size) {
+    let n = toIntegerOrInfinity(size);
+    return n === 1 || n === 2 || n === 4 || n === 8;
+}
+
+function check(size) {
+    let actual = Atomics.isLockFree(size);
+    let want = expected(size);
+    if (actual !== want)
+        throw new Error("Atomics.isLockFree(" + size + ") === " + actual + ", expected " + want);
+}
+
+function foo(size) {
+    return Atomics.isLockFree(size);
+}
+noInline(foo);
+
+let values = [
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12,
+    1.9, 2.1, 4.9, 8.9,
+    4294967296, 4294967297, 4294967298, 4294967300, 4294967304,
+    -4294967295, -1, -0,
+    NaN, Infinity, -Infinity,
+    "1", "4", "4294967297",
+    true, false,
+    { valueOf() { return 4294967297; } },
+    { valueOf() { return 1; } },
+];
+
+for (let i = 0; i < testLoopCount; ++i) {
+    for (let value of values)
+        check(value);
+    if (foo(4294967297) !== false)
+        throw new Error("bad JIT result for 4294967297");
+    if (foo(1) !== true)
+        throw new Error("bad JIT result for 1");
+    if (foo(4) !== true)
+        throw new Error("bad JIT result for 4");
+    if (foo(8) !== true)
+        throw new Error("bad JIT result for 8");
+}

--- a/Source/JavaScriptCore/runtime/AtomicsObject.cpp
+++ b/Source/JavaScriptCore/runtime/AtomicsObject.cpp
@@ -309,21 +309,16 @@ EncodedJSValue isLockFree(JSGlobalObject* globalObject, JSValue arg)
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    int32_t size = arg.toInt32(globalObject);
-    RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
-    
-    bool result;
-    switch (size) {
-    case 1:
-    case 2:
-    case 4:
-    case 8:
-        result = true;
-        break;
-    default:
-        result = false;
-        break;
+    if (arg.isInt32()) [[likely]] {
+        int32_t size = arg.asInt32();
+        bool result = size == 1 || size == 2 || size == 4 || size == 8;
+        return JSValue::encode(jsBoolean(result));
     }
+
+    double size = arg.toIntegerOrInfinity(globalObject);
+    RETURN_IF_EXCEPTION(scope, JSValue::encode(jsUndefined()));
+
+    bool result = size == 1 || size == 2 || size == 4 || size == 8;
     return JSValue::encode(jsBoolean(result));
 }
 


### PR DESCRIPTION
#### 41294576aca94ffb4246dff6c82cadf4c2b58123
<pre>
[JSC] Atomics.isLockFree should use ToIntegerOrInfinity
<a href="https://bugs.webkit.org/show_bug.cgi?id=323323">https://bugs.webkit.org/show_bug.cgi?id=323323</a>

Reviewed by Yusuke Suzuki.

Atomics.isLockFree used ToInt32. A size such as 4294967297 wrapped to 1
and returned true. The spec compares the exact ToIntegerOrInfinity
result to 1, 2, 4, and 8.

* Source/JavaScriptCore/runtime/AtomicsObject.cpp:
* JSTests/stress/atomics-is-lock-free-integer.js: Added.

Canonical link: <a href="https://commits.webkit.org/320715@main">https://commits.webkit.org/320715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9ae61d56ddb5b235b1c904a99715b8ca6eaffd1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150291 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144990 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100526 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125282 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47399 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45459 "Passed tests") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/7187 "Build was cancelled. Recent messages:Printed configuration; Checked out pull request; Found 2104 jsc stress test failures: jsc-layout-tests.yaml/js/script-tests/weakref-finalizationregistry.js.layout, jsc-layout-tests.yaml/js/script-tests/weakref-finalizationregistry.js.layout-dfg-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/weakref-finalizationregistry.js.layout-ftl-eager-no-cjit, jsc-layout-tests.yaml/js/script-tests/weakref-finalizationregistry.js.layout-ftl-no-cjit, jsc-layout-tests.yaml/js/script-tests/weakref-finalizationregistry.js.layout-no-cjit ...; Compiled WebKit (warnings); jscore-tests (cancelled)") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14073 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157766 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45141 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6913 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46795 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197812 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59114 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154524 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41414 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59823 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154171 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48637 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132269 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129074 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58298 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20163 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57672 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57914 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57738 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->