### PR TITLE
Cherry-pick 320071@main (9dcbd254af21). https://bugs.webkit.org/show_bug.cgi?id=318807

### DIFF
--- a/JSTests/stress/uint32-array-result-int32-dfg.js
+++ b/JSTests/stress/uint32-array-result-int32-dfg.js
@@ -1,0 +1,41 @@
+//@ runDefault("--useConcurrentJIT=false", "--useFTLJIT=false", "--jitPolicyScale=0.1")
+// See rdar://176792844 for additional details on this test.
+
+let a = new Uint32Array(4);
+a[0] = 42;
+
+let dummy = [1, 2, 3]; dummy[0] = 1; dummy[0] = {};
+
+const sBodyArgs = ['a', 'idx', 'flag', 'intArr',
+"\n" +
+"    let i = idx;\n" +
+"    if (flag) i = 0.5;\n" +
+"    let v = a[i];\n" +
+"    let d = v - 0.5;\n" +
+"    intArr[0] = v;\n" +
+"    return d;\n"];
+
+let f1 = new Function(...sBodyArgs);
+noInline(f1);
+
+let intArr1 = [1, 2, 3]; intArr1[0] = 1;
+for (let k = 0; k < 100; k++)
+    f1(a, 0, false, intArr1);
+
+for (let k = 0; k < 110; k++)
+    f1(a, 100, false, intArr1);
+
+let evict = new Function('z', 'return z'); evict(0);
+
+let f2 = new Function(...sBodyArgs);
+noInline(f2);
+
+let intArr2 = [1, 2, 3]; intArr2[0] = 1;
+
+for (let k = 0; k < 100; k++)
+    f2(a, 0, false, intArr2);
+
+f2(a, 0, false, intArr2);
+
+if (intArr2[0] !== 42)
+    throw new Error("incorrect value " + intArr2[0]);

--- a/JSTests/stress/yarr-jit-non-bmp-backtrack-index-overflow.js
+++ b/JSTests/stress/yarr-jit-non-bmp-backtrack-index-overflow.js
@@ -1,0 +1,12 @@
+const re = /d\0e?|\u{10000}c/u;
+const subj = "\u{10000}d";
+const m = re.exec(subj);
+
+if (m !== null) {
+    throw new Error(
+        "expected null, got match=" + JSON.stringify(m[0]) +
+        " at index=" + m.index +
+        " (m.index + m[0].length = " + (m.index + m[0].length) +
+        " > subj.length = " + subj.length + ")"
+    );
+}

--- a/JSTests/stress/yarr-jit-non-bmp-backtrack-index-underflow.js
+++ b/JSTests/stress/yarr-jit-non-bmp-backtrack-index-underflow.js
@@ -1,0 +1,5 @@
+const re = /(?!\u{10000})a*|\u{10000}b/u;
+const subj = "\u{10000}cc";
+const m = re.exec(subj);
+if (m[0].length > subj.length)
+    throw new Error("m[0].length (" + m[0].length + ") > subj.length (" + subj.length + ")");

--- a/JSTests/wasm/stress/block-param-type-widening.js
+++ b/JSTests/wasm/stress/block-param-type-widening.js
@@ -1,0 +1,72 @@
+import * as assert from "../assert.js";
+
+// When a block/if/try/try_table declares a parameter type that is a *supertype*
+// of the value actually on the stack, the block body must be validated against
+// the DECLARED type, not the narrower concrete type that flowed in
+// Each case below is built twice with an identical body:
+//   - declared type = anyref (wide): `struct.get 0 0` is invalid on anyref, so
+//     the module must be REJECTED. Before widening, the body saw the concrete
+//     `(ref null 0)` and this was (incorrectly) accepted.
+//   - declared type = (ref null 0) (concrete): `struct.get 0 0` is valid, so the
+//     module must VALIDATE. This control confirms the scaffolding is otherwise
+//     well-formed, so the rejection above is due to widening alone.
+
+function uleb128(n) { const r = []; do { let b = n & 0x7f; n >>>= 7; if (n) b |= 0x80; r.push(b); } while (n); return r; }
+function encodeString(s) { const b = []; for (let i = 0; i < s.length; i++) b.push(s.charCodeAt(i)); return [...uleb128(b.length), ...b]; }
+function section(id, content) { return [id, ...uleb128(content.length), ...content]; }
+
+// Module layout:
+//   type 0: struct { i64 mut }
+//   type 1: <blockSig>       (the signature of the block under test)
+//   type 2: func () -> i64   (the exported function "test")
+function buildModule(blockSig, body0) {
+    const typeSection = section(1, [
+        0x03,
+        0x5F, 0x01, 0x7E, 0x01,          // type 0: struct { i64 mut }
+        ...blockSig,                     // type 1
+        0x60, 0x00, 0x01, 0x7E,          // type 2: () -> i64
+    ]);
+    const funcSection = section(3, [0x01, 0x02]);                               // func 0 : type 2
+    const exportSection = section(7, [0x01, ...encodeString("test"), 0x00, 0x00]); // export "test" func 0
+    const codeSection = section(10, [0x01, ...uleb128(body0.length), ...body0]);
+    return new Uint8Array([0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+        ...typeSection, ...funcSection, ...exportSection, ...codeSection]);
+}
+
+const sigParam = (t) => [0x60, 0x01, ...t, 0x01, 0x7E]; // (t) -> (i64)
+const ANYREF = [0x6E];
+const REF_NULL_0 = [0x63, 0x00]; // (ref null 0)
+
+const GET = [0xFB, 0x02, 0x00, 0x00]; // struct.get 0 0
+const REF_NULL_TYPE0 = [0xD0, 0x00];  // ref.null 0  -> (ref null 0)
+
+// name -> { sig: (refTypeBytes) -> typeEntry, body }
+const cases = {
+    // (block (param T) (result i64) (struct.get 0 0))
+    "block param": {
+        sig: sigParam,
+        body: [0x00, ...REF_NULL_TYPE0, 0x02, 0x01, ...GET, 0x0B, 0x0B],
+    },
+    // (if (param T) (result i64) (then struct.get 0 0) (else drop i64.const 0))
+    "if param": {
+        sig: sigParam,
+        body: [0x00, ...REF_NULL_TYPE0, 0x41, 0x01, 0x04, 0x01, ...GET, 0x05, 0x1A, 0x42, 0x00, 0x0B, 0x0B],
+    },
+    // (try (param T) (result i64) (do struct.get 0 0) (catch_all i64.const 0))
+    "try param": {
+        sig: sigParam,
+        body: [0x00, ...REF_NULL_TYPE0, 0x06, 0x01, ...GET, 0x19, 0x42, 0x00, 0x0B, 0x0B],
+    },
+    // (try_table (param T) (result i64) (struct.get 0 0))   -- 0 catch clauses
+    "try_table param": {
+        sig: sigParam,
+        body: [0x00, ...REF_NULL_TYPE0, 0x1F, 0x01, 0x00, ...GET, 0x0B, 0x0B],
+    },
+};
+
+for (const [name, { sig, body }] of Object.entries(cases)) {
+    assert.falsy(WebAssembly.validate(buildModule(sig(ANYREF), body)),
+        `${name}: struct.get on a widened anyref must be rejected (declared type not the concrete incoming type)`);
+    assert.truthy(WebAssembly.validate(buildModule(sig(REF_NULL_0), body)),
+        `${name}: struct.get on the concrete (ref null 0) must validate`);
+}

--- a/JSTests/wasm/stress/delegate-widens-result-type-to-signature.js
+++ b/JSTests/wasm/stress/delegate-widens-result-type-to-signature.js
@@ -1,0 +1,74 @@
+import * as assert from "../assert.js";
+
+function uleb128(n) { const r = []; do { let b = n & 0x7f; n >>>= 7; if (n) b |= 0x80; r.push(b); } while (n); return r; }
+function encodeString(s) { const b = []; for (let i = 0; i < s.length; i++) b.push(s.charCodeAt(i)); return [...uleb128(b.length), ...b]; }
+function section(id, content) { return [id, ...uleb128(content.length), ...content]; }
+
+function buildModule() {
+    const typeSection = section(1, [
+        3,
+        0x5F, 0x01, 0x7E, 0x01,                         // type 0: struct { i64 mut }
+        0x60, 0x03, 0x7F, 0x6F, 0x64, 0x00, 0x01, 0x7E, // type 1: func (i32, externref, (ref 0)) -> i64
+        0x60, 0x00, 0x01, 0x64, 0x00,                   // type 2: func () -> (ref 0)
+    ]);
+    const funcSection = section(3, [0x02, 0x01, 0x02]);
+    const exportSection = section(7, [0x02,
+        ...encodeString("test"), 0x00, 0x00,
+        ...encodeString("make"), 0x00, 0x01]);
+
+    // (func $test (param $cond i32) (param $ext externref) (param $s (ref 0)) (result i64)
+    //   try (result i64)                 ;; outer: delegate target
+    //     try (result anyref)            ;; inner
+    //       local.get $ext
+    //       any.convert_extern           ;; -> anyref (NaN-boxed JS number)
+    //       local.get $cond
+    //       br_if 0                      ;; carry the anyref to the inner continuation
+    //       drop
+    //       local.get $s                 ;; fallthrough: (ref 0), a subtype of anyref
+    //     delegate 0                     ;; terminates inner try; result MUST widen to anyref
+    //     ref.cast (ref 0)               ;; must NOT elide IsCell / IsWasmGCObject checks
+    //     struct.get 0 0
+    //   catch_all
+    //     i64.const 0
+    //   end)
+    const body0 = [
+        0x00,
+        0x06, 0x7E,             // try (result i64)
+          0x06, 0x6E,           //   try (result anyref)
+            0x20, 0x01,         //     local.get 1
+            0xFB, 0x1A,         //     any.convert_extern
+            0x20, 0x00,         //     local.get 0
+            0x0D, 0x00,         //     br_if 0
+            0x1A,               //     drop
+            0x20, 0x02,         //     local.get 2
+          0x18, 0x00,           //   delegate 0
+          0xFB, 0x16, 0x00,     //   ref.cast (ref 0)
+          0xFB, 0x02, 0x00, 0x00, // struct.get 0 0
+        0x19,                   // catch_all
+          0x42, 0x00,           //   i64.const 0
+        0x0B,                   // end (outer try)
+        0x0B,                   // end (func)
+    ];
+    // (func $make (result (ref 0)) i64.const 0x1234 struct.new 0)
+    const body1 = [0x00, 0x42, 0xB4, 0x24, 0xFB, 0x00, 0x00, 0x0B];
+    const codeSection = section(10, [0x02,
+        ...uleb128(body0.length), ...body0,
+        ...uleb128(body1.length), ...body1]);
+    return new Uint8Array([0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+        ...typeSection, ...funcSection, ...exportSection, ...codeSection]);
+}
+
+const bytes = buildModule();
+assert.truthy(WebAssembly.validate(bytes));
+const instance = new WebAssembly.Instance(new WebAssembly.Module(bytes));
+const struct = instance.exports.make();
+
+for (let i = 0; i < wasmTestLoopCount; ++i) {
+    // cond == 0: br_if not taken; the try body's (ref 0) fallthrough survives the
+    // delegate. Widened to anyref, ref.cast succeeds and struct.get reads the field.
+    assert.eq(instance.exports.test(0, null, struct), 0x1234n);
+    // cond == 1: br_if delivers an anyref-wrapped JS number to the inner continuation.
+    // The post-delegate value is statically anyref, so ref.cast must perform the full
+    // runtime check and trap rather than dereference the non-cell value.
+    assert.throws(() => instance.exports.test(1, 1.5, struct), WebAssembly.RuntimeError, "ref.cast failed to cast reference to target heap type");
+}

--- a/JSTests/wasm/stress/loop-param-type-widening.js
+++ b/JSTests/wasm/stress/loop-param-type-widening.js
@@ -1,0 +1,138 @@
+function uleb128(n) {
+    const r = [];
+    do {
+        let b = n & 0x7f;
+        n >>>= 7;
+        if (n) b |= 0x80;
+        r.push(b);
+    } while (n);
+    return r;
+}
+function encodeString(s) {
+    const b = [];
+    for (let i = 0; i < s.length; i++) b.push(s.charCodeAt(i));
+    return [...uleb128(b.length), ...b];
+}
+function section(id, content) { return [id, ...uleb128(content.length), ...content]; }
+
+// --- Part 1 ---------------------------------------------------------------
+// A loop declaring `(param anyref)` entered with a `(ref $0)` on the stack must
+// typecheck its body against `anyref`, so `struct.get 0 0` at the top of the body
+// is a validation error. Previously the body was typechecked against the narrower
+// `(ref $0)` and the module was (unsoundly) accepted.
+{
+    // Type 0: struct { i64 mut }
+    // Type 1: func (anyref) -> (i64)           — loop block signature
+    // Type 2: func (i32, externref, ref 0) -> (i64)
+    // Type 3: func () -> (ref 0)
+    const typeSection = section(1, [
+        0x04,
+        0x5F, 0x01, 0x7E, 0x01,
+        0x60, 0x01, 0x6E, 0x01, 0x7E,
+        0x60, 0x03, 0x7F, 0x6F, 0x64, 0x00, 0x01, 0x7E,
+        0x60, 0x00, 0x01, 0x64, 0x00,
+    ]);
+    const funcSection = section(3, [0x02, 0x02, 0x03]);
+    const exportSection = section(7, [
+        0x02,
+        ...encodeString("f"), 0x00, 0x00,
+        ...encodeString("make"), 0x00, 0x01,
+    ]);
+    const body0 = [
+        0x01, 0x01, 0x7E,       // 1 local: i64
+        0x20, 0x02,             // local.get 2 (ref $0)
+        0x03, 0x01,             // loop (type 1)  — param anyref
+        0xFB, 0x02, 0x00, 0x00, //   struct.get 0 0    <-- must fail: anyref !<: (ref null $0)
+        0x21, 0x03,             //   local.set 3
+        0x20, 0x01,             //   local.get 1 (externref)
+        0xFB, 0x1A,             //   any.convert_extern
+        0x20, 0x00,             //   local.get 0
+        0x0D, 0x00,             //   br_if 0
+        0x1A,                   //   drop
+        0x20, 0x03,             //   local.get 3
+        0x0B,                   // end loop
+        0x0B,                   // end func
+    ];
+    const body1 = [0x00, 0x42, 0x00, 0xFB, 0x00, 0x00, 0x0B]; // i64.const 0; struct.new 0
+    const codeSection = section(10, [
+        0x02,
+        ...uleb128(body0.length), ...body0,
+        ...uleb128(body1.length), ...body1,
+    ]);
+    const bin = new Uint8Array([
+        0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+        ...typeSection, ...funcSection, ...exportSection, ...codeSection,
+    ]);
+
+    if (WebAssembly.validate(bin))
+        throw new Error("Part 1: module with struct.get on anyref loop param must not validate");
+}
+
+// --- Part 2 ---------------------------------------------------------------
+// A loop declaring `(param (ref null $0))` entered with a non-null `(ref $0)` is
+// valid, but the body must be compiled against the nullable type: struct.get must
+// emit its null check so a null delivered on the back-edge traps cleanly.
+{
+    // Type 0: struct { i64 mut }
+    // Type 1: func (ref null 0) -> (i64)       — loop block signature
+    // Type 2: func (i32, ref 0) -> (i64)
+    // Type 3: func () -> (ref 0)
+    const typeSection = section(1, [
+        0x04,
+        0x5F, 0x01, 0x7E, 0x01,
+        0x60, 0x01, 0x63, 0x00, 0x01, 0x7E,
+        0x60, 0x02, 0x7F, 0x64, 0x00, 0x01, 0x7E,
+        0x60, 0x00, 0x01, 0x64, 0x00,
+    ]);
+    const funcSection = section(3, [0x02, 0x02, 0x03]);
+    const exportSection = section(7, [
+        0x02,
+        ...encodeString("f"), 0x00, 0x00,
+        ...encodeString("make"), 0x00, 0x01,
+    ]);
+    const body0 = [
+        0x01, 0x01, 0x7E,       // 1 local: i64
+        0x20, 0x01,             // local.get 1 (ref $0, non-null)
+        0x03, 0x01,             // loop (type 1)  — param (ref null $0)
+        0xFB, 0x02, 0x00, 0x00, //   struct.get 0 0    <-- must keep null check
+        0x21, 0x02,             //   local.set 2
+        0xD0, 0x71,             //   ref.null none
+        0x20, 0x00,             //   local.get 0
+        0x0D, 0x00,             //   br_if 0        <-- back-edge with null
+        0x1A,                   //   drop
+        0x20, 0x02,             //   local.get 2
+        0x0B,                   // end loop
+        0x0B,                   // end func
+    ];
+    const body1 = [0x00, 0x42, 0x2A, 0xFB, 0x00, 0x00, 0x0B]; // i64.const 42; struct.new 0
+    const codeSection = section(10, [
+        0x02,
+        ...uleb128(body0.length), ...body0,
+        ...uleb128(body1.length), ...body1,
+    ]);
+    const bin = new Uint8Array([
+        0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+        ...typeSection, ...funcSection, ...exportSection, ...codeSection,
+    ]);
+
+    if (!WebAssembly.validate(bin))
+        throw new Error("Part 2: module must validate");
+    const inst = new WebAssembly.Instance(new WebAssembly.Module(bin));
+    const s = inst.exports.make();
+
+    for (let i = 0; i < wasmTestLoopCount; i++) {
+        if (inst.exports.f(0, s) !== 42n)
+            throw new Error("Part 2: expected 42");
+    }
+
+    let trapped = false;
+    try {
+        inst.exports.f(1, s);
+    } catch (e) {
+        if (!(e instanceof WebAssembly.RuntimeError))
+            throw new Error("Part 2: expected WebAssembly.RuntimeError, got " + e);
+        trapped = true;
+    }
+    if (!trapped)
+        throw new Error("Part 2: expected null-dereference trap on back-edge");
+}

--- a/JSTests/wasm/stress/tail-call-unused-pins.js
+++ b/JSTests/wasm/stress/tail-call-unused-pins.js
@@ -1,0 +1,50 @@
+//@ requireOptions("--useWasmFastMemory=true")
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+const watA = `
+(module
+    (type $sig (func (param i32 i64)))
+    (import "e" "mem" (memory 1 1))
+    (import "e" "nop" (func $nop))
+    (table (export "tbl") 1 1 funcref)
+    (func (export "f") (param $do_call i32) (param $off i32) (param $val i64)
+        (call $nop)
+        (if (local.get $do_call)
+            (then (return_call_indirect (type $sig)
+                    (local.get $off) (local.get $val) (i32.const 0))))))
+`;
+
+const watB = `
+(module
+    (import "e" "mem" (memory 1 1))
+    (func (export "g") (param $off i32) (param $val i64)
+        (i64.store (local.get $off) (local.get $val))))
+`;
+
+async function test() {
+    const memA = createWebAssemblyMemoryWithMode({ initial: 1, maximum: 1 }, "Signaling");
+    const memB = createWebAssemblyMemoryWithMode({ initial: 1, maximum: 1 }, "BoundsChecking");
+    assert.eq(WebAssemblyMemoryMode(memA), "Signaling");
+    assert.eq(WebAssemblyMemoryMode(memB), "BoundsChecking");
+
+    const instA = await instantiate(watA, { e: { mem: memA, nop: () => {} } }, { tail_call: true });
+    const { f, tbl } = instA.exports;
+
+    const instB = await instantiate(watB, { e: { mem: memB } });
+    const { g } = instB.exports;
+
+    assert.throws(() => g(0x20000, 0n), WebAssembly.RuntimeError, "Out of bounds memory access");
+
+    // Tier g into BBQ. IPInt's prologue reloads regCS4 on entry but BBQ does not.
+    for (let i = 0; i < wasmTestLoopCount; ++i) g(0, 0n);
+
+    // Tier f to OMG without ever taking the tail-call branch.
+    for (let i = 0; i < wasmTestLoopCount; ++i) f(0, 0, 0n);
+
+    tbl.set(0, g);
+
+    assert.throws(() => f(1, 0x20000, 0n), WebAssembly.RuntimeError, "Out of bounds memory access");
+}
+
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/unreachable-end-if-no-else-widens-to-signature.js
+++ b/JSTests/wasm/stress/unreachable-end-if-no-else-widens-to-signature.js
@@ -1,0 +1,75 @@
+// rdar://180535979
+// The unreachable End handler synthesizes an else for `if`-without-`else` and
+// installs the saved if-param stack as the (reachable) else-arm result. Those
+// values must be widened to the block's declared result types before they
+// propagate to the parent stack: an unreachable then-arm may have `br 0`'d a
+// value that only inhabits the wider result type. Without widening, BBQ's
+// emitRefTestOrCast trusts the stale narrow type and elides the IsCell /
+// IsWasmGCObject runtime checks.
+
+import * as assert from "../assert.js";
+
+function uleb128(n) { const r = []; do { let b = n & 0x7f; n >>>= 7; if (n) b |= 0x80; r.push(b); } while (n); return r; }
+function encodeString(s) { const b = []; for (let i = 0; i < s.length; i++) b.push(s.charCodeAt(i)); return [...uleb128(b.length), ...b]; }
+function section(id, content) { return [id, ...uleb128(content.length), ...content]; }
+
+function buildModule() {
+    const typeSection = section(1, [
+        4,
+        0x5F, 0x01, 0x7E, 0x01,                         // type 0: struct { i64 mut }
+        0x60, 0x01, 0x64, 0x00, 0x01, 0x6E,             // type 1: func (param (ref 0)) (result anyref)
+        0x60, 0x03, 0x7F, 0x6F, 0x64, 0x00, 0x01, 0x7E, // type 2: func (i32, externref, (ref 0)) -> i64
+        0x60, 0x00, 0x01, 0x64, 0x00,                   // type 3: func () -> (ref 0)
+    ]);
+    const funcSection = section(3, [0x02, 0x02, 0x03]);
+    const exportSection = section(7, [0x02,
+        ...encodeString("test"), 0x00, 0x00,
+        ...encodeString("make"), 0x00, 0x01]);
+
+    // (func $test (param $cond i32) (param $ext externref) (param $s (ref 0)) (result i64)
+    //   local.get $s
+    //   local.get $cond
+    //   if (param (ref 0)) (result anyref)
+    //     drop
+    //     local.get $ext
+    //     any.convert_extern
+    //     br 0                  ;; then-arm goes unreachable
+    //   end                     ;; <- parseUnreachableExpression()::End, synthetic else
+    //   ref.cast (ref 0)        ;; must NOT elide IsCell / IsWasmGCObject checks
+    //   struct.get 0 0)
+    const body0 = [
+        0x00,
+        0x20, 0x02,
+        0x20, 0x00,
+        0x04, 0x01,
+        0x1A,
+        0x20, 0x01,
+        0xFB, 0x1A,
+        0x0C, 0x00,
+        0x0B,
+        0xFB, 0x16, 0x00,
+        0xFB, 0x02, 0x00, 0x00,
+        0x0B,
+    ];
+    // (func $make (result (ref 0)) i64.const 0x1234 struct.new 0)
+    const body1 = [0x00, 0x42, 0xB4, 0x24, 0xFB, 0x00, 0x00, 0x0B];
+    const codeSection = section(10, [0x02,
+        ...uleb128(body0.length), ...body0,
+        ...uleb128(body1.length), ...body1]);
+    return new Uint8Array([0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+        ...typeSection, ...funcSection, ...exportSection, ...codeSection]);
+}
+
+const bytes = buildModule();
+assert.truthy(WebAssembly.validate(bytes));
+const instance = new WebAssembly.Instance(new WebAssembly.Module(bytes));
+const struct = instance.exports.make();
+
+for (let i = 0; i < wasmTestLoopCount; ++i) {
+    // cond == 0: synthetic else delivers the (ref 0) param; ref.cast succeeds.
+    assert.eq(instance.exports.test(0, null, struct), 0x1234n);
+    // cond == 1: then-arm br's an anyref-wrapped JS number to the if's
+    // continuation. The post-end value is statically anyref, so ref.cast must
+    // perform the full runtime check and trap.
+    assert.throws(() => instance.exports.test(1, 1.5, struct), WebAssembly.RuntimeError, "ref.cast failed to cast reference to target heap type");
+}

--- a/LayoutTests/svg/animations/smil-seek-huge-repeat-count-crash-expected.txt
+++ b/LayoutTests/svg/animations/smil-seek-huge-repeat-count-crash-expected.txt
@@ -1,0 +1,3 @@
+Passes if it does not crash.
+
+

--- a/LayoutTests/svg/animations/smil-seek-huge-repeat-count-crash.html
+++ b/LayoutTests/svg/animations/smil-seek-huge-repeat-count-crash.html
@@ -1,0 +1,14 @@
+<body>
+    <p>Passes if it does not crash.</p>
+    <svg id="svg">
+        <rect width="100" height="100" fill="green">
+            <animate attributeName="x" from="0" to="10" dur="0.0001s" repeatCount="indefinite"/>
+        </rect>
+    </svg>
+    <script>
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        svg.setCurrentTime(400000);
+    </script>
+</body>

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -3567,8 +3567,13 @@ void SpeculativeJIT::setIntTypedArrayLoadResult(Node* node, JSValueRegs resultRe
 
     if (shouldBox) {
         if (isUInt32) {
-            convertUInt32ToDouble(resultReg, resultFPR);
-            boxDouble(resultFPR, resultRegs);
+            if (node->shouldSpeculateInt32() && canSpeculate) {
+                speculationCheck(ExitKind::Overflow, JSValueRegs(), nullptr, branch32(LessThan, resultReg, TrustedImm32(0)));
+                boxInt32(resultReg, resultRegs);
+            } else {
+                convertUInt32ToDouble(resultReg, resultFPR);
+                boxDouble(resultFPR, resultRegs);
+            }
         } else
             boxInt32(resultRegs.payloadGPR(), resultRegs);
         if (outOfBounds.isSet())

--- a/Source/JavaScriptCore/runtime/RegExpMatchesArray.h
+++ b/Source/JavaScriptCore/runtime/RegExpMatchesArray.h
@@ -112,6 +112,7 @@ ALWAYS_INLINE JSArray* createRegExpMatchesArray(VM& vm, JSGlobalObject* globalOb
 
     result.start = position;
     result.end = subpatternResults[1];
+    RELEASE_ASSERT(result.end >= result.start);
 
     unsigned numSubpatterns = regExp->numSubpatterns();
     bool hasNamedCaptures = regExp->hasNamedCaptures();

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -247,7 +247,13 @@ private:
     [[nodiscard]] PartialResult parseUnreachableExpression();
     [[nodiscard]] PartialResult unifyControl(ArgumentList&, unsigned level);
     [[nodiscard]] PartialResult checkLocalInitialized(uint32_t);
-    [[nodiscard]] PartialResult checkExpressionStack(const ControlType&, bool forceSignature = false);
+
+    enum FallThroughStateTag {
+        NewSiblingBlock,
+        MergePoint,
+    };
+
+    [[nodiscard]] PartialResult checkBlockFallthrough(const ControlType&, FallThroughStateTag);
 
     enum BranchConditionalityTag {
         Unconditional,
@@ -1932,7 +1938,7 @@ auto FunctionParser<Context>::checkLocalInitialized(uint32_t index) -> PartialRe
 }
 
 template<typename Context>
-auto FunctionParser<Context>::checkExpressionStack(const ControlType& controlData, bool forceSignature) -> PartialResult
+auto FunctionParser<Context>::checkBlockFallthrough(const ControlType& controlData, FallThroughStateTag fallthrough) -> PartialResult
 {
     const auto& blockSignature = controlData.signature();
     const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
@@ -1941,7 +1947,11 @@ auto FunctionParser<Context>::checkExpressionStack(const ControlType& controlDat
         const auto actualType = m_expressionStack[m_currentStackBegin + i].type();
         const auto expectedType = blockSignature.returnType(i);
         WASM_VALIDATOR_FAIL_IF(!isSubtype(actualType, expectedType), "control flow returns with unexpected type. "_s, actualType, " is not a "_s, expectedType);
-        if (forceSignature)
+        // The spec requires the output type of a structured control instruction to be
+        // the result type from its signature, even when the fallthrough value is a subtype.
+        // FIXME: We should support some sort of abstract interpretation so this can be the
+        // least upper bound of the merging CFG.
+        if (fallthrough == MergePoint)
             m_expressionStack[m_currentStackBegin + i].setType(expectedType);
     }
 
@@ -2081,21 +2091,21 @@ template<typename Context>
 auto FunctionParser<Context>::parseExpression() -> PartialResult
 {
     switch (m_currentOpcode) {
-#define CREATE_CASE(name, id, b3op, inc, lhsType, rhsType, returnType) case OpType::name: return binaryCase(OpType::name, &Context::add##name, Types::returnType, Types::lhsType, Types::rhsType);
+    #define CREATE_CASE(name, id, b3op, inc, lhsType, rhsType, returnType) case OpType::name: return binaryCase(OpType::name, &Context::add##name, Types::returnType, Types::lhsType, Types::rhsType);
         FOR_EACH_WASM_NON_COMPARE_BINARY_OP(CREATE_CASE)
-#undef CREATE_CASE
+    #undef CREATE_CASE
 
-#define CREATE_CASE(name, id, b3op, inc, lhsType, rhsType, returnType) case OpType::name: return binaryCompareCase(OpType::name, &Context::add##name, Types::returnType, Types::lhsType, Types::rhsType);
+    #define CREATE_CASE(name, id, b3op, inc, lhsType, rhsType, returnType) case OpType::name: return binaryCompareCase(OpType::name, &Context::add##name, Types::returnType, Types::lhsType, Types::rhsType);
         FOR_EACH_WASM_COMPARE_BINARY_OP(CREATE_CASE)
-#undef CREATE_CASE
+    #undef CREATE_CASE
 
-#define CREATE_CASE(name, id, b3op, inc, operandType, returnType) case OpType::name: return unaryCase(OpType::name, &Context::add##name, Types::returnType, Types::operandType);
+    #define CREATE_CASE(name, id, b3op, inc, operandType, returnType) case OpType::name: return unaryCase(OpType::name, &Context::add##name, Types::returnType, Types::operandType);
         FOR_EACH_WASM_NON_COMPARE_UNARY_OP(CREATE_CASE)
-#undef CREATE_CASE
+    #undef CREATE_CASE
 
-#define CREATE_CASE(name, id, b3op, inc, operandType, returnType) case OpType::name: return unaryCompareCase(OpType::name, &Context::add##name, Types::returnType, Types::operandType);
+    #define CREATE_CASE(name, id, b3op, inc, operandType, returnType) case OpType::name: return unaryCompareCase(OpType::name, &Context::add##name, Types::returnType, Types::operandType);
         FOR_EACH_WASM_COMPARE_UNARY_OP(CREATE_CASE)
-#undef CREATE_CASE
+    #undef CREATE_CASE
 
     case Select: {
         TypedExpression condition;
@@ -2141,13 +2151,13 @@ auto FunctionParser<Context>::parseExpression() -> PartialResult
         return { };
     }
 
-#define CREATE_CASE(name, id, b3op, inc, memoryType) case OpType::name: return load(Types::memoryType);
-FOR_EACH_WASM_MEMORY_LOAD_OP(CREATE_CASE)
-#undef CREATE_CASE
+    #define CREATE_CASE(name, id, b3op, inc, memoryType) case OpType::name: return load(Types::memoryType);
+    FOR_EACH_WASM_MEMORY_LOAD_OP(CREATE_CASE)
+    #undef CREATE_CASE
 
-#define CREATE_CASE(name, id, b3op, inc, memoryType) case OpType::name: return store(Types::memoryType);
-FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
-#undef CREATE_CASE
+    #define CREATE_CASE(name, id, b3op, inc, memoryType) case OpType::name: return store(Types::memoryType);
+    FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
+    #undef CREATE_CASE
 
     case F32Const: {
         uint32_t constant;
@@ -2414,9 +2424,9 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             break;
         }
 
-#define CREATE_CASE(name, id, b3op, inc, operandType, returnType) case Ext1OpType::name: return truncSaturated(op, Types::returnType, Types::operandType);
+    #define CREATE_CASE(name, id, b3op, inc, operandType, returnType) case Ext1OpType::name: return truncSaturated(op, Types::returnType, Types::operandType);
         FOR_EACH_WASM_TRUNC_SATURATED_OP(CREATE_CASE)
-#undef CREATE_CASE
+    #undef CREATE_CASE
 
         case Ext1OpType::I64Add128:
         case Ext1OpType::I64Sub128: {
@@ -3085,21 +3095,21 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         m_context.willParseExtendedOpcode();
 
         ExtAtomicOpType op = static_cast<ExtAtomicOpType>(m_currentExtOp);
-#if ENABLE(WEBASSEMBLY_OMGJIT)
+    #if ENABLE(WEBASSEMBLY_OMGJIT)
         if (Options::dumpWasmOpcodeStatistics()) [[unlikely]]
             WasmOpcodeCounter::singleton().increment(op);
-#endif
+    #endif
 
         switch (op) {
-#define CREATE_CASE(name, id, b3op, inc, memoryType) case ExtAtomicOpType::name: return atomicLoad(op, Types::memoryType);
+    #define CREATE_CASE(name, id, b3op, inc, memoryType) case ExtAtomicOpType::name: return atomicLoad(op, Types::memoryType);
         FOR_EACH_WASM_EXT_ATOMIC_LOAD_OP(CREATE_CASE)
-#undef CREATE_CASE
-#define CREATE_CASE(name, id, b3op, inc, memoryType) case ExtAtomicOpType::name: return atomicStore(op, Types::memoryType);
+    #undef CREATE_CASE
+    #define CREATE_CASE(name, id, b3op, inc, memoryType) case ExtAtomicOpType::name: return atomicStore(op, Types::memoryType);
         FOR_EACH_WASM_EXT_ATOMIC_STORE_OP(CREATE_CASE)
-#undef CREATE_CASE
-#define CREATE_CASE(name, id, b3op, inc, memoryType) case ExtAtomicOpType::name: return atomicBinaryRMW(op, Types::memoryType);
+    #undef CREATE_CASE
+    #define CREATE_CASE(name, id, b3op, inc, memoryType) case ExtAtomicOpType::name: return atomicBinaryRMW(op, Types::memoryType);
         FOR_EACH_WASM_EXT_ATOMIC_BINARY_RMW_OP(CREATE_CASE)
-#undef CREATE_CASE
+    #undef CREATE_CASE
         case ExtAtomicOpType::MemoryAtomicWait64:
             return atomicWait(op, Types::I64);
         case ExtAtomicOpType::MemoryAtomicWait32:
@@ -3577,7 +3587,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         ControlEntry& controlEntry = m_controlStack.last();
 
         WASM_VALIDATOR_FAIL_IF(!ControlType::isIf(controlEntry.controlData), "else block isn't associated to an if");
-        WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(controlEntry.controlData));
+        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
         auto ifBranchResults = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
         WASM_TRY_ADD_TO_CONTEXT(addElse(controlEntry.controlData, ifBranchResults));
         m_expressionStack.shrink(m_currentStackBegin);
@@ -3618,7 +3628,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         ControlEntry& controlEntry = m_controlStack.last();
         WASM_VALIDATOR_FAIL_IF(!isTryOrCatch(controlEntry.controlData), "catch block isn't associated to a try");
-        WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(controlEntry.controlData));
+        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
 
         ResultList results;
         auto preCatchStack = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
@@ -3644,7 +3654,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         ControlEntry& controlEntry = m_controlStack.last();
 
         WASM_VALIDATOR_FAIL_IF(!isTryOrCatch(controlEntry.controlData), "catch block isn't associated to a try");
-        WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(controlEntry.controlData));
+        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
 
         auto preCatchStack = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
         WASM_TRY_ADD_TO_CONTEXT(addCatchAll(preCatchStack, controlEntry.controlData));
@@ -3752,7 +3762,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_VALIDATOR_FAIL_IF(!ControlType::isTry(targetData) && !ControlType::isTopLevel(targetData), "delegate target isn't a try or the top level block");
 
         WASM_TRY_ADD_TO_CONTEXT(addDelegate(targetData, controlEntry.controlData));
-        WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(controlEntry.controlData));
+        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
 
         const uint32_t parentBegin = parentEntryBegin();
         auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
@@ -3887,20 +3897,16 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     case End: {
         ControlEntry data = m_controlStack.takeLast();
         if (ControlType::isIf(data.controlData)) {
-            WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(data.controlData));
+            WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(data.controlData, NewSiblingBlock));
             auto ifBranchResults = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
             WASM_TRY_ADD_TO_CONTEXT(addElse(data.controlData, ifBranchResults));
             m_expressionStack.shrink(m_currentStackBegin);
             m_expressionStack.append(data.elseBlockStack.span());
         }
-
         // FIXME: endBlock may modify the expressionStack slice for the result of the block.
         // That's a little too effectful but we don't have a better API right now.
         // see: https://bugs.webkit.org/show_bug.cgi?id=164353
-
-        // The spec requires the output type of a structured control instruction to be
-        // the result type from its signature, even when the fallthrough value is a subtype.
-        WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(data.controlData, true));
+        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(data.controlData, MergePoint));
 
         const uint32_t parentBegin = parentEntryBegin();
         auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
@@ -3964,19 +3970,19 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         return { };
     }
-#if ENABLE(B3_JIT)
+    #if ENABLE(B3_JIT)
         case ExtSIMD: {
             WASM_PARSER_FAIL_IF(!Options::useWasmSIMD(), "wasm-simd is not enabled"_s);
             m_context.notifyFunctionUsesSIMD();
             WASM_PARSER_FAIL_IF(!parseVarUInt32(m_currentExtOp), "can't parse wasm extended opcode"_s);
             m_context.willParseExtendedOpcode();
-    
+
             constexpr bool isReachable = true;
-    
+
             ExtSIMDOpType op = static_cast<ExtSIMDOpType>(m_currentExtOp);
             if (Options::dumpWasmOpcodeStatistics()) [[unlikely]]
                 WasmOpcodeCounter::singleton().increment(op);
-    
+
             switch (op) {
             #define CREATE_SIMD_CASE(name, _, laneOp, lane, signMode) case ExtSIMDOpType::name: return simd<isReachable>(SIMDLaneOperation::laneOp, lane, signMode);
             FOR_EACH_WASM_EXT_SIMD_GENERAL_OP(CREATE_SIMD_CASE)
@@ -4102,7 +4108,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
                 WASM_TRY_ADD_TO_CONTEXT(addElseToUnreachable(data.controlData));
                 m_expressionStack.shrink(m_currentStackBegin);
                 m_expressionStack.append(data.elseBlockStack.span());
-                WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(data.controlData));
+                WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(data.controlData, MergePoint));
 
                 // Reachable End handling: the combined enclosedStack now lives in
                 // m_expressionStack[parentBegin..end].

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -247,13 +247,8 @@ private:
     [[nodiscard]] PartialResult parseUnreachableExpression();
     [[nodiscard]] PartialResult unifyControl(ArgumentList&, unsigned level);
     [[nodiscard]] PartialResult checkLocalInitialized(uint32_t);
-
-    enum FallThroughStateTag {
-        NewSiblingBlock,
-        MergePoint,
-    };
-
-    [[nodiscard]] PartialResult checkBlockFallthrough(const ControlType&, FallThroughStateTag);
+    [[nodiscard]] PartialResult checkArgumentsAndWiden(const BlockSignature&);
+    [[nodiscard]] PartialResult checkResultsAndWiden(const BlockSignature&);
     [[nodiscard]] PartialResult endBlockAndCheckResultTypes(ControlEntry&);
 
     enum BranchConditionalityTag {
@@ -657,12 +652,9 @@ auto FunctionParser<Context>::binaryCompareCase(OpType op, BinaryOperationHandle
             BlockSignature inlineSignature;
             WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get if's signature"_s);
 
-            const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
             const uint32_t argumentCount = inlineSignature.argumentCount();
-            WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few arguments on stack for if block. If expects ", argumentCount, ", but only ", sliceSize, " were present. If block has signature: ", inlineSignature);
+            WASM_FAIL_IF_HELPER_FAILS(checkArgumentsAndWiden(inlineSignature));
             const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
-            for (unsigned i = 0; i < argumentCount; ++i)
-                WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[parentStackHeight + i].type(), inlineSignature.argumentType(i)), "Loop expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", m_expressionStack[parentStackHeight + i].type());
 
             auto args = m_expressionStack.mutableSpan().last(argumentCount);
             ControlType control;
@@ -727,12 +719,9 @@ auto FunctionParser<Context>::unaryCompareCase(OpType op, UnaryOperationHandler 
             BlockSignature inlineSignature;
             WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get if's signature"_s);
 
-            const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
             const uint32_t argumentCount = inlineSignature.argumentCount();
-            WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few arguments on stack for if block. If expects ", argumentCount, ", but only ", sliceSize, " were present. If block has signature: ", inlineSignature);
+            WASM_FAIL_IF_HELPER_FAILS(checkArgumentsAndWiden(inlineSignature));
             const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
-            for (unsigned i = 0; i < argumentCount; ++i)
-                WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[parentStackHeight + i].type(), inlineSignature.argumentType(i)), "Loop expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", m_expressionStack[parentStackHeight + i].type());
 
             auto args = m_expressionStack.mutableSpan().last(argumentCount);
             ControlType control;
@@ -1939,21 +1928,40 @@ auto FunctionParser<Context>::checkLocalInitialized(uint32_t index) -> PartialRe
 }
 
 template<typename Context>
-auto FunctionParser<Context>::checkBlockFallthrough(const ControlType& controlData, FallThroughStateTag fallthrough) -> PartialResult
+auto FunctionParser<Context>::checkArgumentsAndWiden(const BlockSignature& blockSignature) -> PartialResult
 {
-    const auto& blockSignature = controlData.signature();
+    const uint32_t argumentCount = blockSignature.argumentCount();
+    const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
+    WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few values on stack for block. Block expects "_s, argumentCount, ", but only "_s, sliceSize, " were present. Block has signature: "_s, blockSignature);
+    const uint32_t offset = m_expressionStack.size() - argumentCount;
+    for (unsigned i = 0; i < argumentCount; ++i) {
+        auto& slot = m_expressionStack[offset + i];
+        const auto expectedType = blockSignature.argumentType(i);
+        WASM_VALIDATOR_FAIL_IF(!isSubtype(slot.type(), expectedType), "Block expects the argument at index "_s, i, " to be "_s, expectedType, " but argument has type "_s, slot.type());
+        // Widen the operand to the block's declared parameter type, per the spec's
+        // push_ctrl(op, in, out) doing push_vals(in): the block body must be validated
+        // against its declared parameter types, not the narrower subtype that flowed in.
+        // https://webassembly.github.io/spec/core/bikeshed/#validation-of-opcode-sequences
+        slot.setType(expectedType);
+    }
+
+    return { };
+}
+
+template<typename Context>
+auto FunctionParser<Context>::checkResultsAndWiden(const BlockSignature& blockSignature) -> PartialResult
+{
     const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
     WASM_VALIDATOR_FAIL_IF(blockSignature.returnCount() != sliceSize, " block with type: "_s, blockSignature, " returns: "_s, blockSignature.returnCount(), " but stack has: "_s, sliceSize, " values"_s);
     for (unsigned i = 0; i < blockSignature.returnCount(); ++i) {
-        const auto actualType = m_expressionStack[m_currentStackBegin + i].type();
+        auto& slot = m_expressionStack[m_currentStackBegin + i];
         const auto expectedType = blockSignature.returnType(i);
-        WASM_VALIDATOR_FAIL_IF(!isSubtype(actualType, expectedType), "control flow returns with unexpected type. "_s, actualType, " is not a "_s, expectedType);
-        // The spec requires the output type of a structured control instruction to be
-        // the result type from its signature, even when the fallthrough value is a subtype.
-        // FIXME: We should support some sort of abstract interpretation so this can be the
-        // least upper bound of the merging CFG.
-        if (fallthrough == MergePoint)
-            m_expressionStack[m_currentStackBegin + i].setType(expectedType);
+        WASM_VALIDATOR_FAIL_IF(!isSubtype(slot.type(), expectedType), "control flow returns with unexpected type. "_s, slot.type(), " is not a "_s, expectedType);
+        // Widen the operand to the block's declared result type, per the spec's
+        // end doing push_vals(frame.end_types): results leave the block as the
+        // declared type, not the narrower subtype that reached the end.
+        // https://webassembly.github.io/spec/core/bikeshed/#validation-of-opcode-sequences
+        slot.setType(expectedType);
     }
 
     return { };
@@ -1965,7 +1973,7 @@ auto FunctionParser<Context>::endBlockAndCheckResultTypes(ControlEntry& entry) -
     // Widen each result to the block signature type before ending the block.
     // FIXME: mutating the expression stack for the block result is effectful, but there's no
     // better API yet. See https://bugs.webkit.org/show_bug.cgi?id=164353
-    WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(entry.controlData, MergePoint));
+    WASM_FAIL_IF_HELPER_FAILS(checkResultsAndWiden(entry.controlData.signature()));
     const uint32_t parentBegin = parentEntryBegin();
     auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
     // We should avoid adding other callsites of endBlock. Since a new block is a sign of a
@@ -3529,15 +3537,8 @@ auto FunctionParser<Context>::parseExpression() -> PartialResult
         BlockSignature inlineSignature;
         WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get block's signature"_s);
 
-        const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
         const uint32_t argumentCount = inlineSignature.argumentCount();
-
-        WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few values on stack for block. Block expects ", argumentCount, ", but only ", sliceSize, " were present. Block has inlineSignature: ", inlineSignature);
-        const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
-        for (unsigned i = 0; i < argumentCount; ++i) {
-            Type type = m_expressionStack[parentStackHeight + i].type();
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(type, inlineSignature.argumentType(i)), "Block expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", type);
-        }
+        WASM_FAIL_IF_HELPER_FAILS(checkArgumentsAndWiden(inlineSignature));
 
         auto args = m_expressionStack.mutableSpan().last(argumentCount);
         ControlType block;
@@ -3550,15 +3551,9 @@ auto FunctionParser<Context>::parseExpression() -> PartialResult
         BlockSignature inlineSignature;
         WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get loop's signature"_s);
 
-        const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
         const uint32_t argumentCount = inlineSignature.argumentCount();
-
-        WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few values on stack for loop block. Loop expects ", argumentCount, ", but only ", sliceSize, " were present. Loop has inlineSignature: ", inlineSignature);
+        WASM_FAIL_IF_HELPER_FAILS(checkArgumentsAndWiden(inlineSignature));
         const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
-        for (unsigned i = 0; i < argumentCount; ++i) {
-            Type type = m_expressionStack[parentStackHeight + i].type();
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(type, inlineSignature.argumentType(i)), "Loop expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", type);
-        }
 
         auto args = m_expressionStack.mutableSpan().last(argumentCount);
         ControlType loop;
@@ -3577,13 +3572,9 @@ auto FunctionParser<Context>::parseExpression() -> PartialResult
         WASM_TRY_POP_EXPRESSION_STACK_INTO(condition, "if condition"_s);
 
         WASM_VALIDATOR_FAIL_IF(!condition.type().isI32(), "if condition must be i32, got ", condition.type());
-        const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
         const uint32_t argumentCount = inlineSignature.argumentCount();
-
-        WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few arguments on stack for if block. If expects ", argumentCount, ", but only ", sliceSize, " were present. If block has signature: ", inlineSignature);
+        WASM_FAIL_IF_HELPER_FAILS(checkArgumentsAndWiden(inlineSignature));
         const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
-        for (unsigned i = 0; i < argumentCount; ++i)
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[parentStackHeight + i].type(), inlineSignature.argumentType(i)), "Loop expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", m_expressionStack[parentStackHeight + i].type());
 
         auto args = m_expressionStack.mutableSpan().last(argumentCount);
         ControlType control;
@@ -3604,7 +3595,7 @@ auto FunctionParser<Context>::parseExpression() -> PartialResult
         ControlEntry& controlEntry = m_controlStack.last();
 
         WASM_VALIDATOR_FAIL_IF(!ControlType::isIf(controlEntry.controlData), "else block isn't associated to an if");
-        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
+        WASM_FAIL_IF_HELPER_FAILS(checkResultsAndWiden(controlEntry.controlData.signature()));
         auto ifBranchResults = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
         WASM_TRY_ADD_TO_CONTEXT(addElse(controlEntry.controlData, ifBranchResults));
         m_expressionStack.shrink(m_currentStackBegin);
@@ -3618,13 +3609,9 @@ auto FunctionParser<Context>::parseExpression() -> PartialResult
         BlockSignature inlineSignature;
         WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get try's signature"_s);
 
-        const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
         const uint32_t argumentCount = inlineSignature.argumentCount();
-
-        WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few arguments on stack for try block. Try expects ", argumentCount, ", but only ", sliceSize, " were present. Try block has signature: ", inlineSignature);
+        WASM_FAIL_IF_HELPER_FAILS(checkArgumentsAndWiden(inlineSignature));
         const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
-        for (unsigned i = 0; i < argumentCount; ++i)
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(m_expressionStack[parentStackHeight + i].type(), inlineSignature.argumentType(i)), "Try expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", m_expressionStack[parentStackHeight + i].type());
 
         auto args = m_expressionStack.mutableSpan().last(argumentCount);
         ControlType control;
@@ -3645,7 +3632,7 @@ auto FunctionParser<Context>::parseExpression() -> PartialResult
 
         ControlEntry& controlEntry = m_controlStack.last();
         WASM_VALIDATOR_FAIL_IF(!isTryOrCatch(controlEntry.controlData), "catch block isn't associated to a try");
-        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
+        WASM_FAIL_IF_HELPER_FAILS(checkResultsAndWiden(controlEntry.controlData.signature()));
 
         ResultList results;
         auto preCatchStack = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
@@ -3671,7 +3658,7 @@ auto FunctionParser<Context>::parseExpression() -> PartialResult
         ControlEntry& controlEntry = m_controlStack.last();
 
         WASM_VALIDATOR_FAIL_IF(!isTryOrCatch(controlEntry.controlData), "catch block isn't associated to a try");
-        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
+        WASM_FAIL_IF_HELPER_FAILS(checkResultsAndWiden(controlEntry.controlData.signature()));
 
         auto preCatchStack = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
         WASM_TRY_ADD_TO_CONTEXT(addCatchAll(preCatchStack, controlEntry.controlData));
@@ -3687,14 +3674,8 @@ auto FunctionParser<Context>::parseExpression() -> PartialResult
         BlockSignature inlineSignature;
         WASM_PARSER_FAIL_IF(!parseBlockSignatureAndNotifySIMDUseIfNeeded(inlineSignature), "can't get try_table's signature"_s);
 
-        const uint32_t sliceSize = m_expressionStack.size() - m_currentStackBegin;
         const uint32_t argumentCount = inlineSignature.argumentCount();
-        WASM_VALIDATOR_FAIL_IF(sliceSize < argumentCount, "Too few values on stack for block. Block expects ", argumentCount, ", but only ", sliceSize, " were present. Block has inlineSignature: ", inlineSignature);
-        const uint32_t parentStackHeight = m_expressionStack.size() - argumentCount;
-        for (unsigned i = 0; i < argumentCount; ++i) {
-            Type type = m_expressionStack[parentStackHeight + i].type();
-            WASM_VALIDATOR_FAIL_IF(!isSubtype(type, inlineSignature.argumentType(i)), "Block expects the argument at index", i, " to be ", inlineSignature.argumentType(i), " but argument has type ", type);
-        }
+        WASM_FAIL_IF_HELPER_FAILS(checkArgumentsAndWiden(inlineSignature));
 
         uint32_t numberOfCatches;
         Vector<CatchHandler> targets;
@@ -3909,7 +3890,7 @@ auto FunctionParser<Context>::parseExpression() -> PartialResult
     case End: {
         ControlEntry data = m_controlStack.takeLast();
         if (ControlType::isIf(data.controlData)) {
-            WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(data.controlData, NewSiblingBlock));
+            WASM_FAIL_IF_HELPER_FAILS(checkResultsAndWiden(data.controlData.signature()));
             auto ifBranchResults = m_expressionStack.mutableSpan().subspan(m_currentStackBegin);
             WASM_TRY_ADD_TO_CONTEXT(addElse(data.controlData, ifBranchResults));
             m_expressionStack.shrink(m_currentStackBegin);

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -254,6 +254,7 @@ private:
     };
 
     [[nodiscard]] PartialResult checkBlockFallthrough(const ControlType&, FallThroughStateTag);
+    [[nodiscard]] PartialResult endBlockAndCheckResultTypes(ControlEntry&);
 
     enum BranchConditionalityTag {
         Unconditional,
@@ -1955,6 +1956,22 @@ auto FunctionParser<Context>::checkBlockFallthrough(const ControlType& controlDa
             m_expressionStack[m_currentStackBegin + i].setType(expectedType);
     }
 
+    return { };
+}
+
+template<typename Context>
+auto FunctionParser<Context>::endBlockAndCheckResultTypes(ControlEntry& entry) -> PartialResult
+{
+    // Widen each result to the block signature type before ending the block.
+    // FIXME: mutating the expression stack for the block result is effectful, but there's no
+    // better API yet. See https://bugs.webkit.org/show_bug.cgi?id=164353
+    WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(entry.controlData, MergePoint));
+    const uint32_t parentBegin = parentEntryBegin();
+    auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
+    // We should avoid adding other callsites of endBlock. Since a new block is a sign of a
+    // merge point and it would be a security bug to fail to widen the types.
+    WASM_TRY_ADD_TO_CONTEXT(endBlock(entry, enclosedStack));
+    m_currentStackBegin = parentBegin;
     return { };
 }
 
@@ -3762,13 +3779,8 @@ auto FunctionParser<Context>::parseExpression() -> PartialResult
         WASM_VALIDATOR_FAIL_IF(!ControlType::isTry(targetData) && !ControlType::isTopLevel(targetData), "delegate target isn't a try or the top level block");
 
         WASM_TRY_ADD_TO_CONTEXT(addDelegate(targetData, controlEntry.controlData));
-        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
-
-        const uint32_t parentBegin = parentEntryBegin();
-        auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
-        WASM_TRY_ADD_TO_CONTEXT(endBlock(controlEntry, enclosedStack));
-
-        m_currentStackBegin = parentBegin;
+        // Unlike the sibling catch/catch_all arms, delegate ends the try block, so it widens results.
+        WASM_FAIL_IF_HELPER_FAILS(endBlockAndCheckResultTypes(controlEntry));
         resetLocalInitStackToHeight(controlEntry.localInitStackHeight);
         return { };
     }
@@ -3903,16 +3915,7 @@ auto FunctionParser<Context>::parseExpression() -> PartialResult
             m_expressionStack.shrink(m_currentStackBegin);
             m_expressionStack.append(data.elseBlockStack.span());
         }
-        // FIXME: endBlock may modify the expressionStack slice for the result of the block.
-        // That's a little too effectful but we don't have a better API right now.
-        // see: https://bugs.webkit.org/show_bug.cgi?id=164353
-        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(data.controlData, MergePoint));
-
-        const uint32_t parentBegin = parentEntryBegin();
-        auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
-        WASM_TRY_ADD_TO_CONTEXT(endBlock(data, enclosedStack));
-
-        m_currentStackBegin = parentBegin;
+        WASM_FAIL_IF_HELPER_FAILS(endBlockAndCheckResultTypes(data));
         if (!ControlType::isTopLevel(data.controlData))
             resetLocalInitStackToHeight(data.localInitStackHeight);
         return { };
@@ -4108,12 +4111,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
                 WASM_TRY_ADD_TO_CONTEXT(addElseToUnreachable(data.controlData));
                 m_expressionStack.shrink(m_currentStackBegin);
                 m_expressionStack.append(data.elseBlockStack.span());
-                WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(data.controlData, MergePoint));
-
-                // Reachable End handling: the combined enclosedStack now lives in
-                // m_expressionStack[parentBegin..end].
-                auto enclosedStack = m_expressionStack.mutableSpan().subspan(parentBegin);
-                WASM_TRY_ADD_TO_CONTEXT(endBlock(data, enclosedStack));
+                WASM_FAIL_IF_HELPER_FAILS(endBlockAndCheckResultTypes(data));
             } else {
                 m_expressionStack.shrink(m_currentStackBegin);
                 const auto& sig = data.controlData.signature();

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -1314,6 +1314,9 @@ OMGIRGenerator::OMGIRGenerator(AbstractHeapRepository& heaps, CompilationContext
 
     m_proc.pinRegister(GPRInfo::wasmContextInstancePointer);
     m_proc.pinRegister(GPRInfo::wasmBaseMemoryPointer);
+    // FIXME: The wasm ABI effectively has to assume this is a caller save when getting
+    // called by wasm, so there's no point in saving and restoring it if B3 chooses to
+    // use it. We actively don't restore this register in many cases anyway e.g. tail calls.
     if (mode == MemoryMode::BoundsChecking)
         m_proc.pinRegister(GPRInfo::wasmBoundsCheckingSizeRegister);
 
@@ -5538,6 +5541,11 @@ static inline void prepareForTailCallImpl(unsigned functionIndex, CCallHelpers& 
     entries.reserveInitialCapacity(calleeSaves.registerCount() + functionSignature.argumentCount() + 1);
 
     for (const auto& regAtOffset : calleeSaves) {
+        // Don't restore wasmBoundsCheckingSizeRegister since we may have set it when checking for
+        // a cross-instance call. It's not a normal callee save independent of whether we used
+        // it or not.
+        if (regAtOffset.reg() == GPRInfo::wasmBoundsCheckingSizeRegister)
+            continue;
         ShuffleEntry entry;
         entry.src = ShuffleLocation::fromStack(fpOffsetToSPOffset(regAtOffset.offset()));
         if (regAtOffset.reg().isGPR()) {

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -1081,12 +1081,13 @@ float SVGSMILElement::calculateAnimationPercentAndRepeat(SMILTime elapsed, unsig
     SMILTime activeTime = elapsed - m_intervalBegin;
     SMILTime repeatingDuration = this->repeatingDuration();
 
+    // Clamp the page-controlled repeat count to prevent overflow.
     if ((elapsed >= m_intervalEnd && !repeatingDuration.isIndefinite()) || activeTime > repeatingDuration) {
-        repeat = static_cast<unsigned>(repeatingDuration.value() / simpleDuration.value());
-        if (!fmod(repeatingDuration.value(), simpleDuration.value()))
+        repeat = clampTo<unsigned>(repeatingDuration.value() / simpleDuration.value());
+        if (repeat && !fmod(repeatingDuration.value(), simpleDuration.value()))
             --repeat;
     } else
-        repeat = static_cast<unsigned>(activeTime.value() / simpleDuration.value());
+        repeat = clampTo<unsigned>(activeTime.value() / simpleDuration.value());
 
     double percent;
     if (elapsed >= m_intervalEnd || activeTime > repeatingDuration) {
@@ -1262,19 +1263,10 @@ bool SVGSMILElement::progress(SMILTime elapsed, SVGSMILElement& firstAnimation, 
         if (m_activeState == Inactive || m_activeState == Frozen)
             smilEventSender().dispatchEventSoon(*this, eventNames().endEventEvent);
 
-        if (repeat) {
-            // We intentionally dispatch repeat - 1 events here because the first repeat
-            // event (for the initial loop) is sent elsewhere during continuous animation run.
-            // If repeat == 1, no events are dispatched here.
-            for (unsigned i = 1; i < repeat; ++i) {
-                m_pendingRepeatIterations.append(i);
-                smilEventSender().dispatchEventSoon(*this, eventNames().repeatEventEvent);
-            }
-
-            if (m_activeState == Inactive) {
-                m_pendingRepeatIterations.append(repeat);
-                smilEventSender().dispatchEventSoon(*this, eventNames().repeatEventEvent);
-            }
+        // Coalesce the skipped repeat iterations into a single event instead of one per interval.
+        if (repeat > 1 || (repeat && m_activeState == Inactive)) {
+            m_pendingRepeatIterations.append(repeat);
+            smilEventSender().dispatchEventSoon(*this, eventNames().repeatEventEvent);
         }
     }
 


### PR DESCRIPTION
#### 44781232833d490ce7d6e7d7f03a9b2ebc5502ae
<pre>
Cherry-pick 320071@main (9dcbd254af21). <a href="https://bugs.webkit.org/show_bug.cgi?id=318807">https://bugs.webkit.org/show_bug.cgi?id=318807</a>

    [Wasm] Argument and Result block types should always widen
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318807">https://bugs.webkit.org/show_bug.cgi?id=318807</a>
    <a href="https://rdar.apple.com/181458746">rdar://181458746</a>

    Reviewed by Yusuke Suzuki.

    The wasm spec says that any types passing through a block signature
    have to widen to the signature. This is critical both for correctness
    and for security. We didn&apos;t widen in most cases, this change widens
    any time we enter or exit a block via fallthroughs.

    In the branch case we don&apos;t always widen. For br_table in particular, we
    have to check against each branch target, which may have different
    target types but the concrete value type could be a subtype of all of
    them. If we widened the first checked target would pass but on a second
    (or later) it might fail with the first&apos;s widened type.

    Tests: JSTests/wasm/stress/block-param-type-widening.js
           JSTests/wasm/stress/loop-param-type-widening.js

    Originally-landed-as: 305413.1112@safari-7624.5-branch (0aff244e6923). <a href="https://rdar.apple.com/185368381">rdar://185368381</a>
    Canonical link: <a href="https://commits.webkit.org/320071@main">https://commits.webkit.org/320071@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.242@webkitglib/2.54">https://commits.webkit.org/317695.242@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### e4f712201a0dc1accaf04377c363e92f280b89fc
<pre>
Cherry-pick 320264@main (8f069ce3b3ce). <a href="https://bugs.webkit.org/show_bug.cgi?id=316996">https://bugs.webkit.org/show_bug.cgi?id=316996</a>

    [JSC] YarrJIT non-BMP backtrack trampoline (L&gt;F branch) does not add firstCharacterAdditionalReadSize to index, returns start &gt; end
    <a href="https://bugs.webkit.org/show_bug.cgi?id=316996">https://bugs.webkit.org/show_bug.cgi?id=316996</a>
    <a href="https://rdar.apple.com/177699255">rdar://177699255</a>

    Reviewed by Yijia Huang.

    This patch fixes a mistake where firstCharacterAdditionalReadSize isn&apos;t added
    to the index register in YarrJIT during backtracking.

    Test: JSTests/stress/yarr-jit-non-bmp-backtrack-index-underflow.js

    * JSTests/stress/yarr-jit-non-bmp-backtrack-index-overflow.js: Added.
    * JSTests/stress/yarr-jit-non-bmp-backtrack-index-underflow.js: Added.
    * Source/JavaScriptCore/runtime/RegExpMatchesArray.h:
    (JSC::createRegExpMatchesArray):
    * Source/JavaScriptCore/yarr/YarrJIT.cpp:

    Originally-landed-as: 305413.1108@safari-7624.5-branch (30b9a27b47e8). <a href="https://rdar.apple.com/185367107">rdar://185367107</a>
    Canonical link: <a href="https://commits.webkit.org/320264@main">https://commits.webkit.org/320264@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.241@webkitglib/2.54">https://commits.webkit.org/317695.241@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### a614db56d6eff8bc47615291f41feab0f795929c
<pre>
Cherry-pick 320048@main (261bcb42d83f). <a href="https://bugs.webkit.org/show_bug.cgi?id=318755">https://bugs.webkit.org/show_bug.cgi?id=318755</a>

    [Wasm] Delegate should widen types like End
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318755">https://bugs.webkit.org/show_bug.cgi?id=318755</a>
    <a href="https://rdar.apple.com/181457816">rdar://181457816</a>

    Reviewed by Yusuke Suzuki.

    The legacy Delegate wasm bytecode is essentially shorthand for: `Rethrow;
    End`. So like other merge points it needs to widen the types on the
    expression stack. To help avoid this problem in the future add a new
    helper `endBlockAndCheckResultTypes`, which ensures the types are
    appropriately widened.

    Test: JSTests/wasm/stress/delegate-widens-result-type-to-signature.js

    Originally-landed-as: 305413.1096@safari-7624.5-branch (db3010593c27). <a href="https://rdar.apple.com/185366253">rdar://185366253</a>
    Canonical link: <a href="https://commits.webkit.org/320048@main">https://commits.webkit.org/320048@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.240@webkitglib/2.54">https://commits.webkit.org/317695.240@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 96066a337e3ee4443bfc339ccea85d8ebf980d71
<pre>
Cherry-pick 320018@main (36058b8e69ac). <a href="https://bugs.webkit.org/show_bug.cgi?id=318480">https://bugs.webkit.org/show_bug.cgi?id=318480</a>

    [Wasm] Unreachable end ops don&apos;t widen result types
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318480">https://bugs.webkit.org/show_bug.cgi?id=318480</a>
    <a href="https://rdar.apple.com/180535979">rdar://180535979</a>

    Reviewed by Yusuke Suzuki.

    In 305413.1013@safari-7624.5-branch we fixed how result types were
    pushed onto the wasm value stack, widening them to the expected type
    rather than the last predecessor&apos;s type at the merge.

    This missed the case for unreachable expressions in the block, which
    is fixed in this patch.

    Originally-landed-as: 305413.1080@safari-7624.5-branch (f65ca49ea4a7). <a href="https://rdar.apple.com/185368954">rdar://185368954</a>
    Canonical link: <a href="https://commits.webkit.org/320018@main">https://commits.webkit.org/320018@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.239@webkitglib/2.54">https://commits.webkit.org/317695.239@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 9a76f770c76610b74862a11e6bd19aeaee837e06
<pre>
Cherry-pick 305413.1072@safari-7624.5-branch (34249048d66d). <a href="https://bugs.webkit.org/show_bug.cgi?id=318405">https://bugs.webkit.org/show_bug.cgi?id=318405</a>

    Clamp repeat count for SVG animation.
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318405">https://bugs.webkit.org/show_bug.cgi?id=318405</a>
    &lt;<a href="https://rdar.apple.com/176471329">rdar://176471329</a>&gt;

    Reviewed by Said Abou-Hallawa.

    This PR tightens the fix in 301404@main by clamping the repeat count to
    an upper bound to prevent overflow.

    Also coalesce the repeat events dispatched while seeking: rather than firing
    one repeatEvent per skipped interval, dispatch a single repeatEvent. SVG 1.1
    Animation defines a repeatEvent as raised each time the element repeats on a
    normally-advancing timeline; how many events a discontinuous seek replays for
    the intervals it skips is left to SMIL Animation&apos;s timing model, which does not
    require one event per skipped interval (see also the WPT seeking-events-* tests).

    * LayoutTests/svg/animations/smil-seek-huge-repeat-count-crash-expected.txt: Added.
    * LayoutTests/svg/animations/smil-seek-huge-repeat-count-crash.html: Added.
    * Source/WebCore/svg/animation/SVGSMILElement.cpp:
    (WebCore::SVGSMILElement::calculateAnimationPercentAndRepeat const):
    (WebCore::SVGSMILElement::progress):

    Identifier: 305413.1072@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.238@webkitglib/2.54">https://commits.webkit.org/317695.238@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 3573d5d06367114016535f94668f46db3885bb09
<pre>
Cherry-pick 320061@main (929f6e81e0e0). <a href="https://bugs.webkit.org/show_bug.cgi?id=317654">https://bugs.webkit.org/show_bug.cgi?id=317654</a>

    [Wasm] Exclude wasmBoundsCheckingSizeRegister from the callee saves restored
    <a href="https://bugs.webkit.org/show_bug.cgi?id=317654">https://bugs.webkit.org/show_bug.cgi?id=317654</a>
    <a href="https://rdar.apple.com/177693309">rdar://177693309</a>

    Reviewed by Yijia Huang.

    GPRInfo::wasmBoundsCheckingSizeRegister (callee save) is only pinned in B3 when
    the OMG callee is compiled for MemoryMode::BoundsChecking. In Signaling mode
    it stays in B3/Air&apos;s mutable register set, and createTailCallPatchpoint
    declares the full callee-save set as clobberEarly so that B3 does not place
    an input there before the tail-call&apos;s parallel move runs. That clobberEarly
    causes AirHandleCalleeSaves to include regCS4 in the function&apos;s
    calleeSaveRegisterAtOffsetList(). The OMG prologue saves
    wasmBoundsCheckingSizeRegister to the callee save list and when making a
    tail call that callee save is restored after the callee&apos;s memory bounds
    are set.

    The wasm ABI already treats the pinned registers as effectively caller-save
    across wasm-to-wasm calls. Tail calls do not restore them either. Restoring
    wasmBoundsCheckingSizeRegister to the prologue-saved caller value in
    prepareForTailCallImpl is therefore unnecessary.

    This patch teaches emitRestoreCalleeSavesFor to take a dontRestoreRegisters
    set and uses it from prepareForTailCallImpl to skip
    wasmBoundsCheckingSizeRegister. I also added a FIXME at the pinRegister
    site noting that wasmBoundsCheckingSizeRegister is effectively caller-save
    in the wasm ABI.

    Originally-landed-as: 305413.1027@safari-7624.5-branch (654718255548). <a href="https://rdar.apple.com/185368944">rdar://185368944</a>
    Canonical link: <a href="https://commits.webkit.org/320061@main">https://commits.webkit.org/320061@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.237@webkitglib/2.54">https://commits.webkit.org/317695.237@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 62c8556e221d1abc89f62ff5bed8df2fa25d3c5b
<pre>
Cherry-pick 305413.1114@safari-7624.5.1.10-branch (2bc65ac3560e). <a href="https://bugs.webkit.org/show_bug.cgi?id=319112">https://bugs.webkit.org/show_bug.cgi?id=319112</a>

    [JSC] DFG Uint32Array load should consider about Int32 speculation path
    <a href="https://bugs.webkit.org/show_bug.cgi?id=319112">https://bugs.webkit.org/show_bug.cgi?id=319112</a>
    <a href="https://rdar.apple.com/176792844">rdar://176792844</a>

    Reviewed by Mark Lam.

    DFG Uint32Array GetByVal may have Int32 result with speculation. But the
    current code is always using boxed-double for boxed result. We should
    use boxed-int32 when this speculation is set. The same thing is already
    done in FTL.

    Test: JSTests/stress/uint32-array-result-int32-dfg.js

    * JSTests/stress/uint32-array-result-int32-dfg.js: Added.
    * Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
    (JSC::DFG::SpeculativeJIT::setIntTypedArrayLoadResult):

    Identifier: 305413.1114@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.236@webkitglib/2.54">https://commits.webkit.org/317695.236@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5530b52993520bd308f8b603b27f0d507dfd98c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185725 "23 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59630 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53438 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196032 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150424 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187587 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/60998 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59357 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145133 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150424 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188680 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/60998 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53438 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125428 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/60998 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59357 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7323 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53438 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/60998 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53438 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7095 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/46972 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52260 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59357 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197998 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59292 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53438 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154671 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/60000 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53438 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154323 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28187 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/60000 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132349 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129299 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58467 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53438 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57845 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58081 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57908 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->