### PR TITLE
NEW TEST(319873@main): [iOS] TestWebKitAPI.IndexedDB.TransactionOfSuspendedProcessIsNotAbortedByItsOwnQueuedTransaction

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm
@@ -29,6 +29,7 @@
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"
 #import "Helpers/cocoa/TestScriptMessageHandler.h"
+#import "TestNavigationDelegate.h"
 #import "TestURLSchemeHandler.h"
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKUserContentControllerPrivate.h>
@@ -687,6 +688,13 @@ TEST(IndexedDB, TransactionOfSuspendedProcessIsNotAbortedByItsOwnQueuedTransacti
         readyToContinue = true;
     }];
     TestWebKitAPI::Util::run(&readyToContinue);
+
+    // Keep another WebView's process (a separate WebView always uses a separate WebProcess) alive
+    // and foregrounded, so that network process won't be suspended and trigger transaction abort
+    // in a different path.
+    RetainPtr holderWebView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:adoptNS([[WKWebViewConfiguration alloc] init]).get()]);
+    [holderWebView loadHTMLString:@"<script></script>" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
+    [holderWebView _test_waitForDidFinishNavigation];
 
     RetainPtr handler = adoptNS([TestScriptMessageHandler new]);
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);


### PR DESCRIPTION
#### b9ad587b896421cdd72bcee39f1390fc9d6e9421
<pre>
NEW TEST(319873@main): [iOS] TestWebKitAPI.IndexedDB.TransactionOfSuspendedProcessIsNotAbortedByItsOwnQueuedTransaction
<a href="https://bugs.webkit.org/show_bug.cgi?id=323702">https://bugs.webkit.org/show_bug.cgi?id=323702</a>
<a href="https://rdar.apple.com/186958391">rdar://186958391</a>

Reviewed by Jonathan Bedard and Brady Eidson.

This test creates a single WKWebView/WebProcess and fakes it into the Suspended throttle state via
_setThrottleStateForTesting to exercise the &quot;a suspended client&apos;s in-progress transaction is not aborted just because
its own queued transaction is blocked on it&quot; logic in UniqueIDBDatabase. On iOS, dropping that WebProcess&apos;s
foreground/background tokens can, since it is the only WebProcess in the pool, drop the NetworkProcess&apos;s own last
foreground/background assertion as well, causing the real NetworkProcess ProcessThrottler to suspend the NetworkProcess.

A real NetworkProcess suspend runs IDBStorageManager::stopDatabaseActivitiesForSuspend(), which unconditionally aborts
every in-progress transaction&apos;s backing store transaction via UniqueIDBDatabase::abortActiveTransactions() so the
process can safely release its SQLite file locks; this is an intentional, unrelated mechanism to prevent holding a lock
while suspended, not the suspended-client logic under test.

So the test&apos;s outcome ends up depending on whether the NetworkProcess happens to receive a real suspend during the
test&apos;s timing window, which is unrelated to what the test is meant to verify. Fix this by keeping a second WebView (and
therefore a second WebProcess) alive and foregrounded for the duration of the test, so the NetworkProcess always has a
live foreground/background assertion from that second WebProcess.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IndexedDBSuspendImminently.mm:
(TransactionOfSuspendedProcessIsNotAbortedByItsOwnQueuedTransaction)):

Canonical link: <a href="https://commits.webkit.org/320767@main">https://commits.webkit.org/320767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91d01cd983e1fcef698b39ba1e707d92233927a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195982 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150382 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c0ae834-69ac-4bdf-bfc2-91b83a6e7a00) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145092 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100594 "Exiting early after 60 failures. 60 tests run. 60 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3ef77c3-5361-4d10-807f-5f0856b9e7c5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188629 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165661 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125387 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e7f526b9-2d0d-4e3f-bd15-a7c163626f4a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47504 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45545 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45236 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7045 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197945 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59242 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154627 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41450 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59949 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154280 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48744 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129202 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58419 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20258 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57795 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58034 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57860 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->