### PR TITLE
[Site Isolation] Cross-origin iframe is not always rendering after back navigation

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -550,7 +550,27 @@ void RemoteLayerTreeDrawingArea::dispatchAfterEnsuringDrawing(IPC::AsyncReplyID 
 
 void RemoteLayerTreeDrawingArea::adoptLayersFromDrawingArea(DrawingArea& oldDrawingArea)
 {
-    m_remoteLayerTreeContext->adoptLayersFromContext(downcast<RemoteLayerTreeDrawingArea>(oldDrawingArea).m_remoteLayerTreeContext);
+    auto& oldRemoteDrawingArea = downcast<RemoteLayerTreeDrawingArea>(oldDrawingArea);
+    m_remoteLayerTreeContext->adoptLayersFromContext(oldRemoteDrawingArea.m_remoteLayerTreeContext);
+    bool adopted = false;
+    for (auto& oldRootLayer : oldRemoteDrawingArea.m_rootLayers) {
+        if (!oldRootLayer.contentLayer && !oldRootLayer.viewOverlayRootLayer)
+            continue;
+        if (auto* rootLayerInfo = rootLayerInfoWithFrameIdentifier(oldRootLayer.frameID)) {
+            if (!rootLayerInfo->contentLayer && oldRootLayer.contentLayer) {
+                rootLayerInfo->contentLayer = WTF::move(oldRootLayer.contentLayer);
+                adopted = true;
+            }
+            if (!rootLayerInfo->viewOverlayRootLayer && oldRootLayer.viewOverlayRootLayer) {
+                rootLayerInfo->viewOverlayRootLayer = WTF::move(oldRootLayer.viewOverlayRootLayer);
+                adopted = true;
+            }
+        }
+    }
+    if (adopted) {
+        updateRootLayers();
+        triggerRenderingUpdate();
+    }
 }
 
 void RemoteLayerTreeDrawingArea::scheduleRenderingUpdateTimerFired()


### PR DESCRIPTION
#### 3cae5684ef3c2eb8933b65f54e35e50920a59d4b
<pre>
[Site Isolation] Cross-origin iframe is not always rendering after back navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=323674">https://bugs.webkit.org/show_bug.cgi?id=323674</a>
<a href="https://rdar.apple.com/186921540">rdar://186921540</a>

Reviewed by NOBODY (OOPS!).

When WebPageProxy::swapToProvisionalPage is called during a back navigation, we will create
a new drawing area by calling setDrawingArea in the UI process. In the WebConten process, we
should transfer graphics layers from the previous drawing area to the new drawing area, since
these may have been set after WebPage::restoreWithFrameItem was called in the WebContent
process, but before a new drawing area was set.

No new tests, covered by SiteIsolation.MultiProcessBFCacheIframeRendersAfterBackNavigation.

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::adoptLayersFromDrawingArea):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cae5684ef3c2eb8933b65f54e35e50920a59d4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195866 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/81fb0673-e22c-43c0-9c9a-86ddafd5f876) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59181 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/144995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/95785427-5e22-4472-aaf0-15e768d56ae9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48674 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125287 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/588caa43-e84c-42de-9a0a-d73b464be45d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47401 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45144 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6918 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52108 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197817 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59118 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59827 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154176 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48641 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129078 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58302 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20166 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57676 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57918 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57742 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->