### PR TITLE
[JSC][Wasm] Use store/load pairs when BBQ flushes adjacent 8-byte slots

### DIFF
--- a/JSTests/wasm/stress/bbq-flush-store-pairs.js
+++ b/JSTests/wasm/stress/bbq-flush-store-pairs.js
@@ -1,0 +1,40 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+  (func $id (import "m" "id") (param i64) (result i64))
+  (func $idf (import "m" "idf") (param f64) (result f64))
+  (tag $e)
+  (func (export "sumI64") (param i64 i64 i64 i64 i64 i64) (result i64)
+    (drop (call $id (i64.const 0)))
+    (i64.add (local.get 0) (local.get 1))
+    (i64.add (local.get 2))
+    (i64.add (local.get 3))
+    (i64.add (local.get 4))
+    (i64.add (local.get 5)))
+  (func (export "sumF64") (param f64 f64 f64 f64) (result f64)
+    (drop (call $idf (f64.const 0)))
+    (f64.add (local.get 0) (local.get 1))
+    (f64.add (local.get 2))
+    (f64.add (local.get 3)))
+  (func (export "sumAfterCatch") (param i64 i64 i64 i64) (result i64)
+    (try
+      (do (throw $e))
+      (catch $e))
+    (i64.add (local.get 0) (local.get 1))
+    (i64.add (local.get 2))
+    (i64.add (local.get 3)))
+)
+`
+
+async function test() {
+    const { sumI64, sumF64, sumAfterCatch } = (await instantiate(wat, { m: { id: x => x, idf: x => x } }, { exceptions: true })).exports
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        assert.eq(sumI64(1n, 2n, 3n, 4n, 5n, 6n), 21n)
+        assert.eq(sumF64(1, 2, 3, 4), 10)
+        assert.eq(sumAfterCatch(1n, 2n, 3n, 4n), 10n)
+    }
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -62,6 +62,7 @@
 #include "WasmOps.h"
 #include "WasmThunks.h"
 #include "WasmTypeDefinition.h"
+#include <algorithm>
 #include <bit>
 #include <cmath>
 #include <wtf/Assertions.h>
@@ -4300,23 +4301,143 @@ void BBQJIT::loadWebAssemblyGlobalState(GPRReg wasmBaseMemoryPointer, GPRReg was
     m_jit.cageConditionally(Gigacage::Primitive, wasmBaseMemoryPointer, wasmBoundsCheckingSizeRegister, wasmScratchGPR);
 }
 
+static bool isPairable64(TypeKind type)
+{
+    return BBQJIT::sizeOfType(type) == 8;
+}
+
+static bool canPairSpills(const BBQJIT::RegisterSpill& a, const BBQJIT::RegisterSpill& b)
+{
+    if (a.reg.isGPR() != b.reg.isGPR())
+        return false;
+    if (!isPairable64(a.value.type()) || !isPairable64(b.value.type()))
+        return false;
+    return b.slot.asStackOffset() == a.slot.asStackOffset() + 8;
+}
+
+static void sortSpills(Vector<BBQJIT::RegisterSpill, 16>& entries)
+{
+    std::sort(entries.begin(), entries.end(), [](const BBQJIT::RegisterSpill& a, const BBQJIT::RegisterSpill& b) {
+        return a.slot.asStackOffset() < b.slot.asStackOffset();
+    });
+}
+
+void BBQJIT::collectRegisterSpills(Vector<RegisterSpill, 16>& gprs, Vector<RegisterSpill, 16>& fprs)
+{
+    for (Reg r : m_gprAllocator.allocatedRegisters()) {
+        Value value = m_gprAllocator.bindingFor(r.gpr()).toValue();
+        if (value.isNone())
+            continue;
+        gprs.append({ value, Location::fromGPR(r.gpr()), canonicalSlot(value) });
+    }
+    for (Reg r : m_fprAllocator.allocatedRegisters()) {
+        Value value = m_fprAllocator.bindingFor(r.fpr()).toValue();
+        if (value.isNone())
+            continue;
+        fprs.append({ value, Location::fromFPR(r.fpr()), canonicalSlot(value) });
+    }
+}
+
+void BBQJIT::collectRegisterSpills(const RegisterBindings& bindings, Vector<RegisterSpill, 16>& gprs, Vector<RegisterSpill, 16>& fprs)
+{
+    for (unsigned i = 0; i < bindings.m_gprBindings.size(); ++i) {
+        Value value = bindings.m_gprBindings[i].toValue();
+        if (value.isNone())
+            continue;
+        gprs.append({ value, Location::fromGPR(static_cast<GPRReg>(i)), canonicalSlot(value) });
+    }
+    for (unsigned i = 0; i < bindings.m_fprBindings.size(); ++i) {
+        Value value = bindings.m_fprBindings[i].toValue();
+        if (value.isNone())
+            continue;
+        fprs.append({ value, Location::fromFPR(static_cast<FPRReg>(i)), canonicalSlot(value) });
+    }
+}
+
+void BBQJIT::emitStorePairs(Vector<RegisterSpill, 16>& entries)
+{
+    sortSpills(entries);
+    for (size_t i = 0; i < entries.size();) {
+        if (i + 1 < entries.size() && canPairSpills(entries[i], entries[i + 1])) {
+            auto& lo = entries[i];
+            auto& hi = entries[i + 1];
+            if (lo.reg.isGPR())
+                m_jit.storePair64(lo.reg.asGPR(), hi.reg.asGPR(), lo.slot.asAddress());
+            else {
+#if CPU(ARM64)
+                m_jit.storePair64(lo.reg.asFPR(), hi.reg.asFPR(), lo.slot.asAddress().base, TrustedImm32(lo.slot.asAddress().offset));
+#else
+                emitStore(lo.value.type(), lo.reg, lo.slot);
+                emitStore(hi.value.type(), hi.reg, hi.slot);
+#endif
+            }
+            i += 2;
+            continue;
+        }
+        emitStore(entries[i].value.type(), entries[i].reg, entries[i].slot);
+        ++i;
+    }
+}
+
+void BBQJIT::emitLoadPairs(Vector<RegisterSpill, 16>& entries)
+{
+    sortSpills(entries);
+    for (size_t i = 0; i < entries.size();) {
+        if (i + 1 < entries.size() && canPairSpills(entries[i], entries[i + 1])) {
+            auto& lo = entries[i];
+            auto& hi = entries[i + 1];
+            if (lo.reg.isGPR())
+                m_jit.loadPair64(lo.slot.asAddress(), lo.reg.asGPR(), hi.reg.asGPR());
+            else {
+#if CPU(ARM64)
+                m_jit.loadPairDouble(lo.slot.asAddress(), lo.reg.asFPR(), hi.reg.asFPR());
+#else
+                emitLoad(lo.value.type(), lo.slot, lo.reg);
+                emitLoad(hi.value.type(), hi.slot, hi.reg);
+#endif
+            }
+            i += 2;
+            continue;
+        }
+        emitLoad(entries[i].value.type(), entries[i].slot, entries[i].reg);
+        ++i;
+    }
+}
+
+void BBQJIT::bindSpillsToSlots(const Vector<RegisterSpill, 16>& entries)
+{
+    for (const auto& entry : entries) {
+        unbind(entry.value, entry.reg);
+        bind(entry.value, entry.slot);
+    }
+}
+
 void BBQJIT::flushRegistersForException()
 {
-    // Flush all locals.
-    m_gprAllocator.flushIf(*this, [&](GPRReg, const RegisterBinding& binding) {
-        return binding.toValue().isLocal();
+    Vector<RegisterSpill, 16> gprs;
+    Vector<RegisterSpill, 16> fprs;
+    collectRegisterSpills(gprs, fprs);
+    gprs.removeAllMatching([](RegisterSpill& entry) {
+        return !entry.value.isLocal();
     });
-    m_fprAllocator.flushIf(*this, [&](FPRReg, const RegisterBinding& binding) {
-        return binding.toValue().isLocal();
+    fprs.removeAllMatching([](RegisterSpill& entry) {
+        return !entry.value.isLocal();
     });
+    emitStorePairs(gprs);
+    emitStorePairs(fprs);
+    bindSpillsToSlots(gprs);
+    bindSpillsToSlots(fprs);
 }
 
 void BBQJIT::flushRegisters()
 {
-    // Just flush everything.
-    // FIXME: These should be store pairs.
-    m_gprAllocator.flushAllRegisters(*this);
-    m_fprAllocator.flushAllRegisters(*this);
+    Vector<RegisterSpill, 16> gprs;
+    Vector<RegisterSpill, 16> fprs;
+    collectRegisterSpills(gprs, fprs);
+    emitStorePairs(gprs);
+    emitStorePairs(fprs);
+    bindSpillsToSlots(gprs);
+    bindSpillsToSlots(fprs);
 }
 
 void BBQJIT::RegisterBindings::dump(PrintStream& out) const
@@ -4340,34 +4461,20 @@ void BBQJIT::RegisterBindings::dump(PrintStream& out) const
 
 void BBQJIT::slowPathSpillBindings(const RegisterBindings& bindings)
 {
-    for (unsigned i = 0; i < bindings.m_fprBindings.size(); ++i) {
-        Value value = bindings.m_fprBindings[i].toValue();
-        if (!value.isNone())
-            emitStore(value.type(), Location::fromFPR(static_cast<FPRReg>(i)), canonicalSlot(value));
-    }
-
-    // FIXME: These should be store load pairs.
-    for (unsigned i = 0; i < bindings.m_gprBindings.size(); ++i) {
-        Value value = bindings.m_gprBindings[i].toValue();
-        if (!value.isNone())
-            emitStore(value.type(), Location::fromGPR(static_cast<GPRReg>(i)), canonicalSlot(value));
-    }
+    Vector<RegisterSpill, 16> gprs;
+    Vector<RegisterSpill, 16> fprs;
+    collectRegisterSpills(bindings, gprs, fprs);
+    emitStorePairs(fprs);
+    emitStorePairs(gprs);
 }
 
 void BBQJIT::slowPathRestoreBindings(const RegisterBindings& bindings)
 {
-    for (unsigned i = 0; i < bindings.m_fprBindings.size(); ++i) {
-        Value value = bindings.m_fprBindings[i].toValue();
-        if (!value.isNone())
-            emitLoad(value.type(), canonicalSlot(value), Location::fromFPR(static_cast<FPRReg>(i)));
-    }
-
-    // FIXME: These should be store load pairs.
-    for (unsigned i = 0; i < bindings.m_gprBindings.size(); ++i) {
-        Value value = bindings.m_gprBindings[i].toValue();
-        if (!value.isNone())
-            emitLoad(value.type(), canonicalSlot(value), Location::fromGPR(static_cast<GPRReg>(i)));
-    }
+    Vector<RegisterSpill, 16> gprs;
+    Vector<RegisterSpill, 16> fprs;
+    collectRegisterSpills(bindings, gprs, fprs);
+    emitLoadPairs(fprs);
+    emitLoadPairs(gprs);
 }
 
 template<typename Args>

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -2046,6 +2046,17 @@ public:
 
     void flushRegisters();
 
+    struct RegisterSpill {
+        Value value;
+        Location reg;
+        Location slot;
+    };
+    void collectRegisterSpills(Vector<RegisterSpill, 16>& gprs, Vector<RegisterSpill, 16>& fprs);
+    void collectRegisterSpills(const RegisterBindings&, Vector<RegisterSpill, 16>& gprs, Vector<RegisterSpill, 16>& fprs);
+    void emitStorePairs(Vector<RegisterSpill, 16>&);
+    void emitLoadPairs(Vector<RegisterSpill, 16>&);
+    void bindSpillsToSlots(const Vector<RegisterSpill, 16>&);
+
     template<typename Args>
     void saveValuesAcrossCallAndPassArguments(const Args& arguments, const CallInformation&, const RTT& signature);
 


### PR DESCRIPTION
#### bc1312b66fbfb56a5f6ebb55a3f883e824e97e25
<pre>
[JSC][Wasm] Use store/load pairs when BBQ flushes adjacent 8-byte slots
<a href="https://bugs.webkit.org/show_bug.cgi?id=323747">https://bugs.webkit.org/show_bug.cgi?id=323747</a>

Reviewed by NOBODY (OOPS!).

BBQ flushRegisters and the call slow-path spill/restore stored or
loaded one register at a time. Packed i64, f64, and reference locals
sit 8 bytes apart and can use storePair64 / loadPair64.

Exception local flush uses the same pairing. The stress test keeps
those locals in registers across an import call and throw.

* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* JSTests/wasm/stress/bbq-flush-store-pairs.js: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc1312b66fbfb56a5f6ebb55a3f883e824e97e25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196153 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150521 "Built successfully") 
| [⏳ 🧪 bindings](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59476 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145229 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100687 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125534 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47643 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45666 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7416 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14301 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45369 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7224 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47098 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198127 "Built successfully") | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59413 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154786 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60121 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154430 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48885 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132467 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129462 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58583 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20394 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57962 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58196 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58026 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->