### PR TITLE
Cherry-pick 305413.1075@safari-7624.5.1.10-branch (a06fd51c1706). https://bugs.webkit.org/show_bug.cgi?id=318405

### DIFF
--- a/JSTests/stress/arguments-elimination-inlined-load-varargs-preserves-recoveries.js
+++ b/JSTests/stress/arguments-elimination-inlined-load-varargs-preserves-recoveries.js
@@ -1,0 +1,84 @@
+//@ runDefault("--thresholdForJITAfterWarmUp=10", "--thresholdForFTLOptimizeAfterWarmUp=1000", "--useConcurrentJIT=false", "--validateFTLOSRExitLiveness=true")
+
+"use strict";
+
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + ", expected: " + expected);
+}
+
+function five(values1, values2)
+{
+    let result = null;
+    for (let i = 0; i < 5; ++i) {
+        function arg() { "use strict"; return arguments; }
+        const a = arg.apply(undefined, values1);
+        const b = arg.apply(undefined, values2);
+        try {
+            (3881)(b);
+        } catch (error) {
+            a.toString();
+            result = a;
+        }
+    }
+    return result;
+}
+
+function eight(values1, values2)
+{
+    let result = null;
+    for (let i = 0; i < 5; ++i) {
+        function arg() { "use strict"; return arguments; }
+        const a = arg.apply(undefined, values1);
+        const b = arg.apply(undefined, values2);
+        try {
+            (3881)(b);
+        } catch (error) {
+            a.toString();
+            result = a;
+        }
+    }
+    return result;
+}
+
+function filled(length, value)
+{
+    const result = [];
+    for (let i = 0; i < length; ++i)
+        result.push(value);
+    return result;
+}
+
+const fiveMarker = { marker: "five" };
+const eightMarker = { marker: "eight" };
+const seedArray = [{ marker: "seed" }, 1, 2, 3, 4, 5];
+
+const firstFive = filled(5, fiveMarker);
+const overwriteFive = filled(30, fiveMarker);
+overwriteFive[22] = 9;
+
+const firstEight = filled(8, eightMarker);
+const overwriteEight = filled(30, eightMarker);
+overwriteEight[20] = 9;
+
+for (let i = 0; i < testLoopCount; ++i) {
+    five(firstFive, overwriteFive);
+    eight(firstEight, overwriteEight);
+}
+
+const seedValues = filled(30, seedArray);
+seedValues[20] = 9;
+for (let i = 0; i < testLoopCount; ++i)
+    eight(firstEight, seedValues);
+
+const recoveredEight = eight(firstEight, seedValues);
+shouldBe(recoveredEight.length, firstEight.length);
+for (let i = 0; i < firstEight.length; ++i)
+    shouldBe(recoveredEight[i], eightMarker);
+
+const recoveredFive = five(firstFive, overwriteFive);
+shouldBe(recoveredFive.length, firstFive.length);
+for (let i = 0; i < firstFive.length; ++i)
+    shouldBe(recoveredFive[i], fiveMarker);
+shouldBe(recoveredFive[5], undefined);

--- a/JSTests/stress/arguments-elimination-load-varargs-kills-promoted-recoveries.js
+++ b/JSTests/stress/arguments-elimination-load-varargs-kills-promoted-recoveries.js
@@ -1,0 +1,88 @@
+//@ runDefault("--thresholdForJITAfterWarmUp=10", "--thresholdForFTLOptimizeAfterWarmUp=1000", "--useConcurrentJIT=false")
+
+"use strict";
+
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error("bad value: " + actual + ", expected: " + expected);
+}
+noInline(shouldBe);
+
+function five(values1, values2)
+{
+    let result = null;
+    for (let i = 0; i < 5; ++i) {
+        function arg() { "use strict"; return arguments; }
+        const a = arg.apply(undefined, values1);
+        const b = arg.apply(undefined, values2);
+        try {
+            (3881)(b);
+        } catch (error) {
+            a.toString();
+            result = a;
+        }
+    }
+    return result;
+}
+noInline(five);
+
+function eight(values1, values2)
+{
+    let result = null;
+    for (let i = 0; i < 5; ++i) {
+        function arg() { "use strict"; return arguments; }
+        const a = arg.apply(undefined, values1);
+        const b = arg.apply(undefined, values2);
+        try {
+            (3881)(b);
+        } catch (error) {
+            a.toString();
+            result = a;
+        }
+    }
+    return result;
+}
+noInline(eight);
+
+function filled(length, value)
+{
+    const result = [];
+    for (let i = 0; i < length; ++i)
+        result.push(value);
+    return result;
+}
+noInline(filled);
+
+const fiveMarker = { marker: "five" };
+const eightMarker = { marker: "eight" };
+const seedArray = [{ marker: "seed" }, 1, 2, 3, 4, 5];
+
+const firstFive = filled(5, fiveMarker);
+const overwriteFive = filled(30, fiveMarker);
+overwriteFive[22] = 9;
+
+const firstEight = filled(8, eightMarker);
+const overwriteEight = filled(30, eightMarker);
+overwriteEight[20] = 9;
+
+for (let i = 0; i < testLoopCount; ++i) {
+    five(firstFive, overwriteFive);
+    eight(firstEight, overwriteEight);
+}
+
+const seedValues = filled(30, seedArray);
+seedValues[20] = 9;
+for (let i = 0; i < testLoopCount; ++i)
+    eight(firstEight, seedValues);
+
+const recoveredEight = eight(firstEight, seedValues);
+shouldBe(recoveredEight.length, firstEight.length);
+for (let i = 0; i < firstEight.length; ++i)
+    shouldBe(recoveredEight[i], eightMarker);
+
+const recoveredFive = five(firstFive, overwriteFive);
+shouldBe(recoveredFive.length, firstFive.length);
+for (let i = 0; i < firstFive.length; ++i)
+    shouldBe(recoveredFive[i], fiveMarker);
+shouldBe(recoveredFive[5], undefined);

--- a/LayoutTests/ipc/display-capture-source-configuration-change-uaf-expected.txt
+++ b/LayoutTests/ipc/display-capture-source-configuration-change-uaf-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/display-capture-source-configuration-change-uaf.html
+++ b/LayoutTests/ipc/display-capture-source-configuration-change-uaf.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<html>
+<body>
+<p>This test passes if it does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    testRunner.setUserMediaPermission(true);
+}
+if (window.internals)
+    internals.settings.setScreenCaptureEnabled(true);
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+function done() { window.testRunner?.notifyDone(); }
+
+async function main() {
+    if (!window.IPC || !window.testRunner)
+        return done();
+
+    const { CoreIPC, IPCWireTap } = await import('./coreipc.js');
+
+    let idA = null;
+    const tap = new IPCWireTap('GPU', 'Outgoing');
+    tap.tapAll((proc, dest, name, typed, parsed) => {
+        if (name === IPC.messages.UserMediaCaptureManagerProxy_CreateMediaSourceForCaptureDeviceWithConstraints.name)
+            idA = parsed.id;
+    });
+
+    let stream;
+    internals.withUserGesture(() => {
+        stream = navigator.mediaDevices.getDisplayMedia({ video: { width: { max: 3000 }, height: { max: 2000 } } });
+    });
+    await stream;
+    await sleep(300);
+
+    if (idA === null)
+        return done();
+
+    CoreIPC.GPU.UserMediaCaptureManagerProxy.StopProducingData(0, { id: idA });
+    await sleep(100);
+
+    const idB = idA + 1000n;
+    CoreIPC.GPU.UserMediaCaptureManagerProxy.Clone(0, { clonedID: idA, cloneID: idB, pageIdentifier: IPC.pageID });
+    await sleep(50);
+
+    CoreIPC.GPU.UserMediaCaptureManagerProxy.StartProducingData(0, { id: idB, pageIdentifier: IPC.pageID });
+    await sleep(200);
+
+    testRunner.triggerMockCaptureConfigurationChange(false, false, true);
+    await sleep(400);
+
+    CoreIPC.GPU.UserMediaCaptureManagerProxy.RemoveSource(0, { id: idA });
+    await sleep(2000);
+
+    done();
+}
+
+setTimeout(() => { main().catch(done); }, 100);
+setTimeout(done, 30000);
+</script>
+</body>
+</html>

--- a/LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time-expected.txt
+++ b/LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash the GPU process.

--- a/LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time.html
+++ b/LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true MediaContainmentEnabled=false ] -->
+<html><body>
+<p>This test passes if it does not crash the GPU process.</p>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+window.onerror = () => testRunner?.notifyDone();
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// RemoteSourceBufferProxy::RemoveCodedFrames with an invalid MediaTime end argument
+// produced an inverted iterator range in TrackBuffer::removeCodedFrames, which
+// std::minmax_element walked past end(). MediaContainmentEnabled=false ensures the
+// SourceBufferPrivate / TrackBuffer live in the GPU process.
+async function main() {
+    if (!window.IPC)
+        return;
+
+    // Populate a GPU-side TrackBuffer via vanilla MSE.
+    const buf = await (await fetch('../media/media-source/content/test-fragmented-video.mp4')).arrayBuffer();
+    const init = buf.slice(0, 721);
+    const seg0 = buf.slice(721, 721 + 53533);
+    const seg1 = buf.slice(54254, 54254 + 56293);
+
+    const v = document.createElement('video');
+    v.disableRemotePlayback = true;
+    document.body.appendChild(v);
+    const ms = new MediaSource();
+    v.src = URL.createObjectURL(ms);
+    await new Promise(r => ms.addEventListener('sourceopen', r, { once: true }));
+
+    const sb = ms.addSourceBuffer('video/mp4; codecs="avc1.4d281e"');
+    const upd = () => new Promise(r => sb.addEventListener('updateend', r, { once: true }));
+    sb.appendBuffer(init); await upd();
+    sb.appendBuffer(seg0); await upd();
+    sb.appendBuffer(seg1); await upd();
+
+    // start = mid-range valid, end = invalid (timeFlags == 0), currentTime = valid zero.
+    // MediaTime is encoded as { int64_t timeValue, uint32_t timeScale, uint8_t timeFlags }.
+    const args = [
+        { type: 'int64_t', value: 1000000 }, { type: 'uint32_t', value: 1000000 }, { type: 'uint8_t', value: 1 },
+        { type: 'int64_t', value: 0 }, { type: 'uint32_t', value: 1 }, { type: 'uint8_t', value: 0 },
+        { type: 'int64_t', value: 0 }, { type: 'uint32_t', value: 1 }, { type: 'uint8_t', value: 1 },
+    ];
+
+    // The RemoteSourceBufferIdentifier is a small GPU-allocated counter; sweep a generous range.
+    // ignoreInvalidMessageForTesting drops messages to non-existent receivers.
+    const conn = IPC.connectionForProcessTarget('GPU');
+    for (let i = 1; i <= 200; i++)
+        conn.sendWithAsyncReply(i, IPC.messages.RemoteSourceBufferProxy_RemoveCodedFrames.name, args, () => { });
+
+    await sleep(2000);
+}
+
+setTimeout(() => main().finally(() => testRunner?.notifyDone()), 0);
+setTimeout(() => testRunner?.notifyDone(), 30000);
+</script>
+</body></html>

--- a/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
@@ -33,6 +33,7 @@
 #include "DFGArgumentsUtilities.h"
 #include "DFGBlockMapInlines.h"
 #include "DFGClobberize.h"
+#include "DFGCombinedLiveness.h"
 #include "DFGForAllKills.h"
 #include "DFGGraph.h"
 #include "DFGInsertionSet.h"
@@ -722,7 +723,16 @@ private:
             }
 
             if (clobberStack) {
-                for (Node* node : combinedLiveness.liveAtTail[block])
+                // liveAtTail is the union of the CFG successors' liveAtHead, but a candidate can be kept
+                // alive solely by an exceptional exit to a catch entrypoint, which the DFG models as a
+                // non-CFG successor. Such a candidate is OSR-live at the terminal yet absent from
+                // liveAtTail, so a clobber of its source slots in this block would otherwise go
+                // unnoticed. Cover that gap with the nodes live at the terminal but dead on the tail.
+                // FIXME: If this is ever too conservative we can just calculate the locals used by
+                // the catch block for the terminal.
+                NodeSet possiblyLiveOut = bytecodeLivenessAtTerminal(m_graph, block);
+                possiblyLiveOut.addAll(combinedLiveness.liveAtTail[block]);
+                for (Node* node : possiblyLiveOut)
                     removeViaKill(block, block->size(), node);
 
                 for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {

--- a/Source/JavaScriptCore/dfg/DFGCombinedLiveness.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCombinedLiveness.cpp
@@ -62,6 +62,13 @@ NodeSet liveNodesAtHead(Graph& graph, BasicBlock* block)
     return seen;
 }
 
+NodeSet bytecodeLivenessAtTerminal(Graph& graph, BasicBlock* block)
+{
+    NodeSet seen;
+    addBytecodeLiveness(graph, block->ssa->availabilityAtTail, seen, block->last());
+    return seen;
+}
+
 CombinedLiveness::CombinedLiveness(Graph& graph)
     : liveAtHead(graph)
     , liveAtTail(graph)
@@ -81,11 +88,8 @@ CombinedLiveness::CombinedLiveness(Graph& graph)
         // Unreachable
         //
         // And things may definitely be live in bytecode at that point in the program.
-        if (!block->numSuccessors()) {
-            NodeSet seen;
-            addBytecodeLiveness(graph, block->ssa->availabilityAtTail, seen, block->last());
-            liveAtTail[block] = seen;
-        }
+        if (!block->numSuccessors())
+            liveAtTail[block] = bytecodeLivenessAtTerminal(graph, block);
     }
     
     // Now compute the liveAtTail by unifying the liveAtHead of the successors.

--- a/Source/JavaScriptCore/dfg/DFGCombinedLiveness.h
+++ b/Source/JavaScriptCore/dfg/DFGCombinedLiveness.h
@@ -35,6 +35,8 @@ namespace JSC { namespace DFG {
 // Returns the set of nodes live at head, both due to DFG and due to bytecode (i.e. OSR exit).
 NodeSet liveNodesAtHead(Graph&, BasicBlock*);
 
+NodeSet bytecodeLivenessAtTerminal(Graph&, BasicBlock*);
+
 // WARNING: This currently does not reason about the liveness of shadow values. The execution
 // semantics of DFG SSA are that an Upsilon stores to the shadow value of a Phi, and the Phi loads
 // from that shadow value. Hence, the shadow values are like variables, and have liveness. The normal

--- a/Source/JavaScriptCore/dfg/DFGForAllKills.h
+++ b/Source/JavaScriptCore/dfg/DFGForAllKills.h
@@ -34,10 +34,6 @@
 
 namespace JSC { namespace DFG {
 
-namespace ForAllKillsInternal {
-constexpr bool verbose = false;
-}
-
 // Utilities for finding the last points where a node is live in DFG SSA. This accounts for liveness due
 // to OSR exit. This is usually used for enumerating over all of the program points where a node is live,
 // by exploring all blocks where the node is live at tail and then exploring all program points where the
@@ -168,34 +164,6 @@ void forAllKilledNodesAtNodeIndex(
                     return result;
                 });
         });
-}
-
-// Tells you all of the places to start searching from in a basic block. Gives you the node index at which
-// the value is either no longer live. This pretends that nodes are dead at the end of the block, so that
-// you can use this to do per-basic-block analyses.
-template<typename Functor>
-void forAllKillsInBlock(
-    Graph& graph, const CombinedLiveness& combinedLiveness, BasicBlock* block,
-    const Functor& functor)
-{
-    for (Node* node : combinedLiveness.liveAtTail[block])
-        functor(block->size(), node);
-    
-    LocalOSRAvailabilityCalculator localAvailability(graph);
-    localAvailability.beginBlock(block);
-    // Start running functor at the second node, because the functor is expected to only inspect nodes from the start of
-    // the block up to nodeIndex (exclusive), so if nodeIndex is zero then the functor has nothing to do.
-    for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {
-        dataLogLnIf(ForAllKillsInternal::verbose, "local availability at index: ", nodeIndex, " ", localAvailability.m_availability);
-        if (nodeIndex) {
-            forAllKilledNodesAtNodeIndex(
-                graph, localAvailability.m_availability, block, nodeIndex,
-                [&] (Node* node) {
-                    functor(nodeIndex, node);
-                });
-        }
-        localAvailability.executeNode(block->at(nodeIndex));
-    }
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
@@ -359,8 +359,10 @@ void LocalOSRAvailabilityCalculator::executeNode(Node* node)
     case LoadVarargs:
     case ForwardVarargs: {
         LoadVarargsData* data = node->loadVarargsData();
+        killHeaps(data->count);
         m_availability.m_locals.operand(data->count) = Availability(FlushedAt(FlushedInt32, data->machineCount));
         for (unsigned i = data->limit; i--;) {
+            killHeaps(data->start + i);
             m_availability.m_locals.operand(data->start + i) =
                 Availability(FlushedAt(FlushedJSValue, data->machineStart.isValid() ? (data->machineStart + i) : VirtualRegister()));
         }

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -512,8 +512,10 @@ void SourceBufferPrivate::removeCodedFramesInternal(const MediaTime& start, cons
 {
     assertIsCurrent(m_dispatcher.get());
 
+    ASSERT(start.isValid());
+    ASSERT(end.isValid());
     ASSERT(start < end);
-    if (start >= end)
+    if (start.isInvalid() || end.isInvalid() || start >= end)
         return;
 
     // 3.5.9 Coded Frame Removal Algorithm

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -386,6 +386,8 @@ int64_t TrackBuffer::removeCodedFrames(const MediaTime& start, const MediaTime& 
 {
     ASSERT(start.isValid());
     ASSERT(end.isValid());
+    if (start.isInvalid() || end.isInvalid() || start > end)
+        return 0;
     // 3.5.9 Coded Frame Removal Algorithm
     // https://dvcs.w3.org/hg/html-media/raw-file/tip/media-source/media-source.html#sourcebuffer-coded-frame-removal
     

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -46,6 +46,7 @@
 #include <wtf/TZoneMallocInlines.h>
 
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_OPTIONAL_CONNECTION_BASE(assertion, connection())
+#define MESSAGE_CHECK_COMPLETION(assertion, completion) MESSAGE_CHECK_COMPLETION_BASE(assertion, connection(), completion)
 
 namespace WebKit {
 
@@ -216,6 +217,7 @@ void RemoteSourceBufferProxy::startChangingType()
 
 void RemoteSourceBufferProxy::removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime, CompletionHandler<void()>&& completionHandler)
 {
+    MESSAGE_CHECK_COMPLETION(start.isValid() && end.isValid() && start < end, completionHandler());
     protectedSourceBufferPrivate()->removeCodedFrames(start, end, currentTime)->whenSettled(RunLoop::currentSingleton(), WTF::move(completionHandler));
 }
 
@@ -418,6 +420,7 @@ void RemoteSourceBufferProxy::connectionToWebProcessClosed()
 }
 
 #undef MESSAGE_CHECK
+#undef MESSAGE_CHECK_COMPLETION
 
 } // namespace WebKit
 

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
@@ -373,7 +373,7 @@ private:
         Ref source = m_source;
         auto deviceType = source->deviceType();
 
-        if ((deviceType == CaptureDevice::DeviceType::Screen || deviceType == CaptureDevice::DeviceType::Window) && m_videoConstraints && updateVideoConstraints(*m_videoConstraints)) {
+        if (m_isObservingMedia && (deviceType == CaptureDevice::DeviceType::Screen || deviceType == CaptureDevice::DeviceType::Window) && m_videoConstraints && updateVideoConstraints(*m_videoConstraints)) {
             source->removeVideoFrameObserver(*this);
             source->addVideoFrameObserver(*this, { m_widthConstraint, m_heightConstraint }, m_frameRateConstraint);
         }


### PR DESCRIPTION
#### 1a02b444ed81bbc8d6631b9ff01b356c96279172
<pre>
Cherry-pick 305413.1075@safari-7624.5.1.10-branch (a06fd51c1706). <a href="https://bugs.webkit.org/show_bug.cgi?id=318405">https://bugs.webkit.org/show_bug.cgi?id=318405</a>

    [CoreIPC][GPUP] UserMediaCaptureManagerProxySourceProxy can leave a dangling VideoFrameObserver* in RealtimeMediaSource
    <a href="https://rdar.apple.com/174702504">rdar://174702504</a>

    Reviewed by Jer Noble.

    UserMediaCaptureManagerProxySourceProxy::sourceConfigurationChanged() re-registers
    the proxy as a VideoFrameObserver of its RealtimeMediaSource via
    removeVideoFrameObserver()/addVideoFrameObserver() without consulting m_isObservingMedia.
    Since the proxy is registered as a RealtimeMediaSourceObserver unconditionally in its
    constructor, this callback can fire on a stopped (or never-started) proxy and insert a
    raw VideoFrameObserver* into m_videoFrameObservers while m_isObservingMedia remains
    false. The destructor&apos;s unobserveMedia() then early-returns without removing the entry.

    DisplayCaptureSourceCocoa does not override clone(), so UserMediaCaptureManagerProxy::clone()
    yields two proxies sharing the same RealtimeMediaSource; the surviving clone keeps the
    source (and its dangling raw key) alive after the first proxy is freed, and the next
    videoFrameAvailable() virtual-dispatches through freed memory in the GPU process. This
    is reachable from a compromised WebContent process over UserMediaCaptureManagerProxy IPC
    once the page has been granted getDisplayMedia.

    Guard the observer re-registration in sourceConfigurationChanged() on m_isObservingMedia
    so a stopped proxy is never re-inserted into m_videoFrameObservers.

    * LayoutTests/ipc/display-capture-source-configuration-change-uaf-expected.txt: Added.
    * LayoutTests/ipc/display-capture-source-configuration-change-uaf.html: Added.
    * Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp:
    (WebKit::UserMediaCaptureManagerProxySourceProxy::sourceConfigurationChanged):

    Identifier: 305413.1075@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1170@webkitglib/2.52">https://commits.webkit.org/305877.1170@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 5d2821444c02ec410b6d20dcef9afaec26a863b6
<pre>
Cherry-pick 305413.1074@safari-7624.5.1.10-branch (82b25523db98). <a href="https://bugs.webkit.org/show_bug.cgi?id=318405">https://bugs.webkit.org/show_bug.cgi?id=318405</a>

    Validate MediaTime arguments in RemoteSourceBufferProxy::removeCodedFrames
    <a href="https://rdar.apple.com/175520822">rdar://175520822</a>

    Reviewed by Jean-Yves Avenard.

    RemoteSourceBufferProxy::removeCodedFrames forwarded its three MediaTime IPC
    arguments to SourceBufferPrivate::removeCodedFramesInternal without validation,
    and the generated ArgumentCoder&lt;MediaTime&gt; has no [Validator=], so a MediaTime
    with timeFlags == 0 (isInvalid()) survived decode. The release-mode guard
    &quot;if (start &gt;= end) return&quot; in removeCodedFramesInternal was defeated because
    valid &lt;=&gt; invalid is std::partial_ordering::unordered, so start &gt;= end is false.
    In TrackBuffer::removeCodedFrames, lower_bound(invalid) on the
    std::map&lt;MediaTime, ...&gt; walked left to begin() while a valid mid-range start
    resolved to a mid-map iterator; the inverted [mid, begin()) range was passed to
    std::minmax_element, which incremented past end() and dereferenced out-of-range
    tree pointers, crashing the GPU process. A compromised WebContent process could
    trigger this deterministically.

    Reject invalid or unordered start/end at the IPC boundary with
    MESSAGE_CHECK_COMPLETION, and harden SourceBufferPrivate::removeCodedFramesInternal
    and TrackBuffer::removeCodedFrames to early-return when either bound is invalid
    or start is not strictly less than end, mirroring the existing guard in
    SourceBufferPrivate::evictFrames.

    * LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time-expected.txt: Added.
    * LayoutTests/ipc/remote-source-buffer-remove-coded-frames-invalid-media-time.html: Added.
    * Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
    (WebCore::SourceBufferPrivate::removeCodedFramesInternal):
    * Source/WebCore/platform/graphics/TrackBuffer.cpp:
    (WebCore::TrackBuffer::removeCodedFrames):
    * Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
    (WebKit::RemoteSourceBufferProxy::removeCodedFrames):

    Identifier: 305413.1074@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1169@webkitglib/2.52">https://commits.webkit.org/305877.1169@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 610b4f250cc150c9a49998917ff39d236aee1d00
<pre>
Cherry-pick 305413.1062@safari-7624.5.1.10-branch (6c004fb89bd7). <a href="https://bugs.webkit.org/show_bug.cgi?id=318348">https://bugs.webkit.org/show_bug.cgi?id=318348</a>

    OSR Availability Fails to Invalidate Local Recoveries Across LoadVarargs
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318348">https://bugs.webkit.org/show_bug.cgi?id=318348</a>
    <a href="https://rdar.apple.com/178255543">rdar://178255543</a>

    Reviewed by Yusuke Suzuki.

    When a strict-mode `arguments` allocation produced by an inlined varargs call
    is eliminated to PhantomClonedArguments, OSR availability records each argument
    as a promoted heap location backed by the inlined frame&apos;s stack slots. A second
    inlined varargs call that lowers to LoadVarargs may reuse those same virtual
    registers. If an OSR exit later materialises the first allocation it must not
    do so from those reused slots.

    Two independent invariants were violated:

    1. LocalOSRAvailabilityCalculator::executeNode() handles PutStack/KillStack by
       calling killHeaps() before replacing a stack operand&apos;s availability so that
       any promoted heap location flushed to that operand is invalidated. The
       LoadVarargs / ForwardVarargs case replaced the count and argument operands
       without that invalidation, leaving stale promoted recoveries pointing at the
       overwritten slots. Apply the same killHeaps() calls before each replacement.

    2. DFG arguments-elimination interference analysis must disqualify a candidate
       whose source-frame stack slots are clobbered while the candidate is still
       OSR-live. It establishes the candidate&apos;s live range using
       forAllKilledNodesAtNodeIndex() plus CombinedLiveness::liveAtTail.
       liveAtTail was computed only as the union of CFG successors&apos; liveAtHead,
       each of which is pruned by bytecode liveness at the successor&apos;s first node.
       A candidate that is OSR-live at the block&apos;s terminal node but whose
       backing local is bytecode-dead at every CFG successor e.g.

       ```
           // block 1
           let a = ...;
           try {
               foo();
           } catch (e) {
               // block 2
               use(a);
           }
           // block 3
       ```

       Since DFG does not directly model exceptional control flow in the CFG
       `a` would be absent from the CFG/bytecode at block 3 and therefore absent
       from block 1&apos;s liveAtTail, so removeViaKill() would never be called on `a`.

    Note: For 2, we don&apos;t include the bytecodeLiveness for the tail of
    CombinedLiveness because this is both misleading with respect to how tail is
    used in the rest of the DFG. Additionally, it breaks ObjectAllocationSinking.
    ObjectAllocationSinking propagates its heap by pruning at each tail with
    liveAtTail then merging into successors. Since we don&apos;t prune at the head we
    can end up pushing phantom allocations into blocks where they don&apos;t actually
    dominate.

    Tests: JSTests/stress/arguments-elimination-inlined-load-varargs-preserves-recoveries.js
           JSTests/stress/arguments-elimination-load-varargs-kills-promoted-recoveries.js

    Identifier: 305413.1062@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1168@webkitglib/2.52">https://commits.webkit.org/305877.1168@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ae480780ce336b4c6cc64e1c076da8bb0de52a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185662 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59567 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53377 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195970 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150372 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187524 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60936 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59295 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145081 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150372 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188617 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60936 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53377 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125376 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60936 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59295 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7272 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53377 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60936 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53377 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7033 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/46909 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52206 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59295 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197933 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59230 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53377 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154617 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/59937 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53377 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154270 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28184 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/59937 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132287 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129191 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58407 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53377 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57783 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58023 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57848 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->