### PR TITLE
[JSC] Check ArrayBuffer grow/resize length before converting to size_t

### DIFF
--- a/JSTests/stress/arraybuffer-grow-resize-huge-length.js
+++ b/JSTests/stress/arraybuffer-grow-resize-huge-length.js
@@ -1,0 +1,36 @@
+function shouldThrowRangeError(func)
+{
+    var threw = false;
+    try {
+        func();
+    } catch (error) {
+        threw = true;
+        if (!(error instanceof RangeError))
+            throw new Error("expected RangeError, got " + error);
+    }
+    if (!threw)
+        throw new Error("did not throw");
+}
+
+{
+    let buffer = new ArrayBuffer(8, { maxByteLength: 16 });
+    shouldThrowRangeError(() => buffer.resize(1e20));
+    shouldThrowRangeError(() => buffer.resize(Infinity));
+    shouldThrowRangeError(() => buffer.resize(-1));
+    let detached = new ArrayBuffer(8, { maxByteLength: 16 });
+    detached.transfer();
+    shouldThrowRangeError(() => detached.resize(-1));
+    buffer.resize(16);
+    if (buffer.byteLength !== 16)
+        throw new Error("resize to 16 failed");
+}
+
+{
+    let buffer = new SharedArrayBuffer(8, { maxByteLength: 16 });
+    shouldThrowRangeError(() => buffer.grow(1e20));
+    shouldThrowRangeError(() => buffer.grow(Infinity));
+    shouldThrowRangeError(() => buffer.grow(-1));
+    buffer.grow(16);
+    if (buffer.byteLength !== 16)
+        throw new Error("grow to 16 failed");
+}

--- a/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
@@ -288,15 +288,11 @@ JSC_DEFINE_HOST_FUNCTION(arrayBufferProtoFuncResize, (JSGlobalObject* globalObje
     if (!thisObject->impl()->isResizableOrGrowableShared()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "ArrayBuffer is not resizable"_s);
 
-    double newLength = callFrame->argument(0).toIntegerOrInfinity(globalObject);
+    uint64_t newByteLength = callFrame->argument(0).toIndex(globalObject, "newLength"_s);
     RETURN_IF_EXCEPTION(scope, { });
 
     if (thisObject->impl()->isDetached()) [[unlikely]]
         return throwVMTypeError(globalObject, scope, "Receiver is detached"_s);
-
-    if (!std::isfinite(newLength) || newLength < 0)
-        return throwVMRangeError(globalObject, scope, "new length is out of range"_s);
-    size_t newByteLength = static_cast<size_t>(newLength);
 
 #if ENABLE(WEBASSEMBLY)
     // Wasm JS API redefines the abstract operation HostResizeArrayBuffer as follows:
@@ -503,12 +499,9 @@ JSC_DEFINE_HOST_FUNCTION(sharedArrayBufferProtoFuncGrow, (JSGlobalObject* global
     if (!thisObject->impl()->isResizableOrGrowableShared())
         return throwVMTypeError(globalObject, scope, "SharedArrayBuffer is not growable"_s);
 
-    double newLength = callFrame->argument(0).toIntegerOrInfinity(globalObject);
+    uint64_t newByteLength = callFrame->argument(0).toIndex(globalObject, "newLength"_s);
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (!std::isfinite(newLength) || newLength < 0)
-        return throwVMRangeError(globalObject, scope, "new length is out of range"_s);
-    size_t newByteLength = static_cast<size_t>(newLength);
     if (!thisObject->impl()->grow(vm, newByteLength))
         return throwVMRangeError(globalObject, scope, makeString("grow failed with new byte length "_s, newByteLength));
 


### PR DESCRIPTION
#### 223bd0faeeb84888c1553f315d35408758143ba3
<pre>
[JSC] Check ArrayBuffer grow/resize length before converting to size_t
<a href="https://bugs.webkit.org/show_bug.cgi?id=323440">https://bugs.webkit.org/show_bug.cgi?id=323440</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=323441">https://bugs.webkit.org/show_bug.cgi?id=323441</a>

Reviewed by Yusuke Suzuki.

grow and resize used ToIntegerOrInfinity and then cast to size_t after
only checking finite and non-negative. A value such as 1e20 is in range
for double but not for size_t.

Use toIndex so the result is uint64_t and a negative length throws
RangeError before the detached check.

* JSTests/stress/arraybuffer-grow-resize-huge-length.js: Added.
* Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp:
(arrayBufferProtoFuncResize):
(sharedArrayBufferProtoFuncGrow):

Canonical link: <a href="https://commits.webkit.org/320821@main">https://commits.webkit.org/320821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbdeb2648263b2ed2d592b06bbbcb8d9d582ec20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195908 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150323 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145036 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100552 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125331 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47443 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45495 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7228 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14112 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157807 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45180 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6963 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46842 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49896 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197863 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59163 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154569 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41486 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59871 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41785 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154220 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48684 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132220 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129124 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58342 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20202 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57719 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57959 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->