### PR TITLE
[GFC] fit-content() tracks should not be stretched and should cap the growth limit

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-definition/fit-content-track-sizing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-definition/fit-content-track-sizing-expected.txt
@@ -1,0 +1,15 @@
+
+PASS A fit-content() row is not stretched to a definite grid container height
+PASS A fit-content() row is not stretched to the grid container's min-height
+PASS A fit-content() row is floored by its item's automatic minimum size, above the argument
+PASS A fit-content() row's growth limit is clamped by its argument
+PASS A fit-content() argument smaller than the content sizes the row
+PASS A fit-content() argument larger than the content does not size the row
+PASS A percentage fit-content() argument resolves against the grid container's definite height
+PASS A calc() fit-content() argument resolves against the grid container's definite height
+PASS An item spanning fit-content() rows does not grow either past its argument
+PASS A fit-content() argument is applied on a zoomed grid container
+PASS A fit-content() column's growth limit is clamped by its argument
+PASS An auto row in the same position is stretched
+PASS Leftover space goes to the auto row rather than the fit-content() row beside it
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-definition/fit-content-track-sizing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-definition/fit-content-track-sizing.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<title>CSS Grid Layout Test: fit-content() track sizing</title>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-single-span-items">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-stretch">
+<meta name="assert" content="A fit-content() track's growth limit is the maximum of its items' max-content contributions, clamped by the fit-content() argument and then floored by the items' automatic minimum size. Its max track sizing function is max-content rather than auto, so Stretch auto tracks does not expand it and leftover space in the grid container is not distributed to it.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<style>
+  .grid {
+    display: grid;
+    grid-template-columns: 60px;
+    grid-auto-rows: fit-content(40px);
+    height: 300px;
+  }
+
+  .zeroMinimumSize {
+    min-height: 0;
+  }
+</style>
+
+<div class="grid" id="definiteHeight">
+  <div><div style="height: 10px"></div></div>
+</div>
+
+<div class="grid" id="minHeight" style="height: auto; min-height: 300px">
+  <div><div style="height: 10px"></div></div>
+</div>
+
+<div class="grid" id="automaticMinimumSizeFloor">
+  <div><div style="height: 10px"></div></div>
+  <div><div style="height: 100px"></div></div>
+</div>
+
+<div class="grid" id="contentLargerThanArgument">
+  <div class="zeroMinimumSize"><div style="height: 100px"></div></div>
+</div>
+
+<div class="grid" id="smallArgument" style="grid-auto-rows: fit-content(30px)">
+  <div class="zeroMinimumSize"><div style="height: 100px"></div></div>
+</div>
+
+<div class="grid" id="largeArgument" style="grid-auto-rows: fit-content(200px)">
+  <div class="zeroMinimumSize"><div style="height: 100px"></div></div>
+</div>
+
+<div class="grid" id="percentageArgument" style="grid-auto-rows: fit-content(50%)">
+  <div class="zeroMinimumSize"><div style="height: 400px"></div></div>
+</div>
+
+<div class="grid" id="calculatedArgument" style="grid-auto-rows: fit-content(calc(10% + 5px))">
+  <div class="zeroMinimumSize"><div style="height: 400px"></div></div>
+</div>
+
+<div class="grid" id="spanningItem">
+  <div style="grid-row: span 2; min-height: 0"><div style="height: 200px"></div></div>
+</div>
+
+<div class="grid" id="zoomedGrid" style="zoom: 2">
+  <div class="zeroMinimumSize"><div style="height: 400px"></div></div>
+</div>
+
+<div class="grid" id="implicitColumn" style="width: 300px; grid-auto-columns: fit-content(40px)">
+  <div style="grid-column: 2; min-width: 0"><div style="width: 400px; height: 10px"></div></div>
+</div>
+
+<div class="grid" id="autoRow" style="grid-auto-rows: auto">
+  <div><div style="height: 10px"></div></div>
+</div>
+
+<div class="grid" id="autoRowAndFitContentRow" style="grid-auto-rows: fit-content(40px) auto">
+  <div><div style="height: 10px"></div></div>
+  <div><div style="height: 10px"></div></div>
+</div>
+
+<script>
+function usedRowSizes(gridContainer) {
+  return getComputedStyle(gridContainer).gridTemplateRows;
+}
+
+test(() => {
+  assert_equals(usedRowSizes(definiteHeight), "10px");
+}, "A fit-content() row is not stretched to a definite grid container height");
+
+test(() => {
+  assert_equals(usedRowSizes(minHeight), "10px");
+}, "A fit-content() row is not stretched to the grid container's min-height");
+
+test(() => {
+  assert_equals(usedRowSizes(automaticMinimumSizeFloor), "10px 100px");
+}, "A fit-content() row is floored by its item's automatic minimum size, above the argument");
+
+test(() => {
+  assert_equals(usedRowSizes(contentLargerThanArgument), "40px");
+}, "A fit-content() row's growth limit is clamped by its argument");
+
+test(() => {
+  assert_equals(usedRowSizes(smallArgument), "30px");
+}, "A fit-content() argument smaller than the content sizes the row");
+
+test(() => {
+  assert_equals(usedRowSizes(largeArgument), "100px");
+}, "A fit-content() argument larger than the content does not size the row");
+
+test(() => {
+  assert_equals(usedRowSizes(percentageArgument), "150px");
+}, "A percentage fit-content() argument resolves against the grid container's definite height");
+
+test(() => {
+  assert_equals(usedRowSizes(calculatedArgument), "35px");
+}, "A calc() fit-content() argument resolves against the grid container's definite height");
+
+test(() => {
+  assert_equals(usedRowSizes(spanningItem), "40px 40px");
+}, "An item spanning fit-content() rows does not grow either past its argument");
+
+test(() => {
+  assert_equals(usedRowSizes(zoomedGrid), "40px");
+}, "A fit-content() argument is applied on a zoomed grid container");
+
+test(() => {
+  assert_equals(getComputedStyle(implicitColumn).gridTemplateColumns, "60px 40px");
+}, "A fit-content() column's growth limit is clamped by its argument");
+
+test(() => {
+  assert_equals(usedRowSizes(autoRow), "300px");
+}, "An auto row in the same position is stretched");
+
+test(() => {
+  assert_equals(usedRowSizes(autoRowAndFitContentRow), "10px 290px");
+}, "Leftover space goes to the auto row rather than the fit-content() row beside it");
+</script>

--- a/Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridItemSizingFunctions.cpp
@@ -47,10 +47,11 @@ static std::optional<LayoutUnit> gridAreaMaximumSize(size_t startLine, size_t en
     LayoutUnit maximumSize;
     for (auto trackIndex : std::views::iota(startLine, endLine)) {
         auto& trackSizingFunction = trackSizingFunctions[trackIndex];
-        if (!trackSizingFunction.max.isLength())
+        auto maximumBreadthFunction = trackSizingFunction.max.tryBreadth();
+        if (!maximumBreadthFunction || !maximumBreadthFunction->isLength())
             return { };
 
-        auto& maximumBreadth = trackSizingFunction.max.length();
+        auto& maximumBreadth = maximumBreadthFunction->length();
         if (auto fixedMaximumBreadth = maximumBreadth.tryFixed()) {
             maximumSize += Style::evaluate<LayoutUnit>(*fixedMaximumBreadth, trackSizingFunction.zoom);
             continue;

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -235,7 +235,7 @@ TrackSizingFunctions GridLayout::convertGridTrackSizeToTrackSizingFunctions(cons
         return gridTrackSize.minTrackBreadth();
     };
 
-    auto maxTrackSizingFunction = [&]() {
+    auto maxTrackSizingFunction = [&]() -> MaxTrackSizingFunction {
         // If the track was sized with a minmax() function, this is the second argument to that function.
         if (gridTrackSize.isMinMax())
             return gridTrackSize.maxTrackBreadth();
@@ -243,6 +243,9 @@ TrackSizingFunctions GridLayout::convertGridTrackSizeToTrackSizingFunctions(cons
         // Otherwise, the track’s sizing function. In all cases, treat auto and fit-content() as max-content,
         // except where specified otherwise for fit-content().
         // Note: This special treatment is handled inside of TrackSizingAlgorithm.
+        if (gridTrackSize.isFitContent())
+            return Style::GridTrackSize::FitContent { gridTrackSize.fitContentTrackLength() };
+
         return gridTrackSize.maxTrackBreadth();
     };
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridSizer.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridSizer.cpp
@@ -50,32 +50,38 @@ static Vector<LayoutUnit> rowSizesForFirstIterationColumnSizing(const TrackSizin
 {
     return rowTrackSizingFunctionsList.map([&gridContainerInnerInlineSize](const TrackSizingFunctions& trackSizingFunctions) {
         return WTF::switchOn(trackSizingFunctions.max,
-            [&](const Style::GridTrackBreadthLength::Fixed& fixedValue) {
-                return Style::evaluate<LayoutUnit>(fixedValue, trackSizingFunctions.zoom);
+            [&](const Style::GridTrackBreadth& maxTrackSizingFunction) {
+                return WTF::switchOn(maxTrackSizingFunction,
+                    [&](const Style::GridTrackBreadthLength::Fixed& fixedValue) {
+                        return Style::evaluate<LayoutUnit>(fixedValue, trackSizingFunctions.zoom);
+                    },
+                    [&](const Style::GridTrackBreadthLength::Percentage& percentageValue) {
+                        ASSERT_WITH_MESSAGE(gridContainerInnerInlineSize, "The formatting context should have transformed this track size to auto");
+                        return Style::evaluate<LayoutUnit>(percentageValue, *gridContainerInnerInlineSize);
+                    },
+                    [&](const Style::GridTrackBreadth::Calc calculatedValue) -> LayoutUnit {
+                        ASSERT_WITH_MESSAGE(gridContainerInnerInlineSize, "The formatting context should have transformed this track size to auto");
+                        return Style::evaluate<LayoutUnit>(calculatedValue, *gridContainerInnerInlineSize, trackSizingFunctions.zoom);
+                    },
+                    [](const CSS::Keyword::MinContent&) -> LayoutUnit {
+                        return LayoutUnit::max();
+                    },
+                    [](const CSS::Keyword::MaxContent&) {
+                        return LayoutUnit::max();
+                    },
+                    [](const CSS::Keyword::Auto&) -> LayoutUnit {
+                        return LayoutUnit::max();
+                    },
+                    [](const Style::GridTrackBreadth::Flex&) -> LayoutUnit {
+                        return LayoutUnit::max();
+                    },
+                    [](const auto&) -> LayoutUnit {
+                        ASSERT_NOT_IMPLEMENTED_YET();
+                        return { };
+                    });
             },
-            [&](const Style::GridTrackBreadthLength::Percentage& percentageValue) {
-                ASSERT_WITH_MESSAGE(gridContainerInnerInlineSize, "The formatting context should have transformed this track size to auto");
-                return Style::evaluate<LayoutUnit>(percentageValue, *gridContainerInnerInlineSize);
-            },
-            [&](const Style::GridTrackBreadth::Calc calculatedValue) -> LayoutUnit {
-                ASSERT_WITH_MESSAGE(gridContainerInnerInlineSize, "The formatting context should have transformed this track size to auto");
-                return Style::evaluate<LayoutUnit>(calculatedValue, *gridContainerInnerInlineSize, trackSizingFunctions.zoom);
-            },
-            [](const CSS::Keyword::MinContent&) -> LayoutUnit {
+            [](const Style::GridTrackSize::FitContent&) -> LayoutUnit {
                 return LayoutUnit::max();
-            },
-            [](const CSS::Keyword::MaxContent&) {
-                return LayoutUnit::max();
-            },
-            [](const CSS::Keyword::Auto&) -> LayoutUnit {
-                return LayoutUnit::max();
-            },
-            [](const Style::GridTrackBreadth::Flex&) -> LayoutUnit {
-                return LayoutUnit::max();
-            },
-            [](const auto&) -> LayoutUnit {
-                ASSERT_NOT_IMPLEMENTED_YET();
-                return { };
             });
     });
 }

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -269,8 +269,7 @@ static TrackIndexes tracksWithAutoMaxTrackSizingFunction(const UnsizedTracks& un
 {
     TrackIndexes trackIndexes;
     for (auto [trackIndex, track] : WTF::indexedRange(unsizedTracks)) {
-        auto& maxTrackSizingFunction = track.trackSizingFunction.max;
-        if (maxTrackSizingFunction.isAuto())
+        if (track.trackSizingFunction.max.isAuto())
             trackIndexes.append(trackIndex);
     }
     return trackIndexes;
@@ -326,13 +325,19 @@ static std::optional<LayoutUnit> fixedMaxTrackSizingFunctionSum(const WTF::Range
     LayoutUnit sum;
     for (size_t trackIndex = itemSpan.begin(); trackIndex < itemSpan.end(); ++trackIndex) {
         auto& trackSizingFunction = unsizedTracks[trackIndex].trackSizingFunction;
-        auto& maxTrackSizingFunction = trackSizingFunction.max;
-        if (!maxTrackSizingFunction.isLength())
+        auto fixedMaximum = WTF::switchOn(trackSizingFunction.max,
+            [](const Style::GridTrackBreadth& breadth) -> std::optional<Style::GridTrackBreadthLength::Fixed> {
+                if (!breadth.isLength())
+                    return { };
+                return breadth.length().tryFixed();
+            },
+            // The limit "could be the argument to a fit-content() track sizing function".
+            [](const Style::GridTrackSize::FitContent& fitContent) -> std::optional<Style::GridTrackBreadthLength::Fixed> {
+                return fitContent->value.tryFixed();
+            });
+        if (!fixedMaximum)
             return { };
-        auto fixedValue = maxTrackSizingFunction.length().tryFixed();
-        if (!fixedValue)
-            return { };
-        sum += Style::evaluate<LayoutUnit>(*fixedValue, trackSizingFunction.zoom);
+        sum += Style::evaluate<LayoutUnit>(*fixedMaximum, trackSizingFunction.zoom);
     }
     return sum;
 }
@@ -427,42 +432,56 @@ static void sizeTracksToFitNonSpanningItems(const ResolveIntrinsicTrackSizesCont
             }
         );
 
-        auto& maximumTrackSizingFunction = track.trackSizingFunction.max;
-        track.growthLimit = WTF::switchOn(maximumTrackSizingFunction,
-            [&](const CSS::Keyword::MinContent&) -> LayoutUnit {
-                // If the track has a min-content max track sizing function, set its growth
-                // limit to the maximum of the items’ min-content contributions.
-                auto itemContributions = minContentContributions(trackSizingItems, singleSpanningItemsIndexes, gridItemSizingFunctions);
-                ASSERT(itemContributions.size() == singleSpanningItemsIndexes.size());
-                return std::ranges::max(itemContributions);
+        track.growthLimit = WTF::switchOn(track.trackSizingFunction.max,
+            [&](const Style::GridTrackBreadth& maximumTrackSizingFunction) -> LayoutUnit {
+                return WTF::switchOn(maximumTrackSizingFunction,
+                    [&](const CSS::Keyword::MinContent&) -> LayoutUnit {
+                        // If the track has a min-content max track sizing function, set its growth
+                        // limit to the maximum of the items’ min-content contributions.
+                        auto itemContributions = minContentContributions(trackSizingItems, singleSpanningItemsIndexes, gridItemSizingFunctions);
+                        ASSERT(itemContributions.size() == singleSpanningItemsIndexes.size());
+                        return std::ranges::max(itemContributions);
+                    },
+                    [&](const CSS::Keyword::MaxContent&) -> LayoutUnit {
+                        // If the track has a max-content max track sizing function, set its growth
+                        // limit to the maximum of the items’ max-content contributions.
+                        auto itemContributions = maxContentContributions(trackSizingItems, singleSpanningItemsIndexes, gridItemSizingFunctions);
+                        return std::ranges::max(itemContributions);
+                    },
+                    [&](const CSS::Keyword::Auto&) -> LayoutUnit {
+                        // Since it is not explicitly stated otherwise in the spec, auto is treated as max-content:
+                        // If the track has a max-content max track sizing function, set its growth
+                        // limit to the maximum of the items’ max-content contributions.
+                        auto itemContributions = maxContentContributions(trackSizingItems, singleSpanningItemsIndexes, gridItemSizingFunctions);
+                        return std::ranges::max(itemContributions);
+                    },
+                    // A <length-percentage> max track sizing function was already resolved to an absolute
+                    // length by Initialize Track Sizes.
+                    [&](const Style::GridTrackBreadth::Fixed&) -> LayoutUnit {
+                        return track.growthLimit;
+                    },
+                    [&](const Style::GridTrackBreadth::Percentage&) -> LayoutUnit {
+                        return track.growthLimit;
+                    },
+                    [&](const Style::GridTrackBreadth::Calc&) -> LayoutUnit {
+                        return track.growthLimit;
+                    },
+                    [&](const auto&) -> LayoutUnit {
+                        ASSERT_NOT_REACHED();
+                        return { };
+                    }
+                );
             },
-            [&](const CSS::Keyword::MaxContent&) -> LayoutUnit {
-                // If the track has a max-content max track sizing function, set its growth
-                // limit to the maximum of the items’ max-content contributions.
+            // For fit-content() maximums, furthermore clamp this growth limit by the fit-content()
+            // argument.
+            [&](const Style::GridTrackSize::FitContent& fitContent) -> LayoutUnit {
                 auto itemContributions = maxContentContributions(trackSizingItems, singleSpanningItemsIndexes, gridItemSizingFunctions);
-                return std::ranges::max(itemContributions);
-            },
-            [&](const CSS::Keyword::Auto&) -> LayoutUnit {
-                // Since it is not explicitly stated otherwise in the spec, auto is treated as max-content:
-                // If the track has a max-content max track sizing function, set its growth
-                // limit to the maximum of the items’ max-content contributions.
-                auto itemContributions = maxContentContributions(trackSizingItems, singleSpanningItemsIndexes, gridItemSizingFunctions);
-                return std::ranges::max(itemContributions);
-            },
-            // A <length-percentage> max track sizing function was already resolved to an absolute
-            // length by Initialize Track Sizes.
-            [&](const Style::GridTrackBreadth::Fixed&) -> LayoutUnit {
-                return track.growthLimit;
-            },
-            [&](const Style::GridTrackBreadth::Percentage&) -> LayoutUnit {
-                return track.growthLimit;
-            },
-            [&](const Style::GridTrackBreadth::Calc&) -> LayoutUnit {
-                return track.growthLimit;
-            },
-            [&](const auto&) -> LayoutUnit {
-                ASSERT_NOT_REACHED();
-                return { };
+                auto fitContentLimit = [&] -> LayoutUnit {
+                    if (auto fixedArgument = fitContent->value.tryFixed())
+                        return Style::evaluate<LayoutUnit>(*fixedArgument, track.trackSizingFunction.zoom);
+                    return Style::evaluate<LayoutUnit>(fitContent->value, resolveIntrinsicTrackSizesContext.axisConstraint.availableSpace(), track.trackSizingFunction.zoom);
+                }();
+                return std::min(std::ranges::max(itemContributions), fitContentLimit);
             }
         );
 
@@ -556,8 +575,11 @@ static bool hasAffectedTrackSizingFunction(const UnsizedTrack& track, AffectedTr
         // https://drafts.csswg.org/css-grid-1/#track-sizing
         // As a maximum, auto "represents the largest max-content contribution of the grid items
         // occupying the grid track", so it is accommodated together with max-content here.
-        return maxTrackSizingFunction.isAuto()
-            || (maxTrackSizingFunction.isLength() && maxTrackSizingFunction.length().isMaxContent());
+        // FIXME: A fit-content() track's maximum becomes fixed once it reaches its argument,
+        // which would exclude it here.
+        if (auto breadth = maxTrackSizingFunction.tryBreadth())
+            return breadth->isAuto() || (breadth->isLength() && breadth->length().isMaxContent());
+        return true;
     }
     ASSERT_NOT_REACHED();
     return false;
@@ -578,8 +600,11 @@ static bool shouldTrackGrowBeyondGrowthLimits(const UnsizedTrack& track, Affecte
     // to also have a max-content max track sizing function..."
     case AffectedTrackSizingFunction::AutoOrMaxContentMinimum:
     case AffectedTrackSizingFunction::MaxContentMinimum:
-        return maxTrackSizingFunction.isAuto()
-            || (maxTrackSizingFunction.isLength() && maxTrackSizingFunction.length().isMaxContent());
+        // FIXME: A fit-content() track's maximum becomes fixed once it reaches its argument,
+        // which would stop it growing beyond limits here.
+        if (auto breadth = maxTrackSizingFunction.tryBreadth())
+            return breadth->isAuto() || (breadth->isLength() && breadth->length().isMaxContent());
+        return true;
     // "...when accommodating any contribution into growth limits: any affected track that has an
     // intrinsic max track sizing function."
     case AffectedTrackSizingFunction::IntrinsicMaximum:
@@ -964,8 +989,8 @@ static UnsizedTracks initializeTrackSizes(const TrackSizingFunctionsList& trackS
 
             // A fixed sizing function
             // Resolve to an absolute length and use that size as the track’s initial growth limit.
-            if (maxTrackSizingFunction.isLength()) {
-                auto trackBreadthLength = maxTrackSizingFunction.length();
+            if (auto breadth = maxTrackSizingFunction.tryBreadth(); breadth && breadth->isLength()) {
+                auto trackBreadthLength = breadth->length();
                 if (auto fixedValue = trackBreadthLength.tryFixed())
                     return Style::evaluate<LayoutUnit>(*fixedValue, trackSizingFunctions.zoom);
                 if (trackBreadthLength.isPercentOrCalculated())
@@ -991,10 +1016,8 @@ static FlexTracks collectFlexTracks(const UnsizedTracks& unsizedTracks)
     FlexTracks flexTracks;
 
     for (auto [trackIndex, track] : indexedRange(unsizedTracks)) {
-        const auto& maxTrackSizingFunction = track.trackSizingFunction.max;
-
-        if (maxTrackSizingFunction.isFlex()) {
-            auto flexFactor = maxTrackSizingFunction.flex();
+        if (track.trackSizingFunction.max.isFlex()) {
+            auto flexFactor = track.trackSizingFunction.max.flex();
             flexTracks.append(FlexTrack(trackIndex, flexFactor, track.baseSize, track.growthLimit));
         }
     }

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingFunctions.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingFunctions.h
@@ -26,14 +26,63 @@
 #pragma once
 
 #include "StyleGridTrackBreadth.h"
+#include "StyleGridTrackSize.h"
 #include "StyleZoomPrimitives.h"
 
 namespace WebCore {
 namespace Layout {
 
+// https://drafts.csswg.org/css-grid-2/#typedef-track-size
+// fit-content() is only ever a max track sizing function.
+class MaxTrackSizingFunction {
+public:
+    MaxTrackSizingFunction(Style::GridTrackBreadth breadth)
+        : m_value(WTF::move(breadth)) { }
+
+    MaxTrackSizingFunction(Style::GridTrackSize::FitContent fitContent)
+        : m_value(WTF::move(fitContent)) { }
+
+    FORWARD_VARIANT_FUNCTIONS(MaxTrackSizingFunction, m_value)
+
+    // Absent for a fit-content() maximum.
+    std::optional<Style::GridTrackBreadth> tryBreadth() const
+    {
+        if (auto* breadth = std::get_if<Style::GridTrackBreadth>(&m_value))
+            return *breadth;
+        return { };
+    }
+
+    bool isAuto() const
+    {
+        auto breadth = tryBreadth();
+        return breadth && breadth->isAuto();
+    }
+
+    bool isFlex() const
+    {
+        auto breadth = tryBreadth();
+        return breadth && breadth->isFlex();
+    }
+
+    Style::GridTrackBreadth::Flex flex() const
+    {
+        ASSERT(isFlex());
+        return tryBreadth()->flex();
+    }
+
+    bool isContentSized() const
+    {
+        auto breadth = tryBreadth();
+        return !breadth || breadth->isContentSized();
+    }
+
+private:
+    Variant<Style::GridTrackBreadth, Style::GridTrackSize::FitContent> m_value;
+};
+
 struct TrackSizingFunctions {
     Style::GridTrackBreadth min { CSS::Keyword::Auto { } };
-    Style::GridTrackBreadth max { CSS::Keyword::Auto { } };
+    MaxTrackSizingFunction max { Style::GridTrackBreadth { CSS::Keyword::Auto { } } };
     Style::ZoomFactor zoom;
 };
 


### PR DESCRIPTION
#### 18cf15f731e989435408614b778874c7e1cdf148
<pre>
[GFC] fit-content() tracks should not be stretched and should cap the growth limit
<a href="https://bugs.webkit.org/show_bug.cgi?id=323704">https://bugs.webkit.org/show_bug.cgi?id=323704</a>
<a href="https://rdar.apple.com/problem/186961437">rdar://problem/186961437</a>

Reviewed by Alan Baradlay.

Setting fit-content() for a track size has a couple of different
implications during track sizing. For the most part this is supposed to
have the same behavior as &quot;auto,&quot; for the max track sizing function
(getting treated as max-content). There are some nuances that need to be
taken into consideration during track sizing though since that argument
to fit-content can act as a limit during track sizing.

We currently lose this information and cannot do anything with it since
the max track sizing function is a Style::GridTrackBreadth. Instead, we
need to change the max track sizing function so that is can hold either
a Style::GridTrackBreadth or Style::GridTrackSize::FitContent. We do
this by having MaxTrackSizingFunction just be a variant over these two.

Style::GridTrackSize represents a fit-content() track by leaving both of its breadths at their
default value of auto and storing the argument in a separate member, so
GridLayout::convertGridTrackSizeToTrackSizingFunctions() reported such a track&apos;s max track sizing
function as auto and dropped the argument entirely.

Two things followed from that:

1.) <a href="https://drafts.csswg.org/css-grid-1/#algo-stretch">https://drafts.csswg.org/css-grid-1/#algo-stretch</a> only expands
tracks whose max track sizing function is auto. In this case we were
setting the max track sizing function to gridTrackSize.maxTrackBreadth()
which was returning auto in the fit-content case. By now setting
fit-content directly we avoid this.

2.) <a href="https://drafts.csswg.org/css-grid-2/#algo-single-span-items">https://drafts.csswg.org/css-grid-2/#algo-single-span-items</a> says that for fit-content() maximums
the growth limit is furthermore clamped by the fit-content() argument, which was not reachable at
all once the argument had been dropped.

Test: imported/w3c/web-platform-tests/css/css-grid/grid-definition/fit-content-track-sizing.html
Canonical link: <a href="https://commits.webkit.org/320780@main">https://commits.webkit.org/320780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5114426b6ed56b3bded3a93996d6f48d2a406298

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196180 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59503 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145253 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48937 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125560 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47664 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158024 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45395 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7251 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198154 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59439 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165331 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154812 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41457 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60148 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154457 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48907 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129489 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58609 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57988 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58222 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58052 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->