### PR TITLE
Cherry-pick 305413.1077@safari-7624.5.1.10-branch (62fcbfe61a49). https://bugs.webkit.org/show_bug.cgi?id=318405

### DIFF
--- a/JSTests/stress/arguments-elimination-inlined-load-varargs-preserves-recoveries.js
+++ b/JSTests/stress/arguments-elimination-inlined-load-varargs-preserves-recoveries.js
@@ -1,0 +1,84 @@
+//@ runDefault("--thresholdForJITAfterWarmUp=10", "--thresholdForFTLOptimizeAfterWarmUp=1000", "--useConcurrentJIT=false", "--validateFTLOSRExitLiveness=true")
+
+"use strict";
+
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + ", expected: " + expected);
+}
+
+function five(values1, values2)
+{
+    let result = null;
+    for (let i = 0; i < 5; ++i) {
+        function arg() { "use strict"; return arguments; }
+        const a = arg.apply(undefined, values1);
+        const b = arg.apply(undefined, values2);
+        try {
+            (3881)(b);
+        } catch (error) {
+            a.toString();
+            result = a;
+        }
+    }
+    return result;
+}
+
+function eight(values1, values2)
+{
+    let result = null;
+    for (let i = 0; i < 5; ++i) {
+        function arg() { "use strict"; return arguments; }
+        const a = arg.apply(undefined, values1);
+        const b = arg.apply(undefined, values2);
+        try {
+            (3881)(b);
+        } catch (error) {
+            a.toString();
+            result = a;
+        }
+    }
+    return result;
+}
+
+function filled(length, value)
+{
+    const result = [];
+    for (let i = 0; i < length; ++i)
+        result.push(value);
+    return result;
+}
+
+const fiveMarker = { marker: "five" };
+const eightMarker = { marker: "eight" };
+const seedArray = [{ marker: "seed" }, 1, 2, 3, 4, 5];
+
+const firstFive = filled(5, fiveMarker);
+const overwriteFive = filled(30, fiveMarker);
+overwriteFive[22] = 9;
+
+const firstEight = filled(8, eightMarker);
+const overwriteEight = filled(30, eightMarker);
+overwriteEight[20] = 9;
+
+for (let i = 0; i < testLoopCount; ++i) {
+    five(firstFive, overwriteFive);
+    eight(firstEight, overwriteEight);
+}
+
+const seedValues = filled(30, seedArray);
+seedValues[20] = 9;
+for (let i = 0; i < testLoopCount; ++i)
+    eight(firstEight, seedValues);
+
+const recoveredEight = eight(firstEight, seedValues);
+shouldBe(recoveredEight.length, firstEight.length);
+for (let i = 0; i < firstEight.length; ++i)
+    shouldBe(recoveredEight[i], eightMarker);
+
+const recoveredFive = five(firstFive, overwriteFive);
+shouldBe(recoveredFive.length, firstFive.length);
+for (let i = 0; i < firstFive.length; ++i)
+    shouldBe(recoveredFive[i], fiveMarker);
+shouldBe(recoveredFive[5], undefined);

--- a/JSTests/stress/arguments-elimination-load-varargs-kills-promoted-recoveries.js
+++ b/JSTests/stress/arguments-elimination-load-varargs-kills-promoted-recoveries.js
@@ -1,0 +1,88 @@
+//@ runDefault("--thresholdForJITAfterWarmUp=10", "--thresholdForFTLOptimizeAfterWarmUp=1000", "--useConcurrentJIT=false")
+
+"use strict";
+
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + ", expected: " + expected);
+}
+noInline(shouldBe);
+
+function five(values1, values2)
+{
+    let result = null;
+    for (let i = 0; i < 5; ++i) {
+        function arg() { "use strict"; return arguments; }
+        const a = arg.apply(undefined, values1);
+        const b = arg.apply(undefined, values2);
+        try {
+            (3881)(b);
+        } catch (error) {
+            a.toString();
+            result = a;
+        }
+    }
+    return result;
+}
+noInline(five);
+
+function eight(values1, values2)
+{
+    let result = null;
+    for (let i = 0; i < 5; ++i) {
+        function arg() { "use strict"; return arguments; }
+        const a = arg.apply(undefined, values1);
+        const b = arg.apply(undefined, values2);
+        try {
+            (3881)(b);
+        } catch (error) {
+            a.toString();
+            result = a;
+        }
+    }
+    return result;
+}
+noInline(eight);
+
+function filled(length, value)
+{
+    const result = [];
+    for (let i = 0; i < length; ++i)
+        result.push(value);
+    return result;
+}
+noInline(filled);
+
+const fiveMarker = { marker: "five" };
+const eightMarker = { marker: "eight" };
+const seedArray = [{ marker: "seed" }, 1, 2, 3, 4, 5];
+
+const firstFive = filled(5, fiveMarker);
+const overwriteFive = filled(30, fiveMarker);
+overwriteFive[22] = 9;
+
+const firstEight = filled(8, eightMarker);
+const overwriteEight = filled(30, eightMarker);
+overwriteEight[20] = 9;
+
+for (let i = 0; i < testLoopCount; ++i) {
+    five(firstFive, overwriteFive);
+    eight(firstEight, overwriteEight);
+}
+
+const seedValues = filled(30, seedArray);
+seedValues[20] = 9;
+for (let i = 0; i < testLoopCount; ++i)
+    eight(firstEight, seedValues);
+
+const recoveredEight = eight(firstEight, seedValues);
+shouldBe(recoveredEight.length, firstEight.length);
+for (let i = 0; i < firstEight.length; ++i)
+    shouldBe(recoveredEight[i], eightMarker);
+
+const recoveredFive = five(firstFive, overwriteFive);
+shouldBe(recoveredFive.length, firstFive.length);
+for (let i = 0; i < firstFive.length; ++i)
+    shouldBe(recoveredFive[i], fiveMarker);
+shouldBe(recoveredFive[5], undefined);

--- a/JSTests/stress/watchpoint-async-generator-code-deletion.js
+++ b/JSTests/stress/watchpoint-async-generator-code-deletion.js
@@ -1,0 +1,30 @@
+//@ runDefault("--useDollarVM=1", "--useConcurrentJIT=0")
+
+async function sleepAsync(secs) {
+    return new Promise(resolve => setTimeout(resolve, secs * 1000.0));
+}
+
+async function main() {
+    let x = 1;
+
+    $vm.deleteAllCodeWhenIdle();
+    await sleepAsync(0.0);
+
+    function opt() {
+        return x;
+    }
+
+    for (let i = 0; i < testLoopCount; i++) {
+        opt();
+    }
+
+    x = 2;
+
+    if (opt() !== 2)
+        throw new Error("Expected 2, got " + opt());
+}
+
+main().then(undefined, e => {
+    print(e);
+    $vm.abort();
+});

--- a/JSTests/stress/watchpoint-closure-not-affected.js
+++ b/JSTests/stress/watchpoint-closure-not-affected.js
@@ -1,0 +1,29 @@
+//@ runDefault("--useDollarVM=1", "--useConcurrentJIT=0")
+
+async function sleepAsync(secs) {
+    return new Promise(resolve => setTimeout(resolve, secs * 1000.0));
+}
+
+async function test() {
+    var obj = (function() {
+        let x = 1;
+        function opt() { return x; }
+        return { opt, set(v) { x = v; } };
+    })();
+
+    $vm.deleteAllCodeWhenIdle();
+    await sleepAsync(0.0);
+
+    for (let i = 0; i < 1000; i++)
+        obj.opt();
+
+    obj.set(2);
+
+    if (obj.opt() !== 2)
+        throw new Error("Expected 2, got " + obj.opt());
+}
+
+test().then(undefined, e => {
+    print(e);
+    $vm.abort();
+});

--- a/LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash-expected.txt
+++ b/LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash.html
+++ b/LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+function gc()
+{
+    if (window.GCController)
+        GCController.collect();
+}
+
+async function go()
+{
+    // The offline render thread runs renderQuantum() in a tight loop on a dedicated
+    // thread, calling handlePostRenderTasks() (and thus handleDeferredDerefs()) on
+    // every quantum.
+    let context = new OfflineAudioContext(1, 48000 * 120, 48000);
+
+    // |target| holds the AudioParam (target.gain) whose ref-count is raced.
+    let target = new GainNode(context);
+    target.connect(context.destination);
+
+    let lockHog = new GainNode(context);
+
+    let done = false;
+    context.startRendering().then(() => { done = true; }, () => { done = true; });
+
+    for (let iteration = 0; iteration < 200 && !done; ++iteration) {
+        // |sources| each connect their output to target.gain so that
+        // (a) their outputs hold a Ref<AudioParam> in m_params and
+        // (b) target.gain pulls each source on the render thread, taking a
+        //     transient RefPtr<AudioNode> via protect(node()) inside pull().
+        let sources = [];
+        for (let i = 0; i < 16; ++i) {
+            let source = new GainNode(context);
+            source.connect(target.gain);
+            sources.push(source);
+        }
+
+        // Let handlePreRenderTasks() promote the new outputs into m_renderingOutputs.
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        // Hold the graph lock from the main thread so the render thread's
+        // AudioNode::deref() (from the protect() above) tryLock-fails and is
+        // queued onto m_deferredDerefList.
+        for (let i = 0; i < 4000; ++i)
+            lockHog.channelCount = (i & 1) ? 1 : 2;
+
+        // Drop the wrappers; ~JSGainNode runs AudioNode::deref() on the main thread.
+        // Any deferred-deref entries from above keep m_normalRefCount > 0 here.
+        sources = null;
+        gc();
+
+        // Once we stop touching the graph lock, the next handlePostRenderTasks() ->
+        // handleDeferredDerefs() drives a source's m_normalRefCount to 0 on the
+        // render thread, reaching markNodeForDeletionIfNecessary() ->
+        // AudioNodeOutput::disconnectAllParams() and ref'ing / deref'ing target.gain
+        // there. Touch the wrapper concurrently from the main thread.
+        let until = performance.now() + 8;
+        while (performance.now() < until) {
+            target.gain;
+            gc();
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+    }
+
+    document.body.textContent = "PASS if no crash.";
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+window.onload = go;
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -49,6 +49,7 @@
 #include "EvalCodeBlock.h"
 #include "FullCodeOrigin.h"
 #include "FunctionCodeBlock.h"
+#include "FunctionExecutable.h"
 #include "FunctionExecutableDump.h"
 #include "GetPutInfo.h"
 #include "InlineCallFrame.h"
@@ -621,16 +622,29 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
                 if (bytecode.m_var != UINT_MAX) {
                     SymbolTable* symbolTable = uncheckedDowncast<SymbolTable>(getConstant(bytecode.m_symbolTableOrScopeDepth.symbolTable()));
                     const Identifier& ident = identifier(bytecode.m_var);
-                    ConcurrentJSLocker locker(symbolTable->m_lock);
-                    auto iter = symbolTable->find(locker, ident.impl());
-                    ASSERT(iter != symbolTable->end(locker));
-                    if (bytecode.m_getPutInfo.initializationMode() == InitializationMode::ScopedArgumentInitialization) {
-                        ASSERT(bytecode.m_value.isArgument());
-                        unsigned argumentIndex = bytecode.m_value.toArgument() - 1;
-                        symbolTable->prepareToWatchScopedArgument(iter->value, argumentIndex);
-                    } else
-                        iter->value.prepareToWatch();
-                    metadata.m_watchpointSet = iter->value.watchpointSet();
+                    {
+                        ConcurrentJSLocker locker(symbolTable->m_lock);
+                        auto iter = symbolTable->find(locker, ident.impl());
+                        ASSERT(iter != symbolTable->end(locker));
+                        if (bytecode.m_getPutInfo.initializationMode() == InitializationMode::ScopedArgumentInitialization) {
+                            ASSERT(bytecode.m_value.isArgument());
+                            unsigned argumentIndex = bytecode.m_value.toArgument() - 1;
+                            symbolTable->prepareToWatchScopedArgument(iter->value, argumentIndex);
+                        } else
+                            iter->value.prepareToWatch();
+                        metadata.m_watchpointSet = iter->value.watchpointSet();
+                    }
+                    // Generator and async function bodies can resume on a new CodeBlock after the
+                    // original is cleared (e.g. by deleteAllCode). The new CodeBlock's constant pool
+                    // holds a fresh SymbolTable clone, but the suspended activation still references
+                    // the original. Firing the metadata WatchpointSet via touch() at runtime would
+                    // notify watchers of the wrong SymbolTable. Pre-invalidate here so DFG treats
+                    // these captured variables as non-constant, matching ClosureVar semantics.
+                    if (metadata.m_watchpointSet
+                        && ownerExecutable->isFunctionExecutable()
+                        && isGeneratorOrAsyncFunctionBodyParseMode(downcast<FunctionExecutable>(ownerExecutable)->parseMode())) {
+                        metadata.m_watchpointSet->invalidate(vm, PutToScopeFireDetail(this, ident));
+                    }
                 } else
                     metadata.m_watchpointSet = nullptr;
                 break;

--- a/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
@@ -33,6 +33,7 @@
 #include "DFGArgumentsUtilities.h"
 #include <wtf/IndexMap.h>
 #include "DFGClobberize.h"
+#include "DFGCombinedLiveness.h"
 #include "DFGForAllKills.h"
 #include "DFGGraph.h"
 #include "DFGInsertionSet.h"
@@ -722,7 +723,16 @@ private:
             }
 
             if (clobberStack) {
-                for (Node* node : combinedLiveness.liveAtTail[block])
+                // liveAtTail is the union of the CFG successors' liveAtHead, but a candidate can be kept
+                // alive solely by an exceptional exit to a catch entrypoint, which the DFG models as a
+                // non-CFG successor. Such a candidate is OSR-live at the terminal yet absent from
+                // liveAtTail, so a clobber of its source slots in this block would otherwise go
+                // unnoticed. Cover that gap with the nodes live at the terminal but dead on the tail.
+                // FIXME: If this is ever too conservative we can just calculate the locals used by
+                // the catch block for the terminal.
+                NodeSet possiblyLiveOut = bytecodeLivenessAtTerminal(m_graph, block);
+                possiblyLiveOut.addAll(combinedLiveness.liveAtTail[block]);
+                for (Node* node : possiblyLiveOut)
                     removeViaKill(block, block->size(), node);
 
                 for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {

--- a/Source/JavaScriptCore/dfg/DFGCombinedLiveness.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCombinedLiveness.cpp
@@ -61,6 +61,13 @@ NodeSet liveNodesAtHead(Graph& graph, BasicBlock* block)
     return seen;
 }
 
+NodeSet bytecodeLivenessAtTerminal(Graph& graph, BasicBlock* block)
+{
+    NodeSet seen;
+    addBytecodeLiveness(graph, block->ssa->availabilityAtTail, seen, block->last());
+    return seen;
+}
+
 CombinedLiveness::CombinedLiveness(Graph& graph)
     : liveAtHead(graph.numBlocks())
     , liveAtTail(graph.numBlocks())
@@ -80,11 +87,8 @@ CombinedLiveness::CombinedLiveness(Graph& graph)
         // Unreachable
         //
         // And things may definitely be live in bytecode at that point in the program.
-        if (!block->numSuccessors()) {
-            NodeSet seen;
-            addBytecodeLiveness(graph, block->ssa->availabilityAtTail, seen, block->last());
-            liveAtTail[block] = seen;
-        }
+        if (!block->numSuccessors())
+            liveAtTail[block] = bytecodeLivenessAtTerminal(graph, block);
     }
     
     // Now compute the liveAtTail by unifying the liveAtHead of the successors.

--- a/Source/JavaScriptCore/dfg/DFGCombinedLiveness.h
+++ b/Source/JavaScriptCore/dfg/DFGCombinedLiveness.h
@@ -35,6 +35,8 @@ namespace JSC { namespace DFG {
 // Returns the set of nodes live at head, both due to DFG and due to bytecode (i.e. OSR exit).
 NodeSet liveNodesAtHead(Graph&, BasicBlock*);
 
+NodeSet bytecodeLivenessAtTerminal(Graph&, BasicBlock*);
+
 // WARNING: This currently does not reason about the liveness of shadow values. The execution
 // semantics of DFG SSA are that an Upsilon stores to the shadow value of a Phi, and the Phi loads
 // from that shadow value. Hence, the shadow values are like variables, and have liveness. The normal

--- a/Source/JavaScriptCore/dfg/DFGForAllKills.h
+++ b/Source/JavaScriptCore/dfg/DFGForAllKills.h
@@ -34,10 +34,6 @@
 
 namespace JSC { namespace DFG {
 
-namespace ForAllKillsInternal {
-constexpr bool verbose = false;
-}
-
 // Utilities for finding the last points where a node is live in DFG SSA. This accounts for liveness due
 // to OSR exit. This is usually used for enumerating over all of the program points where a node is live,
 // by exploring all blocks where the node is live at tail and then exploring all program points where the
@@ -168,34 +164,6 @@ void forAllKilledNodesAtNodeIndex(
                     return result;
                 });
         });
-}
-
-// Tells you all of the places to start searching from in a basic block. Gives you the node index at which
-// the value is either no longer live. This pretends that nodes are dead at the end of the block, so that
-// you can use this to do per-basic-block analyses.
-template<WTF::ConstInvocable<void(unsigned, Node*)> Functor>
-void forAllKillsInBlock(
-    Graph& graph, const CombinedLiveness& combinedLiveness, BasicBlock* block,
-    const Functor& functor)
-{
-    for (Node* node : combinedLiveness.liveAtTail[block])
-        functor(block->size(), node);
-    
-    LocalOSRAvailabilityCalculator localAvailability(graph);
-    localAvailability.beginBlock(block);
-    // Start running functor at the second node, because the functor is expected to only inspect nodes from the start of
-    // the block up to nodeIndex (exclusive), so if nodeIndex is zero then the functor has nothing to do.
-    for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {
-        dataLogLnIf(ForAllKillsInternal::verbose, "local availability at index: ", nodeIndex, " ", localAvailability.m_availability);
-        if (nodeIndex) {
-            forAllKilledNodesAtNodeIndex(
-                graph, localAvailability.m_availability, block, nodeIndex,
-                [&] (Node* node) {
-                    functor(nodeIndex, node);
-                });
-        }
-        localAvailability.executeNode(block->at(nodeIndex));
-    }
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
@@ -359,8 +359,10 @@ void LocalOSRAvailabilityCalculator::executeNode(Node* node)
     case LoadVarargs:
     case ForwardVarargs: {
         LoadVarargsData* data = node->loadVarargsData();
+        killHeaps(data->count);
         m_availability.m_locals.operand(data->count) = Availability(node->child1().node(), FlushedAt(FlushedInt32, data->machineCount));
         for (unsigned i = data->limit; i--;) {
+            killHeaps(data->start + i);
             m_availability.m_locals.operand(data->start + i) =
                 Availability(FlushedAt(FlushedJSValue, data->machineStart.isValid() ? (data->machineStart + i) : VirtualRegister()));
         }

--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -362,63 +362,60 @@ static void convertImagePixelsFromFloat16ToFloat16(const ConstPixelBufferConvers
     // verbatim. Do not early-return on a color-space mismatch: the destination is allocated
     // uninitialized, so skipping the write would leak heap bytes through getPixelBuffer().
 
-    auto sourceBytes = source.rows.size_bytes();
-    auto sourcePixelComponents = sourceBytes / 2;
-    auto sourcePixels = sourcePixelComponents / 4;
-    auto sourceHeight = sourceBytes / source.bytesPerRow;
-    auto sourceWidth = sourcePixels / sourceHeight;
+    struct Pixel16 {
+        Float16 r;
+        Float16 g;
+        Float16 b;
+        Float16 a;
+    };
+    static_assert(sizeof(Float16) == 2);
+    static_assert(sizeof(Pixel16) == 4 * sizeof(Float16));
 
-    auto destinationBytes = destination.rows.size_bytes();
-    auto destinationPixelComponents = destinationBytes / 2;
-    auto destinationPixels = destinationPixelComponents / 4;
-    auto destinationHeight = destinationBytes / destination.bytesPerRow;
-    auto destinationWidth = destinationPixels / destinationHeight;
+    // FIXME: This lambda should be moved to separate functions and the caller passes a pointer to one of them.
+    auto convertSinglePixel16 = [](const auto& sourceSpan, auto sourceAlphaFormat, auto& destinationSpan, auto destinationAlphaFormat) {
+        ASSERT(sourceSpan.size_bytes() == sizeof(Pixel16));
+        ASSERT(destinationSpan.size_bytes() == sizeof(Pixel16));
 
-    if (destinationSize.height() >= 0 && size_t(destinationSize.height()) < destinationHeight)
-        destinationHeight = size_t(destinationSize.height());
-    if (destinationSize.width() >= 0 && size_t(destinationSize.width()) < destinationWidth)
-        destinationWidth = size_t(destinationSize.width());
-
-    auto sourceRowStartOffset = 0;
-    auto destinationRowStartOffset = 0;
-    for (size_t y = 0; y < sourceHeight && y < destinationHeight; ++y) {
-        size_t offset = 0;
-        for (size_t x = 0; x < sourceWidth && x < destinationWidth; ++x) {
-            struct Pixel16 {
-                Float16 r = { };
-                Float16 g = { };
-                Float16 b = { };
-                Float16 a = { };
-            };
-            static_assert(sizeof(Float16) == 2);
-            static_assert(sizeof(Pixel16) == 4 * sizeof(Float16));
-            union {
-                Pixel16 pixel16 { };
-                std::array<uint8_t, sizeof(Pixel16)> bytes;
-            } pixel16OrBytesUnion;
-            for (size_t byte = 0; byte < sizeof(Pixel16); ++byte)
-                pixel16OrBytesUnion.bytes[byte] = source.rows[sourceRowStartOffset + offset + byte];
-            if (source.format.alphaFormat != destination.format.alphaFormat) {
-                if (source.format.alphaFormat == AlphaPremultiplication::Unpremultiplied && destination.format.alphaFormat == AlphaPremultiplication::Premultiplied) {
-                    auto fa = float(pixel16OrBytesUnion.pixel16.a);
-                    pixel16OrBytesUnion.pixel16.r = Float16(float(pixel16OrBytesUnion.pixel16.r) * fa);
-                    pixel16OrBytesUnion.pixel16.g = Float16(float(pixel16OrBytesUnion.pixel16.g) * fa);
-                    pixel16OrBytesUnion.pixel16.b = Float16(float(pixel16OrBytesUnion.pixel16.b) * fa);
-                } else if (source.format.alphaFormat == AlphaPremultiplication::Premultiplied && destination.format.alphaFormat == AlphaPremultiplication::Unpremultiplied) {
-                    if (auto fa = float(pixel16OrBytesUnion.pixel16.a)) {
-                        pixel16OrBytesUnion.pixel16.r = Float16(float(pixel16OrBytesUnion.pixel16.r) / fa);
-                        pixel16OrBytesUnion.pixel16.g = Float16(float(pixel16OrBytesUnion.pixel16.g) / fa);
-                        pixel16OrBytesUnion.pixel16.b = Float16(float(pixel16OrBytesUnion.pixel16.b) / fa);
-                    }
-                } else
-                    RELEASE_ASSERT_NOT_REACHED();
-            }
-            for (size_t byte = 0; byte < sizeof(Pixel16); ++byte)
-                destination.rows[destinationRowStartOffset + offset + byte] = pixel16OrBytesUnion.bytes[byte];
-            offset += sizeof(Pixel16);
+        if (sourceAlphaFormat == destinationAlphaFormat) {
+            memcpySpan(destinationSpan, sourceSpan);
+            return;
         }
-        sourceRowStartOffset += source.bytesPerRow;
-        destinationRowStartOffset += destination.bytesPerRow;
+
+        const auto& sourcePixel16 = reinterpretCastSpanStartTo<Pixel16>(sourceSpan);
+        auto& destinationPixel16 = reinterpretCastSpanStartTo<Pixel16>(destinationSpan);
+
+        if (destinationAlphaFormat == AlphaPremultiplication::Premultiplied) {
+            auto fa = float(sourcePixel16.a);
+            destinationPixel16.r = Float16(float(sourcePixel16.r) * fa);
+            destinationPixel16.g = Float16(float(sourcePixel16.g) * fa);
+            destinationPixel16.b = Float16(float(sourcePixel16.b) * fa);
+            destinationPixel16.a = Float16(fa);
+            return;
+        }
+
+        if (auto fa = float(sourcePixel16.a)) {
+            destinationPixel16.r = Float16(float(sourcePixel16.r) / fa);
+            destinationPixel16.g = Float16(float(sourcePixel16.g) / fa);
+            destinationPixel16.b = Float16(float(sourcePixel16.b) / fa);
+            destinationPixel16.a = Float16(fa);
+            return;
+        }
+
+        memcpySpan(destinationSpan, sourceSpan);
+    };
+
+    size_t sourceRowStart = 0;
+    size_t destinationRowStart = 0;
+    size_t bytesPerRow = destinationSize.width() * sizeof(Pixel16);
+
+    for (int y = 0; y < destinationSize.height(); ++y) {
+        for (size_t x = 0; x < bytesPerRow; x += sizeof(Pixel16)) {
+            const auto sourceSpan = source.rows.subspan(sourceRowStart + x, sizeof(Pixel16));
+            auto destinationSpan = destination.rows.subspan(destinationRowStart + x, sizeof(Pixel16));
+            convertSinglePixel16(sourceSpan, source.format.alphaFormat, destinationSpan, destination.format.alphaFormat);
+        }
+        sourceRowStart += source.bytesPerRow;
+        destinationRowStart += destination.bytesPerRow;
     }
 }
 


### PR DESCRIPTION
#### 5b71f92830610b9f973e272126e97806e1ec43f9
<pre>
Cherry-pick 305413.1077@safari-7624.5.1.10-branch (62fcbfe61a49). <a href="https://bugs.webkit.org/show_bug.cgi?id=318405">https://bugs.webkit.org/show_bug.cgi?id=318405</a>

    use-after-free of AudioParam via cross-thread non-atomic ref/deref in AudioNodeOutput::disconnectAllParams()
    <a href="https://rdar.apple.com/177930032">rdar://177930032</a>

    Reviewed by Youenn Fablet.

    Make AudioParam use thread-safe refcounted.

    Test: webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash.html

    * LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash-expected.txt: Added.
    * LayoutTests/webaudio/AudioParam/audioparam-cross-thread-ref-deref-crash.html: Added.
    * Source/WebCore/Modules/webaudio/AudioParam.h:

    Identifier: 305413.1077@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.234@webkitglib/2.54">https://commits.webkit.org/317695.234@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 335d74b316363bddb15644766dd16e5f18181ce3
<pre>
Cherry-pick 305413.1062@safari-7624.5-branch (6c004fb89bd7). <a href="https://bugs.webkit.org/show_bug.cgi?id=318348">https://bugs.webkit.org/show_bug.cgi?id=318348</a>

    OSR Availability Fails to Invalidate Local Recoveries Across LoadVarargs
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318348">https://bugs.webkit.org/show_bug.cgi?id=318348</a>
    <a href="https://rdar.apple.com/178255543">rdar://178255543</a>

    Reviewed by Yusuke Suzuki.

    When a strict-mode `arguments` allocation produced by an inlined varargs call
    is eliminated to PhantomClonedArguments, OSR availability records each argument
    as a promoted heap location backed by the inlined frame&apos;s stack slots. A second
    inlined varargs call that lowers to LoadVarargs may reuse those same virtual
    registers. If an OSR exit later materialises the first allocation it must not
    do so from those reused slots.

    Two independent invariants were violated:

    1. LocalOSRAvailabilityCalculator::executeNode() handles PutStack/KillStack by
       calling killHeaps() before replacing a stack operand&apos;s availability so that
       any promoted heap location flushed to that operand is invalidated. The
       LoadVarargs / ForwardVarargs case replaced the count and argument operands
       without that invalidation, leaving stale promoted recoveries pointing at the
       overwritten slots. Apply the same killHeaps() calls before each replacement.

    2. DFG arguments-elimination interference analysis must disqualify a candidate
       whose source-frame stack slots are clobbered while the candidate is still
       OSR-live. It establishes the candidate&apos;s live range using
       forAllKilledNodesAtNodeIndex() plus CombinedLiveness::liveAtTail.
       liveAtTail was computed only as the union of CFG successors&apos; liveAtHead,
       each of which is pruned by bytecode liveness at the successor&apos;s first node.
       A candidate that is OSR-live at the block&apos;s terminal node but whose
       backing local is bytecode-dead at every CFG successor e.g.

       ```
           // block 1
           let a = ...;
           try {
               foo();
           } catch (e) {
               // block 2
               use(a);
           }
           // block 3
       ```

       Since DFG does not directly model exceptional control flow in the CFG
       `a` would be absent from the CFG/bytecode at block 3 and therefore absent
       from block 1&apos;s liveAtTail, so removeViaKill() would never be called on `a`.

    Note: For 2, we don&apos;t include the bytecodeLiveness for the tail of
    CombinedLiveness because this is both misleading with respect to how tail is
    used in the rest of the DFG. Additionally, it breaks ObjectAllocationSinking.
    ObjectAllocationSinking propagates its heap by pruning at each tail with
    liveAtTail then merging into successors. Since we don&apos;t prune at the head we
    can end up pushing phantom allocations into blocks where they don&apos;t actually
    dominate.

    Tests: JSTests/stress/arguments-elimination-inlined-load-varargs-preserves-recoveries.js
           JSTests/stress/arguments-elimination-load-varargs-kills-promoted-recoveries.js

    Identifier: 305413.1062@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.233@webkitglib/2.54">https://commits.webkit.org/317695.233@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### e3b53c7b445e17b565ee7221133e5d15d17792b9
<pre>
Cherry-pick 305413.1059@safari-7624.5.1.10-branch (e66d0b93bf1f). <a href="https://bugs.webkit.org/show_bug.cgi?id=316131">https://bugs.webkit.org/show_bug.cgi?id=316131</a>

    Converting Float16 pixels buffers to Unpremultiplied or premultiplied may miss the last row
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316131">https://bugs.webkit.org/show_bug.cgi?id=316131</a>
    <a href="https://rdar.apple.com/177764433">rdar://177764433</a>

    Reviewed by Gerald Squelart.

    convertImagePixelsFromFloat16ToFloat16() was written with the wrong assumption.
    The calculations in this function assume the source and destination PixelBuffers
    are rectangular. But sometimes they are not. ImageBufferBackend::getPixelBuffer()
    and ImageBufferBackend::putPixelBuffer() get subspans from the source and
    destination PixelBuffers starting from the starting point till the end of these
    PixelBuffers. The bytesPerRow of the PixelBuffer and PixelBufferConversionView
    may be larger than the bytesPerRow of the requested PixelBuffer.

    Like what other conversion functions do, the solution is not to drive the width
    and the height of sourceBuffer and destinationBuffer from the size_bytes and the
    bytesPerRow. The fix is to convert destinationBytesPerRow pixels from the
    sourceBuffer into the destinationBuffer for every row. To get the starting pixel
    for the next row from the sourceBuffer, we need to move by sourceBytesPerRow.

    * Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
    (WebCore::convertImagePixelsFromFloat16ToFloat16):

    Identifier: 305413.1059@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.232@webkitglib/2.54">https://commits.webkit.org/317695.232@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### f7ec8e813f9e7d3969c3654bf49ced1647af18ff
<pre>
Cherry-pick 305413.1026@safari-7624.5.1.10-branch (1af72a6f5454). <a href="https://bugs.webkit.org/show_bug.cgi?id=313499">https://bugs.webkit.org/show_bug.cgi?id=313499</a>

    Pre-invalidate captured-variable WatchpointSets in generator and async function bodies
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313499">https://bugs.webkit.org/show_bug.cgi?id=313499</a>
    <a href="https://rdar.apple.com/173777534">rdar://173777534</a>

    Reviewed by Yusuke Suzuki.

    When deleteAllCode runs while an async generator is suspended, the generator
    body&apos;s CodeBlock is cleared and later re-created from re-parsed source. The
    new CodeBlock&apos;s constant pool gets a fresh SymbolTable clone with fresh
    WatchpointSets, but the suspended activation still references the original.
    A subsequent ResolvedClosureVar put_to_scope on the new CodeBlock fires
    touch() against the fresh clone&apos;s WatchpointSet, which the DFG is not
    watching, so DFG code that constant-folded the captured variable never
    deoptimizes and returns stale values.

    Treat ResolvedClosureVar writes inside suspendable bodies the same way
    ClosureVar writes are already treated: invalidate the WatchpointSet at
    link time. Sibling closures using ClosureVar already pay this cost;
    extending it to the declaring function eliminates the only remaining
    runtime path that relies on SymbolTable identity across re-link.

    Tests: JSTests/stress/watchpoint-async-generator-code-deletion.js
           JSTests/stress/watchpoint-closure-not-affected.js

    * JSTests/stress/watchpoint-async-generator-code-deletion.js: Added.
    (async sleepAsync):
    (async main.opt):
    (async main):
    * JSTests/stress/watchpoint-closure-not-affected.js: Added.
    (async sleepAsync):
    (async test.):
    (async test.obj):
    * Source/JavaScriptCore/bytecode/CodeBlock.cpp:
    (JSC::CodeBlock::finishCreation):

    Identifier: 305413.1026@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.231@webkitglib/2.54">https://commits.webkit.org/317695.231@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/873629217f3c24fb36373a097fcf041225ea58bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185641 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59547 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53360 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195953 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150356 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187503 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60916 "The change is no longer eligible for processing.") | [⏳ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145062 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150356 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188596 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60916 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53360 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125357 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60916 "The change is no longer eligible for processing.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7254 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53360 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60916 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53360 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7013 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/46892 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52189 "The change is no longer eligible for processing.") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197913 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59212 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53360 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154599 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59920 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53360 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154252 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28177 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59920 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132262 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129174 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58390 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53360 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57766 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58006 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57831 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->