### PR TITLE
Validate Settings.yaml and remove two settings defined twice

### DIFF
--- a/Source/WebCore/Scripts/GenerateSettings.rb
+++ b/Source/WebCore/Scripts/GenerateSettings.rb
@@ -74,6 +74,27 @@ def defaultValueFor(name, options, frontend)
   value.is_a?(Hash) ? value : { "default" => value }
 end
 
+SETTINGS_KEYS = %w{
+  comment condition defaultValue disableInLockdownMode inspectorOverride refinedType
+  status type webcoreExcludeFromInternalSettings webcoreGetter webcoreImplementation
+  webcoreName webcoreOnChange
+}
+
+def validate(path, parsed)
+  failed = false
+  parsed.each do |name, options|
+    (options.keys - SETTINGS_KEYS).each do |key|
+      puts "ERROR: #{path}: #{name}: \"#{key}\" is not a known key."
+      failed = true
+    end
+    if options["defaultValue"].is_a?(Hash) && !(options["defaultValue"].keys & FRONTENDS).empty?
+      puts "ERROR: #{path}: #{name}: \"defaultValue\" must not name frontends, these settings are WebCore only."
+      failed = true
+    end
+  end
+  exit(-1) if failed
+end
+
 def load(path)
   parsed = begin
     YAML.load_file(path)
@@ -90,6 +111,8 @@ def load(path)
     end
     previousName = name
   end
+
+  validate(path, parsed) unless File.basename(path) == "UnifiedWebPreferences.yaml"
 
   parsed
 end
@@ -267,14 +290,21 @@ class Settings
     settingsByName = {}
     globalSettingsByName = {}
     settingsFiles.each do |file|
-      parsedSettings = load(file).each do |name, options|
+      load(file).each do |name, options|
         # Preferences excluded from WebCore have no Settings member at all, and the
         # deprecated globals are declared by hand in DeprecatedGlobalSettings.h.
         if options["webcoreDeprecatedGlobalSettings"]
-          globalSettingsByName[name] = Setting.new(name, options)
+          target = globalSettingsByName
         elsif !(options["excludeFrom"] || []).include?("WebCore")
-          settingsByName[name] = Setting.new(name, options)
+          target = settingsByName
+        else
+          next
         end
+        if target.key?(name)
+          puts "ERROR: #{file}: #{name} is already defined, and the later definition would silently win."
+          exit(-1)
+        end
+        target[name] = Setting.new(name, options)
       end
     end
 

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -257,11 +257,6 @@ PaymentRequestEnabled:
   condition: ENABLE(PAYMENT_REQUEST)
   defaultValue: false
 
-PitchCorrectionAlgorithm:
-  type: uint32_t
-  refinedType: MediaPlayerEnums::PitchCorrectionAlgorithm
-  defaultValue: MediaPlayerEnums::PitchCorrectionAlgorithm::BestAllAround
-
 PreferMIMETypeForImages:
   type: bool
   defaultValue: false
@@ -302,12 +297,6 @@ ShouldIgnoreFontLoadCompletions:
 ShouldInjectUserScriptsInInitialEmptyDocument:
   type: bool
   defaultValue: false
-
-StorageBlockingPolicy:
-  type: uint32_t
-  refinedType: StorageBlockingPolicy
-  webcoreOnChange: storageBlockingPolicyChanged
-  defaultValue: StorageBlockingPolicy::AllowAll
 
 SuppressHDRShouldBeAllowedInFullscreenVideo:
   type: bool


### PR DESCRIPTION
#### 68fcd14affc42a3e5089a2bae7a61e94e442560d
<pre>
Validate Settings.yaml and remove two settings defined twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=323662">https://bugs.webkit.org/show_bug.cgi?id=323662</a>

Reviewed by Chris Dumez.

PitchCorrectionAlgorithm and StorageBlockingPolicy were defined in both
UnifiedWebPreferences.yaml and Settings.yaml. Settings.yaml is read second, so
its definition replaced the other one and the WebCore default in the unified
file was never used. Both files gave the same value, so nothing was broken, but
editing the unified file would have had no effect. Remove the two entries from
Settings.yaml, and make defining a setting twice an error.

This changes seven lines of Settings.h and Settings.cpp. The unified file writes
these types with a WebCore:: prefix, which WebKit needs for its static_cast, so
the members are now WebCore::StorageBlockingPolicy and
WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm. Both spellings name the
same types. I.e., no actual change.

GenerateSettings.rb now also does minimal validation for Settings.yaml.

Canonical link: <a href="https://commits.webkit.org/320718@main">https://commits.webkit.org/320718@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f909c556e9d89ae80030488ca98eef895ad6d26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195837 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150270 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/085a8781-d12f-404f-8477-c6d736782dd5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59152 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144973 "Found 1 new test failure: fast/dom/lazy-image-loading-document-leak.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100510 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/594a3ce7-2e9d-4a1f-a7c3-3e1d6a7ed18c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165553 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125265 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4b2b3e6-76de-4ae1-97ba-2b79071af904) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47382 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45439 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45125 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6887 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52081 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49828 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197786 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59089 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154499 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41417 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59798 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41730 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154146 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48619 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132147 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129049 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58274 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20147 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57647 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57890 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57713 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->