### PR TITLE
[JSC][Wasm] Don't keep a second copy of IPInt metadata during compile

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -2988,6 +2988,10 @@ std::unique_ptr<FunctionIPIntMetadataGenerator> IPIntGenerator::finalize()
     if (m_metadata->m_callTargets.size() < m_parser->numCallProfiles())
         m_metadata->m_callTargets.insertFill(m_metadata->m_callTargets.size(), FunctionSpaceIndex { }, m_parser->numCallProfiles() - m_metadata->m_callTargets.size());
 
+    m_metadata->m_metadata.shrinkToFit();
+    m_metadata->m_callTargets.shrinkToFit();
+    m_metadata->m_localInitBytecode.shrinkToFit();
+    m_metadata->m_exceptionHandlers.shrinkToFit();
     return WTF::move(m_metadata);
 }
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -74,10 +74,6 @@ IPIntPlan::IPIntPlan(VM& vm, Ref<ModuleInformation> info, CompilerMode compilerM
 bool IPIntPlan::prepareImpl()
 {
     const auto& functions = m_moduleInformation->functions;
-    if (!tryReserveCapacity(m_wasmInternalFunctions, functions.size(), "WebAssembly functions"_s))
-        return false;
-    m_wasmInternalFunctions.resize(functions.size());
-
     if (!m_ipintCallees)
         m_ipintCallees = IPIntCallees::create(functions.size());
     return true;
@@ -101,40 +97,37 @@ void IPIntPlan::compileFunction(FunctionCodeIndex functionIndex)
         return;
     }
 
-    m_wasmInternalFunctions[functionIndex] = WTF::move(*parseAndCompileResult);
+    auto generator = WTF::move(*parseAndCompileResult);
+    auto callee = IPIntCallee::create(*generator, functionIndexSpace, signature, { });
+    ASSERT(!callee->entrypoint());
+    bool usesSIMD = m_moduleInformation->usesSIMD(functionIndex);
+    // Immediately tier up to BBQ for SIMD, if necesary.
+    if (usesSIMD && !Options::useWasmIPIntSIMD())
+        callee->tierUpCounter().setNewThreshold(0);
 
-    {
-        auto callee = IPIntCallee::create(*m_wasmInternalFunctions[functionIndex], functionIndexSpace, signature, { });
-        ASSERT(!callee->entrypoint());
-        bool usesSIMD = m_moduleInformation->usesSIMD(functionIndex);
-        // Immediately tier up to BBQ for SIMD, if necesary.
-        if (usesSIMD && !Options::useWasmIPIntSIMD())
-            callee->tierUpCounter().setNewThreshold(0);
-
-        if (usesSIMD && !Options::useBBQJIT() && !Options::useWasmIPIntSIMD()) {
-            Locker locker { m_lock };
-            failFunctionCompilation(functionIndex, makeString("JIT is disabled, but the entrypoint for "_s, functionIndex.rawIndex(), " requires JIT"_s));
-            return;
-        }
-
-        CodePtr<WasmEntryPtrTag> entrypoint { };
-#if ENABLE(JIT)
-        if (Options::useJIT())
-            entrypoint = LLInt::inPlaceInterpreterEntryThunk().retaggedCode<WasmEntryPtrTag>();
-#endif
-        if (!entrypoint)
-            entrypoint = LLInt::getCodeFunctionPtr<CFunctionPtrTag>(ipint_trampoline);
-
-        callee->setEntrypointWithoutRegistration(entrypoint);
-        m_ipintCallees->at(functionIndex) = WTF::move(callee);
+    if (usesSIMD && !Options::useBBQJIT() && !Options::useWasmIPIntSIMD()) {
+        Locker locker { m_lock };
+        failFunctionCompilation(functionIndex, makeString("JIT is disabled, but the entrypoint for "_s, functionIndex.rawIndex(), " requires JIT"_s));
+        return;
     }
+
+    CodePtr<WasmEntryPtrTag> entrypoint { };
+#if ENABLE(JIT)
+    if (Options::useJIT())
+        entrypoint = LLInt::inPlaceInterpreterEntryThunk().retaggedCode<WasmEntryPtrTag>();
+#endif
+    if (!entrypoint)
+        entrypoint = LLInt::getCodeFunctionPtr<CFunctionPtrTag>(ipint_trampoline);
+
+    callee->setEntrypointWithoutRegistration(entrypoint);
+    m_ipintCallees->at(functionIndex) = WTF::move(callee);
 }
 
 void IPIntPlan::didCompleteCompilation()
 {
     generateStubsIfNecessary();
 
-    unsigned functionCount = m_wasmInternalFunctions.size();
+    unsigned functionCount = m_ipintCallees->size();
     if (!m_calleesAlreadyRegistered && functionCount) {
         // Set names here rather than at IPIntCallee creation: during streaming the name section
         // (which follows the code section) has not been parsed yet when a function is compiled.

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
@@ -29,7 +29,6 @@
 
 #include "WasmCallee.h"
 #include "WasmEntryPlan.h"
-#include "WasmIPIntGenerator.h"
 
 namespace JSC {
 
@@ -72,7 +71,6 @@ private:
     bool prepareImpl() final;
     void didCompleteCompilation() WTF_REQUIRES_LOCK(m_lock) final;
 
-    Vector<std::unique_ptr<FunctionIPIntMetadataGenerator>> m_wasmInternalFunctions;
     RefPtr<IPIntCallees> m_ipintCallees;
     bool m_calleesAlreadyRegistered { false };
 };

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -424,10 +424,23 @@ protected:
         m_size = std::exchange(other.m_size, 0);
     }
 
+    template<typename OtherMalloc>
+    void adopt(VectorBuffer<T, 0, OtherMalloc>&& other)
+    {
+        crashIfBorrowed();
+        other.crashIfBorrowed();
+        deallocateBuffer(buffer());
+        m_buffer = std::exchange(other.m_buffer, nullptr);
+        m_capacity = other.exchangeCapacity(0);
+        m_size = std::exchange(other.m_size, 0);
+    }
+
 private:
+    template<typename U, size_t otherInlineCapacity, typename OtherMalloc> friend class VectorBuffer;
     friend class JSC::LLIntOffsetsExtractor;
     using Base::m_buffer;
     using Base::m_capacity;
+    using Base::exchangeCapacity;
 };
 
 template<typename T, size_t inlineCapacity, typename Malloc>
@@ -629,6 +642,15 @@ struct UnsafeVectorOverflow {
     }
 };
 
+template<typename FromMalloc, typename ToMalloc>
+constexpr bool vectorMallocsCanAdoptBuffer()
+{
+    if constexpr (std::same_as<FromMalloc, ToMalloc>)
+        return true;
+    else
+        return &FromMalloc::free == &ToMalloc::free;
+}
+
 // Template default values are in Forward.h.
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
 class Vector : private VectorBuffer<T, inlineCapacity, Malloc> {
@@ -775,6 +797,13 @@ public:
 
     Vector(Vector&&);
     Vector& operator=(Vector&&);
+
+    template<size_t otherCapacity, typename otherOverflowBehaviour, size_t otherMinimumCapacity, typename OtherMalloc>
+        requires (!inlineCapacity && !otherCapacity && vectorMallocsCanAdoptBuffer<OtherMalloc, Malloc>())
+    Vector(Vector<T, otherCapacity, otherOverflowBehaviour, otherMinimumCapacity, OtherMalloc>&&);
+    template<size_t otherCapacity, typename otherOverflowBehaviour, size_t otherMinimumCapacity, typename OtherMalloc>
+        requires (!inlineCapacity && !otherCapacity && vectorMallocsCanAdoptBuffer<OtherMalloc, Malloc>())
+    Vector& operator=(Vector<T, otherCapacity, otherOverflowBehaviour, otherMinimumCapacity, OtherMalloc>&&);
 
     [[nodiscard]] size_t size() const { return m_size; }
     [[nodiscard]] size_t sizeInBytes() const { return static_cast<size_t>(m_size) * sizeof(T); }
@@ -1121,6 +1150,35 @@ inline Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>& Vector<T
     asanSetInitialBufferSizeTo(m_size);
     other.asanSetInitialBufferSizeTo(other.m_size);
 
+    return *this;
+}
+
+template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
+template<size_t otherCapacity, typename otherOverflowBehaviour, size_t otherMinimumCapacity, typename OtherMalloc>
+    requires (!inlineCapacity && !otherCapacity && vectorMallocsCanAdoptBuffer<OtherMalloc, Malloc>())
+inline Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::Vector(Vector<T, otherCapacity, otherOverflowBehaviour, otherMinimumCapacity, OtherMalloc>&& other)
+{
+    asanSetBufferSizeToFullCapacity();
+    other.asanSetBufferSizeToFullCapacity();
+    Base::adopt(static_cast<VectorBuffer<T, 0, OtherMalloc>&&>(other));
+    asanSetInitialBufferSizeTo(m_size);
+    other.asanSetInitialBufferSizeTo(other.m_size);
+}
+
+template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
+template<size_t otherCapacity, typename otherOverflowBehaviour, size_t otherMinimumCapacity, typename OtherMalloc>
+    requires (!inlineCapacity && !otherCapacity && vectorMallocsCanAdoptBuffer<OtherMalloc, Malloc>())
+inline Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>& Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::operator=(Vector<T, otherCapacity, otherOverflowBehaviour, otherMinimumCapacity, OtherMalloc>&& other)
+{
+    ASSERT(!typelessPointersAreEqual(&other, this));
+
+    if (m_size)
+        TypeOperations::destruct(begin(), end());
+    asanSetBufferSizeToFullCapacity();
+    other.asanSetBufferSizeToFullCapacity();
+    Base::adopt(static_cast<VectorBuffer<T, 0, OtherMalloc>&&>(other));
+    asanSetInitialBufferSizeTo(m_size);
+    other.asanSetInitialBufferSizeTo(other.m_size);
     return *this;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -2163,6 +2163,50 @@ TEST(WTF_Vector, MoveAssignmentOperator)
     }
 }
 
+TEST(WTF_Vector, MoveBetweenCompatibleMallocs)
+{
+    struct DoubleCapacityMalloc final : public FastMalloc {
+        static constexpr ALWAYS_INLINE size_t nextCapacity(size_t capacity) { return capacity + capacity; }
+    };
+
+    {
+        Vector<uint8_t, 0, UnsafeVectorOverflow, 16, DoubleCapacityMalloc> source;
+        source.grow(64);
+        for (size_t i = 0; i < source.size(); ++i)
+            source[i] = static_cast<uint8_t>(i);
+        const uint8_t* buffer = source.span().data();
+
+        Vector<uint8_t> destination(WTF::move(source));
+        EXPECT_EQ(destination.span().data(), buffer);
+        ASSERT_EQ(destination.size(), 64U);
+        EXPECT_EQ(destination[0], 0);
+        EXPECT_EQ(destination[63], 63);
+        SUPPRESS_USE_AFTER_MOVE {
+            EXPECT_TRUE(source.isEmpty());
+            EXPECT_EQ(source.capacity(), 0U);
+        }
+    }
+
+    {
+        Vector<uint8_t, 0, UnsafeVectorOverflow, 16, DoubleCapacityMalloc> source;
+        source.grow(32);
+        for (size_t i = 0; i < source.size(); ++i)
+            source[i] = static_cast<uint8_t>(i + 1);
+
+        Vector<uint8_t> destination;
+        destination.append(0xFF);
+        const uint8_t* buffer = source.span().data();
+        destination = WTF::move(source);
+        EXPECT_EQ(destination.span().data(), buffer);
+        ASSERT_EQ(destination.size(), 32U);
+        EXPECT_EQ(destination[0], 1);
+        EXPECT_EQ(destination[31], 32);
+        SUPPRESS_USE_AFTER_MOVE {
+            EXPECT_TRUE(source.isEmpty());
+        }
+    }
+}
+
 static Vector<int> mapVector(Vector<int> vector)
 {
     return vector;


### PR DESCRIPTION
#### cc80ed972577f5ec61d2b177e200b92aaadfcab8
<pre>
[JSC][Wasm] Don&apos;t keep a second copy of IPInt metadata during compile
<a href="https://bugs.webkit.org/show_bug.cgi?id=300780">https://bugs.webkit.org/show_bug.cgi?id=300780</a>

Reviewed by NOBODY (OOPS!).

IPIntCallee constructed its metadata Vector from a differently typed
generator buffer, so WTF::move copied. The plan also retained every
generator until it finished, so compile held two copies of all
metadata.

Allow Vector to adopt a buffer when the source and dest Malloc::free
functions match. Shrink the generator buffers after generation, and
destroy the generator at the end of compileFunction.

* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
* Source/JavaScriptCore/wasm/WasmIPIntPlan.h:
* Source/WTF/wtf/Vector.h:
* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc80ed972577f5ec61d2b177e200b92aaadfcab8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196143 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150514 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187706 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145237 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100683 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48911 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165789 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125543 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47638 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45660 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7423 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14302 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45370 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7213 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47089 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52375 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50082 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198117 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59404 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154779 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60112 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154423 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48878 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132457 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129453 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58574 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20395 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57953 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->