### PR TITLE
Cherry-pick 320617@main (c51d679f5b96). https://bugs.webkit.org/show_bug.cgi?id=323594

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
@@ -84,6 +84,7 @@ void RemoteGraphicsContextGLProxyGBM::prepareForDisplay()
     if (contextAttributes().alpha)
         flags.add(TextureMapperFlags::ShouldBlend);
     m_layerContentsDisplayDelegate->setDisplayBuffer(CoordinatedPlatformLayerBufferDMABuf::create(protect(*m_displayBuffer), flags, WTF::move(fenceFD)));
+    m_hasPreparedForDisplay = true;
 }
 
 Ref<RemoteGraphicsContextGLProxy> RemoteGraphicsContextGLProxy::platformCreate(const GraphicsContextGLAttributes& attributes, RemoteRenderingBackendProxy& renderingBackend)


### PR DESCRIPTION
#### 0ab5fa4b71f694842a7e5c49b1e238dc6116f2a8
<pre>
Cherry-pick 320617@main (c51d679f5b96). <a href="https://bugs.webkit.org/show_bug.cgi?id=323594">https://bugs.webkit.org/show_bug.cgi?id=323594</a>

    [WPE][GTK] transferToImageBitmap broken when offscreen WebGL used with GPUProcess
    <a href="https://bugs.webkit.org/show_bug.cgi?id=323594">https://bugs.webkit.org/show_bug.cgi?id=323594</a>

    Reviewed by Carlos Garcia Campos.

    This change marks RemoteGraphicsContextGLProxyGBM::prepareForDisplay()
    execution properly so that RemoteGraphicsContextGLProxy::copyNativeImage()
    won&apos;t bail out early.

    Canonical link: <a href="https://commits.webkit.org/320617@main">https://commits.webkit.org/320617@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.243@webkitglib/2.54">https://commits.webkit.org/317695.243@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90c4f6e8fda0b5a8d26cd8f82b412ec1126369a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185751 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59656 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53464 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196058 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150445 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/61024 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59383 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145155 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150445 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188706 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/61024 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53464 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125450 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/61024 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59383 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53464 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/61024 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53464 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7121 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52286 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59383 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198024 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59318 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53464 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154698 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/60026 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53464 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154350 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28191 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/60026 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132375 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129338 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58493 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53464 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57871 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58107 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57934 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->