### PR TITLE
[cleanup] Move the legacy line boxes from RenderInline to RenderSVGInline, the only inline box that has them

### DIFF
--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -37,6 +37,7 @@
 #include "RenderObjectInlines.h"
 #include "RenderSVGBlock.h"
 #include "RenderSVGForeignObject.h"
+#include "RenderText.h"
 #include "Settings.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StyleComputedStyle+InitialInlines.h"

--- a/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.cpp
@@ -29,6 +29,7 @@
 #include "LayoutIntegrationLineLayout.h"
 #include "RenderBlockFlowInlines.h"
 #include "RenderInline.h"
+#include "RenderSVGInline.h"
 #include "StyleComputedStyle+GettersInlines.h"
 
 namespace WebCore {
@@ -125,7 +126,8 @@ InlineBoxIterator lineLeftmostInlineBoxFor(const RenderInline& renderInline)
 {
     if (CheckedPtr lineLayout = LayoutIntegration::LineLayout::containing(renderInline))
         return lineLayout->firstInlineBoxFor(renderInline);
-    return { BoxLegacyPath { renderInline.firstLegacyInlineBox() } };
+    auto* svgInline = dynamicDowncast<RenderSVGInline>(renderInline);
+    return { BoxLegacyPath { svgInline ? svgInline->firstLegacyInlineBox() : nullptr } };
 }
 
 InlineBoxIterator firstRootInlineBoxFor(const RenderBlockFlow& block)

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
@@ -35,6 +35,7 @@
 #include "RenderInline.h"
 #include "RenderLayer.h"
 #include "RenderObjectInlines.h"
+#include "RenderSVGInline.h"
 #include "RenderTableCell.h"
 #include "RenderTheme.h"
 #include "RenderView.h"
@@ -182,7 +183,7 @@ void LegacyInlineFlowBox::deleteLine()
 
 void LegacyInlineFlowBox::removeLineBoxFromRenderObject()
 {
-    downcast<RenderInline>(renderer()).legacyLineBoxes().removeLineBox(this);
+    downcast<RenderSVGInline>(renderer()).legacyLineBoxes().removeLineBox(this);
 }
 
 void LegacyInlineFlowBox::adjustPosition(float dx, float dy)

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -45,6 +45,7 @@
 #include "RenderLayoutState.h"
 #include "RenderLineBreak.h"
 #include "RenderObjectInlines.h"
+#include "RenderSVGInline.h"
 #include "RenderSVGText.h"
 #include "RenderView.h"
 #include "SVGElementTypeHelpers.h"
@@ -176,8 +177,8 @@ LegacyInlineBox* LegacyLineLayout::createInlineBoxForRenderer(RenderObject* rend
     if (auto* textRenderer = dynamicDowncast<RenderSVGInlineText>(*renderer))
         return textRenderer->createInlineTextBox();
 
-    if (auto* renderInline = dynamicDowncast<RenderInline>(*renderer))
-        return renderInline->createAndAppendInlineFlowBox();
+    if (auto* renderSVGInline = dynamicDowncast<RenderSVGInline>(*renderer))
+        return renderSVGInline->createAndAppendInlineFlowBox();
 
     ASSERT_NOT_REACHED();
     return nullptr;
@@ -187,8 +188,8 @@ static inline void dirtyLineBoxesForRenderer(RenderObject& renderer)
 {
     if (CheckedPtr renderText = dynamicDowncast<RenderSVGInlineText>(renderer))
         renderText->deleteLegacyLineBoxes();
-    else if (CheckedPtr renderInline = dynamicDowncast<RenderInline>(renderer))
-        renderInline->deleteLegacyLineBoxes();
+    else if (CheckedPtr renderSVGInline = dynamicDowncast<RenderSVGInline>(renderer))
+        renderSVGInline->deleteLegacyLineBoxes();
 }
 
 static bool NODELETE parentIsConstructedOrHaveNext(LegacyInlineFlowBox* parentBox)
@@ -209,7 +210,7 @@ LegacyInlineFlowBox* LegacyLineLayout::createLineBoxes(RenderObject* obj, const 
     LegacyInlineFlowBox* parentBox = nullptr;
     LegacyInlineFlowBox* result = nullptr;
     do {
-        RenderInline* inlineFlow = obj != &m_flow ? &downcast<RenderInline>(*obj) : nullptr;
+        RenderSVGInline* inlineFlow = obj != &m_flow ? &downcast<RenderSVGInline>(*obj) : nullptr;
 
         // Get the last box we made for this render object.
         parentBox = inlineFlow ? inlineFlow->lastLegacyInlineBox() : downcast<RenderBlockFlow>(*obj).legacyRootBox();

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -35,7 +35,9 @@
 #include "InlineIteratorInlineBox.h"
 #include "InlineIteratorLineBox.h"
 #include "LayoutIntegrationLineLayout.h"
+#include "LegacyInlineFlowBox.h"
 #include "LegacyInlineTextBox.h"
+#include "LegacyRootInlineBox.h"
 #include "OutlinePainter.h"
 #include "RenderBlock.h"
 #include "RenderBoxInlines.h"
@@ -50,6 +52,7 @@
 #include "RenderLineBreak.h"
 #include "RenderListOutsideMarker.h"
 #include "RenderObjectInlines.h"
+#include "RenderSVGInline.h"
 #include "RenderTable.h"
 #include "RenderTheme.h"
 #include "RenderTreeBuilder.h"
@@ -79,31 +82,19 @@ RenderInline::RenderInline(Type type, Document& document, Style::ComputedStyle&&
 
 RenderInline::~RenderInline() = default;
 
-void RenderInline::willBeDestroyed()
+// Only SVG inlines have legacy line boxes, and they always do: SVG text is always laid out by
+// LegacyLineLayout (Settings::useIFCForSVGText, the in-progress migration off it, is never enabled).
+// Every legacy arm below is therefore reachable from RenderSVGInline only.
+static LegacyInlineFlowBox* firstLegacyInlineBoxFor(const RenderInline& renderer)
 {
-    if (!renderTreeBeingDestroyed()) {
-        if (auto* inlineBox = firstLegacyInlineBox()) {
-            // We can't wait for RenderBoxModelObject::destroy to clear the selection,
-            // because by then we will have nuked the line boxes.
-            if (isSelectionBorder())
-                frame().selection().setNeedsSelectionUpdate();
+    auto* svgInline = dynamicDowncast<RenderSVGInline>(renderer);
+    return svgInline ? svgInline->firstLegacyInlineBox() : nullptr;
+}
 
-            // If line boxes are contained inside a root, that means we're an inline.
-            // In that case, we need to remove all the line boxes so that the parent
-            // lines aren't pointing to deleted children. If the first line box does
-            // not have a parent that means they are either already disconnected or
-            // root lines that can just be destroyed without disconnecting.
-            if (inlineBox->parent()) {
-                for (auto* box = inlineBox; box; box = box->nextLineBox())
-                    box->removeFromParent();
-            }
-        } else if (auto* parent = this->parent(); parent && parent->isSVGRenderer())
-            parent->dirtyLineFromChangedChild();
-    }
-
-    m_legacyLineBoxes.deleteLineBoxes();
-
-    RenderBoxModelObject::willBeDestroyed();
+static LegacyInlineFlowBox* lastLegacyInlineBoxFor(const RenderInline& renderer)
+{
+    auto* svgInline = dynamicDowncast<RenderSVGInline>(renderer);
+    return svgInline ? svgInline->lastLegacyInlineBox() : nullptr;
 }
 
 void RenderInline::updateFromStyle()
@@ -181,7 +172,7 @@ void RenderInline::generateLineBoxRects(GeneratorContext& context) const
             context.addRect(inlineRect);
         return;
     }
-    if (auto* curr = firstLegacyInlineBox()) {
+    if (auto* curr = firstLegacyInlineBoxFor(*this)) {
         for (; curr; curr = curr->nextLineBox())
             context.addRect(FloatRect(curr->topLeft(), curr->size()));
     } else
@@ -253,7 +244,7 @@ LayoutPoint RenderInline::firstInlineBoxTopLeft() const
 {
     if (auto* lineLayout = LayoutIntegration::LineLayout::containing(*this))
         return lineLayout->firstInlineBoxRect(*this).location();
-    if (auto* inlineBox = firstLegacyInlineBox())
+    if (auto* inlineBox = firstLegacyInlineBoxFor(*this))
         return flooredLayoutPoint(inlineBox->locationIncludingFlipping());
     return { };
 }
@@ -357,8 +348,8 @@ LayoutUnit RenderInline::innerPaddingBoxWidth() const
         return { };
     }
 
-    auto* firstInlineBox = firstLegacyInlineBox();
-    auto* lastInlineBox = lastLegacyInlineBox();
+    auto* firstInlineBox = firstLegacyInlineBoxFor(*this);
+    auto* lastInlineBox = lastLegacyInlineBoxFor(*this);
     if (!firstInlineBox || !lastInlineBox)
         return { };
 
@@ -401,28 +392,31 @@ IntRect RenderInline::linesBoundingBox() const
         return enclosingIntRect(layout->enclosingBorderBoxRectFor(*this));
     }
 
+    auto* firstInlineBox = firstLegacyInlineBoxFor(*this);
+    auto* lastInlineBox = lastLegacyInlineBoxFor(*this);
+
     // See <rdar://problem/5289721>, for an unknown reason the linked list here is sometimes inconsistent, first is non-zero and last is zero.  We have been
     // unable to reproduce this at all (and consequently unable to figure ot why this is happening).  The assert will hopefully catch the problem in debug
     // builds and help us someday figure out why.  We also put in a redundant check of lastLineBox() to avoid the crash for now.
-    ASSERT(!firstLegacyInlineBox() == !lastLegacyInlineBox());  // Either both are null or both exist.
+    ASSERT(!firstInlineBox == !lastInlineBox); // Either both are null or both exist.
     IntRect result;
-    if (firstLegacyInlineBox() && lastLegacyInlineBox()) {
+    if (firstInlineBox && lastInlineBox) {
         // Return the width of the minimal left side and the maximal right side.
         float logicalLeftSide = 0;
         float logicalRightSide = 0;
-        for (auto* curr = firstLegacyInlineBox(); curr; curr = curr->nextLineBox()) {
-            if (curr == firstLegacyInlineBox() || curr->logicalLeft() < logicalLeftSide)
+        for (auto* curr = firstInlineBox; curr; curr = curr->nextLineBox()) {
+            if (curr == firstInlineBox || curr->logicalLeft() < logicalLeftSide)
                 logicalLeftSide = curr->logicalLeft();
-            if (curr == firstLegacyInlineBox() || curr->logicalRight() > logicalRightSide)
+            if (curr == firstInlineBox || curr->logicalRight() > logicalRightSide)
                 logicalRightSide = curr->logicalRight();
         }
 
         bool isHorizontal = writingMode().isHorizontal();
 
-        float x = isHorizontal ? logicalLeftSide : firstLegacyInlineBox()->x();
-        float y = isHorizontal ? firstLegacyInlineBox()->y() : logicalLeftSide;
-        float width = isHorizontal ? logicalRightSide - logicalLeftSide : lastLegacyInlineBox()->logicalBottom() - x;
-        float height = isHorizontal ? lastLegacyInlineBox()->logicalBottom() - y : logicalRightSide - logicalLeftSide;
+        float x = isHorizontal ? logicalLeftSide : firstInlineBox->x();
+        float y = isHorizontal ? firstInlineBox->y() : logicalLeftSide;
+        float width = isHorizontal ? logicalRightSide - logicalLeftSide : lastInlineBox->logicalBottom() - x;
+        float height = isHorizontal ? lastInlineBox->logicalBottom() - y : logicalRightSide - logicalLeftSide;
         result = enclosingIntRect(FloatRect(x, y, width, height));
     }
 
@@ -440,23 +434,25 @@ LayoutRect RenderInline::linesVisualOverflowBoundingBox() const
         return layout->inkOverflowBoundingBoxRectFor(*this);
     }
 
-    if (!firstLegacyInlineBox() || !lastLegacyInlineBox())
+    auto* firstInlineBox = firstLegacyInlineBoxFor(*this);
+    auto* lastInlineBox = lastLegacyInlineBoxFor(*this);
+    if (!firstInlineBox || !lastInlineBox)
         return { };
 
     // Return the width of the minimal left side and the maximal right side.
     LayoutUnit logicalLeftSide = LayoutUnit::max();
     LayoutUnit logicalRightSide = LayoutUnit::min();
-    for (auto* curr = firstLegacyInlineBox(); curr; curr = curr->nextLineBox()) {
+    for (auto* curr = firstInlineBox; curr; curr = curr->nextLineBox()) {
         logicalLeftSide = std::min(logicalLeftSide, curr->logicalLeftVisualOverflow());
         logicalRightSide = std::max(logicalRightSide, curr->logicalRightVisualOverflow());
     }
 
-    const LegacyRootInlineBox& firstRootBox = firstLegacyInlineBox()->root();
-    const LegacyRootInlineBox& lastRootBox = lastLegacyInlineBox()->root();
+    const LegacyRootInlineBox& firstRootBox = firstInlineBox->root();
+    const LegacyRootInlineBox& lastRootBox = lastInlineBox->root();
 
-    LayoutUnit logicalTop = firstLegacyInlineBox()->logicalTopVisualOverflow(firstRootBox.lineTop());
+    LayoutUnit logicalTop = firstInlineBox->logicalTopVisualOverflow(firstRootBox.lineTop());
     LayoutUnit logicalWidth = logicalRightSide - logicalLeftSide;
-    LayoutUnit logicalHeight = lastLegacyInlineBox()->logicalBottomVisualOverflow(lastRootBox.lineBottom()) - logicalTop;
+    LayoutUnit logicalHeight = lastInlineBox->logicalBottomVisualOverflow(lastRootBox.lineBottom()) - logicalTop;
 
     LayoutRect rect(logicalLeftSide, logicalTop, logicalWidth, logicalHeight);
     if (!writingMode().isHorizontal())
@@ -482,7 +478,7 @@ LayoutRect RenderInline::clippedOverflowRect(const RenderLayerModelObject* repai
 #endif
 
     auto knownEmpty = [&] {
-        if (firstLegacyInlineBox())
+        if (firstLegacyInlineBoxFor(*this))
             return false;
         if (LayoutIntegration::LineLayout::containing(*this))
             return false;
@@ -673,24 +669,6 @@ const RenderElement* RenderInline::pushMappingToContainer(const RenderLayerModel
     return ancestorSkipped ? ancestorToStopAt : container;
 }
 
-void RenderInline::deleteLegacyLineBoxes()
-{
-    m_legacyLineBoxes.deleteLineBoxes();
-}
-
-std::unique_ptr<LegacyInlineFlowBox> RenderInline::createInlineFlowBox()
-{
-    return makeUnique<LegacyInlineFlowBox>(*this);
-}
-
-LegacyInlineFlowBox* RenderInline::createAndAppendInlineFlowBox()
-{
-    auto newFlowBox = createInlineFlowBox();
-    auto flowBox = newFlowBox.get();
-    m_legacyLineBoxes.appendLineBox(WTF::move(newFlowBox));
-    return flowBox;
-}
-
 LayoutSize RenderInline::offsetForInFlowPositionedInline(const RenderBox* child) const
 {
     // FIXME: This function isn't right with mixed writing modes.
@@ -712,7 +690,7 @@ LayoutSize RenderInline::offsetForInFlowPositionedInline(const RenderBox* child)
     // relative to the inline itself.
     auto inlinePosition = layer()->staticInlinePosition();
     auto blockPosition = layer()->staticBlockPosition();
-    if (auto* inlineBox = firstLegacyInlineBox()) {
+    if (auto* inlineBox = firstLegacyInlineBoxFor(*this)) {
         inlinePosition = LayoutUnit::fromFloatRound(inlineBox->logicalLeft());
         blockPosition = inlineBox->logicalTop();
     } else if (LayoutIntegration::LineLayout::containing(*this)) {

--- a/Source/WebCore/rendering/RenderInline.h
+++ b/Source/WebCore/rendering/RenderInline.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #include <WebCore/RenderBoxModelObject.h>
-#include <WebCore/RenderLineBoxList.h>
 #include <wtf/Platform.h>
 
 namespace WebCore {
@@ -69,14 +68,6 @@ public:
     WEBCORE_EXPORT IntRect linesBoundingBox() const;
     LayoutRect linesVisualOverflowBoundingBox() const;
 
-    LegacyInlineFlowBox* createAndAppendInlineFlowBox();
-
-    RenderLineBoxList& legacyLineBoxes() LIFETIME_BOUND { return m_legacyLineBoxes; }
-    const RenderLineBoxList& legacyLineBoxes() const LIFETIME_BOUND { return m_legacyLineBoxes; }
-    void deleteLegacyLineBoxes();
-    LegacyInlineFlowBox* firstLegacyInlineBox() const LIFETIME_BOUND { return m_legacyLineBoxes.firstLegacyLineBox(); }
-    LegacyInlineFlowBox* lastLegacyInlineBox() const LIFETIME_BOUND { return m_legacyLineBoxes.lastLegacyLineBox(); }
-
     LayoutSize offsetForInFlowPositionedInline(const RenderBox* child) const;
 
     void collectLineBoxRects(Vector<LayoutRect>&, const LayoutPoint& additionalOffset) const;
@@ -87,8 +78,6 @@ public:
     LayoutPoint firstInlineBoxTopLeft() const;
 
 protected:
-    void willBeDestroyed() override;
-
     void styleWillChange(Style::Difference, const Style::ComputedStyle& newStyle) override;
     void styleDidChange(Style::Difference, const Style::ComputedStyle* oldStyle) override;
 
@@ -129,14 +118,7 @@ private:
 
     LayoutRect frameRectForStickyPositioning() const final { return linesBoundingBox(); }
 
-    virtual std::unique_ptr<LegacyInlineFlowBox> createInlineFlowBox(); // Subclassed by RenderSVGInline
-
-    void dirtyLineFromChangedChild() final { m_legacyLineBoxes.dirtyLineFromChangedChild(*this); }
-
     void imageChanged(WrappedImagePtr, const IntRect* = 0) final;
-
-    // All of the line boxes created for this svg inline.
-    RenderLineBoxList m_legacyLineBoxes;
 };
 
 bool isEmptyInline(const RenderInline&);

--- a/Source/WebCore/rendering/RenderLineBoxList.cpp
+++ b/Source/WebCore/rendering/RenderLineBoxList.cpp
@@ -124,7 +124,7 @@ void RenderLineBoxList::shiftLinesBy(LayoutUnit shiftX, LayoutUnit shiftY)
 
 void RenderLineBoxList::dirtyLineFromChangedChild(RenderBoxModelObject& container)
 {
-    ASSERT(is<RenderInline>(container) || is<RenderBlockFlow>(container));
+    ASSERT(is<RenderSVGInline>(container) || is<RenderBlockFlow>(container));
     if (!container.isSVGRenderer())
         return;
 

--- a/Source/WebCore/rendering/svg/RenderSVGInline.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.cpp
@@ -23,7 +23,9 @@
 #include "config.h"
 #include "RenderSVGInline.h"
 
+#include "FrameSelection.h"
 #include "LegacyRenderSVGResource.h"
+#include "LocalFrame.h"
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderObjectInlines.h"
 #include "RenderSVGInlineInlines.h"
@@ -59,6 +61,19 @@ std::unique_ptr<LegacyInlineFlowBox> RenderSVGInline::createInlineFlowBox()
     auto box = makeUnique<SVGInlineFlowBox>(*this);
     box->setHasVirtualLogicalHeight();
     return box;
+}
+
+LegacyInlineFlowBox* RenderSVGInline::createAndAppendInlineFlowBox()
+{
+    auto newFlowBox = createInlineFlowBox();
+    auto flowBox = newFlowBox.get();
+    m_legacyLineBoxes.appendLineBox(WTF::move(newFlowBox));
+    return flowBox;
+}
+
+void RenderSVGInline::deleteLegacyLineBoxes()
+{
+    m_legacyLineBoxes.deleteLineBoxes();
 }
 
 bool RenderSVGInline::isChildAllowed(const RenderObject& child, const Style::ComputedStyle& style) const
@@ -176,12 +191,31 @@ void RenderSVGInline::absoluteQuadsForSelection(Vector<FloatQuad>& quads) const
 
 void RenderSVGInline::willBeDestroyed()
 {
-    if (document().settings().layerBasedSVGEngineEnabled()) {
-        RenderInline::willBeDestroyed();
-        return;
+    if (!document().settings().layerBasedSVGEngineEnabled())
+        SVGResourcesCache::clientDestroyed(*this);
+
+    if (!renderTreeBeingDestroyed()) {
+        if (auto* inlineBox = firstLegacyInlineBox()) {
+            // We can't wait for RenderBoxModelObject::destroy to clear the selection,
+            // because by then we will have nuked the line boxes.
+            if (isSelectionBorder())
+                frame().selection().setNeedsSelectionUpdate();
+
+            // If line boxes are contained inside a root, that means we're an inline.
+            // In that case, we need to remove all the line boxes so that the parent
+            // lines aren't pointing to deleted children. If the first line box does
+            // not have a parent that means they are either already disconnected or
+            // root lines that can just be destroyed without disconnecting.
+            if (inlineBox->parent()) {
+                for (auto* box = inlineBox; box; box = box->nextLineBox())
+                    box->removeFromParent();
+            }
+        } else if (auto* parent = this->parent(); parent && parent->isSVGRenderer())
+            parent->dirtyLineFromChangedChild();
     }
 
-    SVGResourcesCache::clientDestroyed(*this);
+    m_legacyLineBoxes.deleteLineBoxes();
+
     RenderInline::willBeDestroyed();
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGInline.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "RenderInline.h"
+#include "RenderLineBoxList.h"
 #include "SVGPaintServerCache.h"
 
 namespace WebCore {
@@ -39,6 +40,16 @@ public:
     inline SVGGraphicsElement& graphicsElement() const;
 
     bool isChildAllowed(const RenderObject&, const Style::ComputedStyle&) const override;
+
+    // SVG inlines are the only inline boxes laid out by LegacyLineLayout, so they are the only ones
+    // holding legacy line boxes.
+    LegacyInlineFlowBox* createAndAppendInlineFlowBox();
+
+    RenderLineBoxList& legacyLineBoxes() LIFETIME_BOUND { return m_legacyLineBoxes; }
+    const RenderLineBoxList& legacyLineBoxes() const LIFETIME_BOUND { return m_legacyLineBoxes; }
+    void deleteLegacyLineBoxes();
+    LegacyInlineFlowBox* firstLegacyInlineBox() const LIFETIME_BOUND { return m_legacyLineBoxes.firstLegacyLineBox(); }
+    LegacyInlineFlowBox* lastLegacyInlineBox() const LIFETIME_BOUND { return m_legacyLineBoxes.lastLegacyLineBox(); }
 
 private:
     void element() const = delete;
@@ -75,7 +86,9 @@ private:
     void absoluteQuadsForSelection(Vector<FloatQuad>&) const final;
 #endif
 
-    std::unique_ptr<LegacyInlineFlowBox> createInlineFlowBox() final;
+    std::unique_ptr<LegacyInlineFlowBox> createInlineFlowBox();
+
+    void dirtyLineFromChangedChild() final { m_legacyLineBoxes.dirtyLineFromChangedChild(*this); }
 
     void willBeDestroyed() final;
     void styleDidChange(Style::Difference, const Style::ComputedStyle* oldStyle) final;
@@ -83,6 +96,9 @@ private:
     SVGPaintServerCache* svgPaintServerCache() const final { return &m_svgPaintServerCache; }
 
     mutable SVGPaintServerCache m_svgPaintServerCache;
+
+    // All of the line boxes created for this SVG inline.
+    RenderLineBoxList m_legacyLineBoxes;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### d11d7774b7af120d973abc019a54751ab1890cbd
<pre>
[cleanup] Move the legacy line boxes from RenderInline to RenderSVGInline, the only inline box that has them
<a href="https://bugs.webkit.org/show_bug.cgi?id=323672">https://bugs.webkit.org/show_bug.cgi?id=323672</a>
&lt;<a href="https://rdar.apple.com/problem/186920347">rdar://problem/186920347</a>&gt;

Reviewed by Antti Koivisto.

RenderInline has a RenderLineBoxList that only SVG can ever populate.
Move it and all of its accessors - legacyLineBoxes(), createInlineFlowBox(), createAndAppendInlineFlowBox(), deleteLegacyLineBoxes(), firstLegacyInlineBox(), lastLegacyInlineBox()
and dirtyLineFromChangedChild() - to RenderSVGInline, and retarget the external users in LegacyLineLayout, LegacyInlineFlowBox and InlineIteratorInlineBox to it.

No change in behavior.

* Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.cpp:
(WebCore::InlineIterator::lineLeftmostInlineBoxFor):
* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
(WebCore::LegacyInlineFlowBox::removeLineBoxFromRenderObject):
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::LegacyLineLayout::createInlineBoxForRenderer):
(WebCore::dirtyLineBoxesForRenderer):
(WebCore::LegacyLineLayout::createLineBoxes):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::firstLegacyInlineBoxFor):
(WebCore::lastLegacyInlineBoxFor):
(WebCore::RenderInline::generateLineBoxRects):
(WebCore::RenderInline::firstInlineBoxTopLeft):
(WebCore::RenderInline::innerPaddingBoxWidth):
(WebCore::RenderInline::linesBoundingBox):
(WebCore::RenderInline::linesVisualOverflowBoundingBox):
(WebCore::RenderInline::clippedOverflowRect):
(WebCore::RenderInline::offsetForInFlowPositionedInline):
(WebCore::RenderInline::willBeDestroyed): Deleted.
(WebCore::RenderInline::deleteLegacyLineBoxes): Deleted.
(WebCore::RenderInline::createInlineFlowBox): Deleted.
(WebCore::RenderInline::createAndAppendInlineFlowBox): Deleted.
* Source/WebCore/rendering/RenderInline.h:
* Source/WebCore/rendering/RenderLineBoxList.cpp:
(WebCore::RenderLineBoxList::dirtyLineFromChangedChild):
* Source/WebCore/rendering/svg/RenderSVGInline.cpp:
(WebCore::RenderSVGInline::createAndAppendInlineFlowBox):
(WebCore::RenderSVGInline::deleteLegacyLineBoxes):
(WebCore::RenderSVGInline::willBeDestroyed):
* Source/WebCore/rendering/svg/RenderSVGInline.h:

Canonical link: <a href="https://commits.webkit.org/320890@main">https://commits.webkit.org/320890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c172ba5409b0df7128e244236caa0abb6c8352c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196478 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59794 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145473 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49152 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/166006 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125805 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47881 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158235 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45598 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7548 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198456 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59739 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155042 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41540 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60450 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154685 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49120 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129862 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58878 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20577 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58279 "Built successfully") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58498 "Hash c172ba54 for PR 73565 does not build (failure)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58340 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->