### PR TITLE
Back navigation fails to restore website after playing an embedded cross-origin YouTube video

### DIFF
--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -133,38 +133,30 @@ void CachedPage::restore(Page& page)
     m_cachedMainFrame->open();
 
     // Restore the focus appearance for the focused element.
-    RefPtr focusedOrMainFrame = page.focusController().focusedOrMainFrame();
-    if (!focusedOrMainFrame) {
-        // The cached page's data has already been transferred to the live page by open();
-        // release the cached frame state even though the focus restoration block is skipped
-        // (e.g. iframe-process restoration where the page's main frame is a RemoteFrame
-        // and focusController has no focused or main local frame to operate on).
-        clear();
-        return;
-    }
-
-    RefPtr focusedDocument = focusedOrMainFrame->document();
-    if (RefPtr element = focusedDocument->focusedElement()) {
+    if (RefPtr focusedOrMainFrame = page.focusController().focusedOrMainFrame()) {
+        RefPtr focusedDocument = focusedOrMainFrame->document();
+        if (RefPtr element = focusedDocument->focusedElement()) {
 #if PLATFORM(IOS_FAMILY)
-        // We don't want focused nodes changing scroll position when restoring from the cache
-        // as it can cause ugly jumps before we manage to restore the cached position.
-        if (localMainFrame)
-            localMainFrame->selection().suppressScrolling();
+            // We don't want focused nodes changing scroll position when restoring from the cache
+            // as it can cause ugly jumps before we manage to restore the cached position.
+            if (localMainFrame)
+                localMainFrame->selection().suppressScrolling();
 
-        bool hadProhibitsScrolling = false;
-        RefPtr frameView = localMainFrame->virtualView();
-        if (frameView) {
-            hadProhibitsScrolling = frameView->prohibitsScrolling();
-            frameView->setProhibitsScrolling(true);
+            bool hadProhibitsScrolling = false;
+            RefPtr frameView = localMainFrame ? localMainFrame->virtualView() : nullptr;
+            if (frameView) {
+                hadProhibitsScrolling = frameView->prohibitsScrolling();
+                frameView->setProhibitsScrolling(true);
+            }
+#endif
+            element->updateFocusAppearance(SelectionRestorationMode::RestoreOrSelectAll);
+#if PLATFORM(IOS_FAMILY)
+            if (frameView)
+                frameView->setProhibitsScrolling(hadProhibitsScrolling);
+            if (localMainFrame)
+                protect(localMainFrame->selection())->restoreScrolling();
+#endif
         }
-#endif
-        element->updateFocusAppearance(SelectionRestorationMode::RestoreOrSelectAll);
-#if PLATFORM(IOS_FAMILY)
-        if (frameView)
-            frameView->setProhibitsScrolling(hadProhibitsScrolling);
-        if (localMainFrame)
-            protect(localMainFrame->selection())->restoreScrolling();
-#endif
     }
 
     if (m_needsDeviceOrPageScaleChanged && localMainFrame)
@@ -177,7 +169,7 @@ void CachedPage::restore(Page& page)
         page.captionPreferencesChanged();
 #endif
 
-    if (m_needsUpdateContentsSize) {
+    if (m_needsUpdateContentsSize && localMainFrame) {
         if (RefPtr frameView = localMainFrame->virtualView())
             frameView->updateContentsSize();
     }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -5387,6 +5387,65 @@ TEST(SiteIsolation, GoBackToPageWithIframeBFCache)
     checkFrameTreesInProcesses(webView.get(), WTF::move(expectedAfterGoBack));
 }
 
+TEST(SiteIsolation, BFCacheRestoredIframeIsVisibleAndFiresPageShow)
+{
+    auto iframeHTML = "<script>"
+        "  window.__pageshowCount = 0;"
+        "  window.__pageshowPersisted = null;"
+        "  window.addEventListener('pageshow', (event) => {"
+        "    window.__pageshowCount++;"
+        "    window.__pageshowPersisted = event.persisted;"
+        "  });"
+        "</script>"_s;
+    auto mainHTML = "<script>"
+        "  window.__pageshowCount = 0;"
+        "  window.addEventListener('pageshow', () => { window.__pageshowCount++ });"
+        "</script>"
+        "<iframe src='https://frame.com/frame'></iframe>"_s;
+
+    HTTPServer server({
+        { "/a"_s, { mainHTML } },
+        { "/b"_s, { ""_s } },
+        { "/frame"_s, { iframeHTML } }
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto *configuration = server.httpsProxyConfiguration();
+    setFeatureEnabled(configuration, @"MultiProcessBackForwardCacheEnabled", true);
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration, CGRectMake(0, 0, 800, 600));
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
+
+    [webView objectByEvaluatingJavaScript:@"window.__marker = true" inFrame:[webView firstChildFrame]];
+    EXPECT_EQ(1, [[webView objectByEvaluatingJavaScript:@"window.__pageshowCount" inFrame:[webView firstChildFrame]] intValue]);
+    EXPECT_WK_STREQ([webView objectByEvaluatingJavaScript:@"document.visibilityState" inFrame:[webView firstChildFrame]], "visible");
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://b.com/b"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    Vector<ExpectedFrameTree> expectedAfterGoBack = {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://frame.com"_s } } },
+    };
+    while (!frameTreesMatch(frameTrees(webView.get()).get(), Vector<ExpectedFrameTree> { expectedAfterGoBack }))
+        TestWebKitAPI::Util::spinRunLoop();
+
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.__marker ? true : false" inFrame:[webView firstChildFrame]] boolValue]);
+
+    EXPECT_TRUE(TestWebKitAPI::Util::waitFor([&] {
+        return [[webView objectByEvaluatingJavaScript:@"window.__pageshowCount" inFrame:[webView firstChildFrame]] intValue] == 2;
+    }));
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.__pageshowPersisted === true" inFrame:[webView firstChildFrame]] boolValue]);
+
+    EXPECT_WK_STREQ([webView objectByEvaluatingJavaScript:@"document.visibilityState" inFrame:[webView firstChildFrame]], "visible");
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"document.hidden" inFrame:[webView firstChildFrame]] boolValue]);
+
+    EXPECT_EQ(2, [[webView objectByEvaluatingJavaScript:@"window.__pageshowCount"] intValue]);
+    EXPECT_WK_STREQ([webView objectByEvaluatingJavaScript:@"document.visibilityState"], "visible");
+}
+
 TEST(SiteIsolation, BFCacheSameSitePageChangesTopDocumentURL)
 {
     HTTPServer server({


### PR DESCRIPTION
#### 3d1769871dc6bb07eaf1564f65a02de6611ed47f
<pre>
Back navigation fails to restore website after playing an embedded cross-origin YouTube video
<a href="https://bugs.webkit.org/show_bug.cgi?id=323697">https://bugs.webkit.org/show_bug.cgi?id=323697</a>
<a href="https://rdar.apple.com/185123184">rdar://185123184</a>

Reviewed by Sihui Liu.

CachedPage::restore() returned early when focusController().focusedOrMainFrame()
was null, which is always the case in an out-of-process iframe&apos;s process: that
page&apos;s main frame is a RemoteFrame, so the focus controller has no local frame to
operate on. The early return skipped everything after the focus restoration,
including firePageShowEvent(). That is what calls
Document::setVisibilityHiddenDueToDismissal(false) on each restored document, and
that flag alone makes Document::visibilityState() report Hidden - so a restored
cross-origin iframe reported itself permanently hidden even though its page was
visible, and never got a pageshow event either.

HTMLMediaElement caches whether it is hidden in m_elementIsHidden. Once that
latched true, it pushed setPageIsVisible(false) to the player;
MediaPlayerPrivateMediaSourceAVFObjC::updateRendererVisibility() then took
acceleratedRenderingStateChanged() down to renderingCanBeAcceleratedChanged(false),
and the GPU process destroyed the video renderer and its layer. Only video is
gated on visibility, so playback continued as audio only.

Make the focus restoration in CachedPage::restore() conditional instead of
returning early, so firePageShowEvent() and the rest still run when the main frame
is remote. The m_needsUpdateContentsSize block is now reachable with a null
localMainFrame, so guard it.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm

* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::restore):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, BFCacheRestoredIframeIsVisibleAndFiresPageShow)):

Canonical link: <a href="https://commits.webkit.org/320927@main">https://commits.webkit.org/320927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/104d2313d993d3a2e1b714bedf265fc5d456bfa0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150705 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5fd854db-da66-4f30-ad8d-50c815f5bb3e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187984 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59737 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145431 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100812 "4 flakes 15 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/de77120d-06d7-4148-b37b-ecc464489c45) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165966 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125757 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/808f82f4-be41-4583-b342-71286280257f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47842 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45826 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45554 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7484 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198391 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59674 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154998 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60386 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154635 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28287 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49073 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132672 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129800 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58825 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20537 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58218 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58447 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58277 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->