### PR TITLE
[cleanup] Remove RenderInline::updateHitTestResult and absoluteQuadsForSelection overrides that just duplicate the RenderObject base implementations

### DIFF
--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -239,14 +239,6 @@ void RenderInline::absoluteQuads(Vector<FloatQuad>& quads, bool*) const
     generateLineBoxRects(context);
 }
 
-#if PLATFORM(IOS_FAMILY)
-void RenderInline::absoluteQuadsForSelection(Vector<FloatQuad>& quads) const
-{
-    AbsoluteQuadsGeneratorContext context(this, quads);
-    generateLineBoxRects(context);
-}
-#endif
-
 LayoutUnit RenderInline::offsetLeft() const
 {
     return adjustedPositionRelativeToOffsetParent(firstInlineBoxTopLeft()).x();
@@ -679,21 +671,6 @@ const RenderElement* RenderInline::pushMappingToContainer(const RenderLayerModel
     pushOntoGeometryMap(geometryMap, ancestorToStopAt, container, ancestorSkipped);
 
     return ancestorSkipped ? ancestorToStopAt : container;
-}
-
-void RenderInline::updateHitTestResult(HitTestResult& result, const LayoutPoint& point) const
-{
-    if (result.innerNode())
-        return;
-
-    LayoutPoint localPoint(point);
-    if (RefPtr node = nodeForHitTest()) {
-        result.setInnerNode(node.get());
-        if (!result.innerNonSharedNode())
-            result.setInnerNonSharedNode(node.get());
-        result.setPseudoElementIdentifier(style().pseudoElementIdentifier());
-        result.setLocalPoint(localPoint);
-    }
 }
 
 void RenderInline::deleteLegacyLineBoxes()

--- a/Source/WebCore/rendering/RenderInline.h
+++ b/Source/WebCore/rendering/RenderInline.h
@@ -77,10 +77,6 @@ public:
     LegacyInlineFlowBox* firstLegacyInlineBox() const LIFETIME_BOUND { return m_legacyLineBoxes.firstLegacyLineBox(); }
     LegacyInlineFlowBox* lastLegacyInlineBox() const LIFETIME_BOUND { return m_legacyLineBoxes.lastLegacyLineBox(); }
 
-#if PLATFORM(IOS_FAMILY)
-    void absoluteQuadsForSelection(Vector<FloatQuad>& quads) const override;
-#endif
-    
     LayoutSize offsetForInFlowPositionedInline(const RenderBox* child) const;
 
     void collectLineBoxRects(Vector<LayoutRect>&, const LayoutPoint& additionalOffset) const;
@@ -136,8 +132,6 @@ private:
     virtual std::unique_ptr<LegacyInlineFlowBox> createInlineFlowBox(); // Subclassed by RenderSVGInline
 
     void dirtyLineFromChangedChild() final { m_legacyLineBoxes.dirtyLineFromChangedChild(*this); }
-
-    void updateHitTestResult(HitTestResult&, const LayoutPoint&) const final;
 
     void imageChanged(WrappedImagePtr, const IntRect* = 0) final;
 

--- a/Source/WebCore/rendering/svg/RenderSVGInline.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.cpp
@@ -160,6 +160,14 @@ void RenderSVGInline::absoluteQuads(Vector<FloatQuad>& quads, bool* wasFixed) co
         quads.append(localToAbsoluteQuad(FloatRect(textBoundingBox.x() + box->x(), textBoundingBox.y() + box->y(), box->logicalWidth(), box->logicalHeight()), MapCoordinatesMode::UseTransforms, wasFixed));
 }
 
+#if PLATFORM(IOS_FAMILY)
+void RenderSVGInline::absoluteQuadsForSelection(Vector<FloatQuad>& quads) const
+{
+    // Unlike absoluteQuads(), selection geometry is built from the line box rects even with the legacy SVG engine.
+    RenderInline::absoluteQuads(quads, nullptr);
+}
+#endif
+
 void RenderSVGInline::willBeDestroyed()
 {
     if (document().settings().layerBasedSVGEngineEnabled()) {

--- a/Source/WebCore/rendering/svg/RenderSVGInline.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.h
@@ -70,6 +70,9 @@ private:
     void mapLocalToContainer(const RenderLayerModelObject* ancestorContainer, TransformState&, OptionSet<MapCoordinatesMode>, bool* wasFixed) const final;
     const RenderElement* pushMappingToContainer(const RenderLayerModelObject* ancestorToStopAt, RenderGeometryMap&) const final;
     void absoluteQuads(Vector<FloatQuad>&, bool* wasFixed) const final;
+#if PLATFORM(IOS_FAMILY)
+    void absoluteQuadsForSelection(Vector<FloatQuad>&) const final;
+#endif
 
     std::unique_ptr<LegacyInlineFlowBox> createInlineFlowBox() final;
 


### PR DESCRIPTION
#### 74d2c656225a333c9649a4a4a2311b190d9676e0
<pre>
[cleanup] Remove RenderInline::updateHitTestResult and absoluteQuadsForSelection overrides that just duplicate the RenderObject base implementations
<a href="https://bugs.webkit.org/show_bug.cgi?id=323664">https://bugs.webkit.org/show_bug.cgi?id=323664</a>
&lt;<a href="https://rdar.apple.com/problem/186916510">rdar://problem/186916510</a>&gt;

Reviewed by Antti Koivisto.

1. Both RenderInline::updateHitTestResult and RenderInline::absoluteQuadsForSelection look the same as their RenderObject pairs. &lt;- remove them.

2. RenderSVGInline overrides absoluteQuads with a legacy SVG engine specific implementation.
Move the override into RenderSVGInline, where it keeps returning the line box rects, and remove it from RenderInline.

No change in behavior.

* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::absoluteQuadsForSelection): Deleted.
(WebCore::RenderInline::updateHitTestResult): Deleted.
* Source/WebCore/rendering/RenderInline.h:
* Source/WebCore/rendering/svg/RenderSVGInline.cpp:
(WebCore::RenderSVGInline::absoluteQuadsForSelection):
* Source/WebCore/rendering/svg/RenderSVGInline.h:

Canonical link: <a href="https://commits.webkit.org/320723@main">https://commits.webkit.org/320723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/497a9d24731a6811e0d5cfbac5df6c61534a38dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195952 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150355 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7bdd7b11-69e1-4fb1-89f7-def0fd9e7694) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145063 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100575 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48749 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125358 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2152592a-717c-4727-91f0-ee1f8b475fa7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47475 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45521 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157835 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45211 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7012 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52188 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197912 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59211 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154601 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41421 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59919 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154254 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48717 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132261 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129173 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58389 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20233 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57765 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58005 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57830 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->