### PR TITLE
REGRESSION(320153@main) 2D context self drawImage performance regression

### DIFF
--- a/LayoutTests/ipc/feComponentTransfer-empty-tableValues-accelerated.html
+++ b/LayoutTests/ipc/feComponentTransfer-empty-tableValues-accelerated.html
@@ -46,9 +46,6 @@ setTimeout(async () => {
                 bufferFormat: { pixelFormat: 3, useLosslessCompression: 0 },
                 identifier: id, contextIdentifier: ctx,
             });
-            // Drain the unsolicited DidCreateBackend in-turn; otherwise it reaches the stream
-            // connection's dummy receiver, which ASSERT_NOT_REACHED()s in debug builds.
-            sc.connection.waitForMessage(id, IPC.messages.RemoteImageBufferProxy_DidCreateBackend.name);
         }
 
         // Source buffer, filled opaque white.

--- a/LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html
+++ b/LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html
@@ -32,7 +32,6 @@
             identifier: imageBufferIdentifier,
             contextIdentifier: contextIdentifier,
         });
-        const didCreateBackendReply = streamConnection.connection.waitForMessage(imageBufferIdentifier, IPC.messages.RemoteImageBufferProxy_DidCreateBackend.name, 1);
     
         const remoteImageBuffer = streamConnection.newInterface("RemoteImageBuffer", imageBufferIdentifier);
     

--- a/LayoutTests/ipc/invalid-svgfilter-expression-crash.html
+++ b/LayoutTests/ipc/invalid-svgfilter-expression-crash.html
@@ -32,7 +32,6 @@ window.setTimeout(async () => {
         identifier: imageBufferIdentifier,
         contextIdentifier: contextIdentifier
     });
-    const didCreateBackendReply = streamConnection.connection.waitForMessage(imageBufferIdentifier, IPC.messages.RemoteImageBufferProxy_DidCreateBackend.name, 1);
 
     const remoteImageBuffer = streamConnection.newInterface("RemoteImageBuffer", imageBufferIdentifier);
 

--- a/LayoutTests/ipc/restore-empty-stack-crash.html
+++ b/LayoutTests/ipc/restore-empty-stack-crash.html
@@ -10,7 +10,6 @@
             CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0,{renderingBackendIdentifier:393219,connectionHandle:o10});
             o12=o10.newInterface("RemoteRenderingBackend", 393219);
             o12.CreateImageBuffer({logicalSize:{width:32,height:18},renderingMode:3,renderingPurpose:1,resolutionScale:489626271805,colorSpace:sRGBColorSpace(),pixelFormat:2,bufferFormat:{pixelFormat:2,useLosslessCompression:0},identifier:393225,contextIdentifier:393226});
-            o10.connection.waitForMessage(393225, IPC.messages.RemoteImageBufferProxy_DidCreateBackend.name, 1);
             o31=o10.newInterface("RemoteGraphicsContext", 393226);
             o31.Restore({});
             o31.Restore({});

--- a/LayoutTests/ipc/rgba16f-getpixelbuffer-colorspace-mismatch-heap-disclosure.html
+++ b/LayoutTests/ipc/rgba16f-getpixelbuffer-colorspace-mismatch-heap-disclosure.html
@@ -61,9 +61,6 @@ window.setTimeout(async () => {
         contextIdentifier: ctxId
     });
     const ib = sc.newInterface('RemoteImageBuffer', bufId);
-    // Drain the unsolicited DidCreateBackend in-turn; otherwise it reaches the stream
-    // connection's dummy receiver, which ASSERT_NOT_REACHED()s in debug builds.
-    sc.connection.waitForMessage(bufId, IPC.messages.RemoteImageBufferProxy_DidCreateBackend.name);
 
     // Seed the IOSurface with Float16 1.0 (00 3C) as a sentinel.
     const sentinel = new Uint8Array(NBYTES);

--- a/LayoutTests/ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html
+++ b/LayoutTests/ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html
@@ -47,12 +47,6 @@ function fuzz() {
             debug("Failed: " + error)
     }
     try {
-        o35.waitForMessage(imageBufferID, IPC.messages.RemoteImageBufferProxy_DidCreateBackend.name);
-    } catch (error) {
-        if (!(error instanceof TypeError))
-            debug("Failed: " + error)
-    }
-    try {
         o35.sendSyncMessage(imageBufferID,IPC.messages.RemoteImageBuffer_GetShareableBitmap.name, [{type: 'bool',value: 0}]);
     } catch (error) {
         if (!(error instanceof TypeError))

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2609,7 +2609,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/ImageBuffer.h
     platform/graphics/ImageBufferAllocator.h
     platform/graphics/ImageBufferBackend.h
-    platform/graphics/ImageBufferBackendParameters.h
+    platform/graphics/ImageBufferParameters.h
     platform/graphics/ImageBufferDisplayListBackend.h
     platform/graphics/ImageBufferFormat.h
     platform/graphics/ImageBufferResourceLimits.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -3633,7 +3633,7 @@
 		8696CE39297EF0130081C800 /* TextManipulationControllerManipulationFailure.h in Headers */ = {isa = PBXBuildFile; fileRef = 8696CE38297EF0130081C800 /* TextManipulationControllerManipulationFailure.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		86AA52712937ADB50065399E /* TextManipulationItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 86AA52702937ADB40065399E /* TextManipulationItem.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		86AA527C2937BD620065399E /* TextManipulationToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 86AA527B2937BD610065399E /* TextManipulationToken.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		86BBA9F02987EBF300A78986 /* ImageBufferBackendParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 86BBA9EF2987EBF100A78986 /* ImageBufferBackendParameters.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		86BBA9F02987EBF300A78986 /* ImageBufferParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 86BBA9EF2987EBF100A78986 /* ImageBufferParameters.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		86BE340115058CB200CE0FD8 /* PerformanceEntry.h in Headers */ = {isa = PBXBuildFile; fileRef = 86BE33FB15058CB200CE0FD8 /* PerformanceEntry.h */; };
 		86D1969629A674390083B077 /* ServiceWorkerImportedScript.h in Headers */ = {isa = PBXBuildFile; fileRef = 86D1969529A674390083B077 /* ServiceWorkerImportedScript.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		86D196DD29ACE0930083B077 /* TextManipulationItemIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 86D196DC29ACE0920083B077 /* TextManipulationItemIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -16065,7 +16065,7 @@
 		86AA52702937ADB40065399E /* TextManipulationItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextManipulationItem.h; sourceTree = "<group>"; };
 		86AA527B2937BD610065399E /* TextManipulationToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextManipulationToken.h; sourceTree = "<group>"; };
 		86BA766D166427A8005BE5D1 /* FrameLoadRequest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FrameLoadRequest.cpp; sourceTree = "<group>"; };
-		86BBA9EF2987EBF100A78986 /* ImageBufferBackendParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageBufferBackendParameters.h; sourceTree = "<group>"; };
+		86BBA9EF2987EBF100A78986 /* ImageBufferParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageBufferParameters.h; sourceTree = "<group>"; };
 		86BE33FB15058CB200CE0FD8 /* PerformanceEntry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PerformanceEntry.h; sourceTree = "<group>"; };
 		86BE33FC15058CB200CE0FD8 /* PerformanceEntry.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = PerformanceEntry.idl; sourceTree = "<group>"; };
 		86D1969529A674390083B077 /* ServiceWorkerImportedScript.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerImportedScript.h; sourceTree = "<group>"; };
@@ -37086,12 +37086,12 @@
 				724DCF1C284853650026ACF4 /* ImageBufferAllocator.h */,
 				72BAC3A423E17327008D741C /* ImageBufferBackend.cpp */,
 				72BAC3A523E17328008D741C /* ImageBufferBackend.h */,
-				86BBA9EF2987EBF100A78986 /* ImageBufferBackendParameters.h */,
 				72FE4047292F3D3B001D3855 /* ImageBufferContextSwitcher.cpp */,
 				72FE4046292F3D3A001D3855 /* ImageBufferContextSwitcher.h */,
 				72F9A6CA2D30BE6E0019DE4B /* ImageBufferDisplayListBackend.cpp */,
 				72F9A6C92D30BE6E0019DE4B /* ImageBufferDisplayListBackend.h */,
 				0FB266832E3304850071C4A5 /* ImageBufferFormat.h */,
+				86BBA9EF2987EBF100A78986 /* ImageBufferParameters.h */,
 				72BAC3A623E17328008D741C /* ImageBufferPlatformBackend.h */,
 				322B61142C50C22D00FB5440 /* ImageBufferResourceLimits.h */,
 				CD19FEA71F573972000C42FB /* ImageDecoder.cpp */,
@@ -46352,13 +46352,13 @@
 				B2A10B920B3818BD00099AA4 /* ImageBuffer.h in Headers */,
 				724DCF2328486C9B0026ACF4 /* ImageBufferAllocator.h in Headers */,
 				72BAC3AE23E1F0B0008D741C /* ImageBufferBackend.h in Headers */,
-				86BBA9F02987EBF300A78986 /* ImageBufferBackendParameters.h in Headers */,
 				550640B02407587E00AAE045 /* ImageBufferCGBackend.h in Headers */,
 				2D7705C925528D34001D0C94 /* ImageBufferCGBitmapBackend.h in Headers */,
 				7220742F2D07C7F6009FA90F /* ImageBufferCGPDFDocumentBackend.h in Headers */,
 				72F9A6CD2D30DE880019DE4B /* ImageBufferDisplayListBackend.h in Headers */,
 				0FB266842E3304850071C4A5 /* ImageBufferFormat.h in Headers */,
 				727A7F3A24078B84004D2931 /* ImageBufferIOSurfaceBackend.h in Headers */,
+				86BBA9F02987EBF300A78986 /* ImageBufferParameters.h in Headers */,
 				2D7705C7255276CD001D0C94 /* ImageBufferPlatformBackend.h in Headers */,
 				322B61152C50C26300FB5440 /* ImageBufferResourceLimits.h in Headers */,
 				073930C32AC4E85300C1D1B1 /* ImageCapture.h in Headers */,

--- a/Source/WebCore/WebCoreDOMAndRenderingPrefix.h
+++ b/Source/WebCore/WebCoreDOMAndRenderingPrefix.h
@@ -195,7 +195,7 @@
 #include "ImageBuffer.h"
 #include "ImageBufferAllocator.h"
 #include "ImageBufferBackend.h"
-#include "ImageBufferBackendParameters.h"
+#include "ImageBufferParameters.h"
 #include "IntPointHash.h"
 #include "IntRectHash.h"
 #include "JSDOMConvertBase.h"

--- a/Source/WebCore/WebCoreJSBindingsPrefix.h
+++ b/Source/WebCore/WebCoreJSBindingsPrefix.h
@@ -240,7 +240,7 @@
 #include "ImageBuffer.h"
 #include "ImageBufferAllocator.h"
 #include "ImageBufferBackend.h"
-#include "ImageBufferBackendParameters.h"
+#include "ImageBufferParameters.h"
 #include "ImageData.h"
 #include "ImageDataArray.h"
 #include "ImageDataPixelFormat.h"

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -3241,9 +3241,8 @@ std::optional<RenderingMode> CanvasRenderingContext2DBase::renderingModeForTesti
 std::optional<CanvasRenderingContext2DBase::RenderingMode> CanvasRenderingContext2DBase::getEffectiveRenderingModeForTesting()
 {
     if (RefPtr buffer = this->buffer()) {
-        buffer->ensureBackendCreated();
-        if (buffer->hasBackend())
-            return buffer->renderingMode();
+        if (auto renderingMode = buffer->getEffectiveRenderingModeForTesting())
+            return *renderingMode;
     }
     return std::nullopt;
 }

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -762,8 +762,8 @@ void GPUCanvasContextCocoa::updateMemoryCost() const
 {
     // Computes only a rough ballpark figure to drive garbage collection.
     size_t newMemoryCost = 0;
-    if (m_readDisplayBuffer)
-        newMemoryCost += m_readDisplayBuffer->memoryCost();
+    if (RefPtr readDisplayBuffer = m_readDisplayBuffer)
+        newMemoryCost += readDisplayBuffer->memoryCost();
     if (RefPtr image = m_readDisplayBufferImage)
         newMemoryCost += image->sizeInBytes();
     if (m_currentTexture)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -794,7 +794,7 @@ size_t WebGLRenderingContextBase::ReadSurfaceBuffer::memoryCost() const
     size_t cost = 0;
     if (RefPtr image = this->image)
         cost += image->sizeInBytes();
-    if (buffer)
+    if (RefPtr buffer = this->buffer)
         cost += buffer->memoryCost();
     return cost;
 }

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -38,6 +38,7 @@
 #include "ImageBufferPlatformBackend.h"
 #include "ImageUtilities.h"
 #include "MIMETypeRegistry.h"
+#include "NullImageBufferBackend.h"
 #include "ProcessCapabilities.h"
 #include "TransparencyLayerContextSwitcher.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -119,27 +120,27 @@ RefPtr<ImageBuffer> ImageBuffer::create(const FloatSize& size, RenderingMode ren
     return nullptr;
 }
 
-ImageBuffer::ImageBuffer(Parameters parameters, const ImageBufferBackend::Info& backendInfo, const WebCore::ImageBufferCreationContext&, std::unique_ptr<ImageBufferBackend>&& backend, RenderingResourceIdentifier renderingResourceIdentifier)
+ImageBuffer::ImageBuffer(Parameters parameters, const WebCore::ImageBufferCreationContext&, std::unique_ptr<ImageBufferBackend>&& backend, RenderingResourceIdentifier renderingResourceIdentifier)
     : m_parameters(WTF::move(parameters))
-    , m_backendInfo(backendInfo)
     , m_backend(WTF::move(backend))
     , m_renderingResourceIdentifier(renderingResourceIdentifier)
 {
+    ASSERT(m_backend);
 }
 
 ImageBuffer::~ImageBuffer() = default;
 
-IntSize ImageBuffer::calculateBackendSize(FloatSize logicalSize, float resolutionScale)
+IntSize calculateImageBufferBackendSize(FloatSize logicalSize, float resolutionScale)
 {
-    FloatSize scaledSize = { ceilf(resolutionScale * logicalSize.width()), ceilf(resolutionScale * logicalSize.height()) };
+    FloatSize scaledSize { ceilf(resolutionScale * logicalSize.width()), ceilf(resolutionScale * logicalSize.height()) };
     if (scaledSize.isEmpty() || !scaledSize.isExpressibleAsIntSize())
         return { };
     return IntSize { scaledSize };
 }
 
-ImageBufferBackendParameters ImageBuffer::backendParameters(const ImageBufferParameters& parameters)
+IntSize ImageBuffer::calculateBackendSize(FloatSize logicalSize, float resolutionScale)
 {
-    return { calculateBackendSize(parameters.logicalSize, parameters.resolutionScale), parameters.resolutionScale, parameters.colorSpace, parameters.bufferFormat, parameters.purpose };
+    return calculateImageBufferBackendSize(logicalSize, resolutionScale);
 }
 
 bool ImageBuffer::sizeNeedsClamping(const FloatSize& size)
@@ -175,7 +176,7 @@ public:
 
     size_t memoryCost() const final
     {
-        return m_buffer->memoryCost();
+        return protect(m_buffer)->memoryCost();
     }
 
     std::unique_ptr<SerializedImageBuffer> clone() const final
@@ -298,7 +299,7 @@ void ImageBuffer::flushDrawingContext()
     // The direct backend context flush is not part of ImageBuffer abstraction semantics,
     // rather implementation detail of the ImageBufferBackends that need separate management
     // of their context lifetime for purposes of drawing from the image buffer.
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         backend->flushContext();
 }
 
@@ -311,26 +312,26 @@ bool ImageBuffer::flushDrawingContextAsync()
 
 void ImageBuffer::submitDrawingCommands()
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         backend->submitDrawingCommands();
 }
 
 void ImageBuffer::replaceFontsWithRebuildData()
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         backend->replaceFontsWithRebuildData();
 }
 
 void ImageBuffer::rebuildFonts()
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         backend->rebuildFonts();
 }
 
 void ImageBuffer::prepareForDisplay()
 {
     flushDrawingContextAsync();
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         backend->prepareForDisplay();
 }
 
@@ -345,19 +346,26 @@ void ImageBuffer::setBackend(std::unique_ptr<ImageBufferBackend>&& backend)
 
 IntSize ImageBuffer::backendSize() const
 {
-    return calculateBackendSize(m_parameters.logicalSize, m_parameters.resolutionScale);
+    return m_parameters.backendSize();
+}
+
+std::optional<RenderingMode> ImageBuffer::getEffectiveRenderingModeForTesting() const
+{
+    if (!m_backend || is<NullImageBufferBackend>(*m_backend))
+        return std::nullopt;
+    return renderingMode();
 }
 
 RefPtr<NativeImage> ImageBuffer::copyNativeImage() const
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         return backend->copyNativeImage();
     return nullptr;
 }
 
 RefPtr<NativeImage> ImageBuffer::createNativeImageReference() const
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         return backend->createNativeImageReference();
     return nullptr;
 }
@@ -369,7 +377,7 @@ bool ImageBuffer::isRemoteImageBufferProxy() const
 
 RefPtr<NativeImage> ImageBuffer::sinkIntoNativeImage()
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         return backend->sinkIntoNativeImage();
     return nullptr;
 }
@@ -392,7 +400,7 @@ RefPtr<NativeImage> ImageBuffer::filteredNativeImage(Filter& filter)
 {
     ASSERT(!filter.filterRenderingModes().contains(FilterRenderingMode::GraphicsContext));
 
-    auto* backend = ensureBackend();
+    auto* backend = m_backend.get();
     if (!backend)
         return nullptr;
 
@@ -445,7 +453,7 @@ SkSurface* ImageBuffer::surface() const
 #if USE(CAIRO)
 RefPtr<cairo_surface_t> ImageBuffer::createCairoSurface()
 {
-    auto* backend = ensureBackend();
+    auto* backend = m_backend.get();
     if (!backend)
         return nullptr;
 
@@ -464,7 +472,7 @@ RefPtr<cairo_surface_t> ImageBuffer::createCairoSurface()
 
 RefPtr<GraphicsLayerContentsDisplayDelegate> ImageBuffer::layerContentsDisplayDelegate()
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         return backend->layerContentsDisplayDelegate();
     return nullptr;
 }
@@ -478,13 +486,13 @@ RefPtr<NativeImage> ImageBuffer::sinkIntoNativeImage(RefPtr<ImageBuffer> source)
 
 void ImageBuffer::convertToLuminanceMask()
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         backend->convertToLuminanceMask();
 }
 
 void ImageBuffer::transformToColorSpace(const ColorSpace& newColorSpace)
 {
-    if (auto* backend = ensureBackend()) {
+    if (auto* backend = m_backend.get()) {
         backend->transformToColorSpace(newColorSpace);
         m_parameters.colorSpace = newColorSpace;
     }
@@ -513,7 +521,7 @@ RefPtr<PixelBuffer> ImageBuffer::getPixelBuffer(const PixelBufferFormat& destina
     auto destination = allocator.createPixelBuffer(destinationFormat, sourceRectScaled.size());
     if (!destination)
         return nullptr;
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         backend->getPixelBuffer(sourceRectScaled, *destination);
     else
         destination->zeroFill();
@@ -523,7 +531,7 @@ RefPtr<PixelBuffer> ImageBuffer::getPixelBuffer(const PixelBufferFormat& destina
 void ImageBuffer::putPixelBuffer(const PixelBufferSourceView& pixelBuffer, const IntRect& sourceRect, const IntPoint& destinationPoint, AlphaPremultiplication destinationFormat)
 {
     ASSERT(resolutionScale() == 1);
-    auto* backend = ensureBackend();
+    auto* backend = m_backend.get();
     if (!backend)
         return;
     auto sourceRectScaled = sourceRect;
@@ -535,7 +543,7 @@ void ImageBuffer::putPixelBuffer(const PixelBufferSourceView& pixelBuffer, const
 
 RefPtr<SharedBuffer> ImageBuffer::sinkIntoPDFDocument()
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         return backend->sinkIntoPDFDocument();
     return nullptr;
 }
@@ -549,20 +557,20 @@ RefPtr<SharedBuffer> ImageBuffer::sinkIntoPDFDocument(RefPtr<ImageBuffer> source
 
 bool ImageBuffer::isInUse() const
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         return backend->isInUse();
     return false;
 }
 
 void ImageBuffer::releaseGraphicsContext()
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         return backend->releaseGraphicsContext();
 }
 
 bool ImageBuffer::setVolatile()
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         return backend->setVolatile();
 
     return true; // Just claim we succeedded.
@@ -571,7 +579,7 @@ bool ImageBuffer::setVolatile()
 SetNonVolatileResult ImageBuffer::setNonVolatile()
 {
     auto result = SetNonVolatileResult::Valid;
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         result = backend->setNonVolatile();
 
     if (m_hasForcedPurgeForTesting) {
@@ -584,14 +592,14 @@ SetNonVolatileResult ImageBuffer::setNonVolatile()
 
 VolatilityState ImageBuffer::volatilityState() const
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         return backend->volatilityState();
     return VolatilityState::NonVolatile;
 }
 
 void ImageBuffer::setVolatilityState(VolatilityState volatilityState)
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         backend->setVolatilityState(volatilityState);
 }
 
@@ -606,7 +614,7 @@ void ImageBuffer::setVolatileAndPurgeForTesting()
 
 std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBuffer::createFlusher()
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         return backend->createFlusher();
     return nullptr;
 }
@@ -618,7 +626,7 @@ unsigned ImageBuffer::backendGeneration() const
 
 ImageBufferBackendSharing* ImageBuffer::toBackendSharing()
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         return backend->toBackendSharing();
     return nullptr;
 }
@@ -632,7 +640,7 @@ std::optional<DynamicContentScalingDisplayList> ImageBuffer::dynamicContentScali
 
 void ImageBuffer::transferToNewContext(const ImageBufferCreationContext& context)
 {
-    if (auto* backend = ensureBackend())
+    if (auto* backend = m_backend.get())
         backend->transferToNewContext(context);
 }
 

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -30,6 +30,7 @@
 #include <WebCore/ImageBufferAllocator.h>
 #include <WebCore/ImageBufferBackend.h>
 #include <WebCore/ImageBufferFormat.h>
+#include <WebCore/ImageBufferParameters.h>
 #include <WebCore/PlatformScreen.h>
 #include <WebCore/ProcessIdentity.h>
 #include <WebCore/RenderingMode.h>
@@ -80,14 +81,6 @@ struct ImageBufferCreationContext {
     ImageBufferCreationContext() = default;
 };
 
-struct ImageBufferParameters {
-    FloatSize logicalSize;
-    float resolutionScale;
-    ColorSpace colorSpace;
-    ImageBufferFormat bufferFormat;
-    RenderingPurpose purpose;
-};
-
 class ImageBuffer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ImageBuffer> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ImageBuffer, WEBCORE_EXPORT);
 public:
@@ -104,43 +97,24 @@ public:
     static RefPtr<ImageBufferType> create(const FloatSize& size, float resolutionScale, const ColorSpace& colorSpace, ImageBufferFormat bufferFormat, RenderingPurpose purpose, const ImageBufferCreationContext& creationContext, Arguments&&... arguments)
     {
         Parameters parameters { size, resolutionScale, colorSpace, bufferFormat, purpose };
-        auto backendParameters = ImageBuffer::backendParameters(parameters);
-        auto backend = BackendType::create(backendParameters, creationContext);
+        auto backend = BackendType::create(parameters, creationContext);
         if (!backend)
             return nullptr;
-        auto backendInfo = populateBackendInfo<BackendType>(backendParameters);
-        return create<ImageBufferType>(parameters, backendInfo, creationContext, WTF::move(backend), std::forward<Arguments>(arguments)...);
+        return create<ImageBufferType>(parameters, creationContext, WTF::move(backend), std::forward<Arguments>(arguments)...);
     }
 
-    template<typename BackendType, typename ImageBufferType = ImageBuffer, typename... Arguments>
-    static RefPtr<ImageBufferType> create(const FloatSize& size, const ImageBufferCreationContext& creationContext, std::unique_ptr<ImageBufferBackend>&& backend, Arguments&&... arguments)
-    {
-        auto backendParameters = backend->parameters();
-        auto parameters = Parameters { size, backendParameters.resolutionScale, backendParameters.colorSpace, backendParameters.bufferFormat, backendParameters.purpose };
-        auto backendInfo = populateBackendInfo<BackendType>(backendParameters);
-        return create<ImageBufferType>(parameters, backendInfo, creationContext, WTF::move(backend), std::forward<Arguments>(arguments)...);
-    }
-
+    // The backend is the source of the buffer's rendering mode, base transform and
+    // memory cost, so it has to be constructed before the buffer.
     template<typename ImageBufferType = ImageBuffer, typename... Arguments>
-    static RefPtr<ImageBufferType> create(Parameters parameters, const ImageBufferBackend::Info& backendInfo, const WebCore::ImageBufferCreationContext& creationContext, std::unique_ptr<ImageBufferBackend>&& backend, Arguments&&... arguments)
+    static RefPtr<ImageBufferType> create(Parameters parameters, const WebCore::ImageBufferCreationContext& creationContext, std::unique_ptr<ImageBufferBackend>&& backend, Arguments&&... arguments)
     {
-        return adoptRef(new ImageBufferType(parameters, backendInfo, creationContext, WTF::move(backend), std::forward<Arguments>(arguments)...));
-    }
-
-    template<typename BackendType>
-    static ImageBufferBackend::Info populateBackendInfo(const ImageBufferBackend::Parameters& parameters)
-    {
-        return {
-            BackendType::renderingMode,
-            ImageBufferBackend::calculateBaseTransform(parameters),
-            BackendType::calculateMemoryCost(parameters),
-        };
+        ASSERT(backend);
+        return adoptRef(new ImageBufferType(parameters, creationContext, WTF::move(backend), std::forward<Arguments>(arguments)...));
     }
 
     WEBCORE_EXPORT virtual ~ImageBuffer();
 
     WEBCORE_EXPORT static IntSize calculateBackendSize(FloatSize logicalSize, float resolutionScale);
-    WEBCORE_EXPORT static ImageBufferBackendParameters backendParameters(const Parameters&);
 
     // Supported get, putPixelBuffer formats.
     WEBCORE_EXPORT static bool NODELETE supportedPixelBufferFormats(PixelFormat);
@@ -165,7 +139,7 @@ public:
 
     WEBCORE_EXPORT IntSize backendSize() const;
 
-    virtual void ensureBackendCreated() const { ensureBackend(); }
+    WEBCORE_EXPORT virtual std::optional<RenderingMode> getEffectiveRenderingModeForTesting() const;
     bool hasBackend() const { return !!backend(); }
 
     WEBCORE_EXPORT void transferToNewContext(const ImageBufferCreationContext&);
@@ -181,10 +155,9 @@ public:
     PixelFormat pixelFormat() const { return m_parameters.bufferFormat.pixelFormat; }
     const Parameters& parameters() const LIFETIME_BOUND { return m_parameters; }
 
-    RenderingMode renderingMode() const { return m_backendInfo.renderingMode; }
-    AffineTransform baseTransform() const { return m_backendInfo.baseTransform; }
-    size_t memoryCost() const { return m_backendInfo.memoryCost; }
-    const ImageBufferBackend::Info& backendInfo() const LIFETIME_BOUND { return m_backendInfo; }
+    RenderingMode renderingMode() const { return m_backend->renderingMode(); }
+    AffineTransform baseTransform() const { return m_backend->baseTransform(); }
+    size_t memoryCost() const { return m_backend->memoryCost(); }
 
     // Returns NativeImage of the current drawing results. Results in an immutable copy of the current back buffer.
     WEBCORE_EXPORT virtual RefPtr<NativeImage> copyNativeImage() const;
@@ -255,7 +228,7 @@ public:
     WEBCORE_EXPORT void rebuildFonts();
 
 protected:
-    WEBCORE_EXPORT ImageBuffer(ImageBufferParameters, const ImageBufferBackend::Info&, const WebCore::ImageBufferCreationContext&, std::unique_ptr<ImageBufferBackend>&& = nullptr, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
+    WEBCORE_EXPORT ImageBuffer(ImageBufferParameters, const WebCore::ImageBufferCreationContext&, std::unique_ptr<ImageBufferBackend>&&, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());
 
     WEBCORE_EXPORT virtual RefPtr<NativeImage> sinkIntoNativeImage();
     WEBCORE_EXPORT virtual RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread();
@@ -263,10 +236,8 @@ protected:
 
     WEBCORE_EXPORT void setBackend(std::unique_ptr<ImageBufferBackend>&&);
     ImageBufferBackend* backend() const LIFETIME_BOUND { return m_backend.get(); }
-    virtual ImageBufferBackend* ensureBackend() const { return m_backend.get(); }
 
     Parameters m_parameters;
-    ImageBufferBackend::Info m_backendInfo;
     std::unique_ptr<ImageBufferBackend> m_backend;
     RenderingResourceIdentifier m_renderingResourceIdentifier;
     unsigned m_backendGeneration { 0 };

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -38,9 +38,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ThreadSafeImageBufferFlusher);
 
-IntSize ImageBufferBackend::calculateSafeBackendSize(const Parameters& parameters)
+IntSize ImageBufferBackend::calculateSafeBackendSize(const ImageBufferParameters& parameters)
 {
-    IntSize backendSize = parameters.backendSize;
+    IntSize backendSize = parameters.backendSize();
     if (backendSize.isEmpty())
         return backendSize;
 
@@ -61,8 +61,12 @@ size_t ImageBufferBackend::calculateMemoryCost(const IntSize& backendSize, unsig
     return CheckedUint32(backendSize.height()) * bytesPerRow;
 }
 
-ImageBufferBackend::ImageBufferBackend(const Parameters& parameters)
-    : m_parameters(parameters)
+ImageBufferBackend::ImageBufferBackend(const ImageBufferParameters& parameters)
+    : m_backendSize(parameters.backendSize())
+    , m_resolutionScale(parameters.resolutionScale)
+    , m_colorSpace(parameters.colorSpace)
+    , m_bufferFormat(parameters.bufferFormat)
+    , m_purpose(parameters.purpose)
 {
 }
 
@@ -192,17 +196,29 @@ RefPtr<SharedBuffer> ImageBufferBackend::sinkIntoPDFDocument()
     return nullptr;
 }
 
-AffineTransform ImageBufferBackend::calculateBaseTransform(const Parameters& parameters)
+static AffineTransform baseTransformForBackingStore(const IntSize& backendSize, float resolutionScale)
 {
     AffineTransform baseTransform;
 #if USE(CG)
     // CoreGraphics origin is at bottom left corner. GraphicsContext origin is at top left corner. Flip the drawing with GraphicsContext base
     // transform.
     baseTransform.scale(1, -1);
-    baseTransform.translate(0, -parameters.backendSize.height());
+    baseTransform.translate(0, -backendSize.height());
+#else
+    UNUSED_PARAM(backendSize);
 #endif
-    baseTransform.scale(parameters.resolutionScale);
+    baseTransform.scale(resolutionScale);
     return baseTransform;
+}
+
+AffineTransform ImageBufferBackend::calculateBaseTransform(const ImageBufferParameters& parameters)
+{
+    return baseTransformForBackingStore(parameters.backendSize(), parameters.resolutionScale);
+}
+
+AffineTransform ImageBufferBackend::baseTransform() const
+{
+    return baseTransformForBackingStore(m_backendSize, m_resolutionScale);
 }
 
 TextStream& operator<<(TextStream& ts, VolatilityState state)

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -31,7 +31,7 @@
 #include <WebCore/GraphicsLayerContentsDisplayDelegate.h>
 #include <WebCore/GraphicsTypesGL.h>
 #include <WebCore/ImageBufferAllocator.h>
-#include <WebCore/ImageBufferBackendParameters.h>
+#include <WebCore/ImageBufferParameters.h>
 #include <WebCore/ImagePaintingOptions.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/PixelBufferFormat.h>
@@ -105,19 +105,15 @@ public:
 
 class ImageBufferBackend {
 public:
-    using Parameters = ImageBufferBackendParameters;
-
-    struct Info {
-        RenderingMode renderingMode;
-        AffineTransform baseTransform;
-        size_t memoryCost;
-    };
-
     WEBCORE_EXPORT virtual ~ImageBufferBackend();
 
-    WEBCORE_EXPORT static IntSize NODELETE calculateSafeBackendSize(const Parameters&);
+    WEBCORE_EXPORT static IntSize calculateSafeBackendSize(const ImageBufferParameters&);
     WEBCORE_EXPORT static size_t NODELETE calculateMemoryCost(const IntSize& backendSize, unsigned bytesPerRow);
-    WEBCORE_EXPORT static AffineTransform calculateBaseTransform(const Parameters&);
+    WEBCORE_EXPORT static AffineTransform calculateBaseTransform(const ImageBufferParameters&);
+
+    virtual RenderingMode renderingMode() const { return RenderingMode::Unaccelerated; }
+    virtual size_t memoryCost() const { return calculateMemoryCost(m_backendSize, bytesPerRow()); }
+    WEBCORE_EXPORT AffineTransform baseTransform() const;
 
     virtual GraphicsContext& context() = 0;
     virtual void flushContext() { }
@@ -163,30 +159,30 @@ public:
 
     virtual std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher() { return nullptr; }
 
-    static constexpr RenderingMode renderingMode = RenderingMode::Unaccelerated;
-
     virtual bool canMapBackingStore() const = 0;
     virtual void ensureNativeImagesHaveCopiedBackingStore() { }
 
     virtual ImageBufferBackendSharing* toBackendSharing() { return nullptr; }
 
+    virtual bool isNullImageBufferBackend() const { return false; }
+
     virtual RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() const { return nullptr; }
 
     virtual void prepareForDisplay() { }
 
-    const Parameters& parameters() const LIFETIME_BOUND { return m_parameters; }
-
     WEBCORE_EXPORT virtual String debugDescription() const = 0;
 
 protected:
-    WEBCORE_EXPORT ImageBufferBackend(const Parameters&);
+    WEBCORE_EXPORT ImageBufferBackend(const ImageBufferParameters&);
 
     virtual unsigned bytesPerRow() const = 0;
 
-    IntSize size() const { return m_parameters.backendSize; };
-    float resolutionScale() const { return m_parameters.resolutionScale; }
-    const ColorSpace& colorSpace() const LIFETIME_BOUND { return m_parameters.colorSpace; }
-    PixelFormat pixelFormat() const { return m_parameters.bufferFormat.pixelFormat; }
+    IntSize size() const { return m_backendSize; }
+    float resolutionScale() const { return m_resolutionScale; }
+    const ColorSpace& colorSpace() const LIFETIME_BOUND { return m_colorSpace; }
+    ImageBufferFormat bufferFormat() const { return m_bufferFormat; }
+    PixelFormat pixelFormat() const { return m_bufferFormat.pixelFormat; }
+    RenderingPurpose purpose() const { return m_purpose; }
 
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
     void NODELETE convertToLuminanceMaskFloat16();
@@ -196,7 +192,11 @@ protected:
     WEBCORE_EXPORT void getPixelBuffer(const IntRect& srcRect, std::span<const uint8_t> data, PixelBuffer& destination);
     WEBCORE_EXPORT void putPixelBuffer(const PixelBufferSourceView&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat, std::span<uint8_t> destination);
 
-    Parameters m_parameters;
+    const IntSize m_backendSize;
+    const float m_resolutionScale;
+    ColorSpace m_colorSpace;
+    const ImageBufferFormat m_bufferFormat;
+    const RenderingPurpose m_purpose;
 };
 
 WEBCORE_EXPORT TextStream& operator<<(TextStream&, VolatilityState);

--- a/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.cpp
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-std::unique_ptr<ImageBufferDisplayListBackend> ImageBufferDisplayListBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)
+std::unique_ptr<ImageBufferDisplayListBackend> ImageBufferDisplayListBackend::create(const ImageBufferParameters& parameters, const ImageBufferCreationContext&)
 {
     return std::unique_ptr<ImageBufferDisplayListBackend>(new ImageBufferDisplayListBackend(parameters, ControlFactory::singleton()));
 }
@@ -39,14 +39,14 @@ std::unique_ptr<ImageBufferDisplayListBackend> ImageBufferDisplayListBackend::cr
 
 std::unique_ptr<ImageBufferDisplayListBackend> ImageBufferDisplayListBackend::create(const FloatSize& size, float resolutionScale, const ColorSpace& colorSpace, PixelFormat pixelFormat, RenderingPurpose purpose, ControlFactory& controlFactory)
 {
-    Parameters parameters { ImageBuffer::calculateBackendSize(size, resolutionScale), resolutionScale, colorSpace, { pixelFormat }, purpose };
+    ImageBufferParameters parameters { size, resolutionScale, colorSpace, { pixelFormat }, purpose };
     return std::unique_ptr<ImageBufferDisplayListBackend>(new ImageBufferDisplayListBackend(parameters, controlFactory));
 }
 
-ImageBufferDisplayListBackend::ImageBufferDisplayListBackend(const Parameters& parameters, ControlFactory& controlFactory)
+ImageBufferDisplayListBackend::ImageBufferDisplayListBackend(const ImageBufferParameters& parameters, ControlFactory& controlFactory)
     : ImageBufferBackend(parameters)
     , m_controlFactory(controlFactory)
-    , m_drawingContext(FloatRect { { }, parameters.backendSize })
+    , m_drawingContext(FloatRect { { }, parameters.backendSize() })
 {
 }
 

--- a/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.h
@@ -32,15 +32,14 @@ namespace WebCore {
 
 class ImageBufferDisplayListBackend : public ImageBufferBackend {
 public:
-    WEBCORE_EXPORT static std::unique_ptr<ImageBufferDisplayListBackend> create(const Parameters&, const ImageBufferCreationContext&);
+    WEBCORE_EXPORT static std::unique_ptr<ImageBufferDisplayListBackend> create(const ImageBufferParameters&, const ImageBufferCreationContext&);
     WEBCORE_EXPORT static std::unique_ptr<ImageBufferDisplayListBackend> create(const FloatSize&, float resolutionScale, const ColorSpace&, PixelFormat, RenderingPurpose, ControlFactory&);
 
-    static size_t calculateMemoryCost(const Parameters&) { return 0; }
-
-    static constexpr RenderingMode renderingMode = RenderingMode::DisplayList;
+    RenderingMode renderingMode() const final { return RenderingMode::DisplayList; }
+    size_t memoryCost() const final { return 0; }
 
 private:
-    ImageBufferDisplayListBackend(const Parameters&, ControlFactory&);
+    ImageBufferDisplayListBackend(const ImageBufferParameters&, ControlFactory&);
 
     bool canMapBackingStore() const final { return false; }
     unsigned bytesPerRow() const final { return 0; }

--- a/Source/WebCore/platform/graphics/ImageBufferParameters.h
+++ b/Source/WebCore/platform/graphics/ImageBufferParameters.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/ColorSpace.h>
+#include <WebCore/FloatSize.h>
 #include <WebCore/ImageBufferFormat.h>
 #include <WebCore/IntSize.h>
 #include <WebCore/PixelFormat.h>
@@ -33,12 +34,19 @@
 
 namespace WebCore {
 
-struct ImageBufferBackendParameters {
-    IntSize backendSize;
-    float resolutionScale; // Resolution scale is of the ImageBuffer logical size.
+// The size of the backing store that a logical size and a resolution scale ask for.
+// Empty if that cannot be expressed as an IntSize, which the callers treat as a
+// failure to allocate.
+WEBCORE_EXPORT IntSize calculateImageBufferBackendSize(FloatSize logicalSize, float resolutionScale);
+
+struct ImageBufferParameters {
+    FloatSize logicalSize;
+    float resolutionScale;
     ColorSpace colorSpace;
     ImageBufferFormat bufferFormat;
     RenderingPurpose purpose;
+
+    IntSize backendSize() const { return calculateImageBufferBackendSize(logicalSize, resolutionScale); }
 };
 
-} // namespace WTF
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/NullImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/NullImageBufferBackend.cpp
@@ -33,12 +33,17 @@
 
 namespace WebCore {
 
-std::unique_ptr<NullImageBufferBackend> NullImageBufferBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)
+std::unique_ptr<NullImageBufferBackend> NullImageBufferBackend::create(const ImageBufferParameters& parameters, const ImageBufferCreationContext&)
 {
     return std::unique_ptr<NullImageBufferBackend> { new NullImageBufferBackend { parameters } };
 }
 
 NullImageBufferBackend::~NullImageBufferBackend() = default;
+
+size_t NullImageBufferBackend::memoryCost() const
+{
+    return 0;
+}
 
 NullGraphicsContext& NullImageBufferBackend::context()
 {
@@ -67,6 +72,11 @@ void NullImageBufferBackend::putPixelBuffer(const PixelBufferSourceView&, const 
 unsigned NullImageBufferBackend::bytesPerRow() const
 {
     return 0;
+}
+
+bool NullImageBufferBackend::isNullImageBufferBackend() const
+{
+    return true;
 }
 
 bool NullImageBufferBackend::canMapBackingStore() const

--- a/Source/WebCore/platform/graphics/NullImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/NullImageBufferBackend.h
@@ -28,31 +28,36 @@
 #include <WebCore/ImageBufferBackend.h>
 #include <WebCore/NullGraphicsContext.h>
 #include <memory>
+#include <wtf/TypeCasts.h>
 
 namespace WebCore {
 
-// Used for ImageBuffers that return NullGraphicsContext as the ImageBuffer::context().
-// Solves the problem of holding NullGraphicsContext similarly to holding other
-// GraphicsContext instances, via a ImageBuffer reference.
-class WEBCORE_EXPORT NullImageBufferBackend : public ImageBufferBackend {
+// Backend for ImageBuffers that failed to allocate.
+class WEBCORE_EXPORT NullImageBufferBackend final : public ImageBufferBackend {
 public:
-    static std::unique_ptr<NullImageBufferBackend> create(const Parameters&, const ImageBufferCreationContext&);
+    static std::unique_ptr<NullImageBufferBackend> create(const ImageBufferParameters&, const ImageBufferCreationContext&);
     ~NullImageBufferBackend();
-    static size_t calculateMemoryCost(const Parameters&) { return 0; }
+    size_t memoryCost() const final;
 
-    NullGraphicsContext& context() override;
-    RefPtr<NativeImage> copyNativeImage() override;
-    RefPtr<NativeImage> createNativeImageReference() override;
-    void getPixelBuffer(const IntRect&, PixelBuffer&) override;
-    void putPixelBuffer(const PixelBufferSourceView&, const IntRect&, const IntPoint&, AlphaPremultiplication) override;
-    bool canMapBackingStore() const override;
-    String debugDescription() const override;
+    NullGraphicsContext& context() final;
+    RefPtr<NativeImage> copyNativeImage() final;
+    RefPtr<NativeImage> createNativeImageReference() final;
+    void getPixelBuffer(const IntRect&, PixelBuffer&) final;
+    void putPixelBuffer(const PixelBufferSourceView&, const IntRect&, const IntPoint&, AlphaPremultiplication) final;
+    bool canMapBackingStore() const final;
+    String debugDescription() const final;
 
-protected:
+private:
     using ImageBufferBackend::ImageBufferBackend;
-    unsigned bytesPerRow() const override;
+    unsigned bytesPerRow() const final;
+    bool isNullImageBufferBackend() const final;
 
     NullGraphicsContext m_context;
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NullImageBufferBackend)
+    static bool isType(const WebCore::ImageBufferBackend& backend) { return backend.isNullImageBufferBackend(); }
+SPECIALIZE_TYPE_TRAITS_END()
+

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.cpp
@@ -44,15 +44,15 @@ namespace WebCore {
 
 void ImageBufferCairoBackend::transformToColorSpace(const ColorSpace& newColorSpace)
 {
-    if (m_parameters.colorSpace == newColorSpace)
+    if (m_colorSpace == newColorSpace)
         return;
 
     // only sRGB <-> linearRGB are supported at the moment
-    if ((m_parameters.colorSpace != ColorSpace::LinearSRGB() && m_parameters.colorSpace != ColorSpace::SRGB())
+    if ((m_colorSpace != ColorSpace::LinearSRGB() && m_colorSpace != ColorSpace::SRGB())
         || (newColorSpace != ColorSpace::LinearSRGB() && newColorSpace != ColorSpace::SRGB()))
         return;
 
-    m_parameters.colorSpace = newColorSpace;
+    m_colorSpace = newColorSpace;
 
     if (newColorSpace == ColorSpace::LinearSRGB()) {
         static const std::array<uint8_t, 256> linearRgbLUT = [] {

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoImageSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoImageSurfaceBackend.cpp
@@ -42,9 +42,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageBufferCairoImageSurfaceBackend);
 
-IntSize ImageBufferCairoImageSurfaceBackend::calculateSafeBackendSize(const Parameters& parameters)
+IntSize ImageBufferCairoImageSurfaceBackend::calculateSafeBackendSize(const ImageBufferParameters& parameters)
 {
-    IntSize backendSize = parameters.backendSize;
+    IntSize backendSize = parameters.backendSize();
     if (backendSize.isEmpty())
         return { };
 
@@ -68,12 +68,7 @@ unsigned ImageBufferCairoImageSurfaceBackend::calculateBytesPerRow(const IntSize
     return cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, backendSize.width());
 }
 
-size_t ImageBufferCairoImageSurfaceBackend::calculateMemoryCost(const Parameters& parameters)
-{
-    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize));
-}
-
-std::unique_ptr<ImageBufferCairoImageSurfaceBackend> ImageBufferCairoImageSurfaceBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)
+std::unique_ptr<ImageBufferCairoImageSurfaceBackend> ImageBufferCairoImageSurfaceBackend::create(const ImageBufferParameters& parameters, const ImageBufferCreationContext&)
 {
     ASSERT(parameters.bufferFormat.pixelFormat == PixelFormat::BGRA8);
 
@@ -98,12 +93,12 @@ std::unique_ptr<ImageBufferCairoImageSurfaceBackend> ImageBufferCairoImageSurfac
     return std::unique_ptr<ImageBufferCairoImageSurfaceBackend>(new ImageBufferCairoImageSurfaceBackend(parameters, WTF::move(surface)));
 }
 
-std::unique_ptr<ImageBufferCairoImageSurfaceBackend> ImageBufferCairoImageSurfaceBackend::create(const Parameters& parameters, const GraphicsContext&)
+std::unique_ptr<ImageBufferCairoImageSurfaceBackend> ImageBufferCairoImageSurfaceBackend::create(const ImageBufferParameters& parameters, const GraphicsContext&)
 {
     return ImageBufferCairoImageSurfaceBackend::create(parameters, ImageBufferCreationContext { });
 }
 
-ImageBufferCairoImageSurfaceBackend::ImageBufferCairoImageSurfaceBackend(const Parameters& parameters, RefPtr<cairo_surface_t>&& surface)
+ImageBufferCairoImageSurfaceBackend::ImageBufferCairoImageSurfaceBackend(const ImageBufferParameters& parameters, RefPtr<cairo_surface_t>&& surface)
     : ImageBufferCairoSurfaceBackend(parameters, WTF::move(surface))
 {
     ASSERT(cairo_surface_get_type(m_surface.get()) == CAIRO_SURFACE_TYPE_IMAGE);
@@ -111,7 +106,7 @@ ImageBufferCairoImageSurfaceBackend::ImageBufferCairoImageSurfaceBackend(const P
 
 unsigned ImageBufferCairoImageSurfaceBackend::bytesPerRow() const
 {
-    return calculateBytesPerRow(m_parameters.backendSize);
+    return calculateBytesPerRow(size());
 }
 
 void ImageBufferCairoImageSurfaceBackend::platformTransformColorSpace(const std::array<uint8_t, 256>& lookUpTable)

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoImageSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoImageSurfaceBackend.h
@@ -40,15 +40,15 @@ class ImageBufferCairoImageSurfaceBackend : public ImageBufferCairoSurfaceBacken
     WTF_MAKE_TZONE_ALLOCATED(ImageBufferCairoImageSurfaceBackend);
     WTF_MAKE_NONCOPYABLE(ImageBufferCairoImageSurfaceBackend);
 public:
-    static IntSize calculateSafeBackendSize(const Parameters&);
+    static IntSize calculateSafeBackendSize(const ImageBufferParameters&);
     static unsigned calculateBytesPerRow(const IntSize& backendSize);
-    static size_t calculateMemoryCost(const Parameters&);
+    size_t memoryCost() const final { return ImageBufferBackend::calculateMemoryCost(size(), calculateBytesPerRow(size())); }
 
-    static std::unique_ptr<ImageBufferCairoImageSurfaceBackend> create(const Parameters&, const ImageBufferCreationContext&);
-    static std::unique_ptr<ImageBufferCairoImageSurfaceBackend> create(const Parameters&, const GraphicsContext&);
+    static std::unique_ptr<ImageBufferCairoImageSurfaceBackend> create(const ImageBufferParameters&, const ImageBufferCreationContext&);
+    static std::unique_ptr<ImageBufferCairoImageSurfaceBackend> create(const ImageBufferParameters&, const GraphicsContext&);
 
 private:
-    ImageBufferCairoImageSurfaceBackend(const Parameters&, RefPtr<cairo_surface_t>&&);
+    ImageBufferCairoImageSurfaceBackend(const ImageBufferParameters&, RefPtr<cairo_surface_t>&&);
 
     unsigned bytesPerRow() const override;
 

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp
@@ -42,7 +42,7 @@
 
 namespace WebCore {
 
-ImageBufferCairoSurfaceBackend::ImageBufferCairoSurfaceBackend(const Parameters& parameters, RefPtr<cairo_surface_t>&& surface)
+ImageBufferCairoSurfaceBackend::ImageBufferCairoSurfaceBackend(const ImageBufferParameters& parameters, RefPtr<cairo_surface_t>&& surface)
     : ImageBufferCairoBackend(parameters)
     , m_surface(WTF::move(surface))
     , m_context(m_surface.get())

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.h
@@ -49,7 +49,7 @@ public:
     void putPixelBuffer(const PixelBufferSourceView&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat) override;
 
 protected:
-    ImageBufferCairoSurfaceBackend(const Parameters&, RefPtr<cairo_surface_t>&&);
+    ImageBufferCairoSurfaceBackend(const ImageBufferParameters&, RefPtr<cairo_surface_t>&&);
 
     RefPtr<NativeImage> cairoSurfaceCoerceToImage();
     unsigned bytesPerRow() const override;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
@@ -53,7 +53,7 @@ private:
     RetainPtr<CGContextRef> m_context;
 };
 
-ImageBufferCGBackend::ImageBufferCGBackend(const Parameters& parameters, std::unique_ptr<GraphicsContextCG>&& context)
+ImageBufferCGBackend::ImageBufferCGBackend(const ImageBufferParameters& parameters, std::unique_ptr<GraphicsContextCG>&& context)
     : ImageBufferBackend(parameters)
     , m_context(WTF::move(context))
 {
@@ -74,8 +74,8 @@ std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBufferCGBackend::createFlushe
 
 void ImageBufferCGBackend::applyBaseTransform(GraphicsContextCG& context) const
 {
-    context.applyDeviceScaleFactor(m_parameters.resolutionScale);
-    context.setCTM(calculateBaseTransform(m_parameters));
+    context.applyDeviceScaleFactor(resolutionScale());
+    context.setCTM(baseTransform());
 }
 
 String ImageBufferCGBackend::debugDescription() const

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
@@ -39,7 +39,7 @@ public:
     static unsigned NODELETE calculateBytesPerRow(const IntSize& backendSize, PixelFormat);
 
 protected:
-    ImageBufferCGBackend(const Parameters&, std::unique_ptr<GraphicsContextCG>&& = nullptr);
+    ImageBufferCGBackend(const ImageBufferParameters&, std::unique_ptr<GraphicsContextCG>&& = nullptr);
     void applyBaseTransform(GraphicsContextCG&) const;
 
     std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher() override;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
@@ -53,12 +53,7 @@ static CGBitmapInfo bitmapInfoForPixelFormat(PixelFormat pixelFormat)
     return static_cast<CGBitmapInfo>(kCGImageAlphaPremultipliedFirst) | static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Host);
 }
 
-size_t ImageBufferCGBitmapBackend::calculateMemoryCost(const Parameters& parameters)
-{
-    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize, parameters.bufferFormat.pixelFormat));
-}
-
-std::unique_ptr<ImageBufferCGBitmapBackend> ImageBufferCGBitmapBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)
+std::unique_ptr<ImageBufferCGBitmapBackend> ImageBufferCGBitmapBackend::create(const ImageBufferParameters& parameters, const ImageBufferCreationContext&)
 {
     auto pixelFormat = parameters.bufferFormat.pixelFormat;
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
@@ -100,7 +95,7 @@ std::unique_ptr<ImageBufferCGBitmapBackend> ImageBufferCGBitmapBackend::create(c
     return std::unique_ptr<ImageBufferCGBitmapBackend>(new ImageBufferCGBitmapBackend(parameters, data.leakSpan(), WTF::move(dataProvider), WTF::move(context)));
 }
 
-ImageBufferCGBitmapBackend::ImageBufferCGBitmapBackend(const Parameters& parameters, std::span<uint8_t> data, RetainPtr<CGDataProviderRef>&& dataProvider, std::unique_ptr<GraphicsContextCG>&& context)
+ImageBufferCGBitmapBackend::ImageBufferCGBitmapBackend(const ImageBufferParameters& parameters, std::span<uint8_t> data, RetainPtr<CGDataProviderRef>&& dataProvider, std::unique_ptr<GraphicsContextCG>&& context)
     : ImageBufferCGBackend(parameters, WTF::move(context))
     , m_data(data)
     , m_dataProvider(WTF::move(dataProvider))
@@ -120,7 +115,7 @@ GraphicsContext& ImageBufferCGBitmapBackend::context()
 
 unsigned ImageBufferCGBitmapBackend::bytesPerRow() const
 {
-    return calculateBytesPerRow(m_parameters.backendSize, m_parameters.bufferFormat.pixelFormat);
+    return calculateBytesPerRow(size(), pixelFormat());
 }
 
 bool ImageBufferCGBitmapBackend::canMapBackingStore() const
@@ -136,7 +131,7 @@ RefPtr<NativeImage> ImageBufferCGBitmapBackend::copyNativeImage()
 RefPtr<NativeImage> ImageBufferCGBitmapBackend::createNativeImageReference()
 {
     auto backendSize = size();
-    auto pixelFormat = m_parameters.bufferFormat.pixelFormat;
+    auto pixelFormat = this->pixelFormat();
     return NativeImage::create(adoptCF(CGImageCreate(
         backendSize.width(), backendSize.height(), PixelBuffer::bytesPerPixelComponent(pixelFormat) * 8, PixelBuffer::bytesPerPixel(pixelFormat) * 8, bytesPerRow(),
         colorSpace().platformColorSpace(), bitmapInfoForPixelFormat(pixelFormat), m_dataProvider.get(),

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h
@@ -39,14 +39,14 @@ class ImageBufferCGBitmapBackend final : public ImageBufferCGBackend {
 public:
     ~ImageBufferCGBitmapBackend();
 
-    static size_t NODELETE calculateMemoryCost(const Parameters&);
 
-    static std::unique_ptr<ImageBufferCGBitmapBackend> create(const Parameters&, const ImageBufferCreationContext&);
+    static std::unique_ptr<ImageBufferCGBitmapBackend> create(const ImageBufferParameters&, const ImageBufferCreationContext&);
+    size_t memoryCost() const final { return ImageBufferBackend::calculateMemoryCost(size(), calculateBytesPerRow(size(), pixelFormat())); }
     bool canMapBackingStore() const final;
     GraphicsContext& NODELETE context() final;
 
 private:
-    ImageBufferCGBitmapBackend(const Parameters&, std::span<uint8_t> data, RetainPtr<CGDataProviderRef>&&, std::unique_ptr<GraphicsContextCG>&&);
+    ImageBufferCGBitmapBackend(const ImageBufferParameters&, std::span<uint8_t> data, RetainPtr<CGDataProviderRef>&&, std::unique_ptr<GraphicsContextCG>&&);
 
     unsigned bytesPerRow() const final;
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp
@@ -36,16 +36,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageBufferCGPDFDocumentBackend);
 
-size_t ImageBufferCGPDFDocumentBackend::calculateMemoryCost(const Parameters& parameters)
+std::unique_ptr<ImageBufferCGPDFDocumentBackend> ImageBufferCGPDFDocumentBackend::create(const ImageBufferParameters& parameters, const ImageBufferCreationContext&)
 {
-    // FIXME: This is fairly meaningless, because we don't actually have a bitmap, and
-    // should really be based on the PDF document size.
-    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize, parameters.bufferFormat.pixelFormat));
-}
-
-std::unique_ptr<ImageBufferCGPDFDocumentBackend> ImageBufferCGPDFDocumentBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)
-{
-    IntSize backendSize = parameters.backendSize;
+    IntSize backendSize = parameters.backendSize();
     if (backendSize.isEmpty())
         return nullptr;
 
@@ -68,7 +61,7 @@ std::unique_ptr<ImageBufferCGPDFDocumentBackend> ImageBufferCGPDFDocumentBackend
     return std::unique_ptr<ImageBufferCGPDFDocumentBackend>(new ImageBufferCGPDFDocumentBackend(parameters, WTF::move(data), WTF::move(context)));
 }
 
-ImageBufferCGPDFDocumentBackend::ImageBufferCGPDFDocumentBackend(const Parameters& parameters, RetainPtr<CFDataRef>&& data, std::unique_ptr<GraphicsContextCG>&& context)
+ImageBufferCGPDFDocumentBackend::ImageBufferCGPDFDocumentBackend(const ImageBufferParameters& parameters, RetainPtr<CFDataRef>&& data, std::unique_ptr<GraphicsContextCG>&& context)
     : ImageBufferCGBackend(parameters, WTF::move(context))
     , m_data(WTF::move(data))
 {

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.h
@@ -37,15 +37,17 @@ class ImageBufferCGPDFDocumentBackend : public ImageBufferCGBackend {
     WTF_MAKE_TZONE_ALLOCATED(ImageBufferCGPDFDocumentBackend);
     WTF_MAKE_NONCOPYABLE(ImageBufferCGPDFDocumentBackend);
 public:
-    WEBCORE_EXPORT static size_t NODELETE calculateMemoryCost(const Parameters&);
-    WEBCORE_EXPORT static std::unique_ptr<ImageBufferCGPDFDocumentBackend> create(const Parameters&, const ImageBufferCreationContext&);
+    WEBCORE_EXPORT static std::unique_ptr<ImageBufferCGPDFDocumentBackend> create(const ImageBufferParameters&, const ImageBufferCreationContext&);
 
     ~ImageBufferCGPDFDocumentBackend();
 
-    static constexpr RenderingMode renderingMode = RenderingMode::PDFDocument;
+    RenderingMode renderingMode() const final { return RenderingMode::PDFDocument; }
+    // FIXME: This is fairly meaningless, because we don't actually have a bitmap, and
+    // should really be based on the PDF document size.
+    size_t memoryCost() const final { return ImageBufferBackend::calculateMemoryCost(size(), calculateBytesPerRow(size(), pixelFormat())); }
 
 private:
-    ImageBufferCGPDFDocumentBackend(const Parameters&, RetainPtr<CFDataRef>&&, std::unique_ptr<GraphicsContextCG>&&);
+    ImageBufferCGPDFDocumentBackend(const ImageBufferParameters&, RetainPtr<CFDataRef>&&, std::unique_ptr<GraphicsContextCG>&&);
 
     bool canMapBackingStore() const { return false; }
     unsigned bytesPerRow() const final { return 0; }

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -45,9 +45,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageBufferIOSurfaceBackend);
 
-IntSize ImageBufferIOSurfaceBackend::calculateSafeBackendSize(const Parameters& parameters)
+IntSize ImageBufferIOSurfaceBackend::calculateSafeBackendSize(const ImageBufferParameters& parameters)
 {
-    IntSize backendSize = parameters.backendSize;
+    IntSize backendSize = parameters.backendSize();
     if (backendSize.isEmpty())
         return { };
 
@@ -65,12 +65,7 @@ unsigned ImageBufferIOSurfaceBackend::calculateBytesPerRow(const IntSize& backen
     return (bytesPerRow + alignmentMask) & ~alignmentMask;
 }
 
-size_t ImageBufferIOSurfaceBackend::calculateMemoryCost(const Parameters& parameters)
-{
-    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize, parameters.bufferFormat.pixelFormat));
-}
-
-std::unique_ptr<ImageBufferIOSurfaceBackend> ImageBufferIOSurfaceBackend::create(const Parameters& parameters, const ImageBufferCreationContext& creationContext)
+std::unique_ptr<ImageBufferIOSurfaceBackend> ImageBufferIOSurfaceBackend::create(const ImageBufferParameters& parameters, const ImageBufferCreationContext& creationContext)
 {
     IntSize backendSize = calculateSafeBackendSize(parameters);
     if (backendSize.isEmpty())
@@ -89,7 +84,7 @@ std::unique_ptr<ImageBufferIOSurfaceBackend> ImageBufferIOSurfaceBackend::create
     return std::unique_ptr<ImageBufferIOSurfaceBackend> { new ImageBufferIOSurfaceBackend { parameters, WTF::move(surface), WTF::move(cgContext), creationContext.displayID, creationContext.surfacePool.get() } };
 }
 
-ImageBufferIOSurfaceBackend::ImageBufferIOSurfaceBackend(const Parameters& parameters, std::unique_ptr<IOSurface> surface, RetainPtr<CGContextRef> platformContext, PlatformDisplayID displayID, IOSurfacePool* ioSurfacePool)
+ImageBufferIOSurfaceBackend::ImageBufferIOSurfaceBackend(const ImageBufferParameters& parameters, std::unique_ptr<IOSurface> surface, RetainPtr<CGContextRef> platformContext, PlatformDisplayID displayID, IOSurfacePool* ioSurfacePool)
     : ImageBufferCGBackend(parameters)
     , m_surface(WTF::move(surface))
     , m_platformContext(WTF::move(platformContext))
@@ -107,6 +102,15 @@ ImageBufferIOSurfaceBackend::~ImageBufferIOSurfaceBackend()
     IOSurface::moveToPool(WTF::move(m_surface), m_ioSurfacePool.get());
 }
 
+RenderingMode ImageBufferIOSurfaceBackend::renderingMode() const
+{
+    return RenderingMode::Accelerated;
+}
+
+size_t ImageBufferIOSurfaceBackend::memoryCost() const
+{
+    return ImageBufferBackend::calculateMemoryCost(size(), calculateBytesPerRow(size(), pixelFormat()));
+}
 
 GraphicsContext& ImageBufferIOSurfaceBackend::context()
 {

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h
@@ -39,15 +39,15 @@ class WEBCORE_EXPORT ImageBufferIOSurfaceBackend : public ImageBufferCGBackend {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ImageBufferIOSurfaceBackend, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(ImageBufferIOSurfaceBackend);
 public:
-    static IntSize calculateSafeBackendSize(const Parameters&);
+    static IntSize calculateSafeBackendSize(const ImageBufferParameters&);
     static unsigned calculateBytesPerRow(const IntSize& backendSize, PixelFormat);
-    static size_t calculateMemoryCost(const Parameters&);
 
-    static std::unique_ptr<ImageBufferIOSurfaceBackend> create(const Parameters&, const ImageBufferCreationContext&);
+    static std::unique_ptr<ImageBufferIOSurfaceBackend> create(const ImageBufferParameters&, const ImageBufferCreationContext&);
 
     ~ImageBufferIOSurfaceBackend();
     
-    static constexpr RenderingMode renderingMode = RenderingMode::Accelerated;
+    RenderingMode renderingMode() const override;
+    size_t memoryCost() const override;
     bool canMapBackingStore() const final;
 
     IOSurface* surface() override;
@@ -56,7 +56,7 @@ public:
     void submitDrawingCommands() override;
 
 protected:
-    ImageBufferIOSurfaceBackend(const Parameters&, std::unique_ptr<IOSurface>, RetainPtr<CGContextRef> platformContext, PlatformDisplayID, IOSurfacePool*);
+    ImageBufferIOSurfaceBackend(const ImageBufferParameters&, std::unique_ptr<IOSurface>, RetainPtr<CGContextRef> platformContext, PlatformDisplayID, IOSurfacePool*);
     CGContextRef ensurePlatformContext();
     // Returns true if flush happened.
     bool flushContextDraws();

--- a/Source/WebCore/platform/graphics/filters/FilterImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.cpp
@@ -100,8 +100,8 @@ size_t FilterImage::memoryCost() const
 {
     CheckedSize memoryCost;
 
-    if (m_imageBuffer)
-        memoryCost += m_imageBuffer->memoryCost();
+    if (RefPtr imageBuffer = m_imageBuffer)
+        memoryCost += imageBuffer->memoryCost();
 
     if (m_unpremultipliedPixelBuffer)
         memoryCost += m_unpremultipliedPixelBuffer->bytes().size();

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -98,7 +98,7 @@ static inline bool shouldEnableDynamicMSAA()
     return enableDynamicMSAA;
 }
 
-std::unique_ptr<ImageBufferSkiaAcceleratedBackend> ImageBufferSkiaAcceleratedBackend::create(const Parameters& parameters, const ImageBufferCreationContext& creationContext)
+std::unique_ptr<ImageBufferSkiaAcceleratedBackend> ImageBufferSkiaAcceleratedBackend::create(const ImageBufferParameters& parameters, const ImageBufferCreationContext& creationContext)
 {
     IntSize backendSize = calculateSafeBackendSize(parameters);
     if (backendSize.isEmpty())
@@ -135,14 +135,14 @@ std::unique_ptr<ImageBufferSkiaAcceleratedBackend> ImageBufferSkiaAcceleratedBac
     return create(parameters, creationContext, WTF::move(surface));
 }
 
-std::unique_ptr<ImageBufferSkiaAcceleratedBackend> ImageBufferSkiaAcceleratedBackend::create(const Parameters& parameters, const ImageBufferCreationContext&, sk_sp<SkSurface>&& surface)
+std::unique_ptr<ImageBufferSkiaAcceleratedBackend> ImageBufferSkiaAcceleratedBackend::create(const ImageBufferParameters& parameters, const ImageBufferCreationContext&, sk_sp<SkSurface>&& surface)
 {
     ASSERT(surface);
     ASSERT(surface->getCanvas());
     return std::unique_ptr<ImageBufferSkiaAcceleratedBackend>(new ImageBufferSkiaAcceleratedBackend(parameters, WTF::move(surface)));
 }
 
-ImageBufferSkiaAcceleratedBackend::ImageBufferSkiaAcceleratedBackend(const Parameters& parameters, sk_sp<SkSurface>&& surface)
+ImageBufferSkiaAcceleratedBackend::ImageBufferSkiaAcceleratedBackend(const ImageBufferParameters& parameters, sk_sp<SkSurface>&& surface)
     : ImageBufferSkiaSurfaceBackend(parameters, WTF::move(surface), RenderingMode::Accelerated)
 {
 #if USE(COORDINATED_GRAPHICS)
@@ -161,7 +161,7 @@ ImageBufferSkiaAcceleratedBackend::~ImageBufferSkiaAcceleratedBackend()
 
 GraphicsContext& ImageBufferSkiaAcceleratedBackend::context()
 {
-    if (parameters().purpose != RenderingPurpose::Canvas)
+    if (purpose() != RenderingPurpose::Canvas)
         return ImageBufferSkiaSurfaceBackend::context();
 
     ensureCanvasRecordingContext();

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
@@ -46,14 +46,14 @@ class ImageBufferSkiaAcceleratedBackend final : public ImageBufferSkiaSurfaceBac
     WTF_MAKE_TZONE_ALLOCATED(ImageBufferSkiaAcceleratedBackend);
     WTF_MAKE_NONCOPYABLE(ImageBufferSkiaAcceleratedBackend);
 public:
-    static std::unique_ptr<ImageBufferSkiaAcceleratedBackend> create(const Parameters&, const ImageBufferCreationContext&);
-    static std::unique_ptr<ImageBufferSkiaAcceleratedBackend> create(const Parameters&, const ImageBufferCreationContext&, sk_sp<SkSurface>&&);
+    static std::unique_ptr<ImageBufferSkiaAcceleratedBackend> create(const ImageBufferParameters&, const ImageBufferCreationContext&);
+    static std::unique_ptr<ImageBufferSkiaAcceleratedBackend> create(const ImageBufferParameters&, const ImageBufferCreationContext&, sk_sp<SkSurface>&&);
     ~ImageBufferSkiaAcceleratedBackend();
 
-    static constexpr RenderingMode renderingMode = RenderingMode::Accelerated;
+    RenderingMode renderingMode() const final { return RenderingMode::Accelerated; }
 
 private:
-    ImageBufferSkiaAcceleratedBackend(const Parameters&, sk_sp<SkSurface>&&);
+    ImageBufferSkiaAcceleratedBackend(const ImageBufferParameters&, sk_sp<SkSurface>&&);
 
     GraphicsContext& context() final;
     void flushContext() final;

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp
@@ -33,9 +33,9 @@
 
 namespace WebCore {
 
-IntSize ImageBufferSkiaSurfaceBackend::calculateSafeBackendSize(const Parameters& parameters)
+IntSize ImageBufferSkiaSurfaceBackend::calculateSafeBackendSize(const ImageBufferParameters& parameters)
 {
-    IntSize backendSize = parameters.backendSize;
+    IntSize backendSize = parameters.backendSize();
     if (backendSize.isEmpty())
         return backendSize;
 
@@ -56,12 +56,7 @@ unsigned ImageBufferSkiaSurfaceBackend::calculateBytesPerRow(const IntSize& back
     return CheckedUint32(backendSize.width()) * 4;
 }
 
-size_t ImageBufferSkiaSurfaceBackend::calculateMemoryCost(const Parameters& parameters)
-{
-    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize));
-}
-
-ImageBufferSkiaSurfaceBackend::ImageBufferSkiaSurfaceBackend(const Parameters& parameters, sk_sp<SkSurface>&& surface, RenderingMode renderingMode)
+ImageBufferSkiaSurfaceBackend::ImageBufferSkiaSurfaceBackend(const ImageBufferParameters& parameters, sk_sp<SkSurface>&& surface, RenderingMode renderingMode)
     : ImageBufferSkiaBackend(parameters)
     , m_surface(WTF::move(surface))
     , m_context(*m_surface->getCanvas(), renderingMode, parameters.purpose)

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h
@@ -41,14 +41,15 @@ class ImageBufferSkiaSurfaceBackend : public ImageBufferSkiaBackend {
 public:
     virtual ~ImageBufferSkiaSurfaceBackend();
 
-    static IntSize calculateSafeBackendSize(const Parameters&);
+    static IntSize calculateSafeBackendSize(const ImageBufferParameters&);
     static unsigned calculateBytesPerRow(const IntSize&);
-    static size_t calculateMemoryCost(const Parameters&);
+
+    size_t memoryCost() const override { return ImageBufferBackend::calculateMemoryCost(size(), calculateBytesPerRow(size())); }
 
     SkSurface* surface() const LIFETIME_BOUND final { return m_surface.get(); }
 
 protected:
-    ImageBufferSkiaSurfaceBackend(const Parameters&, sk_sp<SkSurface>&&, RenderingMode);
+    ImageBufferSkiaSurfaceBackend(const ImageBufferParameters&, sk_sp<SkSurface>&&, RenderingMode);
 
     GraphicsContext& context() LIFETIME_BOUND override { return m_context; }
     unsigned bytesPerRow() const final;

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageBufferSkiaUnacceleratedBackend);
 
-std::unique_ptr<ImageBufferSkiaUnacceleratedBackend> ImageBufferSkiaUnacceleratedBackend::create(const Parameters& parameters, const ImageBufferCreationContext&)
+std::unique_ptr<ImageBufferSkiaUnacceleratedBackend> ImageBufferSkiaUnacceleratedBackend::create(const ImageBufferParameters& parameters, const ImageBufferCreationContext&)
 {
     IntSize backendSize = calculateSafeBackendSize(parameters);
     if (backendSize.isEmpty())
@@ -51,7 +51,7 @@ std::unique_ptr<ImageBufferSkiaUnacceleratedBackend> ImageBufferSkiaUnaccelerate
     return std::unique_ptr<ImageBufferSkiaUnacceleratedBackend>(new ImageBufferSkiaUnacceleratedBackend(parameters, WTF::move(surface)));
 }
 
-ImageBufferSkiaUnacceleratedBackend::ImageBufferSkiaUnacceleratedBackend(const Parameters& parameters, sk_sp<SkSurface>&& surface)
+ImageBufferSkiaUnacceleratedBackend::ImageBufferSkiaUnacceleratedBackend(const ImageBufferParameters& parameters, sk_sp<SkSurface>&& surface)
     : ImageBufferSkiaSurfaceBackend(parameters, WTF::move(surface), RenderingMode::Unaccelerated)
 {
 }

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.h
@@ -37,11 +37,11 @@ class ImageBufferSkiaUnacceleratedBackend final : public ImageBufferSkiaSurfaceB
     WTF_MAKE_TZONE_ALLOCATED(ImageBufferSkiaUnacceleratedBackend);
     WTF_MAKE_NONCOPYABLE(ImageBufferSkiaUnacceleratedBackend);
 public:
-    static std::unique_ptr<ImageBufferSkiaUnacceleratedBackend> create(const Parameters&, const ImageBufferCreationContext&);
+    static std::unique_ptr<ImageBufferSkiaUnacceleratedBackend> create(const ImageBufferParameters&, const ImageBufferCreationContext&);
     ~ImageBufferSkiaUnacceleratedBackend();
 
 private:
-    ImageBufferSkiaUnacceleratedBackend(const Parameters&, sk_sp<SkSurface>&&);
+    ImageBufferSkiaUnacceleratedBackend(const ImageBufferParameters&, sk_sp<SkSurface>&&);
 
     RefPtr<NativeImage> copyNativeImage() final;
     RefPtr<NativeImage> createNativeImageReference() final;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -8791,11 +8791,8 @@ std::optional<RenderingMode> Internals::getEffectiveRenderingModeOfNewlyCreatedA
     if (!document || !document->page())
         return std::nullopt;
 
-    if (RefPtr imageBuffer = ImageBuffer::create({ 100, 100 }, RenderingMode::Accelerated, RenderingPurpose::DOM, 1, ColorSpace::SRGB(), PixelFormat::BGRA8,  &document->page()->chrome())) {
-        imageBuffer->ensureBackendCreated();
-        if (imageBuffer->hasBackend())
-            return imageBuffer->renderingMode();
-    }
+    if (RefPtr imageBuffer = ImageBuffer::create({ 100, 100 }, RenderingMode::Accelerated, RenderingPurpose::DOM, 1, ColorSpace::SRGB(), PixelFormat::BGRA8,  &document->page()->chrome()))
+        return imageBuffer->getEffectiveRenderingModeForTesting();
     return std::nullopt;
 }
 

--- a/Source/WebCore/testing/ServiceWorkerInternals.cpp
+++ b/Source/WebCore/testing/ServiceWorkerInternals.cpp
@@ -226,10 +226,10 @@ String ServiceWorkerInternals::effectiveRenderingModeOfNewlyCreatedAcceleratedCa
     RefPtr imageBuffer = ImageBuffer::create({ 100, 100 }, RenderingMode::Accelerated, RenderingPurpose::Canvas, 1, ColorSpace::SRGB(), PixelFormat::BGRA8, graphicsClient);
     if (!imageBuffer)
         return "none"_s;
-    imageBuffer->ensureBackendCreated();
-    if (!imageBuffer->hasBackend())
+    auto renderingMode = imageBuffer->getEffectiveRenderingModeForTesting();
+    if (!renderingMode)
         return "none"_s;
-    if (imageBuffer->renderingMode() != RenderingMode::Accelerated)
+    if (*renderingMode != RenderingMode::Accelerated)
         return "unaccelerated"_s;
     return imageBuffer->isRemoteImageBufferProxy() ? "remote"_s : "local-iosurface"_s;
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -61,12 +61,23 @@ RemoteImageBuffer::RemoteImageBuffer(Ref<WebCore::ImageBuffer>&& imageBuffer, We
     , m_context(RemoteImageBufferGraphicsContext::create(m_imageBuffer, contextIdentifier, m_renderingBackend))
 {
     m_renderingBackend->sharedResourceCache().didCreateImageBuffer(m_imageBuffer->renderingPurpose(), m_imageBuffer->renderingMode());
+}
 
-    // If the ImageBuffer was an error buffer, this will fail and nullopt will be sent, signaling
-    // allocation failure.
+void RemoteImageBuffer::getEffectiveRenderingModeForTesting(CompletionHandler<void(std::optional<WebCore::RenderingMode>)>&& completionHandler)
+{
+    assertIsCurrent(workQueue());
+    completionHandler(m_imageBuffer->getEffectiveRenderingModeForTesting());
+}
+
+void RemoteImageBuffer::getBackendHandle(CompletionHandler<void(std::optional<ImageBufferBackendHandle>&&)>&& completionHandler)
+{
+    assertIsCurrent(workQueue());
     auto* sharing = m_imageBuffer->toBackendSharing();
-    auto handle = sharing ? downcast<ImageBufferBackendHandleSharing>(*sharing).createBackendHandle() : std::nullopt;
-    m_renderingBackend->streamConnection().send(Messages::RemoteImageBufferProxy::DidCreateBackend(WTF::move(handle)), m_identifier);
+    if (!sharing) {
+        completionHandler(std::nullopt);
+        return;
+    }
+    completionHandler(downcast<ImageBufferBackendHandleSharing>(*sharing).createBackendHandle());
 }
 
 RemoteImageBuffer::~RemoteImageBuffer()

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
@@ -28,6 +28,7 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "IPCEvent.h"
+#include "ImageBufferBackendHandle.h"
 #include "RemoteGraphicsContextIdentifier.h"
 #include "ScopedActiveMessageReceiveQueue.h"
 #include "ScopedRenderingResourcesRequest.h"
@@ -70,6 +71,8 @@ private:
     void getPixelBufferWithNewMemory(WebCore::SharedMemory::Handle&&, WebCore::PixelBufferFormat, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, CompletionHandler<void()>&&);
     void putPixelBuffer(const WebCore::PixelBufferSourceView&, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, WebCore::IntPoint destPoint, WebCore::AlphaPremultiplication destFormat);
     void copyNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier);
+    void getEffectiveRenderingModeForTesting(CompletionHandler<void(std::optional<WebCore::RenderingMode>)>&&);
+    void getBackendHandle(CompletionHandler<void(std::optional<ImageBufferBackendHandle>&&)>&&);
     void filteredNativeImage(Ref<WebCore::Filter>, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);
     void convertToLuminanceMask();
     void transformToColorSpace(const WebCore::ColorSpace&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
@@ -39,6 +39,8 @@ messages -> RemoteImageBuffer Stream {
     SetFlushSignal(IPC::Signal signal) NotStreamEncodable
     FlushContext()
     FlushContextSync() -> () Synchronous
+    GetEffectiveRenderingModeForTesting() -> (std::optional<WebCore::RenderingMode> renderingMode) Synchronous
+    GetBackendHandle() -> (std::optional<WebKit::ImageBufferBackendHandle> handle) Synchronous NotStreamEncodableReply
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     DynamicContentScalingDisplayList() -> (std::optional<WebCore::DynamicContentScalingDisplayList> displayList) Synchronous NotStreamEncodableReply

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -273,7 +273,7 @@ static RefPtr<ImageBuffer> allocateImageBufferInternal(const FloatSize& logicalS
 
     case RenderingMode::DisplayList:
         if (auto backend = ImageBufferDisplayListBackend::create(logicalSize, resolutionScale, colorSpace, bufferFormat.pixelFormat, purpose, ControlFactory::create()))
-            imageBuffer = ImageBuffer::create<ImageBufferDisplayListBackend, ImageBufferType>(logicalSize, creationContext, WTF::move(backend));
+            imageBuffer = ImageBuffer::create<ImageBufferType>(ImageBuffer::Parameters { logicalSize, resolutionScale, colorSpace, bufferFormat, purpose }, creationContext, WTF::move(backend));
         break;
     }
 
@@ -286,7 +286,7 @@ static void NODELETE adjustImageBufferRenderingMode(const RemoteSharedResourceCa
         renderingMode = RenderingMode::Unaccelerated;
 }
 
-RefPtr<ImageBuffer> RemoteRenderingBackend::allocateImageBuffer(const FloatSize& logicalSize, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const ColorSpace& colorSpace, ImageBufferFormat bufferFormat, ImageBufferCreationContext creationContext)
+RefPtr<ImageBuffer> RemoteRenderingBackend::allocateImageBuffer(const FloatSize& logicalSize, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const ColorSpace& colorSpace, ImageBufferFormat bufferFormat, ImageBufferCreationContext creationContext, std::optional<ImageBufferBackendHandle>&& providedBackingStore)
 {
     assertIsCurrent(workQueue());
     if (purpose == RenderingPurpose::Canvas && m_sharedResourceCache->reachedImageBufferForCanvasLimit())
@@ -299,6 +299,35 @@ RefPtr<ImageBuffer> RemoteRenderingBackend::allocateImageBuffer(const FloatSize&
     }
 
     adjustImageBufferCreationContext(m_sharedResourceCache, creationContext);
+
+    // Backing store the web process allocated is adopted as-is. Its geometry is
+    // attacker-controlled, so the backends validate it against what was requested and
+    // fail the allocation rather than drawing into a surface of the wrong shape. The
+    // rendering mode is not adjusted here: we have to use the backing store we were
+    // given, or none at all.
+    if (providedBackingStore) {
+        ImageBuffer::Parameters parameters { logicalSize, resolutionScale, colorSpace, bufferFormat, purpose };
+        switch (renderingMode) {
+        case RenderingMode::Accelerated:
+#if HAVE(IOSURFACE)
+            if (auto backend = ImageBufferShareableMappedIOSurfaceBackend::create(parameters, WTF::move(*providedBackingStore)))
+                return ImageBuffer::create(parameters, creationContext, WTF::move(backend));
+#endif
+            return nullptr;
+        case RenderingMode::Unaccelerated:
+            if (!std::holds_alternative<ShareableBitmap::Handle>(*providedBackingStore))
+                return nullptr;
+            if (auto backend = ImageBufferShareableBitmapBackend::create(parameters, std::get<ShareableBitmap::Handle>(WTF::move(*providedBackingStore))))
+                return ImageBuffer::create(parameters, creationContext, WTF::move(backend));
+            return nullptr;
+        case RenderingMode::PDFDocument:
+        case RenderingMode::DisplayList:
+            // These have no backing store to hand over.
+            return nullptr;
+        }
+        return nullptr;
+    }
+
     adjustImageBufferRenderingMode(m_sharedResourceCache, purpose, renderingMode);
 
     RefPtr<ImageBuffer> imageBuffer;
@@ -317,9 +346,19 @@ RefPtr<ImageBuffer> RemoteRenderingBackend::allocateImageBuffer(const FloatSize&
 
 void RemoteRenderingBackend::createImageBuffer(const FloatSize& logicalSize, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const ColorSpace& colorSpace, ImageBufferFormat pixelFormat, RenderingResourceIdentifier identifier, RemoteGraphicsContextIdentifier contextIdentifier)
 {
+    createImageBufferWithBackingStore(logicalSize, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat, std::nullopt, identifier, contextIdentifier);
+}
+
+void RemoteRenderingBackend::createMappableImageBuffer(const FloatSize& logicalSize, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const ColorSpace& colorSpace, ImageBufferFormat pixelFormat, ImageBufferBackendHandle&& backingStore, RenderingResourceIdentifier identifier, RemoteGraphicsContextIdentifier contextIdentifier)
+{
+    createImageBufferWithBackingStore(logicalSize, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat, WTF::move(backingStore), identifier, contextIdentifier);
+}
+
+void RemoteRenderingBackend::createImageBufferWithBackingStore(const FloatSize& logicalSize, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const ColorSpace& colorSpace, ImageBufferFormat pixelFormat, std::optional<ImageBufferBackendHandle>&& backingStore, RenderingResourceIdentifier identifier, RemoteGraphicsContextIdentifier contextIdentifier)
+{
     assertIsCurrent(workQueue());
 
-    RefPtr<ImageBuffer> imageBuffer = allocateImageBuffer(logicalSize, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat, { });
+    RefPtr<ImageBuffer> imageBuffer = allocateImageBuffer(logicalSize, renderingMode, purpose, resolutionScale, colorSpace, pixelFormat, { }, WTF::move(backingStore));
     if (!imageBuffer) {
         RELEASE_LOG(RemoteLayerBuffers, "[renderingBackend=%" PRIu64 "] RemoteRenderingBackend::createImageBuffer - failed to allocate image buffer %" PRIu64, m_renderingBackendIdentifier.toUInt64(), identifier.toUInt64());
         // On failure to create a remote image buffer we still create a null display list recorder.
@@ -327,6 +366,7 @@ void RemoteRenderingBackend::createImageBuffer(const FloatSize& logicalSize, Ren
         // them.
         imageBuffer = ImageBuffer::create<NullImageBufferBackend>({ 0, 0 }, 1, ColorSpace::SRGB(), { PixelFormat::BGRA8 }, RenderingPurpose::Unspecified, { });
         RELEASE_ASSERT(imageBuffer);
+        streamConnection().send(Messages::RemoteImageBufferProxy::DidFailToCreateBackend(), identifier);
     }
     auto result = m_remoteImageBuffers.add(identifier, RemoteImageBuffer::create(imageBuffer.releaseNonNull(), identifier, contextIdentifier, *this));
     MESSAGE_CHECK(result.isNewEntry, "Duplicate ImageBuffers");

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -132,7 +132,7 @@ public:
 
     RefPtr<WebCore::ImageBuffer> imageBuffer(WebCore::RenderingResourceIdentifier);
 
-    RefPtr<WebCore::ImageBuffer> allocateImageBuffer(const WebCore::FloatSize& logicalSize, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::ColorSpace&, WebCore::ImageBufferFormat, WebCore::ImageBufferCreationContext);
+    RefPtr<WebCore::ImageBuffer> allocateImageBuffer(const WebCore::FloatSize& logicalSize, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::ColorSpace&, WebCore::ImageBufferFormat, WebCore::ImageBufferCreationContext, std::optional<ImageBufferBackendHandle>&& providedBackingStore = std::nullopt);
 
     RemoteRenderingBackendIdentifier identifier() { return m_renderingBackendIdentifier; }
 private:
@@ -152,6 +152,8 @@ private:
 
     // Messages to be received.
     void createImageBuffer(const WebCore::FloatSize& logicalSize, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::ColorSpace&, WebCore::ImageBufferFormat, WebCore::RenderingResourceIdentifier, RemoteGraphicsContextIdentifier);
+    void createMappableImageBuffer(const WebCore::FloatSize& logicalSize, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::ColorSpace&, WebCore::ImageBufferFormat, ImageBufferBackendHandle&& backingStore, WebCore::RenderingResourceIdentifier, RemoteGraphicsContextIdentifier);
+    void createImageBufferWithBackingStore(const WebCore::FloatSize& logicalSize, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::ColorSpace&, WebCore::ImageBufferFormat, std::optional<ImageBufferBackendHandle>&& backingStore, WebCore::RenderingResourceIdentifier, RemoteGraphicsContextIdentifier);
     void releaseImageBuffer(WebCore::RenderingResourceIdentifier);
     void moveToSerializedBuffer(WebCore::RenderingResourceIdentifier, RemoteSerializedImageBufferIdentifier);
     void moveToImageBuffer(RemoteSerializedImageBufferIdentifier, WebCore::RenderingResourceIdentifier, RemoteGraphicsContextIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -29,6 +29,7 @@
 ]
 messages -> RemoteRenderingBackend Stream {
     CreateImageBuffer(WebCore::FloatSize logicalSize, WebCore::RenderingMode renderingMode, WebCore::RenderingPurpose renderingPurpose, float resolutionScale, WebCore::ColorSpace colorSpace, struct WebCore::ImageBufferFormat bufferFormat, WebCore::RenderingResourceIdentifier identifier, WebKit::RemoteGraphicsContextIdentifier contextIdentifier)
+    CreateMappableImageBuffer(WebCore::FloatSize logicalSize, WebCore::RenderingMode renderingMode, WebCore::RenderingPurpose renderingPurpose, float resolutionScale, WebCore::ColorSpace colorSpace, struct WebCore::ImageBufferFormat bufferFormat, WebKit::ImageBufferBackendHandle backingStore, WebCore::RenderingResourceIdentifier identifier, WebKit::RemoteGraphicsContextIdentifier contextIdentifier) NotStreamEncodable
     ReleaseImageBuffer(WebCore::RenderingResourceIdentifier identifier)
     CreateDisplayListRecorder(WebKit::RemoteDisplayListRecorderIdentifier identifier)
     SinkDisplayListRecorderIntoDisplayList(WebKit::RemoteDisplayListRecorderIdentifier identifier, WebKit::RemoteDisplayListIdentifier displayListIdentifier)

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -510,8 +510,12 @@
     [Legacy] StructureParam WebKit::CoreIPCCFType.object()
 }
 
+[UnsafeWrapper] WebKit::ImageBufferBackendHandle {
+    [Legacy] MessageParam RemoteRenderingBackend.CreateMappableImageBuffer backingStore
+}
+
 [UnsafeWrapper] std::optional<WebKit::ImageBufferBackendHandle> {
-    [Legacy] MessageParam RemoteImageBufferProxy.DidCreateBackend handle
+    [Legacy] MessageParamReply RemoteImageBuffer.GetBackendHandle handle
     [Legacy] MessageParamReply WebPage.TakeSnapshot image
     [Legacy] StructureParam WebKit::RemoteLayerBackingStoreProperties.m_bufferHandle
     [Legacy] StructureParam WebKit::BufferSetBackendHandle.bufferHandle

--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.h
@@ -47,7 +47,7 @@ class DynamicContentScalingImageBufferBackend;
 class DynamicContentScalingBifurcatedImageBuffer : public WebCore::ImageBuffer {
     WTF_MAKE_TZONE_ALLOCATED(DynamicContentScalingBifurcatedImageBuffer);
 public:
-    DynamicContentScalingBifurcatedImageBuffer(WebCore::ImageBufferParameters, const WebCore::ImageBufferBackend::Info&, const WebCore::ImageBufferCreationContext&, std::unique_ptr<WebCore::ImageBufferBackend>&& = nullptr, WebCore::RenderingResourceIdentifier = WebCore::RenderingResourceIdentifier::generate());
+    DynamicContentScalingBifurcatedImageBuffer(WebCore::ImageBufferParameters, const WebCore::ImageBufferCreationContext&, std::unique_ptr<WebCore::ImageBufferBackend>&&, WebCore::RenderingResourceIdentifier = WebCore::RenderingResourceIdentifier::generate());
 
     WebCore::GraphicsContext& NODELETE context() const LIFETIME_BOUND final;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm
@@ -39,9 +39,9 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DynamicContentScalingBifurcatedImageBuffer);
 
-DynamicContentScalingBifurcatedImageBuffer::DynamicContentScalingBifurcatedImageBuffer(Parameters parameters, const WebCore::ImageBufferBackend::Info& backendInfo, const WebCore::ImageBufferCreationContext& creationContext, std::unique_ptr<WebCore::ImageBufferBackend>&& backend, WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
-    : ImageBuffer(parameters, backendInfo, creationContext, WTF::move(backend), renderingResourceIdentifier)
-    , m_dynamicContentScalingBackend(DynamicContentScalingImageBufferBackend::create(ImageBuffer::backendParameters(parameters), creationContext))
+DynamicContentScalingBifurcatedImageBuffer::DynamicContentScalingBifurcatedImageBuffer(Parameters parameters, const WebCore::ImageBufferCreationContext& creationContext, std::unique_ptr<WebCore::ImageBufferBackend>&& backend, WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
+    : ImageBuffer(parameters, creationContext, WTF::move(backend), renderingResourceIdentifier)
+    , m_dynamicContentScalingBackend(DynamicContentScalingImageBufferBackend::create(parameters, creationContext))
 {
 }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.h
@@ -38,11 +38,11 @@ class DynamicContentScalingImageBufferBackend : public WebCore::ImageBufferCGBac
     WTF_MAKE_TZONE_ALLOCATED(DynamicContentScalingImageBufferBackend);
     WTF_MAKE_NONCOPYABLE(DynamicContentScalingImageBufferBackend);
 public:
-    static size_t calculateMemoryCost(const Parameters&);
+    size_t memoryCost() const final { return WebCore::ImageBufferBackend::calculateMemoryCost(size(), calculateBytesPerRow(size(), pixelFormat())); }
 
-    static std::unique_ptr<DynamicContentScalingImageBufferBackend> create(const Parameters&, const WebCore::ImageBufferCreationContext&);
+    static std::unique_ptr<DynamicContentScalingImageBufferBackend> create(const WebCore::ImageBufferParameters&, const WebCore::ImageBufferCreationContext&);
 
-    DynamicContentScalingImageBufferBackend(const Parameters&, const WebCore::ImageBufferCreationContext&, WebCore::RenderingMode);
+    DynamicContentScalingImageBufferBackend(const WebCore::ImageBufferParameters&, const WebCore::ImageBufferCreationContext&, WebCore::RenderingMode);
     ~DynamicContentScalingImageBufferBackend();
 
     WebCore::GraphicsContext& NODELETE context() LIFETIME_BOUND final;

--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm
@@ -49,20 +49,20 @@ namespace WebKit {
 
 using namespace WebCore;
 
-static CFDictionaryRef makeContextOptions(const DynamicContentScalingImageBufferBackend::Parameters& parameters)
+static CFDictionaryRef makeContextOptions(const WebCore::ColorSpace& colorSpace)
 {
-    RetainPtr colorSpace = parameters.colorSpace.platformColorSpace();
-    if (!colorSpace)
+    RetainPtr platformColorSpace = colorSpace.platformColorSpace();
+    if (!platformColorSpace)
         return nil;
     return (CFDictionaryRef)@{
-        @"colorspace" : (id)colorSpace.get()
+        @"colorspace" : (id)platformColorSpace.get()
     };
 }
 
 class GraphicsContextDynamicContentScaling : public WebCore::GraphicsContextCG {
 public:
-    GraphicsContextDynamicContentScaling(const DynamicContentScalingImageBufferBackend::Parameters& parameters, WebCore::RenderingMode renderingMode)
-        : GraphicsContextCG(adoptCF(RECGCommandsContextCreate(parameters.backendSize, makeContextOptions(parameters))).autorelease(), GraphicsContextCG::Unknown, renderingMode)
+    GraphicsContextDynamicContentScaling(const WebCore::IntSize& backendSize, const WebCore::ColorSpace& colorSpace, WebCore::RenderingMode renderingMode)
+        : GraphicsContextCG(adoptCF(RECGCommandsContextCreate(backendSize, makeContextOptions(colorSpace))).autorelease(), GraphicsContextCG::Unknown, renderingMode)
     {
     }
 
@@ -71,22 +71,15 @@ public:
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DynamicContentScalingImageBufferBackend);
 
-size_t DynamicContentScalingImageBufferBackend::calculateMemoryCost(const Parameters& parameters)
+std::unique_ptr<DynamicContentScalingImageBufferBackend> DynamicContentScalingImageBufferBackend::create(const WebCore::ImageBufferParameters& parameters, const WebCore::ImageBufferCreationContext& creationContext)
 {
-    // FIXME: This is fairly meaningless, because we don't actually have a bitmap, and
-    // should really be based on the encoded data size.
-    return WebCore::ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize, parameters.bufferFormat.pixelFormat));
-}
-
-std::unique_ptr<DynamicContentScalingImageBufferBackend> DynamicContentScalingImageBufferBackend::create(const Parameters& parameters, const WebCore::ImageBufferCreationContext& creationContext)
-{
-    if (parameters.backendSize.isEmpty())
+    if (parameters.backendSize().isEmpty())
         return nullptr;
 
     return std::unique_ptr<DynamicContentScalingImageBufferBackend>(new DynamicContentScalingImageBufferBackend(parameters, creationContext, WebCore::RenderingMode::Unaccelerated));
 }
 
-DynamicContentScalingImageBufferBackend::DynamicContentScalingImageBufferBackend(const Parameters& parameters, const WebCore::ImageBufferCreationContext& creationContext, WebCore::RenderingMode renderingMode)
+DynamicContentScalingImageBufferBackend::DynamicContentScalingImageBufferBackend(const WebCore::ImageBufferParameters& parameters, const WebCore::ImageBufferCreationContext& creationContext, WebCore::RenderingMode renderingMode)
     : ImageBufferCGBackend { parameters }
     , m_resourceCache(creationContext.dynamicContentScalingResourceCache)
     , m_renderingMode(renderingMode)
@@ -138,7 +131,7 @@ std::optional<DynamicContentScalingDisplayList> DynamicContentScalingImageBuffer
 WebCore::GraphicsContext& DynamicContentScalingImageBufferBackend::context()
 {
     if (!m_context) {
-        m_context = makeUnique<GraphicsContextDynamicContentScaling>(m_parameters, m_renderingMode);
+        m_context = makeUnique<GraphicsContextDynamicContentScaling>(size(), colorSpace(), m_renderingMode);
         applyBaseTransform(*m_context);
     }
     return *m_context;
@@ -146,7 +139,7 @@ WebCore::GraphicsContext& DynamicContentScalingImageBufferBackend::context()
 
 unsigned DynamicContentScalingImageBufferBackend::bytesPerRow() const
 {
-    return calculateBytesPerRow(m_parameters.backendSize, m_parameters.bufferFormat.pixelFormat);
+    return calculateBytesPerRow(size(), pixelFormat());
 }
 
 void DynamicContentScalingImageBufferBackend::releaseGraphicsContext()

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3275,7 +3275,7 @@ class WebCore::SpeechRecognitionUpdate {
     Vector<WebCore::GradientColorStop, 2> stops();
 };
 
-header: <WebCore/ImageBuffer.h>
+header: <WebCore/ImageBufferParameters.h>
 [CustomHeader] struct WebCore::ImageBufferParameters {
     WebCore::FloatSize logicalSize;
     float resolutionScale;

--- a/Source/WebKit/Shared/WebImage.cpp
+++ b/Source/WebKit/Shared/WebImage.cpp
@@ -76,14 +76,11 @@ Ref<WebImage> WebImage::create(std::optional<ParametersAndHandle>&& parametersAn
     auto [parameters, handle] = WTF::move(*parametersAndHandle);
 
     // FIXME: These should be abstracted as a encodable image buffer handle.
-    auto backendParameters = ImageBuffer::backendParameters(parameters);
-    auto backend = ImageBufferShareableBitmapBackend::create(backendParameters, WTF::move(handle));
+    auto backend = ImageBufferShareableBitmapBackend::create(parameters, WTF::move(handle));
     if (!backend)
         return createEmpty();
-    
-    auto info = ImageBuffer::populateBackendInfo<ImageBufferShareableBitmapBackend>(backendParameters);
 
-    auto buffer = ImageBuffer::create(WTF::move(parameters), info, { }, WTF::move(backend));
+    auto buffer = ImageBuffer::create(WTF::move(parameters), { }, WTF::move(backend));
     if (!buffer)
         return createEmpty();
 

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferBackendHandleSharing.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferBackendHandleSharing.h
@@ -45,6 +45,9 @@ public:
     virtual std::optional<WebCore::DynamicContentScalingDisplayList> dynamicContentScalingDisplayList() { return std::nullopt; }
 #endif
 
+    // True once a backend that stands in for a backing store in another process has
+    // been given its handle.
+    virtual bool hasBackendHandle() const { return true; }
     virtual void setBackendHandle(ImageBufferBackendHandle&&) { }
     virtual void clearBackendHandle() { }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.cpp
@@ -26,29 +26,30 @@
 #include "config.h"
 #include "ImageBufferRemoteDisplayListBackend.h"
 
-#include <WebCore/NativeImage.h>
+#include <WebCore/PixelBuffer.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebKit {
 using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageBufferRemoteDisplayListBackend);
 
-std::unique_ptr<ImageBufferRemoteDisplayListBackend> ImageBufferRemoteDisplayListBackend::create(const Parameters& parameters)
+std::unique_ptr<ImageBufferRemoteDisplayListBackend> ImageBufferRemoteDisplayListBackend::create(const WebCore::ImageBufferParameters& parameters)
 {
     return std::unique_ptr<ImageBufferRemoteDisplayListBackend> { new ImageBufferRemoteDisplayListBackend { parameters } };
 }
 
-ImageBufferRemoteDisplayListBackend::ImageBufferRemoteDisplayListBackend(const Parameters& parameters)
-    : WebCore::NullImageBufferBackend(parameters)
+ImageBufferRemoteDisplayListBackend::ImageBufferRemoteDisplayListBackend(const WebCore::ImageBufferParameters& parameters)
+    : ImageBufferBackend(parameters)
 {
 }
 
 ImageBufferRemoteDisplayListBackend::~ImageBufferRemoteDisplayListBackend() = default;
 
-RefPtr<NativeImage> ImageBufferRemoteDisplayListBackend::createNativeImageReference()
+void ImageBufferRemoteDisplayListBackend::getPixelBuffer(const IntRect&, PixelBuffer& destination)
 {
-    return nullptr;
+    destination.zeroFill();
 }
 
 String ImageBufferRemoteDisplayListBackend::debugDescription() const
@@ -58,4 +59,4 @@ String ImageBufferRemoteDisplayListBackend::debugDescription() const
     return stream.release();
 }
 
-} // namespace WebCore
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.h
@@ -1,52 +1,62 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
- * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+* Copyright (C) 2024 Apple Inc. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+* EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+* CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+* EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+* PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+* OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 
 #pragma once
 
-#include <WebCore/NullImageBufferBackend.h>
+#include <WebCore/ImageBufferBackend.h>
+#include <WebCore/NullGraphicsContext.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
 class RemoteRenderingBackendProxy;
 
-class ImageBufferRemoteDisplayListBackend : public WebCore::NullImageBufferBackend {
+class ImageBufferRemoteDisplayListBackend final : public WebCore::ImageBufferBackend {
     WTF_MAKE_TZONE_ALLOCATED(ImageBufferRemoteDisplayListBackend);
     WTF_MAKE_NONCOPYABLE(ImageBufferRemoteDisplayListBackend);
 public:
-    static std::unique_ptr<ImageBufferRemoteDisplayListBackend> create(const Parameters&);
+    static std::unique_ptr<ImageBufferRemoteDisplayListBackend> create(const WebCore::ImageBufferParameters&);
 
-    virtual ~ImageBufferRemoteDisplayListBackend();
+    ~ImageBufferRemoteDisplayListBackend();
 
-    static constexpr WebCore::RenderingMode renderingMode = WebCore::RenderingMode::DisplayList;
+    WebCore::RenderingMode renderingMode() const final { return WebCore::RenderingMode::DisplayList; }
+    size_t memoryCost() const final { return 0; }
 
 private:
-    ImageBufferRemoteDisplayListBackend(const Parameters&);
+    ImageBufferRemoteDisplayListBackend(const WebCore::ImageBufferParameters&);
 
-    RefPtr<WebCore::NativeImage> createNativeImageReference() override;
-    String debugDescription() const override;
+    WebCore::NullGraphicsContext& context() final { return m_context; }
+    RefPtr<WebCore::NativeImage> copyNativeImage() final { return nullptr; }
+    RefPtr<WebCore::NativeImage> createNativeImageReference() final { return nullptr; }
+    void getPixelBuffer(const WebCore::IntRect&, WebCore::PixelBuffer&) final;
+    void putPixelBuffer(const WebCore::PixelBufferSourceView&, const WebCore::IntRect&, const WebCore::IntPoint&, WebCore::AlphaPremultiplication) final { }
+    bool canMapBackingStore() const final { return false; }
+    unsigned bytesPerRow() const final { return 0; }
+    String debugDescription() const final;
+
+    WebCore::NullGraphicsContext m_context;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemotePDFDocumentBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemotePDFDocumentBackend.cpp
@@ -26,7 +26,9 @@
 #include "config.h"
 #include "ImageBufferRemotePDFDocumentBackend.h"
 
+#include <WebCore/PixelBuffer.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -39,19 +41,17 @@ unsigned ImageBufferRemotePDFDocumentBackend::calculateBytesPerRow(const IntSize
     return CheckedUint32(backendSize.width()) * 4;
 }
 
-size_t ImageBufferRemotePDFDocumentBackend::calculateMemoryCost(const Parameters& parameters)
-{
-    // FIXME: This is fairly meaningless, because we don't actually have a bitmap, and
-    // should really be based on the PDF document size.
-    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters.backendSize));
-}
-
-std::unique_ptr<ImageBufferRemotePDFDocumentBackend> ImageBufferRemotePDFDocumentBackend::create(const Parameters& parameters)
+std::unique_ptr<ImageBufferRemotePDFDocumentBackend> ImageBufferRemotePDFDocumentBackend::create(const WebCore::ImageBufferParameters& parameters)
 {
     return std::unique_ptr<ImageBufferRemotePDFDocumentBackend> { new ImageBufferRemotePDFDocumentBackend { parameters } };
 }
 
 ImageBufferRemotePDFDocumentBackend::~ImageBufferRemotePDFDocumentBackend() = default;
+
+void ImageBufferRemotePDFDocumentBackend::getPixelBuffer(const IntRect&, PixelBuffer& destination)
+{
+    destination.zeroFill();
+}
 
 String ImageBufferRemotePDFDocumentBackend::debugDescription() const
 {
@@ -60,4 +60,4 @@ String ImageBufferRemotePDFDocumentBackend::debugDescription() const
     return stream.release();
 }
 
-} // namespace WebCore
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemotePDFDocumentBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemotePDFDocumentBackend.h
@@ -25,28 +25,38 @@
 
 #pragma once
 
-#include <WebCore/NullImageBufferBackend.h>
+#include <WebCore/ImageBufferBackend.h>
+#include <WebCore/NullGraphicsContext.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebKit {
 
-class ImageBufferRemotePDFDocumentBackend final : public WebCore::NullImageBufferBackend {
+class ImageBufferRemotePDFDocumentBackend final : public WebCore::ImageBufferBackend {
     WTF_MAKE_TZONE_ALLOCATED(ImageBufferRemotePDFDocumentBackend);
     WTF_MAKE_NONCOPYABLE(ImageBufferRemotePDFDocumentBackend);
 public:
     static unsigned NODELETE calculateBytesPerRow(const WebCore::IntSize& backendSize);
-    static size_t NODELETE calculateMemoryCost(const Parameters&);
 
-    static std::unique_ptr<ImageBufferRemotePDFDocumentBackend> create(const Parameters&);
+    static std::unique_ptr<ImageBufferRemotePDFDocumentBackend> create(const WebCore::ImageBufferParameters&);
 
-    virtual ~ImageBufferRemotePDFDocumentBackend();
+    ~ImageBufferRemotePDFDocumentBackend();
 
-    static constexpr WebCore::RenderingMode renderingMode = WebCore::RenderingMode::PDFDocument;
+    WebCore::RenderingMode renderingMode() const final { return WebCore::RenderingMode::PDFDocument; }
+    size_t memoryCost() const final { return WebCore::ImageBufferBackend::calculateMemoryCost(size(), calculateBytesPerRow(size())); }
 
 private:
-    using WebCore::NullImageBufferBackend::NullImageBufferBackend;
+    using WebCore::ImageBufferBackend::ImageBufferBackend;
 
+    WebCore::NullGraphicsContext& context() final { return m_context; }
+    RefPtr<WebCore::NativeImage> copyNativeImage() final { return nullptr; }
+    RefPtr<WebCore::NativeImage> createNativeImageReference() final { return nullptr; }
+    void getPixelBuffer(const WebCore::IntRect&, WebCore::PixelBuffer&) final;
+    void putPixelBuffer(const WebCore::PixelBufferSourceView&, const WebCore::IntRect&, const WebCore::IntPoint&, WebCore::AlphaPremultiplication) final { }
+    bool canMapBackingStore() const final { return false; }
+    unsigned bytesPerRow() const final { return 0; }
     String debugDescription() const final;
+
+    WebCore::NullGraphicsContext m_context;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
@@ -42,9 +42,9 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageBufferShareableBitmapBackend);
 
-IntSize ImageBufferShareableBitmapBackend::calculateSafeBackendSize(const Parameters& parameters)
+IntSize ImageBufferShareableBitmapBackend::calculateSafeBackendSize(const WebCore::ImageBufferParameters& parameters)
 {
-    IntSize backendSize = parameters.backendSize;
+    IntSize backendSize = parameters.backendSize();
     if (backendSize.isEmpty())
         return { };
 
@@ -55,18 +55,13 @@ IntSize ImageBufferShareableBitmapBackend::calculateSafeBackendSize(const Parame
     return backendSize;
 }
 
-unsigned ImageBufferShareableBitmapBackend::calculateBytesPerRow(const Parameters& parameters, const IntSize& backendSize)
+unsigned ImageBufferShareableBitmapBackend::calculateBytesPerRow(const IntSize& backendSize, PixelFormat pixelFormat, const ColorSpace& colorSpace)
 {
     ASSERT(!backendSize.isEmpty());
-    return ShareableBitmapConfiguration::calculateBytesPerRow(backendSize, parameters.bufferFormat.pixelFormat, parameters.colorSpace);
+    return ShareableBitmapConfiguration::calculateBytesPerRow(backendSize, pixelFormat, colorSpace);
 }
 
-size_t ImageBufferShareableBitmapBackend::calculateMemoryCost(const Parameters& parameters)
-{
-    return ImageBufferBackend::calculateMemoryCost(parameters.backendSize, calculateBytesPerRow(parameters, parameters.backendSize));
-}
-
-std::unique_ptr<ImageBufferShareableBitmapBackend> ImageBufferShareableBitmapBackend::create(const Parameters& parameters, const ImageBufferCreationContext& creationContext)
+std::unique_ptr<ImageBufferShareableBitmapBackend> ImageBufferShareableBitmapBackend::create(const WebCore::ImageBufferParameters& parameters, const ImageBufferCreationContext& creationContext)
 {
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
     ASSERT(parameters.bufferFormat.pixelFormat == PixelFormat::BGRA8 || parameters.bufferFormat.pixelFormat == PixelFormat::BGRX8 || parameters.bufferFormat.pixelFormat == PixelFormat::RGBA16F);
@@ -90,10 +85,28 @@ std::unique_ptr<ImageBufferShareableBitmapBackend> ImageBufferShareableBitmapBac
     return makeUnique<ImageBufferShareableBitmapBackend>(parameters, bitmap.releaseNonNull(), WTF::move(context));
 }
 
-std::unique_ptr<ImageBufferShareableBitmapBackend> ImageBufferShareableBitmapBackend::create(const Parameters& parameters, ShareableBitmap::Handle handle)
+std::unique_ptr<ImageBufferShareableBitmapBackend> ImageBufferShareableBitmapBackend::create(const WebCore::ImageBufferParameters& parameters, ShareableBitmap::Handle handle)
 {
     auto bitmap = ShareableBitmap::create(WTF::move(handle), SharedMemory::Protection::ReadWrite, SharedMemory::CopyOnWrite::No);
     if (!bitmap)
+        return nullptr;
+
+    // ShareableBitmap validates the handle against its own configuration, but that
+    // configuration travels with the handle and so is not implied by `parameters`. Pixel
+    // access mixes the two: ImageBufferBackend::getPixelBuffer() takes pixelFormat() and
+    // size() from `parameters` while bytesPerRow() comes from the bitmap, and it offsets
+    // into the mapping before any bounds check. Require the bitmap to be exactly what
+    // this backend would have allocated for these parameters. Note the configuration
+    // normalises the color space, so compare against the normalised value rather than
+    // against `parameters.colorSpace`.
+    auto requestedSize = calculateSafeBackendSize(parameters);
+    if (requestedSize.isEmpty())
+        return nullptr;
+    ShareableBitmapConfiguration requestedConfiguration { requestedSize, parameters.colorSpace, parameters.bufferFormat.pixelFormat };
+    if (bitmap->size() != requestedConfiguration.size()
+        || bitmap->pixelFormat() != requestedConfiguration.pixelFormat()
+        || bitmap->colorSpace() != requestedConfiguration.colorSpace()
+        || bitmap->bytesPerRow() != requestedConfiguration.bytesPerRow())
         return nullptr;
 
     auto context = bitmap->createGraphicsContext();
@@ -103,7 +116,7 @@ std::unique_ptr<ImageBufferShareableBitmapBackend> ImageBufferShareableBitmapBac
     return makeUnique<ImageBufferShareableBitmapBackend>(parameters, bitmap.releaseNonNull(), WTF::move(context));
 }
 
-ImageBufferShareableBitmapBackend::ImageBufferShareableBitmapBackend(const Parameters& parameters, Ref<ShareableBitmap>&& bitmap, std::unique_ptr<GraphicsContext>&& context)
+ImageBufferShareableBitmapBackend::ImageBufferShareableBitmapBackend(const WebCore::ImageBufferParameters& parameters, Ref<ShareableBitmap>&& bitmap, std::unique_ptr<GraphicsContext>&& context)
     : ImageBufferShareableBitmapBackendBase(parameters)
     , m_bitmap(WTF::move(bitmap))
     , m_context(WTF::move(context))

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
@@ -57,16 +57,16 @@ class ImageBufferShareableBitmapBackend final : public ImageBufferShareableBitma
     WTF_MAKE_NONCOPYABLE(ImageBufferShareableBitmapBackend);
 
 public:
-    static WebCore::IntSize calculateSafeBackendSize(const Parameters&);
-    static unsigned calculateBytesPerRow(const Parameters&, const WebCore::IntSize& backendSize);
-    static size_t calculateMemoryCost(const Parameters&);
+    static WebCore::IntSize calculateSafeBackendSize(const WebCore::ImageBufferParameters&);
+    static unsigned calculateBytesPerRow(const WebCore::IntSize& backendSize, WebCore::PixelFormat, const WebCore::ColorSpace&);
 
-    static std::unique_ptr<ImageBufferShareableBitmapBackend> create(const Parameters&, const WebCore::ImageBufferCreationContext&);
-    static std::unique_ptr<ImageBufferShareableBitmapBackend> create(const Parameters&, WebCore::ShareableBitmap::Handle);
+    static std::unique_ptr<ImageBufferShareableBitmapBackend> create(const WebCore::ImageBufferParameters&, const WebCore::ImageBufferCreationContext&);
+    static std::unique_ptr<ImageBufferShareableBitmapBackend> create(const WebCore::ImageBufferParameters&, WebCore::ShareableBitmap::Handle);
 
-    ImageBufferShareableBitmapBackend(const Parameters&, Ref<WebCore::ShareableBitmap>&&, std::unique_ptr<WebCore::GraphicsContext>&&);
+    ImageBufferShareableBitmapBackend(const WebCore::ImageBufferParameters&, Ref<WebCore::ShareableBitmap>&&, std::unique_ptr<WebCore::GraphicsContext>&&);
     virtual ~ImageBufferShareableBitmapBackend();
 
+    size_t memoryCost() const final { return WebCore::ImageBufferBackend::calculateMemoryCost(size(), calculateBytesPerRow(size(), pixelFormat(), colorSpace())); }
     bool canMapBackingStore() const final;
     WebCore::GraphicsContext& context() final { return *m_context; }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -123,8 +123,13 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteImageBufferProxyFlusher);
 
 }
 
-RemoteImageBufferProxy::RemoteImageBufferProxy(Parameters parameters, const ImageBufferBackend::Info& info, RemoteRenderingBackendProxy& renderingBackend)
-    : ImageBuffer(parameters, info, { }, nullptr)
+Ref<RemoteImageBufferProxy> RemoteImageBufferProxy::createForSerializedBuffer(const ImageBuffer::Parameters& parameters, std::unique_ptr<ImageBufferBackend>&& backend, RemoteRenderingBackendProxy& renderingBackend)
+{
+    return adoptRef(*new RemoteImageBufferProxy(parameters, WTF::move(backend), renderingBackend));
+}
+
+RemoteImageBufferProxy::RemoteImageBufferProxy(Parameters parameters, std::unique_ptr<ImageBufferBackend>&& backend, RemoteRenderingBackendProxy& renderingBackend)
+    : ImageBuffer(parameters, { }, WTF::move(backend))
     , m_context({ { }, ImageBuffer::logicalSize() }, ImageBuffer::baseTransform(), ImageBuffer::colorSpace(), ImageBuffer::renderingMode(), renderingBackend)
     , m_renderingBackend(renderingBackend)
 {
@@ -196,85 +201,78 @@ void RemoteImageBufferProxy::backingStoreWillChange()
     prepareForBackingStoreChange();
 }
 
-void RemoteImageBufferProxy::didCreateBackend(std::optional<ImageBufferBackendHandle> backendHandle)
+void RemoteImageBufferProxy::didFailToCreateBackend()
 {
-    ASSERT(!m_backend);
-    // This should match RemoteImageBufferProxy::create<>() call site and RemoteImageBuffer::create<>() call site.
-    // FIXME: this will be removed and backend be constructed in the contructor.
-    std::unique_ptr<ImageBufferBackend> backend;
-    auto backendParameters = this->backendParameters(parameters());
-
-    switch (renderingMode()) {
-    case RenderingMode::Accelerated:
-#if HAVE(IOSURFACE)
-        if (backendHandle && std::holds_alternative<MachSendRight>(*backendHandle)) {
-            if (RemoteRenderingBackendProxy::canMapRemoteImageBufferBackendBackingStore())
-                backend = ImageBufferShareableMappedIOSurfaceBackend::create(backendParameters, WTF::move(*backendHandle));
-            else
-                backend = ImageBufferRemoteIOSurfaceBackend::create(backendParameters, WTF::move(*backendHandle));
-        }
-#endif
-        [[fallthrough]];
-
-    case RenderingMode::Unaccelerated:
-        if (backendHandle && std::holds_alternative<ShareableBitmap::Handle>(*backendHandle)) {
-            m_backendInfo = ImageBuffer::populateBackendInfo<ImageBufferShareableBitmapBackend>(backendParameters);
-            auto handle = std::get<ShareableBitmap::Handle>(WTF::move(*backendHandle));
-            handle.takeOwnershipOfMemory(MemoryLedger::Graphics);
-            backend = ImageBufferShareableBitmapBackend::create(backendParameters, WTF::move(handle));
-        }
-        break;
-
-    case RenderingMode::PDFDocument:
-        backend = ImageBufferRemotePDFDocumentBackend::create(backendParameters);
-        break;
-
-    case RenderingMode::DisplayList:
-        ASSERT(renderingPurpose() == RenderingPurpose::Snapshot);
-        backend = ImageBufferRemoteDisplayListBackend::create(backendParameters);
-        break;
+    m_context.abandon();
+    if (RefPtr renderingBackend = m_renderingBackend.get()) {
+        m_renderingBackend = nullptr;
+        renderingBackend->releaseImageBuffer(*this);
     }
-
-    if (!backend) {
-        m_context.abandon();
-        if (RefPtr renderingBackend = m_renderingBackend.get()) {
-            m_renderingBackend = nullptr;
-            renderingBackend->releaseImageBuffer(*this);
-        }
-        return;
-    }
-    setBackend(WTF::move(backend));
 }
 
-ImageBufferBackend* RemoteImageBufferProxy::ensureBackend() const
+// The backing store of a backend this process cannot map lives in the GPU process,
+// which hands out its handle on request. Everything else was built in the constructor.
+void RemoteImageBufferProxy::ensureBackendHandle() const
 {
-    if (m_backend)
-        return m_backend.get();
+    auto* backend = ImageBuffer::backend();
+    if (!backend || backend->canMapBackingStore())
+        return;
+    auto* sharing = dynamicDowncast<ImageBufferBackendHandleSharing>(backend->toBackendSharing());
+    if (!sharing || sharing->hasBackendHandle())
+        return;
+    // The handle describes the backing store the GPU process is drawing into, so let
+    // it see the buffered draws before it answers.
+    sendPendingDrawsIfNecessary();
+    auto sendResult = sendSync(Messages::RemoteImageBuffer::GetBackendHandle());
+    if (!sendResult.succeeded())
+        return;
+    auto [handle] = sendResult.takeReply();
+    if (!handle)
+        return;
+    sharing->setBackendHandle(WTF::move(*handle));
+}
 
-    RefPtr connection = this->connection();
-    if (!connection)
-        return nullptr;
+std::optional<ImageBufferBackendHandle> RemoteImageBufferProxy::takeBackendHandleForSerialization()
+{
+    auto* backend = ImageBuffer::backend();
+    if (!backend || !backend->canMapBackingStore())
+        return std::nullopt;
+    auto* sharing = dynamicDowncast<ImageBufferBackendHandleSharing>(backend->toBackendSharing());
+    if (!sharing)
+        return std::nullopt;
+    return sharing->takeBackendHandle();
+}
 
-    auto error = connection->waitForAndDispatchImmediately<Messages::RemoteImageBufferProxy::DidCreateBackend>(m_renderingResourceIdentifier);
-    if (error == IPC::Error::NoError)
-        return m_backend.get();
+ImageBufferBackendSharing* RemoteImageBufferProxy::toBackendSharing()
+{
+    ensureBackendHandle();
+    return ImageBuffer::toBackendSharing();
+}
 
-    RefPtr renderingBackend = m_renderingBackend.get();
-    if (!renderingBackend) [[unlikely]] {
-        RELEASE_LOG(RemoteLayerBuffers, "[renderingBackend was deleted] RemoteImageBufferProxy::ensureBackendCreated - waitForAndDispatchImmediately returned error: %" PUBLIC_LOG_STRING,
-            IPC::errorAsString(error).characters());
-        return nullptr;
-    }
+std::optional<ImageBufferBackendHandle> RemoteImageBufferProxy::createBackingStoreHandleForGPUProcess() const
+{
+    // Only backing store this process allocated travels to the GPU process.
+    auto* backend = ImageBuffer::backend();
+    if (!backend || !backend->canMapBackingStore())
+        return std::nullopt;
+    auto* sharing = dynamicDowncast<ImageBufferBackendHandleSharing>(backend->toBackendSharing());
+    if (!sharing)
+        return std::nullopt;
+    return sharing->createBackendHandle();
+}
 
-    RELEASE_LOG(RemoteLayerBuffers, "[renderingBackend=%" PRIu64 "] RemoteImageBufferProxy::ensureBackendCreated - waitForAndDispatchImmediately returned error: %" PUBLIC_LOG_STRING,
-        renderingBackend->renderingBackendIdentifier().toUInt64(), IPC::errorAsString(error).characters());
-    didBecomeUnresponsive();
-    return nullptr;
+std::optional<RenderingMode> RemoteImageBufferProxy::getEffectiveRenderingModeForTesting() const
+{
+    auto sendResult = sendSync(Messages::RemoteImageBuffer::GetEffectiveRenderingModeForTesting());
+    if (!sendResult.succeeded())
+        return std::nullopt;
+    auto [renderingMode] = sendResult.takeReply();
+    return renderingMode;
 }
 
 RefPtr<NativeImage> RemoteImageBufferProxy::copyNativeImage() const
 {
-    auto* backend = ensureBackend();
+    auto* backend = ImageBuffer::backend();
     if (!backend)
         return nullptr;
     if (backend->canMapBackingStore()) {
@@ -295,7 +293,7 @@ RefPtr<NativeImage> RemoteImageBufferProxy::copyNativeImage() const
 
 RefPtr<NativeImage> RemoteImageBufferProxy::createNativeImageReference() const
 {
-    auto* backend = ensureBackend();
+    auto* backend = ImageBuffer::backend();
     if (!backend)
         return { };
     if (backend->canMapBackingStore()) {
@@ -344,7 +342,7 @@ RefPtr<NativeImage> RemoteImageBufferProxy::filteredNativeImage(Filter& filter)
 
 RefPtr<PixelBuffer> RemoteImageBufferProxy::getPixelBuffer(const PixelBufferFormat& destinationFormat, const IntRect& sourceRect, const ImageBufferAllocator& allocator) const
 {
-    auto* backend = ensureBackend();
+    auto* backend = ImageBuffer::backend();
     if (!backend)
         return { };
     // getPixelBuffer observes the buffer's pixels (the non-mappable branch
@@ -369,10 +367,15 @@ void RemoteImageBufferProxy::disconnect()
 {
     m_context.consumeHasDrawn();
     m_context.disconnect();
-    if (m_backend)
-        prepareForBackingStoreChange();
+    prepareForBackingStoreChange();
     m_pendingFlush = nullptr;
-    m_backend = nullptr;
+    // The backend stays: it is where this buffer's properties come from, and a backing
+    // store this process allocated outlives the GPU process. A handle to a GPU process
+    // backing store does not, so drop it and ask again if it is needed.
+    if (auto* backend = ImageBuffer::backend(); backend && !backend->canMapBackingStore()) {
+        if (auto* sharing = dynamicDowncast<ImageBufferBackendHandleSharing>(backend->toBackendSharing()))
+            sharing->clearBackendHandle();
+    }
 }
 
 bool RemoteImageBufferProxy::isValid() const
@@ -387,7 +390,7 @@ GraphicsContext& RemoteImageBufferProxy::context() const
 
 void RemoteImageBufferProxy::putPixelBuffer(const PixelBufferSourceView& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
 {
-    auto* backend = ensureBackend();
+    auto* backend = ImageBuffer::backend();
     if (!backend)
         return;
     if (backend->canMapBackingStore()) {
@@ -488,7 +491,7 @@ void RemoteImageBufferProxy::prepareForBackingStoreChange()
 {
     // If the backing store is mapped in the process and the changes happen in the other
     // process, we need to prepare for the backing store change before we let the change happen.
-    if (auto* backend = ensureBackend())
+    if (auto* backend = ImageBuffer::backend())
         backend->ensureNativeImagesHaveCopiedBackingStore();
 }
 
@@ -505,9 +508,6 @@ std::unique_ptr<SerializedImageBuffer> RemoteImageBufferProxy::sinkIntoSerialize
 
     prepareForBackingStoreChange();
 
-    if (!ensureBackend())
-        return nullptr;
-
     std::unique_ptr result = renderingBackend->moveToSerializedBuffer(*this);
 
     disconnect();
@@ -517,16 +517,46 @@ std::unique_ptr<SerializedImageBuffer> RemoteImageBufferProxy::sinkIntoSerialize
     return ret;
 }
 
-RemoteSerializedImageBufferProxy::RemoteSerializedImageBufferProxy(WebCore::ImageBuffer::Parameters parameters, const WebCore::ImageBufferBackend::Info& info, RemoteRenderingBackendProxy& backend)
+RemoteSerializedImageBufferProxy::RemoteSerializedImageBufferProxy(WebCore::ImageBuffer::Parameters parameters, WebCore::RenderingMode renderingMode, size_t memoryCost, std::optional<ImageBufferBackendHandle>&& backendHandle, RemoteRenderingBackendProxy& backend)
     : m_parameters(parameters)
-    , m_info(info)
+    , m_renderingMode(renderingMode)
+    , m_memoryCost(memoryCost)
+    , m_backendHandle(WTF::move(backendHandle))
     , m_connection(nullptr/*backend.connection()*/)
 {
 }
 
+static std::optional<ImageBufferBackendHandle> copyBackendHandle(const std::optional<ImageBufferBackendHandle>& handle)
+{
+    if (!handle)
+        return std::nullopt;
+    return WTF::switchOn(*handle,
+        [](const ShareableBitmap::Handle& bitmapHandle) -> std::optional<ImageBufferBackendHandle> {
+            return ImageBufferBackendHandle { ShareableBitmap::Handle { bitmapHandle } };
+        }
+#if PLATFORM(COCOA)
+        , [](const MachSendRight& sendRight) -> std::optional<ImageBufferBackendHandle> {
+            return ImageBufferBackendHandle { MachSendRight { sendRight } };
+        }
+#endif
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+        , [](const WebCore::DynamicContentScalingDisplayList&) -> std::optional<ImageBufferBackendHandle> {
+            return std::nullopt;
+        }
+#endif
+    );
+}
+
+std::unique_ptr<WebCore::SerializedImageBuffer> RemoteSerializedImageBufferProxy::clone() const
+{
+    return std::unique_ptr<WebCore::SerializedImageBuffer>(new RemoteSerializedImageBufferProxy(m_parameters, m_renderingMode, m_memoryCost, copyBackendHandle(m_backendHandle), m_connection));
+}
+
 RefPtr<ImageBuffer> RemoteSerializedImageBufferProxy::sinkIntoImageBuffer(std::unique_ptr<RemoteSerializedImageBufferProxy> buffer, RemoteRenderingBackendProxy& renderingBackend)
 {
-    Ref result = renderingBackend.moveToImageBuffer(*buffer);
+    RefPtr result = renderingBackend.moveToImageBuffer(*buffer);
+    if (!result)
+        return nullptr;
     buffer->m_connection = nullptr;
     return result;
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -51,27 +51,38 @@ class RemoteImageBufferProxy final : public WebCore::ImageBuffer {
     WTF_MAKE_TZONE_ALLOCATED(RemoteImageBufferProxy);
     friend class RemoteSerializedImageBufferProxy;
 public:
-    template<typename BackendType>
-    static RefPtr<RemoteImageBufferProxy> create(const WebCore::FloatSize& size, float resolutionScale, const WebCore::ColorSpace& colorSpace, WebCore::ImageBufferFormat bufferFormat, WebCore::RenderingPurpose purpose, RemoteRenderingBackendProxy& remoteRenderingBackendProxy)
+    template<typename BackendType, typename... Args>
+    static RefPtr<RemoteImageBufferProxy> create(const WebCore::ImageBuffer::Parameters& parameters, RemoteRenderingBackendProxy& remoteRenderingBackendProxy, Args&&... backendArgs)
     {
-        Parameters parameters { size, resolutionScale, colorSpace, bufferFormat, purpose };
-        auto backendParameters = ImageBuffer::backendParameters(parameters);
-        if (BackendType::calculateSafeBackendSize(backendParameters).isEmpty())
+        if (BackendType::calculateSafeBackendSize(parameters).isEmpty())
             return nullptr;
-        auto info = populateBackendInfo<BackendType>(backendParameters);
-        return adoptRef(new RemoteImageBufferProxy(parameters, info, remoteRenderingBackendProxy));
+        std::unique_ptr<WebCore::ImageBufferBackend> backend = BackendType::create(parameters, std::forward<Args>(backendArgs)...);
+        if (!backend)
+            return nullptr;
+        return adoptRef(new RemoteImageBufferProxy(parameters, WTF::move(backend), remoteRenderingBackendProxy));
     }
-    static Ref<RemoteImageBufferProxy> create(const WebCore::ImageBuffer::Parameters& parameters, const WebCore::ImageBufferBackend::Info& info, RemoteRenderingBackendProxy& renderingBackend)
-    {
-        return adoptRef(*new RemoteImageBufferProxy(parameters, info, renderingBackend));
-    }
+
+    // Used when re-materialising a serialized buffer. The GPU process keeps the
+    // existing ImageBuffer, so the backend is built from what the serialized buffer
+    // carried: the backing store this process allocated, or nothing at all.
+    static Ref<RemoteImageBufferProxy> createForSerializedBuffer(const WebCore::ImageBuffer::Parameters&, std::unique_ptr<WebCore::ImageBufferBackend>&&, RemoteRenderingBackendProxy&);
 
     ~RemoteImageBufferProxy();
     bool NODELETE isValid() const;
 
     void disconnect();
 
-    WebCore::ImageBufferBackend* ensureBackend() const final;
+    // Non-null iff this process allocated the backing store, in which case the handle
+    // is passed to the GPU process with CreateImageBuffer.
+    std::optional<ImageBufferBackendHandle> createBackingStoreHandleForGPUProcess() const;
+
+    // Reaching for the sharing interface means someone is about to take the backend
+    // handle, so ask the GPU process for it if the backing store is theirs.
+    WebCore::ImageBufferBackendSharing* toBackendSharing() final;
+
+    // The backing store this process allocated travels with the serialized buffer;
+    // for anything else the GPU process is asked for the handle after unserializing.
+    std::optional<ImageBufferBackendHandle> takeBackendHandleForSerialization();
 
     void backingStoreWillChange();
     std::unique_ptr<WebCore::SerializedImageBuffer> sinkIntoSerializedImageBuffer() final;
@@ -79,7 +90,7 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 
     // Messages
-    void didCreateBackend(std::optional<ImageBufferBackendHandle>);
+    void didFailToCreateBackend();
 
     RemoteGraphicsContextIdentifier contextIdentifier() const { return m_context.identifier(); }
 
@@ -89,7 +100,7 @@ public:
     // the GPU process sees the up-to-date contents.
     void sendPendingDrawsIfNecessary() const { m_context.sendPendingDrawsIfNecessary(); }
 private:
-    RemoteImageBufferProxy(Parameters, const WebCore::ImageBufferBackend::Info&, RemoteRenderingBackendProxy&);
+    RemoteImageBufferProxy(Parameters, std::unique_ptr<WebCore::ImageBufferBackend>&&, RemoteRenderingBackendProxy&);
 
     RefPtr<WebCore::NativeImage> copyNativeImage() const final;
     RefPtr<WebCore::NativeImage> createNativeImageReference() const final;
@@ -113,12 +124,17 @@ private:
     std::unique_ptr<WebCore::ThreadSafeImageBufferFlusher> createFlusher() final;
 
     void prepareForBackingStoreChange();
+    std::optional<WebCore::RenderingMode> getEffectiveRenderingModeForTesting() const final;
 
     void NODELETE assertDispatcherIsCurrent() const;
     template<typename T> void send(T&& message) const;
     template<typename T> auto sendSync(T&& message) const;
     RefPtr<IPC::StreamClientConnection> connection() const;
     void didBecomeUnresponsive() const;
+
+    // Fetches the backing store handle from the GPU process, for a backend that
+    // stands in for a backing store this process cannot map.
+    void ensureBackendHandle() const;
 
     RefPtr<RemoteImageBufferProxyFlushFence> m_pendingFlush;
     mutable RemoteGraphicsContextProxy m_context;
@@ -133,25 +149,27 @@ public:
 
     static RefPtr<WebCore::ImageBuffer> sinkIntoImageBuffer(std::unique_ptr<RemoteSerializedImageBufferProxy>, RemoteRenderingBackendProxy&);
 
-    RemoteSerializedImageBufferProxy(WebCore::ImageBuffer::Parameters, const WebCore::ImageBufferBackend::Info&, RemoteRenderingBackendProxy&);
+    RemoteSerializedImageBufferProxy(WebCore::ImageBuffer::Parameters, WebCore::RenderingMode, size_t memoryCost, std::optional<ImageBufferBackendHandle>&&, RemoteRenderingBackendProxy&);
 
     size_t memoryCost() const final
     {
-        return m_info.memoryCost;
+        return m_memoryCost;
     }
 
     const WebCore::ImageBuffer::Parameters& parameters() const LIFETIME_BOUND { return m_parameters; }
-    const WebCore::ImageBufferBackend::Info& info() const LIFETIME_BOUND { return m_info; }
+    WebCore::RenderingMode renderingMode() const { return m_renderingMode; }
+    // Non-null only for a backing store this process allocated, which is handed to
+    // the re-materialised buffer as-is.
+    std::optional<ImageBufferBackendHandle> takeBackendHandle() { return std::exchange(m_backendHandle, std::nullopt); }
 
-    std::unique_ptr<WebCore::SerializedImageBuffer> clone() const final
-    {
-        return std::unique_ptr<WebCore::SerializedImageBuffer>(new RemoteSerializedImageBufferProxy(m_parameters, m_info, m_connection));
-    }
+    std::unique_ptr<WebCore::SerializedImageBuffer> clone() const final;
 
 private:
-    RemoteSerializedImageBufferProxy(const WebCore::ImageBuffer::Parameters& parameters, const WebCore::ImageBufferBackend::Info& info, const RefPtr<IPC::Connection>& connection)
+    RemoteSerializedImageBufferProxy(const WebCore::ImageBuffer::Parameters& parameters, WebCore::RenderingMode renderingMode, size_t memoryCost, std::optional<ImageBufferBackendHandle>&& backendHandle, const RefPtr<IPC::Connection>& connection)
         : m_parameters(parameters)
-        , m_info(info)
+        , m_renderingMode(renderingMode)
+        , m_memoryCost(memoryCost)
+        , m_backendHandle(WTF::move(backendHandle))
         , m_connection(connection)
     {
     }
@@ -165,7 +183,9 @@ private:
     bool isRemoteSerializedImageBufferProxy() const final { return true; }
 
     const WebCore::ImageBuffer::Parameters m_parameters;
-    const WebCore::ImageBufferBackend::Info m_info;
+    const WebCore::RenderingMode m_renderingMode;
+    const size_t m_memoryCost;
+    std::optional<ImageBufferBackendHandle> m_backendHandle;
     RefPtr<IPC::Connection> m_connection;
 };
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.messages.in
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.messages.in
@@ -27,7 +27,7 @@
     DispatchedTo=WebContent
 ]
 messages -> RemoteImageBufferProxy  {
-    DidCreateBackend(std::optional<WebKit::ImageBufferBackendHandle> handle) CanDispatchOutOfOrder
+    DidFailToCreateBackend() CanDispatchOutOfOrder
 }
 
 #endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
@@ -287,7 +287,7 @@ void RemoteImageBufferSetProxy::willPrepareForDisplay()
     if (m_remoteNeedsConfigurationUpdate) {
         send(Messages::RemoteImageBufferSet::UpdateConfiguration(m_configuration));
         ImageBufferParameters parameters { m_configuration.logicalSize, m_configuration.resolutionScale, m_configuration.colorSpace, m_configuration.bufferFormat, m_configuration.renderingPurpose };
-        auto transform = ImageBufferBackend::calculateBaseTransform(ImageBuffer::backendParameters(parameters));
+        auto transform = ImageBufferBackend::calculateBaseTransform(parameters);
         m_context.emplace(FloatRect { { }, m_configuration.logicalSize }, transform, m_configuration.colorSpace, m_configuration.contentsFormat, m_configuration.renderingMode, m_contextIdentifier, *renderingBackend);
     }
     m_remoteNeedsConfigurationUpdate = false;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -208,7 +208,12 @@ void RemoteRenderingBackendProxy::didClose(IPC::Connection&)
             continue;
 
         auto useLosslessCompression = WebCore::UseLosslessCompression::No;
-        send(Messages::RemoteRenderingBackend::CreateImageBuffer(imageBuffer->logicalSize(), imageBuffer->renderingMode(), imageBuffer->renderingPurpose(), imageBuffer->resolutionScale(), imageBuffer->colorSpace(), { imageBuffer->pixelFormat(), useLosslessCompression }, identifier, imageBuffer->contextIdentifier()));
+        // Client-allocated backing store survived the GPU process, so hand the same
+        // surface back rather than allocating a replacement.
+        if (auto backingStore = imageBuffer->createBackingStoreHandleForGPUProcess())
+            send(Messages::RemoteRenderingBackend::CreateMappableImageBuffer(imageBuffer->logicalSize(), imageBuffer->renderingMode(), imageBuffer->renderingPurpose(), imageBuffer->resolutionScale(), imageBuffer->colorSpace(), { imageBuffer->pixelFormat(), useLosslessCompression }, WTF::move(*backingStore), identifier, imageBuffer->contextIdentifier()));
+        else
+            send(Messages::RemoteRenderingBackend::CreateImageBuffer(imageBuffer->logicalSize(), imageBuffer->renderingMode(), imageBuffer->renderingPurpose(), imageBuffer->resolutionScale(), imageBuffer->colorSpace(), { imageBuffer->pixelFormat(), useLosslessCompression }, identifier, imageBuffer->contextIdentifier()));
     }
     for (auto& [identifier, weakImageBufferSet] : m_imageBufferSets) {
         RefPtr imageBufferSet = weakImageBufferSet.get();
@@ -259,34 +264,46 @@ bool RemoteRenderingBackendProxy::canMapRemoteImageBufferBackendBackingStore()
 
 RefPtr<RemoteImageBufferProxy> RemoteRenderingBackendProxy::createImageBuffer(const FloatSize& size, RenderingMode renderingMode, RenderingPurpose purpose, float resolutionScale, const ColorSpace& colorSpace, ImageBufferFormat bufferFormat)
 {
+    // Whoever needs to touch the pixels allocates them. Backends this process maps or
+    // shares onward are allocated here and their handle travels with CreateImageBuffer;
+    // the rest are allocated by the GPU process and are opaque to us.
+    // Note this only needs an IOSurface where canMapRemoteImageBufferBackendBackingStore()
+    // is true, which is exactly when this process is allowed to create one; see
+    // WebPage::platformInitialize()'s shouldBlockIOKit.
+    ImageBuffer::Parameters parameters { size, resolutionScale, colorSpace, bufferFormat, purpose };
+    ImageBufferCreationContext creationContext;
+
     RefPtr<RemoteImageBufferProxy> imageBuffer;
     switch (renderingMode) {
     case RenderingMode::Accelerated:
 #if HAVE(IOSURFACE)
         if (canMapRemoteImageBufferBackendBackingStore())
-            imageBuffer = RemoteImageBufferProxy::create<ImageBufferShareableMappedIOSurfaceBackend>(size, resolutionScale, colorSpace, bufferFormat, purpose, *this);
+            imageBuffer = RemoteImageBufferProxy::create<ImageBufferShareableMappedIOSurfaceBackend>(parameters, *this, creationContext);
         else
-            imageBuffer = RemoteImageBufferProxy::create<ImageBufferRemoteIOSurfaceBackend>(size, resolutionScale, colorSpace, bufferFormat, purpose, *this);
+            imageBuffer = RemoteImageBufferProxy::create<ImageBufferRemoteIOSurfaceBackend>(parameters, *this);
 #endif
         [[fallthrough]];
 
     case RenderingMode::Unaccelerated:
         if (!imageBuffer)
-            imageBuffer = RemoteImageBufferProxy::create<ImageBufferShareableBitmapBackend>(size, resolutionScale, colorSpace, bufferFormat, purpose, *this);
+            imageBuffer = RemoteImageBufferProxy::create<ImageBufferShareableBitmapBackend>(parameters, *this, creationContext);
         break;
 
     case RenderingMode::PDFDocument:
-        imageBuffer = RemoteImageBufferProxy::create<ImageBufferRemotePDFDocumentBackend>(size, resolutionScale, colorSpace, bufferFormat, purpose, *this);
+        imageBuffer = RemoteImageBufferProxy::create<ImageBufferRemotePDFDocumentBackend>(parameters, *this);
         break;
 
     case RenderingMode::DisplayList:
-        imageBuffer = RemoteImageBufferProxy::create<ImageBufferRemoteDisplayListBackend>(size, resolutionScale, colorSpace, bufferFormat, purpose, *this);
+        imageBuffer = RemoteImageBufferProxy::create<ImageBufferRemoteDisplayListBackend>(parameters, *this);
         break;
     }
 
     if (imageBuffer) {
         auto identifier = imageBuffer->renderingResourceIdentifier();
-        send(Messages::RemoteRenderingBackend::CreateImageBuffer(imageBuffer->logicalSize(), imageBuffer->renderingMode(), imageBuffer->renderingPurpose(), imageBuffer->resolutionScale(), imageBuffer->colorSpace(), { imageBuffer->pixelFormat(), bufferFormat.useLosslessCompression }, identifier, imageBuffer->contextIdentifier()));
+        if (auto backingStore = imageBuffer->createBackingStoreHandleForGPUProcess())
+            send(Messages::RemoteRenderingBackend::CreateMappableImageBuffer(imageBuffer->logicalSize(), imageBuffer->renderingMode(), imageBuffer->renderingPurpose(), imageBuffer->resolutionScale(), imageBuffer->colorSpace(), { imageBuffer->pixelFormat(), bufferFormat.useLosslessCompression }, WTF::move(*backingStore), identifier, imageBuffer->contextIdentifier()));
+        else
+            send(Messages::RemoteRenderingBackend::CreateImageBuffer(imageBuffer->logicalSize(), imageBuffer->renderingMode(), imageBuffer->renderingPurpose(), imageBuffer->resolutionScale(), imageBuffer->colorSpace(), { imageBuffer->pixelFormat(), bufferFormat.useLosslessCompression }, identifier, imageBuffer->contextIdentifier()));
         auto addResult = m_imageBuffers.add(identifier, *imageBuffer);
         ASSERT_UNUSED(addResult, addResult.isNewEntry);
     }
@@ -324,14 +341,46 @@ std::unique_ptr<RemoteSerializedImageBufferProxy> RemoteRenderingBackendProxy::m
     auto identifier = imageBuffer.renderingResourceIdentifier();
     bool success = m_imageBuffers.remove(identifier);
     ASSERT_UNUSED(success, success);
-    std::unique_ptr result = makeUnique<RemoteSerializedImageBufferProxy>(imageBuffer.parameters(), imageBuffer.backendInfo(), *this);
+    // Backing store this process allocated travels with the serialized buffer. For
+    // anything else the pixels stay in the GPU process and the handle, if it is ever
+    // needed, is asked for after the buffer is re-materialised.
+    std::unique_ptr result = makeUnique<RemoteSerializedImageBufferProxy>(imageBuffer.parameters(), imageBuffer.renderingMode(), imageBuffer.memoryCost(), imageBuffer.takeBackendHandleForSerialization(), *this);
     send(Messages::RemoteRenderingBackend::MoveToSerializedBuffer(identifier, result->identifier()));
     return result;
 }
 
-Ref<RemoteImageBufferProxy> RemoteRenderingBackendProxy::moveToImageBuffer(RemoteSerializedImageBufferProxy& serialized)
+// The pixels exist in the GPU process, so this process cannot allocate a backing
+// store here: it either re-adopts the one it handed over, or stands in for the
+// GPU process's one with a backend that has no pixels of its own.
+static std::unique_ptr<ImageBufferBackend> createBackendForSerializedBuffer(const ImageBuffer::Parameters& parameters, RenderingMode renderingMode, std::optional<ImageBufferBackendHandle>&& handle)
 {
-    auto result = RemoteImageBufferProxy::create(serialized.parameters(), serialized.info(), *this);
+    switch (renderingMode) {
+    case RenderingMode::Accelerated:
+#if HAVE(IOSURFACE)
+        if (handle && std::holds_alternative<MachSendRight>(*handle))
+            return ImageBufferShareableMappedIOSurfaceBackend::create(parameters, WTF::move(*handle));
+        if (!handle)
+            return ImageBufferRemoteIOSurfaceBackend::create(parameters);
+#endif
+        [[fallthrough]];
+    case RenderingMode::Unaccelerated:
+        if (handle && std::holds_alternative<ShareableBitmap::Handle>(*handle))
+            return ImageBufferShareableBitmapBackend::create(parameters, std::get<ShareableBitmap::Handle>(WTF::move(*handle)));
+        return nullptr;
+    case RenderingMode::PDFDocument:
+        return ImageBufferRemotePDFDocumentBackend::create(parameters);
+    case RenderingMode::DisplayList:
+        return ImageBufferRemoteDisplayListBackend::create(parameters);
+    }
+    return nullptr;
+}
+
+RefPtr<RemoteImageBufferProxy> RemoteRenderingBackendProxy::moveToImageBuffer(RemoteSerializedImageBufferProxy& serialized)
+{
+    auto backend = createBackendForSerializedBuffer(serialized.parameters(), serialized.renderingMode(), serialized.takeBackendHandle());
+    if (!backend)
+        return nullptr;
+    Ref result = RemoteImageBufferProxy::createForSerializedBuffer(serialized.parameters(), WTF::move(backend), *this);
     auto resultIdentifier = result->renderingResourceIdentifier();
     auto addResult = m_imageBuffers.add(resultIdentifier, result);
     ASSERT_UNUSED(addResult, addResult.isNewEntry);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -109,7 +109,7 @@ public:
 
     void transferImageBuffer(std::unique_ptr<RemoteSerializedImageBufferProxy>, WebCore::ImageBuffer&);
     std::unique_ptr<RemoteSerializedImageBufferProxy> moveToSerializedBuffer(RemoteImageBufferProxy&);
-    Ref<RemoteImageBufferProxy> moveToImageBuffer(RemoteSerializedImageBufferProxy&);
+    RefPtr<RemoteImageBufferProxy> moveToImageBuffer(RemoteSerializedImageBufferProxy&);
 
     RefPtr<RemoteImageBufferProxy> cachedImageBuffer(const WebCore::ImageBuffer&) const;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
@@ -41,17 +41,17 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageBufferRemoteIOSurfaceBackend);
 
-IntSize ImageBufferRemoteIOSurfaceBackend::calculateSafeBackendSize(const Parameters& parameters)
+IntSize ImageBufferRemoteIOSurfaceBackend::calculateSafeBackendSize(const WebCore::ImageBufferParameters& parameters)
 {
     return ImageBufferIOSurfaceBackend::calculateSafeBackendSize(parameters);
 }
 
-size_t ImageBufferRemoteIOSurfaceBackend::calculateMemoryCost(const Parameters& parameters)
+std::unique_ptr<ImageBufferRemoteIOSurfaceBackend> ImageBufferRemoteIOSurfaceBackend::create(const WebCore::ImageBufferParameters& parameters)
 {
-    return ImageBufferIOSurfaceBackend::calculateMemoryCost(parameters);
+    return makeUnique<ImageBufferRemoteIOSurfaceBackend>(parameters, MachSendRight { });
 }
 
-std::unique_ptr<ImageBufferRemoteIOSurfaceBackend> ImageBufferRemoteIOSurfaceBackend::create(const Parameters& parameters, ImageBufferBackendHandle handle)
+std::unique_ptr<ImageBufferRemoteIOSurfaceBackend> ImageBufferRemoteIOSurfaceBackend::create(const WebCore::ImageBufferParameters& parameters, ImageBufferBackendHandle handle)
 {
     if (!std::holds_alternative<MachSendRight>(handle)) {
         RELEASE_ASSERT_NOT_REACHED();
@@ -63,11 +63,15 @@ std::unique_ptr<ImageBufferRemoteIOSurfaceBackend> ImageBufferRemoteIOSurfaceBac
 
 std::optional<ImageBufferBackendHandle> ImageBufferRemoteIOSurfaceBackend::createBackendHandle(SharedMemory::Protection) const
 {
+    if (!m_handle)
+        return std::nullopt;
     return MachSendRight { m_handle };
 }
 
 std::optional<ImageBufferBackendHandle> ImageBufferRemoteIOSurfaceBackend::takeBackendHandle(SharedMemory::Protection)
 {
+    if (!m_handle)
+        return std::nullopt;
     return std::exchange(m_handle, { });
 }
 
@@ -98,7 +102,7 @@ GraphicsContext& ImageBufferRemoteIOSurfaceBackend::context()
 
 unsigned ImageBufferRemoteIOSurfaceBackend::bytesPerRow() const
 {
-    return ImageBufferIOSurfaceBackend::calculateBytesPerRow(m_parameters.backendSize, m_parameters.bufferFormat.pixelFormat);
+    return ImageBufferIOSurfaceBackend::calculateBytesPerRow(size(), pixelFormat());
 }
 
 RefPtr<NativeImage> ImageBufferRemoteIOSurfaceBackend::copyNativeImage()

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
@@ -38,18 +38,21 @@ class ImageBufferRemoteIOSurfaceBackend final : public WebCore::ImageBufferBacke
     WTF_MAKE_TZONE_ALLOCATED(ImageBufferRemoteIOSurfaceBackend);
     WTF_MAKE_NONCOPYABLE(ImageBufferRemoteIOSurfaceBackend);
 public:
-    static WebCore::IntSize calculateSafeBackendSize(const Parameters&);
-    static size_t calculateMemoryCost(const Parameters&);
+    static WebCore::IntSize calculateSafeBackendSize(const WebCore::ImageBufferParameters&);
 
-    static std::unique_ptr<ImageBufferRemoteIOSurfaceBackend> create(const Parameters&, ImageBufferBackendHandle);
+    // The GPU process owns the surface. The handle is fetched from it later, and
+    // only if something needs to share the surface onward.
+    static std::unique_ptr<ImageBufferRemoteIOSurfaceBackend> create(const WebCore::ImageBufferParameters&);
+    static std::unique_ptr<ImageBufferRemoteIOSurfaceBackend> create(const WebCore::ImageBufferParameters&, ImageBufferBackendHandle);
 
-    ImageBufferRemoteIOSurfaceBackend(const Parameters& parameters, MachSendRight&& handle)
+    ImageBufferRemoteIOSurfaceBackend(const WebCore::ImageBufferParameters& parameters, MachSendRight&& handle)
         : ImageBufferBackend(parameters)
         , m_handle(WTF::move(handle))
     {
     }
 
-    static constexpr WebCore::RenderingMode renderingMode = WebCore::RenderingMode::Accelerated;
+    WebCore::RenderingMode renderingMode() const final { return WebCore::RenderingMode::Accelerated; }
+    size_t memoryCost() const final { return WebCore::ImageBufferBackend::calculateMemoryCost(size(), bytesPerRow()); }
     bool canMapBackingStore() const final;
 
     WebCore::GraphicsContext& context() final;
@@ -70,6 +73,7 @@ private:
 
     // ImageBufferBackendSharing
     ImageBufferBackendSharing* toBackendSharing() final { return this; }
+    bool hasBackendHandle() const final { return !!m_handle; }
     void setBackendHandle(ImageBufferBackendHandle&&) final;
     void clearBackendHandle() final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp
@@ -41,7 +41,7 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageBufferShareableMappedIOSurfaceBackend);
 
-std::unique_ptr<ImageBufferShareableMappedIOSurfaceBackend> ImageBufferShareableMappedIOSurfaceBackend::create(const Parameters& parameters, const ImageBufferCreationContext& creationContext)
+std::unique_ptr<ImageBufferShareableMappedIOSurfaceBackend> ImageBufferShareableMappedIOSurfaceBackend::create(const WebCore::ImageBufferParameters& parameters, const ImageBufferCreationContext& creationContext)
 {
     IntSize backendSize = calculateSafeBackendSize(parameters);
     if (backendSize.isEmpty())
@@ -62,21 +62,29 @@ std::unique_ptr<ImageBufferShareableMappedIOSurfaceBackend> ImageBufferShareable
     return std::unique_ptr<ImageBufferShareableMappedIOSurfaceBackend> { new ImageBufferShareableMappedIOSurfaceBackend { parameters, WTF::move(surface), WTF::move(cgContext), 0, protect(creationContext.surfacePool) } };
 }
 
-std::unique_ptr<ImageBufferShareableMappedIOSurfaceBackend> ImageBufferShareableMappedIOSurfaceBackend::create(const Parameters& parameters, ImageBufferBackendHandle handle)
+std::unique_ptr<ImageBufferShareableMappedIOSurfaceBackend> ImageBufferShareableMappedIOSurfaceBackend::create(const WebCore::ImageBufferParameters& parameters, ImageBufferBackendHandle handle)
 {
-    if (!std::holds_alternative<MachSendRight>(handle)) {
-        ASSERT_NOT_REACHED();
+    if (!std::holds_alternative<MachSendRight>(handle))
         return nullptr;
-    }
 
-    auto surface = IOSurface::createFromSendRight(WTF::move(std::get<MachSendRight>(handle)));
+    auto surface = IOSurface::createFromUntrustedUncompressedWebKitSendRight(WTF::move(std::get<MachSendRight>(handle)));
     if (!surface)
         return nullptr;
+
+    auto requestedSize = calculateSafeBackendSize(parameters);
+    if (requestedSize.isEmpty())
+        return nullptr;
+    if (surface->size() != requestedSize)
+        return nullptr;
+    if (surface->colorSpace() != parameters.colorSpace)
+        return nullptr;
+    if (!surface->hasFormat({ convertToIOSurfaceFormat(parameters.bufferFormat.pixelFormat), parameters.bufferFormat.useLosslessCompression }))
+        return nullptr;
+
     auto cgContext = surface->createPlatformContext();
     if (!cgContext)
         return nullptr;
 
-    ASSERT(surface->colorSpace() == parameters.colorSpace);
     return std::unique_ptr<ImageBufferShareableMappedIOSurfaceBackend> { new ImageBufferShareableMappedIOSurfaceBackend { parameters, WTF::move(surface), WTF::move(cgContext), 0, nullptr } };
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.h
@@ -41,8 +41,8 @@ class ImageBufferShareableMappedIOSurfaceBackend final : public WebCore::ImageBu
     WTF_MAKE_TZONE_ALLOCATED(ImageBufferShareableMappedIOSurfaceBackend);
     WTF_MAKE_NONCOPYABLE(ImageBufferShareableMappedIOSurfaceBackend);
 public:
-    static std::unique_ptr<ImageBufferShareableMappedIOSurfaceBackend> create(const Parameters&, const WebCore::ImageBufferCreationContext&);
-    static std::unique_ptr<ImageBufferShareableMappedIOSurfaceBackend> create(const Parameters&, ImageBufferBackendHandle);
+    static std::unique_ptr<ImageBufferShareableMappedIOSurfaceBackend> create(const WebCore::ImageBufferParameters&, const WebCore::ImageBufferCreationContext&);
+    static std::unique_ptr<ImageBufferShareableMappedIOSurfaceBackend> create(const WebCore::ImageBufferParameters&, ImageBufferBackendHandle);
 
     using WebCore::ImageBufferIOSurfaceBackend::ImageBufferIOSurfaceBackend;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
@@ -41,7 +41,7 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageBufferShareableMappedIOSurfaceBitmapBackend);
 
-std::unique_ptr<ImageBufferShareableMappedIOSurfaceBitmapBackend> ImageBufferShareableMappedIOSurfaceBitmapBackend::create(const Parameters& parameters, const ImageBufferCreationContext& creationContext)
+std::unique_ptr<ImageBufferShareableMappedIOSurfaceBitmapBackend> ImageBufferShareableMappedIOSurfaceBitmapBackend::create(const WebCore::ImageBufferParameters& parameters, const ImageBufferCreationContext& creationContext)
 {
     IntSize backendSize = ImageBufferIOSurfaceBackend::calculateSafeBackendSize(parameters);
     if (backendSize.isEmpty())
@@ -59,7 +59,7 @@ std::unique_ptr<ImageBufferShareableMappedIOSurfaceBitmapBackend> ImageBufferSha
     return makeUnique<ImageBufferShareableMappedIOSurfaceBitmapBackend>(parameters, WTF::move(surface), WTF::move(*lockAndContext), creationContext.surfacePool.get());
 }
 
-ImageBufferShareableMappedIOSurfaceBitmapBackend::ImageBufferShareableMappedIOSurfaceBitmapBackend(const Parameters& parameters, std::unique_ptr<IOSurface> surface, IOSurface::LockAndContext&& lockAndContext, IOSurfacePool* ioSurfacePool)
+ImageBufferShareableMappedIOSurfaceBitmapBackend::ImageBufferShareableMappedIOSurfaceBitmapBackend(const WebCore::ImageBufferParameters& parameters, std::unique_ptr<IOSurface> surface, IOSurface::LockAndContext&& lockAndContext, IOSurfacePool* ioSurfacePool)
     : ImageBufferCGBackend(parameters)
     , m_surface(WTF::move(surface))
     , m_lock(WTF::move(lockAndContext.lock))

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
@@ -43,13 +43,13 @@ class ImageBufferShareableMappedIOSurfaceBitmapBackend final : public WebCore::I
     WTF_MAKE_TZONE_ALLOCATED(ImageBufferShareableMappedIOSurfaceBitmapBackend);
     WTF_MAKE_NONCOPYABLE(ImageBufferShareableMappedIOSurfaceBitmapBackend);
 public:
-    static std::unique_ptr<ImageBufferShareableMappedIOSurfaceBitmapBackend> create(const Parameters&, const WebCore::ImageBufferCreationContext&);
-    static size_t calculateMemoryCost(const Parameters& parameters) { return WebCore::ImageBufferIOSurfaceBackend::calculateMemoryCost(parameters); }
+    static std::unique_ptr<ImageBufferShareableMappedIOSurfaceBitmapBackend> create(const WebCore::ImageBufferParameters&, const WebCore::ImageBufferCreationContext&);
 
-    ImageBufferShareableMappedIOSurfaceBitmapBackend(const Parameters&, std::unique_ptr<WebCore::IOSurface>, WebCore::IOSurface::LockAndContext&&, WebCore::IOSurfacePool*);
+    ImageBufferShareableMappedIOSurfaceBitmapBackend(const WebCore::ImageBufferParameters&, std::unique_ptr<WebCore::IOSurface>, WebCore::IOSurface::LockAndContext&&, WebCore::IOSurfacePool*);
     ~ImageBufferShareableMappedIOSurfaceBitmapBackend();
 
-    static constexpr WebCore::RenderingMode renderingMode = WebCore::RenderingMode::Accelerated;
+    WebCore::RenderingMode renderingMode() const final { return WebCore::RenderingMode::Accelerated; }
+    size_t memoryCost() const final { return WebCore::ImageBufferBackend::calculateMemoryCost(size(), WebCore::ImageBufferIOSurfaceBackend::calculateBytesPerRow(size(), pixelFormat())); }
     bool canMapBackingStore() const final;
 
     std::optional<ImageBufferBackendHandle> createBackendHandle(WebCore::SharedMemory::Protection = WebCore::SharedMemory::Protection::ReadWrite) const final;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
@@ -158,7 +158,8 @@ public:
             return false;
 
         auto backendHandle = sharing->createBackendHandle(SharedMemory::Protection::ReadOnly);
-        ASSERT(backendHandle);
+        if (!backendHandle)
+            return false;
 
         {
             Locker locker { m_surfaceLock };
@@ -270,7 +271,8 @@ void GraphicsLayerCARemote::setLayerContentsToImageBuffer(PlatformCALayer& layer
         return;
 
     auto backendHandle = sharing->createBackendHandle(SharedMemory::Protection::ReadOnly);
-    ASSERT(backendHandle);
+    if (!backendHandle)
+        return;
 
     layer.setAcceleratesDrawing(true);
 #if HAVE(SUPPORT_HDR_DISPLAY)


### PR DESCRIPTION
#### 1a3eac178b9ff4fdaeec15ca3d3767a788990d33
<pre>
REGRESSION(320153@main) 2D context self drawImage performance regression
<a href="https://bugs.webkit.org/show_bug.cgi?id=323495">https://bugs.webkit.org/show_bug.cgi?id=323495</a>
<a href="https://rdar.apple.com/186731221">rdar://186731221</a>

Reviewed by Matt Woodrow.

Upon creation, remote ImageBuffers would send their surface handle to
WCP. This would hold the underlying IOSurfaces in use, preventing
recycling through IOSurfacePool. For loops that do a lot of self draw,
this would cause IOSurface alloc/dealloc churn.

Fix by not sending the handles. This was a feature used when ImageBuffer
handles were attached to layers after compositing. Currently we use
ImageBufferSets for this. The only cases that the handle is currently
used is PlaceholderRenderingContext and view transitions. The feature
cannot be used effectively, as WCP-&gt;GPUP synchrous flush is needed
anyway before the handles can be attached to layers.

Due to this feature, the RemoteImageBufferProxy and ImageBufferBackend
were more complex than needed: the RemoteImageBufferProxy would need to
start without a backend. Upon operations that needed backend-specific
information, the access would block until the backend was available
through the handle transferring message.

Instead, instantiate the backend at the RemoteImageBufferProxy
instantiation site. For cases that can map the backend backing store,
shared memory and in-process IOSurface, create the backing store at that
moment and send it to GPUP. For cases that cannot map the backing store,
i.e. GPUP IOSurface, fetch the handle through explicit synchronous call
for PlaceholderRenderingContext and view transitions. These will be
removed in future, to be superseeded with corresponding NativeImage
infrastructure.

Remove ImageBufferBackendProperties, this was only needed due to the
complications above.

* LayoutTests/ipc/feComponentTransfer-empty-tableValues-accelerated.html:
* LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html:
* LayoutTests/ipc/invalid-svgfilter-expression-crash.html:
* LayoutTests/ipc/restore-empty-stack-crash.html:
* LayoutTests/ipc/rgba16f-getpixelbuffer-colorspace-mismatch-heap-disclosure.html:
* LayoutTests/ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/WebCoreDOMAndRenderingPrefix.h:
* Source/WebCore/WebCoreJSBindingsPrefix.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::getEffectiveRenderingModeForTesting):
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::ImageBuffer):
(WebCore::calculateImageBufferBackendSize):
(WebCore::ImageBuffer::calculateBackendSize):
(WebCore::ImageBuffer::flushDrawingContext):
(WebCore::ImageBuffer::submitDrawingCommands):
(WebCore::ImageBuffer::replaceFontsWithRebuildData):
(WebCore::ImageBuffer::rebuildFonts):
(WebCore::ImageBuffer::prepareForDisplay):
(WebCore::ImageBuffer::backendSize const):
(WebCore::ImageBuffer::getEffectiveRenderingModeForTesting const):
(WebCore::ImageBuffer::copyNativeImage const):
(WebCore::ImageBuffer::createNativeImageReference const):
(WebCore::ImageBuffer::sinkIntoNativeImage):
(WebCore::ImageBuffer::filteredNativeImage):
(WebCore::ImageBuffer::createCairoSurface):
(WebCore::ImageBuffer::layerContentsDisplayDelegate):
(WebCore::ImageBuffer::convertToLuminanceMask):
(WebCore::ImageBuffer::transformToColorSpace):
(WebCore::ImageBuffer::getPixelBuffer const):
(WebCore::ImageBuffer::putPixelBuffer):
(WebCore::ImageBuffer::sinkIntoPDFDocument):
(WebCore::ImageBuffer::isInUse const):
(WebCore::ImageBuffer::releaseGraphicsContext):
(WebCore::ImageBuffer::setVolatile):
(WebCore::ImageBuffer::setNonVolatile):
(WebCore::ImageBuffer::volatilityState const):
(WebCore::ImageBuffer::setVolatilityState):
(WebCore::ImageBuffer::createFlusher):
(WebCore::ImageBuffer::toBackendSharing):
(WebCore::ImageBuffer::transferToNewContext):
(WebCore::ImageBuffer::backendParameters): Deleted.
* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::ImageBuffer::create):
(WebCore::ImageBuffer::renderingMode const):
(WebCore::ImageBuffer::baseTransform const):
(WebCore::ImageBuffer::memoryCost const):
(WebCore::ImageBuffer::populateBackendInfo): Deleted.
(WebCore::ImageBuffer::ensureBackendCreated const): Deleted.
(WebCore::ImageBuffer::ensureBackend const): Deleted.
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::calculateSafeBackendSize):
(WebCore::ImageBufferBackend::ImageBufferBackend):
(WebCore::baseTransformForBackingStore):
(WebCore::ImageBufferBackend::calculateBaseTransform):
(WebCore::ImageBufferBackend::baseTransform const):
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
(WebCore::ImageBufferBackend::renderingMode const):
(WebCore::ImageBufferBackend::memoryCost const):
(WebCore::ImageBufferBackend::isNullImageBufferBackend const):
(WebCore::ImageBufferBackend::size const):
(WebCore::ImageBufferBackend::resolutionScale const):
(WebCore::ImageBufferBackend::bufferFormat const):
(WebCore::ImageBufferBackend::pixelFormat const):
(WebCore::ImageBufferBackend::purpose const):
* Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.cpp:
(WebCore::ImageBufferDisplayListBackend::create):
(WebCore::ImageBufferDisplayListBackend::ImageBufferDisplayListBackend):
* Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.h:
(WebCore::ImageBufferDisplayListBackend::calculateMemoryCost): Deleted.
* Source/WebCore/platform/graphics/ImageBufferParameters.h: Renamed from Source/WebCore/platform/graphics/ImageBufferBackendParameters.h.
(WebCore::ImageBufferParameters::backendSize const):
* Source/WebCore/platform/graphics/NullImageBufferBackend.cpp:
(WebCore::NullImageBufferBackend::create):
* Source/WebCore/platform/graphics/NullImageBufferBackend.h:
(isType):
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoBackend.cpp:
(WebCore::ImageBufferCairoBackend::transformToColorSpace):
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoImageSurfaceBackend.cpp:
(WebCore::ImageBufferCairoImageSurfaceBackend::calculateSafeBackendSize):
(WebCore::ImageBufferCairoImageSurfaceBackend::create):
(WebCore::ImageBufferCairoImageSurfaceBackend::ImageBufferCairoImageSurfaceBackend):
(WebCore::ImageBufferCairoImageSurfaceBackend::bytesPerRow const):
(WebCore::ImageBufferCairoImageSurfaceBackend::calculateMemoryCost): Deleted.
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoImageSurfaceBackend.h:
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp:
(WebCore::ImageBufferCairoSurfaceBackend::ImageBufferCairoSurfaceBackend):
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp:
(WebCore::ImageBufferCGBackend::ImageBufferCGBackend):
(WebCore::ImageBufferCGBackend::applyBaseTransform const):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp:
(WebCore::ImageBufferCGBitmapBackend::create):
(WebCore::ImageBufferCGBitmapBackend::ImageBufferCGBitmapBackend):
(WebCore::ImageBufferCGBitmapBackend::bytesPerRow const):
(WebCore::ImageBufferCGBitmapBackend::createNativeImageReference):
(WebCore::ImageBufferCGBitmapBackend::calculateMemoryCost): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.cpp:
(WebCore::ImageBufferCGPDFDocumentBackend::create):
(WebCore::ImageBufferCGPDFDocumentBackend::ImageBufferCGPDFDocumentBackend):
(WebCore::ImageBufferCGPDFDocumentBackend::calculateMemoryCost): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::calculateSafeBackendSize):
(WebCore::ImageBufferIOSurfaceBackend::create):
(WebCore::ImageBufferIOSurfaceBackend::ImageBufferIOSurfaceBackend):
(WebCore::ImageBufferIOSurfaceBackend::createImageReference):
(WebCore::ImageBufferIOSurfaceBackend::calculateMemoryCost): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::create):
(WebCore::ImageBufferSkiaAcceleratedBackend::ImageBufferSkiaAcceleratedBackend):
(WebCore::ImageBufferSkiaAcceleratedBackend::context):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp:
(WebCore::ImageBufferSkiaSurfaceBackend::calculateSafeBackendSize):
(WebCore::ImageBufferSkiaSurfaceBackend::ImageBufferSkiaSurfaceBackend):
(WebCore::ImageBufferSkiaSurfaceBackend::calculateMemoryCost): Deleted.
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp:
(WebCore::ImageBufferSkiaUnacceleratedBackend::create):
(WebCore::ImageBufferSkiaUnacceleratedBackend::ImageBufferSkiaUnacceleratedBackend):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::getEffectiveRenderingModeOfNewlyCreatedAcceleratedImageBuffer):
* Source/WebCore/testing/ServiceWorkerInternals.cpp:
(WebCore::ServiceWorkerInternals::effectiveRenderingModeOfNewlyCreatedAcceleratedCanvasBuffer):
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::RemoteImageBuffer):
(WebKit::RemoteImageBuffer::getEffectiveRenderingModeForTesting):
(WebKit::RemoteImageBuffer::getBackendHandle):
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::allocateImageBufferInternal):
(WebKit::RemoteRenderingBackend::allocateImageBuffer):
(WebKit::RemoteRenderingBackend::createImageBuffer):
(WebKit::RemoteRenderingBackend::createMappableImageBuffer):
(WebKit::RemoteRenderingBackend::createImageBufferWithBackingStore):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.h:
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.mm:
(WebKit::DynamicContentScalingBifurcatedImageBuffer::DynamicContentScalingBifurcatedImageBuffer):
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.h:
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.mm:
(WebKit::makeContextOptions):
(WebKit::GraphicsContextDynamicContentScaling::GraphicsContextDynamicContentScaling):
(WebKit::DynamicContentScalingImageBufferBackend::create):
(WebKit::DynamicContentScalingImageBufferBackend::DynamicContentScalingImageBufferBackend):
(WebKit::DynamicContentScalingImageBufferBackend::context):
(WebKit::DynamicContentScalingImageBufferBackend::bytesPerRow const):
(WebKit::DynamicContentScalingImageBufferBackend::calculateMemoryCost): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebImage.cpp:
(WebKit::WebImage::create):
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferBackendHandleSharing.h:
(WebKit::ImageBufferBackendHandleSharing::hasBackendHandle const):
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.cpp:
(WebKit::ImageBufferRemoteDisplayListBackend::create):
(WebKit::ImageBufferRemoteDisplayListBackend::ImageBufferRemoteDisplayListBackend):
(WebKit::ImageBufferRemoteDisplayListBackend::getPixelBuffer):
(WebKit::ImageBufferRemoteDisplayListBackend::createNativeImageReference): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemoteDisplayListBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemotePDFDocumentBackend.cpp:
(WebKit::ImageBufferRemotePDFDocumentBackend::create):
(WebKit::ImageBufferRemotePDFDocumentBackend::getPixelBuffer):
(WebKit::ImageBufferRemotePDFDocumentBackend::calculateMemoryCost): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferRemotePDFDocumentBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp:
(WebKit::ImageBufferShareableBitmapBackend::calculateSafeBackendSize):
(WebKit::ImageBufferShareableBitmapBackend::calculateBytesPerRow):
(WebKit::ImageBufferShareableBitmapBackend::create):
(WebKit::ImageBufferShareableBitmapBackend::ImageBufferShareableBitmapBackend):
(WebKit::ImageBufferShareableBitmapBackend::calculateMemoryCost): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::createForSerializedBuffer):
(WebKit::RemoteImageBufferProxy::RemoteImageBufferProxy):
(WebKit::RemoteImageBufferProxy::didFailToCreateBackend):
(WebKit::RemoteImageBufferProxy::ensureBackendHandle const):
(WebKit::RemoteImageBufferProxy::takeBackendHandleForSerialization):
(WebKit::RemoteImageBufferProxy::toBackendSharing):
(WebKit::RemoteImageBufferProxy::createBackingStoreHandleForGPUProcess const):
(WebKit::RemoteImageBufferProxy::getEffectiveRenderingModeForTesting const):
(WebKit::RemoteImageBufferProxy::copyNativeImage const):
(WebKit::RemoteImageBufferProxy::createNativeImageReference const):
(WebKit::RemoteImageBufferProxy::getPixelBuffer const):
(WebKit::RemoteImageBufferProxy::disconnect):
(WebKit::RemoteImageBufferProxy::putPixelBuffer):
(WebKit::RemoteImageBufferProxy::prepareForBackingStoreChange):
(WebKit::RemoteImageBufferProxy::sinkIntoSerializedImageBuffer):
(WebKit::RemoteSerializedImageBufferProxy::RemoteSerializedImageBufferProxy):
(WebKit::copyBackendHandle):
(WebKit::RemoteSerializedImageBufferProxy::clone const):
(WebKit::RemoteSerializedImageBufferProxy::sinkIntoImageBuffer):
(WebKit::RemoteImageBufferProxy::didCreateBackend): Deleted.
(WebKit::RemoteImageBufferProxy::ensureBackend const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
(WebKit::RemoteSerializedImageBufferProxy::renderingMode const):
(WebKit::RemoteSerializedImageBufferProxy::takeBackendHandle):
(WebKit::RemoteSerializedImageBufferProxy::RemoteSerializedImageBufferProxy):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxy::willPrepareForDisplay):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::didClose):
(WebKit::RemoteRenderingBackendProxy::createImageBuffer):
(WebKit::RemoteRenderingBackendProxy::moveToSerializedBuffer):
(WebKit::createBackendForSerializedBuffer):
(WebKit::RemoteRenderingBackendProxy::moveToImageBuffer):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp:
(WebKit::ImageBufferRemoteIOSurfaceBackend::calculateSafeBackendSize):
(WebKit::ImageBufferRemoteIOSurfaceBackend::create):
(WebKit::ImageBufferRemoteIOSurfaceBackend::createBackendHandle const):
(WebKit::ImageBufferRemoteIOSurfaceBackend::takeBackendHandle):
(WebKit::ImageBufferRemoteIOSurfaceBackend::bytesPerRow const):
(WebKit::ImageBufferRemoteIOSurfaceBackend::calculateMemoryCost): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp:
(WebKit::ImageBufferShareableMappedIOSurfaceBackend::create):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp:
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::create):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::ImageBufferShareableMappedIOSurfaceBitmapBackend):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:
(WebKit::GraphicsLayerCARemote::setLayerContentsToImageBuffer):

Canonical link: <a href="https://commits.webkit.org/320735@main">https://commits.webkit.org/320735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5256c1bcd7333d847af360f5c7202eb43be0f828

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196079 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/77a2087e-741a-4244-916e-06d247d2d791) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187634 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145176 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/139a783c-3c22-4ce0-a69e-4888ba2619fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48856 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125474 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6942e77-61e7-4720-91cb-462db11074fc) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/185101 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47582 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157942 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45314 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7142 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50031 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198045 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59339 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154719 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41428 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60047 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154370 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48821 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129370 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58514 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20337 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57892 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58128 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57955 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->