### PR TITLE
Cherry-pick 305413.1059@safari-7624.5.1.10-branch (e66d0b93bf1f). https://bugs.webkit.org/show_bug.cgi?id=316131

### DIFF
--- a/JSTests/stress/unlinked-metadata-table-finalize-overflow.js
+++ b/JSTests/stress/unlinked-metadata-table-finalize-overflow.js
@@ -1,0 +1,18 @@
+//@ skip if $buildType == "debug" or $memoryLimited or $addressBits <= 32
+//@ slow!
+//@ runDefault
+
+let n = 44739242;
+let s = 'a();'.repeat(n);
+let f = new Function('a', s);
+
+let caught = false;
+try {
+    f(function() { });
+} catch (e) {
+    caught = true;
+    if (!(e instanceof RangeError))
+        throw new Error("Expected RangeError but got: " + e);
+}
+if (!caught)
+    throw new Error("Expected RangeError to be thrown");

--- a/JSTests/wasm/stress/tail-call-unused-pins.js
+++ b/JSTests/wasm/stress/tail-call-unused-pins.js
@@ -1,0 +1,50 @@
+//@ requireOptions("--useWasmFastMemory=true")
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+const watA = `
+(module
+    (type $sig (func (param i32 i64)))
+    (import "e" "mem" (memory 1 1))
+    (import "e" "nop" (func $nop))
+    (table (export "tbl") 1 1 funcref)
+    (func (export "f") (param $do_call i32) (param $off i32) (param $val i64)
+        (call $nop)
+        (if (local.get $do_call)
+            (then (return_call_indirect (type $sig)
+                    (local.get $off) (local.get $val) (i32.const 0))))))
+`;
+
+const watB = `
+(module
+    (import "e" "mem" (memory 1 1))
+    (func (export "g") (param $off i32) (param $val i64)
+        (i64.store (local.get $off) (local.get $val))))
+`;
+
+async function test() {
+    const memA = createWebAssemblyMemoryWithMode({ initial: 1, maximum: 1 }, "Signaling");
+    const memB = createWebAssemblyMemoryWithMode({ initial: 1, maximum: 1 }, "BoundsChecking");
+    assert.eq(WebAssemblyMemoryMode(memA), "Signaling");
+    assert.eq(WebAssemblyMemoryMode(memB), "BoundsChecking");
+
+    const instA = await instantiate(watA, { e: { mem: memA, nop: () => {} } }, { tail_call: true });
+    const { f, tbl } = instA.exports;
+
+    const instB = await instantiate(watB, { e: { mem: memB } });
+    const { g } = instB.exports;
+
+    assert.throws(() => g(0x20000, 0n), WebAssembly.RuntimeError, "Out of bounds memory access");
+
+    // Tier g into BBQ. IPInt's prologue reloads regCS4 on entry but BBQ does not.
+    for (let i = 0; i < wasmTestLoopCount; ++i) g(0, 0n);
+
+    // Tier f to OMG without ever taking the tail-call branch.
+    for (let i = 0; i < wasmTestLoopCount; ++i) f(0, 0, 0n);
+
+    tbl.set(0, g);
+
+    assert.throws(() => f(1, 0x20000, 0n), WebAssembly.RuntimeError, "Out of bounds memory access");
+}
+
+await assert.asyncTest(test());

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024, 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,14 +51,15 @@ void UnlinkedCodeBlockGenerator::addTypeProfilerExpressionInfo(unsigned instruct
     m_typeProfilerInfoMap.set(instructionOffset, range);
 }
 
-void UnlinkedCodeBlockGenerator::finalize(std::unique_ptr<JSInstructionStream> instructions)
+bool UnlinkedCodeBlockGenerator::finalize(std::unique_ptr<JSInstructionStream> instructions)
 {
     ASSERT(instructions);
+    bool metadataOK = true;
     {
         Locker locker { m_codeBlock->cellLock() };
         m_codeBlock->m_instructions = WTF::move(instructions);
         m_codeBlock->allocateSharedProfiles(m_numBinaryArithProfiles, m_numUnaryArithProfiles);
-        m_codeBlock->m_metadata->finalize();
+        metadataOK = m_codeBlock->m_metadata->finalize();
 
         m_codeBlock->m_jumpTargets = WTF::move(m_jumpTargets);
         m_codeBlock->m_identifiers = WTF::move(m_identifiers);
@@ -95,6 +96,7 @@ void UnlinkedCodeBlockGenerator::finalize(std::unique_ptr<JSInstructionStream> i
     }
     m_vm.writeBarrier(m_codeBlock.get());
     m_vm.heap.reportExtraMemoryAllocated(m_codeBlock.get(), m_codeBlock->m_instructions->sizeInBytes() + m_codeBlock->metadataSizeInBytes());
+    return metadataOK;
 }
 
 UnlinkedHandlerInfo* UnlinkedCodeBlockGenerator::handlerForBytecodeIndex(BytecodeIndex bytecodeIndex, RequiredHandler requiredHandler)

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024, 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -193,7 +193,7 @@ public:
 
     void applyModification(BytecodeRewriter&, JSInstructionStreamWriter&);
 
-    void finalize(std::unique_ptr<JSInstructionStream>);
+    [[nodiscard]] bool finalize(std::unique_ptr<JSInstructionStream>);
 
     void dump(PrintStream&) const;
 

--- a/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023, 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 #include "UnlinkedMetadataTable.h"
 
 #include "BytecodeStructs.h"
+#include <wtf/CheckedArithmetic.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -98,41 +99,79 @@ void MetadataStatistics::reportMetadataStatistics()
 }
 #endif
 
-void UnlinkedMetadataTable::finalize()
+bool UnlinkedMetadataTable::finalize()
 {
     ASSERT(!m_isFinalized);
     m_isFinalized = true;
     if (!m_hasMetadata) {
         MetadataTableMalloc::free(m_rawBuffer);
         m_rawBuffer = nullptr;
-        return;
+        return true;
     }
 
-    unsigned offset = s_offset16TableSize;
+    unsigned offset;
+    unsigned valueProfileSize;
     {
+        CheckedUint32 checkedOffset = s_offset16TableSize;
         Offset32* buffer = preprocessBuffer();
-        for (unsigned i = 0; i < s_offsetTableEntries - 1; i++) {
+        for (unsigned i = 0; i < s_offsetTableEntries - 1 && !checkedOffset.hasOverflowed(); i++) {
             unsigned numberOfEntries = buffer[i];
             if (!numberOfEntries) {
-                buffer[i] = offset;
+                buffer[i] = checkedOffset.value();
                 continue;
             }
-            buffer[i] = offset; // We align when we access this.
+            buffer[i] = checkedOffset.value(); // We align when we access this.
             unsigned alignment = metadataAlignment(static_cast<OpcodeID>(i));
             ASSERT(alignment <= s_maxMetadataAlignment);
 
 #if CPU(ADDRESS64)
             // This is only necessary for the first metadata entry, if the buffer
             // is 4-byte aligned and the entry has an alignment requirement of 8
-            ASSERT(offset == roundUpToMultipleOf(alignment, offset) || offset == s_offset16TableSize);
+            ASSERT(checkedOffset.value() == roundUpToMultipleOf(alignment, checkedOffset.value()) || checkedOffset.value() == s_offset16TableSize);
 #endif
-            offset = roundUpToMultipleOf(alignment, offset);
+            unsigned alignedOffset = roundUpToMultipleOf(alignment, checkedOffset.value());
+            if (alignedOffset < checkedOffset.value()) {
+                checkedOffset.overflowed();
+                break;
+            }
+            checkedOffset = alignedOffset;
 
-            offset += numberOfEntries * metadataSize(static_cast<OpcodeID>(i));
+            checkedOffset += CheckedUint32(numberOfEntries) * metadataSize(static_cast<OpcodeID>(i));
 #if ENABLE(METADATA_STATISTICS)
+            // In the unlikely event of an overflow, MetadataStatistics::perOpcodeCount
+            // will not be accurate. But this is OK because these stats are only used for
+            // development time analysis where overflow is not expected.
             MetadataStatistics::perOpcodeCount[i] += numberOfEntries;
 #endif
         }
+
+        // Each computed offset is stored as Offset32 (with an additional s_offset32TableSize bias in the
+        // 32-bit layout) and totalSize() sums valueProfileSize with that biased offset as unsigned.
+        // Reject any function whose metadata cannot be addressed within those limits.
+        CheckedUint32 checkedValueProfileSize = m_numValueProfiles;
+        checkedValueProfileSize *= static_cast<unsigned>(sizeof(ValueProfile));
+
+        // On 32-bits, also guard against potential malloc size overflow in the newBuffer
+        // allocation below, where we add sizeof(LinkingData). On 64-bit, sizes are
+        // auto-casted to a 64-bit size_t that can handle the addition, and hence, does
+        // not need this padding to reserve space for the size of sizeof(LinkingData).
+        unsigned paddingFor32Bit = 0;
+        if constexpr (sizeof(size_t) == sizeof(unsigned))
+            paddingFor32Bit = sizeof(LinkingData);
+
+        if ((checkedOffset + s_offset32TableSize + checkedValueProfileSize + paddingFor32Bit).hasOverflowed()) [[unlikely]] {
+            MetadataTableMalloc::free(m_rawBuffer);
+            m_rawBuffer = nullptr;
+            m_hasMetadata = false;
+            m_is32Bit = false;
+            m_numValueProfiles = 0;
+            return false; // Failure.
+        }
+
+        ASSERT(!checkedOffset.hasOverflowed());
+        ASSERT(!checkedValueProfileSize.hasOverflowed());
+        offset = checkedOffset.value();
+        valueProfileSize = checkedValueProfileSize.value();
         buffer[s_offsetTableEntries - 1] = offset;
         m_is32Bit = offset > UINT16_MAX;
     }
@@ -148,7 +187,6 @@ void UnlinkedMetadataTable::finalize()
     });
 #endif
 
-    unsigned valueProfileSize = m_numValueProfiles * sizeof(ValueProfile);
     if (m_is32Bit) {
         // offset already accounts for s_offset16TableSize
         uint8_t* newBuffer = reinterpret_cast_ptr<uint8_t*>(MetadataTableMalloc::malloc(valueProfileSize + sizeof(LinkingData) + s_offset32TableSize + offset));
@@ -170,6 +208,7 @@ void UnlinkedMetadataTable::finalize()
         MetadataTableMalloc::free(m_rawBuffer);
         m_rawBuffer = newBuffer;
     }
+    return true;
 }
 
 UnlinkedMetadataTable::~UnlinkedMetadataTable()

--- a/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023, 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,7 +81,7 @@ public:
 
     size_t sizeInBytesForGC();
 
-    void finalize();
+    [[nodiscard]] bool finalize();
 
     RefPtr<MetadataTable> link();
 

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2023, 2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Cameron Zwarich <cwzwarich@uwaterloo.ca>
  * Copyright (C) 2012 Igalia, S.L.
  *
@@ -360,7 +360,8 @@ ParserError BytecodeGenerator::generate(unsigned& size)
 
     RELEASE_ASSERT(m_codeBlock->numCalleeLocals() < static_cast<unsigned>(FirstConstantRegisterIndex));
     size = instructions().size();
-    m_codeBlock->finalize(m_writer.finalize());
+    if (!m_codeBlock->finalize(m_writer.finalize())) [[unlikely]]
+        return ParserError(ParserError::OutOfMemory);
 
     // We limit total bytecode sequence size to int32_t so that we can use int32_t jump offsets.
     // Also, this allows us to use one bit of bytecode for some flag, including "ignore-result-flag".

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -1629,9 +1629,9 @@ void AssemblyHelpers::emitSaveCalleeSavesFor(const RegisterAtOffsetList* calleeS
     spooler.finalizeFPR();
 }
 
-void AssemblyHelpers::emitRestoreCalleeSavesFor(const RegisterAtOffsetList* calleeSaves)
+void AssemblyHelpers::emitRestoreCalleeSavesFor(const RegisterAtOffsetList* calleeSaves, RegisterSet dontRestoreRegisters)
 {
-    auto dontRestoreRegisters = RegisterSetBuilder::stackRegisters();
+    dontRestoreRegisters.merge(RegisterSetBuilder::stackRegisters());
     unsigned registerCount = calleeSaves->registerCount();
     if constexpr (AssemblyHelpersInternal::dumpVerbose)
         JIT_COMMENT(*this, "emitRestoreCalleeSavesFor ", *calleeSaves, " dontSave: ", dontRestoreRegisters);

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -416,7 +416,7 @@ public:
 
     void emitSaveOrCopyLLIntBaselineCalleeSavesFor(CodeBlock*, VirtualRegister offsetVirtualRegister, RestoreTagRegisterMode, GPRReg temp1, GPRReg temp2, GPRReg temp3);
 
-    void emitRestoreCalleeSavesFor(const RegisterAtOffsetList* calleeSaves);
+    void emitRestoreCalleeSavesFor(const RegisterAtOffsetList* calleeSaves, RegisterSet dontRestoreRegisters = RegisterSet());
 
     void emitSaveThenMaterializeTagRegisters()
     {

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -1245,6 +1245,9 @@ OMGIRGenerator::OMGIRGenerator(AbstractHeapRepository& heaps, CompilationContext
 
     m_proc.pinRegister(GPRInfo::wasmContextInstancePointer);
     m_proc.pinRegister(GPRInfo::wasmBaseMemoryPointer);
+    // FIXME: The wasm ABI effectively has to assume this is a caller save when getting
+    // called by wasm, so there's no point in saving and restoring it if B3 chooses to
+    // use it. We actively don't restore this register in many cases anyway e.g. tail calls.
     if (mode == MemoryMode::BoundsChecking)
         m_proc.pinRegister(GPRInfo::wasmBoundsCheckingSizeRegister);
 
@@ -5649,8 +5652,10 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
     {
         DisallowMacroScratchRegisterUsage disallowScratch(jit);
 
-        // Set up a valid frame so that we can clobber this one.
-        jit.emitRestore(calleeSaves);
+        // Set up a valid frame so that we can clobber this one. Don't restore
+        // wasmBoundsCheckingSizeRegister since we may have set it above and it's
+        // not a normal callee save independent of whether we used it or not.
+        jit.emitRestoreCalleeSavesFor(&calleeSaves, RegisterSet(GPRInfo::wasmBoundsCheckingSizeRegister));
 
         for (unsigned i = 0; i < params.size(); ++i) {
             auto arg = params[i];
@@ -5677,8 +5682,10 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
     constexpr bool tmpNeedsSaving = false;
     constexpr int tmpSpillOffsetRelativeToOriginalSP = 0;
 
-    // Set up a valid frame so that we can clobber this one.
-    jit.emitRestore(calleeSaves);
+    // Set up a valid frame so that we can clobber this one. Don't restore
+    // wasmBoundsCheckingSizeRegister since we may have set it above and it's
+    // not a normal callee save independent of whether we used it or not.
+    jit.emitRestoreCalleeSavesFor(&calleeSaves, RegisterSet(GPRInfo::wasmBoundsCheckingSizeRegister));
 
 #if ASSERT_ENABLED
     for (unsigned i = 0; i < params.size(); ++i) {

--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -361,63 +361,60 @@ static void convertImagePixelsFromFloat16ToFloat16(const ConstPixelBufferConvers
     // verbatim. Do not early-return on a color-space mismatch: the destination is allocated
     // uninitialized, so skipping the write would leak heap bytes through getPixelBuffer().
 
-    auto sourceBytes = source.rows.size_bytes();
-    auto sourcePixelComponents = sourceBytes / 2;
-    auto sourcePixels = sourcePixelComponents / 4;
-    auto sourceHeight = sourceBytes / source.bytesPerRow;
-    auto sourceWidth = sourcePixels / sourceHeight;
+    struct Pixel16 {
+        Float16 r;
+        Float16 g;
+        Float16 b;
+        Float16 a;
+    };
+    static_assert(sizeof(Float16) == 2);
+    static_assert(sizeof(Pixel16) == 4 * sizeof(Float16));
 
-    auto destinationBytes = destination.rows.size_bytes();
-    auto destinationPixelComponents = destinationBytes / 2;
-    auto destinationPixels = destinationPixelComponents / 4;
-    auto destinationHeight = destinationBytes / destination.bytesPerRow;
-    auto destinationWidth = destinationPixels / destinationHeight;
+    // FIXME: This lambda should be moved to separate functions and the caller passes a pointer to one of them.
+    auto convertSinglePixel16 = [](const auto& sourceSpan, auto sourceAlphaFormat, auto& destinationSpan, auto destinationAlphaFormat) {
+        ASSERT(sourceSpan.size_bytes() == sizeof(Pixel16));
+        ASSERT(destinationSpan.size_bytes() == sizeof(Pixel16));
 
-    if (destinationSize.height() >= 0 && size_t(destinationSize.height()) < destinationHeight)
-        destinationHeight = size_t(destinationSize.height());
-    if (destinationSize.width() >= 0 && size_t(destinationSize.width()) < destinationWidth)
-        destinationWidth = size_t(destinationSize.width());
-
-    auto sourceRowStartOffset = 0;
-    auto destinationRowStartOffset = 0;
-    for (size_t y = 0; y < sourceHeight && y < destinationHeight; ++y) {
-        size_t offset = 0;
-        for (size_t x = 0; x < sourceWidth && x < destinationWidth; ++x) {
-            struct Pixel16 {
-                Float16 r = { };
-                Float16 g = { };
-                Float16 b = { };
-                Float16 a = { };
-            };
-            static_assert(sizeof(Float16) == 2);
-            static_assert(sizeof(Pixel16) == 4 * sizeof(Float16));
-            union {
-                Pixel16 pixel16 { };
-                std::array<uint8_t, sizeof(Pixel16)> bytes;
-            } pixel16OrBytesUnion;
-            for (size_t byte = 0; byte < sizeof(Pixel16); ++byte)
-                pixel16OrBytesUnion.bytes[byte] = source.rows[sourceRowStartOffset + offset + byte];
-            if (source.format.alphaFormat != destination.format.alphaFormat) {
-                if (source.format.alphaFormat == AlphaPremultiplication::Unpremultiplied && destination.format.alphaFormat == AlphaPremultiplication::Premultiplied) {
-                    auto fa = float(pixel16OrBytesUnion.pixel16.a);
-                    pixel16OrBytesUnion.pixel16.r = Float16(float(pixel16OrBytesUnion.pixel16.r) * fa);
-                    pixel16OrBytesUnion.pixel16.g = Float16(float(pixel16OrBytesUnion.pixel16.g) * fa);
-                    pixel16OrBytesUnion.pixel16.b = Float16(float(pixel16OrBytesUnion.pixel16.b) * fa);
-                } else if (source.format.alphaFormat == AlphaPremultiplication::Premultiplied && destination.format.alphaFormat == AlphaPremultiplication::Unpremultiplied) {
-                    if (auto fa = float(pixel16OrBytesUnion.pixel16.a)) {
-                        pixel16OrBytesUnion.pixel16.r = Float16(float(pixel16OrBytesUnion.pixel16.r) / fa);
-                        pixel16OrBytesUnion.pixel16.g = Float16(float(pixel16OrBytesUnion.pixel16.g) / fa);
-                        pixel16OrBytesUnion.pixel16.b = Float16(float(pixel16OrBytesUnion.pixel16.b) / fa);
-                    }
-                } else
-                    RELEASE_ASSERT_NOT_REACHED();
-            }
-            for (size_t byte = 0; byte < sizeof(Pixel16); ++byte)
-                destination.rows[destinationRowStartOffset + offset + byte] = pixel16OrBytesUnion.bytes[byte];
-            offset += sizeof(Pixel16);
+        if (sourceAlphaFormat == destinationAlphaFormat) {
+            memcpySpan(destinationSpan, sourceSpan);
+            return;
         }
-        sourceRowStartOffset += source.bytesPerRow;
-        destinationRowStartOffset += destination.bytesPerRow;
+
+        const auto& sourcePixel16 = reinterpretCastSpanStartTo<Pixel16>(sourceSpan);
+        auto& destinationPixel16 = reinterpretCastSpanStartTo<Pixel16>(destinationSpan);
+
+        if (destinationAlphaFormat == AlphaPremultiplication::Premultiplied) {
+            auto fa = float(sourcePixel16.a);
+            destinationPixel16.r = Float16(float(sourcePixel16.r) * fa);
+            destinationPixel16.g = Float16(float(sourcePixel16.g) * fa);
+            destinationPixel16.b = Float16(float(sourcePixel16.b) * fa);
+            destinationPixel16.a = Float16(fa);
+            return;
+        }
+
+        if (auto fa = float(sourcePixel16.a)) {
+            destinationPixel16.r = Float16(float(sourcePixel16.r) / fa);
+            destinationPixel16.g = Float16(float(sourcePixel16.g) / fa);
+            destinationPixel16.b = Float16(float(sourcePixel16.b) / fa);
+            destinationPixel16.a = Float16(fa);
+            return;
+        }
+
+        memcpySpan(destinationSpan, sourceSpan);
+    };
+
+    size_t sourceRowStart = 0;
+    size_t destinationRowStart = 0;
+    size_t bytesPerRow = destinationSize.width() * sizeof(Pixel16);
+
+    for (int y = 0; y < destinationSize.height(); ++y) {
+        for (size_t x = 0; x < bytesPerRow; x += sizeof(Pixel16)) {
+            const auto sourceSpan = source.rows.subspan(sourceRowStart + x, sizeof(Pixel16));
+            auto destinationSpan = destination.rows.subspan(destinationRowStart + x, sizeof(Pixel16));
+            convertSinglePixel16(sourceSpan, source.format.alphaFormat, destinationSpan, destination.format.alphaFormat);
+        }
+        sourceRowStart += source.bytesPerRow;
+        destinationRowStart += destination.bytesPerRow;
     }
 }
 


### PR DESCRIPTION
#### 958472e57ad79a9b12f2f6618b753edfc06fdf43
<pre>
Cherry-pick 305413.1059@safari-7624.5.1.10-branch (e66d0b93bf1f). <a href="https://bugs.webkit.org/show_bug.cgi?id=316131">https://bugs.webkit.org/show_bug.cgi?id=316131</a>

    Converting Float16 pixels buffers to Unpremultiplied or premultiplied may miss the last row
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316131">https://bugs.webkit.org/show_bug.cgi?id=316131</a>
    <a href="https://rdar.apple.com/177764433">rdar://177764433</a>

    Reviewed by Gerald Squelart.

    convertImagePixelsFromFloat16ToFloat16() was written with the wrong assumption.
    The calculations in this function assume the source and destination PixelBuffers
    are rectangular. But sometimes they are not. ImageBufferBackend::getPixelBuffer()
    and ImageBufferBackend::putPixelBuffer() get subspans from the source and
    destination PixelBuffers starting from the starting point till the end of these
    PixelBuffers. The bytesPerRow of the PixelBuffer and PixelBufferConversionView
    may be larger than the bytesPerRow of the requested PixelBuffer.

    Like what other conversion functions do, the solution is not to drive the width
    and the height of sourceBuffer and destinationBuffer from the size_bytes and the
    bytesPerRow. The fix is to convert destinationBytesPerRow pixels from the
    sourceBuffer into the destinationBuffer for every row. To get the starting pixel
    for the next row from the sourceBuffer, we need to move by sourceBytesPerRow.

    * Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
    (WebCore::convertImagePixelsFromFloat16ToFloat16):

    Identifier: 305413.1059@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1167@webkitglib/2.52">https://commits.webkit.org/305877.1167@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### f0619742772d434d18596148fa75300e84d4ffdd
<pre>
Cherry-pick 305413.1027@safari-7624.5.1.10-branch (654718255548). <a href="https://bugs.webkit.org/show_bug.cgi?id=317654">https://bugs.webkit.org/show_bug.cgi?id=317654</a>

    [Wasm] Exclude wasmBoundsCheckingSizeRegister from the callee saves restored
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317654">https://bugs.webkit.org/show_bug.cgi?id=317654</a>
    <a href="https://rdar.apple.com/177693309">rdar://177693309</a>

    Reviewed by Yijia Huang.

    GPRInfo::wasmBoundsCheckingSizeRegister (callee save) is only pinned in B3 when
    the OMG callee is compiled for MemoryMode::BoundsChecking. In Signaling mode
    it stays in B3/Air&apos;s mutable register set, and createTailCallPatchpoint
    declares the full callee-save set as clobberEarly so that B3 does not place
    an input there before the tail-call&apos;s parallel move runs. That clobberEarly
    causes AirHandleCalleeSaves to include regCS4 in the function&apos;s
    calleeSaveRegisterAtOffsetList(). The OMG prologue saves
    wasmBoundsCheckingSizeRegister to the callee save list and when making a
    tail call that callee save is restored after the callee&apos;s memory bounds
    are set.

    The wasm ABI already treats the pinned registers as effectively caller-save
    across wasm-to-wasm calls. Tail calls do not restore them either. Restoring
    wasmBoundsCheckingSizeRegister to the prologue-saved caller value in
    prepareForTailCallImpl is therefore unnecessary.

    This patch teaches emitRestoreCalleeSavesFor to take a dontRestoreRegisters
    set and uses it from prepareForTailCallImpl to skip
    wasmBoundsCheckingSizeRegister. I also added a FIXME at the pinRegister
    site noting that wasmBoundsCheckingSizeRegister is effectively caller-save
    in the wasm ABI.

    Identifier: 305413.1027@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1166@webkitglib/2.52">https://commits.webkit.org/305877.1166@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 1551df23181febd0ba15a2533234a5f28ec0cd4e
<pre>
Cherry-pick 305413.1022@safari-7624.5.1.10-branch (9343a9521f58). <a href="https://bugs.webkit.org/show_bug.cgi?id=317632">https://bugs.webkit.org/show_bug.cgi?id=317632</a>

    Handle overflows in UnlinkedMetadataTable::finalize().
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317632">https://bugs.webkit.org/show_bug.cgi?id=317632</a>
    <a href="https://rdar.apple.com/172794625">rdar://172794625</a>

    Reviewed by Dan Hecht.

    If the number of opcodes (with metadata of substantive size) is large, the 32-bit unsigned
    computed buffer offsets in UnlinkedMetadataTable::finalize() can overflow.  This patch
    applies the use of CheckedArithmetic to detect and handle any potential overflows.  In the
    event of a detected overflow, we&apos;ll propagate the failure to allocate the bytecode metadata
    up to the BytecodeGenerator, and treat its as an OOM error during parsing.

    Test: JSTests/stress/unlinked-metadata-table-finalize-overflow.js

    * JSTests/stress/unlinked-metadata-table-finalize-overflow.js: Added.
    (try.f):
    (catch):
    * Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp:
    (JSC::UnlinkedCodeBlockGenerator::finalize):
    * Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h:
    * Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp:
    (JSC::UnlinkedMetadataTable::finalize):
    * Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h:
    * Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
    (JSC::BytecodeGenerator::generate):

    Identifier: 305413.1022@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1165@webkitglib/2.52">https://commits.webkit.org/305877.1165@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e04375a55ef42b0bef3f6e586b0de4101b517c27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185497 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59409 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53226 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195821 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150256 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187359 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60774 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59136 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144963 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150256 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188452 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60774 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53226 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125255 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60774 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59136 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7160 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53226 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60774 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53226 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6871 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/46754 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52065 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59136 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197769 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59073 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53226 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154486 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59782 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53226 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154135 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28159 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59782 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132128 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129017 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58259 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53226 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57631 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57874 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57697 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->