### PR TITLE
Avoid computing canvas path bounds when the whole backing store is already dirty

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1213,7 +1213,12 @@ void CanvasRenderingContext2DBase::fillInternal(const Path& path, CanvasFillRule
         clearCanvas();
         c->fillPath(path);
     } else {
-        willUpdateContents(targetSwitcher ? targetSwitcher->expandedBounds() : path.fastBoundingRect());
+#if !USE(COORDINATED_GRAPHICS)
+        if (isEntireBackingStoreDirty())
+            willUpdateContents(std::nullopt);
+        else
+#endif
+            willUpdateContents(targetSwitcher ? targetSwitcher->expandedBounds() : path.fastBoundingRect());
         c->fillPath(path);
     }
 
@@ -1249,7 +1254,12 @@ void CanvasRenderingContext2DBase::strokeInternal(const Path& path)
         clearCanvas();
         c->strokePath(path);
     } else {
-        willUpdateContents(targetSwitcher ? targetSwitcher->expandedBounds() : inflatedStrokeRect(path.fastBoundingRect()));
+#if !USE(COORDINATED_GRAPHICS)
+        if (isEntireBackingStoreDirty())
+            willUpdateContents(std::nullopt);
+        else
+#endif
+            willUpdateContents(targetSwitcher ? targetSwitcher->expandedBounds() : inflatedStrokeRect(path.fastBoundingRect()));
         c->strokePath(path);
     }
 }
@@ -2473,7 +2483,11 @@ void CanvasRenderingContext2DBase::clearAccumulatedDirtyRect()
 
 bool CanvasRenderingContext2DBase::isEntireBackingStoreDirty() const
 {
+#if USE(COORDINATED_GRAPHICS)
     return m_dirtyRect == backingStoreBounds();
+#else
+    return m_dirtyRect.contains(backingStoreBounds());
+#endif
 }
 
 const Vector<CanvasRenderingContext2DBase::State, 1>& CanvasRenderingContext2DBase::stateStack()


### PR DESCRIPTION
#### c39e0c34e9e712b7b075cdc427b1c7a411dadf67
<pre>
Avoid computing canvas path bounds when the whole backing store is already dirty
<a href="https://bugs.webkit.org/show_bug.cgi?id=323688">https://bugs.webkit.org/show_bug.cgi?id=323688</a>
<a href="https://rdar.apple.com/186946552">rdar://186946552</a>

Reviewed by Simon Fraser.

fillInternal() and strokeInternal() always computed a dirty rect, only for willUpdateContents() to
discard it and invalidate with std::nullopt whenever m_dirtyRect already contained it. Take that
path directly instead. In an animation loop that starts each frame with a full-canvas clearRect(),
every following fill and stroke was paying for a bounding box nobody read.

This is limited to !USE(COORDINATED_GRAPHICS), where m_dirtyRect is replaced per draw rather than
united, so the real rect is still needed there.

This also requires fixing isEntireBackingStoreDirty(), which tested m_dirtyRect against
backingStoreBounds() for equality. Accumulated rects are inflated by 1 to cover antialiasing, which
is on by default, so the equality never held. Use contains() on the accumulating ports. No
observable change for the existing caller, willUpdateEntireContents(), which already ended up at the
same invalidation.

~6-7% MotionMark Canvas Lines improvement.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::fillInternal):
(WebCore::CanvasRenderingContext2DBase::strokeInternal):
(WebCore::CanvasRenderingContext2DBase::isEntireBackingStoreDirty const):

Canonical link: <a href="https://commits.webkit.org/320709@main">https://commits.webkit.org/320709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43063511cc80fcb6ff05c59885176525edbadff6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195918 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150329 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f903c39-4c5c-4e8f-b525-cebc43edf0b6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187463 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145041 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100557 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/53eed430-d447-46c1-ac1d-7c952d6f7c71) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165616 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125336 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4eb7e736-3754-4097-b46a-2afc235ad87f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47449 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45500 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157812 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45189 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6973 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52154 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197873 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59173 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154572 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59881 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41794 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154223 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28182 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48694 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132229 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129139 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58352 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20211 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57728 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57969 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57794 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->