### PR TITLE
[JSC] Remove Heap::isPagedOut

### DIFF
--- a/Source/JavaScriptCore/heap/BlockDirectory.cpp
+++ b/Source/JavaScriptCore/heap/BlockDirectory.cpp
@@ -35,7 +35,6 @@
 
 #include <wtf/FunctionTraits.h>
 #include <wtf/Lock.h>
-#include <wtf/SimpleStats.h>
 
 namespace JSC {
 
@@ -62,39 +61,6 @@ void BlockDirectory::setSubspace(Subspace* subspace)
 {
     m_attributes = subspace->attributes();
     m_subspace = subspace;
-}
-
-void BlockDirectory::updatePercentageOfPagedOutPages(SimpleStats& stats)
-{
-    // FIXME: We should figure out a solution for Windows and PlayStation.
-    // QNX doesn't have mincore(), though the information can be had. But since all mapped
-    // pages are resident, does it matter?
-#if OS(UNIX) && !PLATFORM(PLAYSTATION) && !OS(QNX) && !OS(HAIKU)
-    size_t pageSize = WTF::pageSize();
-    ASSERT(!(MarkedBlock::blockSize % pageSize));
-    auto numberOfPagesInMarkedBlock = MarkedBlock::blockSize / pageSize;
-    // For some reason this can be unsigned char or char on different OSes...
-    using MincoreBufferType = std::remove_pointer_t<FunctionTraits<decltype(mincore)>::ArgumentType<2>>;
-    static_assert(std::is_same_v<std::make_unsigned_t<MincoreBufferType>, unsigned char>);
-    Vector<MincoreBufferType, 16> pagedBits(FillWith { }, numberOfPagesInMarkedBlock, MincoreBufferType { });
-
-    for (auto* handle : m_blocks) {
-        if (!handle)
-            continue;
-
-        auto* pageStart = handle->pageStart();
-        auto markedBlockSizeInBytes = handle->backingStorageSize();
-        RELEASE_ASSERT(markedBlockSizeInBytes / pageSize <= numberOfPagesInMarkedBlock);
-        // We could cache this in bulk (e.g. 25 MB chunks) but we haven't seen any data that it actually matters.
-        auto result = mincore(pageStart, markedBlockSizeInBytes, pagedBits.mutableSpan().data());
-        RELEASE_ASSERT(!result);
-        constexpr unsigned pageIsResidentAndNotCompressed = 1;
-        for (unsigned i = 0; i < numberOfPagesInMarkedBlock; ++i)
-            stats.add(!(pagedBits[i] & pageIsResidentAndNotCompressed));
-    }
-#else
-    UNUSED_PARAM(stats);
-#endif
 }
 
 MarkedBlock::Handle* BlockDirectory::findEmptyBlockToSteal()

--- a/Source/JavaScriptCore/heap/BlockDirectory.h
+++ b/Source/JavaScriptCore/heap/BlockDirectory.h
@@ -37,10 +37,6 @@
 #include <wtf/SharedTask.h>
 #include <wtf/Vector.h>
 
-namespace WTF {
-class SimpleStats;
-}
-
 namespace JSC {
 
 class GCDeferralContext;
@@ -91,8 +87,6 @@ public:
     // If WillDeleteBlock::Yes is passed then the block will be left in an invalid state. We do this, however, to avoid potentially paging in / decompressing old blocks to update their handle just before freeing them.
     void removeBlock(MarkedBlock::Handle*, WillDeleteBlock = WillDeleteBlock::No);
 
-    void updatePercentageOfPagedOutPages(WTF::SimpleStats&);
-    
 #if ASSERT_ENABLED
     JS_EXPORT_PRIVATE void assertIsMutatorOrMutatorIsStopped() const WTF_ASSERTS_ACQUIRED_SHARED_LOCK(m_bitvectorLock);
     void assertSweeperIsSuspended() const WTF_ASSERTS_ACQUIRED_LOCK(m_bitvectorLock);

--- a/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
+++ b/Source/JavaScriptCore/heap/FullGCActivityCallback.cpp
@@ -43,15 +43,6 @@ void FullGCActivityCallback::doCollection(VM& vm)
     JSC::Heap& heap = vm.heap;
     setDidGCRecently(false);
 
-#if !PLATFORM(IOS_FAMILY) || PLATFORM(MACCATALYST)
-    MonotonicTime startTime = MonotonicTime::now();
-    if (MemoryPressureHandler::singleton().isUnderMemoryPressure() && heap.isPagedOut()) {
-        cancel();
-        heap.increaseLastFullGCLength(MonotonicTime::now() - startTime);
-        return;
-    }
-#endif
-
     heap.collect(m_synchronousness, CollectionScope::Full);
 }
 

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -500,11 +500,6 @@ Heap::~Heap()
         WeakBlock::destroy(*this, block);
 }
 
-bool Heap::isPagedOut()
-{
-    return m_objectSpace.isPagedOut();
-}
-
 void Heap::dumpHeapStatisticsAtVMDestruction()
 {
     unsigned counter = 0;

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -329,12 +329,6 @@ public:
     static JSC::Heap* heap(const JSValue); // 0 for immediate values
     static JSC::Heap* heap(const HeapCell*);
 
-    // This constant determines how many blocks we iterate between checks of our 
-    // deadline when calling Heap::isPagedOut. Decreasing it will cause us to detect 
-    // overstepping our deadline more quickly, while increasing it will cause 
-    // our scan to run faster. 
-    static constexpr unsigned s_timeCheckResolution = 16;
-
     bool isMarked(const void*);
     static bool testAndSetMarked(HeapVersion, const void*);
 
@@ -497,8 +491,7 @@ public:
     void deleteAllUnlinkedCodeBlocks(DeleteAllCodeEffort);
 
     JS_EXPORT_PRIVATE void didAllocate(size_t);
-    bool isPagedOut();
-    
+
     const JITStubRoutineSet& jitStubRoutines() { return *m_jitStubRoutines; }
     
     void addReference(JSCell*, ArrayBuffer*);

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -28,7 +28,6 @@
 #include "MarkedSpaceInlines.h"
 #include "WeakSetInlines.h"
 #include <wtf/ListDump.h>
-#include <wtf/SimpleStats.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -365,21 +364,6 @@ void MarkedSpace::resumeAllocating()
             return IterationStatus::Continue;
         });
     // Nothing to do for PreciseAllocations.
-}
-
-bool MarkedSpace::isPagedOut()
-{
-    SimpleStats pagedOutPagesStats;
-
-    forEachDirectory(
-        [&] (BlockDirectory& directory) -> IterationStatus {
-            directory.updatePercentageOfPagedOutPages(pagedOutPagesStats);
-            return IterationStatus::Continue;
-        });
-    // FIXME: Consider taking PreciseAllocations into account here.
-    double maxHeapGrowthFactor = VM::isInMiniMode() ? Options::miniVMHeapGrowthFactor() : Options::largeHeapGrowthFactor();
-    double bailoutPercentage = Options::customFullGCCallbackBailThreshold() == -1.0 ? maxHeapGrowthFactor - 1 : Options::customFullGCCallbackBailThreshold();
-    return pagedOutPagesStats.mean() > pagedOutPagesStats.count() * bailoutPercentage;
 }
 
 // FIXME: rdar://139998916

--- a/Source/JavaScriptCore/heap/MarkedSpace.h
+++ b/Source/JavaScriptCore/heap/MarkedSpace.h
@@ -149,8 +149,6 @@ public:
     size_t size();
     size_t NODELETE capacity();
 
-    bool isPagedOut();
-    
     HeapVersion markingVersion() const { return m_markingVersion; }
     HeapVersion newlyAllocatedVersion() const { return m_newlyAllocatedVersion; }
     HeapVersion edenVersion() const { return m_edenVersion; }

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -227,7 +227,6 @@ bool hasCapacityToUseLargeGigacage();
     v(Double, maxEdenSizeForRateLimitingMultiplier, 8.0, Normal, nullptr) \
     v(Double, gcRateLimitingHalfLifeInMS, 1000.00, Normal, nullptr) \
     v(Double, criticalGCMemoryThreshold, 0.80, Normal, "percent memory in use the GC considers critical.  The collector is much more aggressive above this threshold"_s) \
-    v(Double, customFullGCCallbackBailThreshold, -1.0, Normal, "percent of memory paged out before we bail out of timer based Full GCs. -1.0 means use (maxHeapGrowthFactor - 1)"_s) \
     v(Double, minimumMutatorUtilization, 0, Normal, nullptr) \
     v(Double, maximumMutatorUtilization, 0.7, Normal, nullptr) \
     v(Double, epsilonMutatorUtilization, 0.01, Normal, nullptr) \


### PR DESCRIPTION
#### 4577b17ad891b294d77e670a4f8670f920976d44
<pre>
[JSC] Remove Heap::isPagedOut
<a href="https://bugs.webkit.org/show_bug.cgi?id=323689">https://bugs.webkit.org/show_bug.cgi?id=323689</a>
<a href="https://rdar.apple.com/186946846">rdar://186946846</a>

Reviewed by Keith Miller.

Removing Heap::isPagedOut given that we found that this was never
invoked because of a bug. The percentage number etc. needs to be tuned
with fresh benchmarks and metrics, so as it is dead code now, just
removing it. We can have similar or revised version of this later.

* Source/JavaScriptCore/heap/BlockDirectory.cpp:
(JSC::BlockDirectory::updatePercentageOfPagedOutPages): Deleted.
* Source/JavaScriptCore/heap/BlockDirectory.h:
* Source/JavaScriptCore/heap/FullGCActivityCallback.cpp:
(JSC::FullGCActivityCallback::doCollection):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::isPagedOut): Deleted.
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/MarkedSpace.cpp:
(JSC::MarkedSpace::isPagedOut): Deleted.
* Source/JavaScriptCore/heap/MarkedSpace.h:
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/320681@main">https://commits.webkit.org/320681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c63aae2b6f8b8182bdb7c90e336fb50c910603b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185624 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195937 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59259 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188579 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48741 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/125362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47467 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/7259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14138 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157828 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45206 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6996 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46875 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52174 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197896 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59195 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59904 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154247 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28169 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48710 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129159 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58375 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20228 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57750 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57991 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57816 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->