### PR TITLE
Add Device Hub.app for use in simulated_device.py for Xcode 27 and later

### DIFF
--- a/Tools/Scripts/webkitpy/xcode/simulated_device.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device.py
@@ -82,10 +82,15 @@ class SimulatedDeviceManager(object):
 
     xcrun = '/usr/bin/xcrun'
     simulator_device_path = '~/Library/Developer/CoreSimulator/Devices'
-    simulator_bundle_id = 'com.apple.iphonesimulator'
+
+    SIMULATOR_UI_APPS = (
+        ('../Applications/DeviceHub.app', [], 'DeviceHub'),                              # Xcode 27 and later
+        ('Applications/Simulator.app', ['-PasteboardAutomaticSync', '0'], 'Simulator'),  # Xcode 26 and earlier
+    )
+
     launchd_state_path = '/private/var/tmp/com.apple.CoreSimulator.SimDevice.{}'
     _device_identifier_to_name = {}
-    _managing_simulator_app = False
+    _managed_simulator_ui_process = None
     _last_updated_state = 0
 
     @staticmethod
@@ -459,6 +464,47 @@ class SimulatedDeviceManager(object):
         return requests
 
     @classmethod
+    def _find_simulator_ui_app(cls, host):
+        """Locates the application belonging to the active Xcode which can display booted simulators.
+
+        Returns a (path, launch arguments, process name) tuple, or None if the active Xcode ships no such
+        application or the active developer directory cannot be determined."""
+        try:
+            developer_dir = host.executive.run_command(['xcode-select', '--print-path']).rstrip()
+        except (OSError, ScriptError) as error:
+            _log.warning(u'Could not determine the active developer directory, continuing without a simulator UI: {}'.format(error))
+            return None
+
+        for relative_path, arguments, process_name in cls.SIMULATOR_UI_APPS:
+            path = host.filesystem.normpath(host.filesystem.join(developer_dir, relative_path))
+            if host.filesystem.isdir(path):
+                return path, arguments, process_name
+
+        _log.warning(u'No simulator UI application found in {}, continuing without one'.format(developer_dir))
+        return None
+
+    @classmethod
+    def _launch_simulator_ui(cls, host):
+        found = cls._find_simulator_ui_app(host)
+        if not found:
+            return
+        path, arguments, process_name = found
+
+        if host.executive.run_command(['killall', '-0', process_name], return_exit_code=True) == 0:
+            _log.debug(u'{} is already running'.format(process_name))
+            return
+
+        command = ['open', '-g', '-a', path]
+        if arguments:
+            command += ['--args'] + arguments
+        if host.executive.run_command(command, return_exit_code=True):
+            _log.warning(u'Failed to launch {}, continuing without a simulator UI'.format(path))
+            return
+
+        _log.debug(u'Launched {}'.format(path))
+        SimulatedDeviceManager._managed_simulator_ui_process = process_name
+
+    @classmethod
     def initialize_devices(cls, requests, host=None, name_base='Managed', simulator_ui=True, timeout=SIMULATOR_BOOT_TIMEOUT, keep_alive=False, udids=None, **kwargs):
         host = host or SystemHost.get_default()
         if SimulatedDeviceManager.INITIALIZED_DEVICES is not None:
@@ -521,8 +567,8 @@ class SimulatedDeviceManager(object):
 
             cls._boot_device(device, host)
 
-        if simulator_ui and host.executive.run_command(['killall', '-0', 'Simulator.app'], return_exit_code=True) != 0:
-            SimulatedDeviceManager._managing_simulator_app = not host.executive.run_command(['open', '-g', '-b', SimulatedDeviceManager.simulator_bundle_id, '--args', '-PasteboardAutomaticSync', '0'], return_exit_code=True)
+        if simulator_ui:
+            cls._launch_simulator_ui(host)
 
         deadline = time.time() + timeout
         for device in SimulatedDeviceManager.INITIALIZED_DEVICES:
@@ -564,9 +610,9 @@ class SimulatedDeviceManager(object):
     @staticmethod
     def tear_down(host=None, timeout=SIMULATOR_BOOT_TIMEOUT):
         host = host or SystemHost.get_default()
-        if SimulatedDeviceManager._managing_simulator_app:
-            host.executive.run_command(['killall', '-9', 'Simulator.app'], return_exit_code=True)
-            SimulatedDeviceManager._managing_simulator_app = False
+        if SimulatedDeviceManager._managed_simulator_ui_process:
+            host.executive.run_command(['killall', '-9', SimulatedDeviceManager._managed_simulator_ui_process], return_exit_code=True)
+            SimulatedDeviceManager._managed_simulator_ui_process = None
 
         if SimulatedDeviceManager.INITIALIZED_DEVICES is None:
             return

--- a/Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py
@@ -522,7 +522,7 @@ class SimulatedDeviceTest(unittest.TestCase):
         SimulatedDeviceManager.AVAILABLE_DEVICES = []
         SimulatedDeviceManager.INITIALIZED_DEVICES = None
         SimulatedDeviceManager._device_identifier_to_name = {}
-        SimulatedDeviceManager._managing_simulator_app = False
+        SimulatedDeviceManager._managed_simulator_ui_process = None
 
     def tearDown(self):
         SimulatedDeviceTest.reset_simulated_device_manager()
@@ -609,7 +609,7 @@ class SimulatedDeviceTest(unittest.TestCase):
         host = SimulatedDeviceTest.mock_host_for_simctl()
         SimulatedDeviceManager.available_devices(host)
 
-        SimulatedDeviceManager.initialize_devices(DeviceRequest(DeviceType.from_string('iPhone', Version(11))), host=host)
+        SimulatedDeviceManager.initialize_devices(DeviceRequest(DeviceType.from_string('iPhone', Version(11))), host=host, simulator_ui=False)
 
         self.assertEqual(1, len(SimulatedDeviceManager.INITIALIZED_DEVICES))
         self.assertEqual('34FB476C-6FA0-43C8-8945-1BD7A4EBF0DE', SimulatedDeviceManager.INITIALIZED_DEVICES[0].udid)
@@ -624,7 +624,7 @@ class SimulatedDeviceTest(unittest.TestCase):
         host = SimulatedDeviceTest.mock_host_for_simctl()
         SimulatedDeviceManager.available_devices(host)
 
-        SimulatedDeviceManager.initialize_devices(DeviceRequest(DeviceType.from_string('iphone 5s', Version(11))), host=host)
+        SimulatedDeviceManager.initialize_devices(DeviceRequest(DeviceType.from_string('iphone 5s', Version(11))), host=host, simulator_ui=False)
 
         self.assertEqual(1, len(SimulatedDeviceManager.INITIALIZED_DEVICES))
         self.assertEqual('34FB476C-6FA0-43C8-8945-1BD7A4EBF0DE', SimulatedDeviceManager.INITIALIZED_DEVICES[0].udid)
@@ -753,3 +753,94 @@ class LaunchdConfigurationDefaultTest(unittest.TestCase):
     def test_daemons_testing_needs_are_not_disabled(self):
         for label in ('com.apple.sharingd', 'com.apple.eligibilityd', 'com.apple.sleepd'):
             self.assertNotIn(label, disabled_launchd_jobs())
+
+
+class SimulatorUIAppTest(unittest.TestCase):
+    """Xcode 27 replaced Simulator.app with DeviceHub.app, so the active Xcode decides which app we launch.
+    The lookup is by path because `open -b` resolves through LaunchServices, which ignores xcode-select."""
+
+    XCODE_26_DIRS = [
+        '/Xcode26.app/Contents/Developer/Applications/Simulator.app',
+        '/Xcode26.app/Contents/Applications/Devices.app',
+    ]
+    XCODE_27_DIRS = ['/Xcode27.app/Contents/Applications/DeviceHub.app']
+
+    @staticmethod
+    def _host(developer_dir, dirs, running_processes=(), open_exit_code=0):
+        def run_command(args):
+            if args[0] == 'xcode-select':
+                return developer_dir + '\n'
+            if args[0] == 'killall':
+                return 0 if args[-1] in running_processes else 1
+            if args[0] == 'open':
+                return open_exit_code
+            return ''
+
+        return MockSystemHost(
+            executive=MockExecutive2(run_command_fn=run_command),
+            filesystem=MockFileSystem(dirs=dirs),
+        )
+
+    def setUp(self):
+        SimulatedDeviceManager.INITIALIZED_DEVICES = None
+        SimulatedDeviceManager._managed_simulator_ui_process = None
+
+    def tearDown(self):
+        SimulatedDeviceManager._managed_simulator_ui_process = None
+
+    def test_xcode_27_resolves_to_device_hub(self):
+        host = self._host('/Xcode27.app/Contents/Developer', self.XCODE_27_DIRS)
+        self.assertEqual(
+            ('/Xcode27.app/Contents/Applications/DeviceHub.app', [], 'DeviceHub'),
+            SimulatedDeviceManager._find_simulator_ui_app(host))
+
+    def test_xcode_26_resolves_to_simulator(self):
+        host = self._host('/Xcode26.app/Contents/Developer', self.XCODE_26_DIRS)
+        self.assertEqual(
+            ('/Xcode26.app/Contents/Developer/Applications/Simulator.app', ['-PasteboardAutomaticSync', '0'], 'Simulator'),
+            SimulatedDeviceManager._find_simulator_ui_app(host))
+
+    def test_xcode_without_a_ui_app_resolves_to_nothing(self):
+        host = self._host('/Xcode.app/Contents/Developer', ['/Xcode.app/Contents/Developer'])
+        self.assertIsNone(SimulatedDeviceManager._find_simulator_ui_app(host))
+
+    def test_device_hub_is_launched_without_pasteboard_arguments(self):
+        host = self._host('/Xcode27.app/Contents/Developer', self.XCODE_27_DIRS)
+        SimulatedDeviceManager._launch_simulator_ui(host)
+        self.assertIn(['open', '-g', '-a', '/Xcode27.app/Contents/Applications/DeviceHub.app'], host.executive.calls)
+        self.assertEqual('DeviceHub', SimulatedDeviceManager._managed_simulator_ui_process)
+
+    def test_simulator_is_launched_with_pasteboard_sync_disabled(self):
+        host = self._host('/Xcode26.app/Contents/Developer', self.XCODE_26_DIRS)
+        SimulatedDeviceManager._launch_simulator_ui(host)
+        self.assertIn(
+            ['open', '-g', '-a', '/Xcode26.app/Contents/Developer/Applications/Simulator.app', '--args', '-PasteboardAutomaticSync', '0'],
+            host.executive.calls)
+        self.assertEqual('Simulator', SimulatedDeviceManager._managed_simulator_ui_process)
+
+    def test_the_app_is_never_launched_by_bundle_identifier(self):
+        host = self._host('/Xcode26.app/Contents/Developer', self.XCODE_26_DIRS)
+        SimulatedDeviceManager._launch_simulator_ui(host)
+        for call in host.executive.calls:
+            self.assertNotIn('-b', call, 'LaunchServices would ignore xcode-select and may pick another Xcode')
+
+    def test_an_already_running_app_is_not_launched_again(self):
+        host = self._host('/Xcode27.app/Contents/Developer', self.XCODE_27_DIRS, running_processes=('DeviceHub',))
+        SimulatedDeviceManager._launch_simulator_ui(host)
+        self.assertFalse([call for call in host.executive.calls if call[0] == 'open'])
+        self.assertIsNone(
+            SimulatedDeviceManager._managed_simulator_ui_process,
+            'we did not launch it, so we must not kill it')
+
+    def test_a_failed_launch_is_not_torn_down(self):
+        host = self._host('/Xcode27.app/Contents/Developer', self.XCODE_27_DIRS, open_exit_code=1)
+        SimulatedDeviceManager._launch_simulator_ui(host)
+        self.assertIsNone(SimulatedDeviceManager._managed_simulator_ui_process)
+
+    def test_tear_down_kills_the_app_which_was_launched(self):
+        host = self._host('/Xcode26.app/Contents/Developer', self.XCODE_26_DIRS)
+        SimulatedDeviceManager._launch_simulator_ui(host)
+        SimulatedDeviceManager.tear_down(host)
+        # 'Simulator.app' would match no process at all; killall matches process names.
+        self.assertIn(['killall', '-9', 'Simulator'], host.executive.calls)
+        self.assertIsNone(SimulatedDeviceManager._managed_simulator_ui_process)


### PR DESCRIPTION
#### 5700209bda3315d69a0751325bebdf3eca41c07a
<pre>
Add Device Hub.app for use in simulated_device.py for Xcode 27 and later
<a href="https://bugs.webkit.org/show_bug.cgi?id=323691">https://bugs.webkit.org/show_bug.cgi?id=323691</a>
<a href="https://rdar.apple.com/186950257">rdar://186950257</a>

Reviewed by Jonathan Bedard.

As of Xcode 27 the simulator.app was replaced with the device hub.app.
This change assumes the new default of using the device hub.app. But,
takes into account if Xcode 26 or older is being used, and opts to use
the Simulator.app when running tests and spawning simulated devices for
Xcode 26 and older use cases.

* Tools/Scripts/webkitpy/xcode/simulated_device.py:
(SimulatedDeviceManager):
(SimulatedDeviceManager._find_simulator_ui_app):
(SimulatedDeviceManager._launch_simulator_ui):
(SimulatedDeviceManager.initialize_devices):
(SimulatedDeviceManager.tear_down):
* Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py:
(SimulatedDeviceTest.reset_simulated_device_manager):
(LaunchdConfigurationDefaultTest.test_daemons_testing_needs_are_not_disabled):
(SimulatorUIAppTest):
(SimulatorUIAppTest._host):
(SimulatorUIAppTest._host.run_command):
(SimulatorUIAppTest.setUp):
(SimulatorUIAppTest.tearDown):
(SimulatorUIAppTest.test_xcode_27_resolves_to_device_hub):
(SimulatorUIAppTest.test_xcode_26_resolves_to_simulator):
(SimulatorUIAppTest.test_xcode_without_a_ui_app_resolves_to_nothing):
(SimulatorUIAppTest.test_device_hub_is_launched_without_pasteboard_arguments):
(SimulatorUIAppTest.test_simulator_is_launched_with_pasteboard_sync_disabled):
(SimulatorUIAppTest.test_the_app_is_never_launched_by_bundle_identifier):
(SimulatorUIAppTest.test_an_already_running_app_is_not_launched_again):
(SimulatorUIAppTest.test_a_failed_launch_is_not_torn_down):
(SimulatorUIAppTest.test_tear_down_kills_the_app_which_was_launched):

Canonical link: <a href="https://commits.webkit.org/320774@main">https://commits.webkit.org/320774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc8688e1701b96446e6c535899ad36e99eefd90d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150363 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59284 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145065 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100576 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125360 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/184984 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47491 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45528 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157851 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45219 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7021 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197920 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59220 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154606 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59927 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154259 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28222 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48725 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129181 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58397 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20241 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57773 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58013 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57838 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->