### PR TITLE
Work around Clang 18 crash when mapping SVG stroke dash arrays

### DIFF
--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -564,7 +564,7 @@ void SVGRenderSupport::applyStrokeStyleToContext(GraphicsContext& context, const
         }
         
         bool canSetLineDash = false;
-        auto dashArray = DashArray::map(dashes, [&lengthContext, usedZoom, scaleFactor, &canSetLineDash](auto& dash) -> DashArrayElement {
+        auto dashArray = DashArray::map(dashes, [&lengthContext, usedZoom, scaleFactor, &canSetLineDash](const Style::SVGStrokeDasharrayValue& dash) -> DashArrayElement {
             auto value = lengthContext.valueForLength(dash, usedZoom) * scaleFactor;
             if (value > 0)
                 canSetLineDash = true;

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -209,7 +209,7 @@ static void writeSVGStrokePaintingResource(TextStream& ts, const RenderElement& 
     auto zoom = style.usedZoomForLength();
     double dashOffset = lengthContext.valueForLength(style.strokeDashOffset(), zoom);
     double strokeWidth = lengthContext.valueForLength(style.strokeWidth(), zoom);
-    auto dashArray = DashArray::map(style.strokeDashArray(), [&](auto& length) -> DashArrayElement {
+    auto dashArray = DashArray::map(style.strokeDashArray(), [&](const Style::SVGStrokeDasharrayValue& length) -> DashArrayElement {
         return lengthContext.valueForLength(length, zoom);
     });
 


### PR DESCRIPTION
#### d195540b4317093ef9b0e69fa51eaed7ad9d90e0
<pre>
Work around Clang 18 crash when mapping SVG stroke dash arrays

Reviewed by Nikolas Zimmermann.

Clang 18 segfaults in Sema::tryCaptureVariable() while compiling the rendering
unified sources with -std=c++23:

    3  clang::Sema::tryCaptureVariable(...)
    4  clang::Sema::BuildDeclRefExpr(...)
    12 clang::Sema::SubstConstraintExpr(...)
    16 clang::Sema::CheckInstantiatedFunctionTemplateConstraints(...)
    21 clang::Sema::AddTemplateOverloadCandidate(...)
    27 clang::Sema::AddMethodCandidate(...)
    28 clang::Sema::BuildCallToMemberFunction(...)

Resolving lengthContext.valueForLength(dash, zoom) inside the DashArray::map()
lambdas makes the compiler check whether the argument converts to each of the
eight SVGLengthContext::valueForLength() parameter types. The Style wrappers
among them inherit PrimitiveNumericWrapperBase&apos;s variadic constructor, whose
requires-clause mentions its own function parameters:

    template&lt;typename... Args&gt;
    ALWAYS_INLINE PrimitiveNumericWrapperBase(Args&amp;&amp;... args)
       requires (requires { { LengthPercentage&lt;R, V&gt;(args...) }; })

Both call sites took the dash element as auto&amp;, so that constraint is
substituted while the generic lambda body is being instantiated. Clang 18 then
tries to capture the constructor&apos;s parameters and dereferences null.

Upstream fixed this in llvm/llvm-project#93206, &quot;[clang] Fix crash in
tryCaptureVariable for unevaluated lambdas&quot; (commit 3d361b2, merged into main
on 2024-06-04) but this was never backported to Clang 18.x release and still
crashes.

Spelling the lambda parameter type out keeps the body non-dependent, so the
constraint is checked in an ordinary function context instead and the crash
goes away.

* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::applyStrokeStyleToContext):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGStrokePaintingResource):

Canonical link: <a href="https://commits.webkit.org/320746@main">https://commits.webkit.org/320746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cc2229bd3ff5257047eaa03b5b523513b27c7fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196042 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150434 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145146 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100649 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188690 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165711 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125441 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47555 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45593 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157915 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45288 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7105 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198008 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59302 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154682 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41435 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60010 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154334 "Passed tests") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/28199 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48796 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132360 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129314 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58477 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20311 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57855 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58091 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57918 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->