### PR TITLE
Hash and compare only the used characters of a TextMeasurementCache SmallStringKey

### DIFF
--- a/Source/WebCore/platform/graphics/TextMeasurementCache.h
+++ b/Source/WebCore/platform/graphics/TextMeasurementCache.h
@@ -85,7 +85,7 @@ private:
                 copySmallCharacters(std::span { m_characters }, string.span8());
             else
                 copySmallCharacters(std::span { m_characters }, string.span16());
-            m_hashAndLength = RapidHash::computeHashAndMaskTop8Bits(std::span<const char16_t> { m_characters }.first(s_capacity)) | (length << 24);
+            m_hashAndLength = RapidHash::computeHashAndMaskTop8Bits(std::span<const char16_t> { m_characters }.first(length)) | (length << 24);
         }
 
         const char16_t* characters() const LIFETIME_BOUND { return m_characters.data(); }
@@ -97,7 +97,12 @@ private:
         // Empty and deleted values have lengths that are not equal to any valid length.
         static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
 
-        friend bool operator==(const SmallStringKey&, const SmallStringKey&) = default;
+        friend bool operator==(const SmallStringKey& a, const SmallStringKey& b)
+        {
+            if (a.m_hashAndLength != b.m_hashAndLength)
+                return false;
+            return a.isHashTableEmptyValue() || a.isHashTableDeletedValue() || equal(std::span { a.m_characters }.first(a.length()), std::span { b.m_characters }.first(b.length()));
+        }
 
     private:
         static constexpr unsigned s_capacity = MaxTextLength;


### PR DESCRIPTION
#### 8854738a99112e8e38814bce4f6726b24928e0fe
<pre>
Hash and compare only the used characters of a TextMeasurementCache SmallStringKey
<a href="https://bugs.webkit.org/show_bug.cgi?id=323724">https://bugs.webkit.org/show_bug.cgi?id=323724</a>
<a href="https://rdar.apple.com/186973909">rdar://186973909</a>

Reviewed by Gerald Squelart.

SmallStringKey stores text inline in a zero-filled 64-entry char16_t array, and hashed all 128 bytes
of it no matter how short the string was. The defaulted operator== also compared the whole array on
every probe. Hash only the first length code units, and compare m_hashAndLength first. It packs both
the hash and the length, so a mismatched bucket costs one word compare and only a match compares
characters. The trailing bytes were always zero, so the same strings hash and compare equal as
before.

* Source/WebCore/platform/graphics/TextMeasurementCache.h:
(WebCore::TextMeasurementCache::SmallStringKey::SmallStringKey):
(WebCore::TextMeasurementCache::SmallStringKey::operator==):

Canonical link: <a href="https://commits.webkit.org/320710@main">https://commits.webkit.org/320710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20c25868ee90b8bdbbb148c4c82f5188cdfe1fdf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195991 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7b484cb-7913-44f5-92b2-3ef533625c17) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145100 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/408c8abb-254e-467c-bb60-7278b8a47fe6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165665 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125395 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5751f65c-bf41-4ccf-ba5f-34a4a0483890) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47511 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157871 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45240 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7054 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197957 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59251 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154633 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59958 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154286 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28183 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48750 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129217 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58428 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20262 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57804 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58042 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57869 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->