### PR TITLE
[webkitscmpy] Two revert requests with the same reason but different commits posted the same PR with only the description updated

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -50,7 +50,7 @@ except ImportError:
         "See https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/libraries/webkitcorepy"
     )
 
-version = Version(7, 0, 5)
+version = Version(7, 0, 6)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('markupsafe', Version(3, 0, 3), pypi_name='MarkupSafe', wheel=True))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
@@ -36,6 +36,8 @@ class Branch(Command):
     help = 'Create a local development branch from the current checkout state'
 
     PR_PREFIX = 'eng'
+    MAX_BRANCH_NAME_LENGTH = 200
+    MINIMUM_TITLE_MATCH = 8
 
     @classmethod
     def parser(cls, parser, loggers=None):
@@ -89,6 +91,51 @@ class Branch(Command):
     @classmethod
     def to_branch_name(cls, value):
         return string_utils.encode(re.sub(r'\W+', '-', string_utils.decode(value)).strip('-'), target_type=str)
+
+    @classmethod
+    def truncate_branch_name(cls, name, limit=None):
+        limit = limit or cls.MAX_BRANCH_NAME_LENGTH
+        if not name or len(name) <= limit:
+            return name
+        truncated = name[:limit]
+        if '-' in truncated:
+            truncated = truncated[:truncated.rindex('-')]
+        return truncated.rstrip('-')
+
+    @classmethod
+    def branch_matches_issue(cls, repository, branch, issue):
+        """Check if a development branch was created to track a specific issue.
+
+        Branch names may prefix the issue's title with additional context (such as the commits a
+        revert reverts) and may be truncated, so an exact match on the title is not required.
+        """
+        if not branch or not issue:
+            return False
+
+        associated = repository.config().get('branch.{}.bug'.format(branch))
+        if associated:
+            for url in Commit.bug_urls(issue):
+                if url and url in associated:
+                    return True
+
+        candidate = branch.split('/')[-1]
+        if candidate == str(issue.id) or candidate.endswith('-{}'.format(issue.id)):
+            return True
+
+        if not issue.title:
+            return False
+        title = cls.to_branch_name(issue.title)
+        if candidate == title or candidate.endswith('-{}'.format(title)):
+            return True
+
+        components = candidate.split('-')
+        for index in range(len(components)):
+            suffix = '-'.join(components[index:])
+            if len(suffix) < cls.MINIMUM_TITLE_MATCH:
+                break
+            if title.startswith(suffix):
+                return True
+        return False
 
     @classmethod
     def cc_radar(cls, args, repository, issue, rdar=None):
@@ -201,7 +248,7 @@ class Branch(Command):
         return issue, 0
 
     @classmethod
-    def main(cls, args, repository, why=None, redact=False, target_remote='fork', **kwargs):
+    def main(cls, args, repository, why=None, redact=False, target_remote='fork', name_prefix=None, **kwargs):
         if not isinstance(repository, local.Git):
             sys.stderr.write("Can only 'branch' on a native Git repository\n")
             return 1
@@ -214,7 +261,11 @@ class Branch(Command):
             # Support creating a branch from PR or revert when update_issue is False
             args.issue = cls.to_branch_name(args.issue)
 
-        args.issue = cls.normalize_branch_name(args.issue)
+        if name_prefix and not (repository or local.Scm).DEV_BRANCHES.match(args.issue):
+            prefixed = '{}-{}'.format(name_prefix, args.issue).strip('-')
+            args.issue = cls.truncate_branch_name(cls.normalize_branch_name(prefixed))
+        else:
+            args.issue = cls.normalize_branch_name(args.issue)
 
         if run([repository.executable(), 'check-ref-format', args.issue], capture_output=True).returncode:
             sys.stderr.write("'{}' is an invalid branch name, cannot create it\n".format(args.issue))
@@ -241,6 +292,7 @@ class Branch(Command):
                 log.warning("Rebasing existing branch '{}' instead of creating a new one".format(args.issue))
                 if run([repository.executable(), 'rebase', 'HEAD', args.issue, '--autostash'], cwd=repository.root_path).returncode:
                     return 1
+                repository._branch = args.issue  # Assign the cache because of repository.branch's caching
                 print("Rebased the local development branch '{}'".format(args.issue))
                 return 0
             else:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -73,6 +73,13 @@ class PullRequest(Command):
             help='Do not prompt the user for defaults, always use (or do not use) them',
         )
         parser.add_argument(
+            '--reopen-closed', '--no-reopen-closed',
+            dest='reopen_closed', default=None,
+            help='Re-use and re-open (or never re-use) an existing closed pull-request associated with the current branch. '
+                 'Without this argument, non-interactive runs always create a new pull-request.',
+            action=arguments.NoAction,
+        )
+        parser.add_argument(
             '--overwrite', '--amend', action='store_const', const='overwrite',
             dest='technique', default=None,
             help='When creating a pull request, overwrite the existing commit by default',
@@ -239,7 +246,7 @@ class PullRequest(Command):
         return True
 
     @classmethod
-    def pull_request_branch_point(cls, repository, args, **kwargs):
+    def pull_request_branch_point(cls, repository, args, name_prefix=None, **kwargs):
         if args.redact and len(repository.source_remotes()) <= 1:
             sys.stderr.write('No secure remotes found in the current checkout\n')
             return None
@@ -295,6 +302,7 @@ class PullRequest(Command):
                 why="'{}' is not a pull request branch".format(repository.branch),
                 redact=source_remote != repository.default_remote,
                 target_remote='fork' if source_remote == repository.default_remote else '{}-fork'.format(source_remote),
+                name_prefix=name_prefix,
                 **kwargs
             ):
                 sys.stderr.write("Abandoning pushing pull-request because '{}' could not be created\n".format(args.issue))
@@ -313,7 +321,7 @@ class PullRequest(Command):
             if not issue:
                 sys.stderr.write(error)
                 return None
-            if not repository.branch.endswith('/{}'.format(issue.id)) and not repository.branch.endswith('/{}'.format(Branch.to_branch_name(issue.title))):
+            if not Branch.branch_matches_issue(repository, repository.branch, issue):
                 sys.stderr.write(error)
                 return None
 
@@ -361,12 +369,32 @@ class PullRequest(Command):
             # GitHub's search apparently uses substring matching, so check for an exact match.
             if branch != pr.head:
                 continue
+            if existing_pr and existing_pr.opened and not pr.opened:
+                continue
             existing_pr = pr
             if not existing_pr.opened:
                 continue
             if user and existing_pr.author == user:
                 break
         return existing_pr
+
+    @classmethod
+    def will_reopen_closed_pull_request(cls, args, repository, existing_pr):
+        """Decide if a closed pull-request should be re-used (and re-opened) instead of creating a new one.
+
+        Non-interactive invocations never re-use a closed pull-request unless '--reopen-closed' is
+        explicitly passed, since a closed pull-request usually means the change it described is no
+        longer the change being pushed.
+        """
+        reopen_closed = getattr(args, 'reopen_closed', None)
+        if reopen_closed is not None:
+            return reopen_closed
+        if args.defaults is not None:
+            return False
+        return Terminal.choose(
+            "'{}' is already associated with '{}', which is closed.\nWould you like to create a new pull-request?".format(repository.branch, existing_pr),
+            default='No',
+        ) != 'Yes'
 
     @classmethod
     def pre_pr_checks(cls, repository, add_edits=True):
@@ -622,11 +650,7 @@ class PullRequest(Command):
             log.info("Checking if PR already exists...")
             existing_pr = cls.find_existing_pull_request(repository, remote_repo)
             log.info("PR #{} found.".format(existing_pr.number) if existing_pr else "PR not found.")
-            if existing_pr and not existing_pr.opened and not args.defaults and (
-                args.defaults is False or Terminal.choose(
-                    "'{}' is already associated with '{}', which is closed.\nWould you like to create a new pull-request?".format(repository.branch, existing_pr),
-                    default='No',
-            ) == 'Yes'):
+            if existing_pr and not existing_pr.opened and not cls.will_reopen_closed_pull_request(args, repository, existing_pr):
                 existing_pr = None
 
             if existing_pr and user and existing_pr.author != user and (args.defaults or Terminal.choose(

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
@@ -42,6 +42,8 @@ class Revert(Command):
     help = 'Revert provided list of commits and create a pull-request with this revert commit'
     REVERT_TITLE_TEMPLATE = 'Unreviewed, reverting {}'
     REVERT_TITLE_RE = re.compile(r'^Unreviewed, reverting {}'.format(Commit.IDENTIFIER_RE.pattern))
+    REVERT_BRANCH_PREFIX = 'revert'
+    MAX_REVERTED_IN_BRANCH_NAME = 3
 
     @classmethod
     def parser(cls, parser, loggers=None):
@@ -63,6 +65,18 @@ class Revert(Command):
             action=arguments.NoAction,
             help='Create a pull request (or do not) after reverting'
         )
+
+    @classmethod
+    def branch_name_prefix(cls, commit_objects):
+        """Branch name component identifying which commits a revert reverts.
+
+        Without it, two reverts sharing a reason would share a branch, and therefore a pull-request.
+        """
+        reverted = [Branch.to_branch_name(repr(commit)) for commit in commit_objects]
+        if len(reverted) > cls.MAX_REVERTED_IN_BRANCH_NAME:
+            remaining = len(reverted) - cls.MAX_REVERTED_IN_BRANCH_NAME
+            reverted = reverted[:cls.MAX_REVERTED_IN_BRANCH_NAME] + ['and-{}-more'.format(remaining)]
+        return '-'.join([cls.REVERT_BRANCH_PREFIX] + reverted)
 
     @classmethod
     def get_commit_info(cls, args, repository, **kwargs):
@@ -299,9 +313,14 @@ class Revert(Command):
         if not commit_identifiers:
             return 1
 
+        # A branch name with no spaces is assumed to be a branch name the user picked, leave it alone
+        name_prefix = None
+        if issue or not args.issue or ' ' in args.issue:
+            name_prefix = cls.branch_name_prefix(commit_objects)
+
         if not args.issue:
             args.issue = revert_reason
-        branch_point = PullRequest.pull_request_branch_point(repository, args, **kwargs)
+        branch_point = PullRequest.pull_request_branch_point(repository, args, name_prefix=name_prefix, **kwargs)
         if not branch_point:
             return 1
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
@@ -606,3 +606,66 @@ Created the local development branch 'eng/4'
                 }),
                 ['branch.eng/Example-feature-1.bug', 'branch.eng/Example-feature-1.title'],
             )
+
+    def test_truncate_branch_name_under_limit(self):
+        self.assertEqual('eng/short-name', program.Branch.truncate_branch_name('eng/short-name', limit=30))
+
+    def test_truncate_branch_name_at_limit(self):
+        self.assertEqual('eng/exactly-ten', program.Branch.truncate_branch_name('eng/exactly-ten', limit=len('eng/exactly-ten')))
+
+    def test_truncate_branch_name_over_limit(self):
+        self.assertEqual(
+            'eng/revert-5-main-a-reason',
+            program.Branch.truncate_branch_name('eng/revert-5-main-a-reason-that-is-much-too-long', limit=30),
+        )
+
+    def test_truncate_branch_name_without_separator(self):
+        self.assertEqual('a' * 10, program.Branch.truncate_branch_name('a' * 20, limit=10))
+
+    def test_truncate_branch_name_strips_trailing_separators(self):
+        self.assertEqual('eng/reason', program.Branch.truncate_branch_name('eng/reason-----tail', limit=16))
+
+    def test_truncate_branch_name_default_limit(self):
+        name = 'eng/{}'.format('a-' * 200)
+        self.assertEqual(program.Branch.MAX_BRANCH_NAME_LENGTH - 1, len(program.Branch.truncate_branch_name(name)))
+
+    def branch_matches_issue(self, branch, issue_id=1, associated_issue_id=None):
+        with OutputCapture(), mocks.local.Git(self.path), mocks.local.Svn(), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            repository = local.Git(self.path)
+            if associated_issue_id:
+                program.Command.write_branch_variables(
+                    repository, branch,
+                    bug=Tracker.instance().issue(associated_issue_id).link,
+                )
+            return program.Branch.branch_matches_issue(repository, branch, Tracker.instance().issue(issue_id))
+
+    def test_branch_matches_issue_from_config(self):
+        self.assertTrue(self.branch_matches_issue('eng/unrelated-branch-name', associated_issue_id=1))
+
+    def test_branch_matches_issue_id(self):
+        self.assertTrue(self.branch_matches_issue('eng/1'))
+
+    def test_branch_matches_issue_id_with_prefix(self):
+        self.assertTrue(self.branch_matches_issue('eng/revert-5-main-1'))
+
+    def test_branch_matches_issue_title(self):
+        self.assertTrue(self.branch_matches_issue('eng/Example-issue-1'))
+
+    def test_branch_matches_issue_title_with_prefix(self):
+        self.assertTrue(self.branch_matches_issue('eng/revert-5-main-Example-issue-1'))
+
+    def test_branch_matches_issue_truncated_title(self):
+        self.assertTrue(self.branch_matches_issue('eng/revert-5-main-Example-iss'))
+
+    def test_branch_matches_issue_different_issue(self):
+        self.assertFalse(self.branch_matches_issue('eng/revert-5-main-Example-issue-1', issue_id=2))
+
+    def test_branch_matches_issue_no_branch(self):
+        self.assertFalse(self.branch_matches_issue(''))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -847,6 +847,120 @@ No pre-PR checks to run""")
             ],
         )
 
+    def test_github_reopen_defaults(self):
+        with mocks.remote.GitHub() as remote, mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ) as repo, mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
+            with OutputCapture():
+                repo.staged['added.txt'] = 'added'
+                self.assertEqual(0, program.main(
+                    args=('pull-request', '-i', 'pr-branch'),
+                    path=self.path,
+                ))
+
+            local.Git(self.path).remote().pull_requests.get(1).close()
+            self.assertFalse(local.Git(self.path).remote().pull_requests.get(1).opened)
+
+            # Automation cannot answer the "this pull-request is closed" prompt, it must not re-use the closed pull-request
+            with OutputCapture(level=logging.INFO) as captured:
+                repo.staged['added.txt'] = 'diff'
+                self.assertEqual(0, program.main(
+                    args=('pull-request', '-v', '--no-history', '--defaults'),
+                    path=self.path,
+                ))
+
+            self.assertFalse(local.Git(self.path).remote().pull_requests.get(1).opened)
+            self.assertTrue(local.Git(self.path).remote().pull_requests.get(2).opened)
+            self.assertEqual(local.Git(self.path).remote().pull_requests.get(2).head, 'eng/pr-branch')
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Created 'PR 2 | [Testing] Amending commits'!\n"
+            "https://github.example.com/WebKit/WebKit/pull/2\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        log = captured.root.log.getvalue().splitlines()
+        self.assertEqual(
+            [line for line in log if 'Mock process' not in line], [
+                'Amending commit...',
+                "Rebasing 'eng/pr-branch' on 'main'...",
+                "Rebased 'eng/pr-branch' on 'main!'",
+                'Running pre-PR checks...',
+                'No pre-PR checks to run',
+                'Checking if PR already exists...',
+                'PR #1 found.',
+                "Updating 'main' on 'https://github.example.com/Contributor/WebKit'",
+                "Pushing 'eng/pr-branch' to 'fork'...",
+                "Creating pull-request for 'eng/pr-branch'...",
+            ],
+        )
+
+    def test_github_reopen_closed(self):
+        with mocks.remote.GitHub() as remote, mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ) as repo, mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
+            with OutputCapture():
+                repo.staged['added.txt'] = 'added'
+                self.assertEqual(0, program.main(
+                    args=('pull-request', '-i', 'pr-branch'),
+                    path=self.path,
+                ))
+
+            local.Git(self.path).remote().pull_requests.get(1).close()
+            self.assertFalse(local.Git(self.path).remote().pull_requests.get(1).opened)
+
+            # '--reopen-closed' is how automation opts into re-using a closed pull-request
+            with OutputCapture(level=logging.INFO) as captured:
+                repo.staged['added.txt'] = 'diff'
+                self.assertEqual(0, program.main(
+                    args=('pull-request', '-v', '--no-history', '--defaults', '--reopen-closed'),
+                    path=self.path,
+                ))
+
+            self.assertTrue(local.Git(self.path).remote().pull_requests.get(1).opened)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Updated 'PR 1 | [Testing] Amending commits'!\n"
+            "https://github.example.com/WebKit/WebKit/pull/1\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_find_existing_pull_request_prefers_open(self):
+        with OutputCapture(), mocks.remote.GitHub() as remote, mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
+            # A closed pull-request later in iteration order must not hide an open one
+            remote.pull_requests = [dict(
+                number=1,
+                state='open',
+                title='[Testing] Existing commit',
+                user=dict(login='rreviewer'),
+                body='#### 06de5d56554e693db72313f4ca1fb969c30b8ccb\n<pre>\n[Testing] Existing commit\n</pre>',
+                head=dict(ref='eng/pr-branch'),
+                base=dict(ref='main'),
+                draft=False,
+            ), dict(
+                number=2,
+                state='closed',
+                title='[Testing] Abandoned commit',
+                user=dict(login='rreviewer'),
+                body='#### 16de5d56554e693db72313f4ca1fb969c30b8ccb\n<pre>\n[Testing] Abandoned commit\n</pre>',
+                head=dict(ref='eng/pr-branch'),
+                base=dict(ref='main'),
+                draft=False,
+            )]
+
+            repository = local.Git(self.path)
+            existing_pr = program.PullRequest.find_existing_pull_request(
+                repository, repository.remote(), branch='eng/pr-branch',
+            )
+            self.assertEqual(1, existing_pr.number)
+            self.assertTrue(existing_pr.opened)
+
     def test_github_substring_branch(self):
         # Test that a branch that is a substring of another branch doesn't match
         # For example, 'eng/Adopt-LIFETIME_BOUND-for-WTF-Ref' should not match

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
@@ -113,7 +113,7 @@ class TestRevert(testing.PathTestCase):
             captured.stdout.getvalue(),
             "This issue will track the revert and should not be the issue of the commit(s) to be reverted.\n"
             "Enter issue URL or title of new issue (reason for the revert): \n"
-            "Created the local development branch 'eng/Example-feature-1'\n"
+            "Created the local development branch 'eng/revert-5-main-Example-feature-1'\n"
             "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26fa65c)'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
         )
@@ -121,18 +121,18 @@ class TestRevert(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                "Creating the local development branch 'eng/Example-feature-1'...",
+                "Creating the local development branch 'eng/revert-5-main-Example-feature-1'...",
                 'Reverted 5@main',
                 'Automatically relating issues...',
-                "Rebasing 'eng/Example-feature-1' on 'main'...",
-                "Rebased 'eng/Example-feature-1' on 'main!'",
+                "Rebasing 'eng/revert-5-main-Example-feature-1' on 'main'...",
+                "Rebased 'eng/revert-5-main-Example-feature-1' on 'main!'",
                 'Running pre-PR checks...',
                 'No pre-PR checks to run',
                 'Checking if PR already exists...',
                 'PR not found.',
                 "Updating 'main' on 'https://github.example.com/Contributor/WebKit'",
-                "Pushing 'eng/Example-feature-1' to 'fork'...",
-                "Creating pull-request for 'eng/Example-feature-1'...",
+                "Pushing 'eng/revert-5-main-Example-feature-1' to 'fork'...",
+                "Creating pull-request for 'eng/revert-5-main-Example-feature-1'...",
             ],
         )
 
@@ -165,7 +165,7 @@ class TestRevert(testing.PathTestCase):
             captured.stdout.getvalue(),
             "This issue will track the revert and should not be the issue of the commit(s) to be reverted.\n"
             "Enter issue URL or title of new issue (reason for the revert): \n"
-            "Created the local development branch 'eng/Example-feature-1'\n"
+            "Created the local development branch 'eng/revert-5-main-Example-feature-1'\n"
             "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26fa65c)'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
         )
@@ -173,19 +173,19 @@ class TestRevert(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                "Creating the local development branch 'eng/Example-feature-1'...",
+                "Creating the local development branch 'eng/revert-5-main-Example-feature-1'...",
                 'Reverted 5@main',
                 'Automatically relating issues...',
                 'Using committed changes...',
-                "Rebasing 'eng/Example-feature-1' on 'main'...",
-                "Rebased 'eng/Example-feature-1' on 'main!'",
+                "Rebasing 'eng/revert-5-main-Example-feature-1' on 'main'...",
+                "Rebased 'eng/revert-5-main-Example-feature-1' on 'main!'",
                 'Running pre-PR checks...',
                 'No pre-PR checks to run',
                 'Checking if PR already exists...',
                 'PR not found.',
                 "Updating 'main' on 'https://github.example.com/Contributor/WebKit'",
-                "Pushing 'eng/Example-feature-1' to 'fork'...",
-                "Creating pull-request for 'eng/Example-feature-1'...",
+                "Pushing 'eng/revert-5-main-Example-feature-1' to 'fork'...",
+                "Creating pull-request for 'eng/revert-5-main-Example-feature-1'...",
             ],
         )
 
@@ -216,7 +216,7 @@ class TestRevert(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Created the local development branch 'eng/Example-feature-1'\n"
+            "Created the local development branch 'eng/revert-5-main-Example-feature-1'\n"
             "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26fa65c)'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n",
         )
@@ -224,19 +224,19 @@ class TestRevert(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                "Creating the local development branch 'eng/Example-feature-1'...",
+                "Creating the local development branch 'eng/revert-5-main-Example-feature-1'...",
                 'Reverted 5@main',
                 'Automatically relating issues...',
                 'Using committed changes...',
-                "Rebasing 'eng/Example-feature-1' on 'main'...",
-                "Rebased 'eng/Example-feature-1' on 'main!'",
+                "Rebasing 'eng/revert-5-main-Example-feature-1' on 'main'...",
+                "Rebased 'eng/revert-5-main-Example-feature-1' on 'main!'",
                 'Running pre-PR checks...',
                 'No pre-PR checks to run',
                 'Checking if PR already exists...',
                 'PR not found.',
                 "Updating 'main' on 'https://github.example.com/Contributor/WebKit'",
-                "Pushing 'eng/Example-feature-1' to 'fork'...",
-                "Creating pull-request for 'eng/Example-feature-1'...",
+                "Pushing 'eng/revert-5-main-Example-feature-1' to 'fork'...",
+                "Creating pull-request for 'eng/revert-5-main-Example-feature-1'...",
             ],
         )
 
@@ -264,7 +264,7 @@ class TestRevert(testing.PathTestCase):
         self.assertEqual(
             captured.stdout.getvalue(),
             'Enter a reason for the revert: \n'
-            "Created the local development branch 'eng/reason-for-revert'\n",
+            "Created the local development branch 'eng/revert-5-main-reason-for-revert'\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
 
@@ -335,7 +335,7 @@ index 05e8751..0bf3c85 100644
             captured.stdout.getvalue(),
             "This issue will track the revert and should not be the issue of the commit(s) to be reverted.\n"
             "Enter issue URL or title of new issue (reason for the revert): \n"
-            "Created the local development branch 'eng/Example-feature-1'\n"
+            "Created the local development branch 'eng/revert-5-main-Example-feature-1'\n"
             "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26fa65c)'!\n"
             "https://github.example.com/WebKit/WebKit/pull/1\n"
             "Updated 'PR 1 | Unreviewed, reverting 5@main (d8bce26fa65c)'!\n"
@@ -345,30 +345,30 @@ index 05e8751..0bf3c85 100644
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                "Creating the local development branch 'eng/Example-feature-1'...",
+                "Creating the local development branch 'eng/revert-5-main-Example-feature-1'...",
                 'Reverted 5@main',
                 'Automatically relating issues...',
-                "Rebasing 'eng/Example-feature-1' on 'main'...",
-                "Rebased 'eng/Example-feature-1' on 'main!'",
+                "Rebasing 'eng/revert-5-main-Example-feature-1' on 'main'...",
+                "Rebased 'eng/revert-5-main-Example-feature-1' on 'main!'",
                 'Running pre-PR checks...',
                 'No pre-PR checks to run',
                 'Checking if PR already exists...',
                 'PR not found.',
                 "Updating 'main' on 'https://github.example.com/Contributor/WebKit'",
-                "Pushing 'eng/Example-feature-1' to 'fork'...",
-                "Creating 'eng/Example-feature-1-1' as a reference branch",
-                "Creating pull-request for 'eng/Example-feature-1'...",
+                "Pushing 'eng/revert-5-main-Example-feature-1' to 'fork'...",
+                "Creating 'eng/revert-5-main-Example-feature-1-1' as a reference branch",
+                "Creating pull-request for 'eng/revert-5-main-Example-feature-1'...",
                 'Using committed changes...',
-                "Rebasing 'eng/Example-feature-1' on 'main'...",
-                "Rebased 'eng/Example-feature-1' on 'main!'",
+                "Rebasing 'eng/revert-5-main-Example-feature-1' on 'main'...",
+                "Rebased 'eng/revert-5-main-Example-feature-1' on 'main!'",
                 'Running pre-PR checks...',
                 'No pre-PR checks to run',
                 'Checking if PR already exists...',
                 'PR #1 found.',
                 'Checking PR labels for active labels...',
                 "Updating 'main' on 'https://github.example.com/Contributor/WebKit'",
-                "Pushing 'eng/Example-feature-1' to 'fork'...",
-                "Updating pull-request for 'eng/Example-feature-1'..."
+                "Pushing 'eng/revert-5-main-Example-feature-1' to 'fork'...",
+                "Updating pull-request for 'eng/revert-5-main-Example-feature-1'..."
             ],
         )
 
@@ -394,7 +394,7 @@ index 05e8751..0bf3c85 100644
             self.assertEqual(True, 'Unreviewed, reverting 5@main (d8bce26fa65c)' in repo.head.message)
             self.assertEqual(
                 captured.stdout.getvalue(),
-                "Created the local development branch 'eng/Example-feature-1'\n"
+                "Created the local development branch 'eng/revert-5-main-Example-feature-1'\n"
                 "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26fa65c)'!\n"
                 "https://github.example.com/WebKit/WebKit/pull/1\n"
             )
@@ -427,21 +427,21 @@ index 05e8751..0bf3c85 100644
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                "Creating the local development branch 'eng/Example-issue-1'...",
+                "Creating the local development branch 'eng/revert-5-main-Example-issue-1'...",
                 'Reverted 5@main',
                 'Automatically relating issues...',
                 'Using committed changes...',
                 'Detected merging automation, using that instead of local git tooling',
-                "Rebasing 'eng/Example-issue-1' on 'main'...",
-                "Rebased 'eng/Example-issue-1' on 'main!'",
+                "Rebasing 'eng/revert-5-main-Example-issue-1' on 'main'...",
+                "Rebased 'eng/revert-5-main-Example-issue-1' on 'main!'",
                 'Running pre-PR checks...',
                 'No pre-PR checks to run',
                 'Checking if PR already exists...',
                 'PR not found.',
                 "Updating 'main' on 'https://github.example.com/Contributor/WebKit'",
-                "Pushing 'eng/Example-issue-1' to 'fork'...",
-                "Creating 'eng/Example-issue-1-1' as a reference branch",
-                "Creating pull-request for 'eng/Example-issue-1'...",
+                "Pushing 'eng/revert-5-main-Example-issue-1' to 'fork'...",
+                "Creating 'eng/revert-5-main-Example-issue-1-1' as a reference branch",
+                "Creating pull-request for 'eng/revert-5-main-Example-issue-1'...",
                 "Adding 'merge-queue' to 'PR 2 | Unreviewed, reverting 5@main (d8bce26fa65c)'",
             ],
         )
@@ -474,21 +474,135 @@ index 05e8751..0bf3c85 100644
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                "Creating the local development branch 'eng/Example-issue-1'...",
+                "Creating the local development branch 'eng/revert-5-main-Example-issue-1'...",
                 'Reverted 5@main',
                 'Automatically relating issues...',
                 'Using committed changes...',
                 'Detected merging automation, using that instead of local git tooling',
-                "Rebasing 'eng/Example-issue-1' on 'main'...",
-                "Rebased 'eng/Example-issue-1' on 'main!'",
+                "Rebasing 'eng/revert-5-main-Example-issue-1' on 'main'...",
+                "Rebased 'eng/revert-5-main-Example-issue-1' on 'main!'",
                 'Running pre-PR checks...',
                 'No pre-PR checks to run',
                 'Checking if PR already exists...',
                 'PR not found.',
                 "Updating 'main' on 'https://github.example.com/Contributor/WebKit'",
-                "Pushing 'eng/Example-issue-1' to 'fork'...",
-                "Creating 'eng/Example-issue-1-1' as a reference branch",
-                "Creating pull-request for 'eng/Example-issue-1'...",
+                "Pushing 'eng/revert-5-main-Example-issue-1' to 'fork'...",
+                "Creating 'eng/revert-5-main-Example-issue-1-1' as a reference branch",
+                "Creating pull-request for 'eng/revert-5-main-Example-issue-1'...",
                 "Adding 'unsafe-merge-queue' to 'PR 2 | Unreviewed, reverting 5@main (d8bce26fa65c)'",
             ],
         )
+
+    def test_branch_name_prefix_single_commit(self):
+        self.assertEqual('revert-5-main', program.Revert.branch_name_prefix([
+            Commit(hash='d8bce26fa65c6fc8f39c17927abb77f69fab82fc', identifier=5, branch='main'),
+        ]))
+
+    def test_branch_name_prefix_multiple_commits(self):
+        self.assertEqual('revert-5-main-4-main', program.Revert.branch_name_prefix([
+            Commit(hash='d8bce26fa65c6fc8f39c17927abb77f69fab82fc', identifier=5, branch='main'),
+            Commit(hash='bae5d1e90999d4f916a8a15810ccfa43f37a2fd6', identifier=4, branch='main'),
+        ]))
+
+    def test_branch_name_prefix_collapses_long_lists(self):
+        self.assertEqual('revert-5-main-4-main-3-main-and-2-more', program.Revert.branch_name_prefix([
+            Commit(hash='d8bce26fa65c6fc8f39c17927abb77f69fab82fc', identifier=identifier, branch='main')
+            for identifier in (5, 4, 3, 2, 1)
+        ]))
+
+    def test_branch_name_prefix_hash_only(self):
+        self.assertEqual('revert-d8bce26fa65c', program.Revert.branch_name_prefix([
+            Commit(hash='d8bce26fa65c6fc8f39c17927abb77f69fab82fc'),
+        ]))
+
+    def test_branch_name(self):
+        # An issue with no spaces is a branch name the user picked, it should not be prefixed
+        with MockTerminal.input('reason for revert'), OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ) as repo, mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', []):
+            result = program.main(
+                args=('revert', 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc', '-i', 'pr-branch', '--no-issue', '-v', '--no-pr'),
+                path=self.path,
+            )
+            self.assertEqual(0, result)
+            self.assertEqual(local.Git(self.path).branch, 'eng/pr-branch')
+
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_two_reverts_of_different_commits(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ) as repo, bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            self.assertEqual(0, program.main(
+                args=('revert', '5@main', '--issue', '{}/show_bug.cgi?id=2'.format(self.BUGZILLA), '-v', '--no-history', '--pr'),
+                path=self.path,
+            ))
+            self.assertEqual(local.Git(self.path).branch, 'eng/revert-5-main-Example-feature-1')
+
+            self.assertEqual(0, program.main(args=('checkout', 'main'), path=self.path))
+
+            # Reverting a different commit for the same reason must not re-use the first revert's pull-request
+            self.assertEqual(0, program.main(
+                args=('revert', '4@main', '--issue', '{}/show_bug.cgi?id=2'.format(self.BUGZILLA), '-v', '--no-history', '--pr'),
+                path=self.path,
+            ))
+            self.assertEqual(local.Git(self.path).branch, 'eng/revert-4-main-Example-feature-1')
+
+            self.assertEqual(local.Git(self.path).remote().pull_requests.get(1).head, 'eng/revert-5-main-Example-feature-1')
+            self.assertEqual(local.Git(self.path).remote().pull_requests.get(2).head, 'eng/revert-4-main-Example-feature-1')
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Created the local development branch 'eng/revert-5-main-Example-feature-1'\n"
+            "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26fa65c)'!\n"
+            "https://github.example.com/WebKit/WebKit/pull/1\n"
+            "Created the local development branch 'eng/revert-4-main-Example-feature-1'\n"
+            "Created 'PR 2 | Unreviewed, reverting 4@main (bae5d1e90999)'!\n"
+            "https://github.example.com/WebKit/WebKit/pull/2\n",
+        )
+
+    def test_repeated_revert(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, mocks.local.Git(
+            self.path, remote='https://{}'.format(remote.remote),
+            remotes=dict(fork='https://{}/Contributor/WebKit'.format(remote.hosts[0])),
+        ) as repo, bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), mocks.local.Svn(), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            self.assertEqual(0, program.main(
+                args=('revert', '5@main', '--issue', '{}/show_bug.cgi?id=2'.format(self.BUGZILLA), '-v', '--no-history', '--pr'),
+                path=self.path,
+            ))
+            self.assertEqual(0, program.main(args=('checkout', 'main'), path=self.path))
+
+            # Requesting the same revert twice rebases the existing branch, it must still be the branch we push
+            self.assertEqual(0, program.main(
+                args=('revert', '5@main', '--issue', '{}/show_bug.cgi?id=2'.format(self.BUGZILLA), '-v', '--no-history', '--pr'),
+                path=self.path,
+            ))
+            self.assertEqual(local.Git(self.path).branch, 'eng/revert-5-main-Example-feature-1')
+            self.assertEqual(local.Git(self.path).remote().pull_requests.get(1).head, 'eng/revert-5-main-Example-feature-1')
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Created the local development branch 'eng/revert-5-main-Example-feature-1'\n"
+            "Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26fa65c)'!\n"
+            "https://github.example.com/WebKit/WebKit/pull/1\n"
+            "Rebased the local development branch 'eng/revert-5-main-Example-feature-1'\n"
+            "Updated 'PR 1 | Unreviewed, reverting 5@main (d8bce26fa65c)'!\n"
+            "https://github.example.com/WebKit/WebKit/pull/1\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')


### PR DESCRIPTION
#### 7a58f5eb34143bdfd4d55e060ad267479645637a
<pre>
[webkitscmpy] Two revert requests with the same reason but different commits posted the same PR with only the description updated
<a href="https://bugs.webkit.org/show_bug.cgi?id=321686">https://bugs.webkit.org/show_bug.cgi?id=321686</a>
<a href="https://rdar.apple.com/184832018">rdar://184832018</a>

Reviewed by Aakash Jain.

`git-webkit revert` named its development branch and the summary of the Bugzilla using the
revert reason. For the case described in webkit.org/b/321686, this caused the second revert
to force-push over the first and update the pull request instead of opening a new one.

To avoid this, include the reverted commit identifier in the branch name so it becomes something
like eng/revert-318045-main-&lt;reason&gt;. Also stop automation from silently re-using a closed pull-request.
The &quot;associated with a closed pull-request, create a new one?&quot; prompt was gated on `not args.defaults`,
making it dead code for --defaults callers like webkitbot, which is how a closed PR came to be
updated rather than replaced. Non-interactive runs now always create a new pull-request.
Using --reopen-closed opts back in.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Bump version to 7.0.6.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py:
(Branch.truncate_branch_name): Added, since check-ref-format does not bound length.
(Branch.branch_matches_issue): Added.
(Branch.main): Accept name_prefix and prepend it to the branch name. Refresh repository._branch
when rebasing an existing branch, otherwise repository.branch returns a stale cached value
and the wrong ref is pushed.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.parser): Add --reopen-closed.
(PullRequest.pull_request_branch_point): Forward name_prefix to Branch.main and use
Branch.branch_matches_issue.
(PullRequest.find_existing_pull_request): Don&apos;t let a closed pull-request shadow an open one.
(PullRequest.will_reopen_closed_pull_request): Added.
(PullRequest.create_pull_request): Use it.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py:
(Revert.branch_name_prefix): Added.
(Revert.main): Pass the reverted commits to pull_request_branch_point.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py:

Canonical link: <a href="https://commits.webkit.org/320843@main">https://commits.webkit.org/320843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae2bbbc15e96d1d15f58b408e14f6c41a05bf96d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60002 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196397 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59721 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189061 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/49096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/125741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/185435 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/47829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/158183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7468 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/50270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198375 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/185509 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59658 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60370 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/154623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28253 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/49064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58202 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58261 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->