### PR TITLE
[SVG] Mutating a display: contents tspan inside SVG text crashes with anonymous inline wrapper

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-character-positions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-character-positions-expected.txt
@@ -1,0 +1,4 @@
+ABC
+
+PASS Querying character positions across a display:contents tspan in SVG text should terminate
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-character-positions.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-character-positions.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Display: character positions across a display:contents tspan in SVG text</title>
+<link rel="help" href="https://drafts.csswg.org/css-display/#unbox-svg">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg><text id="text" x="0" y="20">A<tspan style="display:contents;color:green">B</tspan>C</text></svg>
+<script>
+test(() => {
+  const text = document.getElementById("text");
+  const count = text.getNumberOfChars();
+  for (let i = 0; i < count; ++i)
+    assert_greater_than_equal(text.getStartPositionOfChar(i).x, 0, "character " + i);
+}, "Querying character positions across a display:contents tspan in SVG text should terminate");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-display-changed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-display-changed-expected.txt
@@ -1,0 +1,4 @@
+Text
+
+PASS Toggling display between inline and contents on a tspan in SVG text should not crash
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-display-changed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-display-changed.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Display: changing display on a display:contents tspan in SVG text</title>
+<link rel="help" href="https://drafts.csswg.org/css-display/#unbox-svg">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg><text id="text"><tspan id="tspan" style="display:contents;color:green">Text</tspan></text></svg>
+<script>
+test(() => {
+  const text = document.getElementById("text");
+  const tspan = document.getElementById("tspan");
+  text.getNumberOfChars();
+  tspan.style.display = "inline";
+  text.getNumberOfChars();
+  tspan.style.display = "contents";
+  assert_greater_than_equal(text.getNumberOfChars(), 0);
+}, "Toggling display between inline and contents on a tspan in SVG text should not crash");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-removed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-removed-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Removing a display:contents tspan from SVG text should not crash
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-removed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-removed.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Display: removing a display:contents tspan from SVG text</title>
+<link rel="help" href="https://drafts.csswg.org/css-display/#unbox-svg">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg><text id="text"><tspan id="tspan" style="display:contents;color:green">Text</tspan></text></svg>
+<script>
+test(() => {
+  const text = document.getElementById("text");
+  text.getNumberOfChars();
+  document.getElementById("tspan").remove();
+  assert_equals(text.getNumberOfChars(), 0);
+}, "Removing a display:contents tspan from SVG text should not crash");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-text-inserted-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-text-inserted-expected.txt
@@ -1,0 +1,4 @@
+TextMore
+
+PASS Inserting text into a display:contents tspan in SVG text should not crash
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-text-inserted.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-text-inserted.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Display: inserting text into a display:contents tspan in SVG text</title>
+<link rel="help" href="https://drafts.csswg.org/css-display/#unbox-svg">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg><text id="text"><tspan id="tspan" style="display:contents;color:green">Text</tspan></text></svg>
+<script>
+test(() => {
+  const text = document.getElementById("text");
+  text.getNumberOfChars();
+  document.getElementById("tspan").appendChild(document.createTextNode("More"));
+  assert_greater_than_equal(text.getNumberOfChars(), 0);
+}, "Inserting text into a display:contents tspan in SVG text should not crash");
+</script>

--- a/Source/WebCore/rendering/svg/RenderSVGInline.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.cpp
@@ -46,6 +46,12 @@ RenderSVGInline::RenderSVGInline(Type type, SVGGraphicsElement& element, Style::
     ASSERT(isRenderSVGInline());
 }
 
+RenderSVGInline::RenderSVGInline(Type type, Document& document, Style::ComputedStyle&& style)
+    : RenderInline(type, document, WTF::move(style))
+{
+    ASSERT(isRenderSVGInline());
+}
+
 RenderSVGInline::~RenderSVGInline() = default;
 
 std::unique_ptr<LegacyInlineFlowBox> RenderSVGInline::createInlineFlowBox()
@@ -189,11 +195,14 @@ void RenderSVGInline::styleDidChange(Style::Difference diff, const Style::Comput
     if (diff == Style::DifferenceResult::Layout)
         invalidateCachedBoundaries();
     RenderInline::styleDidChange(diff, oldStyle);
-    SVGResourcesCache::clientStyleChanged(*this, diff, oldStyle, style());
+    if (!isAnonymous())
+        SVGResourcesCache::clientStyleChanged(*this, diff, oldStyle, style());
 }
 
 bool RenderSVGInline::needsHasSVGTransformFlags() const
 {
+    if (isAnonymous())
+        return false;
     return protect(graphicsElement())->hasTransformRelatedAttributes();
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGInline.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.h
@@ -33,6 +33,7 @@ class RenderSVGInline : public RenderInline {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGInline);
 public:
     RenderSVGInline(Type, SVGGraphicsElement&, Style::ComputedStyle&&);
+    RenderSVGInline(Type, Document&, Style::ComputedStyle&&);
     virtual ~RenderSVGInline();
 
     inline SVGGraphicsElement& graphicsElement() const;

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -51,6 +51,7 @@
 #include "RenderMultiColumnFlow.h"
 #include "RenderMultiColumnSet.h"
 #include "RenderObjectInlines.h"
+#include "RenderSVGInline.h"
 #include "RenderStyleConstants.h"
 #include "RenderTreeUpdaterGeneratedContent.h"
 #include "RenderTreeUpdaterViewTransition.h"
@@ -644,10 +645,16 @@ void RenderTreeUpdater::createTextRenderer(Text& textNode, const Style::TextUpda
     if (textUpdate && textUpdate->inheritedDisplayContentsStyle && *textUpdate->inheritedDisplayContentsStyle) {
         // Wrap text renderer into anonymous inline so we can give it a style.
         // This is to support "<div style='display:contents;color:green'>text</div>" type cases
-        auto newDisplayContentsAnonymousWrapper = WebCore::createRenderer<RenderInline>(RenderObject::Type::Inline, protect(textNode.document()), Style::ComputedStyle::clone(**textUpdate->inheritedDisplayContentsStyle));
+        auto wrapperStyle = Style::ComputedStyle::clone(**textUpdate->inheritedDisplayContentsStyle);
+        auto& parent = renderTreePosition.parent();
+        RenderPtr<RenderInline> newDisplayContentsAnonymousWrapper;
+        if (parent.isRenderSVGText() || parent.isRenderSVGInline())
+            newDisplayContentsAnonymousWrapper = WebCore::createRenderer<RenderSVGInline>(RenderObject::Type::SVGInline, protect(textNode.document()), WTF::move(wrapperStyle));
+        else
+            newDisplayContentsAnonymousWrapper = WebCore::createRenderer<RenderInline>(RenderObject::Type::Inline, protect(textNode.document()), WTF::move(wrapperStyle));
         newDisplayContentsAnonymousWrapper->initializeStyle();
         auto& displayContentsAnonymousWrapper = *newDisplayContentsAnonymousWrapper;
-        m_builder.attach(renderTreePosition.parent(), WTF::move(newDisplayContentsAnonymousWrapper), renderTreePosition.nextSibling());
+        m_builder.attach(parent, WTF::move(newDisplayContentsAnonymousWrapper), renderTreePosition.nextSibling());
 
         textRenderer->setInlineWrapperForDisplayContents(&displayContentsAnonymousWrapper);
         m_builder.attach(displayContentsAnonymousWrapper, WTF::move(textRenderer));

--- a/Source/WebCore/svg/SVGTextPositioningElement.cpp
+++ b/Source/WebCore/svg/SVGTextPositioningElement.cpp
@@ -105,8 +105,10 @@ RefPtr<SVGTextPositioningElement> SVGTextPositioningElement::elementFromRenderer
     if (!is<RenderSVGText>(renderer) && !is<RenderSVGInline>(renderer))
         return nullptr;
 
-    ASSERT(renderer.element());
-    RefPtr element = downcast<SVGElement>(renderer.element());
+    RefPtr element = dynamicDowncast<SVGElement>(renderer.element());
+    if (!element)
+        return nullptr;
+
     return dynamicDowncast<SVGTextPositioningElement>(WTF::move(element));
 }
 


### PR DESCRIPTION
#### d20ce080371f970c61327ee7b0b5eea43d11c0ce
<pre>
[SVG] Mutating a display: contents tspan inside SVG text crashes with anonymous inline wrapper
<a href="https://bugs.webkit.org/show_bug.cgi?id=323710">https://bugs.webkit.org/show_bug.cgi?id=323710</a>
&lt;<a href="https://rdar.apple.com/problem/186967160">rdar://problem/186967160</a>&gt;

Reviewed by Antti Koivisto.

RenderTreeUpdater::createTextRenderer wraps a text renderer in an anonymous RenderInline to carry a display: contents style.
Inside SVG text that wrapper has to be a RenderSVGInline, because everything walking SVG text looks for one:

1. RenderSVGText::subtreeChildWasAdded/subtreeChildWillBeRemoved skip it, so the layout attributes
cache goes stale and checkLayoutAttributesConsistency asserts on removal, on text insertion and on a display change.
2. SVGTextLayoutAttributesBuilder and SVGTextMetricsBuilder do not descend into it, so its text is never measured and getStartPositionOfChar() hangs.

Create it as an anonymous RenderSVGInline instead.

Tests: imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-character-positions.html
       imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-display-changed.html
       imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-removed.html
       imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-text-inserted.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-character-positions-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-character-positions.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-display-changed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-display-changed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-removed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-removed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-text-inserted-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-contents-svg-tspan-child-text-inserted.html: Added.
* Source/WebCore/rendering/svg/RenderSVGInline.cpp:
(WebCore::RenderSVGInline::RenderSVGInline):
(WebCore::RenderSVGInline::styleDidChange):
(WebCore::RenderSVGInline::needsHasSVGTransformFlags):
* Source/WebCore/rendering/svg/RenderSVGInline.h:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::createTextRenderer):
* Source/WebCore/svg/SVGTextPositioningElement.cpp:
(WebCore::SVGTextPositioningElement::elementFromRenderer):

Canonical link: <a href="https://commits.webkit.org/320865@main">https://commits.webkit.org/320865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b731cdf9466acc83fa1f728a6906e27115047a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196402 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150697 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a0b9ca54-0da5-48d4-b588-c8bdc9302da1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187973 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145421 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100803 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/404f8b2c-db8d-4ab5-a6d5-eaad8275bedb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189066 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165958 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125747 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/501ab0c6-9a3a-4da6-85fc-9e9f2b4075b6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47834 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158188 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45546 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7473 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198380 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59663 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165478 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154988 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41521 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60375 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154625 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49077 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129789 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58814 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58207 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58436 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58266 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->