### PR TITLE
Cherry-pick 320398@main (4b6b2cdc9092). https://bugs.webkit.org/show_bug.cgi?id=322424

### DIFF
--- a/LayoutTests/css3/filters/filter-repaint-blur-before-first-paint-expected.txt
+++ b/LayoutTests/css3/filters/filter-repaint-blur-before-first-paint-expected.txt
@@ -1,0 +1,7 @@
+(repaint rects
+  (rect 97 97 106 106)
+)
+(repaint rects
+  (rect 97 397 106 106)
+)
+

--- a/LayoutTests/css3/filters/filter-repaint-blur-before-first-paint.html
+++ b/LayoutTests/css3/filters/filter-repaint-blur-before-first-paint.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .blurred {
+        position: absolute;
+        width: 100px;
+        height: 100px;
+        filter: blur(10px);
+    }
+
+    #first {
+        left: 100px;
+        top: 100px;
+    }
+
+    #second {
+        left: 100px;
+        top: 400px;
+    }
+
+    .inner {
+        position: absolute;
+        left: 25px;
+        top: 25px;
+        width: 50px;
+        height: 50px;
+        background-color: green;
+    }
+
+    .before {
+        background-color: red;
+    }
+</style>
+<script>
+// Neither of the shared repaint helpers fits here: both start tracking at load, while
+// the second measurement must only begin tracking once the first paint has happened...
+let dumpedRects = "";
+
+function trackRepaintRects(mutate)
+{
+    internals.startTrackingRepaints();
+    mutate();
+    document.body.offsetTop;
+    dumpedRects += internals.repaintRectsAsText();
+    internals.stopTrackingRepaints();
+}
+
+if (window.testRunner) {
+    testRunner.dumpAsText(false);
+    testRunner.waitUntilDone();
+}
+
+addEventListener("load", () => {
+    if (!window.testRunner || !window.internals)
+        return;
+
+    trackRepaintRects(() => {
+        document.querySelector("#first .inner").classList.remove("before");
+    });
+
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            trackRepaintRects(() => {
+                document.querySelector("#second .inner").classList.remove("before");
+            });
+
+            const pre = document.createElement("pre");
+            pre.textContent = dumpedRects;
+            document.body.appendChild(pre);
+            testRunner.notifyDone();
+        });
+    });
+});
+</script>
+</head>
+<body>
+<div class="blurred" id="first"><div class="inner before"></div></div>
+<div class="blurred" id="second"><div class="inner before"></div></div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/filter-repaint-blur-canvas-partial-expected.txt
+++ b/LayoutTests/css3/filters/filter-repaint-blur-canvas-partial-expected.txt
@@ -1,0 +1,4 @@
+(repaint rects
+  (rect 96 96 108 108)
+)
+

--- a/LayoutTests/css3/filters/filter-repaint-blur-canvas-partial.html
+++ b/LayoutTests/css3/filters/filter-repaint-blur-canvas-partial.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body {
+        margin: 0;
+    }
+
+    canvas {
+        position: absolute;
+        left: 100px;
+        top: 100px;
+        filter: blur(10px);
+    }
+</style>
+<script src="../../fast/repaint/resources/text-based-repaint.js"></script>
+<script>
+function repaintTest()
+{
+    const context = document.querySelector("canvas").getContext("2d");
+    context.fillStyle = "green";
+    context.fillRect(25, 25, 50, 50);
+}
+</script>
+</head>
+<body onload="runRepaintTest()">
+    <canvas width="100" height="100"></canvas>
+</body>
+</html>

--- a/LayoutTests/css3/filters/filter-repaint-blur-inline-expected.txt
+++ b/LayoutTests/css3/filters/filter-repaint-blur-inline-expected.txt
@@ -1,0 +1,5 @@
+AAAA
+(repaint rects
+  (rect 72 72 216 96)
+)
+

--- a/LayoutTests/css3/filters/filter-repaint-blur-inline.html
+++ b/LayoutTests/css3/filters/filter-repaint-blur-inline.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body {
+        margin: 0;
+        font: 40px Ahem;
+    }
+
+    .box {
+        position: absolute;
+        left: 100px;
+        top: 100px;
+    }
+
+    span {
+        color: green;
+        filter: blur(10px);
+    }
+
+    .before {
+        color: red;
+    }
+</style>
+<script src="../../fast/repaint/resources/text-based-repaint.js"></script>
+<script>
+function repaintTest()
+{
+    document.querySelector("span").classList.remove("before");
+}
+</script>
+</head>
+<body onload="runRepaintTest()">
+    <div class="box"><span class="before">AAAA</span></div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/filter-repaint-blur-inner-content-change-expected.txt
+++ b/LayoutTests/css3/filters/filter-repaint-blur-inner-content-change-expected.txt
@@ -1,0 +1,4 @@
+(repaint rects
+  (rect 122 122 156 156)
+)
+

--- a/LayoutTests/css3/filters/filter-repaint-blur-inner-content-change.html
+++ b/LayoutTests/css3/filters/filter-repaint-blur-inner-content-change.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .blurred {
+        position: absolute;
+        left: 100px;
+        top: 100px;
+        width: 200px;
+        height: 200px;
+        filter: blur(10px);
+    }
+
+    .inner {
+        position: absolute;
+        left: 50px;
+        top: 50px;
+        width: 100px;
+        height: 100px;
+        background-color: green;
+    }
+
+    .inner.before {
+        background-color: red;
+    }
+</style>
+<script src="../../fast/repaint/resources/text-based-repaint.js"></script>
+<script>
+function repaintTest()
+{
+    document.querySelector(".inner").classList.remove("before");
+}
+</script>
+</head>
+<body onload="runRepaintTest()">
+    <div class="blurred">
+        <div class="inner before"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/filter-repaint-blur-nested-non-pixel-moving-filter-expected.html
+++ b/LayoutTests/css3/filters/filter-repaint-blur-nested-non-pixel-moving-filter-expected.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .blurred {
+        position: absolute;
+        left: 100px;
+        top: 100px;
+        width: 200px;
+        height: 200px;
+        filter: blur(10px);
+    }
+
+    .hue-rotated {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 200px;
+        height: 200px;
+        filter: hue-rotate(90deg);
+    }
+
+    .inner {
+        position: absolute;
+        left: 50px;
+        top: 50px;
+        width: 100px;
+        height: 100px;
+        background-color: green;
+    }
+</style>
+</head>
+<body>
+    <div class="blurred">
+        <div class="hue-rotated">
+            <div class="inner"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/filter-repaint-blur-nested-non-pixel-moving-filter.html
+++ b/LayoutTests/css3/filters/filter-repaint-blur-nested-non-pixel-moving-filter.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>The blur ancestor must be found through an intermediate filter that does not move pixels</title>
+<link rel="match" href="filter-repaint-blur-nested-non-pixel-moving-filter-expected.html">
+<script src="../../resources/ui-helper.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .blurred {
+        position: absolute;
+        left: 100px;
+        top: 100px;
+        width: 200px;
+        height: 200px;
+        filter: blur(10px);
+    }
+
+    .hue-rotated {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 200px;
+        height: 200px;
+        filter: hue-rotate(90deg);
+    }
+
+    .inner {
+        position: absolute;
+        left: 50px;
+        top: 50px;
+        width: 100px;
+        height: 100px;
+        background-color: red;
+    }
+</style>
+<script>
+window.testRunner?.waitUntilDone();
+window.testRunner?.dontForceRepaint();
+
+async function runTest()
+{
+    await UIHelper.renderingUpdate();
+    document.querySelector(".inner").style.backgroundColor = "green";
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    window.testRunner?.notifyDone();
+}
+
+window.addEventListener("load", runTest);
+</script>
+</head>
+<body>
+    <div class="blurred">
+        <div class="hue-rotated">
+            <div class="inner"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/filter-repaint-blur-nested-pixel-moving-filter-expected.html
+++ b/LayoutTests/css3/filters/filter-repaint-blur-nested-pixel-moving-filter-expected.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .outer-blur {
+        position: absolute;
+        left: 100px;
+        top: 100px;
+        width: 200px;
+        height: 200px;
+        filter: blur(10px);
+    }
+
+    .inner-blur {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 200px;
+        height: 200px;
+        filter: blur(5px);
+    }
+
+    .inner {
+        position: absolute;
+        left: 50px;
+        top: 50px;
+        width: 100px;
+        height: 100px;
+        background-color: green;
+    }
+</style>
+</head>
+<body>
+    <div class="outer-blur">
+        <div class="inner-blur">
+            <div class="inner"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/filter-repaint-blur-nested-pixel-moving-filter.html
+++ b/LayoutTests/css3/filters/filter-repaint-blur-nested-pixel-moving-filter.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Nested pixel moving filters must both expand the repaint of the innermost content</title>
+<link rel="match" href="filter-repaint-blur-nested-pixel-moving-filter-expected.html">
+<script src="../../resources/ui-helper.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .outer-blur {
+        position: absolute;
+        left: 100px;
+        top: 100px;
+        width: 200px;
+        height: 200px;
+        filter: blur(10px);
+    }
+
+    .inner-blur {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 200px;
+        height: 200px;
+        filter: blur(5px);
+    }
+
+    .inner {
+        position: absolute;
+        left: 50px;
+        top: 50px;
+        width: 100px;
+        height: 100px;
+        background-color: red;
+    }
+</style>
+<script>
+window.testRunner?.waitUntilDone();
+window.testRunner?.dontForceRepaint();
+
+async function runTest()
+{
+    await UIHelper.renderingUpdate();
+    document.querySelector(".inner").style.backgroundColor = "green";
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    window.testRunner?.notifyDone();
+}
+
+window.addEventListener("load", runTest);
+</script>
+</head>
+<body>
+    <div class="outer-blur">
+        <div class="inner-blur">
+            <div class="inner"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/repaint/drop-shadow-change-full-repaint-expected.txt
+++ b/LayoutTests/fast/repaint/drop-shadow-change-full-repaint-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 (repaint rects
-  (rect 200 200 100 100)
+  (rect 172 174 156 156)
   (rect 172 174 156 156)
 )
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1041,6 +1041,15 @@ void RenderElement::styleWillChange(Style::Difference diff, const Style::Compute
             view().decrementRendersWithOutline();
     }
 
+    bool hadPixelMovingFilter = oldStyle && oldStyle->filter().hasFilterThatMovesPixels();
+    bool hasPixelMovingFilter = newStyle.filter().hasFilterThatMovesPixels();
+    if (hadPixelMovingFilter != hasPixelMovingFilter) {
+        if (hasPixelMovingFilter)
+            view().incrementRenderersWithPixelMovingFilter();
+        else
+            view().decrementRenderersWithPixelMovingFilter();
+    }
+
     bool newStyleSlowScroll = false;
     if (Style::hasImageWithAttachment(newStyle.backgroundLayers(), FillAttachment::FixedBackground) && !settings().fixedBackgroundsPaintRelativeToDocument()) {
         newStyleSlowScroll = true;
@@ -1317,6 +1326,9 @@ void RenderElement::willBeDestroyed()
 
         if (style().hasOutline())
             view().decrementRendersWithOutline();
+
+        if (style().filter().hasFilterThatMovesPixels())
+            view().decrementRenderersWithPixelMovingFilter();
 
         if (auto* firstLineStyle = style().pseudoElementStyle({ PseudoElementType::FirstLine }))
             unregisterImages(*firstLineStyle);

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -593,7 +593,7 @@ void RenderLayer::removeOnlyThisLayer()
         m_parent->addChild(*current, nextSib);
         current->setRepaintStatus(RepaintStatus::NeedsFullRepaint);
         if (isComposited())
-            current->computeRepaintRectsIncludingDescendants();
+            current->updateRepaintRectsIncludingDescendants(RepaintRectsUpdate::Recompute);
         current = next;
     }
 
@@ -1050,14 +1050,18 @@ bool RenderLayer::canRender3DTransforms() const
 
 bool RenderLayer::shouldPaintWithFilters(OptionSet<PaintBehavior> paintBehavior) const
 {
-    const auto& filter = renderer().style().filter();
+    return shouldPaintWithFilters(renderer().style().filter(), paintBehavior);
+}
+
+bool RenderLayer::shouldPaintWithFilters(const Style::Filter& filter, OptionSet<PaintBehavior> paintBehavior) const
+{
     if (filter.isNone())
         return false;
 
     if (renderer().isRenderOrLegacyRenderSVGRoot() && filter.isReferenceFilter())
         return false;
 
-    if (RenderLayerFilters::isIdentity(renderer()))
+    if (CSSFilterRenderer::isIdentity(renderer(), filter))
         return false;
 
     if (paintBehavior & PaintBehavior::FlattenCompositingLayers)
@@ -1071,10 +1075,15 @@ bool RenderLayer::shouldPaintWithFilters(OptionSet<PaintBehavior> paintBehavior)
 
 bool RenderLayer::requiresFullLayerImageForFilters() const
 {
-    if (!shouldPaintWithFilters())
+    return requiresFullLayerImageForFilters(renderer().style().filter());
+}
+
+bool RenderLayer::requiresFullLayerImageForFilters(const Style::Filter& filter) const
+{
+    if (!shouldPaintWithFilters(filter))
         return false;
 
-    return m_filters && m_filters->hasFilterThatMovesPixels();
+    return filter.hasFilterThatMovesPixels();
 }
 
 OptionSet<RenderLayer::UpdateLayerPositionsFlag> RenderLayer::flagsForUpdateLayerPositions(RenderLayer& startingLayer)
@@ -1525,22 +1534,27 @@ void RenderLayer::computeRepaintRects(const RenderLayerModelObject* repaintConta
     m_repaintContainer = repaintContainer;
 }
 
-void RenderLayer::computeRepaintRectsIncludingDescendants()
+void RenderLayer::updateRepaintRectsIncludingDescendants(RepaintRectsUpdate update)
 {
     // FIXME: computeRepaintRects() has to walk up the parent chain for every layer to compute the rects.
     // We should make this more efficient.
-    computeRepaintRects(renderer().containerForRepaint().renderer.get());
-    clearClipRects(PaintingClipRects);
+    if (update == RepaintRectsUpdate::Recompute) {
+        computeRepaintRects(renderer().containerForRepaint().renderer.get());
+        clearClipRects(PaintingClipRects);
+    } else {
+        clearRepaintRects();
+        m_repaintContainer = renderer().containerForRepaint().renderer.get();
+    }
 
     for (RenderLayer* layer = firstChild(); layer; layer = layer->nextSibling())
-        layer->computeRepaintRectsIncludingDescendants();
+        layer->updateRepaintRectsIncludingDescendants(update);
 }
 
 void RenderLayer::compositingStatusChanged(LayoutUpToDate layoutUpToDate)
 {
     updateDescendantDependentFlags();
     if (parent() || isRenderViewLayer())
-        computeRepaintRectsIncludingDescendants();
+        updateRepaintRectsIncludingDescendants(RepaintRectsUpdate::Recompute);
     if (layoutUpToDate == LayoutUpToDate::No)
         setSelfAndDescendantsNeedPositionUpdate();
 }
@@ -2498,7 +2512,7 @@ RenderLayer::EnclosingCompositingLayerStatus RenderLayer::enclosingCompositingLa
     return { };
 }
 
-RenderLayer* RenderLayer::enclosingFilterLayer(IncludeSelfOrNot includeSelf) const
+RenderLayer* RenderLayer::enclosingPixelMovingFilterLayer(IncludeSelfOrNot includeSelf) const
 {
     const RenderLayer* curr = (includeSelf == IncludeSelf) ? this : parent();
     for (; curr; curr = curr->parent()) {
@@ -2519,18 +2533,19 @@ RenderLayer* RenderLayer::enclosingFilterRepaintLayer() const
 }
 
 // FIXME: This needs a better name.
-void RenderLayer::setFilterBackendNeedsRepaintingInRect(const LayoutRect& rect)
+void RenderLayer::setFilterBackendNeedsRepaintingInRect(const LayoutRect& rect, UseFilterOutsets useFilterOutsets)
 {
     ASSERT(requiresFullLayerImageForFilters());
-    ASSERT(m_filters);
 
     if (rect.isEmpty())
         return;
     
     LayoutRect rectForRepaint = rect;
-    rectForRepaint.expand(toLayoutBoxExtent(filterOutsets()));
+    if (useFilterOutsets == UseFilterOutsets::Add)
+        rectForRepaint.expand(toLayoutBoxExtent(filterOutsets()));
 
-    m_filters->expandDirtySourceRect(rectForRepaint);
+    if (m_filters)
+        m_filters->expandDirtySourceRect(rectForRepaint);
     
     RenderLayer* parentLayer = enclosingFilterRepaintLayer();
     ASSERT(parentLayer);
@@ -6434,15 +6449,20 @@ void RenderLayer::updateFiltersAfterStyleChange(Style::Difference diff, const St
     else if (m_filters)
         m_filters->removeReferenceFilterClients();
 
+    bool filterValueChanged = oldStyle && oldStyle->filter() != renderer().style().filter();
+
+    if (filterValueChanged && requiresFullLayerImageForFilters(oldStyle->filter()) != requiresFullLayerImageForFilters())
+        updateRepaintRectsIncludingDescendants(RepaintRectsUpdate::Discard);
+
     auto filterChanged = [&] {
         if (!m_filters)
             return false;
         if (diff < Style::DifferenceResult::RepaintLayer)
             return false;
+        if (filterValueChanged)
+            return true;
         if (!oldStyle)
             return false;
-        if (oldStyle->filter() != renderer().style().filter())
-            return true;
         auto currentColorChanged = oldStyle->color() != renderer().style().color();
         if (currentColorChanged && oldStyle->filter().hasFilterThatRequiresRepaintForCurrentColorChange())
             return true;
@@ -6503,10 +6523,7 @@ IntOutsets RenderLayer::filterOutsets() const
     if (m_filters)
         return m_filters->calculateOutsets(renderer(), localBoundingBox());
 
-    if (CheckedPtr boxRenderer = renderBox())
-        return boxRenderer->computeFilterOutsets();
-
-    return { };
+    return renderer().computeFilterOutsets();
 }
 
 void RenderLayer::clearFilters()

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -75,6 +75,7 @@ namespace WebCore {
 
 namespace Style {
 class ComputedStyle;
+struct Filter;
 enum class TransformResolverOption : uint8_t;
 }
 
@@ -678,9 +679,10 @@ public:
     // Ancestor compositing layer, excluding this.
     RenderLayer* ancestorCompositingLayer() const { return enclosingCompositingLayer(ExcludeSelf); }
 
-    RenderLayer* enclosingFilterLayer(IncludeSelfOrNot = IncludeSelf) const;
+    RenderLayer* enclosingPixelMovingFilterLayer(IncludeSelfOrNot = IncludeSelf) const;
     RenderLayer* enclosingFilterRepaintLayer() const;
-    void setFilterBackendNeedsRepaintingInRect(const LayoutRect&);
+    enum class UseFilterOutsets : bool { Add, AlreadyIncluded };
+    void setFilterBackendNeedsRepaintingInRect(const LayoutRect&, UseFilterOutsets = UseFilterOutsets::Add);
 
     inline bool NODELETE canUseOffsetFromAncestor() const;
     bool NODELETE canUseOffsetFromAncestor(const RenderLayer& ancestor) const;
@@ -1024,9 +1026,12 @@ public:
         CheckedPtr<RegionContext> regionContext;
     };
 
-    void computeRepaintRectsIncludingDescendants();
-
 private:
+    enum class RepaintRectsUpdate : bool { Recompute, Discard };
+    void updateRepaintRectsIncludingDescendants(RepaintRectsUpdate);
+
+    bool shouldPaintWithFilters(const Style::Filter&, OptionSet<PaintBehavior> = { }) const;
+    bool requiresFullLayerImageForFilters(const Style::Filter&) const;
 
     void setNextSibling(RenderLayer* next) { m_next = next; }
     void setPreviousSibling(RenderLayer* prev) { m_previous = prev; }

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -141,12 +141,6 @@ void RenderLayerFilters::removeReferenceFilterClients()
     m_internalSVGReferences.clear();
 }
 
-bool RenderLayerFilters::isIdentity(RenderElement& renderer)
-{
-    const auto& filter = renderer.style().filter();
-    return CSSFilterRenderer::isIdentity(renderer, filter);
-}
-
 IntOutsets RenderLayerFilters::calculateOutsets(RenderElement& renderer, const FloatRect& targetBoundingBox)
 {
     const auto& filter = renderer.style().filter();

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -70,7 +70,6 @@ public:
     void updateReferenceFilterClients(const Style::Filter&);
     void removeReferenceFilterClients();
 
-    static bool isIdentity(RenderElement&);
     static IntOutsets calculateOutsets(RenderElement&, const FloatRect& targetBoundingBox);
 
     // Per render

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -901,20 +901,22 @@ RenderObject::RepaintContainerStatus RenderObject::containerForRepaint() const
     CheckedPtr<const RenderLayerModelObject> repaintContainer;
     auto fullRepaintAlreadyScheduled = false;
 
-    if (view().usesCompositing()) {
+    auto usesCompositing = view().usesCompositing();
+    auto hasRenderersWithPixelMovingFilter = view().hasRenderersWithPixelMovingFilter();
+    if (usesCompositing || hasRenderersWithPixelMovingFilter) {
         if (CheckedPtr enclosingLayer = this->enclosingLayer()) {
-            auto compLayerStatus = enclosingLayer->enclosingCompositingLayerForRepaint();
-            if (compLayerStatus.layer) {
-                repaintContainer = &compLayerStatus.layer->renderer();
-                fullRepaintAlreadyScheduled = compLayerStatus.fullRepaintAlreadyScheduled && canRelyOnAncestorLayerFullRepaint(*this, *compLayerStatus.layer);
+            if (usesCompositing) {
+                auto compLayerStatus = enclosingLayer->enclosingCompositingLayerForRepaint();
+                if (compLayerStatus.layer) {
+                    repaintContainer = &compLayerStatus.layer->renderer();
+                    fullRepaintAlreadyScheduled = compLayerStatus.fullRepaintAlreadyScheduled && canRelyOnAncestorLayerFullRepaint(*this, *compLayerStatus.layer);
+                }
             }
-        }
-    }
-    if (view().hasSoftwareFilters()) {
-        if (CheckedPtr parentLayer = enclosingLayer()) {
-            if (CheckedPtr enclosingFilterLayer = parentLayer->enclosingFilterLayer()) {
-                fullRepaintAlreadyScheduled = parentLayer->needsFullRepaint() && canRelyOnAncestorLayerFullRepaint(*this, *parentLayer);
-                return { fullRepaintAlreadyScheduled, &enclosingFilterLayer->renderer() };
+            if (hasRenderersWithPixelMovingFilter) {
+                if (CheckedPtr pixelMovingFilterLayer = enclosingLayer->enclosingPixelMovingFilterLayer()) {
+                    fullRepaintAlreadyScheduled = enclosingLayer->needsFullRepaint() && canRelyOnAncestorLayerFullRepaint(*this, *enclosingLayer);
+                    return { fullRepaintAlreadyScheduled, &pixelMovingFilterLayer->renderer() };
+                }
             }
         }
     }
@@ -971,7 +973,7 @@ void RenderObject::propagateRepaintToParentWithOutlineAutoIfNeeded(const RenderL
     ASSERT_NOT_REACHED();
 }
 
-void RenderObject::repaintUsingContainer(SingleThreadWeakPtr<const RenderLayerModelObject>&& repaintContainer, const LayoutRect& r, bool shouldClipToLayer) const
+void RenderObject::repaintUsingContainer(SingleThreadWeakPtr<const RenderLayerModelObject>&& repaintContainer, const LayoutRect& r, ClipRepaintToLayer clipRepaintToLayer, RepaintRectIsPartial rectIsPartial) const
 {
     if (r.isEmpty())
         return;
@@ -990,7 +992,11 @@ void RenderObject::repaintUsingContainer(SingleThreadWeakPtr<const RenderLayerMo
     propagateRepaintToParentWithOutlineAutoIfNeeded(*repaintContainer, r);
 
     if (repaintContainer->hasFilter() && repaintContainer->layer() && repaintContainer->layer()->requiresFullLayerImageForFilters()) {
-        protect(repaintContainer->layer())->setFilterBackendNeedsRepaintingInRect(r);
+        // The full repaint rect of a RenderBox is its visual overflow, which already includes the filter outsets.
+        auto useFilterOutsets = RenderLayer::UseFilterOutsets::Add;
+        if (rectIsPartial == RepaintRectIsPartial::No && repaintContainer.get() == this && is<RenderBox>(*this))
+            useFilterOutsets = RenderLayer::UseFilterOutsets::AlreadyIncluded;
+        protect(repaintContainer->layer())->setFilterBackendNeedsRepaintingInRect(r, useFilterOutsets);
         return;
     }
 
@@ -1010,7 +1016,7 @@ void RenderObject::repaintUsingContainer(SingleThreadWeakPtr<const RenderLayerMo
     if (view().usesCompositing()) {
         ASSERT(repaintContainer->isComposited());
         if (CheckedPtr layer = repaintContainer->layer())
-            layer->setBackingNeedsRepaintInRect(r, shouldClipToLayer ? GraphicsLayer::ShouldClipToLayer::Clip : GraphicsLayer::ShouldClipToLayer::DoNotClip);
+            layer->setBackingNeedsRepaintInRect(r, clipRepaintToLayer == ClipRepaintToLayer::Yes ? GraphicsLayer::ShouldClipToLayer::Clip : GraphicsLayer::ShouldClipToLayer::DoNotClip);
     }
 }
 
@@ -1043,7 +1049,7 @@ void RenderObject::issueRepaint(std::optional<LayoutRect> partialRepaintRect, Cl
     } else
         repaintRect = clippedOverflowRectForRepaint(repaintContainer.renderer.get());
 
-    repaintUsingContainer(repaintContainer.renderer.get(), repaintRect, clipRepaintToLayer == ClipRepaintToLayer::Yes);
+    repaintUsingContainer(repaintContainer.renderer.get(), repaintRect, clipRepaintToLayer, partialRepaintRect ? RepaintRectIsPartial::Yes : RepaintRectIsPartial::No);
 }
 
 void RenderObject::repaint(ForceRepaint forceRepaint) const
@@ -1087,17 +1093,17 @@ void RenderObject::repaintSlowRepaintObject() const
 
     CheckedPtr repaintContainer = containerForRepaint().renderer;
 
-    bool shouldClipToLayer = true;
+    auto clipRepaintToLayer = ClipRepaintToLayer::Yes;
     IntRect repaintRect;
     // If this is the root background, we need to check if there is an extended background rect. If
     // there is, then we should not allow painting to clip to the layer size.
     if (isDocumentElementRenderer() || isBody()) {
-        shouldClipToLayer = !protect(view->frameView())->hasExtendedBackgroundRectForPainting();
+        clipRepaintToLayer = protect(view->frameView())->hasExtendedBackgroundRectForPainting() ? ClipRepaintToLayer::No : ClipRepaintToLayer::Yes;
         repaintRect = snappedIntRect(view->backgroundRect());
     } else
         repaintRect = snappedIntRect(clippedOverflowRectForRepaint(repaintContainer.get()));
 
-    repaintUsingContainer(repaintContainer.get(), repaintRect, shouldClipToLayer);
+    repaintUsingContainer(repaintContainer.get(), repaintRect, clipRepaintToLayer);
 }
 
 IntRect RenderObject::pixelSnappedAbsoluteClippedOverflowRect() const

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -883,7 +883,9 @@ public:
     RepaintContainerStatus containerForRepaint() const;
     // Actually do the repaint of rect r for this object which has been computed in the coordinate space
     // of repaintContainer. If repaintContainer is nullptr, repaint via the view.
-    void repaintUsingContainer(SingleThreadWeakPtr<const RenderLayerModelObject>&& repaintContainer, const LayoutRect&, bool shouldClipToLayer = true) const;
+    enum class ClipRepaintToLayer : bool { No, Yes };
+    enum class RepaintRectIsPartial : bool { No, Yes };
+    void repaintUsingContainer(SingleThreadWeakPtr<const RenderLayerModelObject>&& repaintContainer, const LayoutRect&, ClipRepaintToLayer = ClipRepaintToLayer::Yes, RepaintRectIsPartial = RepaintRectIsPartial::No) const;
 
     // Repaint the entire object.  Called when, e.g., the color of a border changes, or when a border
     // style changes.
@@ -893,7 +895,6 @@ public:
     // Repaint a specific subrectangle within a given object.  The rect |r| is in the object's coordinate space.
     WEBCORE_EXPORT void repaintRectangle(const LayoutRect&, bool shouldClipToLayer = true) const;
 
-    enum class ClipRepaintToLayer : bool { No, Yes };
     void repaintRectangle(const LayoutRect&, ClipRepaintToLayer, ForceRepaint, std::optional<LayoutBoxExtent> additionalRepaintOutsets = std::nullopt) const;
 
     // Repaint a slow repaint object, which, at this time, means we are repainting an object with background-attachment:fixed.

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -175,11 +175,11 @@ public:
     void incrementRendersWithOutline() { ++m_renderersWithOutlineCount; }
     void decrementRendersWithOutline() { ASSERT(m_renderersWithOutlineCount > 0); --m_renderersWithOutlineCount; }
     bool hasRenderersWithOutline() const { return m_renderersWithOutlineCount; }
+    void incrementRenderersWithPixelMovingFilter() { ++m_renderersWithPixelMovingFilterCount; }
+    void decrementRenderersWithPixelMovingFilter() { ASSERT(m_renderersWithPixelMovingFilterCount > 0); --m_renderersWithPixelMovingFilterCount; }
+    bool hasRenderersWithPixelMovingFilter() const { return m_renderersWithPixelMovingFilterCount; }
 
     ImageQualityController& imageQualityController() LIFETIME_BOUND;
-
-    void setHasSoftwareFilters(bool hasSoftwareFilters) { m_hasSoftwareFilters = hasSoftwareFilters; }
-    bool hasSoftwareFilters() const { return m_hasSoftwareFilters; }
 
     uint64_t rendererCount() const { return m_rendererCount; }
     void didCreateRenderer() { ++m_rendererCount; }
@@ -292,8 +292,7 @@ private:
 
     SingleThreadWeakHashSet<RenderCounter> m_countersNeedingUpdate;
     unsigned m_renderersWithOutlineCount { 0 };
-
-    bool m_hasSoftwareFilters { false };
+    unsigned m_renderersWithPixelMovingFilterCount { 0 };
     bool m_needsRepaintHackAfterCompositingLayerUpdateForDebugOverlaysOnly { false };
     bool m_needsEventRegionUpdateForNonCompositedFrame { false };
 #if ENABLE(TEXT_AUTOSIZING)


### PR DESCRIPTION
#### ec4f132e36ac898a83d2bda8e815f33f356ccefe
<pre>
Cherry-pick 320398@main (4b6b2cdc9092). <a href="https://bugs.webkit.org/show_bug.cgi?id=322424">https://bugs.webkit.org/show_bug.cgi?id=322424</a>

    Content changing inside an element with a blur filter doesn&apos;t properly repaint
    <a href="https://bugs.webkit.org/show_bug.cgi?id=322424">https://bugs.webkit.org/show_bug.cgi?id=322424</a>

    Reviewed by Simon Fraser.

    The ticket contains a reduction obtained from YouTube Shorts, when dark
    mode + ambient mode is enabled. Around the video a glow effect is
    visible, which left stale pixels on our ports while the video was
    running.

    Testcase:

      #glow { position: absolute; left: 50%; top: 50%; width: 380px; height: 660px;
              margin: -330px 0 0 -190px; transform: scale(1.8, 1.3);
              filter: blur(40px); pointer-events: none; }
      #glow canvas { position: absolute; width: 100%; height: 100%; }

    &lt;div id=&quot;glow&quot;&gt;
      &lt;canvas id=&quot;ca&quot; width=&quot;86&quot; height=&quot;126&quot;&gt;&lt;/canvas&gt;
      &lt;canvas id=&quot;cb&quot; width=&quot;86&quot; height=&quot;126&quot;&gt;&lt;/canvas&gt;
    &lt;/div&gt;

    macOS repaints this particular testcase correctly, because #glow ends up
    composited as the canvases are composited and the platform layer applies
    the blur filter. On GTK/WPE they are not: the canvas backing store size is
    86 * 126px, below the minimum area we impose for acceleration
    (CanvasBase::shouldAccelerate(), queries
    Settings::minimumAccelerated2DContextArea which is 128 * 129 with Skia,
    0 elsewhere). Both canvases are drawn in software, into the enclosing layer.

    The code path our ports take has a bug since 204269@main: we no longer set
    setHasSoftwareFilters() anywhere. RenderObject::containerForRepaint() only looks
    for an enclosing filter layer while that flag is set, so it never sees #glow.
    The repaint is issued against the root layer of the page instead, and
    repaintUsingContainer() never calls RenderLayer::setFilterBackendNeedsRepaintingInRect().
    That is the only place that expands the repaint rect by filterOutsets() and was
    missing for us.

    Instead of bringing back the setHasSoftwareFilters() mechanism, mimic
    the outline counter concept: count the renderers with a pixel moving
    filter, and maintain the count properly, instead of keeping a flag on all
    the time as it used to be in the past.

    Furthermore a stale-repaint-rect issue had to be fixed: RenderLayer caches its
    repaint container in m_repaintContainer, together with the repaint rects that
    are expressed relative to that container. Whether a layer is the repaint
    container for its subtree now depends on requiresFullLayerImageForFilters(),
    so removing a pixel moving filter, or turning it into a non-pixel-moving filter,
    leaves every layer in the subtree pointing at a container that is no longer
    a repaint container. That hits an assertion in imported/w3c/web-platform-tests/
    css/filter-effects/animation/filter-interpolation-003.html.

    This fixes the repainting logic in general, whenever software-rendered
    filters are involved, also on Mac platforms as several new testcases
    demonstrate.

    Tests: css3/filters/filter-repaint-blur-before-first-paint.html
           css3/filters/filter-repaint-blur-canvas-partial.html
           css3/filters/filter-repaint-blur-inline.html
           css3/filters/filter-repaint-blur-inner-content-change.html
           css3/filters/filter-repaint-blur-nested-non-pixel-moving-filter.html
           css3/filters/filter-repaint-blur-nested-pixel-moving-filter.html

    * LayoutTests/css3/filters/filter-repaint-blur-before-first-paint-expected.txt: Added.
    * LayoutTests/css3/filters/filter-repaint-blur-before-first-paint.html: Added.
    * LayoutTests/css3/filters/filter-repaint-blur-canvas-partial-expected.txt: Added.
    * LayoutTests/css3/filters/filter-repaint-blur-canvas-partial.html: Added.
    * LayoutTests/css3/filters/filter-repaint-blur-inline-expected.txt: Added.
    * LayoutTests/css3/filters/filter-repaint-blur-inline.html: Added.
    * LayoutTests/css3/filters/filter-repaint-blur-inner-content-change-expected.txt: Added.
    * LayoutTests/css3/filters/filter-repaint-blur-inner-content-change.html: Added.
    * LayoutTests/css3/filters/filter-repaint-blur-nested-non-pixel-moving-filter-expected.html: Added.
    * LayoutTests/css3/filters/filter-repaint-blur-nested-non-pixel-moving-filter.html: Added.
    * LayoutTests/css3/filters/filter-repaint-blur-nested-pixel-moving-filter-expected.html: Added.
    * LayoutTests/css3/filters/filter-repaint-blur-nested-pixel-moving-filter.html: Added.
    * LayoutTests/fast/repaint/drop-shadow-change-full-repaint-expected.txt:
    The first repaint rect dumped was wrong, this fixes it as side-effect.
    * Source/WebCore/rendering/RenderElement.cpp:
    (WebCore::RenderElement::styleWillChange):
    (WebCore::RenderElement::willBeDestroyed):
    * Source/WebCore/rendering/RenderLayer.cpp:
    (WebCore::RenderLayer::removeOnlyThisLayer):
    (WebCore::RenderLayer::shouldPaintWithFilters const):
    (WebCore::RenderLayer::requiresFullLayerImageForFilters const):
    (WebCore::RenderLayer::updateRepaintRectsIncludingDescendants):
    (WebCore::RenderLayer::computeRepaintRectsIncludingDescendants): Deleted, folded into the above.
    (WebCore::RenderLayer::compositingStatusChanged):
    (WebCore::RenderLayer::enclosingPixelMovingFilterLayer const):
    (WebCore::RenderLayer::setFilterBackendNeedsRepaintingInRect):
    (WebCore::RenderLayer::updateFiltersAfterStyleChange):
    (WebCore::RenderLayer::filterOutsets const):
    * Source/WebCore/rendering/RenderLayer.h:
    * Source/WebCore/rendering/RenderLayerFilters.cpp:
    (WebCore::RenderLayerFilters::isIdentity): Deleted.
    * Source/WebCore/rendering/RenderLayerFilters.h:
    * Source/WebCore/rendering/RenderObject.cpp:
    (WebCore::RenderObject::containerForRepaint const):
    (WebCore::RenderObject::repaintUsingContainer const):
    (WebCore::RenderObject::issueRepaint const):
    (WebCore::RenderObject::repaintSlowRepaintObject const):
    * Source/WebCore/rendering/RenderObject.h:
    * Source/WebCore/rendering/RenderView.h:
    * Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
    (WebCore::repaintAndMarkContainingBlockDirtyBeforeTearDown):

    Canonical link: <a href="https://commits.webkit.org/320398@main">https://commits.webkit.org/320398@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.249@webkitglib/2.54">https://commits.webkit.org/317695.249@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94f57f1e7e430afc2a024940e0c39a9bccf77183

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185762 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59667 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53475 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196069 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150455 "Build is in progress. Recent messages:") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187624 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/61035 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59394 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145174 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/150455 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188717 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/61035 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53475 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125471 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/61035 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59394 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53475 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/61035 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53475 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7132 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52297 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59394 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198035 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59329 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53475 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154706 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/60037 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53475 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154357 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28204 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/60037 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132385 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129358 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58504 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53475 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57882 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58118 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57945 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->