### PR TITLE
[css-conditional-5] Support CSSContainerRule.conditions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-rule-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-rule-cssom-expected.txt
@@ -2,9 +2,9 @@
 PASS containerName without query
 PASS containerQuery without name
 PASS containerName and containerQuery
-FAIL .conditions undefined is not an object (evaluating 'rule.conditions.length')
-FAIL .conditions without name undefined is not an object (evaluating 'rule.conditions.length')
-FAIL .conditions without query undefined is not an object (evaluating 'rule.conditions.length')
-FAIL style() undefined is not an object (evaluating 'rule.conditions.length')
-FAIL multiple conditions undefined is not an object (evaluating 'rule.conditions.length')
+PASS .conditions
+PASS .conditions without name
+PASS .conditions without query
+PASS style()
+PASS multiple conditions
 

--- a/Source/WebCore/css/CSSContainerRule.cpp
+++ b/Source/WebCore/css/CSSContainerRule.cpp
@@ -95,5 +95,19 @@ String CSSContainerRule::containerQuery() const
     return builder.toString();
 }
 
+Vector<CSSContainerRule::Condition> CSSContainerRule::conditions() const
+{
+    return WTF::map(styleRuleContainer().containerQuery(), [](const auto& condition) {
+        StringBuilder nameBuilder, queryBuilder;
+        serializeIdentifier(nameBuilder, condition.name);
+        MQ::serialize(queryBuilder, condition.condition);
+
+        return Condition {
+            .name = nameBuilder.toString(),
+            .query = queryBuilder.toString()
+        };
+    });
+}
+
 } // namespace WebCore
 

--- a/Source/WebCore/css/CSSContainerRule.h
+++ b/Source/WebCore/css/CSSContainerRule.h
@@ -40,6 +40,12 @@ public:
     String containerName() const;
     String containerQuery() const;
 
+    struct Condition {
+        String name;
+        String query;
+    };
+    Vector<Condition> conditions() const;
+
 private:
     const StyleRuleContainer& NODELETE styleRuleContainer() const;
 

--- a/Source/WebCore/css/CSSContainerRule.idl
+++ b/Source/WebCore/css/CSSContainerRule.idl
@@ -28,9 +28,18 @@
 typedef USVString CSSOMString;
 
 [
+    JSGenerateToJSObject
+]
+dictionary CSSContainerCondition {
+    required CSSOMString name;
+    required CSSOMString query;
+};
+
+[
     Exposed=Window
 ] interface CSSContainerRule : CSSConditionRule {
     readonly attribute CSSOMString containerName;
     readonly attribute CSSOMString containerQuery;
+    readonly attribute FrozenArray<CSSContainerCondition> conditions;
 };
 


### PR DESCRIPTION
#### ea566e53cf67e9831d9a0f97c2e5ec1667c1c9fe
<pre>
[css-conditional-5] Support CSSContainerRule.conditions
<a href="https://rdar.apple.com/182257864">rdar://182257864</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=319447">https://bugs.webkit.org/show_bug.cgi?id=319447</a>

Reviewed by Tim Nguyen.

318233@main adds support for multiple conditions in @container query.
This patch adds support for CSSContainerRule.conditions, which returns
a list of conditions in the @container rule.

Test: imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-rule-cssom.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/container-rule-cssom-expected.txt:
* Source/WebCore/css/CSSContainerRule.cpp:
(WebCore::CSSContainerRule::conditions const):
* Source/WebCore/css/CSSContainerRule.h:
* Source/WebCore/css/CSSContainerRule.idl:

Canonical link: <a href="https://commits.webkit.org/320762@main">https://commits.webkit.org/320762@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bec2213f33002f7ca86d92a3aefe99fd45fa53f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195957 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150360 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187507 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145068 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100574 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165642 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125363 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5bbb6410-709f-44b2-b45d-f2e875880990) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47479 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45525 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157839 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45216 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7017 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49931 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197917 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59216 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154604 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41445 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59924 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41821 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154257 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48724 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132315 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129178 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58394 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20238 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57770 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58010 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57835 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->