### PR TITLE
Annotate CachedScript's decoded script state as owner-thread state

### DIFF
--- a/Source/WebCore/loader/cache/CachedScript.cpp
+++ b/Source/WebCore/loader/cache/CachedScript.cpp
@@ -49,6 +49,7 @@ CachedScript::~CachedScript() = default;
 
 void CachedScript::setEncoding(const String& chs)
 {
+    assertIsOwnerThread();
     protect(m_decoder)->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
 }
 
@@ -59,6 +60,8 @@ ASCIILiteral CachedScript::encoding() const
 
 StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
 {
+    assertIsOwnerThread();
+
     if (!m_data)
         return emptyString();
 
@@ -71,10 +74,12 @@ StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
         && contiguousData->size()
         && charactersAreAllASCII(contiguousData->span())) {
 
+        releaseOwnerThreadAssertion();
         {
             Locker locker { m_lock };
             m_decodingState = DataAndDecodedStringHaveSameBytes;
         }
+        assertIsOwnerThread();
 
         // If the encoded and decoded data are the same, there is no decoded data cost!
         setDecodedSize(0);
@@ -102,12 +107,14 @@ StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
             m_scriptHash = result.hash();
         ASSERT(!m_scriptHash || m_scriptHash == result.hash());
 
+        releaseOwnerThreadAssertion();
         {
             Locker locker { m_lock };
             m_script = WTF::move(result);
             m_decodingState = DataAndDecodedStringHaveDifferentBytes;
             m_wasForceDecodedAsUTF8 = shouldDecodeAsUTF8Only == ShouldDecodeAsUTF8Only::Yes;
         }
+        assertIsOwnerThread();
         setDecodedSize(m_script.sizeInBytes());
     }
 
@@ -163,6 +170,7 @@ JSC::CodeBlockHash CachedScript::codeBlockHashConcurrently(int startOffset, int 
 
 unsigned CachedScript::scriptHash(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
 {
+    assertIsOwnerThread();
     if (m_decodingState == NeverDecoded || (m_decodingState == DataAndDecodedStringHaveDifferentBytes && m_wasForceDecodedAsUTF8 != (shouldDecodeAsUTF8Only == ShouldDecodeAsUTF8Only::Yes)))
         script(shouldDecodeAsUTF8Only);
     return m_scriptHash;
@@ -196,6 +204,7 @@ void CachedScript::setBodyDataFrom(const CachedResource& resource)
 
     CachedResource::setBodyDataFrom(resource);
 
+    script.assertIsOwnerThread();
     {
         Locker locker { m_lock };
         m_script = script.m_script;

--- a/Source/WebCore/loader/cache/CachedScript.h
+++ b/Source/WebCore/loader/cache/CachedScript.h
@@ -27,6 +27,7 @@
 
 #include "CachedResource.h"
 #include <JavaScriptCore/CodeBlockHash.h>
+#include <wtf/ThreadAssertions.h>
 
 namespace WebCore {
 
@@ -50,25 +51,31 @@ private:
     bool mayTryReplaceEncodedData() const final { return true; }
 
     void setEncoding(const String&) final;
-    ASCIILiteral encoding() const final;
-    const TextResourceDecoder* textResourceDecoder() const final { return m_decoder.get(); }
+    ASCIILiteral encoding() const final WTF_REQUIRES_SHARED_LOCK(m_lock);
+    const TextResourceDecoder* textResourceDecoder() const final WTF_REQUIRES_SHARED_LOCK(m_lock) { return m_decoder.get(); }
     void finishLoading(const FragmentedSharedBuffer*, const NetworkLoadMetrics&) final;
 
     void destroyDecodedData() final;
 
     void setBodyDataFrom(const CachedResource&) final;
 
-    String m_script;
+    // m_script, m_decodingState and m_decoder are written on the main thread under m_lock and read
+    // on compilation threads by codeBlockHashConcurrently(), which locks; the main thread's own
+    // reads use assertIsOwnerThread() instead of locking. m_scriptHash and m_wasForceDecodedAsUTF8
+    // are not read off the main thread, so they need no guard.
+    String m_script WTF_GUARDED_BY_LOCK(m_lock);
     unsigned m_scriptHash { 0 };
     bool m_wasForceDecodedAsUTF8 { false };
     bool m_requiresPrivacyProtections { false };
 
     enum DecodingState : uint8_t { NeverDecoded, DataAndDecodedStringHaveSameBytes, DataAndDecodedStringHaveDifferentBytes };
-    DecodingState m_decodingState { NeverDecoded };
+    DecodingState m_decodingState WTF_GUARDED_BY_LOCK(m_lock) { NeverDecoded };
 
     mutable Lock m_lock;
 
-    RefPtr<TextResourceDecoder> m_decoder;
+    RefPtr<TextResourceDecoder> m_decoder WTF_GUARDED_BY_LOCK(m_lock);
+
+    WTF_DECLARE_OWNER_THREAD_ASSERTIONS(m_lock, mainThreadLike);
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 7e946663438851db54f93b938cf06d2c2b73ac16
<pre>
Annotate CachedScript&apos;s decoded script state as owner-thread state
<a href="https://bugs.webkit.org/show_bug.cgi?id=323735">https://bugs.webkit.org/show_bug.cgi?id=323735</a>

Reviewed by Geoffrey Garen.

m_script, m_decodingState and m_decoder are written on the main thread under m_lock and read
on compilation threads by codeBlockHashConcurrently(), which locks. The lock is therefore
load-bearing for those three, and nothing enforced that the writers took it. Guard them with
WTF_GUARDED_BY_LOCK() and assert on the main thread&apos;s unlocked read paths.

m_scriptHash and m_wasForceDecodedAsUTF8 are deliberately left unguarded. Neither is read
off the main thread, so by the rule that state should only be annotated where failing to
lock would be a bug, they do not qualify; m_scriptHash is in fact written without the lock
in script(), so guarding it would report existing code rather than describe an invariant.

encoding() and textResourceDecoder() read m_decoder from both sides: the main thread calls
them without the lock, and codeBlockHashConcurrently() calls encoding() while holding it.
They can therefore neither assert the owner thread, which would fire on a compilation
thread, nor require the lock exclusively. They instead require it shared, which both callers
satisfy, the main thread through its owner-thread assertion and the compilation thread by
holding the lock. Calls that arrive through a CachedResource pointer use the unannotated base
declaration and so are not checked, which is no weaker than before.

script() reads guarded state before, between and after its two critical sections, so it
asserts once at the top and then releases and re-asserts around each Locker; leaving the
assertion live would report the Locker as acquiring a lock that is already held.
setBodyDataFrom() reads a second CachedScript&apos;s guarded members, and holding this object&apos;s
lock grants nothing for another&apos;s, so it asserts on the source object as well.

No behaviour change is intended: neither helper generates code, so no lock is taken and no
ordering is introduced; both only move thread safety analysis state.

* Source/WebCore/loader/cache/CachedScript.cpp:
(WebCore::CachedScript::setEncoding):
(WebCore::CachedScript::script):
(WebCore::CachedScript::scriptHash):
(WebCore::CachedScript::setBodyDataFrom):
* Source/WebCore/loader/cache/CachedScript.h:

Canonical link: <a href="https://commits.webkit.org/320790@main">https://commits.webkit.org/320790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31777a28d85365a63e48413c7a6344a1f4e96461

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196015 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150409 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae086286-d5cc-412e-8cde-c0594c942ee4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187570 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59340 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145119 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100614 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/07b25926-c515-4293-b843-e11ee0253d69) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165690 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125414 "Found 1 new API test failure: TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/42949672974097MallocReadOnly (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/acbd64c1-3d20-4120-9804-bdfa310e940f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47531 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45572 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157891 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45265 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7078 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197981 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59275 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154655 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41462 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59983 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154308 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48772 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132332 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129272 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58450 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20287 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57828 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58064 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57891 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->