### PR TITLE
Cherry-pick 320673@main (ca3a9f205bce). https://bugs.webkit.org/show_bug.cgi?id=323607

### DIFF
--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -284,6 +284,36 @@ void TestInvocation::forceRepaintDoneCallback(WKErrorRef error, void* context)
     TestController::singleton().notifyDone();
 }
 
+#if PLATFORM(GTK) || PLATFORM(WPE)
+void TestInvocation::presentationUpdateDoneCallback(WKErrorRef error, void* context)
+{
+    if (error)
+        return;
+
+    auto* testInvocation = static_cast<TestInvocation*>(context);
+    RELEASE_ASSERT(TestController::singleton().isCurrentInvocation(testInvocation));
+
+    testInvocation->m_gotPresentationUpdate = true;
+    TestController::singleton().notifyDone();
+}
+
+void TestInvocation::waitForPresentationUpdate()
+{
+    // Tests that use testRunner.dontForceRepaint(), still need the frame reflecting the last
+    // rendering update to reach the view before capturing. Since the coordinated graphics ports
+    // composite/hand-over buffers asynchronously, we need an explicit wait here to capture
+    // the correct frame.
+    m_gotPresentationUpdate = false;
+    WKPageCallAfterNextPresentationUpdate(TestController::singleton().mainWebView()->page(), this, TestInvocation::presentationUpdateDoneCallback);
+    TestController::singleton().runUntil(m_gotPresentationUpdate, m_timeout);
+}
+#else
+void TestInvocation::waitForPresentationUpdate()
+{
+    // Cocoa ports synchronize with the window server in PlatformWebView::windowSnapshotImage().
+}
+#endif
+
 void TestInvocation::dumpResourceLoadStatisticsIfNecessary()
 {
     if (m_shouldDumpResourceLoadStatistics)
@@ -325,7 +355,8 @@ void TestInvocation::dumpResults()
                 m_gotRepaint = false;
                 WKPageForceRepaint(TestController::singleton().mainWebView()->page(), this, TestInvocation::forceRepaintDoneCallback);
                 TestController::singleton().runUntil(m_gotRepaint, TestController::noTimeout);
-            }
+            } else
+                waitForPresentationUpdate();
             dumpPixelsAndCompareWithExpected(SnapshotResultType::WebView, m_repaintRects.get());
         }
     }

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -121,6 +121,10 @@ private:
     bool compareActualHashToExpectedAndDumpResults(const std::string&);
 
     static void forceRepaintDoneCallback(WKErrorRef, void* context);
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    static void presentationUpdateDoneCallback(WKErrorRef, void* context);
+#endif
+    void waitForPresentationUpdate();
 
     bool shouldLogHistoryClientCallbacks() const;
 
@@ -145,6 +149,9 @@ private:
     bool m_gotInitialResponse { false };
     bool m_gotFinalMessage { false };
     bool m_gotRepaint { false };
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    bool m_gotPresentationUpdate { false };
+#endif
     bool m_error { false };
 
     bool m_waitUntilDone { false };


### PR DESCRIPTION
#### 19c5e4df06f438c12f8b7729019beb7afd38b413
<pre>
Cherry-pick 320673@main (ca3a9f205bce). <a href="https://bugs.webkit.org/show_bug.cgi?id=323607">https://bugs.webkit.org/show_bug.cgi?id=323607</a>

    [GTK][WPE] Pixel tests using testRunner.dontForceRepaint() are flaky
    <a href="https://bugs.webkit.org/show_bug.cgi?id=323607">https://bugs.webkit.org/show_bug.cgi?id=323607</a>

    Reviewed by Carlos Garcia Campos.

    WKPageForceRepaint() forces a repaint and then waits for the next presentation
    update. On the coordinated graphics ports that wait is the only synchronization
    between the rendering update in the web process and the snapshot taken by
    WebKitTestRunner. Tests calling testRunner.dontForceRepaint() skipped the call
    entirely, dropping the synchronization together with the repaint, and captured
    whichever frame the UI process last received - fix that behavior by an
    explicit wait.

    Covered by existing tests, such as the recently added
    css3/filters/filter-repaint-blur-nested-pixel-moving-filter.html on
    GTK/WPE.

    * Tools/WebKitTestRunner/TestInvocation.cpp:
    (WTR::TestInvocation::presentationUpdateDoneCallback):
    (WTR::TestInvocation::waitForPresentationUpdate):
    (WTR::TestInvocation::dumpResults):
    * Tools/WebKitTestRunner/TestInvocation.h:

    Canonical link: <a href="https://commits.webkit.org/320673@main">https://commits.webkit.org/320673@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.227@webkitglib/2.54">https://commits.webkit.org/317695.227@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3395b1247ce323e604fcc0a5c13b3ec4bf643a76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185614 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59521 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53334 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195927 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150335 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187476 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60889 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59249 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145043 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150335 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188569 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60889 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53334 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125338 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60889 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59249 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53334 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60889 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53334 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/6986 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59249 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197886 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59185 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53334 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154577 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59894 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53334 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154229 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28170 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59894 "The change is no longer eligible for processing.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129150 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58365 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53334 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57741 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/57981 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57807 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->