### PR TITLE
GPUP spends time setting canvas backing store IOSurfaces as non-volatile

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -280,6 +280,7 @@ private:
 
     std::optional<UsedFormat> m_format;
     std::optional<ColorSpace> m_colorSpace;
+    mutable std::optional<bool> m_knownIsVolatile;
     IntSize m_size;
     size_t m_totalBytes;
 #if HAVE(SUPPORT_HDR_DISPLAY)

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -407,6 +407,7 @@ static RetainPtr<IOSurfaceRef> createSurface(IntSize size, IOSurface::Name name,
 IOSurface::IOSurface(IntSize size, const ColorSpace& colorSpace, IOSurface::Name name, Format format, UseLosslessCompression useLosslessCompression, IOSurfaceOptions options, bool& success)
     : m_format({ format, useLosslessCompression })
     , m_colorSpace(colorSpace)
+    , m_knownIsVolatile(false)
     , m_size(size)
     , m_name(name)
 {
@@ -748,10 +749,17 @@ std::optional<IOSurface::LockAndContext> IOSurface::createBitmapPlatformContext(
 
 SetNonVolatileResult IOSurface::state() const
 {
-    uint32_t previousState = 0;
-    IOReturn ret = IOSurfaceSetPurgeable(m_surface.get(), kIOSurfacePurgeableKeepCurrent, &previousState);
-    ASSERT_UNUSED(ret, ret == kIOReturnSuccess);
-    return previousState == kIOSurfacePurgeableEmpty ? SetNonVolatileResult::Empty : SetNonVolatileResult::Valid;
+    if (m_knownIsVolatile.has_value() && !*m_knownIsVolatile)
+        return SetNonVolatileResult::Valid;
+    uint32_t currentState = 0;
+    IOReturn ret = IOSurfaceSetPurgeable(m_surface.get(), kIOSurfacePurgeableKeepCurrent, &currentState);
+    if (ret != kIOReturnSuccess) {
+        ASSERT_NOT_REACHED();
+        m_knownIsVolatile = std::nullopt;
+        return SetNonVolatileResult::Valid;
+    }
+    m_knownIsVolatile = currentState != kIOSurfacePurgeableNonVolatile;
+    return currentState == kIOSurfacePurgeableEmpty ? SetNonVolatileResult::Empty : SetNonVolatileResult::Valid;
 }
 
 IOSurfaceSeed IOSurface::seed() const
@@ -761,22 +769,24 @@ IOSurfaceSeed IOSurface::seed() const
 
 bool IOSurface::isVolatile() const
 {
-    uint32_t previousState = 0;
-    IOReturn ret = IOSurfaceSetPurgeable(m_surface.get(), kIOSurfacePurgeableKeepCurrent, &previousState);
-    ASSERT_UNUSED(ret, ret == kIOReturnSuccess);
-    return previousState != kIOSurfacePurgeableNonVolatile;
+    if (!m_knownIsVolatile)
+        (void) state();
+    return m_knownIsVolatile.value_or(false);
 }
 
 SetNonVolatileResult IOSurface::setVolatile(bool isVolatile)
 {
+    if (!isVolatile && m_knownIsVolatile.has_value() && !*m_knownIsVolatile)
+        return SetNonVolatileResult::Valid;
     uint32_t previousState = 0;
     IOReturn ret = IOSurfaceSetPurgeable(m_surface.get(), isVolatile ? kIOSurfacePurgeableVolatile : kIOSurfacePurgeableNonVolatile, &previousState);
-    ASSERT_UNUSED(ret, ret == kIOReturnSuccess);
-
-    if (previousState == kIOSurfacePurgeableEmpty)
-        return SetNonVolatileResult::Empty;
-
-    return SetNonVolatileResult::Valid;
+    if (ret != kIOReturnSuccess) {
+        ASSERT_NOT_REACHED();
+        m_knownIsVolatile = std::nullopt;
+        return SetNonVolatileResult::Valid;
+    }
+    m_knownIsVolatile = isVolatile;
+    return previousState == kIOSurfacePurgeableEmpty ? SetNonVolatileResult::Empty : SetNonVolatileResult::Valid;
 }
 
 ColorSpace IOSurface::colorSpace()

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfaceTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfaceTests.mm
@@ -28,6 +28,7 @@
 #import "Helpers/Test.h"
 #import <WebCore/IOSurface.h>
 #import <WebCore/IOSurfacePool.h>
+#import <WebCore/ImageBufferBackend.h>
 #import <WebCore/RenderingMode.h>
 #import <wtf/MachSendRight.h>
 #import <wtf/Threading.h>
@@ -59,6 +60,18 @@ TEST(IOSurfaceTest, CreatePlatformContext)
     EXPECT_FALSE(s1->isInUse());
     c2 = nullptr;
     EXPECT_FALSE(s1->isInUse());
+}
+
+TEST(IOSurfaceTest, Volatility)
+{
+    auto s1 = WebCore::IOSurface::create(nullptr, { 5, 5 }, WebCore::ColorSpace::SRGB());
+    EXPECT_FALSE(s1->isVolatile());
+    EXPECT_EQ(WebCore::SetNonVolatileResult::Valid, s1->setVolatile(false));
+    EXPECT_FALSE(s1->isVolatile());
+    s1->setVolatile(true);
+    EXPECT_TRUE(s1->isVolatile());
+    EXPECT_EQ(WebCore::SetNonVolatileResult::Valid, s1->setVolatile(false));
+    EXPECT_FALSE(s1->isVolatile());
 }
 
 TEST(IOSurfaceTest, createFromUntrustedUncompressedWebKitSendRightSRGB)


### PR DESCRIPTION
#### 169c737cae5df91b33f85474dd9930d433447e54
<pre>
GPUP spends time setting canvas backing store IOSurfaces as non-volatile
<a href="https://bugs.webkit.org/show_bug.cgi?id=323661">https://bugs.webkit.org/show_bug.cgi?id=323661</a>
<a href="https://rdar.apple.com/186907856">rdar://186907856</a>

Reviewed by Mike Wyrzykowski.

Calling into IOKit setting IOSurfaces non-volatile when they are
non-volatile is relatively slow operation. This happens when
surfaces are created.

Fix by caching the state locally.

Test: Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfaceTests.mm

* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::state const):
(WebCore::IOSurface::isVolatile const):
(WebCore::IOSurface::setVolatile):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/IOSurfaceTests.mm:
(TestWebKitAPI::TEST(IOSurfaceTest, Volatility)):

Canonical link: <a href="https://commits.webkit.org/320711@main">https://commits.webkit.org/320711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90fe8abe0fa4a2440ad9ce35376e553a165e09a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150262 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144964 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100503 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125256 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47373 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45430 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157740 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45119 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6877 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197775 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59079 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154488 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41410 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59788 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41724 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154137 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48611 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132137 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129032 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58265 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20141 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57637 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57880 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57703 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->