### PR TITLE
[Site Isolation] Remove process model validation in SiteIsolation.MultiProcessBFCacheSameSiteWithDifferentCrossSiteIframes

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -12399,22 +12399,6 @@ TEST(SiteIsolation, MultiProcessBFCacheCrossSiteToJavaScriptURL)
 
 TEST(SiteIsolation, MultiProcessBFCacheSameSiteWithDifferentCrossSiteIframes)
 {
-    // m_childFrames pollution under same-site BFCache: when a1 (a.com with
-    // b.com iframe) is cached and replaced by a2 (a.com with c.com iframe),
-    // BFCache does NOT destroy the cached frames, so no DidDestroyFrame IPC
-    // fires for b.com. Its stale WebFrameProxy stays in
-    // m_mainFrame->m_childFrames alongside the live c.com WebFrameProxy
-    // from a2.
-    //
-    // After a2 is fully loaded, the live frame tree under m_mainFrame must
-    // only reflect a2 (a.com + c.com remote). The cached b.com WebFrameProxy
-    // must hang off the WebBackForwardCacheEntry and not pollute the live
-    // tree. The b.com process itself remains in the BrowsingContextGroup
-    // while suspended (UI-driven flow does not pull RemotePageProxies out
-    // of the BCG), so getAllFrameTrees still surfaces a third tree from
-    // the suspended b.com process; that tree shows the b.com main as
-    // (remote) and its child as (remote) because the suspended WebPage's
-    // live document is empty (the cached document lives inside CachedPage).
     HTTPServer server({
         { "/a1"_s, { "<iframe src='https://b.com/bframe'></iframe>"_s } },
         { "/bframe"_s, { "b iframe content"_s } },
@@ -12428,27 +12412,27 @@ TEST(SiteIsolation, MultiProcessBFCacheSameSiteWithDifferentCrossSiteIframes)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a1"]]];
     [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
 
-    checkFrameTreesInProcesses(webView.get(), {
-        { "https://a.com"_s, { { RemoteFrame } } },
-        { RemoteFrame, { { "https://b.com"_s } } },
-    });
+    EXPECT_WK_STREQ(@"https://b.com/bframe", [webView objectByEvaluatingJavaScript:@"location.href" inFrame:[webView firstChildFrame]]);
+    [webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker_a1 = true"];
+    [webView objectByEvaluatingJavaScript:@"window.__iframeBfcacheMarker = true" inFrame:[webView firstChildFrame]];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a2"]]];
     [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
 
-    // After a2 loads:
-    //  - a.com (main proc): a.com main with c.com remote child  → live tree, 1 tree
-    //  - b.com (cached proc, suspended): remote main with remote child → cached tree, 1 tree
-    //  - c.com (live iframe proc): remote main with c.com local child → live tree, 1 tree
-    // The stale b.com WebFrameProxy from a1 must be owned by the same-site
-    // BFCache entry, not by m_mainFrame->m_childFrames. The b.com process
-    // tree is still surfaced via the BCG because UI-driven BFCache leaves
-    // RemotePageProxies in place during suspension.
-    checkFrameTreesInProcesses(webView.get(), {
-        { "https://a.com"_s, { { RemoteFrame } } },
-        { RemoteFrame, { { RemoteFrame } } },
-        { RemoteFrame, { { "https://c.com"_s } } },
-    });
+    EXPECT_WK_STREQ(@"https://c.com/cframe", [webView objectByEvaluatingJavaScript:@"location.href" inFrame:[webView firstChildFrame]]);
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_WK_STREQ(@"https://a.com/a1", [webView URL].absoluteString);
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker_a1 ? true : false"] boolValue]);
+
+    // The iframe subtree is reattached after the main frame commits, so c.com is still the child frame for a moment after the navigation finishes.
+    while (![[webView firstChildFrame].securityOrigin.host isEqualToString:@"b.com"])
+        Util::spinRunLoop();
+
+    EXPECT_WK_STREQ(@"https://b.com/bframe", [webView objectByEvaluatingJavaScript:@"location.href" inFrame:[webView firstChildFrame]]);
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.__iframeBfcacheMarker ? true : false" inFrame:[webView firstChildFrame]] boolValue]);
 }
 
 TEST(SiteIsolation, IframePushStateBackForwardRoutesToIframe)


### PR DESCRIPTION
#### 6156a0940859c71c1c3a9278024908aecf9760f7
<pre>
[Site Isolation] Remove process model validation in SiteIsolation.MultiProcessBFCacheSameSiteWithDifferentCrossSiteIframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=323700">https://bugs.webkit.org/show_bug.cgi?id=323700</a>
<a href="https://rdar.apple.com/186956421">rdar://186956421</a>

Reviewed by Per Arne Vollan.

The test asserted the per-process frame tree topology via checkFrameTreesInProcesses(), which reports one tree per web
process. That count is a property of the process model, not of the behavior the test is about: with
SiteIsolationSharedProcessEnabled the b.com and c.com iframes are placed in the same shared process, so the expected
three trees collapse into two and the test fails.

Nothing about the test&apos;s subject depends on where the frames live. It covers same-site back/forward cache with a
cross-site iframe: a1 (a.com with a b.com iframe) is cached and replaced by a2 (a.com with a c.com iframe), and going
back must restore a1 together with its b.com iframe from the cache rather than reloading them. Rewrite it to assert
exactly that, using JavaScript markers set in the main frame and in the iframe before the navigation away — a reload
would produce a fresh global object without them, and reading the iframe-scope marker round-trips to whichever process
hosts the iframe. Reattachment of the iframe subtree happens after the main frame commits, so wait for the child frame
to become b.com again rather than assuming it is there when the navigation finishes.

The test now passes with SiteIsolationSharedProcessEnabled both on and off, without opting out of the shared process and
without a separate variant.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, MultiProcessBFCacheSameSiteWithDifferentCrossSiteIframes)):

Canonical link: <a href="https://commits.webkit.org/320698@main">https://commits.webkit.org/320698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ee0115c75dece88de7047b4b2f3fdd334d8c7df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195945 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145055 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125350 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47468 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157829 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45201 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7004 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197904 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59203 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154593 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41403 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59912 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41806 "Too many flaky failures: http/tests/media/media-play-stream-chunked-icy.html, http/tests/misc/slow-preload-cancel.html, http/tests/navigation/redirect-to-random-url-versus-memory-cache.html, http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.html, http/tests/security/contentSecurityPolicy/shared-worker-blob-url-inherits-csp-importScripts-blocked.html, http/tests/site-isolation/iframe-and-window-open.html, http/tests/storageAccess/has-storage-access-under-general-third-party-cookie-blocking-with-cookie-ephemeral.https.html, http/tests/websocket/tests/hybi/network-process-crash-error.html, http/tests/workers/service/page-cache-service-worker-pending-promise.https.html, http/tests/xmlhttprequest/access-control-preflight-headers-async.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154246 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48711 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129167 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58383 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20223 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57758 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/57999 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57824 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->