### PR TITLE
Add a flag to control whether allowing WebRTC to resolve DNS directly

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7147,7 +7147,15 @@ WebRTCAudioLatencyAdaptationEnabled:
   excludeFrom: [ WebCore ]
   defaultValue: true
 
-# FIXME: Is this implemented for WebKitLegacy? If not, this should be excluded from WebKitLegacy entirely.
+WebRTCDNSResolutionBySocketEnabled:
+  type: bool
+  status: testable
+  category: media
+  condition: ENABLE(WEB_RTC)
+  humanReadableName: "WebRTC DNS Resolution By Socket"
+  humanReadableDescription: "Enable WebRTC DNS Resolution By Socket"
+  defaultValue: false
+
 WebRTCDTMFEnabled:
   type: bool
   status: internal

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.cpp
@@ -38,7 +38,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCDnsResolverFactory);
 
 std::unique_ptr<webrtc::AsyncDnsResolverInterface> LibWebRTCDnsResolverFactory::CreateAndResolve(const webrtc::SocketAddress& address, absl::AnyInvocable<void()> callback)
 {
-    auto resolver = protect(WebProcess::singleton().libWebRTCNetwork().socketFactory())->createAsyncDnsResolver();
+    auto resolver = protect(WebProcess::singleton().libWebRTCNetwork().socketFactory())->createAsyncDnsResolver(m_contextIdentifier);
     resolver->start(address, [callback = WTF::move(callback)] () mutable {
         callback();
     });
@@ -47,7 +47,7 @@ std::unique_ptr<webrtc::AsyncDnsResolverInterface> LibWebRTCDnsResolverFactory::
 
 std::unique_ptr<webrtc::AsyncDnsResolverInterface> LibWebRTCDnsResolverFactory::CreateAndResolve(const webrtc::SocketAddress& address, int /* family */, absl::AnyInvocable<void()> callback)
 {
-    auto resolver = protect(WebProcess::singleton().libWebRTCNetwork().socketFactory())->createAsyncDnsResolver();
+    auto resolver = protect(WebProcess::singleton().libWebRTCNetwork().socketFactory())->createAsyncDnsResolver(m_contextIdentifier);
     // FIXME: Make use of family.
     resolver->start(address, [callback = WTF::move(callback)] () mutable {
         callback();
@@ -57,7 +57,7 @@ std::unique_ptr<webrtc::AsyncDnsResolverInterface> LibWebRTCDnsResolverFactory::
 
 std::unique_ptr<webrtc::AsyncDnsResolverInterface> LibWebRTCDnsResolverFactory::Create()
 {
-    return protect(WebProcess::singleton().libWebRTCNetwork().socketFactory())->createAsyncDnsResolver();
+    return protect(WebProcess::singleton().libWebRTCNetwork().socketFactory())->createAsyncDnsResolver(m_contextIdentifier);
 }
 
 void LibWebRTCDnsResolverFactory::Resolver::Start(const webrtc::SocketAddress& address, absl::AnyInvocable<void()> callback)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.h
@@ -30,6 +30,7 @@
 #include <wtf/Compiler.h>
 
 #include <WebCore/LibWebRTCMacros.h>
+#include <WebCore/ScriptExecutionContextIdentifier.h>
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <webrtc/api/async_dns_resolver.h>
@@ -43,6 +44,11 @@ namespace WebKit {
 class LibWebRTCDnsResolverFactory final : public webrtc::AsyncDnsResolverFactoryInterface {
     WTF_MAKE_TZONE_ALLOCATED(LibWebRTCDnsResolverFactory);
 public:
+    explicit LibWebRTCDnsResolverFactory(WebCore::ScriptExecutionContextIdentifier contextIdentifier)
+        : m_contextIdentifier(contextIdentifier)
+    {
+    }
+
     class Resolver : public webrtc::AsyncDnsResolverInterface {
     public:
         virtual void start(const webrtc::SocketAddress&, Function<void()>&&) = 0;
@@ -57,6 +63,8 @@ private:
     std::unique_ptr<webrtc::AsyncDnsResolverInterface> CreateAndResolve(const webrtc::SocketAddress&, absl::AnyInvocable<void()>) final;
     std::unique_ptr<webrtc::AsyncDnsResolverInterface> CreateAndResolve(const webrtc::SocketAddress&, int family, absl::AnyInvocable<void()>) final;
     std::unique_ptr<webrtc::AsyncDnsResolverInterface> Create() final;
+
+    const WebCore::ScriptExecutionContextIdentifier m_contextIdentifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h
@@ -50,6 +50,8 @@ public:
 
     static void signalUsedInterface(WebCore::ScriptExecutionContextIdentifier, String&&);
 
+    bool useMDNSCandidates() const { return m_useMDNSCandidates; }
+
 private:
     explicit LibWebRTCNetworkManager(WebCore::ScriptExecutionContextIdentifier);
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
@@ -78,7 +78,7 @@ webrtc::scoped_refptr<webrtc::PeerConnectionInterface> LibWebRTCProvider::create
     networkManager->setEnumeratingAllNetworkInterfacesEnabled(isEnumeratingAllNetworkInterfacesEnabled());
     networkManager->setEnumeratingVisibleNetworkInterfacesEnabled(isEnumeratingVisibleNetworkInterfacesEnabled());
 
-    return WebCore::LibWebRTCProvider::createPeerConnection(observer, *networkManager, *socketFactory, WTF::move(configuration), makeUnique<LibWebRTCDnsResolverFactory>());
+    return WebCore::LibWebRTCProvider::createPeerConnection(observer, *networkManager, *socketFactory, WTF::move(configuration), makeUnique<LibWebRTCDnsResolverFactory>(identifier));
 }
 
 void LibWebRTCProvider::disableNonLocalhostConnections()
@@ -158,7 +158,7 @@ std::unique_ptr<webrtc::AsyncPacketSocket> RTCSocketFactory::CreateClientTcpSock
 
 std::unique_ptr<webrtc::AsyncDnsResolverInterface> RTCSocketFactory::CreateAsyncDnsResolver()
 {
-    return protect(WebProcess::singleton().libWebRTCNetwork().socketFactory())->createAsyncDnsResolver();
+    return protect(WebProcess::singleton().libWebRTCNetwork().socketFactory())->createAsyncDnsResolver(m_contextIdentifier);
 }
 
 void RTCSocketFactory::suspend()

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp
@@ -29,10 +29,13 @@
 #if USE(LIBWEBRTC)
 
 #include "LibWebRTCNetwork.h"
+#include "LibWebRTCNetworkManager.h"
 #include "Logging.h"
 #include "NetworkProcessConnection.h"
 #include "NetworkRTCProviderMessages.h"
 #include "WebProcess.h"
+#include <WebCore/Document.h>
+#include <WebCore/Settings.h>
 #include <wtf/MainThread.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -56,6 +59,31 @@ LibWebRTCResolver::~LibWebRTCResolver()
     });
 }
 
+static bool canStart(WebCore::ScriptExecutionContextIdentifier contextIdentifier, const String& name)
+{
+    if (name.endsWithIgnoringASCIICase(".local"_s)) {
+        bool isValidUUID = WTF::isVersion4UUID(StringView { name }.left(name.length() - 6));
+        RELEASE_LOG_ERROR_IF(!isValidUUID, WebRTC, "mDNS candidate is not a Version 4 UUID");
+        return isValidUUID;
+    }
+
+    RefPtr document = WebCore::Document::allDocumentsMap().get(contextIdentifier);
+    if (!document) {
+        RELEASE_LOG_ERROR(WebRTC, "DNS Resolution requested for a missing document");
+        return false;
+    }
+
+    if (document->settings().webRTCDNSResolutionBySocketEnabled()) {
+        RefPtr networkManager = downcast<LibWebRTCNetworkManager>(document->rtcNetworkManager());
+        if (document->settings().webRTCRelayBypassDisabled() || (networkManager && networkManager->useMDNSCandidates())) {
+            RELEASE_LOG_INFO(WebRTC, "WebRTC DNS Resolution disabled by policy");
+            return false;
+        }
+    }
+
+    return true;
+}
+
 void LibWebRTCResolver::start(const webrtc::SocketAddress& address, Function<void()>&& callback)
 {
     ASSERT(!m_callback);
@@ -67,13 +95,20 @@ void LibWebRTCResolver::start(const webrtc::SocketAddress& address, Function<voi
     auto addressString = address.HostAsURIString();
     String name = String::fromLatin1(std::span { addressString });
 
-    if (name.endsWithIgnoringASCIICase(".local"_s) && !WTF::isVersion4UUID(StringView { name }.left(name.length() - 6))) {
-        RELEASE_LOG_ERROR(WebRTC, "mDNS candidate is not a Version 4 UUID");
-        setError(-1);
-        return;
-    }
+    sendOnMainThread([identifier = this->identifier(), name = WTF::move(name).isolatedCopy(), contextIdentifier = m_contextIdentifier](IPC::Connection& connection) {
+        if (!canStart(contextIdentifier, name)) {
+            WebCore::LibWebRTCProvider::callOnWebRTCNetworkThread([identifier]() {
+                auto resolver = protect(WebProcess::singleton().libWebRTCNetwork().socketFactory())->resolver(identifier);
+                if (!resolver)
+                    return;
 
-    sendOnMainThread([identifier = this->identifier(), name = WTF::move(name).isolatedCopy()](IPC::Connection& connection) {
+                resolver->setError(-1);
+                if (auto callback = resolver->takeCallback())
+                    callback();
+            });
+            return;
+        }
+
         connection.send(Messages::NetworkRTCProvider::CreateResolver(identifier, name), 0);
     });
 }

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h
@@ -30,6 +30,7 @@
 #include "LibWebRTCDnsResolverFactory.h"
 #include "LibWebRTCResolverIdentifier.h"
 #include <WebCore/LibWebRTCMacros.h>
+#include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Identified.h>
 #include <wtf/TZoneMalloc.h>
@@ -46,7 +47,11 @@ class LibWebRTCResolver final : public LibWebRTCDnsResolverFactory::Resolver, pr
     WTF_MAKE_TZONE_ALLOCATED(LibWebRTCResolver);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LibWebRTCResolver);
 public:
-    LibWebRTCResolver() = default;
+    explicit LibWebRTCResolver(WebCore::ScriptExecutionContextIdentifier contextIdentifier)
+        : m_contextIdentifier(contextIdentifier)
+    {
+    }
+
     ~LibWebRTCResolver();
 
     void start(const webrtc::SocketAddress&, Function<void()>&&) final;
@@ -67,6 +72,7 @@ private:
 
     static void sendOnMainThread(Function<void(IPC::Connection&)>&&);
 
+    const WebCore::ScriptExecutionContextIdentifier m_contextIdentifier;
     Vector<webrtc::IPAddress> m_addresses;
     webrtc::SocketAddress m_addressToResolve;
     Function<void()> m_callback;

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp
@@ -129,9 +129,9 @@ void LibWebRTCSocketFactory::forSocketInGroup(ScriptExecutionContextIdentifier c
     }
 }
 
-std::unique_ptr<LibWebRTCResolver> LibWebRTCSocketFactory::createAsyncDnsResolver()
+std::unique_ptr<LibWebRTCResolver> LibWebRTCSocketFactory::createAsyncDnsResolver(WebCore::ScriptExecutionContextIdentifier contextIdentifier)
 {
-    auto resolver = makeUnique<LibWebRTCResolver>();
+    auto resolver = makeUnique<LibWebRTCResolver>(contextIdentifier);
 
     ASSERT(!m_resolvers.contains(resolver->identifier()));
     m_resolvers.add(resolver->identifier(), *resolver);

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h
@@ -66,7 +66,7 @@ public:
     CheckedPtr<LibWebRTCResolver> resolver(LibWebRTCResolverIdentifier identifier) { return m_resolvers.get(identifier); }
     void removeResolver(LibWebRTCResolverIdentifier identifier) { m_resolvers.remove(identifier); }
 
-    std::unique_ptr<LibWebRTCResolver> createAsyncDnsResolver();
+    std::unique_ptr<LibWebRTCResolver> createAsyncDnsResolver(WebCore::ScriptExecutionContextIdentifier);
 
     void disableNonLocalhostConnections() { m_disableNonLocalhostConnections = true; }
 

--- a/Tools/TestWebKitAPI/Helpers/cocoa/MiniTURNServer.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/MiniTURNServer.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+
+#include <Network/Network.h>
+#include <wtf/Ref.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/Vector.h>
+
+namespace TestWebKitAPI {
+
+class MiniTURNServerState;
+
+// Mini TURN server: speaks just enough STUN/TURN to get libwebrtc's TurnPort to surface a "relay" ICE candidate.
+// See kMockTurnUsername/kMockTurnPassword for credentials to use.
+class MiniTURNServer {
+public:
+    MiniTURNServer();
+    ~MiniTURNServer();
+
+    uint16_t udpPort() const;
+    uint16_t tcpPort() const;
+
+    enum class Transport : uint8_t { Udp, Tcp };
+    struct Request {
+        Transport transport;
+        uint16_t method;
+    };
+    Vector<Request> takeRequests();
+
+    static bool isStunMethodAllocate(uint16_t);
+
+private:
+    const Ref<MiniTURNServerState> m_state;
+    RetainPtr<nw_listener_t> m_udpListener;
+    RetainPtr<nw_listener_t> m_tcpListener;
+};
+
+} // namespace TestWebKitAPI
+
+#endif

--- a/Tools/TestWebKitAPI/Helpers/cocoa/MiniTURNServer.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/MiniTURNServer.mm
@@ -1,0 +1,519 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "Helpers/cocoa/MiniTURNServer.h"
+
+#import "Helpers/Utilities.h"
+#import <CommonCrypto/CommonDigest.h>
+#import <CommonCrypto/CommonHMAC.h>
+#import <atomic>
+#import <netinet/in.h>
+#import <optional>
+#import <string>
+#import <wtf/BlockPtr.h>
+#import <wtf/Function.h>
+#import <wtf/Lock.h>
+#import <wtf/OSObjectPtr.h>
+#import <wtf/StdLibExtras.h>
+#import <wtf/ThreadSafeRefCounted.h>
+#import <wtf/Vector.h>
+#import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
+
+namespace TestWebKitAPI {
+
+// STUN/TURN wire constants (RFC 5389 / RFC 5766).
+static constexpr uint32_t kStunMagicCookie = 0x2112A442;
+static constexpr uint16_t kStunHeaderSize = 20;
+
+static constexpr uint16_t kStunMethodBinding = 0x001;
+static constexpr uint16_t kStunMethodAllocate = 0x003;
+static constexpr uint16_t kStunMethodRefresh = 0x004;
+static constexpr uint16_t kStunMethodCreatePermission = 0x008;
+
+static constexpr uint16_t kStunAttrMessageIntegrity = 0x0008;
+static constexpr uint16_t kStunAttrErrorCode = 0x0009;
+static constexpr uint16_t kStunAttrLifetime = 0x000D;
+static constexpr uint16_t kStunAttrRealm = 0x0014;
+static constexpr uint16_t kStunAttrNonce = 0x0015;
+static constexpr uint16_t kStunAttrXorRelayedAddress = 0x0016;
+static constexpr uint16_t kStunAttrXorMappedAddress = 0x0020;
+
+// Long-term credentials shared with the JS side of the test.
+static constexpr auto kMockTurnUsername = "testUser";
+static constexpr auto kMockTurnPassword = "testPass";
+static constexpr auto kMockTurnRealm = "webkit.test";
+static constexpr auto kMockTurnNonce = "webkit-mock-turn-nonce-12345678";
+
+class MiniTURNServerState : public ThreadSafeRefCounted<MiniTURNServerState> {
+public:
+    static Ref<MiniTURNServerState> create() { return adoptRef(*new MiniTURNServerState); }
+
+    void recordRequest(MiniTURNServer::Transport transport, uint16_t method)
+    {
+        Locker locker { m_lock };
+        m_requests.append({ transport, method });
+    }
+
+    Vector<MiniTURNServer::Request> takeRequests()
+    {
+        Locker locker { m_lock };
+        return std::exchange(m_requests, { });
+    }
+
+    void setUDPPort(uint16_t port) { m_udpPort.store(port); }
+    void setTCPPort(uint16_t port) { m_tcpPort.store(port); }
+    uint16_t udpPort() const { return m_udpPort.load(); }
+    uint16_t tcpPort() const { return m_tcpPort.load(); }
+
+    RetainPtr<nw_listener_t> startListener(MiniTURNServer::Transport, Function<void(uint16_t)>&&);
+
+private:
+    MiniTURNServerState() = default;
+
+    void handleStunMessage(std::span<const uint8_t>, MiniTURNServer::Transport, const sockaddr* peer, NOESCAPE const Function<void(std::span<const uint8_t>)>& reply);
+    void receiveUDPDatagram(RetainPtr<nw_connection_t>&&);
+    void receiveTCPBytes(RetainPtr<nw_connection_t>&&, Vector<uint8_t>&& accumulated = { });
+
+    Lock m_lock;
+    Vector<MiniTURNServer::Request> m_requests WTF_GUARDED_BY_LOCK(m_lock);
+    std::atomic<uint16_t> m_udpPort { 0 };
+    std::atomic<uint16_t> m_tcpPort { 0 };
+};
+
+static uint16_t extractStunMethod(uint16_t messageType)
+{
+    return (messageType & 0x000F) | ((messageType & 0x00E0) >> 1) | ((messageType & 0x3E00) >> 2);
+}
+
+static uint16_t makeStunSuccessMessageType(uint16_t method)
+{
+    // Success response class bits are C1=1, C0=0 → 0x0100.
+    uint16_t type = 0x0100;
+    type |= (method & 0x000F);
+    type |= (method & 0x0070) << 1;
+    type |= (method & 0x0F80) << 2;
+    return type;
+}
+
+static uint16_t makeStunErrorMessageType(uint16_t method)
+{
+    // Error response class bits are C1=1, C0=1 → 0x0110.
+    uint16_t type = 0x0110;
+    type |= (method & 0x000F);
+    type |= (method & 0x0070) << 1;
+    type |= (method & 0x0F80) << 2;
+    return type;
+}
+
+static void writeU16BE(Vector<uint8_t>& out, uint16_t v)
+{
+    out.append(static_cast<uint8_t>(v >> 8));
+    out.append(static_cast<uint8_t>(v & 0xff));
+}
+
+static void writeU32BE(Vector<uint8_t>& out, uint32_t v)
+{
+    writeU16BE(out, static_cast<uint16_t>(v >> 16));
+    writeU16BE(out, static_cast<uint16_t>(v & 0xffff));
+}
+
+static void appendXorAddressAttributeV4(Vector<uint8_t>& out, uint16_t attrType, uint32_t ipv4HostOrder, uint16_t port)
+{
+    writeU16BE(out, attrType);
+    writeU16BE(out, 8);
+    out.append(0x00);
+    out.append(0x01);
+    writeU16BE(out, port ^ static_cast<uint16_t>(kStunMagicCookie >> 16));
+    writeU32BE(out, ipv4HostOrder ^ kStunMagicCookie);
+}
+
+static void appendXorAddressAttributeV6(Vector<uint8_t>& out, uint16_t attrType, std::span<const uint8_t, 16> ipv6, uint16_t port, std::span<const uint8_t> txnId)
+{
+    writeU16BE(out, attrType);
+    writeU16BE(out, 20);
+    out.append(0x00);
+    out.append(0x02);
+    writeU16BE(out, port ^ static_cast<uint16_t>(kStunMagicCookie >> 16));
+    uint8_t xorKey[16] = {
+        0x21, 0x12, 0xA4, 0x42,
+        txnId[0], txnId[1], txnId[2], txnId[3],
+        txnId[4], txnId[5], txnId[6], txnId[7],
+        txnId[8], txnId[9], txnId[10], txnId[11],
+    };
+    uint8_t xored[16];
+    for (size_t i = 0; i < 16; ++i)
+        xored[i] = ipv6[i] ^ xorKey[i];
+    out.append(std::span<const uint8_t> { xored, 16 });
+}
+
+static void appendLifetimeAttribute(Vector<uint8_t>& out, uint32_t seconds)
+{
+    writeU16BE(out, kStunAttrLifetime);
+    writeU16BE(out, 4);
+    writeU32BE(out, seconds);
+}
+
+static void appendPadTo4(Vector<uint8_t>& out)
+{
+    while (out.size() % 4)
+        out.append(0);
+}
+
+static void appendStringAttribute(Vector<uint8_t>& out, uint16_t attrType, const char* value)
+{
+    auto length = strlen(value);
+    writeU16BE(out, attrType);
+    writeU16BE(out, static_cast<uint16_t>(length));
+    out.append(std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(value), length });
+    appendPadTo4(out);
+}
+
+static void appendErrorCodeAttribute(Vector<uint8_t>& out, uint16_t errorCode, const char* reason)
+{
+    auto reasonLength = strlen(reason);
+    writeU16BE(out, kStunAttrErrorCode);
+    writeU16BE(out, static_cast<uint16_t>(4 + reasonLength));
+    out.append(0x00);
+    out.append(0x00);
+    out.append(static_cast<uint8_t>(errorCode / 100));
+    out.append(static_cast<uint8_t>(errorCode % 100));
+    out.append(std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(reason), reasonLength });
+    appendPadTo4(out);
+}
+
+// Long-term credential key = MD5(username ":" realm ":" password) per RFC 5389 §15.4.
+static Vector<uint8_t> computeLongTermAuthKey(const char* username, const char* realm, const char* password)
+{
+    std::string input;
+    input.reserve(strlen(username) + strlen(realm) + strlen(password) + 2);
+    input.append(username);
+    input.push_back(':');
+    input.append(realm);
+    input.push_back(':');
+    input.append(password);
+    Vector<uint8_t> key(CC_MD5_DIGEST_LENGTH);
+    CC_MD5(input.data(), static_cast<CC_LONG>(input.size()), key.mutableSpan().data());
+    return key;
+}
+
+// Appends MESSAGE-INTEGRITY to `message` per RFC 5389 §15.4.
+static void appendMessageIntegrityAttribute(Vector<uint8_t>& message, std::span<const uint8_t> key)
+{
+    constexpr uint16_t messageIntegrityAttrSize = 24; // 4-byte header + 20-byte HMAC.
+    uint16_t finalBodyLength = static_cast<uint16_t>(message.size() - kStunHeaderSize + messageIntegrityAttrSize);
+    message[2] = static_cast<uint8_t>(finalBodyLength >> 8);
+    message[3] = static_cast<uint8_t>(finalBodyLength & 0xff);
+
+    uint8_t hmac[CC_SHA1_DIGEST_LENGTH];
+    CCHmac(kCCHmacAlgSHA1, key.data(), key.size(), message.span().data(), message.size(), hmac);
+
+    writeU16BE(message, kStunAttrMessageIntegrity);
+    writeU16BE(message, static_cast<uint16_t>(CC_SHA1_DIGEST_LENGTH));
+    message.append(std::span<const uint8_t> { hmac, CC_SHA1_DIGEST_LENGTH });
+}
+
+static bool hasMessageIntegrityAttribute(std::span<const uint8_t> message)
+{
+    if (message.size() < kStunHeaderSize)
+        return false;
+    size_t pos = kStunHeaderSize;
+    while (pos + 4 <= message.size()) {
+        uint16_t attrType = (static_cast<uint16_t>(message[pos]) << 8) | message[pos + 1];
+        uint16_t attrLen = (static_cast<uint16_t>(message[pos + 2]) << 8) | message[pos + 3];
+        pos += 4;
+        if (attrType == kStunAttrMessageIntegrity)
+            return true;
+        pos += (attrLen + 3) & ~static_cast<size_t>(3);
+    }
+    return false;
+}
+
+static RetainPtr<nw_endpoint_t> peerEndPointAddress(nw_connection_t conn)
+{
+    RetainPtr endpoint = adoptNS(nw_connection_copy_endpoint(conn));
+    if (nw_endpoint_get_type(endpoint.get()) != nw_endpoint_type_address)
+        return { };
+    return endpoint;
+}
+
+void MiniTURNServerState::handleStunMessage(std::span<const uint8_t> message, MiniTURNServer::Transport transport, const sockaddr* peer, NOESCAPE const Function<void(std::span<const uint8_t>)>& reply)
+{
+    if (!peer) {
+        NSLog(@"MiniTURNServer handleStunMessage: no sockaddr available");
+        return;
+    }
+
+    if (message.size() < kStunHeaderSize)
+        return;
+
+    uint16_t messageType = (static_cast<uint16_t>(message[0]) << 8) | message[1];
+    uint16_t method = extractStunMethod(messageType);
+    uint32_t cookie = (static_cast<uint32_t>(message[4]) << 24)
+        | (static_cast<uint32_t>(message[5]) << 16)
+        | (static_cast<uint32_t>(message[6]) << 8)
+        | message[7];
+    if (cookie != kStunMagicCookie)
+        return;
+
+    recordRequest(transport, method);
+
+    if (method != kStunMethodBinding && method != kStunMethodAllocate
+        && method != kStunMethodRefresh && method != kStunMethodCreatePermission)
+        return;
+
+    auto txnId = message.subspan(8, 12);
+    bool authenticated = hasMessageIntegrityAttribute(message);
+
+    // If the request lacks MESSAGE-INTEGRITY, the client is doing its first request and we reply with a 401 challenge.
+    if (method != kStunMethodBinding && !authenticated) {
+        Vector<uint8_t> body;
+        appendErrorCodeAttribute(body, 401, "Unauthorized");
+        appendStringAttribute(body, kStunAttrRealm, kMockTurnRealm);
+        appendStringAttribute(body, kStunAttrNonce, kMockTurnNonce);
+
+        Vector<uint8_t> out;
+        writeU16BE(out, makeStunErrorMessageType(method));
+        writeU16BE(out, static_cast<uint16_t>(body.size()));
+        writeU32BE(out, kStunMagicCookie);
+        out.append(txnId);
+        out.append(body.span());
+        reply(out.span());
+        return;
+    }
+
+    // Extract peer address + port and decide which family to encode.
+    bool peerIsV4 = false;
+    uint16_t clientPort = 0;
+    uint32_t clientV4HostOrder = 0;
+    const uint8_t* clientV6Bytes = nullptr;
+    if (peer->sa_family == AF_INET) {
+        peerIsV4 = true;
+        auto* v4 = reinterpret_cast<const sockaddr_in*>(peer);
+        clientPort = ntohs(v4->sin_port);
+        clientV4HostOrder = ntohl(v4->sin_addr.s_addr);
+    } else if (peer->sa_family == AF_INET6) {
+        auto* v6 = reinterpret_cast<const sockaddr_in6*>(peer);
+        clientPort = ntohs(v6->sin6_port);
+        if (IN6_IS_ADDR_V4MAPPED(&v6->sin6_addr)) {
+            peerIsV4 = true;
+            clientV4HostOrder = ntohl(*reinterpret_cast<const uint32_t*>(&v6->sin6_addr.s6_addr[12]));
+        } else
+            clientV6Bytes = v6->sin6_addr.s6_addr;
+    } else
+        return;
+
+    // Emit XOR-MAPPED / XOR-RELAYED in the family matching the peer so libwebrtc's TurnPort accepts them alongside its own network family.
+    auto appendPeerXorMapped = [&](Vector<uint8_t>& out) {
+        if (peerIsV4)
+            appendXorAddressAttributeV4(out, kStunAttrXorMappedAddress, clientV4HostOrder, clientPort);
+        else
+            appendXorAddressAttributeV6(out, kStunAttrXorMappedAddress, std::span<const uint8_t, 16> { clientV6Bytes, 16 }, clientPort, txnId);
+    };
+    auto appendLoopbackXorRelayed = [&](Vector<uint8_t>& out) {
+        uint16_t basePort = transport == MiniTURNServer::Transport::Udp ? udpPort() : tcpPort();
+        uint16_t relayPort = basePort + 1;
+        if (peerIsV4)
+            appendXorAddressAttributeV4(out, kStunAttrXorRelayedAddress, INADDR_LOOPBACK, relayPort);
+        else {
+            static constexpr uint8_t v6Loopback[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 };
+            appendXorAddressAttributeV6(out, kStunAttrXorRelayedAddress, std::span<const uint8_t, 16> { v6Loopback, 16 }, relayPort, txnId);
+        }
+    };
+
+    Vector<uint8_t> body;
+    if (method == kStunMethodAllocate) {
+        appendLoopbackXorRelayed(body);
+        appendPeerXorMapped(body);
+        appendLifetimeAttribute(body, 600);
+    } else if (method == kStunMethodRefresh)
+        appendLifetimeAttribute(body, 600);
+    else if (method == kStunMethodBinding)
+        appendPeerXorMapped(body);
+
+    Vector<uint8_t> out;
+    writeU16BE(out, makeStunSuccessMessageType(method));
+    writeU16BE(out, static_cast<uint16_t>(body.size()));
+    writeU32BE(out, kStunMagicCookie);
+    out.append(txnId);
+    out.append(body.span());
+
+    if (authenticated) {
+        auto key = computeLongTermAuthKey(kMockTurnUsername, kMockTurnRealm, kMockTurnPassword);
+        appendMessageIntegrityAttribute(out, key.span());
+    }
+
+    reply(out.span());
+}
+
+static void sendReply(nw_connection_t connection, std::span<const uint8_t> reply, bool isComplete)
+{
+    OSObjectPtr data = adoptOSObject(dispatch_data_create(reply.data(), reply.size(), nullptr, DISPATCH_DATA_DESTRUCTOR_DEFAULT));
+    nw_connection_send(connection, data.get(), NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, isComplete, ^(nw_error_t sendError) {
+        if (sendError)
+            NSLog(@"MiniTURNServer send error %d", nw_error_get_error_code(sendError));
+    });
+}
+
+void MiniTURNServerState::receiveUDPDatagram(RetainPtr<nw_connection_t>&& connection)
+{
+    auto* rawConnection = connection.get();
+    nw_connection_receive_message(rawConnection, makeBlockPtr([protectedThis = Ref { *this }, connection = WTF::move(connection)](dispatch_data_t content, nw_content_context_t, bool, nw_error_t error) mutable {
+        if (error) {
+            NSLog(@"MiniTURNServer UDP receive error %d", nw_error_get_error_code(error));
+            return;
+        }
+        if (content && dispatch_data_get_size(content) >= kStunHeaderSize) {
+            Vector<uint8_t> bytes;
+            dispatch_data_apply_span(content, [&](std::span<const uint8_t> chunk) {
+                bytes.append(chunk);
+                return true;
+            });
+
+            RetainPtr endpoint = peerEndPointAddress(connection.get());
+            protectedThis->handleStunMessage(bytes.span(), MiniTURNServer::Transport::Udp, nw_endpoint_get_address(endpoint.get()), [&connection](auto reply) {
+                bool isComplete = true;
+                sendReply(connection.get(), reply, isComplete);
+            });
+        }
+        protectedThis->receiveUDPDatagram(WTF::move(connection));
+    }).get());
+}
+
+void MiniTURNServerState::receiveTCPBytes(RetainPtr<nw_connection_t>&& connection, Vector<uint8_t>&& accumulated)
+{
+    auto* rawConnection = connection.get();
+    nw_connection_receive(rawConnection, 1, std::numeric_limits<uint32_t>::max(), makeBlockPtr([protectedThis = Ref { *this }, connection = WTF::move(connection), accumulated = WTF::move(accumulated)](dispatch_data_t content, nw_content_context_t, bool isComplete, nw_error_t error) mutable {
+        if (error) {
+            NSLog(@"MiniTURNServer TCP receive error %d", nw_error_get_error_code(error));
+            return;
+        }
+        if (content) {
+            dispatch_data_apply_span(content, [&](std::span<const uint8_t> chunk) {
+                accumulated.append(chunk);
+                return true;
+            });
+        }
+
+        RetainPtr endpoint = peerEndPointAddress(connection.get());
+        while (accumulated.size() >= kStunHeaderSize) {
+            uint16_t bodyLen = (static_cast<uint16_t>(accumulated[2]) << 8) | accumulated[3];
+            size_t total = kStunHeaderSize + bodyLen;
+            if (accumulated.size() < total)
+                break;
+            std::span<const uint8_t> message { accumulated.span().data(), total };
+            protectedThis->handleStunMessage(message, MiniTURNServer::Transport::Tcp, nw_endpoint_get_address(endpoint.get()), [&connection](auto reply) {
+                bool isComplete = false;
+                sendReply(connection.get(), reply, isComplete);
+            });
+            accumulated.removeAt(0, total);
+        }
+        if (!isComplete)
+            protectedThis->receiveTCPBytes(WTF::move(connection), WTF::move(accumulated));
+    }).get());
+}
+
+RetainPtr<nw_listener_t> MiniTURNServerState::startListener(MiniTURNServer::Transport transport, Function<void(uint16_t)>&& onReady)
+{
+    bool isUDP = transport == MiniTURNServer::Transport::Udp;
+    RetainPtr<nw_parameters_t> parameters = isUDP
+        ? adoptNS(nw_parameters_create_secure_udp(NW_PARAMETERS_DISABLE_PROTOCOL, NW_PARAMETERS_DEFAULT_CONFIGURATION))
+        : adoptNS(nw_parameters_create_secure_tcp(NW_PARAMETERS_DISABLE_PROTOCOL, NW_PARAMETERS_DEFAULT_CONFIGURATION));
+
+    RetainPtr listener = adoptNS(nw_listener_create(parameters.get()));
+    nw_listener_set_queue(listener.get(), mainDispatchQueueSingleton());
+
+    nw_listener_set_state_changed_handler(listener.get(), makeBlockPtr([listener, onReady = WTF::move(onReady), isUDP](nw_listener_state_t state, nw_error_t error) mutable {
+        if (state == nw_listener_state_failed) {
+            NSLog(@"MiniTURNServer %s listener failed with error %d", isUDP ? "UDP" : "TCP", error ? nw_error_get_error_code(error) : 0);
+            return;
+        }
+        if (state == nw_listener_state_ready && onReady) {
+            uint16_t port = nw_listener_get_port(listener.get());
+            auto handler = std::exchange(onReady, { });
+            handler(port);
+        }
+    }).get());
+
+    nw_listener_set_new_connection_handler(listener.get(), makeBlockPtr([protectedThis = Ref { *this }, isUDP](nw_connection_t connection) {
+        nw_connection_set_queue(connection, mainDispatchQueueSingleton());
+        nw_connection_start(connection);
+        if (isUDP)
+            protectedThis->receiveUDPDatagram({ connection });
+        else
+            protectedThis->receiveTCPBytes({ connection });
+    }).get());
+
+    nw_listener_start(listener.get());
+    return listener;
+}
+
+MiniTURNServer::MiniTURNServer()
+    : m_state(MiniTURNServerState::create())
+{
+    bool udpReady = false;
+    bool tcpReady = false;
+    m_udpListener = m_state->startListener(Transport::Udp, [&udpReady, state = Ref { m_state }](uint16_t port) {
+        state->setUDPPort(port);
+        udpReady = true;
+    });
+    m_tcpListener = m_state->startListener(Transport::Tcp, [&tcpReady, state = Ref { m_state }](uint16_t port) {
+        state->setTCPPort(port);
+        tcpReady = true;
+    });
+    Util::run(&udpReady);
+    Util::run(&tcpReady);
+}
+
+MiniTURNServer::~MiniTURNServer()
+{
+    if (auto listener = std::exchange(m_udpListener, { }))
+        nw_listener_cancel(listener.get());
+    if (auto listener = std::exchange(m_tcpListener, { }))
+        nw_listener_cancel(listener.get());
+}
+
+uint16_t MiniTURNServer::udpPort() const
+{
+    return m_state->udpPort();
+}
+
+uint16_t MiniTURNServer::tcpPort() const
+{
+    return m_state->tcpPort();
+}
+
+auto MiniTURNServer::takeRequests() -> Vector<Request>
+{
+    return m_state->takeRequests();
+}
+
+bool MiniTURNServer::isStunMethodAllocate(uint16_t method)
+{
+    return method == kStunMethodAllocate;
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/PlatformCocoa.cmake
+++ b/Tools/TestWebKitAPI/PlatformCocoa.cmake
@@ -251,6 +251,7 @@ list(APPEND TestWebKit_SOURCES
 
     Helpers/cocoa/HTTPServer.mm
     Helpers/cocoa/PDFTestHelpers.swift
+    Helpers/cocoa/MiniTURNServer.mm
     Helpers/cocoa/TestCocoaImageAndCocoaColor.mm
     Helpers/cocoa/TestElementFullscreenDelegate.mm
     Helpers/cocoa/TestNSBundleExtras.m

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -617,6 +617,7 @@
 				cocoa/JavaScriptTypes.swift,
 				cocoa/PDFTestHelpers.swift,
 				cocoa/SafeBrowsingTestUtilities.swift,
+				cocoa/MiniTURNServer.mm,
 				cocoa/StdLibExtras.swift,
 				"cocoa/SwiftUI+Extras.swift",
 				cocoa/TestCocoaImageAndCocoaColor.mm,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebRTC.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebRTC.mm
@@ -29,8 +29,13 @@
 
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/PlatformUtilities.h"
+#import "Helpers/Test.h"
+#import "Helpers/cocoa/MiniTURNServer.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/_WKFeature.h>
+#import <wtf/Function.h>
 
 @interface WebRTCMessageHandler : NSObject <WKScriptMessageHandler>
 - (void)setMessageHandler:(Function<void(WKScriptMessage*)>&&)messageHandler;
@@ -200,6 +205,93 @@ TEST(WebKit2, RTCDataChannelPostMessage)
     isReady = false;
     [webView2 stringByEvaluatingJavaScript:@"closePC1()"];
     TestWebKitAPI::Util::run(&isReady);
+}
+
+TEST(WebKit2, WebRTCTurnAllocationWithDirectDNSDisabled)
+{
+    MiniTURNServer turnServer;
+
+    static constexpr auto pageTemplate =
+    "<html><body><script>"
+    "function runTest(port, transportType) {"
+    "    gatherRelayCandidate(port, transportType);"
+    "}"
+    "async function gatherRelayCandidate(port, transportType) {"
+    "    try {"
+    "        const pc = new RTCPeerConnection({"
+    "            iceServers: [{"
+    "                urls: ["
+    "                    `turn:localhost:${port}?transport=${transportType}`"
+    "                ],"
+    "                username: 'testUser',"
+    "                credential: 'testPass'"
+    "            }],"
+    "            iceTransportPolicy: 'relay'"
+    "        });"
+    "        pc.onicecandidate = (event) => {"
+    "            if (!event.candidate)"
+    "                return;"
+    "            const c = event.candidate.candidate;"
+    "            if (!c.includes(' typ relay '))"
+    "                return;"
+    "            pc.close();"
+    "            window.webkit.messageHandlers.webrtc.postMessage('GOT_RELAY');"
+    "        };"
+    "        pc.createDataChannel('probe');"
+    "        const offer = await pc.createOffer();"
+    "        await pc.setLocalDescription(offer);"
+    "    } catch (e) {"
+    "        window.webkit.messageHandlers.webrtc.postMessage('GOT_ERROR: ' + e.message);"
+    "        pc.close();"
+    "    }"
+    "}"
+    "</script></body></html>"_s;
+
+    HTTPServer server({ { "/"_s, { pageTemplate } } }, HTTPServer::Protocol::Http);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"WebRTCDNSResolutionBySocketEnabled"])
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+    }
+
+    RetainPtr messageHandler = adoptNS([[WebRTCMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"webrtc"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    bool gotRelayCandidate = false;
+    RetainPtr<NSString> errorMessage;
+    [messageHandler setMessageHandler:[&gotRelayCandidate, &errorMessage](WKScriptMessage *message) {
+        NSString *body = [message body];
+        if ([body isEqualToString:@"GOT_RELAY"])
+            gotRelayCandidate = true;
+        else
+            errorMessage = body;
+    }];
+
+    [webView loadRequest:server.request()];
+    [webView _test_waitForDidFinishNavigation];
+
+    [webView stringByEvaluatingJavaScript:
+        [NSString stringWithFormat:@"runTest(%u, 'tcp')", turnServer.tcpPort()]];
+    TestWebKitAPI::Util::run(&gotRelayCandidate);
+    EXPECT_NULL(errorMessage.get());
+    EXPECT_TRUE(turnServer.takeRequests().containsIf([](auto& request) {
+        return MiniTURNServer::isStunMethodAllocate(request.method) && request.transport == MiniTURNServer::Transport::Tcp;
+    }));
+
+    errorMessage = { };
+    gotRelayCandidate = false;
+    [webView stringByEvaluatingJavaScript:
+        [NSString stringWithFormat:@"runTest(%u, 'udp')", turnServer.udpPort()]];
+    TestWebKitAPI::Util::run(&gotRelayCandidate);
+    EXPECT_NULL(errorMessage.get());
+    EXPECT_TRUE(turnServer.takeRequests().containsIf([](auto& request) {
+        return MiniTURNServer::isStunMethodAllocate(request.method) && request.transport == MiniTURNServer::Transport::Udp;
+    }));
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 8eb608658b83025730ac1fccd25f19521d1bbd77
<pre>
Add a flag to control whether allowing WebRTC to resolve DNS directly
<a href="https://rdar.apple.com/186852502">rdar://186852502</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=323606">https://bugs.webkit.org/show_bug.cgi?id=323606</a>

Reviewed by Alex Christensen.

We add a flag to disable DNS direct resolution triggered by WebRTC.
WebRTC DNS resolution is triggered for TURN/STUN servers.

By default, the flag disables the DNS resolution except for mDNS and if private relay is bypassed, say if page has access to camera or microphone.
To support this we have to pass the ScriptExecutionContextIdentifier to the LibWebRTCResolver.
We use it to get to the resolver&apos;s document, which allows to check for flags and know whether private relay is bypassed.

We add a test that validates that, even if DNS resolution fails, we can still allocate UDP and TCP TURN candidates.
There is no support for STUN candidates yet as private relay is not supporting UDP bind.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.cpp:
(WebKit::LibWebRTCDnsResolverFactory::CreateAndResolve):
(WebKit::LibWebRTCDnsResolverFactory::Create):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp:
(WebKit::LibWebRTCProvider::createPeerConnection):
(WebKit::RTCSocketFactory::CreateAsyncDnsResolver):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.cpp:
(WebKit::canStart):
(WebKit::LibWebRTCResolver::start):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCResolver.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp:
(WebKit::LibWebRTCSocketFactory::createAsyncDnsResolver):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCSocketFactory.h:
* Tools/TestWebKitAPI/Helpers/cocoa/MiniTURNServer.h: Copied from Source/WebKit/WebProcess/Network/webrtc/LibWebRTCDnsResolverFactory.h.
* Tools/TestWebKitAPI/Helpers/cocoa/MiniTURNServer.mm: Added.
(TestWebKitAPI::MiniTURNServerState::create):
(TestWebKitAPI::MiniTURNServerState::recordRequest):
(TestWebKitAPI::MiniTURNServerState::takeRequests):
(TestWebKitAPI::MiniTURNServerState::setUDPPort):
(TestWebKitAPI::MiniTURNServerState::setTCPPort):
(TestWebKitAPI::MiniTURNServerState::udpPort const):
(TestWebKitAPI::MiniTURNServerState::tcpPort const):
(TestWebKitAPI::extractStunMethod):
(TestWebKitAPI::makeStunSuccessMessageType):
(TestWebKitAPI::makeStunErrorMessageType):
(TestWebKitAPI::writeU16BE):
(TestWebKitAPI::writeU32BE):
(TestWebKitAPI::appendXorAddressAttributeV4):
(TestWebKitAPI::appendXorAddressAttributeV6):
(TestWebKitAPI::appendLifetimeAttribute):
(TestWebKitAPI::appendPadTo4):
(TestWebKitAPI::appendStringAttribute):
(TestWebKitAPI::appendErrorCodeAttribute):
(TestWebKitAPI::computeLongTermAuthKey):
(TestWebKitAPI::appendMessageIntegrityAttribute):
(TestWebKitAPI::hasMessageIntegrityAttribute):
(TestWebKitAPI::peerEndPointAddress):
(TestWebKitAPI::handleStunMessage):
(TestWebKitAPI::sendReply):
(TestWebKitAPI::receiveUDPDatagram):
(TestWebKitAPI::receiveTCPBytes):
(TestWebKitAPI::startListener):
(TestWebKitAPI::MiniTURNServer::MiniTURNServer):
(TestWebKitAPI::MiniTURNServer::~MiniTURNServer):
(TestWebKitAPI::MiniTURNServer::udpPort const):
(TestWebKitAPI::MiniTURNServer::tcpPort const):
(TestWebKitAPI::MiniTURNServer::takeRequests):
(TestWebKitAPI::MiniTURNServer::isStunMethodAllocate):
* Tools/TestWebKitAPI/PlatformCocoa.cmake:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebRTC.mm:
(TestWebKitAPI::TEST(WebKit2, WebRTCTurnAllocationWithDirectDNSDisabled)):

Canonical link: <a href="https://commits.webkit.org/320825@main">https://commits.webkit.org/320825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a413e2fc78f7130b1db2a7176e8434435aa6f0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186030 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196322 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a1daa4ab-c425-424d-8b9f-cd255115f7a8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59648 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145371 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d4f251ba-e3f3-45c1-ada8-566620f10e9a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165912 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125689 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/57c77255-d0cb-4cd8-a2b6-647e6d930ddd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47780 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7549 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14429 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158134 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45499 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7393 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47270 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198300 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59586 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154926 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41489 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60295 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154567 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49012 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129695 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58741 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58131 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58363 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58189 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->