### PR TITLE
Avoid out-of-bounds read in isPlayReadySanitizedInitializationData

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
@@ -223,7 +223,7 @@ bool isPlayReadySanitizedInitializationData(const SharedBuffer& buffer)
     // The protection data starts with a 10-byte PlayReady version
     // header that needs to be skipped over to avoid XML parsing
     // errors.
-    auto view = StringView::fromLatin1(byteCast<char>(buffer.span().data()));
+    auto view = StringView::fromLatin1(byteCast<Latin1Character>(buffer.span()));
     auto startTag = view.find('<');
     if (startTag == notFound)
         return false;


### PR DESCRIPTION
Reviewed by NOBODY (OOPS!).

isPlayReadySanitizedInitializationData() builds a StringView from the raw
Encrypted Media init-data to locate the start of the PlayReady XML, but it
hands buffer.span().data() to StringView::fromLatin1(const char*), which
measures the length with strlen(). That buffer comes straight from
MediaKeySession.generateRequest() and is arbitrary binary that is not NUL
terminated, so strlen() runs past the end of the SharedBuffer allocation
until it reaches a zero byte. It is reachable on GStreamer ports for any
"cenc" init-data that is not a valid pssh box: extractKeyIDsCenc() then fails
and sanitizeCenc() falls back to this helper, so a blob with no NUL byte (for
example one at least kCencMaxBoxSize long filled with non-zero bytes) becomes
a heap over-read. A '<' located in the over-read region can also push startTag
beyond buffer.size(), after which the following buffer.span().subspan(startTag)
reads out of range as well. I noticed it while auditing the non-Cocoa
init-data paths. Using the bounded fromLatin1(std::span) overload, as the
sibling keyids parser already does, keeps the view within buffer.size() and
closes both reads.

* Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp:
(WebCore::isPlayReadySanitizedInitializationData):
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f642ad47585c37b7ba0b3daada538edef7dcf8e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196025 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150418 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187580 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145128 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100622 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48812 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165698 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125423 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47538 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45581 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45275 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7088 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52253 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197991 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59285 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154664 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/59993 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154317 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48784 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132341 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129284 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58460 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20298 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57838 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58074 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->