### PR TITLE
[Cocoa] Update key handling for WebDriver to match Chrome and other WebKit ports

### DIFF
--- a/Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm
+++ b/Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm
@@ -126,25 +126,38 @@ std::optional<unichar> WebAutomationSession::charCodeForVirtualKey(Inspector::Pr
         // According to the internet its functionality is similar to 'Escape'.
     case Inspector::Protocol::Automation::VirtualKey::Escape:
         return 0x1B;
+    // The '*Right' variants use the numeric keypad's keyCodes so that the DOM reports code=Numpad*,
+    // but they still produce the navigation character rather than the digit, so that the DOM 'key'
+    // matches the primary key ("ArrowLeft", "Home", ...) as the WebDriver key table requires.
     case Inspector::Protocol::Automation::VirtualKey::PageUp:
+    case Inspector::Protocol::Automation::VirtualKey::PageUpRight:
         return NSPageUpFunctionKey;
     case Inspector::Protocol::Automation::VirtualKey::PageDown:
+    case Inspector::Protocol::Automation::VirtualKey::PageDownRight:
         return NSPageDownFunctionKey;
     case Inspector::Protocol::Automation::VirtualKey::End:
+    case Inspector::Protocol::Automation::VirtualKey::EndRight:
         return NSEndFunctionKey;
     case Inspector::Protocol::Automation::VirtualKey::Home:
+    case Inspector::Protocol::Automation::VirtualKey::HomeRight:
         return NSHomeFunctionKey;
     case Inspector::Protocol::Automation::VirtualKey::LeftArrow:
+    case Inspector::Protocol::Automation::VirtualKey::LeftArrowRight:
         return NSLeftArrowFunctionKey;
     case Inspector::Protocol::Automation::VirtualKey::UpArrow:
+    case Inspector::Protocol::Automation::VirtualKey::UpArrowRight:
         return NSUpArrowFunctionKey;
     case Inspector::Protocol::Automation::VirtualKey::RightArrow:
+    case Inspector::Protocol::Automation::VirtualKey::RightArrowRight:
         return NSRightArrowFunctionKey;
     case Inspector::Protocol::Automation::VirtualKey::DownArrow:
+    case Inspector::Protocol::Automation::VirtualKey::DownArrowRight:
         return NSDownArrowFunctionKey;
     case Inspector::Protocol::Automation::VirtualKey::Insert:
+    case Inspector::Protocol::Automation::VirtualKey::InsertRight:
         return NSInsertFunctionKey;
     case Inspector::Protocol::Automation::VirtualKey::Delete:
+    case Inspector::Protocol::Automation::VirtualKey::DeleteRight:
         return NSDeleteFunctionKey;
     case Inspector::Protocol::Automation::VirtualKey::Space:
         return ' ';
@@ -181,8 +194,9 @@ std::optional<unichar> WebAutomationSession::charCodeForVirtualKey(Inspector::Pr
     case Inspector::Protocol::Automation::VirtualKey::NumberPadSubtract:
         return '-';
     case Inspector::Protocol::Automation::VirtualKey::NumberPadSeparator:
-        // The 'Separator' key is only present on a few international keyboards.
-        // It is usually mapped to the same character as Decimal ('.' or ',').
+        // The 'Separator' key is only present on a few international keyboards, where it is the
+        // keypad's comma. It is distinct from Decimal, which is the keypad's period.
+        return ',';
     case Inspector::Protocol::Automation::VirtualKey::NumberPadDecimal:
         return '.';
     case Inspector::Protocol::Automation::VirtualKey::NumberPadDivide:

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -433,25 +433,38 @@ static int keyCodeForCharKey(CharKey charKey)
     case 'm':
     case 'M':
         return kVK_ANSI_M;
+    // The shifted forms below assume a US layout, consistent with the punctuation pairs that
+    // follow. Pairing them means a character like '@' reports code "Digit2" rather than
+    // "Unidentified".
     case '1':
+    case '!':
         return kVK_ANSI_1;
     case '2':
+    case '@':
         return kVK_ANSI_2;
     case '3':
+    case '#':
         return kVK_ANSI_3;
     case '4':
+    case '$':
         return kVK_ANSI_4;
     case '5':
+    case '%':
         return kVK_ANSI_5;
     case '6':
+    case '^':
         return kVK_ANSI_6;
     case '7':
+    case '&':
         return kVK_ANSI_7;
     case '8':
+    case '*':
         return kVK_ANSI_8;
     case '9':
+    case '(':
         return kVK_ANSI_9;
     case '0':
+    case ')':
         return kVK_ANSI_0;
     case '=':
     case '+':
@@ -486,6 +499,11 @@ static int keyCodeForCharKey(CharKey charKey)
     case '`':
     case '~':
         return kVK_ANSI_Grave;
+    case ' ':
+        // A literal space must produce the same events as the 'space' virtual key (U+E00D).
+        // Without this it falls through to unknownKeyCode and the DOM reports code
+        // "Unidentified" for one and "Space" for the other.
+        return kVK_Space;
     }
 
     return unknownKeyCode;
@@ -522,7 +540,10 @@ static unsigned short keyCodeForVirtualKey(VirtualKey key)
     case VirtualKey::Tab:
         return kVK_Tab;
     case VirtualKey::Clear:
-        return kVK_ANSI_KeypadClear;
+        // The WebDriver 'clear' key has no physical equivalent on Apple keyboards, and is not
+        // the keypad's Clear/NumLock key. Emit no keyCode so the DOM reports an empty 'code'
+        // and DOM_KEY_LOCATION_STANDARD; the DOM 'key' still comes from the characters.
+        return unknownKeyCode;
     case VirtualKey::Enter:
         return kVK_ANSI_KeypadEnter;
     case VirtualKey::Pause:
@@ -534,44 +555,60 @@ static unsigned short keyCodeForVirtualKey(VirtualKey key)
         // According to the internet its functionality is similar to 'Escape'.
     case VirtualKey::Escape:
         return kVK_Escape;
+    // The '*Right' variants are the "right hand" keys from the WebDriver key table, which are the
+    // numeric keypad's navigation keys. They must use the keypad keyCodes so that the DOM reports
+    // code=Numpad* and location=DOM_KEY_LOCATION_NUMPAD, rather than aliasing the primary keys.
     case VirtualKey::PageUp:
-    case VirtualKey::PageUpRight:
         return kVK_PageUp;
+    case VirtualKey::PageUpRight:
+        return kVK_ANSI_Keypad9;
     case VirtualKey::PageDown:
-    case VirtualKey::PageDownRight:
         return kVK_PageDown;
+    case VirtualKey::PageDownRight:
+        return kVK_ANSI_Keypad3;
     case VirtualKey::End:
-    case VirtualKey::EndRight:
         return kVK_End;
+    case VirtualKey::EndRight:
+        return kVK_ANSI_Keypad1;
     case VirtualKey::Home:
-    case VirtualKey::HomeRight:
         return kVK_Home;
+    case VirtualKey::HomeRight:
+        return kVK_ANSI_Keypad7;
     case VirtualKey::LeftArrow:
-    case VirtualKey::LeftArrowRight:
         return kVK_LeftArrow;
+    case VirtualKey::LeftArrowRight:
+        return kVK_ANSI_Keypad4;
     case VirtualKey::UpArrow:
-    case VirtualKey::UpArrowRight:
         return kVK_UpArrow;
+    case VirtualKey::UpArrowRight:
+        return kVK_ANSI_Keypad8;
     case VirtualKey::RightArrow:
-    case VirtualKey::RightArrowRight:
         return kVK_RightArrow;
+    case VirtualKey::RightArrowRight:
+        return kVK_ANSI_Keypad6;
     case VirtualKey::DownArrow:
-    case VirtualKey::DownArrowRight:
         return kVK_DownArrow;
+    case VirtualKey::DownArrowRight:
+        return kVK_ANSI_Keypad2;
     case VirtualKey::Insert:
-    case VirtualKey::InsertRight:
         // The 'insert' key does not exist on Apple keyboards and has no keyCode.
         // The semantics are unclear so just abort and do nothing.
         return unknownKeyCode;
+    case VirtualKey::InsertRight:
+        return kVK_ANSI_Keypad0;
     case VirtualKey::Delete:
-    case VirtualKey::DeleteRight:
         return kVK_ForwardDelete;
+    case VirtualKey::DeleteRight:
+        return kVK_ANSI_KeypadDecimal;
     case VirtualKey::Space:
         return kVK_Space;
     case VirtualKey::Semicolon:
-        return kVK_ANSI_Semicolon;
+        // The WebDriver 'semicolon' key (U+E018) is not the primary keyboard's ';'. It has no
+        // physical equivalent here, so emit no keyCode and let the character supply the DOM 'key'.
+        return unknownKeyCode;
     case VirtualKey::Equals:
-        return kVK_ANSI_Equal;
+        // The WebDriver 'equals' key (U+E019) is the keypad's '=', not the primary keyboard's.
+        return kVK_ANSI_KeypadEquals;
     case VirtualKey::Return:
         return kVK_Return;
     case VirtualKey::NumberPad0:
@@ -601,12 +638,11 @@ static unsigned short keyCodeForVirtualKey(VirtualKey key)
     case VirtualKey::NumberPadSubtract:
         return kVK_ANSI_KeypadMinus;
     case VirtualKey::NumberPadSeparator:
-        // The 'Separator' key is only present on a few international keyboards.
-        // It is usually mapped to the same character as Decimal ('.' or ',').
-        [[fallthrough]];
+        // The 'Separator' key is only present on a few international keyboards. It is distinct
+        // from Decimal: the WebDriver key table expects key ',' and code 'NumpadComma'.
+        return kVK_JIS_KeypadComma;
     case VirtualKey::NumberPadDecimal:
         return kVK_ANSI_KeypadDecimal;
-        // FIXME: this might be locale-dependent. See the above comment.
     case VirtualKey::NumberPadDivide:
         return kVK_ANSI_KeypadDivide;
     case VirtualKey::Function1:
@@ -672,12 +708,27 @@ static NSEventModifierFlags NODELETE eventModifierFlagsForVirtualKey(VirtualKey 
     case VirtualKey::UpArrow:
     case VirtualKey::RightArrow:
     case VirtualKey::DownArrow:
+        // Real hardware arrow keys set NSEventModifierFlagNumericPad on macOS, but WebCore's
+        // isKeypadEvent() turns that into DOM_KEY_LOCATION_NUMPAD. The primary arrows must report
+        // DOM_KEY_LOCATION_STANDARD, so only the keypad's own navigation keys set the flag below.
+        return NSEventModifierFlagFunction;
+
+    case VirtualKey::PageUpRight:
+    case VirtualKey::PageDownRight:
+    case VirtualKey::EndRight:
+    case VirtualKey::HomeRight:
+    case VirtualKey::LeftArrowRight:
+    case VirtualKey::UpArrowRight:
+    case VirtualKey::RightArrowRight:
+    case VirtualKey::DownArrowRight:
+    case VirtualKey::InsertRight:
+    case VirtualKey::DeleteRight:
         return NSEventModifierFlagNumericPad | NSEventModifierFlagFunction;
 
     case VirtualKey::Delete:
         return NSEventModifierFlagFunction;
 
-    case VirtualKey::Clear:
+    case VirtualKey::Equals:
     case VirtualKey::NumberPad0:
     case VirtualKey::NumberPad1:
     case VirtualKey::NumberPad2:


### PR DESCRIPTION
#### d4ba76464422865075d4f62aaebd9825c3b6338b
<pre>
[Cocoa] Update key handling for WebDriver to match Chrome and other WebKit ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=323705">https://bugs.webkit.org/show_bug.cgi?id=323705</a>
<a href="https://rdar.apple.com/186961436">rdar://186961436</a>

Reviewed by BJ Burg.

The &quot;*Right&quot; variants of key inputs were not being handled properly in
WebAutomationSession::charCodeForVirtualKey(...) in Cocoa, though this was already properly
implemented in GTK/WPE.

This patch corrects these code paths so that we improve WPT scores in keyboard handling and
set the groundwork for a follow-up patch to address the remaining failures. That follow
up will also correct iOS more completely, as it lacks some context needed to properly
pass WPT tests at present.

This change moves the key_events.py test from 67/93 to 87/93.

Tests: webdriver/tests/classic/perform_actions/key_events.py

* Source/WebKit/UIProcess/Automation/cocoa/WebAutomationSessionCocoa.mm:
(WebKit::WebAutomationSession::charCodeForVirtualKey const):
* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::keyCodeForCharKey):
(WebKit::keyCodeForVirtualKey):
(WebKit::eventModifierFlagsForVirtualKey):

Canonical link: <a href="https://commits.webkit.org/320741@main">https://commits.webkit.org/320741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f4c08591e2726b3cc05eb1f033f97dd289f3a0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195965 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150367 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145073 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100580 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188610 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165647 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125368 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47494 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45532 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157854 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45221 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7027 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52201 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197926 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59225 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154611 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41432 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59932 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154264 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48727 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132278 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129186 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58402 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20243 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57778 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58018 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57843 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->