### PR TITLE
REGRESSION(320449@main): [GLib] SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory times out on regions of 4 GB and above

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedMemoryTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedMemoryTests.cpp
@@ -335,14 +335,17 @@ TEST_P(SharedMemoryFromMemoryTest, CreateCOWFromMemory)
 
 #if PLATFORM(COCOA)
 #define ANY_MEMORY_SOURCE testing::Values(MemorySource::Malloc, MemorySource::SharedMemory, MemorySource::ExplicitMapping)
+#define ANY_MEMORY_SIZE testing::Values(1, 2, KB, 100 * KB, 500 * MB, 4 * GB + 1, 20 * GB)
 #else
 #define ANY_MEMORY_SOURCE testing::Values(MemorySource::Malloc, MemorySource::SharedMemory)
+// Overcommit makes allocating the regions over 4 GB succeed, so the physical copy has to commit all of them.
+#define ANY_MEMORY_SIZE testing::Values(1, 2, KB, 100 * KB, 500 * MB)
 #endif
 
 INSTANTIATE_TEST_SUITE_P(SharedMemoryTest,
     SharedMemoryFromMemoryTest,
     testing::Combine(
-        testing::Values(1, 2, KB, 100 * KB, 500 * MB, 4 * GB + 1, 20 * GB),
+        ANY_MEMORY_SIZE,
         testing::Values(0, 1, 444, 4097),
         ANY_MEMORY_SOURCE,
         testing::Values(SharedMemory::Protection::ReadOnly, SharedMemory::Protection::ReadWrite)),


### PR DESCRIPTION
#### 0700ee330c58972a00608b6498103ee6f07751e9
<pre>
REGRESSION(320449@main): [GLib] SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory times out on regions of 4 GB and above
<a href="https://bugs.webkit.org/show_bug.cgi?id=323626">https://bugs.webkit.org/show_bug.cgi?id=323626</a>

Reviewed by Carlos Alberto Lopez Perez.

320449@main added SharedMemoryTests.cpp to the CMake build, so it runs on the
GTK and WPE ports for the first time. The test tolerates the 4 GB + 1 and
20 GB regions failing to allocate and skips them in that case. On Linux the
allocation never fails because of overcommit, and CreateHandleCopyFromMemory,
the only one of these tests that does any work outside Cocoa, then copies the
whole region into a freshly created memfd. That commits up to 42 GB and takes
around 30 seconds even when run alone, at the timeout of run-api-tests, so
every GTK and WPE bot times out on these cases.

Outside Cocoa these sizes only exercise a memcpy into shared memory, which the
smaller regions already cover, so leave them to Cocoa, matching how the memory
sources are already selected per platform.

* Tools/TestWebKitAPI/Tests/WebCore/SharedMemoryTests.cpp:

Canonical link: <a href="https://commits.webkit.org/320816@main">https://commits.webkit.org/320816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3626700e9d05c295aeaec9bce27caebfc1386294

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59919 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53708 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196313 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187883 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59639 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188976 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/49040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/125676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/47773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/158127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/45491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7384 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/50217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198291 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59577 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/165423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60286 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/154559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28242 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/49005 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129679 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58732 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58122 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58354 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->