### PR TITLE
[Site Isolation] A dialog from a document the page has left can still reach the client

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11319,9 +11319,21 @@ void WebPageProxy::closePage()
     m_uiClient->close(this);
 }
 
+static bool isInDisplayedFrameTree(WebFrameProxy& frame, WebFrameProxy* currentMainFrame)
+{
+    RefPtr<WebFrameProxy> topFrame = &frame;
+    while (RefPtr parent = topFrame->parentFrame())
+        topFrame = WTF::move(parent);
+
+    return topFrame.get() == currentMainFrame;
+}
+
 void WebPageProxy::runModalJavaScriptDialog(RefPtr<WebFrameProxy>&& frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void(WebPageProxy&, WebFrameProxy* frame, FrameInfoData&& frameInfo, String&& message2, CompletionHandler<void()>&&, DialogDisposition)>&& runDialogCallback)
 {
-    m_queuedModalDialogs.append([weakThis = WeakPtr { *this }, frame = WTF::move(frame), frameInfo = WTF::move(frameInfo), message = WTF::move(message), runDialogCallback = WTF::move(runDialogCallback)](DialogDisposition disposition) mutable {
+    if (frame && !isInDisplayedFrameTree(*frame, m_mainFrame.get()))
+        return runDialogCallback(*this, frame.get(), WTF::move(frameInfo), WTF::move(message), [] { }, DialogDisposition::Cancel);
+
+    m_queuedModalDialogs.append({ frame, [weakThis = WeakPtr { *this }, frame = WTF::move(frame), frameInfo = WTF::move(frameInfo), message = WTF::move(message), runDialogCallback = WTF::move(runDialogCallback)](DialogDisposition disposition) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -11341,7 +11353,7 @@ void WebPageProxy::runModalJavaScriptDialog(RefPtr<WebFrameProxy>&& frame, Frame
                 protectedThis->runNextModalJavaScriptDialogIfNeeded();
             }, DialogDisposition::Show);
         });
-    });
+    } });
     runNextModalJavaScriptDialogIfNeeded();
 }
 
@@ -11351,17 +11363,27 @@ void WebPageProxy::runNextModalJavaScriptDialogIfNeeded()
     if (m_isSafeBrowsingCheckInProgress)
         return;
 #endif
-    if (m_isRunningModalJavaScriptDialog || m_queuedModalDialogs.isEmpty())
+    if (m_isRunningModalJavaScriptDialog)
         return;
 
-    m_isRunningModalJavaScriptDialog = true;
-    m_queuedModalDialogs.takeFirst()(DialogDisposition::Show);
+    while (!m_queuedModalDialogs.isEmpty()) {
+        auto dialog = m_queuedModalDialogs.takeFirst();
+        // The frame tree can change while a request waits in the queue.
+        RefPtr frame = dialog.frame.get();
+        if (!frame || !isInDisplayedFrameTree(*frame, m_mainFrame.get())) {
+            dialog.show(DialogDisposition::Cancel);
+            continue;
+        }
+        m_isRunningModalJavaScriptDialog = true;
+        dialog.show(DialogDisposition::Show);
+        return;
+    }
 }
 
 void WebPageProxy::purgeQueuedModalDialogs()
 {
     for (auto& dialog : std::exchange(m_queuedModalDialogs, { }))
-        dialog(DialogDisposition::Cancel);
+        dialog.show(DialogDisposition::Cancel);
 }
 
 void WebPageProxy::runJavaScriptAlert(IPC::Connection& connection, FrameIdentifier frameID, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void()>&& reply)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -4321,7 +4321,11 @@ private:
 
     bool m_lastNavigationWasAppInitiated { true };
     bool m_isRunningModalJavaScriptDialog { false };
-    Deque<Function<void(DialogDisposition)>> m_queuedModalDialogs;
+    struct QueuedModalDialog {
+        WeakPtr<WebFrameProxy> frame;
+        Function<void(DialogDisposition)> show;
+    };
+    Deque<QueuedModalDialog> m_queuedModalDialogs;
     bool m_isSuspended { false };
 
 #if HAVE(SAFE_BROWSING)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -2016,14 +2016,13 @@ TEST(SiteIsolation, QueuedDialogPurgedByMainFrameNavigation)
     // cannot be shown while the first is held, so a longer wait here is harmless.
     TestWebKitAPI::Util::runFor(Seconds(0.5));
 
-    // Navigate the main frame and wait for the new provisional load to start, which is where the queue
-    // is purged.
-    __block bool navigationStarted = false;
-    navigationDelegate.get().didStartProvisionalNavigation = ^(WKWebView *, WKNavigation *) {
-        navigationStarted = true;
+    // Waiting for the provisional load would be racy: the old frames are the page's tree until the commit.
+    __block bool navigationCommitted = false;
+    navigationDelegate.get().didCommitNavigation = ^(WKWebView *, WKNavigation *) {
+        navigationCommitted = true;
     };
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/next"]]];
-    while (!navigationStarted)
+    while (!navigationCommitted)
         TestWebKitAPI::Util::runFor(Seconds(0.05));
 
     // Release the first dialog. If the queued dialog had not been purged, dismissing the first would
@@ -2031,6 +2030,52 @@ TEST(SiteIsolation, QueuedDialogPurgedByMainFrameNavigation)
     std::exchange(firstCompletion, nullptr)();
 
     // Let anything still in flight settle, then confirm only the first dialog was ever delivered.
+    TestWebKitAPI::Util::runFor(Seconds(0.5));
+    EXPECT_EQ(totalDialogs, 1u);
+}
+
+TEST(SiteIsolation, QueuedSameProcessDialogPurgedByMainFrameNavigation)
+{
+    // Same-site iframes share a process, so the first frame's modal run loop blocks the second frame's script.
+    HTTPServer server({
+        { "/example"_s, { "<iframe src='https://webkit.org/first'></iframe>"
+            "<iframe src='https://webkit.org/second'></iframe>"_s } },
+        { "/first"_s, { "<script>alert('first dialog')</script>"_s } },
+        { "/second"_s, { "<script>alert('second dialog')</script>"_s } },
+        { "/next"_s, { "<p>next</p>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+
+    __block unsigned totalDialogs = 0;
+    __block BlockPtr<void()> firstCompletion;
+    RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
+    uiDelegate.get().runJavaScriptAlertPanelWithMessage = ^(WKWebView *, NSString *message, WKFrameInfo *frameInfo, void (^completionHandler)(void)) {
+        if (!totalDialogs++) {
+            firstCompletion = makeBlockPtr(completionHandler);
+            return;
+        }
+        completionHandler();
+    };
+    webView.get().UIDelegate = uiDelegate.get();
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+
+    while (!firstCompletion)
+        TestWebKitAPI::Util::runFor(Seconds(0.05));
+
+    TestWebKitAPI::Util::runFor(Seconds(0.5));
+
+    __block bool navigationCommitted = false;
+    navigationDelegate.get().didCommitNavigation = ^(WKWebView *, WKNavigation *) {
+        navigationCommitted = true;
+    };
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/next"]]];
+    while (!navigationCommitted)
+        TestWebKitAPI::Util::runFor(Seconds(0.05));
+
+    std::exchange(firstCompletion, nullptr)();
+
     TestWebKitAPI::Util::runFor(Seconds(0.5));
     EXPECT_EQ(totalDialogs, 1u);
 }


### PR DESCRIPTION
#### d4b8cb8d2eef6760b8c4e09aee8105ce788a17cd
<pre>
[Site Isolation] A dialog from a document the page has left can still reach the client
<a href="https://bugs.webkit.org/show_bug.cgi?id=323687">https://bugs.webkit.org/show_bug.cgi?id=323687</a>
<a href="https://rdar.apple.com/186946399">rdar://186946399</a>

Reviewed by Brady Eidson.

SiteIsolation.QueuedDialogPurgedByMainFrameNavigation fails with SiteIsolationSharedProcessEnabled. When two iframes end
up in the same process, the modal run loop for the first frame&apos;s alert() blocks the second frame&apos;s script, so its
request only reaches the UI process after the first dialog is dismissed. purgeQueuedModalDialogs() has long since run -
it fires when the main frame starts a provisional load - so the late request is queued and shown, on behalf of a page
the user has already left. This is not specific to shared process mode: two same-site iframes share a process in the
default configuration and reproduce it, which is what the new test QueuedSameProcessDialogPurgedByMainFrameNavigation
covers.

Check in WebPageProxy::runModalJavaScriptDialog, the single funnel for alert, confirm and prompt, that the requesting
frame is still in the displayed frame tree, and cancel it if not. DialogDisposition::Cancel is the path the purge
already uses: it replies to the Web process so the blocked alert() returns, without invoking the UI client. The check
runs again on the way out of the queue, since the tree can change while a request waits there.

This is a frame-identity check, so it is not the complete fix. It cannot separate two documents that share one
WebFrameProxy - ProvisionalPageProxy&apos;s m_shouldReuseMainFrame branch - and for a same-process main frame navigation it
only takes effect once didDestroyFrame has arrived, so it depends on that teardown IPC rather than on the commit. The
complete fix is document identity: compare the requesting document&apos;s identifier against the one committed in that frame,
and that frame&apos;s top document against the main frame&apos;s. It is blocked on a separate defect - on a back/forward cache
restore didCommitLoadForFrame reports the identifier of the document being navigated away from, because
FrameLoader::commitProvisionalLoad dispatches the commit before it restores the cached page - and will be followed up
separately.

Verified that a back/forward cache restore is not over-refused: after going back, dialogs from the restored main frame
and from its restored cross-site subframe are still delivered.

Tests: SiteIsolation.QueuedSameProcessDialogPurgedByMainFrameNavigation

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::isInDisplayedFrameTree):
(WebKit::WebPageProxy::runModalJavaScriptDialog):
(WebKit::WebPageProxy::runNextModalJavaScriptDialogIfNeeded):
(WebKit::WebPageProxy::purgeQueuedModalDialogs):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, QueuedDialogPurgedByMainFrameNavigation)):
(TestWebKitAPI::TEST(SiteIsolation, QueuedSameProcessDialogPurgedByMainFrameNavigation)):

Canonical link: <a href="https://commits.webkit.org/320870@main">https://commits.webkit.org/320870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14d97ae4c884dae29cf228a63318620e6030ea19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196011 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150405 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/17f50839-1450-4f8d-ba8b-322123e83282) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145113 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100611 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5916c157-e71d-4804-952a-e04c57ccf8a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165684 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125408 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9af14b0c-a7c1-402a-8d48-27641085b5c0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47528 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45567 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45259 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7074 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52239 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197977 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59271 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154651 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41523 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59979 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41864 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154303 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48767 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132328 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129263 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58446 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20281 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57824 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58060 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57887 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->