### PR TITLE
[JSC] Move BlockDirectory for-stealing list to AlignedMemoryAllocator

### DIFF
--- a/Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp
@@ -27,8 +27,6 @@
 #include "AlignedMemoryAllocator.h"
 
 #include "BlockDirectory.h"
-#include "HeapInlines.h"
-#include "Subspace.h"
 
 namespace JSC { 
 
@@ -36,23 +34,26 @@ AlignedMemoryAllocator::AlignedMemoryAllocator() = default;
 
 AlignedMemoryAllocator::~AlignedMemoryAllocator() = default;
 
-void AlignedMemoryAllocator::registerDirectory(JSC::Heap& heap, BlockDirectory* directory)
+void AlignedMemoryAllocator::registerDirectory(BlockDirectory* directory)
 {
     RELEASE_ASSERT(!directory->nextDirectoryInAlignedMemoryAllocator());
-    
-    if (m_directories.isEmpty()) {
-        ASSERT_UNUSED(heap, !Thread::mayBeGCThread() || heap.worldIsStopped());
-        for (Subspace* subspace = m_subspaces.first(); subspace; subspace = subspace->nextSubspaceInAlignedMemoryAllocator())
-            subspace->didCreateFirstDirectory(directory);
-    }
-    
+
     m_directories.append(std::mem_fn(&BlockDirectory::setNextDirectoryInAlignedMemoryAllocator), directory);
+    m_directoryForEmptyAllocation = m_directories.first();
 }
 
-void AlignedMemoryAllocator::registerSubspace(Subspace* subspace)
+void AlignedMemoryAllocator::prepareForAllocation()
 {
-    RELEASE_ASSERT(!subspace->nextSubspaceInAlignedMemoryAllocator());
-    m_subspaces.append(std::mem_fn(&Subspace::setNextSubspaceInAlignedMemoryAllocator), subspace);
+    m_directoryForEmptyAllocation = m_directories.first();
+}
+
+MarkedBlock::Handle* AlignedMemoryAllocator::findEmptyBlockToSteal()
+{
+    for (; m_directoryForEmptyAllocation; m_directoryForEmptyAllocation = m_directoryForEmptyAllocation->nextDirectoryInAlignedMemoryAllocator()) {
+        if (MarkedBlock::Handle* block = m_directoryForEmptyAllocation->findEmptyBlockToSteal())
+            return block;
+    }
+    return nullptr;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/AlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/AlignedMemoryAllocator.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/MarkedBlock.h>
 #include <wtf/PrintStream.h>
 #include <wtf/SinglyLinkedListWithTail.h>
 
@@ -32,7 +33,6 @@ namespace JSC {
 
 class BlockDirectory;
 class Heap;
-class Subspace;
 
 class AlignedMemoryAllocator {
     WTF_MAKE_NONCOPYABLE(AlignedMemoryAllocator);
@@ -48,10 +48,11 @@ public:
     // FIXME: Make this virtual after we stop suppporting the Montery Clang.
     virtual void dump(PrintStream&) const { }
 
-    void registerDirectory(Heap&, BlockDirectory*);
-    BlockDirectory* firstDirectory() const LIFETIME_BOUND { return m_directories.first(); }
+    void registerDirectory(BlockDirectory*);
 
-    void registerSubspace(Subspace*);
+    void prepareForAllocation();
+
+    MarkedBlock::Handle* findEmptyBlockToSteal();
 
     // Some of derived memory allocators do not have these features because they do not use them.
     // For example, IsoAlignedMemoryAllocator does not have "realloc" feature since it never extends / shrinks the allocated memory region.
@@ -61,7 +62,7 @@ public:
 
 private:
     SinglyLinkedListWithTail<BlockDirectory> m_directories;
-    SinglyLinkedListWithTail<Subspace> m_subspaces;
+    BlockDirectory* m_directoryForEmptyAllocation { nullptr };
 };
 
 } // namespace WTF

--- a/Source/JavaScriptCore/heap/CompleteSubspace.cpp
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.cpp
@@ -98,7 +98,7 @@ Allocator CompleteSubspace::allocatorForSlow(size_t size)
     }
     
     directory->setNextDirectoryInSubspace(m_firstDirectory);
-    m_alignedMemoryAllocator->registerDirectory(m_space.heap(), directory);
+    m_alignedMemoryAllocator->registerDirectory(directory);
     WTF::storeStoreFence();
     m_firstDirectory = directory;
     return allocator;

--- a/Source/JavaScriptCore/heap/IsoSubspace.cpp
+++ b/Source/JavaScriptCore/heap/IsoSubspace.cpp
@@ -50,7 +50,7 @@ IsoSubspace::IsoSubspace(CString name, JSC::Heap& heap, const HeapCellType& heap
     Locker locker { m_space.directoryLock() };
     m_directory.setSubspace(this);
     m_space.addBlockDirectory(locker, &m_directory);
-    m_alignedMemoryAllocator->registerDirectory(heap, &m_directory);
+    m_alignedMemoryAllocator->registerDirectory(&m_directory);
     m_firstDirectory = &m_directory;
 }
 

--- a/Source/JavaScriptCore/heap/LocalAllocator.cpp
+++ b/Source/JavaScriptCore/heap/LocalAllocator.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "LocalAllocator.h"
 
+#include "AlignedMemoryAllocator.h"
 #include "AllocatingScope.h"
 #include "FreeListInlines.h"
 #include "GCDeferralContext.h"
@@ -211,11 +212,12 @@ void* LocalAllocator::tryAllocateWithoutCollecting(size_t cellSize)
     }
     
     if (Options::stealEmptyBlocksFromOtherAllocators()) {
-        if (MarkedBlock::Handle* block = m_directory->m_subspace->findEmptyBlockToSteal()) {
-            RELEASE_ASSERT(block->alignedMemoryAllocator() == m_directory->m_subspace->alignedMemoryAllocator());
-            
+        AlignedMemoryAllocator* allocator = m_directory->m_subspace->alignedMemoryAllocator();
+        if (MarkedBlock::Handle* block = allocator->findEmptyBlockToSteal()) {
+            RELEASE_ASSERT(block->alignedMemoryAllocator() == allocator);
+
             block->sweep(nullptr);
-            
+
             block->removeFromDirectory();
             m_directory->addBlock(block);
             return allocateIn(block, cellSize);

--- a/Source/JavaScriptCore/heap/Subspace.cpp
+++ b/Source/JavaScriptCore/heap/Subspace.cpp
@@ -48,11 +48,9 @@ void Subspace::initialize(const HeapCellType& heapCellType, AlignedMemoryAllocat
 {
     m_heapCellType = &heapCellType;
     m_alignedMemoryAllocator = alignedMemoryAllocator;
-    m_directoryForEmptyAllocation = m_alignedMemoryAllocator->firstDirectory();
 
     JSC::Heap& heap = m_space.heap();
     heap.objectSpace().m_subspaces.append(this);
-    m_alignedMemoryAllocator->registerSubspace(this);
 }
 
 Subspace::~Subspace() = default;
@@ -74,16 +72,7 @@ void Subspace::prepareForAllocation()
             directory.prepareForAllocation();
         });
 
-    m_directoryForEmptyAllocation = m_alignedMemoryAllocator->firstDirectory();
-}
-
-MarkedBlock::Handle* Subspace::findEmptyBlockToSteal()
-{
-    for (; m_directoryForEmptyAllocation; m_directoryForEmptyAllocation = m_directoryForEmptyAllocation->nextDirectoryInAlignedMemoryAllocator()) {
-        if (MarkedBlock::Handle* block = m_directoryForEmptyAllocation->findEmptyBlockToSteal())
-            return block;
-    }
-    return nullptr;
+    m_alignedMemoryAllocator->prepareForAllocation();
 }
 
 Ref<SharedTask<BlockDirectory*()>> Subspace::parallelDirectorySource()

--- a/Source/JavaScriptCore/heap/Subspace.h
+++ b/Source/JavaScriptCore/heap/Subspace.h
@@ -64,11 +64,6 @@ public:
 
     void prepareForAllocation();
     
-    void didCreateFirstDirectory(BlockDirectory* directory) { m_directoryForEmptyAllocation = directory; }
-    
-    // Finds an empty block from any Subspace that agrees to trade blocks with us.
-    MarkedBlock::Handle* findEmptyBlockToSteal();
-    
     template<typename Func>
     void forEachDirectory(const Func&);
     
@@ -96,9 +91,6 @@ public:
     
     void sweepBlocks();
     
-    Subspace* nextSubspaceInAlignedMemoryAllocator() const { return m_nextSubspaceInAlignedMemoryAllocator; }
-    void setNextSubspaceInAlignedMemoryAllocator(Subspace* subspace) { m_nextSubspaceInAlignedMemoryAllocator = subspace; }
-    
     virtual void didResizeBits(unsigned newSize);
     virtual void didRemoveBlock(unsigned blockIndex);
     virtual void didBeginSweepingToFreeList(MarkedBlock::Handle*);
@@ -118,13 +110,10 @@ protected:
     AlignedMemoryAllocator* m_alignedMemoryAllocator { nullptr };
     
     BlockDirectory* m_firstDirectory { nullptr };
-    BlockDirectory* m_directoryForEmptyAllocation { nullptr }; // Uses the MarkedSpace linked list of blocks.
     SentinelLinkedList<PreciseAllocation, BasicRawSentinelNode<PreciseAllocation>> m_preciseAllocations;
 
     SubspaceKind m_kind;
     uint8_t m_remainingLowerTierPreciseCount { 0 }; // Lower tier is a precise allocation but we use the term lower to avoid confusion with precise-only.
-
-    Subspace* m_nextSubspaceInAlignedMemoryAllocator { nullptr };
 
     CString m_name;
 };


### PR DESCRIPTION
#### 03c6c950449526f3b8d8740bed1fb6a92083dade
<pre>
[JSC] Move BlockDirectory for-stealing list to AlignedMemoryAllocator
<a href="https://bugs.webkit.org/show_bug.cgi?id=323680">https://bugs.webkit.org/show_bug.cgi?id=323680</a>
<a href="https://rdar.apple.com/186935769">rdar://186935769</a>

Reviewed by Marcus Plutowski.

Holding BlockDirectory cursor for each subspace is meaningless. Let&apos;s
just move it to AlignedMemoryAllocator and query to that to find
steal-able MarkedBlock instead.

* Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp:
(JSC::AlignedMemoryAllocator::registerDirectory):
(JSC::AlignedMemoryAllocator::prepareForAllocation):
(JSC::AlignedMemoryAllocator::findEmptyBlockToSteal):
(JSC::AlignedMemoryAllocator::registerSubspace): Deleted.
* Source/JavaScriptCore/heap/AlignedMemoryAllocator.h:
* Source/JavaScriptCore/heap/CompleteSubspace.cpp:
(JSC::CompleteSubspace::allocatorForSlow):
* Source/JavaScriptCore/heap/IsoSubspace.cpp:
(JSC::IsoSubspace::IsoSubspace):
* Source/JavaScriptCore/heap/LocalAllocator.cpp:
(JSC::LocalAllocator::tryAllocateWithoutCollecting):
* Source/JavaScriptCore/heap/Subspace.cpp:
(JSC::Subspace::initialize):
(JSC::Subspace::prepareForAllocation):
(JSC::Subspace::findEmptyBlockToSteal): Deleted.
* Source/JavaScriptCore/heap/Subspace.h:
(JSC::Subspace::didCreateFirstDirectory): Deleted.
(JSC::Subspace::nextSubspaceInAlignedMemoryAllocator const): Deleted.
(JSC::Subspace::setNextSubspaceInAlignedMemoryAllocator): Deleted.

Canonical link: <a href="https://commits.webkit.org/320674@main">https://commits.webkit.org/320674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b40f4559832b0f685185cc75a4682ed8b7309f9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195897 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d1d222b-e099-4e18-b728-61815325e837) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59215 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145032 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48714 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125327 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/eba617ea-b233-4d64-bfd3-9b9eac6936bb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47440 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/7225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14117 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157804 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45185 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6952 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46831 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52136 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197852 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59152 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59860 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154210 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28165 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48677 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129109 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58331 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20207 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57708 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57948 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57773 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->