### PR TITLE
Cherry-pick 319473@main (ca336a9d896b). https://bugs.webkit.org/show_bug.cgi?id=322060

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform-input-017.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform-input-017.html
@@ -13,7 +13,7 @@
     difficult to construct a correct reference file for more complex
     transforms.)'>
     <link rel="match" href="transform-input-017-ref.html">
-    <meta name="fuzzy" content="maxDifference=0-48;totalPixels=0-16">
+    <meta name="fuzzy" content="maxDifference=0-48;totalPixels=0-66">
     <style>
       input {
         /* Margin to avoid overlap of translated inputs */

--- a/Source/WebCore/platform/graphics/adwaita/Adwaita.h
+++ b/Source/WebCore/platform/graphics/adwaita/Adwaita.h
@@ -92,6 +92,7 @@ constexpr auto buttonBackgroundPressedColorLight = SRGBA<uint8_t> { 214, 214, 21
 constexpr auto buttonBackgroundHoveredColorLight = SRGBA<uint8_t> { 248, 248, 248 };
 constexpr auto toggleBorderColorLight = SRGBA<uint8_t> { 0, 0, 0, 50 };
 constexpr auto toggleBorderHoveredColorLight = SRGBA<uint8_t> { 0, 0, 0, 80 };
+constexpr auto toggleBackgroundColorLight = Color::white;
 
 constexpr auto buttonBorderColorDark = SRGBA<uint8_t> { 255, 255, 255, 50 };
 constexpr auto buttonBackgroundColorDark = SRGBA<uint8_t> { 52, 52, 52 };
@@ -99,9 +100,11 @@ constexpr auto buttonBackgroundPressedColorDark = SRGBA<uint8_t> { 30, 30, 30 };
 constexpr auto buttonBackgroundHoveredColorDark = SRGBA<uint8_t> { 60, 60, 60 };
 constexpr auto toggleBorderColorDark = SRGBA<uint8_t> { 255, 255, 255, 50 };
 constexpr auto toggleBorderHoveredColorDark = SRGBA<uint8_t> { 255, 255, 255, 80 };
+constexpr auto toggleBackgroundColorDark = SRGBA<uint8_t> { 45, 45, 45 };
 
 constexpr double toggleSize = 14.;
-constexpr int toggleBorderSize = 2;
+constexpr double toggleBorderSizeRatio = 2. / 20.;
+constexpr double toggleBorderRadiusRatio = 6. / 20.;
 constexpr int toggleFocusOffset = 1;
 
 constexpr auto spinButtonBorderColorLight = SRGBA<uint8_t> { 0, 0, 0, 25 };

--- a/Source/WebCore/platform/graphics/adwaita/ToggleButtonAdwaita.cpp
+++ b/Source/WebCore/platform/graphics/adwaita/ToggleButtonAdwaita.cpp
@@ -65,13 +65,16 @@ void ToggleButtonAdwaita::drawCheckbox(GraphicsContext& graphicsContext, const F
 
     SRGBA<uint8_t> toggleBorderColor;
     SRGBA<uint8_t> toggleBorderHoverColor;
+    Color toggleBackgroundColor;
 
     if (style.states.contains(ControlStyle::State::DarkAppearance)) {
         toggleBorderColor = toggleBorderColorDark;
         toggleBorderHoverColor = toggleBorderHoveredColorDark;
+        toggleBackgroundColor = toggleBackgroundColorDark;
     } else {
         toggleBorderColor = toggleBorderColorLight;
         toggleBorderHoverColor = toggleBorderHoveredColorLight;
+        toggleBackgroundColor = toggleBackgroundColorLight;
     }
 
     Color accentColor = this->accentColor(style);
@@ -81,7 +84,9 @@ void ToggleButtonAdwaita::drawCheckbox(GraphicsContext& graphicsContext, const F
     if (!style.states.contains(ControlStyle::State::Enabled))
         graphicsContext.beginTransparencyLayer(disabledOpacity);
 
-    FloatSize corner(2, 2);
+    auto borderSize = fieldRect.width() * toggleBorderSizeRatio;
+    auto cornerRadius = fieldRect.width() * toggleBorderRadiusRatio;
+    FloatSize corner(cornerRadius, cornerRadius);
     Path path;
 
     if (style.states.containsAny({ ControlStyle::State::Checked, ControlStyle::State::Indeterminate })) {
@@ -98,7 +103,7 @@ void ToggleButtonAdwaita::drawCheckbox(GraphicsContext& graphicsContext, const F
         graphicsContext.translate(fieldRect.x(), fieldRect.y());
         graphicsContext.scale(FloatSize::narrowPrecision(fieldRect.width() / toggleSize, fieldRect.height() / toggleSize));
         if (style.states.contains(ControlStyle::State::Indeterminate))
-            path.addRoundedRect(FloatRect(2, 5, 10, 4), corner);
+            path.addRoundedRect(FloatRect(2, 5, 10, 4), FloatSize(2, 2));
         else {
             path.moveTo({ 2.43, 6.57 });
             path.addLineTo({ 7.5, 11.63 });
@@ -120,10 +125,10 @@ void ToggleButtonAdwaita::drawCheckbox(GraphicsContext& graphicsContext, const F
         graphicsContext.fillPath(path);
         path.clear();
 
-        fieldRect.inflate(-toggleBorderSize);
-        corner.expand(-buttonBorderSize, -buttonBorderSize);
+        fieldRect.inflate(-borderSize);
+        corner.expand(-borderSize, -borderSize);
         path.addRoundedRect(fieldRect, corner);
-        graphicsContext.setFillColor(foregroundColor);
+        graphicsContext.setFillColor(toggleBackgroundColor);
         graphicsContext.fillPath(path);
     }
 
@@ -149,13 +154,16 @@ void ToggleButtonAdwaita::drawRadio(GraphicsContext& graphicsContext, const Floa
 
     SRGBA<uint8_t> toggleBorderColor;
     SRGBA<uint8_t> toggleBorderHoverColor;
+    Color toggleBackgroundColor;
 
     if (style.states.contains(ControlStyle::State::DarkAppearance)) {
         toggleBorderColor = toggleBorderColorDark;
         toggleBorderHoverColor = toggleBorderHoveredColorDark;
+        toggleBackgroundColor = toggleBackgroundColorDark;
     } else {
         toggleBorderColor = toggleBorderColorLight;
         toggleBorderHoverColor = toggleBorderHoveredColorLight;
+        toggleBackgroundColor = toggleBackgroundColorLight;
     }
 
     Color accentColor = this->accentColor(style);
@@ -165,6 +173,7 @@ void ToggleButtonAdwaita::drawRadio(GraphicsContext& graphicsContext, const Floa
     if (!style.states.contains(ControlStyle::State::Enabled))
         graphicsContext.beginTransparencyLayer(disabledOpacity);
 
+    auto borderSize = fieldRect.width() * toggleBorderSizeRatio;
     Path path;
 
     if (style.states.containsAny({ ControlStyle::State::Checked, ControlStyle::State::Indeterminate })) {
@@ -190,9 +199,9 @@ void ToggleButtonAdwaita::drawRadio(GraphicsContext& graphicsContext, const Floa
         graphicsContext.fillPath(path);
         path.clear();
 
-        fieldRect.inflate(-toggleBorderSize);
+        fieldRect.inflate(-borderSize);
         path.addEllipseInRect(fieldRect);
-        graphicsContext.setFillColor(foregroundColor);
+        graphicsContext.setFillColor(toggleBackgroundColor);
         graphicsContext.fillPath(path);
     }
 


### PR DESCRIPTION
#### 4bcb62d5ae37d2ee1ae790e2c83b6282bcf5e5d0
<pre>
Cherry-pick 319473@main (ca336a9d896b). <a href="https://bugs.webkit.org/show_bug.cgi?id=322060">https://bugs.webkit.org/show_bug.cgi?id=322060</a>

    [Adwaita] Fix togglebutton not respecting dark mode
    <a href="https://bugs.webkit.org/show_bug.cgi?id=322060">https://bugs.webkit.org/show_bug.cgi?id=322060</a>

    Reviewed by Adrian Perez de Castro.

    Previously it ignored dark mode entirely. Also made minor tweak
    to it&apos;s border to be rounded like everything else is.

    * LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/transform-input-017.html: Tweak fuzzyness.
    * Source/WebCore/platform/graphics/adwaita/Adwaita.h:
    * Source/WebCore/platform/graphics/adwaita/ToggleButtonAdwaita.cpp:
    (WebCore::ToggleButtonAdwaita::drawCheckbox):
    (WebCore::ToggleButtonAdwaita::drawRadio):

    Canonical link: <a href="https://commits.webkit.org/319473@main">https://commits.webkit.org/319473@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.250@webkitglib/2.54">https://commits.webkit.org/317695.250@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25eb7617e154feb9581688fd35cca69eec1a13b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185858 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59756 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53559 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196156 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150523 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187720 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/61131 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59479 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145232 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150523 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188813 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/61131 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53559 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125537 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/61131 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59479 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53559 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/61131 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53559 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7227 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52382 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59479 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198130 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59416 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53559 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154789 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/60124 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53559 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154433 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28218 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/60124 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132469 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129465 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58586 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53559 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57965 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58199 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/58029 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->