### PR TITLE
[ANGLE] Re-enable PoolAllocator under AddressSanitizer

### DIFF
--- a/Source/ThirdParty/ANGLE/src/common/PoolAlloc.h
+++ b/Source/ThirdParty/ANGLE/src/common/PoolAlloc.h
@@ -10,12 +10,11 @@
 #ifndef COMMON_POOLALLOC_H_
 #define COMMON_POOLALLOC_H_
 
-// This include MUST precede the ANGLE_WITH_ASAN / ANGLE_WITH_TSAN check below
-// to define those macros.
+// This include MUST precede the ANGLE_WITH_TSAN check below to define that macro.
 #include "common/platform.h"
 
-#if defined(ANGLE_WITH_ASAN) || defined(ANGLE_WITH_TSAN)
-#    define ANGLE_DISABLE_POOL_ALLOC  // Use system allocator under sanitizers for accurate detection
+#if defined(ANGLE_WITH_TSAN)
+#    define ANGLE_DISABLE_POOL_ALLOC
 #elif !defined(NDEBUG)
 #    define ANGLE_POOL_ALLOC_GUARD_BLOCKS  // define to enable guard block checking
 #endif


### PR DESCRIPTION
#### 8a3192a38590a4578a7fe810744b0d471aebdb8e
<pre>
[ANGLE] Re-enable PoolAllocator under AddressSanitizer
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=323682">https://bugs.webkit.org/show_bug.cgi?id=323682</a>&gt;
&lt;<a href="https://rdar.apple.com/186936657">rdar://186936657</a>&gt;

Reviewed by Kimmo Kinnunen.

Restrict the `ANGLE_DISABLE_POOL_ALLOC` bypass to ThreadSanitizer so
that `angle::PoolAllocator` is used again under AddressSanitizer.  The
bypass was introduced for both sanitizers in 312740@main; routing
every translator allocation through the system allocator makes ANGLE
pathologically slow under ASan.

`PoolAllocator` already poisons and unpoisons its own redzones through
`__asan_poison_memory_region()` / `__asan_unpoison_memory_region()`,
so ASan continues to detect out-of-bounds access to pool allocations
with the pool enabled, and there is no signal that disabling the pool
helps ASan find additional bugs.  Only ThreadSanitizer still requires
the bypass.

* Source/ThirdParty/ANGLE/src/common/PoolAlloc.h:

Canonical link: <a href="https://commits.webkit.org/320756@main">https://commits.webkit.org/320756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76f4fbd9dba69cc5c69d651ea46dce187c6f629a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195910 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150325 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/37be7b6c-d5d5-49a9-a1c7-910e18a10e8d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59228 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145034 "Found 1 new test failure: fast/dom/lazy-image-loading-document-leak.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100555 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5d7912a9-c991-4e48-942b-ed77b844454b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188548 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125329 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/658d01be-5048-4962-9e62-c87b060ac50e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47445 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45496 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45182 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6965 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197865 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59165 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154567 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59873 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154217 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28213 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48685 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129127 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58344 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20204 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57721 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57961 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57786 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->