### PR TITLE
Adopt WTF_DECLARE_OWNER_THREAD_ASSERTIONS in the remaining owner-thread classes

### DIFF
--- a/Source/WTF/wtf/ThreadAssertions.h
+++ b/Source/WTF/wtf/ThreadAssertions.h
@@ -174,13 +174,14 @@ inline ThreadLikeAssertion ThreadLike::createThreadLikeAssertion(uint32_t uid)
 // WTF_GUARDED_BY_LOCK() as usual, and call assertIsOwnerThread() on the unlocked read path:
 //
 // struct MyClass {
-//     Element* element() const { assertIsOwnerThread(m_lock, mainThreadLike); return m_element.get(); }
+//     Element* element() const { assertIsOwnerThread(); return m_element.get(); }
 //     void setElement(Element* element) { Locker locker { m_lock }; m_element = element; }
 //     // Runs on another thread, so it must lock even though it only reads.
 //     void visit(Visitor& visitor) const { Locker locker { m_lock }; visitor.append(m_element); }
 // private:
 //     mutable Lock m_lock;
 //     RefPtr<Element> m_element WTF_GUARDED_BY_LOCK(m_lock);
+//     WTF_DECLARE_OWNER_THREAD_ASSERTIONS(m_lock, mainThreadLike);
 // };
 //
 // The owner may be given as mainThreadLike, or as a ThreadLikeAssertion member for state owned by

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -183,7 +183,7 @@ CSSStyleSheet::~CSSStyleSheet()
 
 Node* CSSStyleSheet::ownerNode() const
 {
-    assertIsOwnerThread(m_opaqueRootLockForGC, mainThreadLike);
+    assertIsOwnerThread();
     return m_ownerNode.get();
 }
 
@@ -592,7 +592,7 @@ ExceptionOr<void> CSSStyleSheet::replaceSync(String&& text)
 
 bool CSSStyleSheet::isDetached() const
 {
-    assertIsOwnerThread(m_opaqueRootLockForGC, mainThreadLike);
+    assertIsOwnerThread();
     return !m_ownerNode
         && !m_ownerRule
         && m_adoptingTreeScopes.isEmptyIgnoringNullReferences();

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -31,6 +31,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/Lock.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/ThreadAssertions.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
@@ -195,6 +196,7 @@ private:
     // Only mutated on the main thread while holding m_opaqueRootLockForGC, so main-thread reads
     // use assertIsOwnerThread() instead of locking; the GC thread must lock even to read.
     CheckedPtr<Node> m_ownerNode WTF_GUARDED_BY_LOCK(m_opaqueRootLockForGC);
+    WTF_DECLARE_OWNER_THREAD_ASSERTIONS(m_opaqueRootLockForGC, mainThreadLike);
     CheckedPtr<CSSImportRule> m_ownerRule;
 
     TextPosition m_startPosition;

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -88,7 +88,7 @@ Attr::~Attr()
 
 ExceptionOr<void> Attr::setValue(const AtomString& value)
 {
-    assertIsOwnerThread(m_elementLockForGC, mainThreadLike);
+    assertIsOwnerThread();
     if (RefPtr element = m_element.get()) {
         auto verifiedValue = value;
         if (protect(document())->contextDocument().requiresTrustedTypes()) {
@@ -136,7 +136,7 @@ CSSStyleProperties* Attr::style()
 {
     // This is not part of the DOM API, and therefore not available to webpages. However, WebKit SPI
     // lets clients use this via the Objective-C and JavaScript bindings.
-    assertIsOwnerThread(m_elementLockForGC, mainThreadLike);
+    assertIsOwnerThread();
     RefPtr styledElement = dynamicDowncast<StyledElement>(m_element.get());
     if (!styledElement)
         return nullptr;
@@ -148,7 +148,7 @@ CSSStyleProperties* Attr::style()
 
 AtomString Attr::value() const
 {
-    assertIsOwnerThread(m_elementLockForGC, mainThreadLike);
+    assertIsOwnerThread();
     if (RefPtr element = m_element.get())
         return element->getAttributeForBindings(qualifiedName());
     return m_standaloneValue;

--- a/Source/WebCore/dom/Attr.h
+++ b/Source/WebCore/dom/Attr.h
@@ -45,7 +45,7 @@ public:
 
     String name() const { return qualifiedName().toString(); }
     bool specified() const { return true; }
-    Element* ownerElement() const { assertIsOwnerThread(m_elementLockForGC, mainThreadLike); return m_element.get(); }
+    Element* ownerElement() const { assertIsOwnerThread(); return m_element.get(); }
 
     WEBCORE_EXPORT AtomString value() const;
     WEBCORE_EXPORT ExceptionOr<void> setValue(const AtomString&);
@@ -82,6 +82,7 @@ private:
     // m_element is only mutated on the main thread while holding m_elementLockForGC, so main-thread
     // reads use assertIsOwnerThread() instead of locking; the GC thread must lock even to read.
     CheckedPtr<Element> m_element WTF_GUARDED_BY_LOCK(m_elementLockForGC);
+    WTF_DECLARE_OWNER_THREAD_ASSERTIONS(m_elementLockForGC, mainThreadLike);
     QualifiedName m_name;
     AtomString m_standaloneValue;
     RefPtr<MutableStyleProperties> m_style;

--- a/Source/WebCore/dom/TreeWalker.cpp
+++ b/Source/WebCore/dom/TreeWalker.cpp
@@ -62,7 +62,7 @@ inline Node* TreeWalker::setCurrent(Ref<Node>&& node)
 
 ExceptionOr<Node*> TreeWalker::parentNode()
 {
-    assertIsOwnerThread(m_currentLock, mainThreadLike);
+    assertIsOwnerThread();
     RefPtr node = m_current.ptr();
     while (node != &root()) {
         node = node->parentNode();
@@ -81,7 +81,7 @@ ExceptionOr<Node*> TreeWalker::parentNode()
 
 ExceptionOr<Node*> TreeWalker::firstChild()
 {
-    assertIsOwnerThread(m_currentLock, mainThreadLike);
+    assertIsOwnerThread();
     for (RefPtr node = m_current->firstChild(); node; ) {
         auto filterResult = acceptNode(*node);
         if (filterResult.hasException())
@@ -115,7 +115,7 @@ ExceptionOr<Node*> TreeWalker::firstChild()
 
 ExceptionOr<Node*> TreeWalker::lastChild()
 {
-    assertIsOwnerThread(m_currentLock, mainThreadLike);
+    assertIsOwnerThread();
     for (RefPtr node = m_current->lastChild(); node; ) {
         auto filterResult = acceptNode(*node);
         if (filterResult.hasException())
@@ -149,7 +149,7 @@ ExceptionOr<Node*> TreeWalker::lastChild()
 
 template<TreeWalker::SiblingTraversalType type> ExceptionOr<Node*> TreeWalker::traverseSiblings()
 {
-    assertIsOwnerThread(m_currentLock, mainThreadLike);
+    assertIsOwnerThread();
     RefPtr node = m_current.ptr();
     if (node == &root())
         return nullptr;
@@ -193,7 +193,7 @@ ExceptionOr<Node*> TreeWalker::nextSibling()
 
 ExceptionOr<Node*> TreeWalker::previousNode()
 {
-    assertIsOwnerThread(m_currentLock, mainThreadLike);
+    assertIsOwnerThread();
     if (!filter()) {
         if (m_current.ptr() == &root())
             return nullptr;
@@ -250,7 +250,7 @@ ExceptionOr<Node*> TreeWalker::previousNode()
 
 ExceptionOr<Node*> TreeWalker::nextNode()
 {
-    assertIsOwnerThread(m_currentLock, mainThreadLike);
+    assertIsOwnerThread();
     if (!filter()) {
         for (RefPtr node = NodeTraversal::next(m_current, &root()); node; node = NodeTraversal::next(*node, &root())) {
             if (matchesWhatToShow(*node))

--- a/Source/WebCore/dom/TreeWalker.h
+++ b/Source/WebCore/dom/TreeWalker.h
@@ -45,8 +45,8 @@ public:
         return adoptRef(*new TreeWalker(rootNode, whatToShow, WTF::move(filter)));
     }                            
 
-    Node& currentNode() { assertIsOwnerThread(m_currentLock, mainThreadLike); return m_current.get(); }
-    const Node& currentNode() const { assertIsOwnerThread(m_currentLock, mainThreadLike); return m_current.get(); }
+    Node& currentNode() { assertIsOwnerThread(); return m_current.get(); }
+    const Node& currentNode() const { assertIsOwnerThread(); return m_current.get(); }
 
     WebCoreOpaqueRoot opaqueRootForCurrentNodeInGCThread() const;
 
@@ -72,6 +72,7 @@ private:
     // Only mutated on the main thread while holding m_currentLock, so main-thread reads use
     // assertIsOwnerThread() instead of locking; the GC thread must lock even to read.
     Ref<Node> m_current WTF_GUARDED_BY_LOCK(m_currentLock);
+    WTF_DECLARE_OWNER_THREAD_ASSERTIONS(m_currentLock, mainThreadLike);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLCollection.cpp
+++ b/Source/WebCore/html/HTMLCollection.cpp
@@ -162,7 +162,7 @@ void HTMLCollection::invalidateNamedElementCache(Document& document) const
 
 Element* HTMLCollection::namedItemSlow(const AtomString& name) const
 {
-    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
+    assertIsOwnerThread();
     // The pathological case. We need to walk the entire subtree.
     updateNamedElementCache();
     ASSERT(m_namedElementCache);
@@ -183,7 +183,7 @@ Element* HTMLCollection::namedItemSlow(const AtomString& name) const
 // Documented in https://dom.spec.whatwg.org/#interface-htmlcollection.
 const Vector<AtomString>& HTMLCollection::supportedPropertyNames()
 {
-    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
+    assertIsOwnerThread();
     updateNamedElementCache();
     ASSERT(m_namedElementCache);
 
@@ -192,7 +192,7 @@ const Vector<AtomString>& HTMLCollection::supportedPropertyNames()
 
 bool HTMLCollection::isSupportedPropertyName(const AtomString& name)
 {
-    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
+    assertIsOwnerThread();
     updateNamedElementCache();
     ASSERT(m_namedElementCache);
 
@@ -230,7 +230,7 @@ void HTMLCollection::updateNamedElementCache() const
 
 Vector<Ref<Element>> HTMLCollection::namedItems(const AtomString& name) const
 {
-    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
+    assertIsOwnerThread();
     // FIXME: This non-virtual function can't possibly be doing the correct thing for
     // any derived class that overrides the virtual namedItem function.
 

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -27,6 +27,7 @@
 #include <WebCore/HTMLNames.h>
 #include <WebCore/LiveNodeList.h>
 #include <wtf/HashMap.h>
+#include <wtf/ThreadAssertions.h>
 
 namespace WebCore {
 
@@ -113,6 +114,7 @@ protected:
     // main-thread reads use assertIsOwnerThread() instead of locking; memoryCost() runs on the
     // GC thread and must lock even to read.
     mutable std::unique_ptr<CollectionNamedElementCache> m_namedElementCache WTF_GUARDED_BY_LOCK(m_namedElementCacheAssignmentLock);
+    WTF_DECLARE_OWNER_THREAD_ASSERTIONS(m_namedElementCacheAssignmentLock, mainThreadLike);
 };
 
 inline size_t CollectionNamedElementCache::memoryCost() const

--- a/Source/WebCore/html/HTMLCollectionInlines.h
+++ b/Source/WebCore/html/HTMLCollectionInlines.h
@@ -111,7 +111,7 @@ inline void HTMLCollection::invalidateCache()
 
 inline bool HTMLCollection::hasNamedElementCache() const
 {
-    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
+    assertIsOwnerThread();
     return !!m_namedElementCache;
 }
 
@@ -129,7 +129,7 @@ inline void HTMLCollection::setNamedItemCache(std::unique_ptr<CollectionNamedEle
 
 inline const CollectionNamedElementCache& HTMLCollection::namedItemCaches() const LIFETIME_BOUND
 {
-    assertIsOwnerThread(m_namedElementCacheAssignmentLock, mainThreadLike);
+    assertIsOwnerThread();
     ASSERT(!!m_namedElementCache);
     return *m_namedElementCache;
 }

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -275,7 +275,7 @@ void TextTrackCue::didChange(bool affectOrder)
 
 TextTrack* TextTrackCue::track() const
 {
-    assertIsOwnerThread(m_trackLockForGC, mainThreadLike);
+    assertIsOwnerThread();
     return m_track.get();
 }
 

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -40,6 +40,7 @@
 #include <wtf/JSONValues.h>
 #include <wtf/Lock.h>
 #include <wtf/MediaTime.h>
+#include <wtf/ThreadAssertions.h>
 
 namespace JSC {
 
@@ -178,6 +179,7 @@ private:
     // Only mutated on the main thread while holding m_trackLockForGC, so main-thread reads use
     // assertIsOwnerThread() instead of locking; the GC thread must lock even to read.
     CheckedPtr<TextTrack> m_track WTF_GUARDED_BY_LOCK(m_trackLockForGC);
+    WTF_DECLARE_OWNER_THREAD_ASSERTIONS(m_trackLockForGC, mainThreadLike);
 
     const RefPtr<DocumentFragment> m_cueNode;
     const RefPtr<TextTrackCueBox> m_displayTree;

--- a/Source/WebCore/xml/XSLStyleSheet.h
+++ b/Source/WebCore/xml/XSLStyleSheet.h
@@ -92,7 +92,7 @@ public:
     String type() const override { return "text/xml"_s; }
     bool disabled() const override { return m_isDisabled; }
     void setDisabled(bool b) override { m_isDisabled = b; }
-    Node* ownerNode() const override { assertIsOwnerThread(m_opaqueRootLockForGC, mainThreadLike); return m_ownerNode.get(); }
+    Node* ownerNode() const override { assertIsOwnerThread(); return m_ownerNode.get(); }
     String href() const override { return m_originalURL; }
     String title() const override { return { }; }
 
@@ -114,6 +114,7 @@ private:
     // Only mutated on the main thread while holding m_opaqueRootLockForGC, so main-thread reads
     // use assertIsOwnerThread() instead of locking; the GC thread must lock even to read.
     CheckedPtr<Node> m_ownerNode WTF_GUARDED_BY_LOCK(m_opaqueRootLockForGC);
+    WTF_DECLARE_OWNER_THREAD_ASSERTIONS(m_opaqueRootLockForGC, mainThreadLike);
     String m_originalURL;
     URL m_finalURL;
     bool m_isDisabled { false };


### PR DESCRIPTION
#### 0f31212799440abd778e7bdcb0ad2af0f0f4b95e
<pre>
Adopt WTF_DECLARE_OWNER_THREAD_ASSERTIONS in the remaining owner-thread classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=323736">https://bugs.webkit.org/show_bug.cgi?id=323736</a>

Reviewed by Geoffrey Garen.

320637@main annotated six classes by naming the lock and the owner thread at each unlocked
read, and 320703@main then added WTF_DECLARE_OWNER_THREAD_ASSERTIONS() and used it for Range,
leaving two spellings of the same thing in the tree. Declare the assertions in the other six
classes too and collapse their twenty-two call sites to assertIsOwnerThread(), which states
the choice of owner once per class instead of once per read. CSSStyleSheet.h, HTMLCollection.h
and TextTrackCue.h gain an explicit &lt;wtf/ThreadAssertions.h&gt;: they had been picking the free
function up transitively through their implementation files, which no longer suffices now that
the macro expands in the header.

* Source/WTF/wtf/ThreadAssertions.h:
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::ownerNode const):
(WebCore::CSSStyleSheet::isDetached const):
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/dom/Attr.cpp:
(WebCore::Attr::setValue):
(WebCore::Attr::style):
(WebCore::Attr::value const):
* Source/WebCore/dom/Attr.h:
* Source/WebCore/dom/TreeWalker.cpp:
* Source/WebCore/dom/TreeWalker.h:
* Source/WebCore/html/HTMLCollection.cpp:
(WebCore::HTMLCollection::namedItemSlow const):
(WebCore::HTMLCollection::supportedPropertyNames):
(WebCore::HTMLCollection::isSupportedPropertyName):
(WebCore::HTMLCollection::namedItems const):
* Source/WebCore/html/HTMLCollection.h:
* Source/WebCore/html/HTMLCollectionInlines.h:
(WebCore::HTMLCollection::hasNamedElementCache const):
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::TextTrackCue::track const):
* Source/WebCore/html/track/TextTrackCue.h:
* Source/WebCore/xml/XSLStyleSheet.h:

Canonical link: <a href="https://commits.webkit.org/320789@main">https://commits.webkit.org/320789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f35906584cf94ce1b42f00c825bb59b418e46e4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185715 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150415 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c63c4fd-be75-43f8-bb7c-3eb805c71c42) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187577 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59347 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145135 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100626 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/59bc2427-6846-4da5-9857-6af6c60fee1f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165699 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125430 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e622a691-40e8-4e5b-a436-5178bbae75e6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47540 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45578 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7325 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14208 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45276 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7085 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/46962 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52250 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197988 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59282 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154662 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41461 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59990 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154315 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48780 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132338 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129280 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58457 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20299 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57835 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58071 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57898 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->