### PR TITLE
[GTK][WPE] Skia compositor: move the code to create DMABuf promise images from CoordinatedPlatformLayerBufferDMABuf to DMABufBuffer

### DIFF
--- a/Source/WebCore/platform/graphics/DMABufBuffer.cpp
+++ b/Source/WebCore/platform/graphics/DMABufBuffer.cpp
@@ -27,11 +27,21 @@
 #include "DMABufBuffer.h"
 
 #if USE(GBM)
+#include "BitmapTexturePool.h"
 #include "CoordinatedPlatformLayerBuffer.h"
 #include "GBMVersioning.h"
-#include "GLDisplay.h"
+#include "GLContext.h"
+#include "GLFence.h"
+#include "PlatformDisplay.h"
 #include <atomic>
 #include <drm_fourcc.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/gpu/ganesh/GrYUVABackendTextures.h>
+#include <skia/gpu/ganesh/SkImageGanesh.h>
+#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
+#include <skia/private/chromium/GrPromiseImageTexture.h>
+#include <skia/private/chromium/SkImageChromium.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 #if USE(LIBEPOXY)
 #include <epoxy/egl.h>
@@ -61,11 +71,6 @@ DMABufBuffer::DMABufBuffer(uint64_t id, Attributes&& attributes)
 }
 
 DMABufBuffer::~DMABufBuffer() = default;
-
-void DMABufBuffer::setBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&& buffer)
-{
-    m_buffer = WTF::move(buffer);
-}
 
 std::optional<DMABufBuffer::Attributes> DMABufBuffer::takeAttributes()
 {
@@ -176,6 +181,363 @@ std::optional<Vector<EGLint>> DMABufBuffer::buildEGLImageAttributes(const Attrib
         return static_cast<EGLint>(value);
     });
 }
+
+#if USE(TEXTURE_MAPPER)
+void DMABufBuffer::setBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&& buffer)
+{
+    m_buffer = WTF::move(buffer);
+}
+
+#else
+
+static bool formatIsYUV(uint32_t fourcc)
+{
+    switch (fourcc) {
+    case DRM_FORMAT_YUV420:
+    case DRM_FORMAT_YVU420:
+    case DRM_FORMAT_NV12:
+    case DRM_FORMAT_NV21:
+    case DRM_FORMAT_YUV444:
+    case DRM_FORMAT_YUV411:
+    case DRM_FORMAT_YUV422:
+    case DRM_FORMAT_AYUV:
+    case DRM_FORMAT_P010:
+        return true;
+    }
+
+    return false;
+}
+
+struct YUVPlaneInfo {
+    uint32_t fourcc;
+    unsigned glFormat;
+    IntSize subsampling;
+};
+
+static const HashMap<uint32_t, Vector<YUVPlaneInfo>>& yuvFormatPlaneInfo()
+{
+    static NeverDestroyed<HashMap<uint32_t, Vector<YUVPlaneInfo>>> yuvFormatsMap = [] {
+        HashMap<uint32_t, Vector<YUVPlaneInfo>> map;
+        // 1 plane formats.
+        map.set(DRM_FORMAT_AYUV, Vector<YUVPlaneInfo> {
+            { DRM_FORMAT_ABGR8888, GL_RGBA8, { 1, 1 } },
+        });
+
+        // 2 plane formats.
+        map.set(DRM_FORMAT_NV12, Vector<YUVPlaneInfo> {
+            { DRM_FORMAT_R8, GL_R8, { 1, 1 } },
+            { DRM_FORMAT_GR88, GL_RG8, { 2, 2 } },
+        });
+        map.set(DRM_FORMAT_NV21, Vector<YUVPlaneInfo> {
+            { DRM_FORMAT_R8, GL_R8, { 1, 1 } },
+            { DRM_FORMAT_GR88, GL_RG8, { 2, 2 } },
+        });
+        map.set(DRM_FORMAT_P010, Vector<YUVPlaneInfo> {
+            { DRM_FORMAT_R16, GL_R16, { 1, 1 } },
+            { DRM_FORMAT_GR1616, GL_RG16, { 2, 2 } },
+        });
+
+        // 3 plane formats.
+        map.set(DRM_FORMAT_YUV420, Vector<YUVPlaneInfo> {
+            { DRM_FORMAT_R8, GL_R8, { 1, 1 } },
+            { DRM_FORMAT_R8, GL_R8, { 2, 2 } },
+            { DRM_FORMAT_R8, GL_R8, { 2, 2 } },
+        });
+        map.set(DRM_FORMAT_YVU420, Vector<YUVPlaneInfo> {
+            { DRM_FORMAT_R8, GL_R8, { 1, 1 } },
+            { DRM_FORMAT_R8, GL_R8, { 2, 2 } },
+            { DRM_FORMAT_R8, GL_R8, { 2, 2 } },
+        });
+        map.set(DRM_FORMAT_YUV444, Vector<YUVPlaneInfo> {
+            { DRM_FORMAT_R8, GL_R8, { 1, 1 } },
+            { DRM_FORMAT_R8, GL_R8, { 1, 1 } },
+            { DRM_FORMAT_R8, GL_R8, { 1, 1 } },
+        });
+        map.set(DRM_FORMAT_YUV411, Vector<YUVPlaneInfo> {
+            { DRM_FORMAT_R8, GL_R8, { 1, 1 } },
+            { DRM_FORMAT_R8, GL_R8, { 4, 1 } },
+            { DRM_FORMAT_R8, GL_R8, { 4, 1 } },
+        });
+        map.set(DRM_FORMAT_YUV422, Vector<YUVPlaneInfo> {
+            { DRM_FORMAT_R8, GL_R8, { 1, 1 } },
+            { DRM_FORMAT_R8, GL_R8, { 2, 1 } },
+            { DRM_FORMAT_R8, GL_R8, { 2, 1 } },
+        });
+        return map;
+    }();
+    return yuvFormatsMap;
+}
+
+bool DMABufBuffer::importIfNeeded()
+{
+    if (!m_importedTextures.isEmpty())
+        return true;
+
+    auto& display = PlatformDisplay::sharedDisplay();
+    auto importPlane = [&](const Attributes& planeAttributes, unsigned glFormat) {
+        auto eglImage = createEGLImage(display.glDisplay(), planeAttributes);
+        if (!eglImage)
+            return false;
+
+        Ref texture = BitmapTexturePool::singleton().createTextureForImage(eglImage, planeAttributes.size, { });
+        m_importedTextures.append(texture);
+        display.destroyEGLImage(eglImage);
+
+        GrGLTextureInfo externalTexture;
+        externalTexture.fTarget = GL_TEXTURE_2D;
+        externalTexture.fID = texture->id();
+        externalTexture.fFormat = glFormat;
+        m_importedBackendTextures.append(GrBackendTextures::MakeGL(texture->size().width(), texture->size().height(), skgpu::Mipmapped::kNo, externalTexture));
+        return true;
+    };
+
+    if (formatIsYUV(m_attributes.fourcc.value)) {
+        const auto& iter = yuvFormatPlaneInfo().find(m_attributes.fourcc.value);
+        if (iter == yuvFormatPlaneInfo().end())
+            return false;
+
+        const auto& planeInfo = iter->value;
+        for (unsigned i = 0; i < planeInfo.size(); ++i) {
+            const auto& plane = planeInfo[i];
+            IntSize planeSize { m_attributes.size.width() / plane.subsampling.width(), m_attributes.size.height() / plane.subsampling.height() };
+            auto planeFds = Vector<UnixFileDescriptor>::from(m_attributes.fds[i].borrow());
+            Attributes planeAttributes { planeSize, plane.fourcc, WTF::move(planeFds), { m_attributes.offsets[i] }, { m_attributes.strides[i] }, m_attributes.modifier };
+            if (!importPlane(planeAttributes, plane.glFormat)) {
+                LOG_ERROR("Failed to import DMA-BUF YUV buffer: could not create an EGL image for plane %u", i);
+                m_importedTextures.clear();
+                m_importedBackendTextures.clear();
+                return false;
+            }
+        }
+    } else {
+        if (!importPlane(m_attributes, GL_RGBA8)) {
+            LOG_ERROR("Failed to import DMA-BUF YUV buffer: could not create an EGL image");
+            m_importedTextures.clear();
+            m_importedBackendTextures.clear();
+            return false;
+        }
+    }
+
+    return true;
+}
+
+const GrBackendTexture& DMABufBuffer::backendTexture(size_t planeIndex) const
+{
+    RELEASE_ASSERT(planeIndex < m_importedBackendTextures.size());
+    return m_importedBackendTextures[planeIndex];
+}
+
+SkYUVAInfo DMABufBuffer::yuvaInfo() const
+{
+    auto planeConfig = SkYUVAInfo::PlaneConfig::kUnknown;
+    auto subsampling = SkYUVAInfo::Subsampling::kUnknown;
+    switch (m_attributes.fourcc.value) {
+    case DRM_FORMAT_AYUV:
+        planeConfig = SkYUVAInfo::PlaneConfig::kYUVA;
+        subsampling = SkYUVAInfo::Subsampling::k444;
+        break;
+    case DRM_FORMAT_NV21:
+        planeConfig = SkYUVAInfo::PlaneConfig::kY_VU;
+        subsampling = SkYUVAInfo::Subsampling::k420;
+        break;
+    case DRM_FORMAT_NV12:
+    case DRM_FORMAT_P010:
+        planeConfig = SkYUVAInfo::PlaneConfig::kY_UV;
+        subsampling = SkYUVAInfo::Subsampling::k420;
+        break;
+    case DRM_FORMAT_YUV420:
+        planeConfig = SkYUVAInfo::PlaneConfig::kY_U_V;
+        subsampling = SkYUVAInfo::Subsampling::k420;
+        break;
+    case DRM_FORMAT_YVU420:
+        planeConfig = SkYUVAInfo::PlaneConfig::kY_V_U;
+        subsampling = SkYUVAInfo::Subsampling::k420;
+        break;
+    case DRM_FORMAT_YUV444:
+        planeConfig = SkYUVAInfo::PlaneConfig::kY_U_V;
+        subsampling = SkYUVAInfo::Subsampling::k444;
+        break;
+    case DRM_FORMAT_YUV411:
+        planeConfig = SkYUVAInfo::PlaneConfig::kY_U_V;
+        subsampling = SkYUVAInfo::Subsampling::k411;
+        break;
+    case DRM_FORMAT_YUV422:
+        planeConfig = SkYUVAInfo::PlaneConfig::kY_U_V;
+        subsampling = SkYUVAInfo::Subsampling::k422;
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    SkYUVColorSpace yuvaColorSpace = [&] {
+        switch (m_colorSpace.value_or(DMABufBuffer::ColorSpace::Bt601)) {
+        case DMABufBuffer::ColorSpace::Bt601:
+            return kRec601_Limited_SkYUVColorSpace;
+        case DMABufBuffer::ColorSpace::Bt709:
+            return kRec709_Full_SkYUVColorSpace;
+        case DMABufBuffer::ColorSpace::Bt2020:
+            return kBT2020_8bit_Full_SkYUVColorSpace;
+        case DMABufBuffer::ColorSpace::Smpte240M:
+            return kSMPTE240_Full_SkYUVColorSpace;
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    }();
+
+    return SkYUVAInfo(SkISize::Make(m_attributes.size.width(), m_attributes.size.height()), planeConfig, subsampling, yuvaColorSpace);
+}
+
+sk_sp<SkColorSpace> DMABufBuffer::skiaColorSpace() const
+{
+    switch (m_transferFunction.value_or(DMABufBuffer::TransferFunction::Bt709)) {
+    case DMABufBuffer::TransferFunction::Bt709:
+        return SkColorSpace::MakeRGB(SkNamedTransferFn::kRec709, SkNamedGamut::kSRGB);
+    case DMABufBuffer::TransferFunction::Pq:
+        return SkColorSpace::MakeRGB(SkNamedTransferFn::kPQ, SkNamedGamut::kRec2020);
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+sk_sp<SkImage> DMABufBuffer::createImage(SkColorType colorType, SkAlphaType alphaType, GrSurfaceOrigin origin)
+{
+    if (!importIfNeeded())
+        return nullptr;
+
+    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    ASSERT(grContext);
+
+    if (!formatIsYUV(m_attributes.fourcc.value)) {
+        ref();
+        return SkImages::BorrowTextureFrom(grContext, backendTexture(0), origin, colorType, alphaType, SkColorSpace::MakeSRGB(), +[](void* userData) {
+            static_cast<DMABufBuffer*>(userData)->deref();
+        }, this);
+    }
+
+    SkYUVAInfo info = yuvaInfo();
+    GrYUVABackendTextures yuvaBackendTextures(info, m_importedBackendTextures.span().data(), origin);
+    if (!yuvaBackendTextures.isValid()) {
+        LOG_ERROR("Failed to create Skia image for DMA-BUF YUV video buffer: invalid backend texture information");
+        return nullptr;
+    }
+
+    ref();
+    return SkImages::TextureFromYUVATextures(grContext, yuvaBackendTextures, skiaColorSpace(), +[](void* userData) {
+        static_cast<DMABufBuffer*>(userData)->deref();
+    }, this);
+}
+
+class PromiseDMABufImageContext final : public ThreadSafeRefCounted<PromiseDMABufImageContext> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PromiseDMABufImageContext);
+public:
+    static Ref<PromiseDMABufImageContext> create(Ref<DMABufBuffer>&& buffer, std::unique_ptr<GLFence>&& glFence, WTF::UnixFileDescriptor&& fenceFD)
+    {
+        return adoptRef(*new PromiseDMABufImageContext(WTF::move(buffer), WTF::move(glFence), WTF::move(fenceFD)));
+    }
+
+    ~PromiseDMABufImageContext() = default;
+
+    sk_sp<GrPromiseImageTexture> promiseImageTexture(size_t planeIndex)
+    {
+        auto& display = PlatformDisplay::sharedDisplay();
+        auto* glContext = display.skiaGLContext();
+        if (!glContext || !glContext->makeContextCurrent())
+            return nullptr;
+
+        if (auto glFence = WTF::move(m_fence))
+            glFence->serverWait();
+        else if (m_fenceFD) {
+            if (auto glFence = GLFence::importFD(display.glDisplay(), WTF::move(m_fenceFD)))
+                glFence->serverWait();
+        }
+
+        if (!m_dmabuf->importIfNeeded())
+            return nullptr;
+
+        return GrPromiseImageTexture::Make(m_dmabuf->backendTexture(planeIndex));
+    }
+
+private:
+    PromiseDMABufImageContext(Ref<DMABufBuffer>&& buffer, std::unique_ptr<GLFence>&& glFence, WTF::UnixFileDescriptor&& fenceFD)
+        : m_dmabuf(WTF::move(buffer))
+        , m_fence(WTF::move(glFence))
+        , m_fenceFD(WTF::move(fenceFD))
+    {
+    }
+
+    const Ref<DMABufBuffer> m_dmabuf;
+    std::unique_ptr<GLFence> m_fence;
+    WTF::UnixFileDescriptor m_fenceFD;
+};
+
+struct PromiseDMABufYUVPlaneContext {
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(PromiseDMABufYUVPlaneContext);
+
+    PromiseDMABufYUVPlaneContext(Ref<PromiseDMABufImageContext>&& dmabufContext, size_t planeIndex)
+        : context(WTF::move(dmabufContext))
+        , index(planeIndex)
+    {
+    }
+
+    Ref<PromiseDMABufImageContext> context;
+    size_t index { 0 };
+};
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(PromiseDMABufYUVPlaneContext);
+
+sk_sp<SkImage> DMABufBuffer::createPromiseImage(const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext, SkColorType colorType, SkAlphaType alphaType, GrSurfaceOrigin origin, std::unique_ptr<GLFence>&& glFence, WTF::UnixFileDescriptor&& fenceFD)
+{
+    ASSERT(threadSafeGrContext);
+
+    if (!formatIsYUV(m_attributes.fourcc.value)) {
+        Ref context = PromiseDMABufImageContext::create(Ref { *this }, WTF::move(glFence), WTF::move(fenceFD));
+
+        auto backendFormat = threadSafeGrContext->defaultBackendFormat(colorType, GrRenderable::kYes);
+        ASSERT(backendFormat.isValid());
+
+        return SkImages::PromiseTextureFrom(threadSafeGrContext, backendFormat, SkISize::Make(m_attributes.size.width(), m_attributes.size.height()), skgpu::Mipmapped::kNo,
+            origin, colorType, alphaType, SkColorSpace::MakeSRGB(),
+            +[](void* userData) -> sk_sp<GrPromiseImageTexture> {
+                auto& context = *static_cast<PromiseDMABufImageContext*>(userData);
+                return context.promiseImageTexture(0);
+            },
+            +[](void* userData) {
+                Ref context = adoptRef(*static_cast<PromiseDMABufImageContext*>(userData));
+            }, &context.leakRef());
+    }
+
+    const auto& iter = yuvFormatPlaneInfo().find(m_attributes.fourcc.value);
+    if (iter == yuvFormatPlaneInfo().end()) {
+        LOG_ERROR("Failed to create Skia image for DMA-BUF YUV buffer: unknown plane configuration");
+        return nullptr;
+    }
+
+    Ref context = PromiseDMABufImageContext::create(Ref { *this }, WTF::move(glFence), WTF::move(fenceFD));
+    const auto& planeInfo = iter->value;
+    std::array<GrBackendFormat, 4> backendFormats;
+    for (unsigned i = 0; i < planeInfo.size(); ++i)
+        backendFormats[i] = GrBackendFormats::MakeGL(planeInfo[i].glFormat, GL_TEXTURE_2D);
+
+
+    SkYUVAInfo info = yuvaInfo();
+    GrYUVABackendTextureInfo yuvaBackendTexturesInfo(info, backendFormats.data(), skgpu::Mipmapped::kNo, origin);
+    if (!yuvaBackendTexturesInfo.isValid()) {
+        LOG_ERROR("Failed to create Skia image for DMA-BUF YUV video buffer: invalid backend texture information");
+        return nullptr;
+    }
+
+    std::array<PromiseDMABufYUVPlaneContext*, 4> planeContexts;
+    for (unsigned i = 0; i < planeInfo.size(); ++i)
+        planeContexts[i] = makeUnique<PromiseDMABufYUVPlaneContext>(context.copyRef(), i).release();
+
+    return SkImages::PromiseTextureFromYUVA(threadSafeGrContext, yuvaBackendTexturesInfo, skiaColorSpace(),
+        +[](void* userData) -> sk_sp<GrPromiseImageTexture> {
+            auto& planeContext = *static_cast<PromiseDMABufYUVPlaneContext*>(userData);
+            return planeContext.context->promiseImageTexture(planeContext.index);
+        },
+        +[](void* userData) {
+            std::unique_ptr<PromiseDMABufYUVPlaneContext> planeContext(static_cast<PromiseDMABufYUVPlaneContext*>(userData));
+        }, reinterpret_cast<void**>(planeContexts.data()));
+}
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/DMABufBuffer.h
+++ b/Source/WebCore/platform/graphics/DMABufBuffer.h
@@ -27,15 +27,24 @@
 
 #if USE(COORDINATED_GRAPHICS)
 #include "DMABufBufferAttributes.h"
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorSpace.h>
+#include <skia/core/SkImage.h>
+#include <skia/core/SkYUVAInfo.h>
+#include <skia/gpu/ganesh/GrBackendSurface.h>
+#include <skia/gpu/ganesh/GrContextThreadSafeProxy.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/unix/UnixFileDescriptor.h>
 
 typedef int32_t EGLint;
 typedef void* EGLImage;
 
 namespace WebCore {
-
+class BitmapTexture;
 class CoordinatedPlatformLayerBuffer;
 class GLDisplay;
+class GLFence;
 
 class DMABufBuffer final : public ThreadSafeRefCounted<DMABufBuffer> {
 public:
@@ -67,8 +76,18 @@ public:
     static EGLImage createEGLImage(GLDisplay&, const Attributes&);
     static std::optional<Vector<EGLint>> buildEGLImageAttributes(const Attributes&, Attributes::EnableModifiers = Attributes::EnableModifiers::Yes);
 
+#if USE(TEXTURE_MAPPER)
     CoordinatedPlatformLayerBuffer* buffer() const LIFETIME_BOUND { return m_buffer.get(); }
     void setBuffer(std::unique_ptr<CoordinatedPlatformLayerBuffer>&&);
+#else
+    bool importIfNeeded();
+    sk_sp<SkColorSpace> skiaColorSpace() const;
+    SkYUVAInfo yuvaInfo() const;
+    const GrBackendTexture& backendTexture(size_t) const;
+
+    sk_sp<SkImage> createImage(SkColorType, SkAlphaType, GrSurfaceOrigin);
+    sk_sp<SkImage> createPromiseImage(const sk_sp<GrContextThreadSafeProxy>&, SkColorType, SkAlphaType, GrSurfaceOrigin, std::unique_ptr<GLFence>&&, WTF::UnixFileDescriptor&&);
+#endif
 
 private:
     explicit DMABufBuffer(Attributes&&);
@@ -78,7 +97,12 @@ private:
     Attributes m_attributes;
     std::optional<ColorSpace> m_colorSpace;
     std::optional<TransferFunction> m_transferFunction;
+#if USE(TEXTURE_MAPPER)
     std::unique_ptr<CoordinatedPlatformLayerBuffer> m_buffer;
+#else
+    Vector<GrBackendTexture, 4> m_importedBackendTextures;
+    Vector<RefPtr<BitmapTexture>, 4> m_importedTextures;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
@@ -44,18 +44,6 @@
 #include "TextureMapper.h"
 #endif
 
-#if USE(SKIA)
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-#include <skia/core/SkColorSpace.h>
-#include <skia/core/SkYUVAInfo.h>
-#include <skia/gpu/ganesh/GrYUVABackendTextures.h>
-#include <skia/gpu/ganesh/SkImageGanesh.h>
-#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
-#include <skia/private/chromium/GrPromiseImageTexture.h>
-#include <skia/private/chromium/SkImageChromium.h>
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
-#endif
-
 namespace WebCore {
 
 #if USE(TEXTURE_MAPPER)
@@ -112,6 +100,7 @@ CoordinatedPlatformLayerBufferDMABuf::CoordinatedPlatformLayerBufferDMABuf(Ref<D
 
 CoordinatedPlatformLayerBufferDMABuf::~CoordinatedPlatformLayerBufferDMABuf() = default;
 
+#if USE(TEXTURE_MAPPER)
 static RefPtr<BitmapTexture> importToTexture(const IntSize& textureSize, const DMABufBuffer::Attributes& dmaBufAttributes, OptionSet<BitmapTexture::Flags> textureFlags)
 {
     auto& display = PlatformDisplay::sharedDisplay();
@@ -306,7 +295,6 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferDM
     return texture ? CoordinatedPlatformLayerBufferRGB::create(texture.releaseNonNull(), m_flags, nullptr) : nullptr;
 }
 
-#if USE(TEXTURE_MAPPER)
 void CoordinatedPlatformLayerBufferDMABuf::paintToTextureMapper(TextureMapper& textureMapper, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity)
 {
     waitForContentsIfNeeded();
@@ -325,250 +313,14 @@ void CoordinatedPlatformLayerBufferDMABuf::paintToTextureMapper(TextureMapper& t
 
 #else
 
-class PromiseDMABufImageContext final : public ThreadSafeRefCounted<PromiseDMABufImageContext> {
-    WTF_MAKE_TZONE_ALLOCATED_INLINE(PromiseDMABufImageContext);
-public:
-    static Ref<PromiseDMABufImageContext> create(Ref<DMABufBuffer>&& buffer, OptionSet<TextureMapperFlags> flags, std::unique_ptr<GLFence>&& glFence, WTF::UnixFileDescriptor&& fd)
-    {
-        return adoptRef(*new PromiseDMABufImageContext(WTF::move(buffer), flags, WTF::move(glFence), WTF::move(fd)));
-    }
-
-    ~PromiseDMABufImageContext() = default;
-
-    sk_sp<GrPromiseImageTexture> promiseImageTexture()
-    {
-        if (!makeContextCurrentAndWaitForContentsIfNeeded())
-            return nullptr;
-
-        const auto& attributes = m_dmabuf->attributes();
-        if (!m_dmabuf->buffer()) {
-            std::unique_ptr<CoordinatedPlatformLayerBuffer> buffer;
-            OptionSet<BitmapTexture::Flags> textureFlags;
-            if (m_flags.contains(TextureMapperFlags::ShouldBlend))
-                textureFlags.add(BitmapTexture::Flags::SupportsAlpha);
-            if (auto texture = importToTexture(attributes.size, attributes, textureFlags))
-                buffer = CoordinatedPlatformLayerBufferRGB::create(texture.releaseNonNull(), { }, nullptr);
-            m_dmabuf->setBuffer(WTF::move(buffer));
-        }
-
-        auto* buffer = m_dmabuf->buffer();
-        if (!is<CoordinatedPlatformLayerBufferRGB>(buffer))
-            return nullptr;
-
-        return createPromiseImageTexture(downcast<CoordinatedPlatformLayerBufferRGB>(*buffer).textureID(), GL_RGBA8, attributes.size);
-    }
-
-    sk_sp<GrPromiseImageTexture> promiseImageTextureForPlane(size_t planeIndex, unsigned planeFormat, const IntSize& planeSize)
-    {
-        if (!makeContextCurrentAndWaitForContentsIfNeeded())
-            return nullptr;
-
-        if (!m_dmabuf->buffer())
-            m_dmabuf->setBuffer(importYUV(m_dmabuf, m_flags));
-
-        auto* buffer = m_dmabuf->buffer();
-        if (!is<CoordinatedPlatformLayerBufferYUV>(buffer))
-            return nullptr;
-
-        auto texture = downcast<CoordinatedPlatformLayerBufferYUV>(*buffer).texture(planeIndex);
-        if (!texture)
-            return nullptr;
-
-        return createPromiseImageTexture(texture->id(), planeFormat, planeSize);
-    }
-
-private:
-    PromiseDMABufImageContext(Ref<DMABufBuffer>&& buffer, OptionSet<TextureMapperFlags> flags, std::unique_ptr<GLFence>&& glFence, WTF::UnixFileDescriptor&& fd)
-        : m_dmabuf(WTF::move(buffer))
-        , m_flags(flags)
-        , m_fence(WTF::move(glFence))
-        , m_fenceFD(WTF::move(fd))
-    {
-    }
-
-    bool makeContextCurrentAndWaitForContentsIfNeeded()
-    {
-        auto& display = PlatformDisplay::sharedDisplay();
-        auto* glContext = display.skiaGLContext();
-        if (!glContext || !glContext->makeContextCurrent())
-            return false;
-
-        if (auto glFence = WTF::move(m_fence))
-            glFence->serverWait();
-        else if (m_fenceFD) {
-            if (auto glFence = GLFence::importFD(display.glDisplay(), WTF::move(m_fenceFD)))
-                glFence->serverWait();
-        }
-
-        return true;
-    }
-
-    sk_sp<GrPromiseImageTexture> createPromiseImageTexture(unsigned id, unsigned format, const IntSize& size)
-    {
-        GrGLTextureInfo externalTexture;
-        externalTexture.fTarget = GL_TEXTURE_2D;
-        externalTexture.fID = id;
-        externalTexture.fFormat = format;
-        auto backendTexture = GrBackendTextures::MakeGL(size.width(), size.height(), skgpu::Mipmapped::kNo, externalTexture);
-        return GrPromiseImageTexture::Make(backendTexture);
-    }
-
-    const Ref<DMABufBuffer> m_dmabuf;
-    OptionSet<TextureMapperFlags> m_flags;
-    std::unique_ptr<GLFence> m_fence;
-    WTF::UnixFileDescriptor m_fenceFD;
-};
-
-struct PromiseDMABufYUVPlaneContext {
-    WTF_MAKE_STRUCT_TZONE_ALLOCATED(PromiseDMABufYUVPlaneContext);
-
-    PromiseDMABufYUVPlaneContext(Ref<PromiseDMABufImageContext>&& dmabufContext, size_t planeIndex, unsigned glFormat, int width, int height)
-        : context(WTF::move(dmabufContext))
-        , index(planeIndex)
-        , format(glFormat)
-        , size(width, height)
-    {
-    }
-
-    Ref<PromiseDMABufImageContext> context;
-    size_t index { 0 };
-    unsigned format { 0 };
-    IntSize size;
-};
-
-WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(PromiseDMABufYUVPlaneContext);
-
 void CoordinatedPlatformLayerBufferDMABuf::createSkiaImageIfNeeded(const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
 {
     if (!threadSafeGrContext)
         return;
 
-    auto backendFormat = threadSafeGrContext->defaultBackendFormat(kRGBA_8888_SkColorType, GrRenderable::kYes);
-    ASSERT(backendFormat.isValid());
-
-    Ref context = PromiseDMABufImageContext::create(m_dmabuf.copyRef(), m_flags, WTF::move(m_fence), WTF::move(m_fenceFD));
-
-    const auto& attributes = m_dmabuf->attributes();
-    if (formatIsYUV(attributes.fourcc.value)) {
-        auto planeConfig = SkYUVAInfo::PlaneConfig::kUnknown;
-        auto subsampling = SkYUVAInfo::Subsampling::kUnknown;
-        std::array<GrBackendFormat, 4> backendFormats;
-        std::array<PromiseDMABufYUVPlaneContext*, 4> planeContexts;
-
-        auto setPlaneFormatAndContext = [&](size_t index, unsigned glFormat, int width, int height) {
-            backendFormats[index] = GrBackendFormats::MakeGL(glFormat, GL_TEXTURE_2D);
-            planeContexts[index] = makeUnique<PromiseDMABufYUVPlaneContext>(context.copyRef(), index, glFormat, width, height).release();
-        };
-
-        auto format = yuvFormatFromDRMFourcc(attributes.fourcc.value);
-        switch (format) {
-        case CoordinatedPlatformLayerBufferYUV::Format::AYUV:
-            planeConfig = SkYUVAInfo::PlaneConfig::kYUVA;
-            subsampling = SkYUVAInfo::Subsampling::k444;
-            setPlaneFormatAndContext(0, GL_RGBA8, attributes.size.width(), attributes.size.height());
-            break;
-        case CoordinatedPlatformLayerBufferYUV::Format::NV12:
-        case CoordinatedPlatformLayerBufferYUV::Format::NV21:
-        case CoordinatedPlatformLayerBufferYUV::Format::P010: {
-            planeConfig = format == CoordinatedPlatformLayerBufferYUV::Format::NV21 ? SkYUVAInfo::PlaneConfig::kY_VU : SkYUVAInfo::PlaneConfig::kY_UV;
-            subsampling = SkYUVAInfo::Subsampling::k420;
-            setPlaneFormatAndContext(0, format == CoordinatedPlatformLayerBufferYUV::Format::P010 ? GL_R16 : GL_R8, attributes.size.width(), attributes.size.height());
-            setPlaneFormatAndContext(1, format == CoordinatedPlatformLayerBufferYUV::Format::P010 ? GL_RG16 : GL_RG8, attributes.size.width() / 2, attributes.size.height() / 2);
-            break;
-        }
-        case CoordinatedPlatformLayerBufferYUV::Format::YUV420:
-        case CoordinatedPlatformLayerBufferYUV::Format::YVU420:
-            planeConfig = format == CoordinatedPlatformLayerBufferYUV::Format::YVU420 ? SkYUVAInfo::PlaneConfig::kY_V_U : SkYUVAInfo::PlaneConfig::kY_U_V;
-            subsampling = SkYUVAInfo::Subsampling::k420;
-            setPlaneFormatAndContext(0, GL_R8, attributes.size.width(), attributes.size.height());
-            setPlaneFormatAndContext(1, GL_R8, attributes.size.width() / 2, attributes.size.height() / 2);
-            setPlaneFormatAndContext(2, GL_R8, attributes.size.width() / 2, attributes.size.height() / 2);
-            break;
-        case CoordinatedPlatformLayerBufferYUV::Format::YUV444:
-            planeConfig = SkYUVAInfo::PlaneConfig::kY_U_V;
-            subsampling = SkYUVAInfo::Subsampling::k444;
-            setPlaneFormatAndContext(0, GL_R8, attributes.size.width(), attributes.size.height());
-            setPlaneFormatAndContext(1, GL_R8, attributes.size.width(), attributes.size.height());
-            setPlaneFormatAndContext(2, GL_R8, attributes.size.width(), attributes.size.height());
-            break;
-        case CoordinatedPlatformLayerBufferYUV::Format::YUV411:
-            planeConfig = SkYUVAInfo::PlaneConfig::kY_U_V;
-            subsampling = SkYUVAInfo::Subsampling::k411;
-            setPlaneFormatAndContext(0, GL_R8, attributes.size.width(), attributes.size.height());
-            setPlaneFormatAndContext(1, GL_R8, attributes.size.width() / 4, attributes.size.height());
-            setPlaneFormatAndContext(2, GL_R8, attributes.size.width() / 4, attributes.size.height());
-            break;
-        case CoordinatedPlatformLayerBufferYUV::Format::YUV422:
-            planeConfig = SkYUVAInfo::PlaneConfig::kY_U_V;
-            subsampling = SkYUVAInfo::Subsampling::k422;
-            setPlaneFormatAndContext(0, GL_R8, attributes.size.width(), attributes.size.height());
-            setPlaneFormatAndContext(1, GL_R8, attributes.size.width() / 2, attributes.size.height());
-            setPlaneFormatAndContext(2, GL_R8, attributes.size.width() / 2, attributes.size.height());
-            break;
-        case CoordinatedPlatformLayerBufferYUV::Format::A420:
-            // Not supported in DMA-BUF.
-            RELEASE_ASSERT_NOT_REACHED();
-            break;
-        }
-
-        if (planeConfig == SkYUVAInfo::PlaneConfig::kUnknown) {
-            LOG_ERROR("Failed to create Skia image for DMA-BUF YUV video buffer: unknown plane configuration");
-            return;
-        }
-
-        SkYUVColorSpace yuvaColorSpace = [&] {
-            switch (m_dmabuf->colorSpace().value_or(DMABufBuffer::ColorSpace::Bt601)) {
-            case DMABufBuffer::ColorSpace::Bt601:
-                return kRec601_Limited_SkYUVColorSpace;
-            case DMABufBuffer::ColorSpace::Bt709:
-                return kRec709_Full_SkYUVColorSpace;
-            case DMABufBuffer::ColorSpace::Bt2020:
-                return kBT2020_8bit_Full_SkYUVColorSpace;
-            case DMABufBuffer::ColorSpace::Smpte240M:
-                return kSMPTE240_Full_SkYUVColorSpace;
-            }
-            RELEASE_ASSERT_NOT_REACHED();
-        }();
-
-        SkYUVAInfo info(SkISize::Make(m_size.width(), m_size.height()), planeConfig, subsampling, yuvaColorSpace);
-        auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
-        GrYUVABackendTextureInfo yuvaBackendTexturesInfo(info, backendFormats.data(), skgpu::Mipmapped::kNo, origin);
-        if (!yuvaBackendTexturesInfo.isValid()) {
-            LOG_ERROR("Failed to create Skia image for DMA-BUF YUV video buffer: invalid backend texture information");
-            return;
-        }
-
-        sk_sp<SkColorSpace> colorSpace = [&] {
-            switch (m_dmabuf->transferFunction().value_or(DMABufBuffer::TransferFunction::Bt709)) {
-            case DMABufBuffer::TransferFunction::Bt709:
-                return SkColorSpace::MakeRGB(SkNamedTransferFn::kRec709, SkNamedGamut::kSRGB);
-            case DMABufBuffer::TransferFunction::Pq:
-                return SkColorSpace::MakeRGB(SkNamedTransferFn::kPQ, SkNamedGamut::kRec2020);
-            }
-            RELEASE_ASSERT_NOT_REACHED();
-        }();
-
-        m_image = SkImages::PromiseTextureFromYUVA(threadSafeGrContext, yuvaBackendTexturesInfo, colorSpace,
-            +[](void* userData) -> sk_sp<GrPromiseImageTexture> {
-                auto& planeContext = *static_cast<PromiseDMABufYUVPlaneContext*>(userData);
-                return planeContext.context->promiseImageTextureForPlane(planeContext.index, planeContext.format, planeContext.size);
-            },
-            +[](void* userData) {
-                std::unique_ptr<PromiseDMABufYUVPlaneContext> planeContext(static_cast<PromiseDMABufYUVPlaneContext*>(userData));
-            }, reinterpret_cast<void**>(planeContexts.data()));
-    } else {
-        auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
-        auto alphaType = m_flags.contains(TextureMapperFlags::ShouldBlend) ? kPremul_SkAlphaType : kOpaque_SkAlphaType;
-        m_image = SkImages::PromiseTextureFrom(threadSafeGrContext, backendFormat, SkISize::Make(attributes.size.width(), attributes.size.height()), skgpu::Mipmapped::kNo,
-            origin, kRGBA_8888_SkColorType, alphaType, SkColorSpace::MakeSRGB(),
-            +[](void* userData) -> sk_sp<GrPromiseImageTexture> {
-                auto& context = *static_cast<PromiseDMABufImageContext*>(userData);
-                return context.promiseImageTexture();
-            },
-            +[](void* userData) {
-                Ref context = adoptRef(*static_cast<PromiseDMABufImageContext*>(userData));
-            }, &context.leakRef());
-    }
+    auto alphaType = m_flags.contains(TextureMapperFlags::ShouldBlend) ? kPremul_SkAlphaType : kOpaque_SkAlphaType;
+    auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
+    m_image = m_dmabuf->createPromiseImage(threadSafeGrContext, kRGBA_8888_SkColorType, alphaType, origin, WTF::move(m_fence), WTF::move(m_fenceFD));
 }
 
 sk_sp<SkImage> CoordinatedPlatformLayerBufferDMABuf::skiaImage()
@@ -583,13 +335,9 @@ sk_sp<SkImage> CoordinatedPlatformLayerBufferDMABuf::skiaImage()
             fence->serverWait();
     }
 
-    if (!m_dmabuf->buffer())
-        m_dmabuf->setBuffer(importDMABuf());
-
-    if (auto* buffer = m_dmabuf->buffer())
-        return buffer->skiaImage();
-
-    return nullptr;
+    auto alphaType = m_flags.contains(TextureMapperFlags::ShouldBlend) ? kPremul_SkAlphaType : kOpaque_SkAlphaType;
+    auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
+    return m_dmabuf->createImage(kRGBA_8888_SkColorType, alphaType, origin);
 }
 #endif
 


### PR DESCRIPTION
#### d95f64460bc6e7a7950185889acff5e389bd2f66
<pre>
[GTK][WPE] Skia compositor: move the code to create DMABuf promise images from CoordinatedPlatformLayerBufferDMABuf to DMABufBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=323746">https://bugs.webkit.org/show_bug.cgi?id=323746</a>

Reviewed by Nikolas Zimmermann.

Not only it really belongs to DMABufBuffer but it will allow to use it
from CoordinatedPlatformLayerBufferVideo without having to use an inner
CoordinatedPlatformLayerBufferDMABuf buffer.

* Source/WebCore/platform/graphics/DMABufBuffer.cpp:
(WebCore::formatIsYUV):
(WebCore::DMABufBuffer::importIfNeeded):
(WebCore::DMABufBuffer::backendTexture const):
(WebCore::DMABufBuffer::setBuffer):
(WebCore::yuvFormatPlaneInfo):
(WebCore::DMABufBuffer::yuvaInfo const):
(WebCore::DMABufBuffer::skiaColorSpace const):
(WebCore::DMABufBuffer::createImage):
(WebCore::PromiseDMABufYUVPlaneContext::PromiseDMABufYUVPlaneContext):
(WebCore::DMABufBuffer::createPromiseImage):
* Source/WebCore/platform/graphics/DMABufBuffer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp:
(WebCore::CoordinatedPlatformLayerBufferDMABuf::createSkiaImageIfNeeded):
(WebCore::CoordinatedPlatformLayerBufferDMABuf::skiaImage):
(): Deleted.
(WebCore::PromiseDMABufYUVPlaneContext::PromiseDMABufYUVPlaneContext): Deleted.

Canonical link: <a href="https://commits.webkit.org/320727@main">https://commits.webkit.org/320727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12f39fde4a0c4b83e593c1c84bc6d7c55c3fed3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196077 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145172 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48851 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125469 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47577 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157937 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45308 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7140 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52305 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198043 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59337 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154715 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60050 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154366 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28192 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48822 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129368 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58512 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20331 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57890 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58126 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57953 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->