### PR TITLE
[JSC] Attempt to remove many bound-check assertions inside loop via RELEASE_ASSERT etc.

### DIFF
--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -1277,7 +1277,13 @@ void JSBigInt::karatsubaMain(std::span<Digit> z, std::span<const Digit> x, std::
         multiplyZeroPadded(x, y, z.first(2 * n));
         return;
     }
-    ASSERT(scratch.size() >= 4 * n);
+    RELEASE_ASSERT(n <= std::numeric_limits<size_t>::max() / 4);
+    RELEASE_ASSERT(scratch.size() >= 4 * n);
+    // Trimming scratch to exactly the footprint this level touches lets every subspan of it below
+    // be proven in bounds from the size alone, rather than each one re-testing it at run time. z
+    // gets no such treatment: karatsubaStart may pass one shorter than 2 * n, which is why the
+    // writes into it go through clampedSubspan.
+    scratch = scratch.first(4 * n);
     ASSERT(!(n & 1));
     size_t n2 = n >> 1;
     auto x0 = clampedSubspan(x, 0, n2);
@@ -1623,7 +1629,7 @@ JSBigInt::Digit JSBigInt::inplaceSub(std::span<Digit> z, std::span<const Digit> 
 
 bool JSBigInt::greaterThanOrEqual(std::span<const Digit> a, std::span<const Digit> b)
 {
-    ASSERT(a.size() == b.size());
+    RELEASE_ASSERT(a.size() == b.size());
     for (size_t i = a.size(); i-- > 0;) {
         if (a[i] != b[i])
             return a[i] > b[i];
@@ -1644,7 +1650,7 @@ static std::span<JSBigInt::Digit> spanCopy(std::span<JSBigInt::Digit> z, std::sp
 std::span<JSBigInt::Digit> JSBigInt::leftShift(std::span<Digit> z, std::span<const Digit> x, unsigned shift)
 {
     ASSERT(shift < digitBits);
-    ASSERT(z.size() >= x.size());
+    RELEASE_ASSERT(z.size() >= x.size());
     if (shift == 0)
         return spanCopy(z, x);
 
@@ -1737,6 +1743,7 @@ std::tuple<std::span<JSBigInt::Digit>, std::span<JSBigInt::Digit>> JSBigInt::div
     auto uSpan = u.mutableSpan();
     {
         auto filled = leftShift(uSpan, a, shift);
+        RELEASE_ASSERT(filled.size() <= uSpan.size());
         if (uSpan.size() != filled.size())
             zeroSpan(uSpan.subspan(filled.size()));
     }
@@ -2465,7 +2472,7 @@ void JSBigInt::cachedModFold(std::span<Digit> r, std::span<const Digit> a, std::
 // scratch buffer becomes a stack array with no zeroing. The arithmetic is identical to cachedMod;
 // see the commentary there for the algorithm and the error bound the corrective loop relies on.
 template<size_t N, size_t ASize>
-ALWAYS_INLINE void JSBigInt::cachedModFixed(VM& vm, std::span<Digit, N> r, std::span<const Digit, ASize> a, std::span<const Digit, N> b)
+ALWAYS_INLINE void JSBigInt::cachedModFixed(std::span<Digit, N> r, std::span<const Digit, ASize> a, std::span<const Digit, N> b, std::span<const Digit, N + 1> inv)
 {
     static_assert(N >= 2);
     static_assert(ASize >= N && ASize <= 2 * N);
@@ -2473,8 +2480,6 @@ ALWAYS_INLINE void JSBigInt::cachedModFixed(VM& vm, std::span<Digit, N> r, std::
     constexpr size_t invSize = N + 1;
     constexpr size_t startPos = 2 * N - 2;
     constexpr size_t scratchSize = ASize + invSize;
-
-    auto inv = vm.m_bigIntCachedInverse.span().first<invSize>();
 
     // Step 1: high digits of A * Inv. Only digits from startPos up are computed, so the low part
     // of scratch is left untouched here and is overwritten by step 3 before it is read.
@@ -2529,9 +2534,9 @@ ALWAYS_INLINE void JSBigInt::cachedModFixed(VM& vm, std::span<Digit, N> r, std::
 std::span<const JSBigInt::Digit> JSBigInt::cachedMod(VM& vm, std::span<Digit> r, std::span<const Digit> a, std::span<const Digit> b)
 {
     size_t n = b.size();
-    ASSERT(n >= 2 && n <= maxCachedModDivisorSize);
+    RELEASE_ASSERT(n >= 2 && n <= maxCachedModDivisorSize);
     ASSERT(a.size() >= n && a.size() <= 2 * n);
-    ASSERT(r.size() >= n);
+    RELEASE_ASSERT(r.size() >= n);
 
     r = r.first(n);
 
@@ -2563,11 +2568,11 @@ std::span<const JSBigInt::Digit> JSBigInt::cachedMod(VM& vm, std::span<Digit> r,
         return r;
     }
 
-    // cachedModFixed reads the inverse through a static-extent span, which has no bounds check of
-    // its own, and the size-agnostic path below indexes it up to n. Both rely on the inverse having
-    // been rebuilt for this divisor, which happens in cachedModMakeInverse when the divisor is
-    // armed.
-    ASSERT(vm.m_bigIntCachedInverse.size() == n + 1);
+    // Both the size-specialized path below and the size-agnostic code after it index the inverse up
+    // to n, and rely on it having been rebuilt for this divisor, which happens in
+    // cachedModMakeInverse when the divisor is armed. Asserting the size here rather than trusting
+    // it also lets the compiler fold away the bounds check on every one of those accesses.
+    RELEASE_ASSERT(vm.m_bigIntCachedInverse.size() == n + 1);
     auto inv = vm.m_bigIntCachedInverse.span().first(n + 1);
 
     // Divisors up to maxFixedCachedModDivisorSize digits get a size-specialized path. With every
@@ -2585,7 +2590,7 @@ std::span<const JSBigInt::Digit> JSBigInt::cachedMod(VM& vm, std::span<Digit> r,
         auto dispatchDividend = [&]<size_t N, size_t ASize>(auto&& self) ALWAYS_INLINE_LAMBDA -> bool {
             if constexpr (ASize <= 2 * N) {
                 if (a.size() == ASize) {
-                    cachedModFixed<N, ASize>(vm, r.first<N>(), a.first<ASize>(), b.first<N>());
+                    cachedModFixed<N, ASize>(r.first<N>(), a.first<ASize>(), b.first<N>(), inv.first<N + 1>());
                     return true;
                 }
                 return self.template operator()<N, ASize + 1>(self);
@@ -2666,18 +2671,20 @@ std::span<const JSBigInt::Digit> JSBigInt::cachedMod(VM& vm, std::span<Digit> r,
     constexpr unsigned maxCachedModScratchSize = 3 * maxCachedModDivisorSize + 1;
     ASSERT(scratchSpace <= maxCachedModScratchSize);
     Vector<Digit, maxCachedModScratchSize> scratch(scratchSpace);
+    auto scratchSpan = scratch.mutableSpan();
+    RELEASE_ASSERT(scratchSpan.size() > 2 * n);
     if (a.size() >= inv.size())
-        multiplySpecialHigh(a, inv, scratch.mutableSpan(), startPos);
+        multiplySpecialHigh(a, inv, scratchSpan, startPos);
     else
-        multiplySpecialHigh(inv, a, scratch.mutableSpan(), startPos);
+        multiplySpecialHigh(inv, a, scratchSpan, startPos);
 
     // Step 2: Extract estimated quotient Q from position 2n in the product.
     // This means right-shifting 2n digits.
-    auto qSpan = scratch.span().subspan(2 * n);
+    auto qSpan = scratchSpan.subspan(2 * n);
 
     // Step 3: Compute product_low = B * Q (only low n+1 digits needed).
     // Reuse the low part of scratch for product_low (no overlap with qSpan).
-    auto productLow = scratch.mutableSpan().first(n + 1);
+    auto productLow = scratchSpan.first(n + 1);
     multiplySpecialLow(b, qSpan, productLow);
 
     // Step 4: R = A[0..n-1] - product_low[0..n-1].
@@ -3565,7 +3572,7 @@ JSBigInt::ComparisonResult JSBigInt::compare(JSValue x, JSValue y)
 std::span<JSBigInt::Digit> JSBigInt::addSchoolbook(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result)
 {
     RELEASE_ASSERT(x.size() >= y.size());
-    RELEASE_ASSERT(result.size() >= (x.size() + 1));
+    RELEASE_ASSERT(result.size() > x.size());
     Digit carry = 0;
     size_t i = 0;
     for (; i < y.size(); i++) {
@@ -3784,7 +3791,7 @@ inline std::span<JSBigInt::Digit> JSBigInt::absoluteBitwiseOp(std::span<const Di
     if (x.size() < y.size())
         std::swap(x, y);
 
-    ASSERT(x.size() >= y.size());
+    RELEASE_ASSERT(x.size() >= y.size());
 
     size_t numPairs = y.size();
     size_t maxLength = x.size();
@@ -3848,7 +3855,7 @@ std::span<JSBigInt::Digit> JSBigInt::absoluteXor(std::span<const Digit> x, std::
 
 std::span<JSBigInt::Digit> JSBigInt::absoluteAddOne(std::span<const Digit> x, std::span<Digit> result)
 {
-    ASSERT(result.size() >= addOneLength(x));
+    RELEASE_ASSERT(result.size() > x.size());
     Digit carry = 1;
     size_t i = 0;
     for (; i < x.size(); i++) {
@@ -3864,7 +3871,7 @@ std::span<JSBigInt::Digit> JSBigInt::absoluteAddOne(std::span<const Digit> x, st
 std::span<JSBigInt::Digit> JSBigInt::absoluteSubOne(std::span<const Digit> x, std::span<Digit> result)
 {
     ASSERT(!x.empty());
-    ASSERT(result.size() >= subOneLength(x));
+    RELEASE_ASSERT(result.size() >= x.size());
     Digit borrow = 1;
     for (size_t i = 0; i < x.size(); i++) {
         Digit newBorrow = 0;
@@ -3901,6 +3908,7 @@ JSBigInt::ImplResult JSBigInt::leftShiftByAbsolute(JSGlobalObject* globalObject,
 
     Vector<Digit, 16> resultVector(resultLength);
     auto result = resultVector.mutableSpan();
+    RELEASE_ASSERT(result.size() == resultLength);
     if (!bitsShift) {
         size_t i = 0;
         for (; i < digitShift; i++)
@@ -3980,6 +3988,8 @@ JSBigInt::ImplResult JSBigInt::rightShiftByAbsolute(JSGlobalObject* globalObject
     ASSERT(resultLength <= length);
     Vector<Digit, 16> resultVector(resultLength);
     auto result = resultVector.mutableSpan();
+    RELEASE_ASSERT(result.size() == resultLength);
+    RELEASE_ASSERT(resultLength >= 1);
 
     if (!bitsShift) {
         result[resultLength - 1] = 0;
@@ -4129,7 +4139,7 @@ String JSBigInt::toStringGeneric(VM& vm, JSGlobalObject* nullOrGlobalObjectForOO
     // https://bugs.webkit.org/show_bug.cgi?id=180671
     Vector<Latin1Character> resultString;
 
-    ASSERT(radix >= 2 && radix <= 36);
+    RELEASE_ASSERT(radix >= 2 && radix <= 36);
     ASSERT(!x->isZero());
 
     unsigned length = x->length();
@@ -4261,12 +4271,11 @@ JSValue JSBigInt::parseInt(JSGlobalObject* nullOrGlobalObjectForOOM, VM& vm, std
     while (p < data.size() && data[p] == '0')
         ++p;
 
-    int endIndex = data.size() - 1;
-    // Removing trailing spaces
-    while (endIndex >= static_cast<int>(p) && isStrWhiteSpace(data[endIndex]))
-        --endIndex;
-
-    size_t length = endIndex + 1;
+    // Removing trailing spaces. Trimming the span itself rather than tracking an end index keeps
+    // every read below provably within it, and nothing past the trailing spaces is read again.
+    while (data.size() > p && isStrWhiteSpace(data.back()))
+        data = data.first(data.size() - 1);
+    size_t length = data.size();
 
     if (p == length) {
 #if USE(BIGINT32)
@@ -4351,6 +4360,8 @@ JSValue JSBigInt::parseInt(JSGlobalObject* nullOrGlobalObjectForOOM, VM& vm, std
     unsigned limita = 'a' + (static_cast<int32_t>(radix) - 10);
     unsigned limitA = 'A' + (static_cast<int32_t>(radix) - 10);
     unsigned initialLength = length - p;
+    ASSERT(2 <= radix && radix <= 36);
+    size_t bitsPerChar = maxBitsPerCharTable[radix];
     Vector<Digit, 16> resultVector;
     while (p < length) {
         Checked<uint64_t, CrashOnOverflow> digit = 0;
@@ -4391,10 +4402,7 @@ JSValue JSBigInt::parseInt(JSGlobalObject* nullOrGlobalObjectForOOM, VM& vm, std
                 }
             }
 
-            auto computeLength = [](unsigned radix, unsigned charcount) -> std::optional<unsigned> {
-                ASSERT(2 <= radix && radix <= 36);
-
-                size_t bitsPerChar = maxBitsPerCharTable[radix];
+            auto computeLength = [](size_t bitsPerChar, unsigned charcount) -> std::optional<unsigned> {
                 size_t chars = charcount;
                 const unsigned roundup = bitsPerCharTableMultiplier - 1;
                 if (chars <= (std::numeric_limits<size_t>::max() - roundup) / bitsPerChar) {
@@ -4413,7 +4421,7 @@ JSValue JSBigInt::parseInt(JSGlobalObject* nullOrGlobalObjectForOOM, VM& vm, std
                 return std::nullopt;
             };
 
-            auto length = computeLength(radix, initialLength);
+            auto length = computeLength(bitsPerChar, initialLength);
             if (!length) [[unlikely]] {
                 if (nullOrGlobalObjectForOOM) {
                     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -4788,8 +4796,8 @@ JSBigInt::ImplResult JSBigInt::asIntNImpl(JSGlobalObject* globalObject, uint64_t
     // its bits below (n-1) are zero. In that case, the result is the minimum
     // n-bit integer (example: asIntN(3, -12n) => -4n).
     bool hasBit = (topDigit & compareDigit) == compareDigit;
-    ASSERT(n <= INT32_MAX);
-    int32_t N = static_cast<int32_t>(n);
+    ASSERT(n <= maxLengthBits);
+    unsigned N = static_cast<unsigned>(n);
     if (!hasBit)
         RELEASE_AND_RETURN(scope, truncateToNBits(globalObject, N, bigInt));
     if (!bigInt.sign())
@@ -4827,7 +4835,7 @@ JSBigInt::ImplResult JSBigInt::asUintNImpl(JSGlobalObject* globalObject, uint64_
             throwOutOfMemoryError(globalObject, scope, "BigInt generated from this operation is too big"_s);
             return nullptr;
         }
-        RELEASE_AND_RETURN(scope, truncateAndSubFromPowerOfTwo(globalObject, static_cast<int32_t>(n), bigInt, false));
+        RELEASE_AND_RETURN(scope, truncateAndSubFromPowerOfTwo(globalObject, static_cast<unsigned>(n), bigInt, false));
     }
 
     // If bigInt is positive and has up to n bits, return it directly.
@@ -4848,36 +4856,38 @@ JSBigInt::ImplResult JSBigInt::asUintNImpl(JSGlobalObject* globalObject, uint64_
     }
 
     // Otherwise, truncate.
-    ASSERT(n <= INT32_MAX);
-    RELEASE_AND_RETURN(scope, truncateToNBits(globalObject, static_cast<int32_t>(n), bigInt));
+    ASSERT(n < maxLengthBits);
+    RELEASE_AND_RETURN(scope, truncateToNBits(globalObject, static_cast<unsigned>(n), bigInt));
 }
 
 template <typename BigIntImpl>
-JSBigInt::ImplResult JSBigInt::truncateToNBits(JSGlobalObject* globalObject, int32_t n, BigIntImpl bigInt)
+JSBigInt::ImplResult JSBigInt::truncateToNBits(JSGlobalObject* globalObject, unsigned n, BigIntImpl bigInt)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto span = bigInt.digits();
 
-    ASSERT(n != 0);
     ASSERT(span.size() > n / digitBits);
 
-    int32_t neededDigits = (n + (digitBits - 1)) / digitBits;
-    ASSERT(neededDigits <= static_cast<int32_t>(span.size()));
+    // asIntNImpl and asUintNImpl both return early unless n names at least one and at most
+    // maxLengthBits bits of bigInt, so neededDigits is between 1 and span.size().
+    RELEASE_ASSERT(n > 0);
+    size_t neededDigits = (static_cast<size_t>(n) + digitBits - 1) / digitBits;
+    ASSERT(neededDigits <= span.size());
 
     Vector<Digit, 16> resultVector(neededDigits);
     auto result = resultVector.mutableSpan();
 
     // Copy all digits except the MSD.
-    int32_t last = neededDigits - 1;
-    for (int32_t i = 0; i < last; i++)
+    size_t last = neededDigits - 1;
+    for (size_t i = 0; i < last; i++)
         result[i] = span[i];
 
     // The MSD might contain extra bits that we don't want.
     Digit msd = span[last];
     if (n % digitBits != 0) {
-        int32_t drop = digitBits - (n % digitBits);
+        unsigned drop = digitBits - (n % digitBits);
         msd = (msd << drop) >> drop;
     }
     result[last] = msd;
@@ -4886,29 +4896,29 @@ JSBigInt::ImplResult JSBigInt::truncateToNBits(JSGlobalObject* globalObject, int
 
 // Subtracts the least significant n bits of abs(bigInt) from 2^n.
 template <typename BigIntImpl>
-JSBigInt::ImplResult JSBigInt::truncateAndSubFromPowerOfTwo(JSGlobalObject* globalObject, int32_t n, BigIntImpl bigInt, bool resultSign)
+JSBigInt::ImplResult JSBigInt::truncateAndSubFromPowerOfTwo(JSGlobalObject* globalObject, unsigned n, BigIntImpl bigInt, bool resultSign)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ASSERT(n != 0);
-    ASSERT(n <= static_cast<int32_t>(maxLengthBits));
+    ASSERT(n <= maxLengthBits);
 
     auto span = bigInt.digits();
 
-    int32_t neededDigits = (n + (digitBits - 1)) / digitBits;
-    ASSERT(neededDigits <= static_cast<int32_t>(maxLength)); // Follows from n <= maxLengthBits.
+    RELEASE_ASSERT(n > 0);
+    size_t neededDigits = (static_cast<size_t>(n) + digitBits - 1) / digitBits;
+    ASSERT(neededDigits <= maxLength); // Follows from n <= maxLengthBits.
 
     Vector<Digit, 16> resultVector(neededDigits);
     auto result = resultVector.mutableSpan();
 
     // Process all digits except the MSD.
-    int32_t i = 0;
-    int32_t last = neededDigits - 1;
-    int32_t length = span.size();
+    size_t i = 0;
+    size_t last = neededDigits - 1;
+    size_t length = span.size();
     Digit borrow = 0;
     // Take digits from bigInt unless its length is exhausted.
-    int32_t limit = std::min(last, length);
+    size_t limit = std::min(last, length);
     for (; i < limit; i++) {
         Digit newBorrow = 0;
         Digit difference = digitSub(0, span[i], newBorrow);
@@ -4926,14 +4936,14 @@ JSBigInt::ImplResult JSBigInt::truncateAndSubFromPowerOfTwo(JSGlobalObject* glob
 
     // The MSD might contain extra bits that we don't want.
     Digit msd = last < length ? span[last] : 0;
-    int32_t msdBitsConsumed = n % digitBits;
+    unsigned msdBitsConsumed = n % digitBits;
     Digit resultMSD;
     if (msdBitsConsumed == 0) {
         Digit newBorrow = 0;
         resultMSD = digitSub(0, msd, newBorrow);
         resultMSD = digitSub(resultMSD, borrow, newBorrow);
     } else {
-        int32_t drop = digitBits - msdBitsConsumed;
+        unsigned drop = digitBits - msdBitsConsumed;
         msd = (msd << drop) >> drop;
         Digit minuendMSD = static_cast<Digit>(1) << (digitBits - drop);
         Digit newBorrow = 0;

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -612,14 +612,14 @@ private:
     static constexpr unsigned maxInPlaceSubSize = 16;
     static constexpr unsigned maxInPlaceCachedModSize = 8;
     static_assert(maxInPlaceCachedModSize <= maxCachedModDivisorSize);
-    // Only divisors that remainderImpl arms have a cached inverse, and cachedModFixed reads that
-    // inverse through a span whose extent is fixed at compile time.
+    // Only divisors that remainderImpl arms have a cached inverse, and cachedModFixed takes that
+    // inverse as a span whose extent is fixed at compile time.
     static_assert(maxFixedCachedModDivisorSize <= maxCachedModDivisorSize);
     static void cachedModMakeInverse(VM&, std::span<const Digit> b);
     static Digit cachedModFoldFactor(std::span<const Digit> b);
     static std::span<const Digit> cachedMod(VM&, std::span<Digit> r, std::span<const Digit>, std::span<const Digit>);
     template<size_t N, size_t ASize>
-    static void cachedModFixed(VM&, std::span<Digit, N> r, std::span<const Digit, ASize>, std::span<const Digit, N> b);
+    static void cachedModFixed(std::span<Digit, N> r, std::span<const Digit, ASize>, std::span<const Digit, N> b, std::span<const Digit, N + 1> inverse);
     template<typename RSpan, typename ASpan, typename BSpan>
     static void cachedModFoldImpl(RSpan r, ASpan, BSpan b, Digit c);
     template<size_t N, size_t ASize>
@@ -666,9 +666,9 @@ private:
     template <typename BigIntImpl>
     static ImplResult asUintNImpl(JSGlobalObject*, uint64_t, BigIntImpl);
     template <typename BigIntImpl>
-    static ImplResult truncateToNBits(JSGlobalObject*, int32_t, BigIntImpl);
+    static ImplResult truncateToNBits(JSGlobalObject*, unsigned, BigIntImpl);
     template <typename BigIntImpl>
-    static ImplResult truncateAndSubFromPowerOfTwo(JSGlobalObject*, int32_t, BigIntImpl, bool resultSign);
+    static ImplResult truncateAndSubFromPowerOfTwo(JSGlobalObject*, unsigned, BigIntImpl, bool resultSign);
 
     JS_EXPORT_PRIVATE static uint64_t NODELETE toBigUInt64Heap(JSBigInt*);
 


### PR DESCRIPTION
#### f52d0e486a0e85e1f7f6bd41c5bb2a939a9da1c3
<pre>
[JSC] Attempt to remove many bound-check assertions inside loop via RELEASE_ASSERT etc.
<a href="https://bugs.webkit.org/show_bug.cgi?id=323699">https://bugs.webkit.org/show_bug.cgi?id=323699</a>
<a href="https://rdar.apple.com/186956345">rdar://186956345</a>

Reviewed by Yijia Huang.

std::span uses release-assert for bound-check. While clang is having
analysis to remove unnecessary bound-check, it is not sufficient in many
cases and it ends up emitting it in the middle of loop. We can remove
this if we emit RELEASE_ASSERT explicitly out of the loop with a
specific condition as a hint to clang to prove that this bound-check is
unnecessary. This patch systematically analyze JSBigInt compiled binary
to detect brk generated from std::span, and puts the right precondition
etc. to remove this from the loop. Sometimes, we replace int32_t to
size_t for index as int32_t is hard to prove for clang about
bound-check. Since std::span::size is size_t and it is unsigned, the
behavior is fully specified in C++ spec, and clang can relatively easily
prove the value&apos;s bound.

* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::JSBigInt::karatsubaMain):
(JSC::JSBigInt::greaterThanOrEqual):
(JSC::JSBigInt::leftShift):
(JSC::JSBigInt::divideSchoolbook):
(JSC::JSBigInt::cachedModFixed):
(JSC::JSBigInt::cachedMod):
(JSC::JSBigInt::addSchoolbook):
(JSC::JSBigInt::absoluteBitwiseOp):
(JSC::JSBigInt::absoluteAddOne):
(JSC::JSBigInt::absoluteSubOne):
(JSC::JSBigInt::leftShiftByAbsolute):
(JSC::JSBigInt::rightShiftByAbsolute):
(JSC::JSBigInt::toStringGeneric):
(JSC::JSBigInt::parseInt):
(JSC::JSBigInt::asIntNImpl):
(JSC::JSBigInt::asUintNImpl):
(JSC::JSBigInt::truncateToNBits):
(JSC::JSBigInt::truncateAndSubFromPowerOfTwo):
* Source/JavaScriptCore/runtime/JSBigInt.h:

Canonical link: <a href="https://commits.webkit.org/320745@main">https://commits.webkit.org/320745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/620d07988c645f343fa493f0b96f2b881d3d6f27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195959 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150362 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/067f9d0a-8ca1-4389-a9aa-3cf650e594a9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145070 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100579 "Exiting early after 60 failures. 60 tests run. 61 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3868687b-e582-4d6b-a5a7-892a217810c5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125365 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b007475f-ec90-41a5-b045-1ad9a74d7615) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47485 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45526 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7262 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14149 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157845 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45217 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7019 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46898 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197919 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59218 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154609 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59926 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154262 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28208 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48722 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132271 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129180 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58396 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20239 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57772 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58012 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57837 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->