### PR TITLE
Cherry-pick 305413.1074@safari-7624.5-branch (82b25523db98). https://bugs.webkit.org/show_bug.cgi?id=318405

### DIFF
--- a/LayoutTests/fast/images/image-load-event-in-modal-dialog-crash-expected.txt
+++ b/LayoutTests/fast/images/image-load-event-in-modal-dialog-crash-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Window 'showModalDialog' function is deprecated and will be removed soon.
+CONSOLE MESSAGE: showModalDialog() is deprecated and will be removed. Please use the <dialog> element instead.
+PASS if no crash.

--- a/LayoutTests/fast/images/image-load-event-in-modal-dialog-crash.html
+++ b/LayoutTests/fast/images/image-load-event-in-modal-dialog-crash.html
@@ -1,0 +1,37 @@
+<!-- webkit-test-runner [ ShowModalDialogEnabled=true ] --><!DOCTYPE html>
+<html>
+<body>
+<div id="host" style="display:none"></div>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+if (window.internals)
+    internals.setCanShowModalDialogOverride(true);
+
+var host = document.getElementById('host');
+var sr = host.attachShadow({mode: 'open'});
+sr.innerHTML = '<picture id="pic"><source srcset="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"><img></picture>';
+var pic = sr.getElementById('pic');
+
+pic.addEventListener('load', function listener() {
+    pic.removeEventListener('load', listener, true);
+    // Removing the <img> from its <picture> re-enters ImageLoader::updatedHasPendingEvent()
+    // and arms m_derefElementTimer.
+    pic.textContent = '';
+    // showModalDialog spins a nested run loop which fires m_derefElementTimer, dropping
+    // m_protectedElement while ImageLoader::dispatchPendingLoadEvent() is still on the stack.
+    showModalDialog('resources/self-closing-modal-dialog.html');
+
+    // The trailing updatedHasPendingEvent() (the crash point) runs after this handler
+    // returns, so finish on the next task rather than waiting a fixed delay.
+    setTimeout(function() {
+        document.write('PASS if no crash.');
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+}, /*capture*/ true);
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/images/resources/self-closing-modal-dialog.html
+++ b/LayoutTests/fast/images/resources/self-closing-modal-dialog.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script>
+setTimeout(function() {
+    if (window.testRunner)
+        testRunner.abortModal();
+    window.close();
+}, 10);
+</script>

--- a/LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time-expected.txt
+++ b/LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash the GPU process.

--- a/LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time.html
+++ b/LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true MediaContainmentEnabled=false ] -->
+<html><body>
+<p>This test passes if it does not crash the GPU process.</p>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+window.onerror = () => testRunner?.notifyDone();
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// RemoteSourceBufferProxy::RemoveCodedFrames with an invalid MediaTime end argument
+// produced an inverted iterator range in TrackBuffer::removeCodedFrames, which
+// std::minmax_element walked past end(). MediaContainmentEnabled=false ensures the
+// SourceBufferPrivate / TrackBuffer live in the GPU process.
+async function main() {
+    if (!window.IPC)
+        return;
+
+    // Populate a GPU-side TrackBuffer via vanilla MSE.
+    const buf = await (await fetch('../media/media-source/content/test-fragmented-video.mp4')).arrayBuffer();
+    const init = buf.slice(0, 721);
+    const seg0 = buf.slice(721, 721 + 53533);
+    const seg1 = buf.slice(54254, 54254 + 56293);
+
+    const v = document.createElement('video');
+    v.disableRemotePlayback = true;
+    document.body.appendChild(v);
+    const ms = new MediaSource();
+    v.src = URL.createObjectURL(ms);
+    await new Promise(r => ms.addEventListener('sourceopen', r, { once: true }));
+
+    const sb = ms.addSourceBuffer('video/mp4; codecs="avc1.4d281e"');
+    const upd = () => new Promise(r => sb.addEventListener('updateend', r, { once: true }));
+    sb.appendBuffer(init); await upd();
+    sb.appendBuffer(seg0); await upd();
+    sb.appendBuffer(seg1); await upd();
+
+    // start = mid-range valid, end = invalid (timeFlags == 0), currentTime = valid zero.
+    // MediaTime is encoded as { int64_t timeValue, uint32_t timeScale, uint8_t timeFlags }.
+    const args = [
+        { type: 'int64_t', value: 1000000 }, { type: 'uint32_t', value: 1000000 }, { type: 'uint8_t', value: 1 },
+        { type: 'int64_t', value: 0 }, { type: 'uint32_t', value: 1 }, { type: 'uint8_t', value: 0 },
+        { type: 'int64_t', value: 0 }, { type: 'uint32_t', value: 1 }, { type: 'uint8_t', value: 1 },
+    ];
+
+    // The RemoteSourceBufferIdentifier is a small GPU-allocated counter; sweep a generous range.
+    // ignoreInvalidMessageForTesting drops messages to non-existent receivers.
+    const conn = IPC.connectionForProcessTarget('GPU');
+    for (let i = 1; i <= 200; i++)
+        conn.sendWithAsyncReply(i, IPC.messages.RemoteSourceBufferProxy_RemoveCodedFrames.name, args, () => { });
+
+    await sleep(2000);
+}
+
+setTimeout(() => main().finally(() => testRunner?.notifyDone()), 0);
+setTimeout(() => testRunner?.notifyDone(), 30000);
+</script>
+</body></html>

--- a/LayoutTests/webaudio/mediaelementsource-clear-detached-frame-expected.txt
+++ b/LayoutTests/webaudio/mediaelementsource-clear-detached-frame-expected.txt
@@ -1,0 +1,10 @@
+Test that removing an iframe whose <audio> is connected as a MediaElementAudioSourceNode in the parent document does not crash, even if the audio render thread is mid-render when HTMLMediaElement::clearMediaPlayer() runs.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Did not crash after detaching iframe whose audio element is connected to a MediaElementAudioSourceNode.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webaudio/mediaelementsource-clear-detached-frame.html
+++ b/LayoutTests/webaudio/mediaelementsource-clear-detached-frame.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<head>
+    <script src="../resources/js-test.js"></script>
+    <script>
+        function runTest()
+        {
+            description("Test that removing an iframe whose &lt;audio&gt; is connected as a MediaElementAudioSourceNode in the parent document does not crash, even if the audio render thread is mid-render when HTMLMediaElement::clearMediaPlayer() runs.");
+            jsTestIsAsync = true;
+
+            const context = new AudioContext({ sampleRate: 44100 });
+
+            const frame = document.createElement("iframe");
+            frame.src = "resources/mediaelementsource-clear-detached-frame-iframe.html";
+            frame.onload = async function() {
+                const audio = frame.contentDocument.querySelector("audio");
+                const source = context.createMediaElementSource(audio);
+                source.connect(context.destination);
+                audio.play().catch(() => { });
+
+                await new Promise(resolve => setTimeout(resolve, 200));
+
+                frame.remove();
+
+                setTimeout(function() {
+                    testPassed("Did not crash after detaching iframe whose audio element is connected to a MediaElementAudioSourceNode.");
+                    finishJSTest();
+                }, 100);
+            };
+            document.body.appendChild(frame);
+        }
+    </script>
+</head>
+<body onload="runTest()">
+</body>

--- a/LayoutTests/webaudio/resources/mediaelementsource-clear-detached-frame-iframe.html
+++ b/LayoutTests/webaudio/resources/mediaelementsource-clear-detached-frame-iframe.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <audio src="media/24bit-22khz.wav" loop></audio>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6847,7 +6847,7 @@ void HTMLMediaElement::userCancelledLoad()
     updateActiveTextTrackCues(MediaTime::zeroTime());
 }
 
-void HTMLMediaElement::clearMediaPlayer()
+void HTMLMediaElement::clearMediaPlayer() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
     invalidateWatchtimeTimer();
     invalidateBufferingStopwatch();
@@ -6887,6 +6887,12 @@ void HTMLMediaElement::clearMediaPlayer()
     }
 
     if (RefPtr player = m_player) {
+#if ENABLE(WEB_AUDIO)
+        RefPtr audioSourceNode = m_audioSourceNode.get();
+        std::optional<Locker<Lock>> audioSourceNodeLocker;
+        if (audioSourceNode)
+            audioSourceNodeLocker.emplace(audioSourceNode->processLock());
+#endif
         player->invalidate();
         m_player = nullptr;
     }

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -700,7 +700,8 @@ void ImageLoader::dispatchPendingLoadEvent()
     if (!m_image)
         return;
     m_hasPendingLoadEvent = false;
-    if (element().document().hasLivingRenderTree())
+    Ref protectedElement = element();
+    if (protectedElement->document().hasLivingRenderTree())
         dispatchLoadEvent();
 
     // Only consider updating the protection ref-count of the Element immediately before returning
@@ -714,8 +715,9 @@ void ImageLoader::dispatchPendingErrorEvent()
         return;
     m_hasPendingErrorEvent = false;
     loadEventSender().cancelEvent(*this, eventNames().errorEvent);
-    if (element().document().hasLivingRenderTree())
-        protect(element())->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
+    Ref protectedElement = element();
+    if (protectedElement->document().hasLivingRenderTree())
+        protectedElement->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
 
     // Only consider updating the protection ref-count of the Element immediately before returning
     // from this function as doing so might result in the destruction of this ImageLoader.

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -551,8 +551,10 @@ void SourceBufferPrivate::removeCodedFramesInternal(const MediaTime& start, cons
 {
     assertIsCurrent(m_dispatcher.get());
 
+    ASSERT(start.isValid());
+    ASSERT(end.isValid());
     ASSERT(start < end);
-    if (start >= end)
+    if (start.isInvalid() || end.isInvalid() || start >= end)
         return;
 
     // 3.5.9 Coded Frame Removal Algorithm

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -492,6 +492,8 @@ int64_t TrackBuffer::removeCodedFrames(const MediaTime& startIn, const MediaTime
     MediaTime start = startIn;
     ASSERT(start.isValid());
     ASSERT(end.isValid());
+    if (start.isInvalid() || end.isInvalid() || start > end)
+        return 0;
     // 3.5.9 Coded Frame Removal Algorithm
     // https://dvcs.w3.org/hg/html-media/raw-file/tip/media-source/media-source.html#sourcebuffer-coded-frame-removal
     


### PR DESCRIPTION
#### b0e7c826df35210daa6f6f75b8be10b5992da299
<pre>
Cherry-pick 305413.1074@safari-7624.5-branch (82b25523db98). <a href="https://bugs.webkit.org/show_bug.cgi?id=318405">https://bugs.webkit.org/show_bug.cgi?id=318405</a>

    Validate MediaTime arguments in RemoteSourceBufferProxy::removeCodedFrames
    <a href="https://rdar.apple.com/175520822">rdar://175520822</a>

    Reviewed by Jean-Yves Avenard.

    RemoteSourceBufferProxy::removeCodedFrames forwarded its three MediaTime IPC
    arguments to SourceBufferPrivate::removeCodedFramesInternal without validation,
    and the generated ArgumentCoder&lt;MediaTime&gt; has no [Validator=], so a MediaTime
    with timeFlags == 0 (isInvalid()) survived decode. The release-mode guard
    &quot;if (start &gt;= end) return&quot; in removeCodedFramesInternal was defeated because
    valid &lt;=&gt; invalid is std::partial_ordering::unordered, so start &gt;= end is false.
    In TrackBuffer::removeCodedFrames, lower_bound(invalid) on the
    std::map&lt;MediaTime, ...&gt; walked left to begin() while a valid mid-range start
    resolved to a mid-map iterator; the inverted [mid, begin()) range was passed to
    std::minmax_element, which incremented past end() and dereferenced out-of-range
    tree pointers, crashing the GPU process. A compromised WebContent process could
    trigger this deterministically.

    Reject invalid or unordered start/end at the IPC boundary with
    MESSAGE_CHECK_COMPLETION, and harden SourceBufferPrivate::removeCodedFramesInternal
    and TrackBuffer::removeCodedFrames to early-return when either bound is invalid
    or start is not strictly less than end, mirroring the existing guard in
    SourceBufferPrivate::evictFrames.

    * LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time-expected.txt: Added.
    * LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time.html: Added.
    * Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
    (WebCore::SourceBufferPrivate::removeCodedFramesInternal):
    * Source/WebCore/platform/graphics/TrackBuffer.cpp:
    (WebCore::TrackBuffer::removeCodedFrames):
    * Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
    (WebKit::RemoteSourceBufferProxy::removeCodedFrames):

    Identifier: 305413.1074@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.222@webkitglib/2.54">https://commits.webkit.org/317695.222@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 1508f0c86e8eeb5d50f8126772ad48093465a3a8
<pre>
Cherry-pick 305413.1065@safari-7624.5.1.10-branch (e186258f7967). <a href="https://bugs.webkit.org/show_bug.cgi?id=315989">https://bugs.webkit.org/show_bug.cgi?id=315989</a>

    Use-after-free in MediaElementAudioSourceNode::provideInput when iframe is detached
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315989">https://bugs.webkit.org/show_bug.cgi?id=315989</a>
    <a href="https://rdar.apple.com/175673159">rdar://175673159</a>

    Reviewed by Chris Dumez.

    HTMLMediaElement::clearMediaPlayer() resets m_player on the main thread without holding
    m_audioSourceNode-&gt;processLock(), but the audio render thread reads m_player via
    audioSourceProvider() inside MediaElementAudioSourceNode::process() while holding that lock.
    Because audioSourceProvider() returns a raw AudioSourceProvider* and drops its local
    RefPtr&lt;MediaPlayer&gt; on return, and MediaPlayer is DestructionThread::Main, the main thread can
    synchronously run ~MediaPlayer (destroying the RemoteAudioSourceProvider) while the render thread
    is still inside provideInput() with the now-dangling pointer.

    This is reachable from HTMLMediaElement::stop() (ActiveDOMObject stop on iframe detach) and
    userCancelledLoad().

    Match the contract already enforced by createMediaPlayer() and
    mediaPlayerWill/DidInitializeMediaEngine() by holding the audio node&apos;s processLock around
    player-&gt;invalidate() / m_player = nullptr in clearMediaPlayer(). process() acquires the same lock
    with tryLock(), so this cannot deadlock — the render thread will simply zero its output for one
    quantum while the main thread tears down.

    Test: webaudio/mediaelementsource-clear-detached-frame.html

    * LayoutTests/webaudio/mediaelementsource-clear-detached-frame-expected.txt: Added.
    * LayoutTests/webaudio/mediaelementsource-clear-detached-frame.html: Added.
    * LayoutTests/webaudio/resources/mediaelementsource-clear-detached-frame-iframe.html: Added.
    * Source/WebCore/html/HTMLMediaElement.cpp:
    (WebCore::HTMLMediaElement::clearMediaPlayer): Deleted.

    Identifier: 305413.1065@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.221@webkitglib/2.54">https://commits.webkit.org/317695.221@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 48cd5ac71dd3b546cf23e1be5f5817141ede4b93
<pre>
Cherry-pick 305413.1064@safari-7624.5-branch (fe774071a22a). <a href="https://bugs.webkit.org/show_bug.cgi?id=318348">https://bugs.webkit.org/show_bug.cgi?id=318348</a>

    [WebCore] Use-after-free in ImageLoader::dispatchPendingLoadEvent / dispatchPendingErrorEvent
    <a href="https://rdar.apple.com/177909775">rdar://177909775</a>

    Reviewed by Alan Baradlay.

    dispatchPendingLoadEvent() and dispatchPendingErrorEvent() dispatch author script and then
    touch `this` again via updatedHasPendingEvent(). The only thing keeping the element alive
    across the dispatch is a full-expression-scoped Ref plus the m_protectedElement member, and
    the 0s m_derefElementTimer can clear that member. A load handler can re-arm the timer by
    removing the &lt;img&gt; from its &lt;picture&gt; (selectImageSource(RelevantMutation::Yes) calls
    updatedHasPendingEvent()), then spin a nested run loop via showModalDialog(). The timer
    fires and drops m_protectedElement while the dispatch is still on the stack. When the
    dispatch returns the temporary Ref destructs as the last reference, ~HTMLImageElement frees
    the loader via its unique_ptr&lt;HTMLImageLoader&gt;, and the trailing updatedHasPendingEvent()
    runs on freed `this`.

    Hold a stack Ref to the element across the dispatch and the trailing updatedHasPendingEvent()
    in both functions. The loader is owned by the element, so keeping the element alive keeps
    this ImageLoader alive.

    Test: fast/images/image-load-event-in-modal-dialog-crash.html

    * LayoutTests/fast/images/image-load-event-in-modal-dialog-crash-expected.txt: Added.
    * LayoutTests/fast/images/image-load-event-in-modal-dialog-crash.html: Added.
    * LayoutTests/fast/images/resources/self-closing-modal-dialog.html: Added.
    * Source/WebCore/loader/ImageLoader.cpp:
    (WebCore::ImageLoader::dispatchPendingLoadEvent):
    (WebCore::ImageLoader::dispatchPendingErrorEvent):

    Identifier: 305413.1064@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.220@webkitglib/2.54">https://commits.webkit.org/317695.220@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ca5296730762223cefd050edaaf608c57d08106

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185520 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59432 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53249 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195844 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150276 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187382 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60797 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59159 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144979 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150276 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188475 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60797 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53249 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125271 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60797 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59159 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53249 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60797 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53249 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6895 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52088 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59159 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197793 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59096 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53249 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154507 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59805 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53249 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154154 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28160 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59805 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132157 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129056 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58281 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53249 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57654 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57897 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57720 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->