### PR TITLE
[WebGPU][WGSL] Three or more inlined calls to one function over a 256-byte struct silently miscompile on iOS

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -232,6 +232,7 @@ private:
     void serializeVariable(AST::Variable&);
     void generatePackingHelpers(AST::Structure&);
     bool emitPackedVector(const Types::Vector&, bool shouldPack);
+    bool NODELETE shouldForceInlining(AST::Function&) const;
 
     bool outlineConstant(const Type*, AST::Expression&);
     void serializeConstant(const Type*, ConstantValue);
@@ -796,6 +797,27 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
     m_shaderModule.clearUsesPackedVec3();
 }
 
+bool FunctionDefinitionWriter::shouldForceInlining(AST::Function& functionDefinition) const
+{
+    if (metalAppleGPUFamily() < 9 || m_entryPointStage)
+        return false;
+
+    auto* returnType = functionDefinition.maybeReturnType();
+    if (!returnType)
+        return false;
+
+    auto* type = returnType->inferredType();
+    if (!type)
+        return false;
+
+    if (!std::holds_alternative<Types::Struct>(*type) && !std::holds_alternative<Types::Array>(*type))
+        return false;
+
+    constexpr unsigned minimumInlinedReturnSize = 128;
+    auto size = type->maybeSize();
+    return size && *size >= minimumInlinedReturnSize;
+}
+
 void FunctionDefinitionWriter::visit(AST::Function& functionDefinition)
 {
     if (!m_visitedFunctions.add(&functionDefinition).isNewEntry)
@@ -808,6 +830,9 @@ void FunctionDefinitionWriter::visit(AST::Function& functionDefinition)
         checkErrorAndVisit(attribute);
         m_body.append(' ');
     }
+
+    if (shouldForceInlining(functionDefinition))
+        m_body.append("__attribute__((always_inline)) "_s);
 
     if (functionDefinition.maybeReturnType())
         visit(functionDefinition.maybeReturnType()->inferredType());

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm
@@ -58,6 +58,30 @@ static void testCompilation(const String& wgsl, Checks&&... checks)
     performChecks(std::get<String>(generationResult), std::forward<Checks>(checks)...);
 }
 
+template<typename... Checks>
+static void testCompilationForAppleGPUFamily(unsigned appleGPUFamily, const String& wgsl, Checks&&... checks)
+{
+    auto staticCheckResult = staticCheck(wgsl);
+    EXPECT_TRUE(std::holds_alternative<WGSL::SuccessfulCheck>(staticCheckResult));
+    auto& successfulCheck = std::get<WGSL::SuccessfulCheck>(staticCheckResult);
+
+    auto maybePrepareResult = prepare(successfulCheck);
+    EXPECT_TRUE(std::holds_alternative<WGSL::PrepareResult>(maybePrepareResult));
+    auto& prepareResult = std::get<WGSL::PrepareResult>(maybePrepareResult);
+
+    auto generationResult = generate(successfulCheck, prepareResult, WGSL::DeviceState { .appleGPUFamily = appleGPUFamily });
+    EXPECT_TRUE(std::holds_alternative<String>(generationResult));
+    auto msl = std::get<String>(generationResult);
+
+    auto metalCompilationResult = metalCompile(msl, appleGPUFamily);
+    EXPECT_TRUE(std::holds_alternative<id<MTLLibrary>>(metalCompilationResult));
+
+    auto library = std::get<id<MTLLibrary>>(metalCompilationResult);
+    EXPECT_TRUE(library != nil);
+
+    performChecks(std::get<String>(generationResult), std::forward<Checks>(checks)...);
+}
+
 static void expectPrepareError(const String& wgsl, const String& errorMessage)
 {
     auto staticCheckResult = staticCheck(wgsl);
@@ -381,6 +405,31 @@ TEST_F(WGSLMetalCompilationTests, GlobalOrdering)
 TEST_F(WGSLMetalCompilationTests, GlobalSameBinding)
 {
     testCompilation(file("global-same-binding.wgsl"_s));
+}
+
+TEST_F(WGSLMetalCompilationTests, InlineLargeAggregateReturns)
+{
+    auto shader = makeString(
+        "struct Big { v : array<vec4<u32>, 8> }"
+        "struct Small { v : array<vec4<u32>, 2> }"
+        "@group(0) @binding(0) var<storage, read> input : array<Big>;"
+        "@group(0) @binding(1) var<storage, read_write> output : array<Big>;"
+        "fn combineBig(a : Big, b : Big) -> Big { var r = a; for (var i = 0u; i < 8u; i++) { r.v[i] += b.v[i]; } return r; }"
+        "fn combineSmall(a : Small, b : Small) -> Small { var r = a; for (var i = 0u; i < 2u; i++) { r.v[i] += b.v[i]; } return r; }"
+        "fn sumBig(a : Big) -> u32 { var r = 0u; for (var i = 0u; i < 8u; i++) { r += a.v[i].x; } return r; }"_s,
+        fn("var acc = input[0];"
+            "var small = Small(array<vec4<u32>, 2>(input[0].v[0], input[0].v[1]));"
+            "for (var i = 1u; i < 4u; i++) { acc = combineBig(acc, input[i]); small = combineSmall(small, small); }"
+            "acc.v[0].x += sumBig(acc) + small.v[0].x;"
+            "output[0] = acc;"_s));
+
+    testCompilationForAppleGPUFamily(8, shader,
+        checkNotLiteral("__attribute__((always_inline)) type0 function0"_s));
+
+    testCompilationForAppleGPUFamily(9, shader,
+        checkLiteral("__attribute__((always_inline)) type0 function0"_s),
+        checkNotLiteral("__attribute__((always_inline)) type1 function1"_s),
+        checkNotLiteral("__attribute__((always_inline)) unsigned function2"_s));
 }
 
 TEST_F(WGSLMetalCompilationTests, GlobalUsedByCallee)

--- a/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
+++ b/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
@@ -140,19 +140,19 @@ inline Variant<WGSL::PrepareResult, WGSL::Error> prepare(const WGSL::SuccessfulC
     return WGSL::prepare(shaderModule, pipelineLayouts);
 }
 
-inline Variant<String, WGSL::Error> generate(const WGSL::SuccessfulCheck& staticCheckResult, WGSL::PrepareResult& prepareResult)
+inline Variant<String, WGSL::Error> generate(const WGSL::SuccessfulCheck& staticCheckResult, WGSL::PrepareResult& prepareResult, WGSL::DeviceState&& deviceState = { })
 {
     auto& shaderModule = staticCheckResult.ast;
     HashMap<String, WGSL::ConstantValue> constantValues;
-    return WGSL::generate(shaderModule, prepareResult, constantValues, { });
+    return WGSL::generate(shaderModule, prepareResult, constantValues, WTF::move(deviceState));
 }
 
 #ifdef __OBJC__
-inline Variant<id<MTLLibrary>, NSError *> metalCompile(const String& msl)
+inline Variant<id<MTLLibrary>, NSError *> metalCompile(const String& msl, unsigned appleGPUFamily = 8)
 {
     auto device = MTLCreateSystemDefaultDevice();
     auto options = [MTLCompileOptions new];
-    options.preprocessorMacros = @{ @"__wgslMetalAppleGPUFamily" : [NSString stringWithFormat:@"%u", 8] };
+    options.preprocessorMacros = @{ @"__wgslMetalAppleGPUFamily" : [NSString stringWithFormat:@"%u", appleGPUFamily] };
     NSError *error = nil;
     RetainPtr library = [device newLibraryWithSource:msl.createNSString().get() options:options error:&error];
     if (error != nil)


### PR DESCRIPTION
#### 6d963be7219adf39702f65263029f1b0bf09782d
<pre>
[WebGPU][WGSL] Three or more inlined calls to one function over a 256-byte struct silently miscompile on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=323560">https://bugs.webkit.org/show_bug.cgi?id=323560</a>
<a href="https://rdar.apple.com/186804865">rdar://186804865</a>

Reviewed by Dan Glastonbury.

Instead of using always_inline which causes miscompilations on Apple9 devices,
allow the compiler to decide whether or not to perform the inlining.

Tests: Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm
       Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::shouldForceInlining const):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm:
(TestWGSLAPI::testCompilationForAppleGPUFamily):
(TestWGSLAPI::TEST_F(WGSLMetalCompilationTests, InlineLargeAggregateReturns)):
* Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h:
(TestWGSLAPI::generate):

Canonical link: <a href="https://commits.webkit.org/320697@main">https://commits.webkit.org/320697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a137eb97bd2b4cefce668242aed44ceb8657d1e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195977 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187531 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59302 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48772 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125382 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47498 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45231 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7040 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/49948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197940 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59237 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41401 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59944 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154276 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48740 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129197 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58414 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20253 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57790 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58029 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57855 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->