### PR TITLE
[AppKit Gestures] Hover state can move away from the pointer during pan gesture driven scrolling

### DIFF
--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3598,7 +3598,8 @@ HandleUserInputEventResult EventHandler::handleWheelEventInternal(const Platform
     auto allowsScrollingState = SetForScope(m_currentWheelEventAllowsScrolling, processingSteps.contains(WheelEventProcessingSteps::SynchronousScrolling));
     
     setFrameWasScrolledByUser();
-    setLastKnownMousePosition(event.position(), event.globalPosition(), LastKnownMousePositionSource::Wheel);
+    if (event.inputSource() == MouseEventInputSource::UserDriven)
+        setLastKnownMousePosition(event.position(), event.globalPosition(), LastKnownMousePositionSource::Wheel);
 
     if (m_frame->isMainFrame()) {
         RefPtr page = m_frame->page();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4988,7 +4988,11 @@ void WebPageProxy::continueWheelEventHandling(Ref<WebWheelEvent>&& wheelEvent, c
     LOG_WITH_STREAM(WheelEvents, stream << "WebPageProxy::continueWheelEventHandling - " << result);
 
     if (!result.needsMainThreadProcessing()) {
-        if (m_mainFrame && wheelEvent->phase() == WebWheelEvent::Phase::Began) {
+        bool setLastKnownMousePosition = m_mainFrame && wheelEvent->phase() == WebWheelEvent::Phase::Began;
+#if PLATFORM(COCOA)
+        setLastKnownMousePosition = setLastKnownMousePosition && wheelEvent->inputSource() == WebEventInputSource::UserDriven;
+#endif
+        if (setLastKnownMousePosition) {
             // When wheel events are handled entirely in the UI process, we still need to tell the web process where the mouse is for cursor updates.
             sendToProcessContainingFrame(m_mainFrame->frameID(), Messages::WebPage::SetLastKnownMousePosition(m_mainFrame->frameID(), wheelEvent->position(), wheelEvent->globalPosition(), WebCore::LastKnownMousePositionSource::Wheel));
         }

--- a/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptTypes.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptTypes.swift
@@ -285,11 +285,23 @@ public enum DOMEventType: String, Hashable, Sendable {
     /// The `pointerup` event.
     case pointerup
 
+    /// The `pointerover` event.
+    case pointerover
+
+    /// The `pointerout` event.
+    case pointerout
+
     /// The `mousedown` event.
     case mousedown
 
     /// The `mouseup` event.
     case mouseup
+
+    /// The `mouseover` event.
+    case mouseover
+
+    /// The `mouseout` event.
+    case mouseout
 }
 
 /// A DOM UI event observed on an element.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -1662,6 +1662,53 @@ extension AppKitGesturesTests.Basic {
         let end = try await settledScrollPosition()
         #expect(end.y - start.y > 20)
     }
+
+    @Test
+    func scrollEndingOnHoverTargetDoesNotActivateIt() async throws {
+        try await loadFixedHoverBar(installWheelListener: true)
+        try await establishElementUnderMouse(byClickingElementWithID: "anchor")
+
+        let barBounds = try await screenBounds(ofElementWithID: "bar")
+        let start = screenBounds(ofPointInWindowCoordinates: CGPoint(x: window.frame.midX, y: 40))
+        let end = barBounds.center
+
+        try await observeBoundaryEvents(onElementWithID: "bar")
+        try await performScroll(from: start, to: end)
+
+        let actual = try await page.callJavaScript(JavaScriptMessages.EventLog())
+        #expect(actual.isEmpty)
+    }
+
+    @Test
+    func scrollBeginningOnHoverTargetDoesNotActivateIt() async throws {
+        try await loadFixedHoverBar(installWheelListener: false)
+        try await establishElementUnderMouse(byClickingElementWithID: "anchor")
+
+        let barBounds = try await screenBounds(ofElementWithID: "bar")
+        let end = screenBounds(ofPointInWindowCoordinates: CGPoint(x: window.frame.midX, y: 560))
+
+        try await observeBoundaryEvents(onElementWithID: "bar")
+        try await performScroll(from: barBounds.center, to: end)
+
+        let actual = try await page.callJavaScript(JavaScriptMessages.EventLog())
+        #expect(actual.isEmpty)
+    }
+
+    @Test
+    func scrollDoesNotMoveHoverWhileCursorRests() async throws {
+        try await loadFixedHoverBar(installWheelListener: true)
+        try await establishElementUnderMouse(byRestingCursorOnElementWithID: "anchor")
+
+        let barBounds = try await screenBounds(ofElementWithID: "bar")
+        let start = screenBounds(ofPointInWindowCoordinates: CGPoint(x: window.frame.midX, y: 40))
+        let end = barBounds.center
+
+        try await observeBoundaryEvents(onElementWithID: "bar")
+        try await performScroll(from: start, to: end)
+
+        let actual = try await page.callJavaScript(JavaScriptMessages.EventLog())
+        #expect(actual.isEmpty)
+    }
 }
 
 private let coalescedFlickEventFrequency = 20
@@ -1812,6 +1859,107 @@ extension AppKitGesturesTests.Basic {
 
         Issue.record("scroll position never settled; last sample was \(previous)")
         return previous
+    }
+
+    private func loadFixedHoverBar(installWheelListener: Bool) async throws {
+        let wheelListener =
+            installWheelListener
+            ? #"document.addEventListener("wheel", () => {}, { passive: false });"#
+            : ""
+
+        let filler = (0..<80)
+            .map { "<p>Filler paragraph \($0)</p>" }
+            .joined(separator: "\n")
+
+        let html = """
+            <!DOCTYPE html>
+            <style>
+              body { margin: 0; font-size: 40px; }
+              #spacer, #anchor { height: 120px; }
+              #anchor { background: silver; }
+              #bar { position: fixed; top: 260px; left: 0; right: 0; height: 80px; background: gold; }
+            </style>
+            <div id="spacer"></div>
+            <div id="anchor">anchor</div>
+            <div id="bar">bar</div>
+            <div id="filler">\(filler)</div>
+            <script>
+              \(wheelListener)
+
+              let ticks = 0;
+              document.addEventListener("scroll", () => {
+                  ticks++;
+                  document.getElementById("filler").style.paddingBottom = (ticks % 2) + "px";
+              }, { passive: true });
+            </script>
+            """
+
+        try await page.load(html: html).wait()
+        await page.waitForNextPresentationUpdate()
+    }
+
+    private func establishElementUnderMouse(byClickingElementWithID id: String) async throws {
+        let bounds = try await screenBounds(ofElementWithID: id)
+        try await page.callJavaScript(JavaScriptMessages.InstallEventLog(in: id, for: [.mouseover]))
+        await recap.play { composer in
+            composer._wk_click(at: bounds.center, for: .seconds(0.05))
+        }
+        try await requireElementUnderMouse(isElementWithID: id)
+    }
+
+    private func establishElementUnderMouse(byRestingCursorOnElementWithID id: String) async throws {
+        // Need window coordinates here since we will call mouseMove(to:),
+        // and not the Recap composer, which expects screen coordinates.
+        let point = try await windowPoint(ofElementWithID: id)
+        page.mouseMove(to: NSPoint(x: point.x - 20, y: point.y))
+        page.mouseMove(to: point)
+        await page.waitForPendingMouseEvents()
+        await page.waitForNextPresentationUpdate()
+        let hovered = try await innermostHoveredElementID()
+        try #require(hovered == id, "the cursor left hover on \(hovered.isEmpty ? "nothing" : hovered), not #\(id)")
+    }
+
+    private func requireElementUnderMouse(isElementWithID id: String) async throws {
+        await page.waitForPendingMouseEvents()
+        await page.waitForNextPresentationUpdate()
+        let received = try await page.callJavaScript(JavaScriptMessages.EventLog())
+        try #require(
+            received.contains { $0.type == .mouseover },
+            "#\(id) did not become the element under the mouse"
+        )
+    }
+
+    private func performScroll(from start: CGPoint, to end: CGPoint) async throws {
+        await recap.play { composer in
+            composer._wk_scroll(withStart: start, end: end, duration: .seconds(0.2))
+        }
+        let scrolled = try await settledScrollPosition()
+        try #require(scrolled.y > 0, "the gesture did not scroll the page")
+    }
+
+    private func observeBoundaryEvents(onElementWithID id: String) async throws {
+        try await page.callJavaScript(
+            JavaScriptMessages.InstallEventLog(in: id, for: [.mouseover, .mouseout, .pointerover, .pointerout])
+        )
+    }
+
+    private func innermostHoveredElementID() async throws -> String {
+        try await page.callJavaScript(returning: String.self) {
+            """
+            const hovered = document.querySelectorAll(":hover");
+            return hovered.length ? hovered[hovered.length - 1].id : "";
+            """
+        }
+    }
+
+    private func windowPoint(ofElementWithID id: String) async throws -> NSPoint {
+        let viewportRect = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: id))
+        guard let contentView = window.contentViewController?.view else {
+            preconditionFailure("the test window has no content view")
+        }
+        var rect = CGRect(viewportRect)
+        rect.origin.y += Self.topInset
+        return NSPoint(x: rect.midX, y: contentView.frame.height - rect.midY)
     }
 }
 


### PR DESCRIPTION
#### e502098485b1b7d14391b6ad8ae28dc2407e8397
<pre>
[AppKit Gestures] Hover state can move away from the pointer during pan gesture driven scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=323481">https://bugs.webkit.org/show_bug.cgi?id=323481</a>
<a href="https://rdar.apple.com/186098436">rdar://186098436</a>

Reviewed by Richard Robinson, Pascoe, and Wenson Hsieh.

A wheel event carries a &quot;last known mouse&quot; position because, for a
physical scroll wheel or trackpad, that position is the pointer&apos;s, and
is used to drive cursor updates, hover state, boundary events, etc. This
does not hold for wheel events synthesized from gestures, though. In
that case, we want to skip writing the last known mouse position when
the input source is not user-driven. Note that we apply this mitigation
in two places depending on whether the web content has wheel event
listeners.

The dissonance described above became easier to hit after 300277@main
added updateMouseEventTargetAfterLayoutIfNeeded(), which samples the
same position on a timer for as long as layout keeps changing, but the
general symptom _is_ long-standing behavior (courtesy of the &quot;fake mouse
move event dispatch&quot; path).

To facilitate testing, we add the boundary event types to DOMEventType
so tests can observe them.

Test:
- AppKitGesturesTests.Basic/scrollEndingOnHoverTargetDoesNotActivateIt
- AppKitGesturesTests.Basic/scrollBeginningOnHoverTargetDoesNotActivateIt
- AppKitGesturesTests.Basic/scrollDoesNotMoveHoverWhileCursorRests

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::shouldUpdateAutoscroll):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleWheelEvent):
* Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptTypes.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:

Canonical link: <a href="https://commits.webkit.org/320744@main">https://commits.webkit.org/320744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e938709205e313bd908823391b8afc2be0b3b9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195971 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150373 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59296 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145080 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100586 "Exiting early after 60 failures. 60 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125375 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c3d25a80-f18e-4eb8-9522-5fc281d6676f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47493 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45535 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157853 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45226 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7034 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197934 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59231 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154618 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59938 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41831 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154271 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28207 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48733 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132288 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129192 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58408 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20248 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57784 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58024 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57849 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->