### PR TITLE
[JSC] Elide dead 32-bit self-moves on arm64

### DIFF
--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -263,6 +263,8 @@ public:
     ARM64Assembler()
         : m_indexOfLastWatchpoint(INT_MIN)
         , m_indexOfTailOfLastWatchpoint(INT_MIN)
+        , m_indexOfLastLabel(INT_MIN)
+        , m_lastInstruction(0)
     {
         m_jumpsToLink.reserveInitialCapacity(64);
     }
@@ -3746,6 +3748,7 @@ public:
         AssemblerLabel result = m_buffer.label();
         if (static_cast<int>(result.offset()) != m_indexOfLastWatchpoint)
             result = label();
+        m_indexOfLastLabel = result.offset();
         m_indexOfLastWatchpoint = result.offset();
         m_indexOfTailOfLastWatchpoint = result.offset() + maxJumpReplacementSize();
         return result;
@@ -3758,7 +3761,22 @@ public:
             nop();
             result = m_buffer.label();
         }
+        m_indexOfLastLabel = result.offset();
         return result;
+    }
+
+    // True if the instruction just emitted wrote rd with bits 63:32 cleared and no label has been
+    // bound since, so every path to the current position executes it. labelIgnoringWatchpoints() is
+    // deliberately not a barrier: it marks positions inside jump-replacement regions, which no
+    // branch may target.
+    bool lastInstructionZeroExtendsRegister(RegisterID rd)
+    {
+        if (isSp(rd) || isZr(rd))
+            return false;
+        size_t codeSize = m_buffer.codeSize();
+        if (codeSize < sizeof(int) || static_cast<int>(codeSize) == m_indexOfLastLabel)
+            return false;
+        return zeroExtendsRegister(m_lastInstruction, rd);
     }
 
     AssemblerLabel align(int alignment)
@@ -4457,6 +4475,58 @@ protected:
         return insn == 0xd503201f;
     }
 
+    // Does this instruction write rd with bits 63:32 cleared? True for every sf=0 data-processing
+    // instruction, every load into a W register, and the 64-bit instructions whose result provably
+    // fits in 32 bits: MOVZ with hw < 2, UBFX of width at most 32 (which includes LSR by 32 or
+    // more), and AND or MOV with a bitmask immediate confined to the low half.
+    static bool zeroExtendsRegister(int instruction, RegisterID rd)
+    {
+        ASSERT(!isSp(rd) && !isZr(rd));
+        unsigned insn = static_cast<unsigned>(instruction);
+        if ((insn & 0x1f) != static_cast<unsigned>(rd))
+            return false;
+        if (!(insn & 0x80000000)) {
+            if ((insn & 0x1f800000) == 0x11000000 // add/subtract immediate
+                || (insn & 0x1f800000) == 0x12000000 // logical immediate
+                || (insn & 0x1f800000) == 0x12800000 // move wide immediate
+                || (insn & 0x1f800000) == 0x13000000 // bitfield
+                || (insn & 0x1f800000) == 0x13800000 // extract
+                || (insn & 0x1f000000) == 0x0a000000 // logical shifted register
+                || (insn & 0x1f000000) == 0x0b000000 // add/subtract shifted or extended register
+                || (insn & 0x1fe0fc00) == 0x1a000000 // add/subtract with carry
+                || (insn & 0x1fe00000) == 0x1a800000 // conditional select
+                || (insn & 0x1f000000) == 0x1b000000 // data-processing 3-source
+                || (insn & 0x7fe00000) == 0x1ac00000 // data-processing 2-source
+                || (insn & 0x7fe00000) == 0x5ac00000) // data-processing 1-source
+                return true;
+        }
+        // Loads into a W register in every addressing mode: LDRB, LDRH and LDR (opc=01), LDRSB and
+        // LDRSH (opc=11). V=0 excludes SIMD loads; size=11 or opc=10 would be an X-register load.
+        unsigned sizeAndOpc = insn & 0xfec00000;
+        if (sizeAndOpc == 0x38400000 || sizeAndOpc == 0x78400000 || sizeAndOpc == 0xb8400000 || sizeAndOpc == 0x38c00000 || sizeAndOpc == 0x78c00000)
+            return true;
+        // MOVZ Xd, #imm16, LSL #0 or LSL #16.
+        if ((insn & 0xffc00000) == 0xd2800000)
+            return true;
+        unsigned immr = (insn >> 16) & 0x3f;
+        unsigned imms = (insn >> 10) & 0x3f;
+        // UBFM Xd, Xn, #immr, #imms with imms >= immr is UBFX of width imms - immr + 1.
+        if ((insn & 0xffc00000) == 0xd3400000)
+            return imms >= immr && imms - immr < 32;
+        // 64-bit AND, ANDS or ORR-from-ZR with a bitmask immediate: N=1 means one 64-bit element of
+        // imms + 1 ones rotated right by immr, so the result is confined to the low half if that is.
+        if ((insn & 0x9fc00000) == 0x92400000 && imms != 63) {
+            unsigned opc = (insn >> 29) & 3;
+            if (opc == 2 || (opc == 1 && ((insn >> 5) & 0x1f) != 31))
+                return false;
+            uint64_t mask = (1ull << (imms + 1)) - 1;
+            if (immr)
+                mask = (mask >> immr) | (mask << (64 - immr));
+            return !(mask >> 32);
+        }
+        return false;
+    }
+
     static bool disassembleCompareAndBranchImmediate(void* address, Datasize& sf, bool& op, int& imm19, RegisterID& rt)
     {
         int insn = *static_cast<int*>(address);
@@ -4513,6 +4583,7 @@ protected:
 
     ALWAYS_INLINE void insn(int instruction)
     {
+        m_lastInstruction = instruction;
         m_buffer.putInt(instruction);
     }
 
@@ -4991,6 +5062,8 @@ protected:
     Vector<LinkRecord, 0, UnsafeVectorOverflow> m_jumpsToLink;
     int m_indexOfLastWatchpoint;
     int m_indexOfTailOfLastWatchpoint;
+    int m_indexOfLastLabel;
+    int m_lastInstruction;
     AssemblerBuffer m_buffer;
 
 public:

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -4380,7 +4380,7 @@ public:
     {
         if (src == ARM64Registers::zr && dest != ARM64Registers::sp)
             m_assembler.movz<32>(dest, 0);
-        else
+        else if (src != dest || !m_assembler.lastInstructionZeroExtendsRegister(dest))
             m_assembler.mov<32>(dest, src);
     }
 

--- a/Source/JavaScriptCore/assembler/testmasm.cpp
+++ b/Source/JavaScriptCore/assembler/testmasm.cpp
@@ -7141,6 +7141,206 @@ static void testCachedTempRegisterImm32Normalization()
         CHECK_EQ(invoke<int>(test), 1);
     }
 }
+
+static void testZeroExtend32ToWordAfterZeroExtendingWrite()
+{
+    // zeroExtend32ToWord(r, r) emits nothing when the previous instruction already wrote r as a
+    // W register and no label was bound in between; every other shape still emits the mov.
+    size_t emitted = 0;
+    auto zeroExtendMeasured = [&] (CCallHelpers& jit, GPRReg src, GPRReg dest) {
+        size_t before = jit.m_assembler.buffer().codeSize();
+        jit.zeroExtend32ToWord(src, dest);
+        emitted = jit.m_assembler.buffer().codeSize() - before;
+    };
+    constexpr size_t instructionSize = 4;
+    constexpr uint64_t dirty = 0xffffffff00000000ull;
+
+    // add32 writes W: the mov is dropped and the result is still clean.
+    {
+        auto test = compile([&] (CCallHelpers& jit) {
+            emitFunctionPrologue(jit);
+            jit.add32(GPRInfo::argumentGPR0, GPRInfo::argumentGPR1, GPRInfo::returnValueGPR);
+            zeroExtendMeasured(jit, GPRInfo::returnValueGPR, GPRInfo::returnValueGPR);
+            emitFunctionEpilogue(jit);
+            jit.ret();
+        });
+        CHECK_EQ(emitted, 0u);
+        CHECK_EQ(invoke<uint64_t>(test, dirty | 1, dirty | 2), 3ull);
+    }
+
+    // add64 writes X: the mov stays.
+    {
+        auto test = compile([&] (CCallHelpers& jit) {
+            emitFunctionPrologue(jit);
+            jit.add64(GPRInfo::argumentGPR0, GPRInfo::argumentGPR1, GPRInfo::returnValueGPR);
+            zeroExtendMeasured(jit, GPRInfo::returnValueGPR, GPRInfo::returnValueGPR);
+            emitFunctionEpilogue(jit);
+            jit.ret();
+        });
+        CHECK_EQ(emitted, instructionSize);
+        CHECK_EQ(invoke<uint64_t>(test, dirty | 1, 2), 3ull);
+    }
+
+    // A label between the two means control can arrive without the add: the mov stays.
+    {
+        auto test = compile([&] (CCallHelpers& jit) {
+            emitFunctionPrologue(jit);
+            jit.add32(GPRInfo::argumentGPR0, GPRInfo::argumentGPR1, GPRInfo::returnValueGPR);
+            (void)jit.label();
+            zeroExtendMeasured(jit, GPRInfo::returnValueGPR, GPRInfo::returnValueGPR);
+            emitFunctionEpilogue(jit);
+            jit.ret();
+        });
+        CHECK_EQ(emitted, instructionSize);
+        CHECK_EQ(invoke<uint64_t>(test, dirty | 1, dirty | 2), 3ull);
+    }
+
+    // Linking a jump binds a label too; the path that skips the add arrives with a dirty upper half.
+    {
+        auto test = compile([&] (CCallHelpers& jit) {
+            emitFunctionPrologue(jit);
+            auto skip = jit.branchTest32(CCallHelpers::NonZero, GPRInfo::argumentGPR1);
+            jit.add32(CCallHelpers::TrustedImm32(1), GPRInfo::argumentGPR0);
+            skip.link(&jit);
+            zeroExtendMeasured(jit, GPRInfo::argumentGPR0, GPRInfo::argumentGPR0);
+            jit.move(GPRInfo::argumentGPR0, GPRInfo::returnValueGPR);
+            emitFunctionEpilogue(jit);
+            jit.ret();
+        });
+        CHECK_EQ(emitted, instructionSize);
+        CHECK_EQ(invoke<uint64_t>(test, dirty | 5, 1), 5ull);
+        CHECK_EQ(invoke<uint64_t>(test, dirty | 5, 0), 6ull);
+    }
+
+    // A 32-bit load zero-extends; a 64-bit load does not.
+    {
+        uint64_t memory = 0xffffffffffffffffull;
+        auto test32 = compile([&] (CCallHelpers& jit) {
+            emitFunctionPrologue(jit);
+            jit.load32(CCallHelpers::Address(GPRInfo::argumentGPR0), GPRInfo::returnValueGPR);
+            zeroExtendMeasured(jit, GPRInfo::returnValueGPR, GPRInfo::returnValueGPR);
+            emitFunctionEpilogue(jit);
+            jit.ret();
+        });
+        CHECK_EQ(emitted, 0u);
+        CHECK_EQ(invoke<uint64_t>(test32, &memory), 0xffffffffull);
+
+        auto test64 = compile([&] (CCallHelpers& jit) {
+            emitFunctionPrologue(jit);
+            jit.load64(CCallHelpers::Address(GPRInfo::argumentGPR0), GPRInfo::returnValueGPR);
+            zeroExtendMeasured(jit, GPRInfo::returnValueGPR, GPRInfo::returnValueGPR);
+            emitFunctionEpilogue(jit);
+            jit.ret();
+        });
+        CHECK_EQ(emitted, instructionSize);
+        CHECK_EQ(invoke<uint64_t>(test64, &memory), 0xffffffffull);
+    }
+
+    // Immediates: a W move, a one-instruction X movz and a low-half bitmask leave the upper half
+    // clear; a movk or a bitmask reaching into bits 63:32 keeps the mov.
+    {
+        auto check = [&] (auto immediate, size_t expectedEmitted, uint64_t expectedResult) {
+            auto test = compile([&] (CCallHelpers& jit) {
+                emitFunctionPrologue(jit);
+                jit.move(immediate, GPRInfo::returnValueGPR);
+                zeroExtendMeasured(jit, GPRInfo::returnValueGPR, GPRInfo::returnValueGPR);
+                emitFunctionEpilogue(jit);
+                jit.ret();
+            });
+            CHECK_EQ(emitted, expectedEmitted);
+            CHECK_EQ(invoke<uint64_t>(test), expectedResult);
+        };
+        check(CCallHelpers::TrustedImm32(7), 0u, 7ull);
+        check(CCallHelpers::TrustedImm32(-100), 0u, 0xffffff9cull);
+        check(CCallHelpers::TrustedImm64(5), 0u, 5ull);
+        check(CCallHelpers::TrustedImm64(0x12345), instructionSize, 0x12345ull);
+        check(CCallHelpers::TrustedImm64(0x100000001ll), instructionSize, 1ull);
+        check(CCallHelpers::TrustedImm64(0x100000000ll), instructionSize, 0ull);
+    }
+
+    // 64-bit results that provably fit in 32 bits: a right shift by 32 or more, a bitmask AND
+    // confined to the low half, and a bitmask move; a shorter shift or a wider mask keeps the mov.
+    {
+        auto check = [&] (auto emit, size_t expectedEmitted, uint64_t expectedResult) {
+            auto test = compile([&] (CCallHelpers& jit) {
+                emitFunctionPrologue(jit);
+                emit(jit);
+                zeroExtendMeasured(jit, GPRInfo::returnValueGPR, GPRInfo::returnValueGPR);
+                emitFunctionEpilogue(jit);
+                jit.ret();
+            });
+            CHECK_EQ(emitted, expectedEmitted);
+            CHECK_EQ(invoke<uint64_t>(test, dirty | 5), expectedResult);
+        };
+        check([] (CCallHelpers& jit) {
+            jit.urshift64(CCallHelpers::TrustedImm32(32), GPRInfo::returnValueGPR);
+        }, 0u, 0xffffffffull);
+        check([] (CCallHelpers& jit) {
+            jit.urshift64(CCallHelpers::TrustedImm32(16), GPRInfo::returnValueGPR);
+        }, instructionSize, 0xffff0000ull);
+        check([] (CCallHelpers& jit) {
+            jit.and64(CCallHelpers::TrustedImm64(0xffffffffll), GPRInfo::returnValueGPR);
+        }, 0u, 5ull);
+        check([] (CCallHelpers& jit) {
+            jit.and64(CCallHelpers::TrustedImm64(0x7ffffff0ll), GPRInfo::returnValueGPR);
+        }, 0u, 0ull);
+        check([] (CCallHelpers& jit) {
+            jit.and64(CCallHelpers::TrustedImm64(0xffffffff00000000ll), GPRInfo::returnValueGPR);
+        }, instructionSize, 0ull);
+        check([] (CCallHelpers& jit) {
+            jit.and64(CCallHelpers::TrustedImm64(0x1ffffffffll), GPRInfo::returnValueGPR);
+        }, instructionSize, 5ull);
+        check([] (CCallHelpers& jit) {
+            jit.move(CCallHelpers::TrustedImm64(0x10), GPRInfo::returnValueGPR);
+        }, 0u, 0x10ull);
+        check([] (CCallHelpers& jit) {
+            jit.move(CCallHelpers::TrustedImm64(0x1000000000ll), GPRInfo::returnValueGPR);
+        }, instructionSize, 0ull);
+    }
+
+    // Only the register the previous instruction wrote is known to be clean.
+    {
+        auto test = compile([&] (CCallHelpers& jit) {
+            emitFunctionPrologue(jit);
+            jit.add32(GPRInfo::argumentGPR0, GPRInfo::argumentGPR1, GPRInfo::argumentGPR1);
+            zeroExtendMeasured(jit, GPRInfo::argumentGPR0, GPRInfo::argumentGPR0);
+            jit.move(GPRInfo::argumentGPR0, GPRInfo::returnValueGPR);
+            emitFunctionEpilogue(jit);
+            jit.ret();
+        });
+        CHECK_EQ(emitted, instructionSize);
+        CHECK_EQ(invoke<uint64_t>(test, dirty | 5, 1), 5ull);
+    }
+
+    // A move between different registers is never dropped.
+    {
+        auto test = compile([&] (CCallHelpers& jit) {
+            emitFunctionPrologue(jit);
+            jit.add32(GPRInfo::argumentGPR0, GPRInfo::argumentGPR1, GPRInfo::argumentGPR1);
+            zeroExtendMeasured(jit, GPRInfo::argumentGPR1, GPRInfo::returnValueGPR);
+            emitFunctionEpilogue(jit);
+            jit.ret();
+        });
+        CHECK_EQ(emitted, instructionSize);
+        CHECK_EQ(invoke<uint64_t>(test, dirty | 5, dirty | 1), 6ull);
+    }
+
+    // moveConditionally32 compares 32 bits but selects with a 64-bit csel, so the mov stays.
+    {
+        auto test = compile([&] (CCallHelpers& jit) {
+            emitFunctionPrologue(jit);
+            jit.move(CCallHelpers::TrustedImm32(0), GPRInfo::argumentGPR1);
+            jit.moveConditionally32(CCallHelpers::LessThan, GPRInfo::argumentGPR0, CCallHelpers::TrustedImm32(0), GPRInfo::argumentGPR1, GPRInfo::argumentGPR0, GPRInfo::argumentGPR1);
+            zeroExtendMeasured(jit, GPRInfo::argumentGPR1, GPRInfo::argumentGPR1);
+            jit.move(GPRInfo::argumentGPR1, GPRInfo::returnValueGPR);
+            emitFunctionEpilogue(jit);
+            jit.ret();
+        });
+        CHECK_EQ(emitted, instructionSize);
+        CHECK_EQ(invoke<uint64_t>(test, dirty | 5), 5ull);
+        CHECK_EQ(invoke<uint64_t>(test, dirty | 0x80000000ull), 0ull);
+    }
+}
 #endif
 
 #if CPU(X86_64)
@@ -8766,6 +8966,7 @@ void run(const char* filter) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     RUN(testMove16ToFloat16Comprehensive());
     RUN(testFMovHalfPrecisionEncoding());
     RUN(testCachedTempRegisterImm32Normalization());
+    RUN(testZeroExtend32ToWordAfterZeroExtendingWrite());
 #endif
 
     RUN(testGPRInfoConsistency());

--- a/Source/JavaScriptCore/b3/air/AirEmitShuffle.cpp
+++ b/Source/JavaScriptCore/b3/air/AirEmitShuffle.cpp
@@ -106,6 +106,12 @@ Vector<Inst, 2> ShufflePair::insts(Code& code, Value* origin) const
     ASSERT(isValidForm(moveFor(bank(), width()), Arg::Tmp, Arg::Addr));
 
     ASSERT(src().isSomeImm());
+    // Only Move32 lacks an immediate form, and it zero-extends, so a register destination takes the
+    // zero-extended value in a single Move.
+    if (dst().isTmp()) {
+        ASSERT(width() == Width32);
+        return { Inst(Move, origin, Arg::bigImm(static_cast<uint32_t>(src().value())), dst()) };
+    }
     Tmp tmp = code.newTmp(bank());
     ASSERT(isValidForm(Move, Arg::BigImm, Arg::Tmp));
     ASSERT(isValidForm(moveFor(bank(), width()), Arg::Tmp, dst().kind()));
@@ -349,6 +355,11 @@ Vector<Inst> emitShuffle(
         Opcode move = moveForWidth(pair.width());
         
         if (!isValidForm(move, pair.src().kind(), pair.dst().kind())) {
+            if (pair.src().isSomeImm() && pair.dst().isTmp()) {
+                ASSERT(move == Move32);
+                result.append(Inst(Move, origin, Arg::bigImm(static_cast<uint32_t>(pair.src().value())), pair.dst()));
+                return;
+            }
             Tmp scratch =
                 getScratch(scratchIndex, findPossibleScratch(code, bank, pair.src(), pair.dst()));
             RELEASE_ASSERT(scratch);


### PR DESCRIPTION
#### 84dcf3b908967754afa27af0226fa9bdf3259643
<pre>
[JSC] Elide dead 32-bit self-moves on arm64
<a href="https://bugs.webkit.org/show_bug.cgi?id=323729">https://bugs.webkit.org/show_bug.cgi?id=323729</a>

Reviewed by NOBODY (OOPS!).

zeroExtend32ToWord(r, r) is spelled mov wN, wN on arm64, and every tier
emits it defensively: BBQ before it uses an i32 as an address operand,
extends it to i64 or wraps an i64 to i32 (the upper half of an i32 in a
register is don&apos;t-care in BBQ&apos;s register model), the DFG when it strictly
fills an Int32, and B3/Air for ZExt32 and for every 32-bit C call argument.
Nearly every time, the instruction right before it already left the upper
half of the register clear -- a 32-bit add, a 32-bit load, a right shift of
an i64 by 32 -- so the mov does nothing:

    add w0, w0, w1          ; DFG ArithAdd
    mov w0, w0              ; zeroExtend32ToWord(w0, w0)

    ldur w1, [x29, #-0x10]  ; BBQ reloads an i32 local
    mov w1, w1              ; i64.extend_i32_u

    lsr x0, x0, #32         ; BBQ i64.shr_u
    mov w0, w0              ; i32.wrap_i64

    mov x2, #5              ; Air: Move $5 into the argument register,
    mov w2, w2              ; then Move32 to zero-extend it

Two changes:

* MacroAssemblerARM64::zeroExtend32ToWord(src, dest) with src == dest now
  asks the assembler whether the instruction it just emitted already wrote
  dest with the upper half clear, and emits nothing if so. ARM64Assembler
  remembers the last instruction word it emitted (insn() is the only
  emission path) and decodes it: every sf=0 data-processing class, every
  load into a W register, and the 64-bit instructions whose result provably
  fits in 32 bits -- MOVZ with hw &lt; 2, UBFX of width at most 32 (which is
  what LSR by 32 or more is), and AND or MOV with a bitmask immediate
  confined to the low half. The one way this could go wrong is control
  arriving at the mov without having executed the producer, so the
  assembler also records the offset of the most recent label(): Label
  construction, Jump::link(), JumpList::link(), align() and
  padBeforePatch() all bind through it, and a label at the current
  position disables the elision. labelIgnoringWatchpoints() is
  deliberately not a barrier. It marks positions inside jump-replacement
  regions, which no branch may target, and the DFG and Air evaluate it
  after every slow path and instruction for the PC-to-origin map, so
  treating it as one would disable the elision almost everywhere.

* B3/Air materialized a 32-bit immediate C call argument as Move $imm into
  a fresh Tmp followed by Move32 into the argument register, both in
  ShufflePair::insts() and in emitShuffle()&apos;s shift path. TmpWidth only
  narrows the def width of an Imm move and this one is a BigImm, so the
  register allocator could not turn the Move32 into a Move and delete it
  after coalescing; it survived as mov x2, #5; mov w2, w2. A register
  destination now takes a single Move of the zero-extended immediate.

Scanning everything the JITs emit while running JetStream 3 on arm64 (54.6M
instructions in 109,925 code blocks), armlint reports 2844 redundant
zero-extensions after a zeroing write: 1903 in BBQ, 410 in FTL, 289 in the
DFG, 238 in OMG and 4 in FTL OSR exits. After this change it reports 20: 9
in FTL, 7 in BBQ, 3 in the DFG and 1 in OMG, every one of them an and with
a mask after a cset, lsr or ldrb rather than a self-move, so none is a
zeroExtend32ToWord() call.

Counting every mov wN, wN in the corpus rather than only the ones armlint
can prove dead: 57364 before, 53617 after, so 3747 instructions (15 KB) are
gone. BBQ goes from 32770 to 30874 and the count is identical across two
runs of the new binary; FTL goes from 2624 to 1752 and OMG from 1734 to
1297, more than armlint&apos;s site counts because the Air change also removes
Move32s whose preceding Move armlint does not model as a zeroing write; the
DFG goes from 10043 to 9495. Two dumps of the same binary differ by 83 in
this count, and by 0.3% in total code bytes (the JIT embeds pointers whose
movz/movk count depends on where things were allocated), so the 15 KB is
real per instruction but invisible in the corpus total. What remains is
30874 self-moves in BBQ and 9495 in the DFG whose producer is not the
immediately preceding instruction; catching those needs a set of
known-clean registers rather than a look at the last instruction.

JetStream 3 under the jsc shell on this M-series machine, 16 interleaved
pairs (eight A,B then eight B,A so run-order drift cancels), geomean paired
B/A: -0.21%, 95% CI [-1.19%, +0.77%], median -0.17%, and the sign flips with
the run order (A,B pairs -0.49%, B,A pairs +0.08%). Seven of 75 subtests
move by more than their own confidence interval, in both directions, with
the largest at about 2% either way. So the change is instruction count and
code size only, as expected for a register-to-register mov that the core
renames away.

testmasm gains testZeroExtend32ToWordAfterZeroExtendingWrite, which checks
both the emitted size and the result of each shape with dirty upper halves
in the inputs: add32, a 32-bit load, a W move, a one-instruction X movz,
lsr x by 32, and64 with a low-half bitmask and a bitmask mov elide the mov;
add64, a 64-bit load, a movk or a bitmask reaching into the upper half,
lsr x by 16, a wider and64 mask, a csel (moveConditionally32 selects 64
bits), a label() or a linked jump between the two instructions, a different
register, and src != dest all keep it. testmasm goes from 465 to 466 tests;
testb3, testair and all 20810 JSTests/stress runs (default and
no-cjit-validate modes) pass.

Found with armlint.

* Source/JavaScriptCore/assembler/ARM64Assembler.h:
(JSC::ARM64Assembler::ARM64Assembler):
(JSC::ARM64Assembler::labelForWatchpoint):
(JSC::ARM64Assembler::label):
(JSC::ARM64Assembler::lastInstructionZeroExtendsRegister):
(JSC::ARM64Assembler::zeroExtendsRegister):
(JSC::ARM64Assembler::insn):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::zeroExtend32ToWord):
* Source/JavaScriptCore/assembler/testmasm.cpp:
(JSC::testZeroExtend32ToWordAfterZeroExtendingWrite):
(JSC::run):
* Source/JavaScriptCore/b3/air/AirEmitShuffle.cpp:
(JSC::B3::Air::ShufflePair::insts const):
(JSC::B3::Air::emitShuffle):

Co-Authored-By: Claude Fable 5.1 &lt;noreply@anthropic.com&gt;
Claude-Session: <a href="https://claude.ai/code/session_01EaeigoH8u1YuiVpZZQdTQ8">https://claude.ai/code/session_01EaeigoH8u1YuiVpZZQdTQ8</a>
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1eea18760c7f272f68c492ac14f1b650d1b5ac1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196800 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150974 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60111 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145715 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100986 "1 flakes 14 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126085 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48137 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46068 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7898 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14754 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158482 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45824 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7875 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47753 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198792 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60049 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155312 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60760 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42375 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154947 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49362 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132938 "Failed to build and analyze WebKit") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/130227 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59172 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20803 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58588 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58803 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58694 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->