### PR TITLE
[WPE][GTK] rumble does not work in case of libmanette 0.2.13

### DIFF
--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
@@ -222,7 +222,7 @@ void ManetteGamepad::effectDelayTimerFired()
 
 void ManetteGamepad::startRumble(const GamepadEffectParameters& parameters)
 {
-#if LIBMANETTE_CHECK_VERSION(0, 2, 13)
+#if MANETTE_CHECK_VERSION(1, 0, 0)
     manette_device_rumble(m_device.get(), parameters.strongMagnitude, parameters.weakMagnitude, static_cast<guint>(parameters.duration));
 #else
     manette_device_rumble(m_device.get(), parameters.strongMagnitude * G_MAXUINT16, parameters.weakMagnitude * G_MAXUINT16, static_cast<guint>(parameters.duration));

--- a/Source/WebKit/WPEPlatform/wpe/WPEGamepadManette.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGamepadManette.cpp
@@ -173,7 +173,7 @@ static gboolean wpeGamepadManetteHasRumble(WPEGamepad* gamepad)
 static gboolean wpeGamepadManetteRumble(WPEGamepad* gamepad, gdouble strongMagnitude, gdouble weakMagnitude, guint durationMs)
 {
     auto* priv = WPE_GAMEPAD_MANETTE(gamepad)->priv;
-#if LIBMANETTE_CHECK_VERSION(0, 2, 13)
+#if MANETTE_CHECK_VERSION(1, 0, 0)
     return manette_device_rumble(priv->device.get(), strongMagnitude, weakMagnitude, durationMs);
 #else
     return manette_device_rumble(priv->device.get(), strongMagnitude * G_MAXUINT16, weakMagnitude * G_MAXUINT16, durationMs);


### PR DESCRIPTION
#### 9f1b3cc7564972d2b7a5bc49db9faf850a7344b9
<pre>
[WPE][GTK] rumble does not work in case of libmanette 0.2.13
<a href="https://bugs.webkit.org/show_bug.cgi?id=323663">https://bugs.webkit.org/show_bug.cgi?id=323663</a>

Reviewed by Carlos Garcia Campos.

Macros from libmanette: LIBMANETTE_CHECK_VERSION(deprecated) and
MANETTE_CHECK_VERSION evaluate to TRUE in case of greater than or
equal to. This caused that in case of version 0.2.13 wrong values
were passed to manette_device_rumble (normalized floating-point
rumble magnitudes) and it was rounded to 0 (guint16).

The normalized floating-point rumble magnitudes are demanded in
case of libmanette version &gt;= 1.0.0.

Also deprecated macro is replaced with the new one.

No new tests.
* Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp:
(WebCore::ManetteGamepad::startRumble):
* Source/WebKit/WPEPlatform/wpe/WPEGamepadManette.cpp:
(wpeGamepadManetteRumble):

Canonical link: <a href="https://commits.webkit.org/320820@main">https://commits.webkit.org/320820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3aad64dbe60579e07448f360aab7d2d2d6a89b2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196083 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150604 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187639 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145177 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100743 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165738 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125475 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47585 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45618 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157944 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45317 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7147 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198050 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59343 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154722 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41485 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60052 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154372 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48825 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132401 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129374 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58518 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20340 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57896 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58131 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->