### PR TITLE
Cherry-pick 320274@main (65ef7f38f8f9). https://bugs.webkit.org/show_bug.cgi?id=315389

### DIFF
--- a/JSTests/stress/b3-ccmp-chain.js
+++ b/JSTests/stress/b3-ccmp-chain.js
@@ -1,0 +1,51 @@
+// Regression tests for B3 ccmp-chain lowering of nested boolean expressions on ARM64.
+
+let arr = [0, 1, 2, 3, 4, 5, 6, 7];
+
+function f(arr, i, a, b, c, d) {
+    if (i < 0)
+        return -2;
+    if ((i < arr.length) & (((((a == b) & (c == d)) | (a ^ c)) == 0))) {
+        return arr[i];
+    }
+    return -1;
+}
+noInline(f);
+for (let j = 0; j < testLoopCount; j++) {
+    let r1 = f(arr, j & 7, 5, 6, 5, 5);
+    if (r1 !== arr[j & 7])
+        throw new Error("T1 mismatch: f(arr, " + (j & 7) + ", 5, 6, 5, 5) got " + r1);
+    let r2 = f(arr, j & 7, 5, 5, 5, 5);
+    if (r2 !== -1)
+        throw new Error("T1 mismatch: f(arr, " + (j & 7) + ", 5, 5, 5, 5) got " + r2);
+}
+// T1
+if (f(arr, 0x7ffffff0, 5, 5, 5, -10) !== -1) throw new Error("T1 mismatch case 1");
+if (f(arr, 0x7ffffff0, 5, 5, 5, 10) !== -1) throw new Error("T1 mismatch case 2");
+if (f(arr, 5, 5, 6, 5, 5) !== arr[5]) throw new Error("T1 mismatch case 3");
+if (f(arr, 5, 5, 5, 5, 5) !== -1) throw new Error("T1 mismatch case 4");
+
+function f_legit_chain(a, b, c, d, e, g) {
+    if ((a == b) & (c < d) & (e != g))
+        return 1;
+    return 0;
+}
+noInline(f_legit_chain);
+let cases = [
+    [5, 5, 1, 2, 3, 4, 1],
+    [5, 5, 2, 1, 3, 4, 0],
+    [5, 6, 1, 2, 3, 4, 0],
+    [5, 5, 1, 2, 3, 3, 0],
+    [0, 0, 0, 1, 0, 0, 0],
+    [-1, -1, -3, -2, 1, 0, 1],
+];
+for (let j = 0; j < testLoopCount; j++) {
+    for (let [a, b, c, d, e, g] of cases)
+        f_legit_chain(a, b, c, d, e, g);
+}
+// T2
+for (let [a, b, c, d, e, g, exp] of cases) {
+    let got = f_legit_chain(a, b, c, d, e, g);
+    if (got !== exp)
+        throw new Error("T2 regression: f_legit_chain(" + [a, b, c, d, e, g] + ") got " + got + " expected " + exp);
+}

--- a/JSTests/stress/unlinked-metadata-table-finalize-overflow.js
+++ b/JSTests/stress/unlinked-metadata-table-finalize-overflow.js
@@ -1,0 +1,18 @@
+//@ skip if $buildType == "debug" or $memoryLimited or $addressBits <= 32
+//@ slow!
+//@ runDefault
+
+let n = 44739242;
+let s = 'a();'.repeat(n);
+let f = new Function('a', s);
+
+let caught = false;
+try {
+    f(function() { });
+} catch (e) {
+    caught = true;
+    if (!(e instanceof RangeError))
+        throw new Error("Expected RangeError but got: " + e);
+}
+if (!caught)
+    throw new Error("Expected RangeError to be thrown");

--- a/JSTests/wasm/gc/backwards-graph-multi-backedge-licm.js
+++ b/JSTests/wasm/gc/backwards-graph-multi-backedge-licm.js
@@ -1,0 +1,109 @@
+//@ runDefaultWasm("--useConcurrentJIT=0", "--thresholdForBBQOptimizeAfterWarmUp=0", "--thresholdForBBQOptimizeSoon=0", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0")
+
+load("wast.js", "caller relative");
+
+const moduleBytes = WebAssemblyText.encode(`
+(module
+  (type $sink (struct (field i64)))
+  (type $probe
+    (struct
+      (field i64)
+      (field (ref $sink))
+      (field (ref $sink))
+      (field (ref $sink))))
+  (type $small
+    (struct
+      (field i64)
+      (field i64)
+      (field i64)
+      (field i64)))
+  (global $keep (mut i32) (i32.const 0))
+
+  (func (export "makeSink") (param $value i64) (result (ref $sink))
+    (struct.new $sink (local.get $value)))
+
+  (func (export "makeProbe")
+    (param $value i64)
+    (param $sink (ref $sink))
+    (result (ref $probe))
+    (struct.new $probe
+      (local.get $value)
+      (local.get $sink)
+      (local.get $sink)
+      (local.get $sink)))
+
+  (func (export "makeSmall") (result (ref $small))
+    (struct.new $small
+      (i64.const 0)
+      (i64.const 0)
+      (i64.const 0)
+      (i64.const 0)))
+
+  (func (export "readAfterCast")
+    (param $source anyref)
+    (param $valid (ref $sink))
+    (param $bit i64)
+    (param $forceBit i32)
+    (param $useLoaded i32)
+    (param $lateLoop i32)
+    (result i64)
+    (local $probeLocal (ref $probe))
+    (loop $loop (result i64)
+      (block $castSucceeded (result (ref $probe))
+        (br_on_cast $castSucceeded
+          (ref null any)
+          (ref $probe)
+          (local.get $source))
+        (global.set $keep (i32.const 1))
+        (br $loop))
+      (local.set $probeLocal)
+
+      (struct.get $probe 2 (local.get $probeLocal))
+      (struct.get $probe 3 (local.get $probeLocal))
+      (struct.get $probe 2 (local.get $probeLocal))
+      (local.get $valid)
+      (struct.get $probe 1 (local.get $probeLocal))
+      (struct.get $sink 0)
+      (local.get $bit)
+      i64.shr_u
+      i32.wrap_i64
+      i32.const 1
+      i32.and
+      (local.get $forceBit)
+      (local.get $useLoaded)
+      (select (result i32))
+      i32.eqz
+      (select (result (ref $sink)))
+      (struct.get $sink 0)
+      i64.const 1
+      i64.and
+      i32.wrap_i64
+      (select (result (ref $sink)))
+      (struct.get $sink 0)
+      (br_if $loop (local.get $lateLoop))))
+)
+`);
+
+const { makeProbe, makeSink, makeSmall, readAfterCast } =
+    new WebAssembly.Instance(new WebAssembly.Module(moduleBytes)).exports;
+const sink = makeSink(0x5152535455565758n);
+const probe = makeProbe(0x1111111111111111n, sink);
+
+for (let iteration = 0; iteration < 1000; ++iteration)
+    readAfterCast(probe, sink, 0n, 0, 1, 0);
+
+// Correct semantics: cast failure loops forever before any control-dependent
+// struct.get executes. OMG-compiled Wasm loops have no watchdog poll (rdar://103455312), so bound
+// the test by exiting from a helper thread once the main thread has had time to
+// reach the loop.
+$.agent.start(`
+    $.agent.sleep(10); // 10 ms
+    quit();
+`);
+
+try {
+    readAfterCast(makeSmall(), sink, 0n, 0, 1, 0);
+    throw new Error("readAfterCast on a failed cast should not return");
+} catch (e) {
+    throw new Error("B3 LICM hoisted control-dependent struct.get past br_on_cast: " + e);
+}

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -82,6 +82,7 @@
 #include "SIMDShuffle.h"
 #include <wtf/IndexMap.h>
 #include <wtf/IndexSet.h>
+#include <wtf/Scope.h>
 #include <wtf/StdLibExtras.h>
 
 #if !ASSERT_ENABLED
@@ -2448,6 +2449,7 @@ private:
     };
 
 #if CPU(ARM64)
+
     static bool NODELETE isComparisonOpcode(B3::Opcode opcode)
     {
         switch (opcode) {
@@ -2565,11 +2567,19 @@ private:
         }
     }
 
-    CompareChainNode* findCompareChain(Value* value, SegmentedVector<CompareChainNode>& nodes, Vector<CompareChainNode*, 16>& logicalNodes, Vector<Value*, 16> usedValues)
+    CompareChainNode* findCompareChain(Value* value, SegmentedVector<CompareChainNode>& nodes, Vector<CompareChainNode*, 16>& logicalNodes, Vector<Value*, 16>& usedValues)
     {
         dataLogLnIf(B3LowerToAirInternal::verbose, "    findCompareChain: nodes.size()=", nodes.size(), ", value=", pointerDump(value));
         if (!value)
             return nullptr;
+
+        // Roll back logicalNodes/usedValues unless rollback.release() is reached.
+        size_t savedLogicalSize = logicalNodes.size();
+        size_t savedUsedSize = usedValues.size();
+        auto rollback = makeScopeExit([&] {
+            logicalNodes.shrink(savedLogicalSize);
+            usedValues.shrink(savedUsedSize);
+        });
 
         B3::Opcode opcode = value->opcode();
         dataLogLnIf(B3LowerToAirInternal::verbose, "    findCompareChain: opcode=", opcode);
@@ -2610,6 +2620,7 @@ private:
                     dataLogLnIf(B3LowerToAirInternal::verbose, "    findCompareChain: applying negation to chain");
                     negatedChain->markRequiresNegation();
                     usedValues.append(value);
+                    rollback.release();
                     return negatedChain;
                 }
             }
@@ -2622,6 +2633,7 @@ private:
                 : relationalConditionForOpcode(opcode);
             dataLogLnIf(B3LowerToAirInternal::verbose, "    findCompareChain: created comparison node");
             usedValues.append(value);
+            rollback.release();
             return node;
         }
 
@@ -2639,6 +2651,9 @@ private:
 
             // Negation handling: detect (chain) == 0 pattern
             // This optimizes patterns like !(a && b) which become (a && b) == 0
+            //
+            // FIXME: is this guard reachable? value's children must have the same type, child(0) must be integral,
+            // unclear whether the recursive call to findCompareChain can return int64
             if (value->type() != Int32 && value->child(1)->isInt(1)) {
                 dataLogLnIf(B3LowerToAirInternal::verbose, "    findCompareChain: detected == 0 pattern, checking for negation");
                 CompareChainNode* negatedChain = findCompareChain(value->child(0), nodes, logicalNodes, usedValues);
@@ -2646,9 +2661,11 @@ private:
                     dataLogLnIf(B3LowerToAirInternal::verbose, "    findCompareChain: applying negation to chain");
                     negatedChain->markRequiresNegation();
                     usedValues.append(value);
+                    rollback.release();
                     return negatedChain;
                 }
             }
+            return nullptr;
         }
 
         // Check if this is a BitAnd or BitOr
@@ -2682,7 +2699,6 @@ private:
             // We don't allow combining two logic operations
             if (!leftNode->isComparison() && !rightNode->isComparison()) {
                 dataLogLnIf(B3LowerToAirInternal::verbose, "    findCompareChain: both children are logic ops, rejecting");
-                logicalNodes.clear();
                 return nullptr;
             }
 
@@ -2702,6 +2718,7 @@ private:
             logicalNodes.append(node);
             usedValues.append(value);
             dataLogLnIf(B3LowerToAirInternal::verbose, "    findCompareChain: created logic op node (", (opcode == BitAnd ? "AND" : "OR"), ")");
+            rollback.release();
             return node;
         }
 

--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -201,7 +201,7 @@ public:
     Dominators& dominators();
     JS_EXPORT_PRIVATE NaturalLoops& naturalLoops();
     BackwardsCFG& backwardsCFG();
-    BackwardsDominators& backwardsDominators();
+    JS_EXPORT_PRIVATE BackwardsDominators& backwardsDominators();
 
     void addFastConstant(const ValueKey&);
     bool NODELETE isFastConstant(const ValueKey&);

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1324,6 +1324,7 @@ void testShuffleDoesntTrashCalleeSaves();
 void testDemotePatchpointTerminal();
 void testReportUsedRegistersLateUseFollowedByEarlyDefDoesNotMarkUseAsDead();
 void testInfiniteLoopDoesntCauseBadHoisting();
+void testBackwardsDominatorsWithMultipleBackEdges();
 void testDivImmArgFloat(float, float);
 void testDivImmsFloat(float, float);
 void testModArgDouble(double);

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1531,6 +1531,7 @@ void testCCmpNegatedAnd32(int32_t, int32_t);
 void testCCmpNegatedOr32(int32_t, int32_t);
 void testCCmpMixedWidth32And64(int32_t, int64_t, int32_t);
 void testCCmpMixedWidth64And32(int64_t, int32_t);
+void testCCmpChainRollback(int32_t, int32_t, int32_t, int32_t, int32_t, int32_t);
 
 // ARM64 fccmp tests (floating-point conditional compare)
 void testFCCmpAndDouble(double, double, double, double);

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -1198,6 +1198,7 @@ void run(const TestConfig* config)
     RUN(testLoopWithMultipleHeaderEdges());
 
     RUN(testInfiniteLoopDoesntCauseBadHoisting());
+    RUN(testBackwardsDominatorsWithMultipleBackEdges());
 
     RUN(testFloatMaxMin());
     RUN(testDoubleMaxMin());

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -1407,6 +1407,13 @@ void run(const TestConfig* config)
     RUN(testFCCmpNegatedAndDouble(1.0, 2.0, 4.0, 3.0));  // !(true && false) = true
     RUN(testFCCmpNegatedAndDouble(2.0, 1.0, 4.0, 3.0));  // !(false && false) = true
 
+    RUN(testCCmpChainRollback(5, 8, 5, 5, 5, 10)); // in-bounds, expected 1
+    RUN(testCCmpChainRollback(5, 8, 1, 2, 3, 4)); // inner expr non-zero, expected 0
+    RUN(testCCmpChainRollback(5, 8, 5, 5, 5, 5)); // inner expr non-zero (both eq), expected 0
+    RUN(testCCmpChainRollback(-1, 8, 5, 5, 5, 10)); // signed i<len, expected 1
+    RUN(testCCmpChainRollback(200, 8, 5, 5, 5, 10)); // i>=len; pre-fix wrongly returns 1
+    RUN(testCCmpChainRollback(5, 8, 5, 5, 5, -10)); // c>d, expected 1
+
     RUN_UNARY(testSShrCompare32, int32OperandsMore());
     RUN_UNARY(testSShrCompare64, int64OperandsMore());
 

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "testb3.h"
+#include "B3BackwardsDominators.h"
 #include <wtf/WasmSIMD128.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -2176,6 +2177,70 @@ void testInfiniteLoopDoesntCauseBadHoisting()
     auto code = compileProc(proc);
     RELEASE_ASSERT(!proc.calleeSaveRegisterAtOffsetList().registerCount());
     invoke<void>(*code, static_cast<intptr_t>(55)); // Shouldn't crash dereferncing 55.
+}
+
+void testBackwardsDominatorsWithMultipleBackEdges()
+{
+    // A loop whose header has two latches (back-edge sources), where only one
+    // of them also exits the loop:
+    //
+    //   root    --> header
+    //   header  --> success | failure          (branch)
+    //   success --> header (back edge) | exit   (branch)   // latch that can exit
+    //   failure --> header (back edge)                     // latch with no exit
+    //   exit    --> Return                                 // the only terminal
+    //
+    // `success` and `failure` are both back-edge sources. The `failure` latch
+    // has no exit of its own, so control that keeps taking it loops forever.
+    // BackwardsGraph treats that as a form of terminality: it computes
+    // post-dominators by reversing the CFG and giving the synthetic reverse
+    // root a successor for every terminal and every back-edge source.
+    //
+    // The property B3 LICM (and the control-equivalence consumers) rely on is
+    // the post-dominator relation: `success` must NOT post-dominate the header
+    // or the loop entry, because control can stay in the loop forever via the
+    // exit-less `failure` latch without ever reaching `success`. If `failure`
+    // is missing from the reverse root's successors, the header is reachable in
+    // the reverse CFG only through `success`, so `success` falsely
+    // post-dominates the header (and `root`) -- the false relationship that
+    // would let LICM hoist a control-dependent read out of the loop.
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* header = proc.addBlock();
+    BasicBlock* success = proc.addBlock();
+    BasicBlock* failure = proc.addBlock();
+    BasicBlock* exit = proc.addBlock();
+    auto arguments = cCallArgumentValues<intptr_t>(proc, root);
+    Value* arg = arguments[0];
+
+    root->appendNewControlValue(proc, Jump, Origin(), header);
+    header->appendNewControlValue(
+        proc, Branch, Origin(),
+        header->appendNew<Value>(proc, Equal, Origin(), arg,
+            header->appendNew<ConstPtrValue>(proc, Origin(), 10)),
+        success, failure);
+    success->appendNewControlValue(
+        proc, Branch, Origin(),
+        success->appendNew<Value>(proc, Equal, Origin(), arg,
+            success->appendNew<ConstPtrValue>(proc, Origin(), 20)),
+        header, exit);
+    failure->appendNewControlValue(proc, Jump, Origin(), header);
+    exit->appendNewControlValue(proc, Return, Origin());
+
+    proc.resetReachability();
+
+    BackwardsDominators& backwardsDominators = proc.backwardsDominators();
+
+    // Sanity: `header` genuinely post-dominates the entry (root's only successor
+    // is header), so the checks below are not vacuously true.
+    CHECK(backwardsDominators.dominates(header, root));
+
+    // The actual property: `success` must not post-dominate the header or the
+    // loop entry, because the exit-less `failure` latch is an escape that
+    // bypasses `success`. A dropped `failure` back-edge source makes both of
+    // these falsely true.
+    CHECK(!backwardsDominators.dominates(success, header));
+    CHECK(!backwardsDominators.dominates(success, root));
 }
 
 static void testSimpleTuplePair(unsigned first, int64_t second)

--- a/Source/JavaScriptCore/b3/testb3_8.cpp
+++ b/Source/JavaScriptCore/b3/testb3_8.cpp
@@ -2659,6 +2659,43 @@ void testCCmpMixedWidth64And32(int64_t a, int32_t b)
     CHECK_EQ(compileAndRun<int32_t>(proc, a, b), expected);
 }
 
+// Regression for findCompareChain rollback: pre-fix, BitOr's BitXor-child
+// failure leaked an inner logic node, dropping LessThan from the chain.
+void testCCmpChainRollback(int32_t i, int32_t len, int32_t a, int32_t b, int32_t c, int32_t d)
+{
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* thenCase = proc.addBlock();
+    BasicBlock* elseCase = proc.addBlock();
+    auto arguments = cCallArgumentValues<int32_t, int32_t, int32_t, int32_t, int32_t, int32_t>(proc, root);
+
+    Value* iLtLen = root->appendNew<Value>(proc, LessThan, Origin(), arguments[0], arguments[1]);
+    Value* eqAB = root->appendNew<Value>(proc, Equal, Origin(), arguments[2], arguments[3]);
+    Value* eqCD = root->appendNew<Value>(proc, Equal, Origin(), arguments[4], arguments[5]);
+    Value* innerAnd = root->appendNew<Value>(proc, BitAnd, Origin(), eqAB, eqCD);
+    Value* xorAC = root->appendNew<Value>(proc, BitXor, Origin(), arguments[2], arguments[4]);
+    Value* outerOr = root->appendNew<Value>(proc, BitOr, Origin(), innerAnd, xorAC);
+    Value* eqZero = root->appendNew<Value>(proc, Equal, Origin(),
+        outerOr, root->appendNew<Const32Value>(proc, Origin(), 0));
+    Value* condition = root->appendNew<Value>(proc, BitAnd, Origin(), iLtLen, eqZero);
+
+    root->appendNewControlValue(
+        proc, Branch, Origin(), condition,
+        FrequentedBlock(thenCase), FrequentedBlock(elseCase));
+
+    thenCase->appendNewControlValue(
+        proc, Return, Origin(),
+        thenCase->appendNew<Const32Value>(proc, Origin(), 1));
+
+    elseCase->appendNewControlValue(
+        proc, Return, Origin(),
+        elseCase->appendNew<Const32Value>(proc, Origin(), 0));
+
+    int zero = 0; // style checker complains about == 0
+    int32_t expected = (i < len && ((((a == b) & (c == d)) | (a ^ c)) == zero)) ? 1 : 0;
+    CHECK_EQ(compileAndRun<int32_t>(proc, i, len, a, b, c, d), expected);
+}
+
 void testConstDoubleZero()
 {
     Procedure proc;

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024, 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -59,14 +59,15 @@ void UnlinkedCodeBlockGenerator::addTypeProfilerExpressionInfo(unsigned instruct
     m_typeProfilerInfoMap.set(instructionOffset, range);
 }
 
-void UnlinkedCodeBlockGenerator::finalize(std::unique_ptr<JSInstructionStream> instructions)
+bool UnlinkedCodeBlockGenerator::finalize(std::unique_ptr<JSInstructionStream> instructions)
 {
     ASSERT(instructions);
+    bool metadataOK = true;
     {
         Locker locker { m_codeBlock->cellLock() };
         m_codeBlock->m_instructions = WTF::move(instructions);
         m_codeBlock->allocateSharedProfiles(m_numBinaryArithProfiles, m_numUnaryArithProfiles);
-        m_codeBlock->m_metadata->finalize();
+        metadataOK = m_codeBlock->m_metadata->finalize();
 
         m_codeBlock->m_jumpTargets = WTF::move(m_jumpTargets);
         m_codeBlock->m_identifiers = WTF::move(m_identifiers);
@@ -103,6 +104,7 @@ void UnlinkedCodeBlockGenerator::finalize(std::unique_ptr<JSInstructionStream> i
     }
     m_vm.writeBarrier(m_codeBlock.get());
     m_vm.heap.reportExtraMemoryAllocated(m_codeBlock.get(), m_codeBlock->m_instructions->sizeInBytes() + m_codeBlock->metadataSizeInBytes());
+    return metadataOK;
 }
 
 UnlinkedHandlerInfo* UnlinkedCodeBlockGenerator::handlerForBytecodeIndex(BytecodeIndex bytecodeIndex, RequiredHandler requiredHandler)

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024, 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -190,7 +190,7 @@ public:
 
     void applyModification(BytecodeRewriter&, JSInstructionStreamWriter&);
 
-    void finalize(std::unique_ptr<JSInstructionStream>);
+    [[nodiscard]] bool finalize(std::unique_ptr<JSInstructionStream>);
 
     void NODELETE dump(PrintStream&) const;
 

--- a/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023, 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 #include "UnlinkedMetadataTable.h"
 
 #include "BytecodeStructs.h"
+#include <wtf/CheckedArithmetic.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -98,41 +99,79 @@ void MetadataStatistics::reportMetadataStatistics()
 }
 #endif
 
-void UnlinkedMetadataTable::finalize()
+bool UnlinkedMetadataTable::finalize()
 {
     ASSERT(!m_isFinalized);
     m_isFinalized = true;
     if (!m_hasMetadata) {
         MetadataTableMalloc::free(m_rawBuffer);
         m_rawBuffer = nullptr;
-        return;
+        return true;
     }
 
-    unsigned offset = s_offset16TableSize;
+    unsigned offset;
+    unsigned valueProfileSize;
     {
+        CheckedUint32 checkedOffset = s_offset16TableSize;
         Offset32* buffer = preprocessBuffer();
-        for (unsigned i = 0; i < s_offsetTableEntries - 1; i++) {
+        for (unsigned i = 0; i < s_offsetTableEntries - 1 && !checkedOffset.hasOverflowed(); i++) {
             unsigned numberOfEntries = buffer[i];
             if (!numberOfEntries) {
-                buffer[i] = offset;
+                buffer[i] = checkedOffset.value();
                 continue;
             }
-            buffer[i] = offset; // We align when we access this.
+            buffer[i] = checkedOffset.value(); // We align when we access this.
             unsigned alignment = metadataAlignment(static_cast<OpcodeID>(i));
             ASSERT(alignment <= s_maxMetadataAlignment);
 
 #if CPU(ADDRESS64)
             // This is only necessary for the first metadata entry, if the buffer
             // is 4-byte aligned and the entry has an alignment requirement of 8
-            ASSERT(offset == roundUpToMultipleOf(alignment, offset) || offset == s_offset16TableSize);
+            ASSERT(checkedOffset.value() == roundUpToMultipleOf(alignment, checkedOffset.value()) || checkedOffset.value() == s_offset16TableSize);
 #endif
-            offset = roundUpToMultipleOf(alignment, offset);
+            unsigned alignedOffset = roundUpToMultipleOf(alignment, checkedOffset.value());
+            if (alignedOffset < checkedOffset.value()) {
+                checkedOffset.overflowed();
+                break;
+            }
+            checkedOffset = alignedOffset;
 
-            offset += numberOfEntries * metadataSize(static_cast<OpcodeID>(i));
+            checkedOffset += CheckedUint32(numberOfEntries) * metadataSize(static_cast<OpcodeID>(i));
 #if ENABLE(METADATA_STATISTICS)
+            // In the unlikely event of an overflow, MetadataStatistics::perOpcodeCount
+            // will not be accurate. But this is OK because these stats are only used for
+            // development time analysis where overflow is not expected.
             MetadataStatistics::perOpcodeCount[i] += numberOfEntries;
 #endif
         }
+
+        // Each computed offset is stored as Offset32 (with an additional s_offset32TableSize bias in the
+        // 32-bit layout) and totalSize() sums valueProfileSize with that biased offset as unsigned.
+        // Reject any function whose metadata cannot be addressed within those limits.
+        CheckedUint32 checkedValueProfileSize = m_numValueProfiles;
+        checkedValueProfileSize *= static_cast<unsigned>(sizeof(ValueProfile));
+
+        // On 32-bits, also guard against potential malloc size overflow in the newBuffer
+        // allocation below, where we add sizeof(LinkingData). On 64-bit, sizes are
+        // auto-casted to a 64-bit size_t that can handle the addition, and hence, does
+        // not need this padding to reserve space for the size of sizeof(LinkingData).
+        unsigned paddingFor32Bit = 0;
+        if constexpr (sizeof(size_t) == sizeof(unsigned))
+            paddingFor32Bit = sizeof(LinkingData);
+
+        if ((checkedOffset + s_offset32TableSize + checkedValueProfileSize + paddingFor32Bit).hasOverflowed()) [[unlikely]] {
+            MetadataTableMalloc::free(m_rawBuffer);
+            m_rawBuffer = nullptr;
+            m_hasMetadata = false;
+            m_is32Bit = false;
+            m_numValueProfiles = 0;
+            return false; // Failure.
+        }
+
+        ASSERT(!checkedOffset.hasOverflowed());
+        ASSERT(!checkedValueProfileSize.hasOverflowed());
+        offset = checkedOffset.value();
+        valueProfileSize = checkedValueProfileSize.value();
         buffer[s_offsetTableEntries - 1] = offset;
         m_is32Bit = offset > UINT16_MAX;
     }
@@ -148,7 +187,6 @@ void UnlinkedMetadataTable::finalize()
     });
 #endif
 
-    unsigned valueProfileSize = m_numValueProfiles * sizeof(ValueProfile);
     if (m_is32Bit) {
         // offset already accounts for s_offset16TableSize
         uint8_t* newBuffer = reinterpret_cast_ptr<uint8_t*>(MetadataTableMalloc::malloc(valueProfileSize + sizeof(LinkingData) + s_offset32TableSize + offset));
@@ -170,6 +208,7 @@ void UnlinkedMetadataTable::finalize()
         MetadataTableMalloc::free(m_rawBuffer);
         m_rawBuffer = newBuffer;
     }
+    return true;
 }
 
 UnlinkedMetadataTable::~UnlinkedMetadataTable()

--- a/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023, 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,7 +81,7 @@ public:
 
     size_t sizeInBytesForGC();
 
-    void finalize();
+    [[nodiscard]] bool finalize();
 
     RefPtr<MetadataTable> link();
 

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2023, 2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Cameron Zwarich <cwzwarich@uwaterloo.ca>
  * Copyright (C) 2012 Igalia, S.L.
  *
@@ -371,7 +371,8 @@ ParserError BytecodeGenerator::generate(unsigned& size)
 
     RELEASE_ASSERT(m_codeBlock->numCalleeLocals() < static_cast<unsigned>(FirstConstantRegisterIndex));
     size = instructions().size();
-    m_codeBlock->finalize(m_writer.finalize());
+    if (!m_codeBlock->finalize(m_writer.finalize())) [[unlikely]]
+        return ParserError(ParserError::OutOfMemory);
 
     // We limit total bytecode sequence size to int32_t so that we can use int32_t jump offsets.
     // Also, this allows us to use one bit of bytecode for some flag, including "ignore-result-flag".

--- a/Source/WTF/wtf/BackwardsGraph.h
+++ b/Source/WTF/wtf/BackwardsGraph.h
@@ -50,9 +50,9 @@ public:
         GraphNodeWorklist<typename Graph::Node, typename Graph::Set> worklist;
 
         auto addRootSuccessor = [&] (typename Graph::Node node) {
-            if (worklist.push(node)) {
+            if (m_rootSuccessorSet.add(node))
                 m_rootSuccessorList.append(node);
-                m_rootSuccessorSet.add(node);
+            if (worklist.push(node)) {
                 while (typename Graph::Node node = worklist.pop())
                     worklist.pushAll(graph.predecessors(node));
             }
@@ -77,8 +77,10 @@ public:
 
         for (unsigned i = 0; i < graph.numNodes(); ++i) {
             if (typename Graph::Node node = graph.node(i)) {
-                if (!graph.successors(node).size())
+                if (!graph.successors(node).size()) {
+                    ASSERT(!worklist.saw(node));
                     addRootSuccessor(node);
+                }
             }
         }
 
@@ -88,8 +90,10 @@ public:
         // edges. That would require thinking, so we just use a rough heuristic: add the highest
         // numbered nodes first, which is totally fine if the input program is already sorted nicely.
         for (unsigned i = graph.numNodes(); i--;) {
-            if (typename Graph::Node node = graph.node(i))
-                addRootSuccessor(node);
+            if (typename Graph::Node node = graph.node(i)) {
+                if (!worklist.saw(node))
+                    addRootSuccessor(node);
+            }
         }
     }
 


### PR DESCRIPTION
#### 2b0366caa04401a0bdee31482a168928e1811381
<pre>
Cherry-pick 320274@main (65ef7f38f8f9). <a href="https://bugs.webkit.org/show_bug.cgi?id=315389">https://bugs.webkit.org/show_bug.cgi?id=315389</a>

    Make B3 ccmp chain matcher use RAII
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315389">https://bugs.webkit.org/show_bug.cgi?id=315389</a>
    <a href="https://rdar.apple.com/176792415">rdar://176792415</a>

    Reviewed by Keith Miller.

    B3 ccmp chain matcher needs to roll back if a given pattern match fails
    part way through. RAII is a more principled and less error prone way to
    handle this.

    Test: JSTests/stress/b3-ccmp-chain.js

    * JSTests/stress/b3-ccmp-chain.js: Added.
    (f):
    (f_legit_chain):
    * Source/JavaScriptCore/b3/B3LowerToAir.cpp:
    * Source/JavaScriptCore/b3/testb3.h:
    * Source/JavaScriptCore/b3/testb3_1.cpp:
    (run):
    * Source/JavaScriptCore/b3/testb3_8.cpp:
    (testCCmpChainRollback):

    Originally-landed-as: 305413.1024@safari-7624.5-branch (7e01f14f8eb7). <a href="https://rdar.apple.com/185367009">rdar://185367009</a>
    Canonical link: <a href="https://commits.webkit.org/320274@main">https://commits.webkit.org/320274@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.230@webkitglib/2.54">https://commits.webkit.org/317695.230@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### a0c79c002d3adaa88824db4f34ea31d6e4efe3ff
<pre>
Cherry-pick 305413.1022@safari-7624.5.1.10-branch (9343a9521f58). <a href="https://bugs.webkit.org/show_bug.cgi?id=317632">https://bugs.webkit.org/show_bug.cgi?id=317632</a>

    Handle overflows in UnlinkedMetadataTable::finalize().
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317632">https://bugs.webkit.org/show_bug.cgi?id=317632</a>
    <a href="https://rdar.apple.com/172794625">rdar://172794625</a>

    Reviewed by Dan Hecht.

    If the number of opcodes (with metadata of substantive size) is large, the 32-bit unsigned
    computed buffer offsets in UnlinkedMetadataTable::finalize() can overflow.  This patch
    applies the use of CheckedArithmetic to detect and handle any potential overflows.  In the
    event of a detected overflow, we&apos;ll propagate the failure to allocate the bytecode metadata
    up to the BytecodeGenerator, and treat its as an OOM error during parsing.

    Test: JSTests/stress/unlinked-metadata-table-finalize-overflow.js

    * JSTests/stress/unlinked-metadata-table-finalize-overflow.js: Added.
    (try.f):
    (catch):
    * Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.cpp:
    (JSC::UnlinkedCodeBlockGenerator::finalize):
    * Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h:
    * Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.cpp:
    (JSC::UnlinkedMetadataTable::finalize):
    * Source/JavaScriptCore/bytecode/UnlinkedMetadataTable.h:
    * Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
    (JSC::BytecodeGenerator::generate):

    Identifier: 305413.1022@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.229@webkitglib/2.54">https://commits.webkit.org/317695.229@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 92b9fe2ead6631aefb500e90a2d352a88affa11f
<pre>
Cherry-pick 305413.1019@safari-7624.5.1.10-branch (dec21f1baf1f). <a href="https://bugs.webkit.org/show_bug.cgi?id=317603">https://bugs.webkit.org/show_bug.cgi?id=317603</a>

    [JSC] Fix BackwardsGraph for loops with multiple back-edge sources
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317603">https://bugs.webkit.org/show_bug.cgi?id=317603</a>
    <a href="https://rdar.apple.com/178735697">rdar://178735697</a>

    Reviewed by Marcus Plutowski.

    The addRootSuccessor lambda in WTF::BackwardsGraph used a single
    GraphNodeWorklist both to decide synthetic-root membership and to drive
    the predecessor-coverage flood. Depending on the order that back-edges
    were processed, this would cause some back-edge sources to not be
    included as backwards root successors.

    B3::BackwardsDominators, built on the resulting incomplete reverse CFG, can
    then report that a block post-dominates the loop pre-header even though a
    potentially-infinite loop between them means the block may never execute.
    B3HoistLoopInvariantValues uses post-dominators to conclude a control-dependent
    value always runs once the loop is entered, and hoists it into the pre-header,
    so the value can execute on paths where it should not.

    Decouple the two roles: addRootSuccessor now records every distinct back-edge
    source and terminal in m_rootSuccessorSet unconditionally, and uses the
    worklist only to bound the predecessor flood.

    Tests: JSTests/wasm/gc/backwards-graph-multi-backedge-licm.js
           Source/JavaScriptCore/b3/testb3_1.cpp
           Source/JavaScriptCore/b3/testb3_7.cpp

    * JSTests/wasm/gc/backwards-graph-multi-backedge-licm.js: Added.
    (catch):
    * Source/JavaScriptCore/b3/B3Procedure.h:
    * Source/JavaScriptCore/b3/testb3.h:
    * Source/JavaScriptCore/b3/testb3_1.cpp:
    (run):
    * Source/JavaScriptCore/b3/testb3_7.cpp:
    (testBackwardsDominatorsWithMultipleBackEdges):
    * Source/WTF/wtf/BackwardsGraph.h:
    (WTF::BackwardsGraph::BackwardsGraph):

    Identifier: 305413.1019@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.228@webkitglib/2.54">https://commits.webkit.org/317695.228@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/879ce60d1a39c00946984a1a1185d5b05f4ecc36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185606 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59513 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53327 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195921 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150332 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60881 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59241 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145044 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150332 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188561 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60881 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53327 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125339 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60881 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59241 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7236 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53327 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60881 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53327 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6978 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/46857 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52158 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59241 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197878 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59177 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53327 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154575 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59886 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53327 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154227 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28172 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59886 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132232 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129144 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58357 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53327 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57733 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57973 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57799 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->