### PR TITLE
Avoid mach port refcount churn when copying ProcessIdentity

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCreateImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCreateImpl.cpp
@@ -57,9 +57,9 @@ RefPtr<GPU> create(ScheduleWorkFunction&& scheduleWorkFunction, const WebCore::P
         .cocoaDescriptor = WGPUInstanceCocoaDescriptor {
             .scheduleWorkBlock = scheduleWorkBlock.get(),
 #if HAVE(TASK_IDENTITY_TOKEN)
-            .webProcessResourceOwner = webProcessIdentity ? &webProcessIdentity->taskId() : nullptr,
+            .webProcessResourceOwner = webProcessIdentity ? webProcessIdentity->taskIdToken() : MACH_PORT_NULL,
 #else
-            .webProcessResourceOwner = nullptr,
+            .webProcessResourceOwner = MACH_PORT_NULL,
 #endif
         }
     };

--- a/Source/WebCore/platform/ProcessIdentity.cpp
+++ b/Source/WebCore/platform/ProcessIdentity.cpp
@@ -40,7 +40,7 @@ ProcessIdentity::ProcessIdentity(CurrentProcessTag)
     task_id_token_t identityToken;
     kern_return_t kr = task_create_identity_token(mach_task_self(), &identityToken);
     if (kr == KERN_SUCCESS)
-        m_taskIdToken = MachSendRight::adopt(identityToken);
+        m_taskIdToken = Box<MachSendRight>::create(MachSendRight::adopt(identityToken));
     else
         RELEASE_LOG_ERROR(Process, "task_create_identity_token() failed: %{private}s (%x)", mach_error_string(kr), kr);
 #endif
@@ -57,18 +57,10 @@ ProcessIdentity::operator bool() const
 
 #if HAVE(TASK_IDENTITY_TOKEN)
 ProcessIdentity::ProcessIdentity(MachSendRight&& taskIdToken)
-    : m_taskIdToken(WTF::move(taskIdToken))
 {
+    if (taskIdToken)
+        m_taskIdToken = Box<MachSendRight>::create(WTF::move(taskIdToken));
 }
 #endif
-
-ProcessIdentity& ProcessIdentity::operator=(const ProcessIdentity& other)
-{
-#if HAVE(TASK_IDENTITY_TOKEN)
-    m_taskIdToken = MachSendRight { other.m_taskIdToken };
-#endif
-    UNUSED_PARAM(other);
-    return *this;
-}
 
 }

--- a/Source/WebCore/platform/ProcessIdentity.h
+++ b/Source/WebCore/platform/ProcessIdentity.h
@@ -29,6 +29,7 @@
 
 #if HAVE(TASK_IDENTITY_TOKEN)
 #include <wtf/ArgumentCoder.h>
+#include <wtf/Box.h>
 #include <wtf/MachSendRight.h>
 #else
 #endif
@@ -47,23 +48,33 @@ public:
 
     // Creates an empty process identity that does not grant any access.
     ProcessIdentity() = default;
-    WEBCORE_EXPORT ProcessIdentity(const ProcessIdentity&) = default;
+    ProcessIdentity(const ProcessIdentity&) = default;
+    ProcessIdentity(ProcessIdentity&&) = default;
 
     // Returns true for a process identity or false on empty identity.
     WEBCORE_EXPORT operator bool() const;
 
-    WEBCORE_EXPORT ProcessIdentity& operator=(const ProcessIdentity&);
+    // Two identities are equal when they grant access to the same process.
+#if HAVE(TASK_IDENTITY_TOKEN)
+    bool operator==(const ProcessIdentity& other) const { return taskIdToken() == other.taskIdToken(); }
+#else
+    bool operator==(const ProcessIdentity&) const { return true; }
+#endif
+
+    ProcessIdentity& operator=(const ProcessIdentity&) = default;
+    ProcessIdentity& operator=(ProcessIdentity&&) = default;
 
 #if HAVE(TASK_IDENTITY_TOKEN)
-    task_id_token_t taskIdToken() const { return m_taskIdToken.sendRight(); }
-    const MachSendRight& taskId() const LIFETIME_BOUND { return m_taskIdToken; }
+    task_id_token_t taskIdToken() const { return m_taskIdToken ? m_taskIdToken->sendRight() : MACH_PORT_NULL; }
 #endif
 
 private:
 #if HAVE(TASK_IDENTITY_TOKEN)
     friend struct IPC::ArgumentCoder<ProcessIdentity>;
-    WEBCORE_EXPORT ProcessIdentity(MachSendRight&& taskIdToken);
-    MachSendRight m_taskIdToken;
+    WEBCORE_EXPORT explicit ProcessIdentity(MachSendRight&& taskIdToken);
+    MachSendRight copyTaskIdSendRight() const { return m_taskIdToken ? MachSendRight { *m_taskIdToken } : MachSendRight { }; }
+
+    Box<MachSendRight> m_taskIdToken;
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -863,6 +863,8 @@ void IOSurface::convertToFormat(IOSurfacePool* pool, std::unique_ptr<IOSurface>&
 void IOSurface::setOwnershipIdentity(const ProcessIdentity& resourceOwner)
 {
     ASSERT(resourceOwner);
+    if (resourceOwner == m_resourceOwner)
+        return;
     m_resourceOwner = resourceOwner;
     setOwnershipIdentity(m_surface.get(), resourceOwner);
 }

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -516,10 +516,8 @@ Device::ExternalTextureData Device::createExternalTextureFromPixelBuffer(CVPixel
         return { mtlTextures[0], mtlTextures[1], simd::float3x2(1.f), colorSpaceConversionMatrix };
     }
 
-    if (auto optionalWebProcessID = webProcessID()) {
-        if (auto webProcessID = optionalWebProcessID->sendRight())
-            IOSurfaceSetOwnershipIdentity(ioSurface, webProcessID, kIOSurfaceMemoryLedgerTagGraphics, 0);
-    }
+    if (auto webProcessID = this->webProcessID())
+        IOSurfaceSetOwnershipIdentity(ioSurface, webProcessID, kIOSurfaceMemoryLedgerTagGraphics, 0);
 
     id<MTLTexture> baseTexture = nil;
     id<MTLTexture> mtlTexture0 = nil;

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -220,7 +220,9 @@ public:
     RefPtr<XRSubImage> getXRViewSubImage(XRProjectionLayer&);
     RefPtr<XRSubImage> NODELETE getXRViewSubImage() const;
     id<MTLTexture> _Nullable getXRViewSubImageDepthTexture() const;
-    const std::optional<const MachSendRight> webProcessID() const;
+    // The task identity token of the process the resources should be attributed to,
+    // or MACH_PORT_NULL if the resources should not be attributed.
+    mach_port_t webProcessID() const;
 #if CPU(X86_64)
     bool isIntel() const { return [m_device.name localizedCaseInsensitiveContainsString:@"intel"]; }
 #else

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -442,13 +442,8 @@ static void setOwnerWithIdentity(id<MTLResourceSPI> resource, auto webProcessID)
 
 void Device::setOwnerWithIdentity(id<MTLResource> resource) const
 {
-    if (auto optionalWebProcessID = webProcessID()) {
-        auto webProcessID = optionalWebProcessID->sendRight();
-        if (!webProcessID)
-            return;
-
+    if (auto webProcessID = this->webProcessID())
         WebGPU::setOwnerWithIdentity((id<MTLResourceSPI>)resource, webProcessID);
-    }
 }
 
 void Device::destroy()
@@ -657,10 +652,10 @@ void Device::setLabel(String&&)
     // Because MTLDevices are process-global, we can't set the label on it, because 2 contexts' labels would fight each other.
 }
 
-const std::optional<const MachSendRight> Device::webProcessID() const
+mach_port_t Device::webProcessID() const
 {
     auto scheduler = instance();
-    return scheduler ? scheduler->webProcessID() : std::nullopt;
+    return scheduler ? scheduler->webProcessID().sendRight() : MACH_PORT_NULL;
 }
 
 id<MTLBuffer> Device::dispatchCallBuffer()

--- a/Source/WebGPU/WebGPU/ExternalTexture.mm
+++ b/Source/WebGPU/WebGPU/ExternalTexture.mm
@@ -103,10 +103,8 @@ void ExternalTexture::update(CVPixelBufferRef pixelBuffer)
 {
 #if HAVE(IOSURFACE_SET_OWNERSHIP_IDENTITY) && HAVE(TASK_IDENTITY_TOKEN)
     if (RetainPtr ioSurface = CVPixelBufferGetIOSurface(pixelBuffer)) {
-        if (auto optionalWebProcessID = protect(m_device)->webProcessID()) {
-            if (auto webProcessID = optionalWebProcessID->sendRight())
-                IOSurfaceSetOwnershipIdentity(ioSurface.get(), webProcessID, kIOSurfaceMemoryLedgerTagGraphics, 0);
-        }
+        if (auto webProcessID = protect(m_device)->webProcessID())
+            IOSurfaceSetOwnershipIdentity(ioSurface.get(), webProcessID, kIOSurfaceMemoryLedgerTagGraphics, 0);
     }
 #endif
     m_pixelBuffer = pixelBuffer;

--- a/Source/WebGPU/WebGPU/Instance.h
+++ b/Source/WebGPU/WebGPU/Instance.h
@@ -77,11 +77,11 @@ public:
     // This can be called on a background thread.
     using WorkItem = Function<void()>;
     void scheduleWork(WorkItem&&);
-    const std::optional<const MachSendRight>& NODELETE webProcessID() const;
+    const MachSendRight& NODELETE webProcessID() const;
     id<MTLDevice> device() const;
 
 private:
-    Instance(WGPUScheduleWorkBlock, const WTF::MachSendRight* webProcessResourceOwner);
+    Instance(WGPUScheduleWorkBlock, WTF::MachSendRight webProcessResourceOwner);
     explicit Instance();
 
     // This can be called on a background thread.
@@ -91,7 +91,7 @@ private:
     Deque<WGPUWorkItem> m_pendingWork WTF_GUARDED_BY_LOCK(m_lock);
     using CommandBufferContainer = Vector<WeakObjCPtr<id<MTLCommandBuffer>>>;
     HashMap<Ref<Device>, CommandBufferContainer> retainedDeviceInstances WTF_GUARDED_BY_LOCK(m_lock);
-    const std::optional<const MachSendRight> m_webProcessID;
+    const MachSendRight m_webProcessID;
     const WGPUScheduleWorkBlock m_scheduleWorkBlock;
     Lock m_lock;
     bool m_isValid { true };

--- a/Source/WebGPU/WebGPU/Instance.mm
+++ b/Source/WebGPU/WebGPU/Instance.mm
@@ -57,11 +57,11 @@ Ref<Instance> Instance::create(const WGPUInstanceDescriptor& descriptor)
 {
     const WGPUInstanceCocoaDescriptor& cocoaDescriptor = descriptor.cocoaDescriptor;
 
-    return adoptRef(*new Instance(cocoaDescriptor.scheduleWorkBlock, reinterpret_cast<const WTF::MachSendRight*>(cocoaDescriptor.webProcessResourceOwner)));
+    return adoptRef(*new Instance(cocoaDescriptor.scheduleWorkBlock, MachSendRight::create(cocoaDescriptor.webProcessResourceOwner)));
 }
 
-Instance::Instance(WGPUScheduleWorkBlock scheduleWorkBlock, const MachSendRight* webProcessResourceOwner)
-    : m_webProcessID(webProcessResourceOwner ? std::optional<MachSendRight>(*webProcessResourceOwner) : std::nullopt)
+Instance::Instance(WGPUScheduleWorkBlock scheduleWorkBlock, MachSendRight webProcessResourceOwner)
+    : m_webProcessID(WTF::move(webProcessResourceOwner))
     , m_scheduleWorkBlock(scheduleWorkBlock ? WTF::move(scheduleWorkBlock) : ^(WGPUWorkItem workItem) { defaultScheduleWork(WTF::move(workItem)); })
 {
 }
@@ -84,7 +84,7 @@ void Instance::scheduleWork(WorkItem&& workItem)
     m_scheduleWorkBlock(makeBlockPtr(WTF::move(workItem)).get());
 }
 
-const std::optional<const MachSendRight>& Instance::webProcessID() const
+const MachSendRight& Instance::webProcessID() const
 {
     return m_webProcessID;
 }

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
@@ -82,9 +82,7 @@ private:
     Deque<Ref<Texture>> m_inFlightFrames;
     size_t m_maximumInFlightFrames { 0 };
     Seconds m_lastDrainedFrameGPUCost { 0_s };
-#if HAVE(IOSURFACE_SET_OWNERSHIP_IDENTITY) && HAVE(TASK_IDENTITY_TOKEN)
-    std::optional<const MachSendRight> m_webProcessID;
-#endif
+    const MachSendRight m_webProcessID;
     WGPUColorSpace m_colorSpace { WGPUColorSpace::SRGB };
     WGPUToneMappingMode m_toneMappingMode { WGPUToneMappingMode_Standard };
     WGPUCompositeAlphaMode m_alphaMode { WGPUCompositeAlphaMode_Premultiplied };

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -53,13 +53,8 @@ Ref<PresentationContextIOSurface> PresentationContextIOSurface::create(const WGP
 }
 
 PresentationContextIOSurface::PresentationContextIOSurface(const WGPUSurfaceDescriptor&, const Instance& instance)
-#if HAVE(IOSURFACE_SET_OWNERSHIP_IDENTITY) && HAVE(TASK_IDENTITY_TOKEN)
     : m_webProcessID(instance.webProcessID())
-#endif
 {
-#if !(HAVE(IOSURFACE_SET_OWNERSHIP_IDENTITY) && HAVE(TASK_IDENTITY_TOKEN))
-    UNUSED_PARAM(instance);
-#endif
 }
 
 PresentationContextIOSurface::~PresentationContextIOSurface() = default;
@@ -69,12 +64,9 @@ void PresentationContextIOSurface::renderBuffersWereRecreated(NSArray<IOSurface 
     m_existingRenderBuffers = WTF::move(m_renderBuffers);
     m_ioSurfaces = ioSurfaces;
 #if HAVE(IOSURFACE_SET_OWNERSHIP_IDENTITY) && HAVE(TASK_IDENTITY_TOKEN)
-    if (m_webProcessID) {
-        mach_port_t webProcessID = m_webProcessID->sendRight();
-        if (webProcessID) {
-            for (IOSurface *surface in ioSurfaces)
-                IOSurfaceSetOwnershipIdentity(bridge_cast(surface), webProcessID, kIOSurfaceMemoryLedgerTagGraphics, 0);
-        }
+    if (auto webProcessID = m_webProcessID.sendRight()) {
+        for (IOSurface *surface in ioSurfaces)
+            IOSurfaceSetOwnershipIdentity(bridge_cast(surface), webProcessID, kIOSurfaceMemoryLedgerTagGraphics, 0);
     }
 #endif
     m_renderBuffers.clear();

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -38,6 +38,7 @@
 #endif
 
 #include <CoreFoundation/CoreFoundation.h>
+#include <mach/port.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnullability-completeness"
@@ -912,7 +913,8 @@ typedef struct WGPUInstanceCocoaDescriptor {
     // It's fine to pass NULL here, but if you do, you must periodically call
     // wgpuInstanceProcessEvents() to synchronously run the queued callbacks.
     __unsafe_unretained WGPUScheduleWorkBlock scheduleWorkBlock;
-    const void* webProcessResourceOwner;
+    // task_id_token_t if supported.
+    mach_port_t webProcessResourceOwner;
 } WGPUInstanceCocoaDescriptor;
 
 typedef struct WGPUInstanceDescriptor {

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -336,7 +336,7 @@
     [Legacy] StructureParam WebKit::CoreIPCCVPixelBufferRef.m_sendRight
     [Legacy] StructureParam WebCore::GraphicsContextGLExternalImageSourceIOSurfaceHandle.handle
     [Legacy] StructureParam WebCore::GraphicsContextGLExternalImageSourceMTLSharedTextureHandle.handle
-    [Legacy] StructureParam WebCore::ProcessIdentity.m_taskIdToken
+    [Legacy] StructureParam WebCore::ProcessIdentity.copyTaskIdSendRight()
     [Legacy] StructureParam WebCore::SharedMemoryHandle.m_handle
     [Legacy] StructureParam WTF::MachSendRightAnnotated.sendRight
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3284,7 +3284,7 @@ header: <WebCore/ImageBuffer.h>
 
 [RValue] class WebCore::ProcessIdentity {
 #if HAVE(TASK_IDENTITY_TOKEN)
-    MachSendRight m_taskIdToken;
+    MachSendRight copyTaskIdSendRight();
 #endif
 };
 


### PR DESCRIPTION
#### f8c29b6b6c9342c101102463a496ea95c245d921
<pre>
Avoid mach port refcount churn when copying ProcessIdentity
<a href="https://bugs.webkit.org/show_bug.cgi?id=323668">https://bugs.webkit.org/show_bug.cgi?id=323668</a>
<a href="https://rdar.apple.com/186917888">rdar://186917888</a>

Reviewed by NOBODY (OOPS!).

Avoid calling into kernel when passing ProcessIdentity instances around.
Instead of passing MachSendRights, pass Box&lt;MachSendRight&gt;s.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCreateImpl.cpp:
(WebCore::WebGPU::create):
* Source/WebCore/platform/ProcessIdentity.cpp:
(WebCore::ProcessIdentity::ProcessIdentity):
(WebCore::ProcessIdentity::operator=): Deleted.
* Source/WebCore/platform/ProcessIdentity.h:
(WebCore::ProcessIdentity::operator== const):
(WebCore::ProcessIdentity::taskIdToken const):
(WebCore::ProcessIdentity::copyTaskIdSendRight const):
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::setOwnershipIdentity):
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createExternalTextureFromPixelBuffer const):
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::setOwnerWithIdentity const):
(WebGPU::Device::webProcessID const):
* Source/WebGPU/WebGPU/ExternalTexture.mm:
(WebGPU::ExternalTexture::update):
* Source/WebGPU/WebGPU/Instance.h:
* Source/WebGPU/WebGPU/Instance.mm:
(WebGPU::Instance::create):
(WebGPU::Instance::Instance):
(WebGPU::Instance::webProcessID const):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.h:
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::PresentationContextIOSurface):
(WebGPU::PresentationContextIOSurface::renderBuffersWereRecreated):
* Source/WebGPU/WebGPU/WebGPU.h:
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8c29b6b6c9342c101102463a496ea95c245d921

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195850 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150281 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/144987 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100522 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188482 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165573 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125279 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/184855 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47389 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45449 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157756 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45145 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6901 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197800 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59102 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154515 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59811 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41750 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154162 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48632 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132163 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129062 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58287 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20167 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57660 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57903 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57726 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->