### PR TITLE
REGRESSION(320449@main): [GLib] API tests WebKit.CloseFromWithinCreatePage and WebKit.CreatePageThenDocumentOpenMIMEType time out

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/CloseFromWithinCreatePage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/CloseFromWithinCreatePage.cpp
@@ -80,7 +80,8 @@ TEST(WebKit, CloseFromWithinCreatePage)
     auto configuration = adoptWK(WKPageCopyPageConfiguration(webView.page()));
     auto preferences = WKPageConfigurationGetPreferences(configuration.get());
     WKPreferencesSetUniversalAccessFromFileURLsAllowed(preferences, true);
-    
+    WKPreferencesSetJavaScriptCanOpenWindowsAutomatically(preferences, true);
+
     WKRetainPtr<WKURLRef> url = adoptWK(Util::createURLForResource("close-from-within-create-page", "html"));
     WKPageLoadURL(webView.page(), url.get());
 
@@ -124,6 +125,7 @@ TEST(WebKit, CreatePageThenDocumentOpenMIMEType)
     auto configuration = adoptWK(WKPageCopyPageConfiguration(webView.page()));
     auto preferences = WKPageConfigurationGetPreferences(configuration.get());
     WKPreferencesSetUniversalAccessFromFileURLsAllowed(preferences, true);
+    WKPreferencesSetJavaScriptCanOpenWindowsAutomatically(preferences, true);
 
     testDone = false;
     WKRetainPtr<WKURLRef> url = adoptWK(Util::createURLForResource("window-open-then-document-open", "html"));


### PR DESCRIPTION
#### d4dbea574aed88c1fcff4ffdf4855d826178e87c
<pre>
REGRESSION(320449@main): [GLib] API tests WebKit.CloseFromWithinCreatePage and WebKit.CreatePageThenDocumentOpenMIMEType time out
<a href="https://bugs.webkit.org/show_bug.cgi?id=323733">https://bugs.webkit.org/show_bug.cgi?id=323733</a>

Reviewed by Fujii Hironori.

320449@main added these tests to the CMake build, so they run on the GTK and
WPE ports for the first time. Both load a page whose onload handler calls
window.open() and wait for an alert from the opened page. On GTK and WPE the
JavaScriptCanOpenWindowsAutomatically preference defaults to false, unlike on
macOS, so the call is rejected for lack of a user gesture, the UI client is
never asked to create the page and the tests wait forever.

Enable the preference explicitly, as the tests already do for universal access
from file URLs.

* Tools/TestWebKitAPI/Tests/WebKit/WKPage/CloseFromWithinCreatePage.cpp:
(TestWebKitAPI::TEST(WebKit, CloseFromWithinCreatePage)):
(TestWebKitAPI::TEST(WebKit, CreatePageThenDocumentOpenMIMEType)):

Canonical link: <a href="https://commits.webkit.org/320719@main">https://commits.webkit.org/320719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a64b8a920e2ac77d70df2d1e0c89a8e6c1a68575

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196012 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150406 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145115 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100610 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125410 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47525 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157885 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45258 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7075 "Built successfully") | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197978 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59272 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154652 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41419 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59980 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154304 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48770 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129266 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58447 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20280 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57825 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58061 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57888 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->