### PR TITLE
Cherry-pick 305413.1082@safari-7624.5.1.10-branch (bd4c91c57d10). https://bugs.webkit.org/show_bug.cgi?id=318480

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -103,6 +103,8 @@ media/encrypted-media/encrypted-media-append-encrypted-unencrypted.html [ Skip ]
 media/media-source/media-source-append-play-corrupt-aac.html [ Skip ]
 media/media-source/media-source-mp4ttsimple.html [ Skip ]
 media/media-source/media-source-inband-cea608-track.html [ Skip ]
+# WebM generator not present in safari-7624.5-branch branch.
+media/media-source/media-source-webm-reversed-timestamps-crash.html [ Failure ]
 media/modern-media-controls/ios-inline-media-controls/touch [ Skip ]
 media/modern-media-controls/overflow-support [ Skip ]
 media/modern-media-controls/visionos-inline-media-controls [ Skip ]

--- a/LayoutTests/ipc/display-capture-source-configuration-change-uaf-expected.txt
+++ b/LayoutTests/ipc/display-capture-source-configuration-change-uaf-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/ipc/display-capture-source-configuration-change-uaf.html
+++ b/LayoutTests/ipc/display-capture-source-configuration-change-uaf.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<html>
+<body>
+<p>This test passes if it does not crash.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    testRunner.setUserMediaPermission(true);
+}
+if (window.internals)
+    internals.settings.setScreenCaptureEnabled(true);
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+function done() { window.testRunner?.notifyDone(); }
+
+async function main() {
+    if (!window.IPC || !window.testRunner)
+        return done();
+
+    const { CoreIPC, IPCWireTap } = await import('./coreipc.js');
+
+    let idA = null;
+    const tap = new IPCWireTap('GPU', 'Outgoing');
+    tap.tapAll((proc, dest, name, typed, parsed) => {
+        if (name === IPC.messages.UserMediaCaptureManagerProxy_CreateMediaSourceForCaptureDeviceWithConstraints.name)
+            idA = parsed.id;
+    });
+
+    let stream;
+    internals.withUserGesture(() => {
+        stream = navigator.mediaDevices.getDisplayMedia({ video: { width: { max: 3000 }, height: { max: 2000 } } });
+    });
+    await stream;
+    await sleep(300);
+
+    if (idA === null)
+        return done();
+
+    CoreIPC.GPU.UserMediaCaptureManagerProxy.StopProducingData(0, { id: idA });
+    await sleep(100);
+
+    const idB = idA + 1000n;
+    CoreIPC.GPU.UserMediaCaptureManagerProxy.Clone(0, { clonedID: idA, cloneID: idB, pageIdentifier: IPC.pageID });
+    await sleep(50);
+
+    CoreIPC.GPU.UserMediaCaptureManagerProxy.StartProducingData(0, { id: idB, pageIdentifier: IPC.pageID });
+    await sleep(200);
+
+    testRunner.triggerMockCaptureConfigurationChange(false, false, true);
+    await sleep(400);
+
+    CoreIPC.GPU.UserMediaCaptureManagerProxy.RemoveSource(0, { id: idA });
+    await sleep(2000);
+
+    done();
+}
+
+setTimeout(() => { main().catch(done); }, 100);
+setTimeout(done, 30000);
+</script>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash-expected.txt
+++ b/LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash-expected.txt
@@ -1,0 +1,11 @@
+Tests that appending a WebM cluster whose block timestamps decrease, after abort(), does not crash.
+
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+RUN(sourceBuffer.abort())
+EVENT(updateend)
+EVENT(updateend)
+EXPECTED (source.readyState == 'open') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash.html
+++ b/LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-webm-reversed-timestamps-crash</title>
+    <script src="webm-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // A WebM SimpleBlock cluster whose block timestamps go backward causes the
+    // WebM parser to compute a negative sample duration. When appended after
+    // abort() (which resets the track buffer's highest presentation timestamp
+    // while preserving its samples), Coded Frame Processing step 1.14 calls
+    // findSamplesBetweenPresentationTimes() with endTime < beginTime; the
+    // resulting reversed iterator range walks past the end of the sample map.
+    // This test passes if it does not crash.
+
+    var source;
+    var sourceBuffer;
+    var initData;
+
+    function simpleBlockCluster(trackNumber, clusterTimecode, blocks)
+    {
+        // Hand-roll a Cluster of SimpleBlocks (no BlockDuration), so the
+        // parser must derive each sample's duration from the gap to the
+        // next block's timestamp.
+        function vintSize(n)
+        {
+            if (n < 0x7F)
+                return new Uint8Array([0x80 | n]);
+            return new Uint8Array([0x40 | (n >> 8), n & 0xFF]);
+        }
+        var body = [new Uint8Array([0xE7, 0x81, clusterTimecode & 0xFF])];
+        for (var block of blocks) {
+            var ts = new Uint8Array(2);
+            new DataView(ts.buffer).setInt16(0, block.timestamp, false);
+            var payload = WebM.concat(new Uint8Array([0x80 | trackNumber]), ts,
+                new Uint8Array([block.isSync ? 0x80 : 0x00]), block.data);
+            body.push(new Uint8Array([0xA3]), vintSize(payload.byteLength), payload);
+        }
+        var clusterBody = WebM.concat(...body);
+        return WebM.concat(new Uint8Array([0x1F, 0x43, 0xB6, 0x75]),
+            vintSize(clusterBody.byteLength), clusterBody);
+    }
+
+    async function runTest()
+    {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(WebM.VIDEO_TYPE)) {
+            consoleWrite('SKIPPED: ' + WebM.VIDEO_TYPE + ' is not supported');
+            return;
+        }
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(WebM.VIDEO_TYPE);
+
+        initData = WebM.initSegment({ tracks: [{ id: 1, type: 'video', defaultDuration: 0 }] });
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        var samples = [{ duration: 50, isSync: true }];
+        for (var i = 0; i < 7; ++i)
+            samples.push({ duration: 50, isSync: false });
+        sourceBuffer.appendBuffer(WebM.mediaSegment({
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: samples }]
+        }));
+        await waitFor(sourceBuffer, 'updateend');
+
+        run('sourceBuffer.abort()');
+
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+
+        sourceBuffer.appendBuffer(simpleBlockCluster(1, 0, [
+            { timestamp: 200, isSync: true, data: new Uint8Array([0x30, 0x12, 0x00, 0x9D, 0x01, 0x2A, 0x40, 0x01, 0xF0, 0x00, 0x00]) },
+            { timestamp: 10, isSync: false, data: new Uint8Array([0xD1, 0x02, 0x00]) },
+            { timestamp: 250, isSync: false, data: new Uint8Array([0xD1, 0x02, 0x00]) },
+        ]));
+        await waitFor(sourceBuffer, 'updateend');
+
+        testExpected('source.readyState', 'open');
+    }
+
+    window.addEventListener('load', () => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <div>Tests that appending a WebM cluster whose block timestamps decrease, after abort(), does not crash.</div>
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediasource/SampleMap.cpp
+++ b/Source/WebCore/Modules/mediasource/SampleMap.cpp
@@ -324,6 +324,8 @@ DecodeOrderSampleMap::iterator DecodeOrderSampleMap::findSyncSampleAfterDecodeIt
 
 PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSamplesBetweenPresentationTimes(const MediaTime& beginTime, const MediaTime& endTime) LIFETIME_BOUND
 {
+    if (endTime <= beginTime)
+        return { end(), end() };
     // startTime is inclusive, so use lower_bound to include samples wich start exactly at startTime.
     // endTime is not inclusive, so use lower_bound to exclude samples which start exactly at endTime.
     auto lower_bound = m_samples.lower_bound(beginTime);
@@ -335,6 +337,8 @@ PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSampl
 
 PresentationOrderSampleMap::iterator_range PresentationOrderSampleMap::findSamplesBetweenPresentationTimesFromEnd(const MediaTime& beginTime, const MediaTime& endTime) LIFETIME_BOUND
 {
+    if (endTime <= beginTime)
+        return { end(), end() };
     reverse_iterator rangeEnd = std::find_if(rbegin(), rend(), [&endTime](const auto& value) {
         return value.first < endTime;
     });

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -1166,6 +1166,17 @@ void WebMParser::VideoTrackData::processPendingMediaSamples(const MediaTime& pre
     if (!m_pendingMediaSamples.size())
         return;
     auto& lastSample = m_pendingMediaSamples.last();
+    // The WebM container does not encode per-frame durations; we derive them
+    // from the gap to the next frame's presentation time. A malformed cluster
+    // whose block timestamps decrease would yield a negative duration here,
+    // which propagates to SourceBufferPrivate::processMediaSample() as
+    // frameEndTimestamp < presentationTimestamp. Treat any non-increasing
+    // timestamp the same as the existing equal-timestamp case below: leave the
+    // pending sample queued (with zero duration) until a later frame arrives.
+    if (presentationTime < lastSample.presentationTime) {
+        lastSample.duration = MediaTime::zeroTime();
+        return;
+    }
     lastSample.duration = presentationTime - lastSample.presentationTime;
     if (presentationTime == lastSample.presentationTime)
         return;

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp
@@ -376,7 +376,7 @@ private:
         Ref source = m_source;
         auto deviceType = source->deviceType();
 
-        if ((deviceType == CaptureDevice::DeviceType::Screen || deviceType == CaptureDevice::DeviceType::Window) && m_videoConstraints && updateVideoConstraints(*m_videoConstraints)) {
+        if (m_isObservingMedia && (deviceType == CaptureDevice::DeviceType::Screen || deviceType == CaptureDevice::DeviceType::Window) && m_videoConstraints && updateVideoConstraints(*m_videoConstraints)) {
             source->removeVideoFrameObserver(*this);
             source->addVideoFrameObserver(*this, { m_widthConstraint, m_heightConstraint }, m_frameRateConstraint);
         }

--- a/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
@@ -231,6 +231,10 @@ TEST_F(SampleMapTest, findSamplesBetweenPresentationTimes)
     iterator_range = presentationMap.findSamplesBetweenPresentationTimes(MediaTime(30, 1), MediaTime(31, 1));
     EXPECT_TRUE(presentationMap.end() == iterator_range.first);
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
+
+    iterator_range = presentationMap.findSamplesBetweenPresentationTimes(MediaTime(5, 1), MediaTime(2, 1));
+    EXPECT_TRUE(presentationMap.end() == iterator_range.first);
+    EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 }
 
 TEST_F(SampleMapTest, findSamplesBetweenPresentationTimesFromEnd)
@@ -266,6 +270,10 @@ TEST_F(SampleMapTest, findSamplesBetweenPresentationTimesFromEnd)
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 
     iterator_range = presentationMap.findSamplesBetweenPresentationTimesFromEnd(MediaTime(30, 1), MediaTime(31, 1));
+    EXPECT_TRUE(presentationMap.end() == iterator_range.first);
+    EXPECT_TRUE(presentationMap.end() == iterator_range.second);
+
+    iterator_range = presentationMap.findSamplesBetweenPresentationTimesFromEnd(MediaTime(5, 1), MediaTime(2, 1));
     EXPECT_TRUE(presentationMap.end() == iterator_range.first);
     EXPECT_TRUE(presentationMap.end() == iterator_range.second);
 }


### PR DESCRIPTION
#### 6507c86e90f991da609f062b8362bd74b8c1fc04
<pre>
Cherry-pick 305413.1082@safari-7624.5.1.10-branch (bd4c91c57d10). <a href="https://bugs.webkit.org/show_bug.cgi?id=318480">https://bugs.webkit.org/show_bug.cgi?id=318480</a>

    Malformed WebM with non-monotonically increasing presentation timestamps can cause a crash.
    <a href="https://rdar.apple.com/177494050">rdar://177494050</a>

    Reviewed by Eric Carlson.

    We guard against non-monotonically increasing presentation timestamps in SourceBufferParserWebM
    and SampleMap

    Tests: media/media-source/media-source-webm-reversed-timestamps-crash.html
           Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp

    * LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash-expected.txt: Added.
    * LayoutTests/media/media-source/media-source-webm-reversed-timestamps-crash.html: Added.
    * Source/WebCore/Modules/mediasource/SampleMap.cpp:
    (WebCore::PresentationOrderSampleMap::findSamplesBetweenPresentationTimes):
    (WebCore::PresentationOrderSampleMap::findSamplesBetweenPresentationTimesFromEnd):
    * Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
    (WebCore::WebMParser::VideoTrackData::processPendingMediaSamples):
    * Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp:
    (TestWebKitAPI::TEST_F(SampleMapTest, findSamplesBetweenPresentationTimes)):
    (TestWebKitAPI::TEST_F(SampleMapTest, findSamplesBetweenPresentationTimesFromEnd)):

    Identifier: 305413.1082@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.248@webkitglib/2.54">https://commits.webkit.org/317695.248@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 6c4fdcaba1fb630ac5f7819bf1e46c59f486f8de
<pre>
Cherry-pick 305413.1075@safari-7624.5.1.10-branch (a06fd51c1706). <a href="https://bugs.webkit.org/show_bug.cgi?id=318405">https://bugs.webkit.org/show_bug.cgi?id=318405</a>

    [CoreIPC][GPUP] UserMediaCaptureManagerProxySourceProxy can leave a dangling VideoFrameObserver* in RealtimeMediaSource
    <a href="https://rdar.apple.com/174702504">rdar://174702504</a>

    Reviewed by Jer Noble.

    UserMediaCaptureManagerProxySourceProxy::sourceConfigurationChanged() re-registers
    the proxy as a VideoFrameObserver of its RealtimeMediaSource via
    removeVideoFrameObserver()/addVideoFrameObserver() without consulting m_isObservingMedia.
    Since the proxy is registered as a RealtimeMediaSourceObserver unconditionally in its
    constructor, this callback can fire on a stopped (or never-started) proxy and insert a
    raw VideoFrameObserver* into m_videoFrameObservers while m_isObservingMedia remains
    false. The destructor&apos;s unobserveMedia() then early-returns without removing the entry.

    DisplayCaptureSourceCocoa does not override clone(), so UserMediaCaptureManagerProxy::clone()
    yields two proxies sharing the same RealtimeMediaSource; the surviving clone keeps the
    source (and its dangling raw key) alive after the first proxy is freed, and the next
    videoFrameAvailable() virtual-dispatches through freed memory in the GPU process. This
    is reachable from a compromised WebContent process over UserMediaCaptureManagerProxy IPC
    once the page has been granted getDisplayMedia.

    Guard the observer re-registration in sourceConfigurationChanged() on m_isObservingMedia
    so a stopped proxy is never re-inserted into m_videoFrameObservers.

    * LayoutTests/ipc/display-capture-source-configuration-change-uaf-expected.txt: Added.
    * LayoutTests/ipc/display-capture-source-configuration-change-uaf.html: Added.
    * Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp:
    (WebKit::UserMediaCaptureManagerProxySourceProxy::sourceConfigurationChanged):

    Identifier: 305413.1075@safari-7624.5-branch

Canonical link: <a href="https://commits.webkit.org/317695.247@webkitglib/2.54">https://commits.webkit.org/317695.247@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61c58e29832a691c212a8268dbece611533ac065

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185767 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59672 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53480 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196074 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150460 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187629 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/61040 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59399 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145170 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150460 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188722 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/61040 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53480 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125467 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/61040 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59399 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53480 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/61040 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53480 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7137 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52302 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59399 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198040 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59334 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53480 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154712 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/60042 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53480 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154363 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28203 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/60042 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132390 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129365 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58509 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53480 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57887 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58123 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57950 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->