### PR TITLE
Cherry-pick 305413.1096@safari-7624.5-branch (db3010593c27). https://bugs.webkit.org/show_bug.cgi?id=318755

### DIFF
--- a/JSTests/wasm/stress/delegate-widens-result-type-to-signature.js
+++ b/JSTests/wasm/stress/delegate-widens-result-type-to-signature.js
@@ -1,0 +1,74 @@
+import * as assert from "../assert.js";
+
+function uleb128(n) { const r = []; do { let b = n & 0x7f; n >>>= 7; if (n) b |= 0x80; r.push(b); } while (n); return r; }
+function encodeString(s) { const b = []; for (let i = 0; i < s.length; i++) b.push(s.charCodeAt(i)); return [...uleb128(b.length), ...b]; }
+function section(id, content) { return [id, ...uleb128(content.length), ...content]; }
+
+function buildModule() {
+    const typeSection = section(1, [
+        3,
+        0x5F, 0x01, 0x7E, 0x01,                         // type 0: struct { i64 mut }
+        0x60, 0x03, 0x7F, 0x6F, 0x64, 0x00, 0x01, 0x7E, // type 1: func (i32, externref, (ref 0)) -> i64
+        0x60, 0x00, 0x01, 0x64, 0x00,                   // type 2: func () -> (ref 0)
+    ]);
+    const funcSection = section(3, [0x02, 0x01, 0x02]);
+    const exportSection = section(7, [0x02,
+        ...encodeString("test"), 0x00, 0x00,
+        ...encodeString("make"), 0x00, 0x01]);
+
+    // (func $test (param $cond i32) (param $ext externref) (param $s (ref 0)) (result i64)
+    //   try (result i64)                 ;; outer: delegate target
+    //     try (result anyref)            ;; inner
+    //       local.get $ext
+    //       any.convert_extern           ;; -> anyref (NaN-boxed JS number)
+    //       local.get $cond
+    //       br_if 0                      ;; carry the anyref to the inner continuation
+    //       drop
+    //       local.get $s                 ;; fallthrough: (ref 0), a subtype of anyref
+    //     delegate 0                     ;; terminates inner try; result MUST widen to anyref
+    //     ref.cast (ref 0)               ;; must NOT elide IsCell / IsWasmGCObject checks
+    //     struct.get 0 0
+    //   catch_all
+    //     i64.const 0
+    //   end)
+    const body0 = [
+        0x00,
+        0x06, 0x7E,             // try (result i64)
+          0x06, 0x6E,           //   try (result anyref)
+            0x20, 0x01,         //     local.get 1
+            0xFB, 0x1A,         //     any.convert_extern
+            0x20, 0x00,         //     local.get 0
+            0x0D, 0x00,         //     br_if 0
+            0x1A,               //     drop
+            0x20, 0x02,         //     local.get 2
+          0x18, 0x00,           //   delegate 0
+          0xFB, 0x16, 0x00,     //   ref.cast (ref 0)
+          0xFB, 0x02, 0x00, 0x00, // struct.get 0 0
+        0x19,                   // catch_all
+          0x42, 0x00,           //   i64.const 0
+        0x0B,                   // end (outer try)
+        0x0B,                   // end (func)
+    ];
+    // (func $make (result (ref 0)) i64.const 0x1234 struct.new 0)
+    const body1 = [0x00, 0x42, 0xB4, 0x24, 0xFB, 0x00, 0x00, 0x0B];
+    const codeSection = section(10, [0x02,
+        ...uleb128(body0.length), ...body0,
+        ...uleb128(body1.length), ...body1]);
+    return new Uint8Array([0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+        ...typeSection, ...funcSection, ...exportSection, ...codeSection]);
+}
+
+const bytes = buildModule();
+assert.truthy(WebAssembly.validate(bytes));
+const instance = new WebAssembly.Instance(new WebAssembly.Module(bytes));
+const struct = instance.exports.make();
+
+for (let i = 0; i < wasmTestLoopCount; ++i) {
+    // cond == 0: br_if not taken; the try body's (ref 0) fallthrough survives the
+    // delegate. Widened to anyref, ref.cast succeeds and struct.get reads the field.
+    assert.eq(instance.exports.test(0, null, struct), 0x1234n);
+    // cond == 1: br_if delivers an anyref-wrapped JS number to the inner continuation.
+    // The post-delegate value is statically anyref, so ref.cast must perform the full
+    // runtime check and trap rather than dereference the non-cell value.
+    assert.throws(() => instance.exports.test(1, 1.5, struct), WebAssembly.RuntimeError, "ref.cast failed to cast reference to target heap type");
+}

--- a/JSTests/wasm/stress/unreachable-end-if-no-else-widens-to-signature.js
+++ b/JSTests/wasm/stress/unreachable-end-if-no-else-widens-to-signature.js
@@ -1,0 +1,75 @@
+// rdar://180535979
+// The unreachable End handler synthesizes an else for `if`-without-`else` and
+// installs the saved if-param stack as the (reachable) else-arm result. Those
+// values must be widened to the block's declared result types before they
+// propagate to the parent stack: an unreachable then-arm may have `br 0`'d a
+// value that only inhabits the wider result type. Without widening, BBQ's
+// emitRefTestOrCast trusts the stale narrow type and elides the IsCell /
+// IsWasmGCObject runtime checks.
+
+import * as assert from "../assert.js";
+
+function uleb128(n) { const r = []; do { let b = n & 0x7f; n >>>= 7; if (n) b |= 0x80; r.push(b); } while (n); return r; }
+function encodeString(s) { const b = []; for (let i = 0; i < s.length; i++) b.push(s.charCodeAt(i)); return [...uleb128(b.length), ...b]; }
+function section(id, content) { return [id, ...uleb128(content.length), ...content]; }
+
+function buildModule() {
+    const typeSection = section(1, [
+        4,
+        0x5F, 0x01, 0x7E, 0x01,                         // type 0: struct { i64 mut }
+        0x60, 0x01, 0x64, 0x00, 0x01, 0x6E,             // type 1: func (param (ref 0)) (result anyref)
+        0x60, 0x03, 0x7F, 0x6F, 0x64, 0x00, 0x01, 0x7E, // type 2: func (i32, externref, (ref 0)) -> i64
+        0x60, 0x00, 0x01, 0x64, 0x00,                   // type 3: func () -> (ref 0)
+    ]);
+    const funcSection = section(3, [0x02, 0x02, 0x03]);
+    const exportSection = section(7, [0x02,
+        ...encodeString("test"), 0x00, 0x00,
+        ...encodeString("make"), 0x00, 0x01]);
+
+    // (func $test (param $cond i32) (param $ext externref) (param $s (ref 0)) (result i64)
+    //   local.get $s
+    //   local.get $cond
+    //   if (param (ref 0)) (result anyref)
+    //     drop
+    //     local.get $ext
+    //     any.convert_extern
+    //     br 0                  ;; then-arm goes unreachable
+    //   end                     ;; <- parseUnreachableExpression()::End, synthetic else
+    //   ref.cast (ref 0)        ;; must NOT elide IsCell / IsWasmGCObject checks
+    //   struct.get 0 0)
+    const body0 = [
+        0x00,
+        0x20, 0x02,
+        0x20, 0x00,
+        0x04, 0x01,
+        0x1A,
+        0x20, 0x01,
+        0xFB, 0x1A,
+        0x0C, 0x00,
+        0x0B,
+        0xFB, 0x16, 0x00,
+        0xFB, 0x02, 0x00, 0x00,
+        0x0B,
+    ];
+    // (func $make (result (ref 0)) i64.const 0x1234 struct.new 0)
+    const body1 = [0x00, 0x42, 0xB4, 0x24, 0xFB, 0x00, 0x00, 0x0B];
+    const codeSection = section(10, [0x02,
+        ...uleb128(body0.length), ...body0,
+        ...uleb128(body1.length), ...body1]);
+    return new Uint8Array([0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+        ...typeSection, ...funcSection, ...exportSection, ...codeSection]);
+}
+
+const bytes = buildModule();
+assert.truthy(WebAssembly.validate(bytes));
+const instance = new WebAssembly.Instance(new WebAssembly.Module(bytes));
+const struct = instance.exports.make();
+
+for (let i = 0; i < wasmTestLoopCount; ++i) {
+    // cond == 0: synthetic else delivers the (ref 0) param; ref.cast succeeds.
+    assert.eq(instance.exports.test(0, null, struct), 0x1234n);
+    // cond == 1: then-arm br's an anyref-wrapped JS number to the if's
+    // continuation. The post-end value is statically anyref, so ref.cast must
+    // perform the full runtime check and trap.
+    assert.throws(() => instance.exports.test(1, 1.5, struct), WebAssembly.RuntimeError, "ref.cast failed to cast reference to target heap type");
+}

--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -95,6 +95,8 @@ media/encrypted-media/encrypted-media-append-encrypted-unencrypted.html [ Skip ]
 media/media-source/media-source-append-play-corrupt-aac.html [ Skip ]
 media/media-source/media-source-mp4ttsimple.html [ Skip ]
 media/media-source/media-source-inband-cea608-track.html [ Skip ]
+# WebM generator not present in safari-7624.5-branch branch.
+media/media-source/media-source-webm-reversed-timestamps-crash.html [ Failure ]
 media/modern-media-controls/ios-inline-media-controls/touch [ Skip ]
 media/modern-media-controls/overflow-support [ Skip ]
 media/modern-media-controls/visionos-inline-media-controls [ Skip ]

--- a/LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash-expected.txt
+++ b/LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash-expected.txt
@@ -1,0 +1,11 @@
+Tests that appending a WebM cluster whose block timestamps decrease, after abort(), does not crash.
+
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+RUN(sourceBuffer.abort())
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (source.readyState == 'open') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash.html
+++ b/LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-webm-reversed-timestamps-crash</title>
+    <script src="webm-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // A WebM SimpleBlock cluster whose block timestamps go backward causes the
+    // WebM parser to compute a negative sample duration. When appended after
+    // abort() (which resets the track buffer's highest presentation timestamp
+    // while preserving its samples), Coded Frame Processing step 1.14 calls
+    // findSamplesBetweenPresentationTimes() with endTime < beginTime; the
+    // resulting reversed iterator range walks past the end of the sample map.
+    // This test passes if it does not crash.
+
+    var source;
+    var sourceBuffer;
+    var initData;
+
+    function simpleBlockCluster(trackNumber, clusterTimecode, blocks)
+    {
+        // Hand-roll a Cluster of SimpleBlocks (no BlockDuration), so the
+        // parser must derive each sample's duration from the gap to the
+        // next block's timestamp.
+        function vintSize(n)
+        {
+            if (n < 0x7F)
+                return new Uint8Array([0x80 | n]);
+            return new Uint8Array([0x40 | (n >> 8), n & 0xFF]);
+        }
+        var body = [new Uint8Array([0xE7, 0x81, clusterTimecode & 0xFF])];
+        for (var block of blocks) {
+            var ts = new Uint8Array(2);
+            new DataView(ts.buffer).setInt16(0, block.timestamp, false);
+            var payload = WebM.concat(new Uint8Array([0x80 | trackNumber]), ts,
+                new Uint8Array([block.isSync ? 0x80 : 0x00]), block.data);
+            body.push(new Uint8Array([0xA3]), vintSize(payload.byteLength), payload);
+        }
+        var clusterBody = WebM.concat(...body);
+        return WebM.concat(new Uint8Array([0x1F, 0x43, 0xB6, 0x75]),
+            vintSize(clusterBody.byteLength), clusterBody);
+    }
+
+    async function runTest()
+    {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(WebM.VIDEO_TYPE)) {
+            consoleWrite('SKIPPED: ' + WebM.VIDEO_TYPE + ' is not supported');
+            return;
+        }
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(WebM.VIDEO_TYPE);
+
+        initData = WebM.initSegment({ tracks: [{ id: 1, type: 'video', defaultDuration: 0 }] });
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        var samples = [{ duration: 50, isSync: true }];
+        for (var i = 0; i < 7; ++i)
+            samples.push({ duration: 50, isSync: false });
+        sourceBuffer.appendBuffer(WebM.mediaSegment({
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: samples }]
+        }));
+        await waitFor(sourceBuffer, 'updateend');
+
+        run('sourceBuffer.abort()');
+
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        sourceBuffer.appendBuffer(simpleBlockCluster(1, 0, [
+            { timestamp: 200, isSync: true, data: new Uint8Array([0x30, 0x12, 0x00, 0x9D, 0x01, 0x2A, 0x40, 0x01, 0xF0, 0x00, 0x00]) },
+            { timestamp: 10, isSync: false, data: new Uint8Array([0xD1, 0x02, 0x00]) },
+            { timestamp: 250, isSync: false, data: new Uint8Array([0xD1, 0x02, 0x00]) },
+        ]));
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('source.readyState', 'open');
+    }
+
+    window.addEventListener('load', () => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <div>Tests that appending a WebM cluster whose block timestamps decrease, after abort(), does not crash.</div>
+    <video></video>
+</body>
+</html>

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -219,6 +219,7 @@ private:
     };
 
     [[nodiscard]] PartialResult checkBlockFallthrough(const ControlType&, FallThroughStateTag);
+    [[nodiscard]] PartialResult endBlockAndCheckResultTypes(ControlEntry&);
 
     enum BranchConditionalityTag {
         Unconditional,
@@ -1823,6 +1824,19 @@ auto FunctionParser<Context>::checkBlockFallthrough(const ControlType& controlDa
             m_expressionStack[i].setType(expectedType);
     }
 
+    return { };
+}
+
+template<typename Context>
+auto FunctionParser<Context>::endBlockAndCheckResultTypes(ControlEntry& entry) -> PartialResult
+{
+    // Widen each result to the block signature type before ending the block.
+    // FIXME: mutating the expression stack for the block result is effectful, but there's no
+    // better API yet. See https://bugs.webkit.org/show_bug.cgi?id=164353
+    WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(entry.controlData, MergePoint));
+    // We should avoid adding other callsites of endBlock. Since a new block is a sign of a
+    // merge point and it would be a security bug to fail to widen the types.
+    WASM_TRY_ADD_TO_CONTEXT(endBlock(entry, m_expressionStack));
     return { };
 }
 
@@ -3587,8 +3601,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_VALIDATOR_FAIL_IF(!ControlType::isTry(targetData) && !ControlType::isTopLevel(targetData), "delegate target isn't a try or the top level block");
 
         WASM_TRY_ADD_TO_CONTEXT(addDelegate(targetData, controlEntry.controlData));
-        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
-        WASM_TRY_ADD_TO_CONTEXT(endBlock(controlEntry, m_expressionStack));
+        // Unlike the sibling catch/catch_all arms, delegate ends the try block, so it widens results.
+        WASM_FAIL_IF_HELPER_FAILS(endBlockAndCheckResultTypes(controlEntry));
         m_expressionStack.swap(controlEntry.enclosedExpressionStack);
         resetLocalInitStackToHeight(controlEntry.localInitStackHeight);
         return { };
@@ -3723,11 +3737,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_ADD_TO_CONTEXT(addElse(data.controlData, m_expressionStack));
             m_expressionStack = WTF::move(data.elseBlockStack);
         }
-        // FIXME: This is a little weird in that it will modify the expressionStack for the result of the block.
-        // That's a little too effectful for me but I don't have a better API right now.
-        // see: https://bugs.webkit.org/show_bug.cgi?id=164353
-        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(data.controlData, MergePoint));
-        WASM_TRY_ADD_TO_CONTEXT(endBlock(data, m_expressionStack));
+        WASM_FAIL_IF_HELPER_FAILS(endBlockAndCheckResultTypes(data));
         m_expressionStack.swap(data.enclosedExpressionStack);
         if (!ControlType::isTopLevel(data.controlData))
             resetLocalInitStackToHeight(data.localInitStackHeight);
@@ -3789,36 +3799,36 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         return { };
     }
 #if ENABLE(B3_JIT)
-            case ExtSIMD: {
-                WASM_PARSER_FAIL_IF(!Options::useWasmSIMD(), "wasm-simd is not enabled"_s);
-                m_context.notifyFunctionUsesSIMD();
-                WASM_PARSER_FAIL_IF(!parseVarUInt32(m_currentExtOp), "can't parse wasm extended opcode"_s);
-                m_context.willParseExtendedOpcode();
-        
-                constexpr bool isReachable = true;
-        
-                ExtSIMDOpType op = static_cast<ExtSIMDOpType>(m_currentExtOp);
-                if (Options::dumpWasmOpcodeStatistics()) [[unlikely]]
-                    WasmOpcodeCounter::singleton().increment(op);
-        
-                switch (op) {
-                #define CREATE_SIMD_CASE(name, _, laneOp, lane, signMode) case ExtSIMDOpType::name: return simd<isReachable>(SIMDLaneOperation::laneOp, lane, signMode);
-                FOR_EACH_WASM_EXT_SIMD_GENERAL_OP(CREATE_SIMD_CASE)
-                #undef CREATE_SIMD_CASE
-                #define CREATE_SIMD_CASE(name, _, laneOp, lane, signMode, relArg) case ExtSIMDOpType::name: return simd<isReachable>(SIMDLaneOperation::laneOp, lane, signMode, relArg);
-                FOR_EACH_WASM_EXT_SIMD_REL_OP(CREATE_SIMD_CASE)
-                #undef CREATE_SIMD_CASE
-                default:
-                    WASM_PARSER_FAIL_IF(true, "invalid extended simd op "_s, m_currentExtOp);
-                    break;
+                case ExtSIMD: {
+                    WASM_PARSER_FAIL_IF(!Options::useWasmSIMD(), "wasm-simd is not enabled"_s);
+                    m_context.notifyFunctionUsesSIMD();
+                    WASM_PARSER_FAIL_IF(!parseVarUInt32(m_currentExtOp), "can't parse wasm extended opcode"_s);
+                    m_context.willParseExtendedOpcode();
+            
+                    constexpr bool isReachable = true;
+            
+                    ExtSIMDOpType op = static_cast<ExtSIMDOpType>(m_currentExtOp);
+                    if (Options::dumpWasmOpcodeStatistics()) [[unlikely]]
+                        WasmOpcodeCounter::singleton().increment(op);
+            
+                    switch (op) {
+                    #define CREATE_SIMD_CASE(name, _, laneOp, lane, signMode) case ExtSIMDOpType::name: return simd<isReachable>(SIMDLaneOperation::laneOp, lane, signMode);
+                    FOR_EACH_WASM_EXT_SIMD_GENERAL_OP(CREATE_SIMD_CASE)
+                    #undef CREATE_SIMD_CASE
+                    #define CREATE_SIMD_CASE(name, _, laneOp, lane, signMode, relArg) case ExtSIMDOpType::name: return simd<isReachable>(SIMDLaneOperation::laneOp, lane, signMode, relArg);
+                    FOR_EACH_WASM_EXT_SIMD_REL_OP(CREATE_SIMD_CASE)
+                    #undef CREATE_SIMD_CASE
+                    default:
+                        WASM_PARSER_FAIL_IF(true, "invalid extended simd op "_s, m_currentExtOp);
+                        break;
+                    }
+                    return { };
                 }
-                return { };
-            }
-        #else
-            case ExtSIMD:
-                WASM_PARSER_FAIL_IF(true, "wasm-simd is not supported"_s);
-                return { };
-        #endif
+            #else
+                case ExtSIMD:
+                    WASM_PARSER_FAIL_IF(true, "wasm-simd is not supported"_s);
+                    return { };
+            #endif
     }
 
     ASSERT_NOT_REACHED();
@@ -3916,8 +3926,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
             if (ControlType::isIf(data.controlData)) {
                 WASM_TRY_ADD_TO_CONTEXT(addElseToUnreachable(data.controlData));
                 m_expressionStack = WTF::move(data.elseBlockStack);
-                WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(data.controlData, MergePoint));
-                WASM_TRY_ADD_TO_CONTEXT(endBlock(data, m_expressionStack));
+                WASM_FAIL_IF_HELPER_FAILS(endBlockAndCheckResultTypes(data));
             } else {
                 Stack emptyStack;
                 WASM_TRY_ADD_TO_CONTEXT(addEndToUnreachable(data, emptyStack));

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -212,7 +212,13 @@ private:
     [[nodiscard]] PartialResult parseUnreachableExpression();
     [[nodiscard]] PartialResult unifyControl(ArgumentList&, unsigned level);
     [[nodiscard]] PartialResult checkLocalInitialized(uint32_t);
-    [[nodiscard]] PartialResult checkExpressionStack(const ControlType&, bool forceSignature = false);
+
+    enum FallThroughStateTag {
+        NewSiblingBlock,
+        MergePoint,
+    };
+
+    [[nodiscard]] PartialResult checkBlockFallthrough(const ControlType&, FallThroughStateTag);
 
     enum BranchConditionalityTag {
         Unconditional,
@@ -1801,7 +1807,7 @@ auto FunctionParser<Context>::checkLocalInitialized(uint32_t index) -> PartialRe
 }
 
 template<typename Context>
-auto FunctionParser<Context>::checkExpressionStack(const ControlType& controlData, bool forceSignature) -> PartialResult
+auto FunctionParser<Context>::checkBlockFallthrough(const ControlType& controlData, FallThroughStateTag fallthrough) -> PartialResult
 {
     const auto& blockSignature = controlData.signature();
     WASM_VALIDATOR_FAIL_IF(blockSignature.returnCount() != m_expressionStack.size(), " block with type: "_s, blockSignature, " returns: "_s, blockSignature.returnCount(), " but stack has: "_s, m_expressionStack.size(), " values"_s);
@@ -1809,7 +1815,11 @@ auto FunctionParser<Context>::checkExpressionStack(const ControlType& controlDat
         const auto actualType = m_expressionStack[i].type();
         const auto expectedType = blockSignature.returnType(i);
         WASM_VALIDATOR_FAIL_IF(!isSubtype(actualType, expectedType), "control flow returns with unexpected type. "_s, actualType, " is not a "_s, expectedType);
-        if (forceSignature)
+        // The spec requires the output type of a structured control instruction to be
+        // the result type from its signature, even when the fallthrough value is a subtype.
+        // FIXME: We should support some sort of abstract interpretation so this can be the
+        // least upper bound of the merging CFG.
+        if (fallthrough == MergePoint)
             m_expressionStack[i].setType(expectedType);
     }
 
@@ -3399,7 +3409,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         ControlEntry& controlEntry = m_controlStack.last();
 
         WASM_VALIDATOR_FAIL_IF(!ControlType::isIf(controlEntry.controlData), "else block isn't associated to an if");
-        WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(controlEntry.controlData));
+        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
         WASM_TRY_ADD_TO_CONTEXT(addElse(controlEntry.controlData, m_expressionStack));
         m_expressionStack = WTF::move(controlEntry.elseBlockStack);
         resetLocalInitStackToHeight(controlEntry.localInitStackHeight);
@@ -3439,7 +3449,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         ControlEntry& controlEntry = m_controlStack.last();
         WASM_VALIDATOR_FAIL_IF(!isTryOrCatch(controlEntry.controlData), "catch block isn't associated to a try");
-        WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(controlEntry.controlData));
+        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
 
         ResultList results;
         Stack preCatchStack;
@@ -3465,7 +3475,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         ControlEntry& controlEntry = m_controlStack.last();
 
         WASM_VALIDATOR_FAIL_IF(!isTryOrCatch(controlEntry.controlData), "catch block isn't associated to a try");
-        WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(controlEntry.controlData));
+        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
 
         ResultList results;
         Stack preCatchStack;
@@ -3577,7 +3587,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         WASM_VALIDATOR_FAIL_IF(!ControlType::isTry(targetData) && !ControlType::isTopLevel(targetData), "delegate target isn't a try or the top level block");
 
         WASM_TRY_ADD_TO_CONTEXT(addDelegate(targetData, controlEntry.controlData));
-        WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(controlEntry.controlData));
+        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(controlEntry.controlData, NewSiblingBlock));
         WASM_TRY_ADD_TO_CONTEXT(endBlock(controlEntry, m_expressionStack));
         m_expressionStack.swap(controlEntry.enclosedExpressionStack);
         resetLocalInitStackToHeight(controlEntry.localInitStackHeight);
@@ -3709,16 +3719,14 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     case End: {
         ControlEntry data = m_controlStack.takeLast();
         if (ControlType::isIf(data.controlData)) {
-            WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(data.controlData));
+            WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(data.controlData, NewSiblingBlock));
             WASM_TRY_ADD_TO_CONTEXT(addElse(data.controlData, m_expressionStack));
             m_expressionStack = WTF::move(data.elseBlockStack);
         }
-        // The spec requires the output type of a structured control instruction to be
-        // the result type from its signature, even when the fallthrough value is a subtype.
         // FIXME: This is a little weird in that it will modify the expressionStack for the result of the block.
         // That's a little too effectful for me but I don't have a better API right now.
         // see: https://bugs.webkit.org/show_bug.cgi?id=164353
-        WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(data.controlData, true));
+        WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(data.controlData, MergePoint));
         WASM_TRY_ADD_TO_CONTEXT(endBlock(data, m_expressionStack));
         m_expressionStack.swap(data.enclosedExpressionStack);
         if (!ControlType::isTopLevel(data.controlData))
@@ -3781,36 +3789,36 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         return { };
     }
 #if ENABLE(B3_JIT)
-        case ExtSIMD: {
-            WASM_PARSER_FAIL_IF(!Options::useWasmSIMD(), "wasm-simd is not enabled"_s);
-            m_context.notifyFunctionUsesSIMD();
-            WASM_PARSER_FAIL_IF(!parseVarUInt32(m_currentExtOp), "can't parse wasm extended opcode"_s);
-            m_context.willParseExtendedOpcode();
-    
-            constexpr bool isReachable = true;
-    
-            ExtSIMDOpType op = static_cast<ExtSIMDOpType>(m_currentExtOp);
-            if (Options::dumpWasmOpcodeStatistics()) [[unlikely]]
-                WasmOpcodeCounter::singleton().increment(op);
-    
-            switch (op) {
-            #define CREATE_SIMD_CASE(name, _, laneOp, lane, signMode) case ExtSIMDOpType::name: return simd<isReachable>(SIMDLaneOperation::laneOp, lane, signMode);
-            FOR_EACH_WASM_EXT_SIMD_GENERAL_OP(CREATE_SIMD_CASE)
-            #undef CREATE_SIMD_CASE
-            #define CREATE_SIMD_CASE(name, _, laneOp, lane, signMode, relArg) case ExtSIMDOpType::name: return simd<isReachable>(SIMDLaneOperation::laneOp, lane, signMode, relArg);
-            FOR_EACH_WASM_EXT_SIMD_REL_OP(CREATE_SIMD_CASE)
-            #undef CREATE_SIMD_CASE
-            default:
-                WASM_PARSER_FAIL_IF(true, "invalid extended simd op "_s, m_currentExtOp);
-                break;
+            case ExtSIMD: {
+                WASM_PARSER_FAIL_IF(!Options::useWasmSIMD(), "wasm-simd is not enabled"_s);
+                m_context.notifyFunctionUsesSIMD();
+                WASM_PARSER_FAIL_IF(!parseVarUInt32(m_currentExtOp), "can't parse wasm extended opcode"_s);
+                m_context.willParseExtendedOpcode();
+        
+                constexpr bool isReachable = true;
+        
+                ExtSIMDOpType op = static_cast<ExtSIMDOpType>(m_currentExtOp);
+                if (Options::dumpWasmOpcodeStatistics()) [[unlikely]]
+                    WasmOpcodeCounter::singleton().increment(op);
+        
+                switch (op) {
+                #define CREATE_SIMD_CASE(name, _, laneOp, lane, signMode) case ExtSIMDOpType::name: return simd<isReachable>(SIMDLaneOperation::laneOp, lane, signMode);
+                FOR_EACH_WASM_EXT_SIMD_GENERAL_OP(CREATE_SIMD_CASE)
+                #undef CREATE_SIMD_CASE
+                #define CREATE_SIMD_CASE(name, _, laneOp, lane, signMode, relArg) case ExtSIMDOpType::name: return simd<isReachable>(SIMDLaneOperation::laneOp, lane, signMode, relArg);
+                FOR_EACH_WASM_EXT_SIMD_REL_OP(CREATE_SIMD_CASE)
+                #undef CREATE_SIMD_CASE
+                default:
+                    WASM_PARSER_FAIL_IF(true, "invalid extended simd op "_s, m_currentExtOp);
+                    break;
+                }
+                return { };
             }
-            return { };
-        }
-    #else
-        case ExtSIMD:
-            WASM_PARSER_FAIL_IF(true, "wasm-simd is not supported"_s);
-            return { };
-    #endif
+        #else
+            case ExtSIMD:
+                WASM_PARSER_FAIL_IF(true, "wasm-simd is not supported"_s);
+                return { };
+        #endif
     }
 
     ASSERT_NOT_REACHED();
@@ -3908,7 +3916,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
             if (ControlType::isIf(data.controlData)) {
                 WASM_TRY_ADD_TO_CONTEXT(addElseToUnreachable(data.controlData));
                 m_expressionStack = WTF::move(data.elseBlockStack);
-                WASM_FAIL_IF_HELPER_FAILS(checkExpressionStack(data.controlData));
+                WASM_FAIL_IF_HELPER_FAILS(checkBlockFallthrough(data.controlData, MergePoint));
                 WASM_TRY_ADD_TO_CONTEXT(endBlock(data, m_expressionStack));
             } else {
                 Stack emptyStack;

--- a/Source/WebCore/Modules/mediasource/SampleMap.cpp
+++ b/Source/WebCore/Modules/mediasource/SampleMap.cpp
@@ -291,6 +291,8 @@ DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSampleAfterDecodeIt
 
 PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSamplesBetweenPresentationTimes(const MediaTime& beginTime, const MediaTime& endTime) LIFETIME_BOUND
 {
+    if (endTime <= beginTime)
+        return { end(), end() };
     // startTime is inclusive, so use lower_bound to include samples wich start exactly at startTime.
     // endTime is not inclusive, so use lower_bound to exclude samples which start exactly at endTime.
     auto lower_bound = m_samples.lower_bound(beginTime);
@@ -302,6 +304,8 @@ PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSampl
 
 PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSamplesBetweenPresentationTimesFromEnd(const MediaTime& beginTime, const MediaTime& endTime) LIFETIME_BOUND
 {
+    if (endTime <= beginTime)
+        return { end(), end() };
     reverse_iterator rangeEnd = std::find_if(rbegin(), rend(), [&endTime](const auto& value) {
         return value.first < endTime;
     });

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -1201,6 +1201,17 @@ void WebMParser::VideoTrackData::processPendingMediaSamples(const MediaTime& pre
     if (!m_pendingMediaSamples.size())
         return;
     auto& lastSample = m_pendingMediaSamples.last();
+    // The WebM container does not encode per-frame durations; we derive them
+    // from the gap to the next frame's presentation time. A malformed cluster
+    // whose block timestamps decrease would yield a negative duration here,
+    // which propagates to SourceBufferPrivate::processMediaSample() as
+    // frameEndTimestamp < presentationTimestamp. Treat any non-increasing
+    // timestamp the same as the existing equal-timestamp case below: leave the
+    // pending sample queued (with zero duration) until a later frame arrives.
+    if (presentationTime < lastSample.presentationTime) {
+        lastSample.duration = MediaTime::zeroTime();
+        return;
+    }
     lastSample.duration = presentationTime - lastSample.presentationTime;
     if (presentationTime == lastSample.presentationTime)
         return;

--- a/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
@@ -231,6 +231,10 @@ TEST_F(SampleMapTest, findSamplesBetweenPresentationTimes)
     iterator_range = presentationMap.findSamplesBetweenPresentationTimes(MediaTime(30, 1), MediaTime(31, 1));
     EXPECT_TRUE(presentationMap.end() == iterator_range.first);
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
+
+    iterator_range = presentationMap.findSamplesBetweenPresentationTimes(MediaTime(5, 1), MediaTime(2, 1));
+    EXPECT_TRUE(presentationMap.end() == iterator_range.first);
+    EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 }
 
 TEST_F(SampleMapTest, findSamplesBetweenPresentationTimesFromEnd)
@@ -266,6 +270,10 @@ TEST_F(SampleMapTest, findSamplesBetweenPresentationTimesFromEnd)
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 
     iterator_range = presentationMap.findSamplesBetweenPresentationTimesFromEnd(MediaTime(30, 1), MediaTime(31, 1));
+    EXPECT_TRUE(presentationMap.end() == iterator_range.first);
+    EXPECT_TRUE(presentationMap.end() == iterator_range.second);
+
+    iterator_range = presentationMap.findSamplesBetweenPresentationTimesFromEnd(MediaTime(5, 1), MediaTime(2, 1));
     EXPECT_TRUE(presentationMap.end() == iterator_range.first);
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 }


### PR DESCRIPTION
#### c31030bfedab2087992dd22757f54f0fc0d561fb
<pre>
Cherry-pick 305413.1096@safari-7624.5-branch (db3010593c27). <a href="https://bugs.webkit.org/show_bug.cgi?id=318755">https://bugs.webkit.org/show_bug.cgi?id=318755</a>

    [Wasm] Delegate should widen types like End
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318755">https://bugs.webkit.org/show_bug.cgi?id=318755</a>
    <a href="https://rdar.apple.com/181457816">rdar://181457816</a>

    Reviewed by Yusuke Suzuki.

    The legacy Delegate wasm bytecode is essentially shorthand for: `Rethrow;
    End`. So like other merge points it needs to widen the types on the
    expression stack. To help avoid this problem in the future add a new
    helper `endBlockAndCheckResultTypes`, which ensures the types are
    appropriately widened.

    Test: JSTests/wasm/stress/delegate-widens-result-type-to-signature.js
    Identifier: 305413.1096@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1173@webkitglib/2.52">https://commits.webkit.org/305877.1173@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 6360962b83fae44a3324e0cd9baef9a2cdd95517
<pre>
Cherry-pick 305413.1082@safari-7624.5.1.10-branch (bd4c91c57d10). <a href="https://bugs.webkit.org/show_bug.cgi?id=318480">https://bugs.webkit.org/show_bug.cgi?id=318480</a>

    Malformed WebM with non-monotonically increasing presentation timestamps can cause a crash.
    <a href="https://rdar.apple.com/177494050">rdar://177494050</a>

    Reviewed by Eric Carlson.

    We guard against non-monotonically increasing presentation timestamps in SourceBufferParserWebM
    and SampleMap

    Tests: media/media-source/media-source-webm-reversed-timestamps-crash.html
           Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp

    * LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash-expected.txt: Added.
    * LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash.html: Added.
    * Source/WebCore/Modules/mediasource/SampleMap.cpp:
    (WebCore::PresentationOrderSampleMap::findSamplesBetweenPresentationTimes):
    (WebCore::PresentationOrderSampleMap::findSamplesBetweenPresentationTimesFromEnd):
    * Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
    (WebCore::WebMParser::VideoTrackData::processPendingMediaSamples):
    * Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp:
    (TestWebKitAPI::TEST_F(SampleMapTest, findSamplesBetweenPresentationTimes)):
    (TestWebKitAPI::TEST_F(SampleMapTest, findSamplesBetweenPresentationTimesFromEnd)):

    Identifier: 305413.1082@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1172@webkitglib/2.52">https://commits.webkit.org/305877.1172@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 78fb97044c74f29aaf46193b94d6218cb60c99bd
<pre>
Cherry-pick 305413.1080@safari-7624.5-branch (f65ca49ea4a7). <a href="https://bugs.webkit.org/show_bug.cgi?id=318480">https://bugs.webkit.org/show_bug.cgi?id=318480</a>

    [Wasm] Unreachable end ops don&apos;t widen result types
    <a href="https://bugs.webkit.org/show_bug.cgi?id=318480">https://bugs.webkit.org/show_bug.cgi?id=318480</a>
    <a href="https://rdar.apple.com/180535979">rdar://180535979</a>

    Reviewed by Yusuke Suzuki.

    In 305413.1013@safari-7624.5-branch we fixed how result types were
    pushed onto the wasm value stack, widening them to the expected type
    rather than the last predecessor&apos;s type at the merge.

    This missed the case for unreachable expressions in the block, which
    is fixed in this patch.

    Identifier: 305413.1080@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/305877.1171@webkitglib/2.52">https://commits.webkit.org/305877.1171@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/638c956d444ac6d48e0234052da4e52934c6df65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185734 "10 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59639 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53447 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196041 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150433 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187596 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/61007 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59366 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145143 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150433 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188689 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/61007 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53447 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125438 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/61007 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59366 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7333 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53447 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/61007 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53447 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7104 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/46981 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52269 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59366 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198007 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59301 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53447 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154681 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/60009 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53447 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154333 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28201 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/60009 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132359 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129313 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58476 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53447 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57854 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58090 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57917 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->