### PR TITLE
Cherry-pick 320647@main (1508d59b56eb). https://bugs.webkit.org/show_bug.cgi?id=323436

### DIFF
--- a/LayoutTests/webanimations/accelerated-animation-not-invalidated-by-sibling-timeline-ticks-expected.txt
+++ b/LayoutTests/webanimations/accelerated-animation-not-invalidated-by-sibling-timeline-ticks-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A fully accelerated animation must not invalidate style only because another non-accelerated animation is running.
+

--- a/LayoutTests/webanimations/accelerated-animation-not-invalidated-by-sibling-timeline-ticks.html
+++ b/LayoutTests/webanimations/accelerated-animation-not-invalidated-by-sibling-timeline-ticks.html
@@ -1,0 +1,29 @@
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="threaded-animations/threaded-animations-utils.js"></script>
+<div id="pump" style="width: 100px; height: 100px;"></div>
+<div id="test" style="width: 100px; height: 100px;"></div>
+<script>
+
+promise_test(async () => {
+    // #pump can never run accelerated (animates layout-affecting "width"), so it keeps ticking the shared timeline;
+    // #test must not invalidate style only because it shares that timeline.
+
+    document.getElementById("pump").animate({ width: ["100px", "200px"] }, { duration: 50, iterations: Infinity });
+
+    const testElement = document.getElementById("test");
+    const testAnimation = testElement.animate({ opacity: [1, 0.4] }, { duration: 50, iterations: Infinity });
+    await animationAcceleration(testAnimation);
+
+    assert_equals(internals.acceleratedAnimationsForElement(testElement).length, 1, "The animation should be running accelerated.");
+
+    // It takes two frames for the style update to settle after the accelerated animation starts.
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+
+    assert_equals(internals.lastStyleUpdateSize, 1, "Only the non-accelerated #pump element should have had its style resolved.");
+}, "A fully accelerated animation must not invalidate style only because another non-accelerated animation is running.");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2130,7 +2130,21 @@ void KeyframeEffect::addPendingAcceleratedAction(AcceleratedAction action)
 
 void KeyframeEffect::animationDidTick()
 {
-    invalidate();
+    auto canSkipInvalidation = [this]() {
+        if (!isCompletelyAccelerated() || !isRunningAccelerated())
+            return false;
+        if (getBasicTiming().phase != m_phaseAtLastApplication)
+            return false;
+#if ENABLE(THREADED_ANIMATIONS)
+        if (canHaveAcceleratedRepresentation() && m_isAssociatedWithProgressBasedTimeline)
+            return false;
+#endif
+        return true;
+    };
+
+    if (!canSkipInvalidation())
+        invalidate();
+
     updateAcceleratedActions();
 
 #if ENABLE(THREADED_ANIMATIONS)


### PR DESCRIPTION
#### 6fc5f640beedd0c5fdb28bd47fbd214d3c328d1b
<pre>
Cherry-pick 320647@main (1508d59b56eb). <a href="https://bugs.webkit.org/show_bug.cgi?id=323436">https://bugs.webkit.org/show_bug.cgi?id=323436</a>

    [Web Animations] Fully accelerated animations unnecessarily invalidate style while a non-accelerated animation is running
    <a href="https://bugs.webkit.org/show_bug.cgi?id=323436">https://bugs.webkit.org/show_bug.cgi?id=323436</a>

    Reviewed by Antoine Quint.

    When a page has at least one animation that cannot run on the
    compositor, that animation forces the page to process animation updates
    on every frame. While this happens, other animations on the same page
    that are otherwise running entirely on the compositor have their style
    needlessly recalculated on every update too, and in some cases this can
    force layout.

    `KeyframeEffect::animationDidTick()` unconditionally invalidated the
    target&apos;s style on every tick, even for effects that were fully
    accelerated and confirmed running on the compositor, whenever some other
    animation on the shared timeline forced that tick.

    Skip `invalidate()` when the effect is completely accelerated, confirmed
    running accelerated, and its phase hasn&apos;t changed since it was last
    applied.

    Progress-based (scroll/view) timeline effects are excluded from this
    fast path, since their current time is driven by input rather than
    tracked autonomously by the compositor, and can change within the same
    phase.

    Test: webanimations/accelerated-animation-not-invalidated-by-sibling-timeline-ticks.html

    * Source/WebCore/animation/KeyframeEffect.cpp:
    (WebCore::KeyframeEffect::animationDidTick):
    * LayoutTests/webanimations/accelerated-animation-not-invalidated-by-sibling-timeline-ticks-expected.txt: Added.
    * LayoutTests/webanimations/accelerated-animation-not-invalidated-by-sibling-timeline-ticks.html: Added.

    Canonical link: <a href="https://commits.webkit.org/320647@main">https://commits.webkit.org/320647@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.245@webkitglib/2.54">https://commits.webkit.org/317695.245@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c50c5a63064fa8ef1b49b3ebd334ed016929ab91

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185753 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59658 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53466 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196060 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150447 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187615 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/61026 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59385 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145158 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150447 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188708 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/61026 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53466 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125453 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/61026 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59385 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53466 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/61026 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53466 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7123 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52288 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59385 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198026 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59320 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53466 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154699 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/60028 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53466 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154351 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28189 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/60028 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132379 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129344 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58495 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53466 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57873 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58109 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57936 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->