### PR TITLE
Cherry-pick 320607@main (d010ad1606e1). https://bugs.webkit.org/show_bug.cgi?id=323410

### DIFF
--- a/LayoutTests/compositing/filters/drop-shadow-clipped-by-parent-overflow-expected.html
+++ b/LayoutTests/compositing/filters/drop-shadow-clipped-by-parent-overflow-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<style>
+    .clipper {
+        width: 150px;
+        height: 150px;
+        overflow: hidden;
+        position: relative;
+        background: white;
+    }
+    .filtered {
+        width: 100%;
+        height: 100%;
+        background: green;
+        will-change: transform;
+    }
+</style>
+
+You should see no red.
+
+<div class="clipper">
+    <div class="filtered"></div>
+</div>

--- a/LayoutTests/compositing/filters/drop-shadow-clipped-by-parent-overflow.html
+++ b/LayoutTests/compositing/filters/drop-shadow-clipped-by-parent-overflow.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<style>
+    .clipper {
+        width: 150px;
+        height: 150px;
+        overflow: hidden;
+        position: relative;
+        background: white;
+    }
+    .filtered {
+        width: 100%;
+        height: 100%;
+        background: green;
+        will-change: transform;
+        filter: drop-shadow(100px 100px 10px red);
+    }
+</style>
+
+You should see no red.
+
+<div class="clipper">
+    <div class="filtered"></div>
+</div>

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -1032,6 +1032,10 @@ void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& 
             childBounds = m_children[0]->m_rect;
         if (m_children[0]->m_contentsBuffer || m_children[0]->m_imageBackingStore || (m_children[0]->m_contentsSolidColor.isValid() && m_children[0]->m_contentsSolidColor.isVisible()))
             childBounds.unite(m_children[0]->m_contentsRect);
+
+        if (auto childFilter = m_children[0]->filter(); childFilter && !childFilter->outsets.isZero() && !m_children[0]->m_masksToBounds && !m_children[0]->m_mask)
+            childBounds.expand(toFloatBoxExtent(childFilter->outsets));
+
         return matrix.mapRect(SkRect(rect.rect())).contains(childMatrix.mapRect(SkRect(childBounds)));
     };
 


### PR DESCRIPTION
#### e6ed333b7d0a8a8752b7300bd3a8d89a377f62c5
<pre>
Cherry-pick 320607@main (d010ad1606e1). <a href="https://bugs.webkit.org/show_bug.cgi?id=323410">https://bugs.webkit.org/show_bug.cgi?id=323410</a>

    SkiaCompositingLayer: canSkipClip should account for filter outsets
    <a href="https://bugs.webkit.org/show_bug.cgi?id=323410">https://bugs.webkit.org/show_bug.cgi?id=323410</a>

    Reviewed by Carlos Garcia Campos.

    A single child layer which has a filter outsets was not clipped properly.

    * LayoutTests/compositing/filters/drop-shadow-clipped-by-parent-overflow-expected.html: Added.
    * LayoutTests/compositing/filters/drop-shadow-clipped-by-parent-overflow.html: Added.
    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
    (WebCore::SkiaCompositingLayer::paintSelfAndChildren):

    Canonical link: <a href="https://commits.webkit.org/320607@main">https://commits.webkit.org/320607@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.244@webkitglib/2.54">https://commits.webkit.org/317695.244@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc39a3e8fb11b238b67937057ef7aedd215176fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185752 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59657 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53465 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196059 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150446 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187614 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/61025 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59384 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145156 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150446 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188707 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/61025 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53465 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125451 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/61025 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59384 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53465 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/61025 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53465 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7122 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52287 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59384 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198025 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59319 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53465 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154701 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/60027 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53465 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154352 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28190 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/60027 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132377 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129343 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58494 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53465 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57872 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58108 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57935 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->