### PR TITLE
MockRealtimeVideoSource shares five members between its capture run loop and its caller's thread without synchronization

### DIFF
--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -270,7 +270,7 @@ auto MockRealtimeVideoSource::takePhotoInternal(PhotoSettings&&) -> Ref<TakePhot
         return TakePhotoNativePromise::createAndReject("Already taking photo"_s);
 
     {
-        Locker lock { m_imageBufferLock };
+        Locker lock { m_frameGenerationLock };
         invalidateDrawingState();
     }
 
@@ -380,8 +380,10 @@ const RealtimeMediaSourceSettings& MockRealtimeVideoSource::settings()
             settings.setTorch(torch());
         }
 
-        if (canBePowerEfficient())
+        if (canBePowerEfficient()) {
+            Locker lock { m_frameGenerationLock };
             settings.setPowerEfficient(m_preset ? m_preset->isEfficient() : false);
+        }
         supportedConstraints.setSupportsPowerEfficient(true);
 
         supportedConstraints.setSupportsBackgroundBlur(true);
@@ -401,15 +403,23 @@ void MockRealtimeVideoSource::applyFrameRateAndZoomWithPreset(double frameRate, 
 {
     UNUSED_PARAM(zoom);
     ASSERT(m_beingConfigured);
-    m_preset = WTF::move(preset);
-    if (m_preset)
-        setIntrinsicSize(m_preset->size());
+    std::optional<IntSize> intrinsicSize;
+    {
+        Locker lock { m_frameGenerationLock };
+        m_preset = WTF::move(preset);
+        if (m_preset)
+            intrinsicSize = m_preset->size();
+    }
+    if (intrinsicSize)
+        setIntrinsicSize(*intrinsicSize);
     if (isProducingData())
         startCaptureTimer(frameRate);
 }
 
 IntSize MockRealtimeVideoSource::captureSize() const
 {
+    assertIsHeld(m_frameGenerationLock);
+
     return m_preset ? m_preset->size() : this->size();
 }
 
@@ -420,7 +430,7 @@ VideoFrameRotation MockRealtimeVideoSource::videoFrameRotation() const
 
 void MockRealtimeVideoSource::invalidateDrawingState()
 {
-    assertIsHeld(m_imageBufferLock);
+    assertIsHeld(m_frameGenerationLock);
 
     m_imageBuffer = nullptr;
     m_drawingState = { };
@@ -428,7 +438,7 @@ void MockRealtimeVideoSource::invalidateDrawingState()
 
 MockRealtimeVideoSource::DrawingState& MockRealtimeVideoSource::drawingState()
 {
-    assertIsHeld(m_imageBufferLock);
+    assertIsHeld(m_frameGenerationLock);
 
     if (!m_drawingState)
         m_drawingState = { DrawingState(captureSize().height() * .08) };
@@ -440,7 +450,7 @@ void MockRealtimeVideoSource::settingsDidChange(OptionSet<RealtimeMediaSourceSet
 {
     m_currentSettings = std::nullopt;
     if (settings.containsAny({ RealtimeMediaSourceSettings::Flag::Width, RealtimeMediaSourceSettings::Flag::Height })) {
-        Locker lock { m_imageBufferLock };
+        Locker lock { m_frameGenerationLock };
         invalidateDrawingState();
     }
 
@@ -479,18 +489,24 @@ void MockRealtimeVideoSource::startProducingData()
 #endif
 
     startCaptureTimer();
+
+    Locker lock { m_frameGenerationLock };
     m_startTime = MonotonicTime::now();
 }
 
 void MockRealtimeVideoSource::stopProducingData()
 {
     stopCaptureTimer();
+
+    Locker lock { m_frameGenerationLock };
     m_elapsedTime += MonotonicTime::now() - m_startTime;
     m_startTime = MonotonicTime::nan();
 }
 
 Seconds MockRealtimeVideoSource::elapsedTime()
 {
+    assertIsHeld(m_frameGenerationLock);
+
     if (m_startTime.isNaN())
         return m_elapsedTime;
 
@@ -581,7 +597,7 @@ void MockRealtimeVideoSource::drawBoxes(GraphicsContext& context)
 
 void MockRealtimeVideoSource::drawText(GraphicsContext& context)
 {
-    assertIsHeld(m_imageBufferLock);
+    assertIsHeld(m_frameGenerationLock);
 
     unsigned milliseconds = lround(elapsedTime().milliseconds());
     unsigned seconds = milliseconds / 1000 % 60;
@@ -666,14 +682,19 @@ void MockRealtimeVideoSource::drawText(GraphicsContext& context)
 
 void MockRealtimeVideoSource::delaySamples(Seconds delta)
 {
-    m_delayUntil = MonotonicTime::now() + delta;
+    // generateFrame() reads and clears m_delayUntil on m_runLoop's thread, so set it there too
+    // rather than synchronizing it. The deadline is computed here so it is unaffected by how
+    // long the dispatch takes to run.
+    m_runLoop->dispatch([this, protectedThis = Ref { *this }, delayUntil = MonotonicTime::now() + delta] {
+        m_delayUntil = delayUntil;
+    });
 }
 
 RefPtr<ImageBuffer> MockRealtimeVideoSource::generatePhoto()
 {
     ASSERT(!isMainThread());
 
-    Locker lock { m_imageBufferLock };
+    Locker lock { m_frameGenerationLock };
     invalidateDrawingState();
     auto currentImage = generateFrameInternal();
     invalidateDrawingState();
@@ -683,7 +704,7 @@ RefPtr<ImageBuffer> MockRealtimeVideoSource::generatePhoto()
 
 RefPtr<ImageBuffer> MockRealtimeVideoSource::generateFrameInternal()
 {
-    assertIsHeld(m_imageBufferLock);
+    assertIsHeld(m_frameGenerationLock);
 
     RefPtr buffer = imageBufferInternal();
     if (!buffer)
@@ -715,19 +736,19 @@ void MockRealtimeVideoSource::generateFrame()
         m_delayUntil = MonotonicTime();
     }
 
-    Locker lock { m_imageBufferLock };
+    Locker lock { m_frameGenerationLock };
     generateFrameInternal();
 }
 
 ImageBuffer* MockRealtimeVideoSource::imageBuffer()
 {
-    Locker lock { m_imageBufferLock };
+    Locker lock { m_frameGenerationLock };
     return imageBufferInternal();
 }
 
 ImageBuffer* MockRealtimeVideoSource::imageBufferInternal()
 {
-    assertIsHeld(m_imageBufferLock);
+    assertIsHeld(m_frameGenerationLock);
 
     if (m_imageBuffer)
         return m_imageBuffer.get();
@@ -769,7 +790,7 @@ void MockRealtimeVideoSource::orientationChanged(IntDegrees orientation)
     if (m_isUsingRotationAngleForHorizonLevelDisplayChanged)
         return;
 
-    auto deviceOrientation = m_deviceOrientation;
+    auto deviceOrientation = m_deviceOrientation.load();
     switch (orientation) {
     case 0:
         m_deviceOrientation = VideoFrame::Rotation::None;

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.h
@@ -151,14 +151,17 @@ private:
     DrawingState& drawingState();
     void invalidateDrawingState();
 
-    std::optional<DrawingState> m_drawingState WTF_GUARDED_BY_LOCK(m_imageBufferLock);
-    mutable RefPtr<ImageBuffer> m_imageBuffer WTF_GUARDED_BY_LOCK(m_imageBufferLock);
+    std::optional<DrawingState> m_drawingState WTF_GUARDED_BY_LOCK(m_frameGenerationLock);
+    mutable RefPtr<ImageBuffer> m_imageBuffer WTF_GUARDED_BY_LOCK(m_frameGenerationLock);
 
     Path m_path;
     DashArray m_dashWidths;
 
-    MonotonicTime m_startTime { MonotonicTime::nan() };
-    Seconds m_elapsedTime { 0_s };
+    // Written on the caller's thread and read on m_runLoop's thread by drawText() and
+    // updateSampleBuffer(), both of which run under the lock.
+    MonotonicTime m_startTime WTF_GUARDED_BY_LOCK(m_frameGenerationLock) { MonotonicTime::nan() };
+    Seconds m_elapsedTime WTF_GUARDED_BY_LOCK(m_frameGenerationLock) { 0_s };
+    // Only used by generateFrame() and delaySamples(), both on m_runLoop's thread.
     MonotonicTime m_delayUntil;
 
     unsigned m_frameNumber { 0 };
@@ -170,10 +173,12 @@ private:
     Color m_fillColor { Color::black };
     Color m_fillColorWithZoom { Color::red };
     MockMediaDevice m_device;
-    std::optional<VideoPreset> m_preset;
-    VideoFrameRotation m_deviceOrientation;
+    std::optional<VideoPreset> m_preset WTF_GUARDED_BY_LOCK(m_frameGenerationLock);
+    // Read on both the caller's thread by settings() and m_runLoop's thread by
+    // videoFrameRotation(), which is virtual and so may be called from anywhere.
+    std::atomic<VideoFrameRotation> m_deviceOrientation;
 
-    Lock m_imageBufferLock;
+    Lock m_frameGenerationLock;
     std::optional<PhotoCapabilities> m_photoCapabilities;
     std::optional<PhotoSettings> m_photoSettings;
     bool m_beingConfigured { false };


### PR DESCRIPTION
#### 42ca5cc802a1492a3d701874b0e7cbd03aa2f948
<pre>
MockRealtimeVideoSource shares five members between its capture run loop and its caller&apos;s thread without synchronization
<a href="https://bugs.webkit.org/show_bug.cgi?id=323742">https://bugs.webkit.org/show_bug.cgi?id=323742</a>

Reviewed by Jean-Yves Avenard.

Frames are generated on m_runLoop, a dedicated run loop, while the source is controlled from
the caller&apos;s thread; generateFrame() and generatePhoto() assert !isMainThread() to say so. The
class already guards m_imageBuffer and m_drawingState with a lock, makes m_isTakingPhoto and
m_captureWasInterrupted atomic, and marshals timer start and stop onto m_runLoop. Five members
were left out of all of that, and the run loop reaches four of them indirectly, through helper
calls, which is what kept them hidden:

- m_startTime and m_elapsedTime are written by startProducingData() and stopProducingData(),
  and read by elapsedTime(), which drawText() and MockRealtimeVideoSourceMac::updateSampleBuffer()
  both call while generating a frame.
- m_preset is written by applyFrameRateAndZoomWithPreset() and read by captureSize(), which the
  whole draw path calls.
- m_deviceOrientation is written by orientationChanged() and
  rotationAngleForHorizonLevelDisplayChanged(), and read by videoFrameRotation() from
  updateSampleBuffer().
- m_delayUntil is written by delaySamples() and both read and cleared by generateFrame().

Each is fixed by whichever mechanism matches how it is reached rather than by one blanket
approach. m_startTime, m_elapsedTime and m_preset become WTF_GUARDED_BY_LOCK: every reader on
the run loop already held the lock, so only the writers needed changing, and elapsedTime() and
captureSize() get assertIsHeld() to match how the surrounding code already declares this.
m_deviceOrientation becomes atomic instead, because the lock does not fit it: videoFrameRotation()
is virtual on RealtimeMediaSource and so may be called from anywhere, and settings() reads the
member on the caller&apos;s thread. m_delayUntil moves entirely onto m_runLoop by dispatching from
delaySamples(), the same way startCaptureTimer() and stopCaptureTimer() already work; the
deadline is still computed at call time so it does not shift with dispatch latency.

Annotating m_preset immediately turned up a third accessor that reading the code had not:
settings() reads it on the caller&apos;s thread, which now takes the lock for that one read.
applyFrameRateAndZoomWithPreset() is restructured so setIntrinsicSize(), which notifies
observers, is not called while holding the lock.

The lock is renamed from m_imageBufferLock to m_frameGenerationLock. It already guarded
m_drawingState and now covers three further members that are not image buffers.

None of this is reachable by web content: MockRealtimeVideoSource is only created by
MockRealtimeMediaSourceCenter, that is, when mock capture devices are enabled for testing. Nor
was any of it a memory-safety problem, since everything read across the thread boundary is
plain data, a MonotonicTime, a Seconds, an enum, or the IntSize inside m_preset. The visible
symptom would have been a wrong timestamp, rotation or frame size in a generated mock frame.

* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::takePhotoInternal):
(WebCore::MockRealtimeVideoSource::settings):
(WebCore::MockRealtimeVideoSource::applyFrameRateAndZoomWithPreset):
(WebCore::MockRealtimeVideoSource::captureSize const):
(WebCore::MockRealtimeVideoSource::invalidateDrawingState):
(WebCore::MockRealtimeVideoSource::drawingState):
(WebCore::MockRealtimeVideoSource::settingsDidChange):
(WebCore::MockRealtimeVideoSource::startProducingData):
(WebCore::MockRealtimeVideoSource::stopProducingData):
(WebCore::MockRealtimeVideoSource::elapsedTime):
(WebCore::MockRealtimeVideoSource::drawText):
(WebCore::MockRealtimeVideoSource::delaySamples):
(WebCore::MockRealtimeVideoSource::generatePhoto):
(WebCore::MockRealtimeVideoSource::generateFrameInternal):
(WebCore::MockRealtimeVideoSource::generateFrame):
(WebCore::MockRealtimeVideoSource::imageBuffer):
(WebCore::MockRealtimeVideoSource::imageBufferInternal):
(WebCore::MockRealtimeVideoSource::orientationChanged):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.h:
(WebCore::MockRealtimeVideoSource::WTF_GUARDED_BY_LOCK):

Canonical link: <a href="https://commits.webkit.org/320813@main">https://commits.webkit.org/320813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0b1b126c311b0f38076c9dad801709070eeb532

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196038 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150430 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/476296f7-0571-40e3-bca6-c7a0a3c8eb72) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61004 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145140 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100630 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8b6ba2e2-0eae-4a05-a51f-68f1e42a0e82) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165708 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125435 "Found 1 new API test failure: TestWebCore.SharedMemoryTest/SharedMemoryFromMemoryTest.CreateHandleCopyFromMemory/42949672974097MallocReadOnly (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f7e10437-9bef-4d8c-8c41-5400e92e2ccb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47551 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45590 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157911 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45285 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7101 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198004 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59298 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154677 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41481 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60006 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154329 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48793 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132354 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129309 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58473 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20308 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57851 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58087 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57914 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->