### PR TITLE
WPT getBBox tests wrongly expect a zero bbox for a non-rendered ancestor

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-06-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-06-expected.txt
@@ -1,5 +1,7 @@
 
-FAIL Non-rendered symbol with rect returns zero bbox assert_equals: symbol1_rect.getBBox().x expected 0 but got 50
-FAIL display:none <g> with rect returns zero bbox assert_equals: g_none_rect.getBBox().x expected 0 but got 70
+PASS symbol: the non-rendered container reports zero
+PASS symbol: the rect child reports the geometry it would have if rendered
+PASS display:none <g>: the non-rendered container reports zero
+PASS display:none <g>: the rect child reports the geometry it would have if rendered
 PASS display:none <rect> returns zero bbox
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-06.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-06.html
@@ -22,19 +22,53 @@
     assert_equals(bbox.height, height, id + ".getBBox().height");
   }
 
-  // Per resolution (issue #1018): non-rendered elements return zero bbox
-  // instead of throwing InvalidStateError.
+  // coords.html #BoundingBoxes says a non-rendered element still has one:
+  //
+  //   "Even if an element is not in the rendering tree - due to it being
+  //   'display: none', within a 'defs' element, not usually rendered like a
+  //   'symbol' element or not currently present in the document tree - it
+  //   still has a bounding box. A call to getBBox on the element will return
+  //   the same rectangle as if the element were rendered. However, an element
+  //   that is not in the rendering tree does not contribute to the bounding
+  //   box of any ancestor element."
+  //
+  // TWO SEPARATE REQUIREMENTS, and each gets its own test below rather than
+  // being bundled with the other. Measured 2026-09-08: Chrome returns the
+  // container's box as {50,60,100,150}, the child's own rectangle, where the
+  // second sentence requires {0,0,0,0}. Firefox returns {0,0,0,0} for the
+  // child, where the first sentence requires {50,60,100,150}. A single test
+  // asserting both would go red in Chrome and in Firefox and say nothing
+  // about which sentence each one broke.
+  //
+  // svgwg issue #1018 is a SEPARATE rule again and does not reach these
+  // cases. It covers an element whose own geometric attributes are missing or
+  // invalid, and it landed in types.html as "If the element's geometric
+  // attributes are missing or have invalid values (e.g. negative width or
+  // height), such that the element is not rendered, then a SVGRect with x, y,
+  // width and height all set to 0 is returned." Every rect below has valid
+  // geometry, so that sentence does not apply to it.
 
   test(() => {
     assert_bbox("symbol1", 0, 0, 0, 0);
-    assert_bbox("symbol1_rect", 0, 0, 0, 0);
-  }, "Non-rendered symbol with rect returns zero bbox");
+  }, "symbol: the non-rendered container reports zero");
+
+  test(() => {
+    assert_bbox("symbol1_rect", 50, 60, 100, 150);
+  }, "symbol: the rect child reports the geometry it would have if rendered");
 
   test(() => {
     assert_bbox("g_none", 0, 0, 0, 0);
-    assert_bbox("g_none_rect", 0, 0, 0, 0);
-  }, "display:none <g> with rect returns zero bbox");
+  }, "display:none <g>: the non-rendered container reports zero");
 
+  test(() => {
+    assert_bbox("g_none_rect", 70, 80, 200, 250);
+  }, "display:none <g>: the rect child reports the geometry it would have if rendered");
+
+  // DELIBERATELY LEFT ASSERTING ZERO, and it contradicts the paragraph quoted
+  // above, which asks for {90, 100, 20, 25} here just as it does for the two
+  // children above. All three engines return zero, so this is a convergence
+  // against the prose rather than a single engine's bug, and which side should
+  // move is a question for the WG, not something to settle by editing a test.
   test(() => {
     assert_bbox("none_rect", 0, 0, 0, 0);
   }, "display:none <rect> returns zero bbox");

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-07-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-07-expected.txt
@@ -40,11 +40,11 @@ PASS group with only zero-dimension children has zero bbox
 PASS group with zero-dim and normal children: zero-dim child does not affect bbox
 PASS use element with unresolved href returns zero bbox
 PASS use element referencing zero-dimension rect returns zero bbox
-FAIL getBBox on rect inside defs does not throw and returns zero bbox assert_equals: x expected 0 but got 10
-FAIL getBBox on circle inside defs does not throw and returns zero bbox assert_equals: x expected 0 but got 25
-FAIL getBBox on rect inside group inside defs does not throw and returns zero bbox assert_equals: width expected 0 but got 30
-FAIL getBBox on rect inside clipPath does not throw and returns zero bbox assert_equals: width expected 0 but got 80
-FAIL getBBox on rect inside mask does not throw and returns zero bbox assert_equals: width expected 0 but got 60
+PASS getBBox on rect inside defs returns the rect it would have if rendered
+PASS getBBox on circle inside defs returns the circle it would have if rendered
+PASS getBBox on rect inside group inside defs returns the rect it would have if rendered
+PASS getBBox on rect inside clipPath returns the rect it would have if rendered
+PASS getBBox on rect inside mask returns the rect it would have if rendered
 PASS display:none rect with negative width does not throw and returns zero bbox
 PASS visibility:hidden rect has normal bbox
 PASS opacity:0 rect has normal bbox

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-07.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-07.html
@@ -254,9 +254,17 @@ test_bbox("use_zero_ref", 0, 0, 0, 0,
   "use element referencing zero-dimension rect returns zero bbox");
 
 // ========================================================================
-// F. Non-rendered elements — getBBox must NOT throw (issue #1018)
-// Per resolution: remove throwing for invalid getBBox(), return 0 values
-// for x, y, width, height instead of throwing InvalidStateError.
+// F. Non-rendered ANCESTRY: getBBox must not throw, and returns the
+// rectangle the element would have if it were rendered.
+//
+// coords.html #BoundingBoxes: "Even if an element is not in the rendering
+// tree [...] it still has a bounding box. A call to getBBox on the element
+// will return the same rectangle as if the element were rendered."
+//
+// svgwg issue #1018 is a different rule and does not reach these cases. It
+// covers an element whose OWN geometric attributes are missing or invalid;
+// see none_neg_w further down for that case. Every element below has valid
+// geometry and is non-rendered only because of where it sits.
 // ========================================================================
 
 test(function() {
@@ -265,47 +273,47 @@ test(function() {
   // Must not throw an InvalidStateError.
   assert_not_equals(el, null, "element exists");
   bbox = el.getBBox();
-  assert_equals(bbox.x, 0, "x");
-  assert_equals(bbox.y, 0, "y");
-  assert_equals(bbox.width, 0, "width");
-  assert_equals(bbox.height, 0, "height");
-}, "getBBox on rect inside defs does not throw and returns zero bbox");
+  assert_equals(bbox.x, 10, "x");
+  assert_equals(bbox.y, 20, "y");
+  assert_equals(bbox.width, 100, "width");
+  assert_equals(bbox.height, 50, "height");
+}, "getBBox on rect inside defs returns the rect it would have if rendered");
 
 test(function() {
   var el = document.getElementById("defs_circle");
   var bbox = el.getBBox();
-  assert_equals(bbox.x, 0, "x");
-  assert_equals(bbox.y, 0, "y");
-  assert_equals(bbox.width, 0, "width");
-  assert_equals(bbox.height, 0, "height");
-}, "getBBox on circle inside defs does not throw and returns zero bbox");
+  assert_equals(bbox.x, 25, "x");
+  assert_equals(bbox.y, 25, "y");
+  assert_equals(bbox.width, 50, "width");
+  assert_equals(bbox.height, 50, "height");
+}, "getBBox on circle inside defs returns the circle it would have if rendered");
 
 test(function() {
   var el = document.getElementById("defs_g_rect");
   var bbox = el.getBBox();
   assert_equals(bbox.x, 0, "x");
   assert_equals(bbox.y, 0, "y");
-  assert_equals(bbox.width, 0, "width");
-  assert_equals(bbox.height, 0, "height");
-}, "getBBox on rect inside group inside defs does not throw and returns zero bbox");
+  assert_equals(bbox.width, 30, "width");
+  assert_equals(bbox.height, 30, "height");
+}, "getBBox on rect inside group inside defs returns the rect it would have if rendered");
 
 test(function() {
   var el = document.getElementById("clip_rect");
   var bbox = el.getBBox();
   assert_equals(bbox.x, 0, "x");
   assert_equals(bbox.y, 0, "y");
-  assert_equals(bbox.width, 0, "width");
-  assert_equals(bbox.height, 0, "height");
-}, "getBBox on rect inside clipPath does not throw and returns zero bbox");
+  assert_equals(bbox.width, 80, "width");
+  assert_equals(bbox.height, 80, "height");
+}, "getBBox on rect inside clipPath returns the rect it would have if rendered");
 
 test(function() {
   var el = document.getElementById("mask_rect");
   var bbox = el.getBBox();
   assert_equals(bbox.x, 0, "x");
   assert_equals(bbox.y, 0, "y");
-  assert_equals(bbox.width, 0, "width");
-  assert_equals(bbox.height, 0, "height");
-}, "getBBox on rect inside mask does not throw and returns zero bbox");
+  assert_equals(bbox.width, 60, "width");
+  assert_equals(bbox.height, 60, "height");
+}, "getBBox on rect inside mask returns the rect it would have if rendered");
 
 // Non-rendered element with invalid dimensions: should not throw,
 // should return zero bbox per resolution.


### PR DESCRIPTION
#### 543ba52c13f984411079edf2f128465a9c3d700d
<pre>
WPT getBBox tests wrongly expect a zero bbox for a non-rendered ancestor
<a href="https://bugs.webkit.org/show_bug.cgi?id=323707">https://bugs.webkit.org/show_bug.cgi?id=323707</a>
<a href="https://rdar.apple.com/186965141">rdar://186965141</a>

Reviewed by Nikolas Zimmermann.

Seven subtests asserted that a graphics element inside defs, clipPath,
mask, a display:none &lt;g&gt; or a &lt;symbol&gt; returns a zero bounding box. SVG
2 coords.html says it returns the rectangle it would have had if
rendered, and that only the non-rendered ancestor reports zero, because
a non-rendered element does not contribute to the bounding box of any
ancestor. WebKit follows both sentences and was marked failing; Gecko
returns zero for the children and was marked passing.

The comment in getBBox-06 attributes the zero to svgwg issue #1018. That
resolution is about an element whose own geometric attributes are
missing or invalid, and the phrase &quot;non-rendered element&quot; carried over
from the InvalidStateError sentence the resolution deleted. Every
element here has valid geometry.

Each test in getBBox-06 asserted the container and its child together.
Split into one subtest each, because measurement in all three engines
showed Chrome and Firefox breaking different sentences: Chrome returns
the container&apos;s box as its child&apos;s rectangle, and Firefox returns zero
for the child. One subtest asserting both hid that. Safari goes from 7
failures to 0, Chrome from 7 to 2, Gecko from 0 to 7.

Values measured 2026-09-08 in Safari 26.4, Safari 27.0, Firefox 157.0
and Chrome 155.0.0.0, controls passing in all four and the two Safari
builds identical, so the baselines come from measurement rather than
from the one coordinate each failing assertion printed.

none_rect is left asserting zero. coords.html asks for its real
rectangle too, but all three engines return zero, so that one is a
question for the WG and is now named in a comment instead of being
silent.

All ten subtests pass. This will be exported to WPT.

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-06.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-06-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-07.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-07-expected.txt:

Canonical link: <a href="https://commits.webkit.org/320886@main">https://commits.webkit.org/320886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bdedb007bf87719cc6dbca52489cc4c6e3ff784

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195975 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150377 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74b21c1c-d8b0-4958-8e76-8671b5df8b14) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60941 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59300 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145086 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100589 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a59a6758-fa72-4e1a-a34d-2a14dd7d7d40) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165653 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125381 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7d06f07-0bbe-4aed-9c85-6028bff46f0f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47500 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45540 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157860 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45228 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7038 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197938 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154622 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41536 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59942 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41833 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154275 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48738 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129196 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58412 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20250 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57788 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58028 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57853 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->