### PR TITLE
Cherry-pick 320106@main (4307d59b79a4). https://bugs.webkit.org/show_bug.cgi?id=321148

### DIFF
--- a/Tools/Scripts/webkitpy/__init__.py
+++ b/Tools/Scripts/webkitpy/__init__.py
@@ -97,7 +97,7 @@ AutoInstall.register(
             wheel=True,
             )
 )
-AutoInstall.register(Package('pytest_asyncio', Version(1, 1, 1), pypi_name='pytest-asyncio', implicit_deps=['pytest'] + (['backports.asyncio_runner'] if sys.version_info < (3, 11) else []), wheel=True))
+AutoInstall.register(Package('pytest_asyncio', Version(0, 19, 0), pypi_name='pytest-asyncio', implicit_deps=['pytest'], wheel=True))
 AutoInstall.register(Package('pytest_timeout', Version(2, 4, 0), pypi_name='pytest-timeout', implicit_deps=['pytest'], wheel=True))
 AutoInstall.register(Package('websockets', Version(12, 0), wheel=True))
 

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -4348,8 +4348,8 @@
     "imported/w3c/webdriver/tests/bidi/browsing_context/user_prompt_opened/handler.py": {
         "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/288344"}},
         "subtests": {
-            "test_accept": {"expected": {"all": {"status": ["SKIP"], "bug": "webkit.org/b/321148"}}},
-            "test_accept_and_notify": {"expected": {"all": {"status": ["SKIP"], "bug": "webkit.org/b/321148"}}}
+            "test_accept": {"expected": {"all": {"status": ["PASS"] }}},
+            "test_accept_and_notify": {"expected": {"all": {"status": ["PASS"] }}}
         }
     },
 
@@ -5664,15 +5664,6 @@
             "test_subscribe_to_one_context": {
                 "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288067"}}
             },
-            "test_close_context[tab]": {
-                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/321148"}}
-            },
-            "test_close_context[window]": {
-                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/321148"}}
-            },
-            "test_navigate": {
-                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/321148"}}
-            },
             "test_sandbox[evaluate]": {
                 "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288067"}}
             },
@@ -5884,7 +5875,7 @@
             "test_params_events_value_invalid_event_name[]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_value_invalid_event_name[foo]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_events_value_invalid_event_name[foo.bar]": {"expected": {"all": {"status": ["PASS"]}}},
-            "test_params_events_value_valid_and_invalid_event_name": {"expected": {"all": {"status": ["SKIP"], "bug": "webkit.org/b/321148"}}},
+            "test_params_events_value_valid_and_invalid_event_name": {"expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/282977"}}},
             "test_params_contexts_invalid_type[True]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_contexts_invalid_type[foo]": {"expected": {"all": {"status": ["PASS"]}}},
             "test_params_contexts_invalid_type[42]": {"expected": {"all": {"status": ["PASS"]}}},


### PR DESCRIPTION
#### 809df762c48b25ae8791d8247d710b5b3847dc92
<pre>
Cherry-pick 320106@main (4307d59b79a4). <a href="https://bugs.webkit.org/show_bug.cgi?id=321148">https://bugs.webkit.org/show_bug.cgi?id=321148</a>

    [WebDriver][Tools] Some WPT tests depend on a deprecated event_loop fixture from pytest-asyncio
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321148">https://bugs.webkit.org/show_bug.cgi?id=321148</a>

    Reviewed by Sam Sneddon and Carlos Alberto Lopez Perez.

    Rolls back to pytest-async 0.19.0, matching the vendored version in the
    WPT tests and providing the proper `event_loop` fixture needed by
    WebDriverBiDi tests that wait for a given event.

    Previously, pytest-asyncio was updated from 0.18.3 to 1.1.1 in
    315890@main, which focused on the pytest 7-&gt;8 bump for python 3.14
    compatibility. While the pytest bump was required, the pytest-asyncio
    was too much, introducing those breaking changes.

    This commit also removes the backports.asyncio_runner dependency,
    originally added as a follow-up fix in 317620@main, as it&apos;s not needed
    anymore (only with pytest-asyncio &gt;= 1.1.0).

    * Tools/Scripts/webkitpy/__init__.py:
    * WebDriverTests/TestExpectations.json:

    Canonical link: <a href="https://commits.webkit.org/320106@main">https://commits.webkit.org/320106@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.235@webkitglib/2.54">https://commits.webkit.org/317695.235@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6d73267fb39c08962a00f173d2de5f0e666dac0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185509 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59421 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53238 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195833 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150266 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187371 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60786 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59148 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144968 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150266 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188464 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60786 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53238 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125260 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/184837 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60786 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59148 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53238 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60786 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53238 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6883 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59148 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197782 "Built successfully") | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/184912 "The change is no longer eligible for processing.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59085 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53238 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154496 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59794 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53238 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154143 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28179 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59794 "The change is no longer eligible for processing.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129039 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58270 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53238 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57643 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57886 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57709 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->