### PR TITLE
ImageDecoderAVFObjC mutates its sample map and sample images without the lock the decoding work queue reads them under

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.h
@@ -32,6 +32,7 @@
 #include <WebCore/SampleMap.h>
 #include <wtf/Lock.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadAssertions.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -99,11 +100,11 @@ private:
     AVAssetTrack *firstEnabledTrack();
     void readSamples();
     void readTrackMetadata();
-    bool storeSampleBuffer(CMSampleBufferRef);
-    void NODELETE advanceCursor();
+    bool storeSampleBuffer(CMSampleBufferRef) WTF_REQUIRES_LOCK(m_sampleGeneratorLock);
+    void NODELETE advanceCursor() WTF_REQUIRES_LOCK(m_sampleGeneratorLock);
     void setTrack(AVAssetTrack *);
 
-    const ImageDecoderAVFObjCSample* NODELETE sampleAtIndex(size_t) const;
+    const ImageDecoderAVFObjCSample* NODELETE sampleAtIndex(size_t) const WTF_REQUIRES_SHARED_LOCK(m_sampleGeneratorLock);
     bool sampleIsComplete(const ImageDecoderAVFObjCSample&) const;
 
     String m_mimeType;
@@ -111,16 +112,21 @@ private:
     RetainPtr<AVURLAsset> m_asset;
     RetainPtr<AVAssetTrack> m_track;
     RetainPtr<WebCoreSharedBufferResourceLoaderDelegate> m_loader;
-    std::unique_ptr<ImageRotationSessionVT> m_imageRotationSession;
+    std::unique_ptr<ImageRotationSessionVT> m_imageRotationSession WTF_GUARDED_BY_LOCK(m_sampleGeneratorLock);
     const Ref<WebCoreDecompressionSession> m_decompressionSession;
     Function<void(EncodedDataStatus)> m_encodedDataStatusChangedCallback;
 
-    SampleMap m_sampleData;
-    DecodeOrderSampleMap::iterator m_cursor;
+    // Mutated on the main thread while holding m_sampleGeneratorLock and read on the image
+    // decoding work queue by createFrameImageAtIndex(), which locks; the main thread's own reads
+    // use assertIsOwnerThread() instead of locking.
+    SampleMap m_sampleData WTF_GUARDED_BY_LOCK(m_sampleGeneratorLock);
+    DecodeOrderSampleMap::iterator m_cursor WTF_GUARDED_BY_LOCK(m_sampleGeneratorLock);
     Lock m_sampleGeneratorLock;
     bool m_isAllDataReceived { false };
     std::optional<IntSize> m_size;
     ProcessIdentity m_resourceOwner;
+
+    WTF_DECLARE_OWNER_THREAD_ASSERTIONS(m_sampleGeneratorLock, mainThreadLike);
 };
 
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
@@ -399,6 +399,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 void ImageDecoderAVFObjC::readSamples()
 {
+    assertIsOwnerThread();
     if (!m_sampleData.empty())
         return;
 
@@ -409,12 +410,23 @@ void ImageDecoderAVFObjC::readSamples()
     [assetReader addOutput:referenceOutput.get()];
     [assetReader startReading];
 
+    Vector<Ref<ImageDecoderAVFObjCSample>> samples;
     while (auto sampleBuffer = adoptCF([referenceOutput copyNextSampleBuffer])) {
         // NOTE: Some samples emitted by the AVAssetReader simply denote the boundary of edits
         // and do not carry media data.
         if (!(PAL::CMSampleBufferGetNumSamples(sampleBuffer.get())))
             continue;
-        m_sampleData.addSample(ImageDecoderAVFObjCSample::create(WTF::move(sampleBuffer)).get());
+        samples.append(ImageDecoderAVFObjCSample::create(WTF::move(sampleBuffer)));
+    }
+
+    releaseOwnerThreadAssertion();
+    {
+        // m_sampleData is read on the image decoding work queue by createFrameImageAtIndex(), so
+        // populating it must not race with it. The samples are read above without the lock so that
+        // reading from the asset does not block the work queue.
+        Locker locker { m_sampleGeneratorLock };
+        for (auto& sample : samples)
+            m_sampleData.addSample(sample.get());
     }
 
     if (m_encodedDataStatusChangedCallback)
@@ -423,8 +435,8 @@ void ImageDecoderAVFObjC::readSamples()
 
 void ImageDecoderAVFObjC::readTrackMetadata()
 {
-    // m_imageRotationSession and m_size are read on the image decoding work queue by
-    // createFrameImageAtIndex(), so replacing them here must not race with it.
+    // m_imageRotationSession is read on the image decoding work queue by storeSampleBuffer(), so
+    // replacing it here must not race with it. m_size is only ever read on the main thread.
     Locker locker { m_sampleGeneratorLock };
 
     AffineTransform finalTransform = CGAffineTransformConcat(m_asset.get().preferredTransform, m_track.get().preferredTransform);
@@ -518,6 +530,7 @@ void ImageDecoderAVFObjC::setEncodedDataStatusChangeCallback(WTF::Function<void(
 
 EncodedDataStatus ImageDecoderAVFObjC::encodedDataStatus() const
 {
+    assertIsOwnerThread();
     if (!m_sampleData.empty())
         return EncodedDataStatus::Complete;
     if (m_size)
@@ -536,6 +549,7 @@ IntSize ImageDecoderAVFObjC::size() const
 
 size_t ImageDecoderAVFObjC::frameCount() const
 {
+    assertIsOwnerThread();
     return m_sampleData.size();
 }
 
@@ -564,12 +578,14 @@ IntSize ImageDecoderAVFObjC::frameSizeAtIndex(size_t, SubsamplingLevel) const
 
 bool ImageDecoderAVFObjC::frameIsCompleteAtIndex(size_t index) const
 {
+    assertIsOwnerThread();
     RefPtr sampleData = sampleAtIndex(index);
     return sampleData && sampleIsComplete(*sampleData);
 }
 
 Seconds ImageDecoderAVFObjC::frameDurationAtIndex(size_t index) const
 {
+    assertIsOwnerThread();
     RefPtr sampleData = sampleAtIndex(index);
     if (!sampleData)
         return { };
@@ -579,12 +595,14 @@ Seconds ImageDecoderAVFObjC::frameDurationAtIndex(size_t index) const
 
 bool ImageDecoderAVFObjC::frameHasAlphaAtIndex(size_t index) const
 {
+    assertIsOwnerThread();
     RefPtr sampleData = sampleAtIndex(index);
     return sampleData && sampleData->hasAlpha();
 }
 
 Vector<ImageDecoder::FrameInfo> ImageDecoderAVFObjC::frameInfos() const
 {
+    assertIsOwnerThread();
     if (m_sampleData.empty())
         return { };
 
@@ -696,6 +714,10 @@ void ImageDecoderAVFObjC::setData(const FragmentedSharedBuffer& data, bool allDa
 
 void ImageDecoderAVFObjC::clearFrameBufferCache(size_t index)
 {
+    // The sample images are read on the image decoding work queue by createFrameImageAtIndex(),
+    // which retains them; releasing them here must not race with that.
+    Locker locker { m_sampleGeneratorLock };
+
     size_t i = 0;
     for (auto& samplePair : m_sampleData.presentationOrder()) {
         protect(toSample(samplePair))->setImage(nullptr);


### PR DESCRIPTION
#### 17eb50c5ed5d5466c4a16ef7160531ee6c2f2f98
<pre>
ImageDecoderAVFObjC mutates its sample map and sample images without the lock the decoding work queue reads them under
<a href="https://bugs.webkit.org/show_bug.cgi?id=323739">https://bugs.webkit.org/show_bug.cgi?id=323739</a>

Reviewed by Jean-Yves Avenard.

createFrameImageAtIndex() runs on AsyncImageDecoder&apos;s org.webkit.ImageDecoder work queue and
takes m_sampleGeneratorLock to read m_sampleData, to read and advance m_cursor, and to read and
replace the samples&apos; decoded CGImages. readTrackMetadata() and setTrack() take the same lock to
mutate that state from the main thread. Two other main-thread mutators did not.

readSamples() called m_sampleData.addSample() unlocked, while the work queue searches and
iterates the same SampleMap, which is backed by StdMap; inserting into a red-black tree while
another thread walks it can follow pointers through a rebalance. This was already
self-inconsistent, since setTrack() clears the very same container under the lock twenty lines
earlier.

clearFrameBufferCache() called setImage(nullptr) on each sample unlocked. Since
ImageDecoderAVFObjCSample::image() hands out a raw CGImageRef, createFrameImageAtIndex()&apos;s
&quot;RetainPtr image = sampleData-&gt;image()&quot; loads the pointer and retains it in two steps, and this
released it in between, so the work queue could retain and return freed memory. That window is
reachable rather than theoretical: BitmapImageSource::destroyDecodedData() routes to
clearFrameBufferCache() precisely in the branch where the work queue is not known to be idle.

Take m_sampleGeneratorLock in both. readSamples() collects the samples into a Vector first and
inserts them under the lock, so that reading from the AVAssetReader does not block the work
queue, and still fires the encoded-data-status callback outside the lock, since that callback
re-enters BitmapImageSource.

Then annotate the state so this cannot regress. m_sampleData, m_cursor and
m_imageRotationSession are now WTF_GUARDED_BY_LOCK(m_sampleGeneratorLock), and the main thread&apos;s
unlocked reads use the assertIsOwnerThread() helpers added in 320637@main. storeSampleBuffer()
and advanceCursor() are only ever called from inside createFrameImageAtIndex()&apos;s critical
section, so they declare WTF_REQUIRES_LOCK rather than locking again. sampleAtIndex() is reached
both from the work queue holding the lock and from the frame-metadata accessors on the main
thread without it, so it requires the lock shared, which both callers satisfy. Both unlocked
writes fixed here are writes to guarded state while holding only shared access, which is exactly
what this reports.

m_size is deliberately left unguarded: it is only ever read on the main thread.
createFrameImageAtIndex() does not touch it, and the other reader, size() by way of
frameSizeAtIndex(), is reached from BitmapImageSource::fetchFrameMetaDataAtIndex() on the main
thread. The comment in readTrackMetadata() claiming otherwise is corrected; only
m_imageRotationSession is read off the main thread there, by storeSampleBuffer().

Note that in the default Cocoa configuration the decoder runs in the GPU process, driven purely
by IPC on one thread, with no AsyncImageDecoder and so no work queue. The racing arrangement is
WebContent with UseGPUProcessForMediaEnabled off, where the factory constructs
ImageDecoderAVFObjC directly and AsyncImageDecoder decodes on its work queue.

* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm:
(WebCore::ImageDecoderAVFObjC::readSamples):
(WebCore::ImageDecoderAVFObjC::readTrackMetadata):
(WebCore::ImageDecoderAVFObjC::encodedDataStatus const):
(WebCore::ImageDecoderAVFObjC::frameCount const):
(WebCore::ImageDecoderAVFObjC::frameIsCompleteAtIndex const):
(WebCore::ImageDecoderAVFObjC::frameDurationAtIndex const):
(WebCore::ImageDecoderAVFObjC::frameHasAlphaAtIndex const):
(WebCore::ImageDecoderAVFObjC::frameInfos const):
(WebCore::ImageDecoderAVFObjC::clearFrameBufferCache):

Canonical link: <a href="https://commits.webkit.org/320808@main">https://commits.webkit.org/320808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5913c110ab49af1cd9b7372c000a3a89e4792707

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53439 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196033 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150425 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187588 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/60999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59358 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145136 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100627 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165703 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125431 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47547 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45586 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157907 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45280 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7096 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/49995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/197999 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59293 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154673 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41480 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60001 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154325 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48789 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132350 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129304 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58468 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20303 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57846 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58082 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57909 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->