### PR TITLE
AX: In isolated tree mode, a br after an inline-block is left out of the line's range

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -10,7 +10,6 @@ accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html [ Crash
 accessibility/mac/frame-with-title.html [ Failure ]
 accessibility/mac/pseudo-element-text-markers.html [ Failure ]
 accessibility/mac/ruby-hierarchy-roles.html [ Failure Pass ]
-accessibility/mac/search-predicate-from-ignored-element.html [ Failure ]
 accessibility/mac/attributed-string/attributed-string-has-completion-annotation.html [ Failure ]
 accessibility/isolated-tree/mac/attributed-string/attributed-string-has-completion-annotation.html [ Failure ]
 

--- a/LayoutTests/accessibility/isolated-tree/mac/search-predicate-from-ignored-element-expected.txt
+++ b/LayoutTests/accessibility/isolated-tree/mac/search-predicate-from-ignored-element-expected.txt
@@ -1,0 +1,14 @@
+This tests the ability to search for accessible elements from an ignored element.
+
+PASS: element.stringForTextMarkerRange(range) === 'First line of text'
+PASS: element.stringForTextMarkerRange(range) === `button
+`
+PASS: resultElement.stringValue === 'AXValue: Third line of text'
+PASS: resultElement.stringValue === 'AXValue: First line of text'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+

--- a/LayoutTests/accessibility/isolated-tree/mac/search-predicate-from-ignored-element.html
+++ b/LayoutTests/accessibility/isolated-tree/mac/search-predicate-from-ignored-element.html
@@ -1,0 +1,48 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<div id="container" role="group">
+<div id="test">First line of text<br>
+<button id="button" aria-hidden="true">button</button>
+<br>Third line of text</div>
+</div>
+
+<script>
+let output = "This tests the ability to search for accessible elements from an ignored element.\n\n";
+
+if (window.accessibilityController) {
+    var container = accessibilityController.accessibleElementById("container");
+    var element = accessibilityController.accessibleElementById("test").childAtIndex(0);
+    var range = element.textMarkerRangeForElement(element);
+    output += expect("element.stringForTextMarkerRange(range)", "'First line of text'");
+
+    // Try to get the ignored element using line text marker calls.
+    var marker = element.endTextMarkerForTextMarkerRange(range);
+    marker = element.nextTextMarker(marker);
+    marker = element.nextTextMarker(marker);
+    range = element.lineTextMarkerRangeForTextMarker(marker);
+    // The range for the line containing the button must include a '\n' since the <button> element is followed by <br>.
+    output += expect("element.stringForTextMarkerRange(range)", "`button\n`");
+
+    marker = element.startTextMarkerForTextMarkerRange(range);
+    var startElement = element.accessibilityElementForTextMarker(marker);
+
+    // Search forward
+    var resultElement = container.uiElementForSearchPredicate(startElement, true, "AXAnyTypeSearchKey", "", false);
+    output += expect("resultElement.stringValue", "'AXValue: Third line of text'");
+
+    // Search backward
+    resultElement = container.uiElementForSearchPredicate(startElement, false, "AXAnyTypeSearchKey", "", false);
+    output += expect("resultElement.stringValue", "'AXValue: First line of text'");
+
+    document.getElementById("container").style.visibility = "hidden";
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -1581,6 +1581,18 @@ AXTextMarker AXTextMarker::findLine(AXDirection direction, AXTextUnitBoundary bo
             if ((currentObject->role() == AccessibilityRole::LineBreak && includeTrailingLineBreak == IncludeTrailingLineBreak::No)
                 || offsetOfCollapsedTrailingNewline(*currentObject, nextRuns) == std::optional<unsigned> { 0 })
                 break;
+
+            if (direction == AXDirection::Next && boundary == AXTextUnitBoundary::End
+                && currentObject->role() == AccessibilityRole::LineBreak && nextRuns
+                && nextRuns->containingBlock != currentRuns->containingBlock) {
+                // A <br> terminates the line the content before it sits on, so it belongs to the line
+                // being measured even though its lineID (containing block + line index) differs:
+                //   <div>First line<br><button>butto|n</button><br>Third line</div>
+                // The button's text lays out in its own block, the <br> in the <div>. Line indices
+                // within one block still rule, so a <br> starting a blank line isn't pulled in.
+                return { *currentObject, nextRuns->totalLength(), origin };
+            }
+
             currentRuns = nextRuns;
             // Reset the runIndex to 0 or the maximum, since we should start iterating from the very beginning/end of the next object's runs, depending on the direction.
             runIndex = direction == AXDirection::Next ? 0 : currentRuns->size() - 1;


### PR DESCRIPTION
#### b28aef30d8c0c4f13e7e70fba91ba9287e61d735
<pre>
AX: In isolated tree mode, a br after an inline-block is left out of the line&apos;s range
<a href="https://bugs.webkit.org/show_bug.cgi?id=323726">https://bugs.webkit.org/show_bug.cgi?id=323726</a>
<a href="https://rdar.apple.com/186974686">rdar://186974686</a>

Reviewed by Dominic Mazzoni.

For markup like this:

    &lt;div&gt;First line of text&lt;br&gt;&lt;button aria-hidden=&quot;true&quot;&gt;button&lt;/button&gt;&lt;br&gt;Third line&lt;/div&gt;

AXLineTextMarkerRangeForTextMarker returned &quot;button&quot; for the button&apos;s line rather than
&quot;button\n&quot;, losing the newline the trailing br contributes.

An AXTextRunLineID is a (containing block, line index) pair. The button&apos;s text lays out in
the button&apos;s own anonymous block while the br after it lays out in the div, so the two
never compare equal and AXTextMarker::findLine&apos;s walk stops at the lineID change without
ever reaching the br.

When walking forwards for a line end and the next object with runs is a line break in a
different containing block, take its end position.

Makes search-predicate-from-ignored-element.html pass in ITM, since that
test dumped the string value of its search results, which differed due
to this bug.

* LayoutTests/accessibility-isolated-tree/TestExpectations:
* LayoutTests/accessibility/isolated-tree/mac/search-predicate-from-ignored-element-expected.txt: Added.
* LayoutTests/accessibility/isolated-tree/mac/search-predicate-from-ignored-element.html: Added.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::findLine const):

Canonical link: <a href="https://commits.webkit.org/320728@main">https://commits.webkit.org/320728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57220bc2bc375220b6fec323ddad73aecc8069c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/195998 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150393 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60964 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145105 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100598 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125400 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47515 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45556 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157875 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45249 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7061 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197964 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59258 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154638 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41425 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59966 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154290 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48757 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132312 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129238 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58433 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20271 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57811 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58047 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57875 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->