### PR TITLE
[GTK][WPE] Skia compositor: use promise images for video buffers using GL memory

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -953,11 +953,59 @@ size_t GstMappedFrame::planeHeight(uint32_t planeIndex) const
 }
 
 #if USE(GSTREAMER_GL)
-GLuint GstMappedFrame::textureID(int planeIndex) const
+GstGLMemory* GstMappedFrame::glMemory(uint32_t planeIndex) const
 {
     RELEASE_ASSERT(isValid());
     RELEASE_ASSERT(m_frame.map->flags & GST_MAP_GL);
-    return *reinterpret_cast<GLuint*>(m_frame.data[planeIndex]);
+    RELEASE_ASSERT(planeIndex < GST_VIDEO_INFO_N_PLANES(&m_frame.info));
+    return GST_GL_MEMORY_CAST(m_frame.map[planeIndex].memory);
+}
+
+unsigned GstMappedFrame::textureID(uint32_t planeIndex) const
+{
+    return gst_gl_memory_get_texture_id(glMemory(planeIndex));
+}
+
+IntSize GstMappedFrame::textureSize(uint32_t planeIndex) const
+{
+    auto* memory = glMemory(planeIndex);
+    return { gst_gl_memory_get_texture_width(memory), gst_gl_memory_get_texture_height(memory) };
+}
+
+unsigned GstMappedFrame::textureFormat(uint32_t planeIndex) const
+{
+    auto format = gst_gl_memory_get_texture_format(glMemory(planeIndex));
+    switch (format) {
+    case GST_GL_RED:
+        if (GST_VIDEO_INFO_COMP_DEPTH(&m_frame.info, planeIndex) == 8)
+            return GST_GL_R8;
+        return GST_GL_R16;
+    case GST_GL_RG:
+        if (GST_VIDEO_INFO_COMP_DEPTH(&m_frame.info, planeIndex) == 8)
+            return GST_GL_RG8;
+        return GST_GL_RG16;
+    case GST_GL_RGB:
+        if (GST_VIDEO_INFO_COMP_DEPTH(&m_frame.info, planeIndex) == 8)
+            return GST_GL_RGB8;
+        return GST_GL_RGB16;
+    case GST_GL_RGBA:
+        if (GST_VIDEO_INFO_COMP_DEPTH(&m_frame.info, planeIndex) == 8)
+            return GST_GL_RGBA8;
+        return GST_GL_RGBA16;
+    default:
+        break;
+    }
+    return format;
+}
+
+void GstMappedFrame::waitForCPUSyncIfNeeded() const
+{
+    RELEASE_ASSERT(isValid());
+    if (!m_needsCPUSync)
+        return;
+
+    if (auto* meta = gst_buffer_get_gl_sync_meta(m_frame.buffer))
+        gst_gl_sync_meta_wait_cpu(meta, reinterpret_cast<GstGLBaseMemory*>(gst_buffer_peek_memory(m_frame.buffer, 0))->context);
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -35,9 +35,7 @@
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/text/CStringView.h>
 
-#if USE(GSTREAMER_GL)
-#include "GraphicsTypesGL.h"
-#endif
+typedef struct _GstGLMemory GstGLMemory;
 
 namespace WebCore {
 
@@ -242,16 +240,27 @@ public:
     bool operator!() const { return !m_frame.buffer; }
 
 #if USE(GSTREAMER_GL)
-    GLuint textureID(int) const;
+    unsigned textureID(uint32_t) const;
+    IntSize textureSize(uint32_t) const;
+    unsigned textureFormat(uint32_t) const;
+    void setNeedsCPUSync(bool needsCPUSync) { m_needsCPUSync = needsCPUSync; }
+    void waitForCPUSyncIfNeeded() const;
 #endif
 
     unsigned componentPlane(int) const;
     unsigned componentPlaneOffset(int) const;
 
 private:
+#if USE(GSTREAMER_GL)
+    GstGLMemory* glMemory(uint32_t) const;
+#endif
+
     GstVideoFrame m_frame;
     GstVideoAlignment m_alignment;
     std::array<size_t, GST_VIDEO_MAX_PLANES> m_planeSizes { };
+#if USE(GSTREAMER_GL)
+    bool m_needsCPUSync { false };
+#endif
 };
 
 class GstMappedAudioBuffer {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h
@@ -53,7 +53,9 @@ class CoordinatedPlatformLayerBuffer
 public:
     enum class Type : uint8_t {
         RGB,
+#if USE(TEXTURE_MAPPER)
         YUV,
+#endif
         ExternalOES,
         HolePunch,
         Video,

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
@@ -42,6 +42,11 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
 #include <skia/core/SkImage.h>
 #include <skia/core/SkPixmap.h>
+#include <skia/gpu/ganesh/GrYUVABackendTextures.h>
+#include <skia/gpu/ganesh/SkImageGanesh.h>
+#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
+#include <skia/private/chromium/GrPromiseImageTexture.h>
+#include <skia/private/chromium/SkImageChromium.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
@@ -71,8 +76,15 @@ CoordinatedPlatformLayerBufferVideo::CoordinatedPlatformLayerBufferVideo(Ref<Vid
     : CoordinatedPlatformLayerBuffer(Type::Video, WTF::move(size), flags, nullptr)
     , m_videoFrame(WTF::move(frame))
     , m_videoDecoderPlatform(videoDecoderPlatform)
-    , m_buffer(createBufferIfNeeded(gstGLEnabled, threadSafeGrContext))
+#if USE(TEXTURE_MAPPER)
+    , m_buffer(createBufferIfNeeded(gstGLEnabled))
+#endif
 {
+#if USE(TEXTURE_MAPPER)
+    UNUSED_PARAM(threadSafeGrContext);
+#else
+    createSkiaImageIfNeeded(threadSafeGrContext, gstGLEnabled);
+#endif
 }
 
 CoordinatedPlatformLayerBufferVideo::~CoordinatedPlatformLayerBufferVideo() = default;
@@ -113,7 +125,8 @@ static std::pair<CoordinatedPlatformLayerBufferYUV::YuvToRgbColorSpace, Coordina
 }
 #endif
 
-std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVideo::createBufferIfNeeded(bool gstGLEnabled, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
+#if USE(TEXTURE_MAPPER)
+std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVideo::createBufferIfNeeded(bool gstGLEnabled)
 {
     const auto& sample = m_videoFrame->sample();
     auto buffer = gst_sample_get_buffer(sample.get());
@@ -139,7 +152,7 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVi
 
 #if GST_CHECK_VERSION(1, 24, 0)
     if (gst_is_dmabuf_memory(memory))
-        return createBufferFromDMABufMemory(threadSafeGrContext);
+        return createBufferFromDMABufMemory();
 #endif // GST_CHECK_VERSION(1, 24, 0)
 #endif // USE(GBM)
 
@@ -150,7 +163,6 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVi
     UNUSED_PARAM(gstGLEnabled);
 #endif
 
-#if USE(TEXTURE_MAPPER)
     // When not having a texture, we map the frame here and upload the pixels to a texture in the
     // compositor thread, in paintToTextureMapper(), which also allows us to use the texture mapper
     // bitmap texture pool.
@@ -163,29 +175,12 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVi
 
     if (GST_VIDEO_INFO_HAS_ALPHA(m_mappedVideoFrame->info()))
         m_flags.add({ TextureMapperFlags::ShouldBlend, TextureMapperFlags::ShouldPremultiply });
-#else
-    auto mappedFrame = makeUnique<GstMappedFrame>(sample, GST_MAP_READ);
-    if (!mappedFrame->isValid())
-        return nullptr;
-
-    if (GST_VIDEO_INFO_HAS_ALPHA(mappedFrame->info()))
-        m_flags.add({ TextureMapperFlags::ShouldBlend, TextureMapperFlags::ShouldPremultiply });
-    auto alphaType = GST_VIDEO_INFO_HAS_ALPHA(mappedFrame->info()) ? kUnpremul_SkAlphaType : kOpaque_SkAlphaType;
-    auto imageInfo = SkImageInfo::Make(mappedFrame->width(), mappedFrame->height(), kBGRA_8888_SkColorType, alphaType, SkColorSpace::MakeSRGB());
-    SkPixmap pixmap(imageInfo, mappedFrame->planeData(0).data(), mappedFrame->planeStride(0));
-    auto image = SkImages::RasterFromPixmap(pixmap, [](const void*, void* userData) {
-        std::unique_ptr<GstMappedFrame> mappedFrame(static_cast<GstMappedFrame*>(userData));
-    }, mappedFrame.release());
-    if (!image)
-        return nullptr;
-    return CoordinatedPlatformLayerBufferSkiaImage::create(image, nullptr);
-#endif
 
     return nullptr;
 }
 
 #if USE(GBM) && GST_CHECK_VERSION(1, 24, 0)
-std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVideo::createBufferFromDMABufMemory(const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
+std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVideo::createBufferFromDMABufMemory()
 {
     auto videoInfo = m_videoFrame->info();
     if (GST_VIDEO_INFO_HAS_ALPHA(&videoInfo))
@@ -193,12 +188,7 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVi
 
     auto dmabuf = m_videoFrame->getDMABuf();
     RELEASE_ASSERT(dmabuf);
-#if USE(TEXTURE_MAPPER)
-    UNUSED_PARAM(threadSafeGrContext);
     return CoordinatedPlatformLayerBufferDMABuf::create(dmabuf.releaseNonNull(), m_flags, nullptr);
-#else
-    return CoordinatedPlatformLayerBufferDMABuf::create(dmabuf.releaseNonNull(), m_flags, nullptr, threadSafeGrContext);
-#endif
 }
 #endif // USE(GBM) && GST_CHECK_VERSION(1, 24, 0)
 
@@ -246,6 +236,8 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVi
         return nullptr;
     }
 
+    m_mappedVideoFrame->setNeedsCPUSync(m_videoDecoderPlatform != GstVideoDecoderPlatform::OpenMAX);
+
     if (GST_VIDEO_INFO_HAS_ALPHA(m_mappedVideoFrame->info()))
         m_flags.add({ TextureMapperFlags::ShouldBlend, TextureMapperFlags::ShouldPremultiply });
 
@@ -292,7 +284,6 @@ std::unique_ptr<CoordinatedPlatformLayerBuffer> CoordinatedPlatformLayerBufferVi
 }
 #endif
 
-#if USE(TEXTURE_MAPPER)
 void CoordinatedPlatformLayerBufferVideo::createBufferFromMappedFrameIfNeeded()
 {
     if (!m_mappedVideoFrame)
@@ -300,13 +291,7 @@ void CoordinatedPlatformLayerBufferVideo::createBufferFromMappedFrameIfNeeded()
 
     RELEASE_ASSERT(*m_mappedVideoFrame);
 #if USE(GSTREAMER_GL)
-    if (m_videoDecoderPlatform != GstVideoDecoderPlatform::OpenMAX) {
-        if (auto* meta = gst_buffer_get_gl_sync_meta(m_mappedVideoFrame->get()->buffer)) {
-            GstMemory* memory = gst_buffer_peek_memory(m_mappedVideoFrame->get()->buffer, 0);
-            GstGLContext* context = reinterpret_cast<GstGLBaseMemory*>(memory)->context;
-            gst_gl_sync_meta_wait_cpu(meta, context);
-        }
-    }
+    m_mappedVideoFrame->waitForCPUSyncIfNeeded();
 #endif
 
     if (m_buffer)
@@ -344,17 +329,327 @@ void CoordinatedPlatformLayerBufferVideo::paintToTextureMapper(TextureMapper& te
 
 #else
 
-sk_sp<SkImage> CoordinatedPlatformLayerBufferVideo::skiaImage()
-{
 #if USE(GSTREAMER_GL)
-    if (m_mappedVideoFrame && m_videoDecoderPlatform != GstVideoDecoderPlatform::OpenMAX) {
-        if (auto* meta = gst_buffer_get_gl_sync_meta(m_mappedVideoFrame->get()->buffer)) {
-            GstMemory* memory = gst_buffer_peek_memory(m_mappedVideoFrame->get()->buffer, 0);
-            GstGLContext* context = reinterpret_cast<GstGLBaseMemory*>(memory)->context;
-            gst_gl_sync_meta_wait_cpu(meta, context);
-        }
+class PromiseGLVideoFrameContext final : public ThreadSafeRefCounted<PromiseGLVideoFrameContext> {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PromiseGLVideoFrameContext);
+public:
+    static Ref<PromiseGLVideoFrameContext> create(std::unique_ptr<GstMappedFrame>&& frame)
+    {
+        return adoptRef(*new PromiseGLVideoFrameContext(WTF::move(frame)));
+    }
+
+    ~PromiseGLVideoFrameContext() = default;
+
+    sk_sp<GrPromiseImageTexture> promiseImageTexture(size_t planeIndex)
+    {
+        m_mappedFrame->waitForCPUSyncIfNeeded();
+
+        GrGLTextureInfo externalTexture;
+        externalTexture.fTarget = GL_TEXTURE_2D;
+        externalTexture.fID = m_mappedFrame->textureID(planeIndex);
+        externalTexture.fFormat = m_mappedFrame->textureFormat(planeIndex);
+        auto textureSize = m_mappedFrame->textureSize(planeIndex);
+        return GrPromiseImageTexture::Make(GrBackendTextures::MakeGL(textureSize.width(), textureSize.height(), skgpu::Mipmapped::kNo, externalTexture));
+    }
+
+private:
+    explicit PromiseGLVideoFrameContext(std::unique_ptr<GstMappedFrame>&& mappedFrame)
+        : m_mappedFrame(WTF::move(mappedFrame))
+    {
+    }
+
+    std::unique_ptr<GstMappedFrame> m_mappedFrame;
+};
+
+struct PromiseGLVideoPlaneContext {
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED(PromiseGLVideoPlaneContext);
+
+    PromiseGLVideoPlaneContext(Ref<PromiseGLVideoFrameContext>&& frameContext, size_t planeIndex)
+        : context(WTF::move(frameContext))
+        , index(planeIndex)
+    {
+    }
+
+    Ref<PromiseGLVideoFrameContext> context;
+    size_t index { 0 };
+};
+
+WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(PromiseGLVideoPlaneContext);
+
+static bool isSinglePlaneGLMemory(GstGLMemory* memory, GstVideoInfo* videoInfo, std::optional<GstVideoDecoderPlatform> videoDecoderPlatform)
+{
+    if (gst_gl_memory_get_texture_target(memory) == GST_GL_TEXTURE_TARGET_EXTERNAL_OES)
+        return true;
+
+    if (GST_VIDEO_INFO_IS_RGB(videoInfo) && GST_VIDEO_INFO_N_PLANES(videoInfo) == 1)
+        return true;
+
+    if (videoDecoderPlatform && *videoDecoderPlatform == GstVideoDecoderPlatform::ImxVPU && GST_VIDEO_INFO_IS_YUV(videoInfo) && GST_VIDEO_INFO_N_COMPONENTS(videoInfo) >= 3 && GST_VIDEO_INFO_N_PLANES(videoInfo) <= 4)
+        return true;
+
+    return false;
+}
+#endif
+
+void CoordinatedPlatformLayerBufferVideo::createSkiaImageIfNeeded(const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext, bool gstGLEnabled)
+{
+    const auto& sample = m_videoFrame->sample();
+    auto* buffer = gst_sample_get_buffer(sample.get());
+    auto* memory = gst_buffer_peek_memory(buffer, 0);
+
+#if USE(GBM)
+    if (gst_is_fd_memory(memory) && m_videoDecoderPlatform && *m_videoDecoderPlatform == GstVideoDecoderPlatform::Qualcomm) {
+        createSkiaImageForQualcommDecoder();
+        return;
+    }
+
+#if GST_CHECK_VERSION(1, 24, 0)
+    if (gst_is_dmabuf_memory(memory)) {
+        createSkiaImageForDMABufMemory(threadSafeGrContext);
+        return;
     }
 #endif
+#endif // USE(GBM)
+
+    unsigned mapFlags = GST_MAP_READ;
+#if USE(GSTREAMER_GL)
+    if (gstGLEnabled && gst_is_gl_memory(memory))
+        mapFlags |= GST_MAP_GL;
+#else
+    UNUSED_PARAM(gstGLEnabled);
+#endif
+
+    auto mappedFrame = makeUnique<GstMappedFrame>(sample, static_cast<GstMapFlags>(mapFlags));
+    if (!mappedFrame->isValid()) {
+        LOG_ERROR("Failed to create Skia image for video buffer: error mapping video frame");
+        return;
+    }
+
+    if (GST_VIDEO_INFO_HAS_ALPHA(mappedFrame->info()))
+        m_flags.add({ TextureMapperFlags::ShouldBlend, TextureMapperFlags::ShouldPremultiply });
+
+    if (mapFlags == GST_MAP_READ) {
+        createSkiaImageForMainMemory(WTF::move(mappedFrame));
+        return;
+    }
+
+#if USE(GSTREAMER_GL)
+    if (mapFlags & GST_MAP_GL) {
+        createSkiaImageForGLMemory(GST_GL_MEMORY_CAST(memory), WTF::move(mappedFrame), threadSafeGrContext);
+        return;
+    }
+#endif
+}
+
+#if USE(GBM)
+void CoordinatedPlatformLayerBufferVideo::createSkiaImageForQualcommDecoder()
+{
+    // FIXME: switch to use promise images, use an inner CoordinatedPlatformLayerBuffer for now.
+
+    // The buffers produced by the Qualcomm decoder contain a single GstMemory which stores the
+    // GBM FD pointing to the decoded frame. The frame format is YUV (NV12). As this is stored
+    // in a single memory the existing DMABuf/YUV layer buffers cannot be used for rendering. So
+    // we rely on the EXT_YUV_target OpenGL ES extension to convert it to a RGB texture for
+    // rendering.
+    auto dmabufFormat = m_videoFrame->dmaBufFormat();
+    RELEASE_ASSERT(dmabufFormat);
+    // The driver converts YUV to RGB while sampling, so it needs the frame colorimetry.
+    const auto& info = m_videoFrame->info();
+    auto yuvColorSpace = yuvColorSpaceFromVideoInfo(info).first;
+    auto sampleRange = GST_VIDEO_INFO_COLORIMETRY(&info).range == GST_VIDEO_COLOR_RANGE_0_255
+        ? CoordinatedPlatformLayerBufferExternalOES::SampleRange::Full
+        : CoordinatedPlatformLayerBufferExternalOES::SampleRange::Narrow;
+    auto* buffer = gst_sample_get_buffer(m_videoFrame->sample().get());
+    m_buffer = CoordinatedPlatformLayerBufferExternalOES::create(GRefPtr(buffer), dmabufFormat->first, yuvColorSpace, sampleRange, m_size, m_flags);
+}
+
+#if GST_CHECK_VERSION(1, 24, 0)
+void CoordinatedPlatformLayerBufferVideo::createSkiaImageForDMABufMemory(const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
+{
+    const auto& videoInfo = m_videoFrame->info();
+    if (GST_VIDEO_INFO_HAS_ALPHA(&videoInfo))
+        m_flags.add({ TextureMapperFlags::ShouldBlend, TextureMapperFlags::ShouldPremultiply });
+
+    auto dmabuf = m_videoFrame->getDMABuf();
+    ASSERT(dmabuf);
+
+    auto alphaType = m_flags.contains(TextureMapperFlags::ShouldBlend) ? kPremul_SkAlphaType : kOpaque_SkAlphaType;
+    auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
+    m_image = dmabuf->createPromiseImage(threadSafeGrContext, kRGBA_8888_SkColorType, alphaType, origin, nullptr, { });
+}
+#endif
+#endif // USE(GBM)
+
+void CoordinatedPlatformLayerBufferVideo::createSkiaImageForMainMemory(std::unique_ptr<GstMappedFrame>&& mappedFrame)
+{
+    auto alphaType = GST_VIDEO_INFO_HAS_ALPHA(mappedFrame->info()) ? kUnpremul_SkAlphaType : kOpaque_SkAlphaType;
+    auto imageInfo = SkImageInfo::Make(mappedFrame->width(), mappedFrame->height(), kBGRA_8888_SkColorType, alphaType, SkColorSpace::MakeSRGB());
+    SkPixmap pixmap(imageInfo, mappedFrame->planeData(0).data(), mappedFrame->planeStride(0));
+    m_image = SkImages::RasterFromPixmap(pixmap, [](const void*, void* userData) {
+        std::unique_ptr<GstMappedFrame> mappedFrame(static_cast<GstMappedFrame*>(userData));
+    }, mappedFrame.release());
+}
+
+#if USE(GSTREAMER_GL)
+void CoordinatedPlatformLayerBufferVideo::createSkiaImageForGLMemory(GstGLMemory* glMemory, std::unique_ptr<GstMappedFrame>&& mappedFrame, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
+{
+    mappedFrame->setNeedsCPUSync(m_videoDecoderPlatform != GstVideoDecoderPlatform::OpenMAX);
+
+    auto* videoInfo = mappedFrame->info();
+    if (isSinglePlaneGLMemory(glMemory, videoInfo, m_videoDecoderPlatform)) {
+        createSkiaImageForSinglePlaneGLMemory(glMemory, WTF::move(mappedFrame), threadSafeGrContext);
+        return;
+    }
+
+    if (GST_VIDEO_INFO_IS_YUV(videoInfo) && GST_VIDEO_INFO_N_COMPONENTS(videoInfo) >= 3 && GST_VIDEO_INFO_N_PLANES(videoInfo) <= 4)
+        createSkiaImageForYUVGLMemory(WTF::move(mappedFrame), threadSafeGrContext);
+}
+
+void CoordinatedPlatformLayerBufferVideo::createSkiaImageForSinglePlaneGLMemory(GstGLMemory* glMemory, std::unique_ptr<GstMappedFrame>&& mappedFrame, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
+{
+    const bool isExternal = gst_gl_memory_get_texture_target(glMemory) == GST_GL_TEXTURE_TARGET_EXTERNAL_OES;
+    auto backendFormat = isExternal ? GrBackendFormats::MakeGLExternal() : threadSafeGrContext->defaultBackendFormat(kRGBA_8888_SkColorType, GrRenderable::kYes);
+    ASSERT(backendFormat.isValid());
+
+    auto frameSize = SkISize::Make(mappedFrame->width(), mappedFrame->height());
+    auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
+    auto alphaType = GST_VIDEO_INFO_HAS_ALPHA(mappedFrame->info()) ? kUnpremul_SkAlphaType : kOpaque_SkAlphaType;
+
+    m_image = SkImages::PromiseTextureFrom(threadSafeGrContext, backendFormat, frameSize, skgpu::Mipmapped::kNo,
+        origin, kRGBA_8888_SkColorType, alphaType, SkColorSpace::MakeSRGB(),
+        +[](void* userData) -> sk_sp<GrPromiseImageTexture> {
+            auto& mappedFrame = *static_cast<GstMappedFrame*>(userData);
+            mappedFrame.waitForCPUSyncIfNeeded();
+
+            auto* memory = GST_GL_MEMORY_CAST(gst_buffer_peek_memory(mappedFrame.get()->buffer, 0));
+            GrGLTextureInfo externalTexture;
+            externalTexture.fTarget = gst_gl_memory_get_texture_target(memory) == GST_GL_TEXTURE_TARGET_EXTERNAL_OES ? GL_TEXTURE_EXTERNAL_OES : GL_TEXTURE_2D;
+            externalTexture.fID = mappedFrame.textureID(0);
+            externalTexture.fFormat = GL_RGBA8;
+            return GrPromiseImageTexture::Make(GrBackendTextures::MakeGL(mappedFrame.width(), mappedFrame.height(), skgpu::Mipmapped::kNo, externalTexture));
+        },
+        +[](void* userData) {
+            std::unique_ptr<GstMappedFrame> mappedFrame(static_cast<GstMappedFrame*>(userData));
+        }, mappedFrame.release());
+}
+
+static std::optional<SkYUVAInfo> buildYUVAInfoFromMappedFrame(GstMappedFrame& mappedFrame)
+{
+    auto planeConfig = SkYUVAInfo::PlaneConfig::kUnknown;
+    auto subsampling = SkYUVAInfo::Subsampling::kUnknown;
+    switch (GST_VIDEO_INFO_FORMAT(mappedFrame.info())) {
+    case GST_VIDEO_FORMAT_BGRx:
+    case GST_VIDEO_FORMAT_RGBx:
+    case GST_VIDEO_FORMAT_BGRA:
+    case GST_VIDEO_FORMAT_RGBA:
+        planeConfig = SkYUVAInfo::PlaneConfig::kYUVA;
+        subsampling = SkYUVAInfo::Subsampling::k444;
+        break;
+    case GST_VIDEO_FORMAT_I420:
+        planeConfig = SkYUVAInfo::PlaneConfig::kY_U_V;
+        subsampling = SkYUVAInfo::Subsampling::k420;
+        break;
+    case GST_VIDEO_FORMAT_YV12:
+        planeConfig = SkYUVAInfo::PlaneConfig::kY_V_U;
+        subsampling = SkYUVAInfo::Subsampling::k420;
+        break;
+    case GST_VIDEO_FORMAT_NV12:
+    case GST_VIDEO_FORMAT_P010_10LE:
+        planeConfig = SkYUVAInfo::PlaneConfig::kY_UV;
+        subsampling = SkYUVAInfo::Subsampling::k420;
+        break;
+    case GST_VIDEO_FORMAT_NV21:
+        planeConfig = SkYUVAInfo::PlaneConfig::kY_VU;
+        subsampling = SkYUVAInfo::Subsampling::k420;
+        break;
+    case GST_VIDEO_FORMAT_Y444:
+        planeConfig = SkYUVAInfo::PlaneConfig::kY_U_V;
+        subsampling = SkYUVAInfo::Subsampling::k444;
+        break;
+    case GST_VIDEO_FORMAT_Y41B:
+        planeConfig = SkYUVAInfo::PlaneConfig::kY_U_V;
+        subsampling = SkYUVAInfo::Subsampling::k411;
+        break;
+    case GST_VIDEO_FORMAT_Y42B:
+        planeConfig = SkYUVAInfo::PlaneConfig::kY_U_V;
+        subsampling = SkYUVAInfo::Subsampling::k422;
+        break;
+    case GST_VIDEO_FORMAT_A420:
+        planeConfig = SkYUVAInfo::PlaneConfig::kY_U_V_A;
+        subsampling = SkYUVAInfo::Subsampling::k420;
+        break;
+    default:
+        break;
+    }
+
+    if (planeConfig == SkYUVAInfo::PlaneConfig::kUnknown) {
+        LOG_ERROR("Failed to create Skia image for video buffer: unsupported buffer format");
+        return std::nullopt;
+    }
+
+    const auto& colorimetry = GST_VIDEO_INFO_COLORIMETRY(mappedFrame.info());
+
+    // Default to bt601. This is the same behaviour as GStreamer's glcolorconvert element.
+    SkYUVColorSpace yuvaColorSpace = kRec601_Limited_SkYUVColorSpace;
+    if (gst_video_colorimetry_matches(&colorimetry, GST_VIDEO_COLORIMETRY_BT709))
+        yuvaColorSpace = kRec709_Full_SkYUVColorSpace;
+    else if (gst_video_colorimetry_matches(&colorimetry, GST_VIDEO_COLORIMETRY_BT2020))
+        yuvaColorSpace = kBT2020_8bit_Full_SkYUVColorSpace;
+    else if (gst_video_colorimetry_matches(&colorimetry, GST_VIDEO_COLORIMETRY_BT2100_PQ))
+        yuvaColorSpace = kBT2020_8bit_Full_SkYUVColorSpace;
+    else if (gst_video_colorimetry_matches(&colorimetry, GST_VIDEO_COLORIMETRY_SMPTE240M))
+        yuvaColorSpace = kSMPTE240_Full_SkYUVColorSpace;
+
+    return SkYUVAInfo(SkISize::Make(mappedFrame.width(), mappedFrame.height()), planeConfig, subsampling, yuvaColorSpace);
+}
+
+void CoordinatedPlatformLayerBufferVideo::createSkiaImageForYUVGLMemory(std::unique_ptr<GstMappedFrame>&& mappedFrame, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
+{
+    auto info = buildYUVAInfoFromMappedFrame(*mappedFrame);
+    if (!info)
+        return;
+
+    auto* videoInfo = mappedFrame->info();
+    unsigned planeCount = GST_VIDEO_INFO_N_PLANES(videoInfo);
+    ASSERT(planeCount <= 4);
+    std::array<GrBackendFormat, 4> backendFormats;
+    for (unsigned i = 0; i < planeCount; ++i)
+        backendFormats[i] = GrBackendFormats::MakeGL(mappedFrame->textureFormat(i), GL_TEXTURE_2D);
+
+    auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
+    GrYUVABackendTextureInfo yuvaBackendTexturesInfo(*info, backendFormats.data(), skgpu::Mipmapped::kNo, origin);
+    if (!yuvaBackendTexturesInfo.isValid()) {
+        LOG_ERROR("Failed to create Skia image for YUV video buffer: invalid backend texture information");
+        return;
+    }
+
+    Ref context = PromiseGLVideoFrameContext::create(WTF::move(mappedFrame));
+    std::array<PromiseGLVideoPlaneContext*, 4> planeContexts;
+    for (unsigned i = 0; i < planeCount; ++i)
+        planeContexts[i] = makeUnique<PromiseGLVideoPlaneContext>(context.copyRef(), i).release();
+
+    auto colorSpace = [&]() -> sk_sp<SkColorSpace> {
+        const auto& colorimetry = GST_VIDEO_INFO_COLORIMETRY(videoInfo);
+        if (gst_video_colorimetry_matches(&colorimetry, GST_VIDEO_COLORIMETRY_BT2100_PQ))
+            return SkColorSpace::MakeRGB(SkNamedTransferFn::kPQ, SkNamedGamut::kRec2020);
+        return SkColorSpace::MakeRGB(SkNamedTransferFn::kRec709, SkNamedGamut::kSRGB);
+    }();
+
+    m_image = SkImages::PromiseTextureFromYUVA(threadSafeGrContext, yuvaBackendTexturesInfo, colorSpace,
+        +[](void* userData) -> sk_sp<GrPromiseImageTexture> {
+            auto& planeContext = *static_cast<PromiseGLVideoPlaneContext*>(userData);
+            return planeContext.context->promiseImageTexture(planeContext.index);
+        },
+        +[](void* userData) {
+            std::unique_ptr<PromiseGLVideoPlaneContext> planeContext(static_cast<PromiseGLVideoPlaneContext*>(userData));
+        }, reinterpret_cast<void**>(planeContexts.data()));
+}
+#endif
+
+sk_sp<SkImage> CoordinatedPlatformLayerBufferVideo::skiaImage()
+{
+    if (m_image)
+        return m_image;
 
     if (m_buffer)
         return m_buffer->skiaImage();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h
@@ -49,26 +49,45 @@ public:
 private:
 #if USE(TEXTURE_MAPPER)
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
-#else
-    sk_sp<SkImage> skiaImage() override;
-#endif
 
-    std::unique_ptr<CoordinatedPlatformLayerBuffer> createBufferIfNeeded(bool gstGLEnabled, const sk_sp<GrContextThreadSafeProxy>&);
+    std::unique_ptr<CoordinatedPlatformLayerBuffer> createBufferIfNeeded(bool gstGLEnabled);
 #if USE(GBM) && GST_CHECK_VERSION(1, 24, 0)
-    std::unique_ptr<CoordinatedPlatformLayerBuffer> createBufferFromDMABufMemory(const sk_sp<GrContextThreadSafeProxy>&);
+    std::unique_ptr<CoordinatedPlatformLayerBuffer> createBufferFromDMABufMemory();
 #endif
 #if USE(GSTREAMER_GL)
     std::unique_ptr<CoordinatedPlatformLayerBuffer> createBufferFromGLMemory();
 #endif
-
-#if USE(TEXTURE_MAPPER)
     void createBufferFromMappedFrameIfNeeded();
+
+#else
+    sk_sp<SkImage> skiaImage() override;
+
+    void createSkiaImageIfNeeded(const sk_sp<GrContextThreadSafeProxy>&, bool gstGLEnabled);
+
+#if USE(GBM)
+    void createSkiaImageForQualcommDecoder();
+#if GST_CHECK_VERSION(1, 24, 0)
+    void createSkiaImageForDMABufMemory(const sk_sp<GrContextThreadSafeProxy>&);
+#endif
+#endif
+
+    void createSkiaImageForMainMemory(std::unique_ptr<GstMappedFrame>&&);
+
+#if USE(GSTREAMER_GL)
+    void createSkiaImageForGLMemory(GstGLMemory*, std::unique_ptr<GstMappedFrame>&&, const sk_sp<GrContextThreadSafeProxy>&);
+    void createSkiaImageForSinglePlaneGLMemory(GstGLMemory*, std::unique_ptr<GstMappedFrame>&&, const sk_sp<GrContextThreadSafeProxy>&);
+    void createSkiaImageForYUVGLMemory(std::unique_ptr<GstMappedFrame>&&, const sk_sp<GrContextThreadSafeProxy>&);
+#endif
 #endif
 
     Ref<VideoFrameGStreamer> m_videoFrame;
-    std::optional<GstMappedFrame> m_mappedVideoFrame;
     std::optional<GstVideoDecoderPlatform> m_videoDecoderPlatform;
     std::unique_ptr<CoordinatedPlatformLayerBuffer> m_buffer;
+#if USE(TEXTURE_MAPPER)
+    std::optional<GstMappedFrame> m_mappedVideoFrame;
+#else
+    sk_sp<SkImage> m_image;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
@@ -26,31 +26,10 @@
 #include "config.h"
 #include "CoordinatedPlatformLayerBufferYUV.h"
 
-#if USE(COORDINATED_GRAPHICS)
+#if USE(COORDINATED_GRAPHICS) && USE(TEXTURE_MAPPER)
 #include "BitmapTexturePool.h"
 #include "PlatformDisplay.h"
-
-#if USE(TEXTURE_MAPPER)
 #include "TextureMapper.h"
-#else
-#if USE(LIBEPOXY)
-#include <epoxy/gl.h>
-#else
-#include <GLES3/gl3.h>
-#endif
-#endif
-
-#if USE(SKIA)
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-#include <skia/core/SkColorSpace.h>
-#include <skia/core/SkImage.h>
-#include <skia/core/SkYUVAInfo.h>
-#include <skia/gpu/ganesh/GrBackendSurface.h>
-#include <skia/gpu/ganesh/GrYUVABackendTextures.h>
-#include <skia/gpu/ganesh/SkImageGanesh.h>
-#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
-WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
-#endif
 
 namespace WebCore {
 
@@ -92,7 +71,6 @@ CoordinatedPlatformLayerBufferYUV::CoordinatedPlatformLayerBufferYUV(Format form
 
 CoordinatedPlatformLayerBufferYUV::~CoordinatedPlatformLayerBufferYUV() = default;
 
-#if USE(TEXTURE_MAPPER)
 void CoordinatedPlatformLayerBufferYUV::paintToTextureMapper(TextureMapper& textureMapper, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity)
 {
     waitForContentsIfNeeded();
@@ -171,140 +149,6 @@ void CoordinatedPlatformLayerBufferYUV::paintToTextureMapper(TextureMapper& text
     }
 }
 
-#else
-
-sk_sp<SkImage> CoordinatedPlatformLayerBufferYUV::skiaImage()
-{
-    waitForContentsIfNeeded();
-
-    auto planeConfig = SkYUVAInfo::PlaneConfig::kUnknown;
-    auto subsampling = SkYUVAInfo::Subsampling::kUnknown;
-    GrGLTextureInfo externalTexture = { GL_TEXTURE_2D, 0, 0, skgpu::Protected::kNo };
-    std::array<GrBackendTexture, 4> backendTextures;
-
-    switch (m_planeCount) {
-    case 1:
-        RELEASE_ASSERT(m_format == Format::AYUV);
-        planeConfig = SkYUVAInfo::PlaneConfig::kYUVA;
-        subsampling = SkYUVAInfo::Subsampling::k444;
-
-        externalTexture.fID = m_planes[m_yuvPlane[0]];
-        externalTexture.fFormat = GL_RGBA8;
-        backendTextures[0] = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
-        break;
-    case 2:
-        RELEASE_ASSERT(m_format == Format::NV12 || m_format == Format::NV21 || m_format == Format::P010);
-        planeConfig = m_format == Format::NV21 ? SkYUVAInfo::PlaneConfig::kY_VU : SkYUVAInfo::PlaneConfig::kY_UV;
-        subsampling = SkYUVAInfo::Subsampling::k420;
-
-        externalTexture.fID = m_planes[m_yuvPlane[0]];
-        externalTexture.fFormat = m_format == Format::P010 ? GL_R16 : GL_R8;
-        backendTextures[0] = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
-
-        externalTexture.fID = m_planes[m_yuvPlane[1]];
-        externalTexture.fFormat = m_format == Format::P010 ? GL_RG16 : GL_RG8;
-        backendTextures[1] = GrBackendTextures::MakeGL(m_size.width() / 2, m_size.height() / 2, skgpu::Mipmapped::kNo, externalTexture);
-        break;
-    case 3:
-        planeConfig = m_format == Format::YVU420 ? SkYUVAInfo::PlaneConfig::kY_V_U : SkYUVAInfo::PlaneConfig::kY_U_V;
-
-        externalTexture.fID = m_planes[m_yuvPlane[0]];
-        externalTexture.fFormat = GL_R8;
-        backendTextures[0] = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
-
-        switch (m_format) {
-        case Format::YUV420:
-        case Format::YVU420:
-            subsampling = SkYUVAInfo::Subsampling::k420;
-
-            externalTexture.fID = m_planes[m_yuvPlane[1]];
-            backendTextures[1] = GrBackendTextures::MakeGL(m_size.width() / 2, m_size.height() / 2, skgpu::Mipmapped::kNo, externalTexture);
-            externalTexture.fID = m_planes[m_yuvPlane[2]];
-            backendTextures[2] = GrBackendTextures::MakeGL(m_size.width() / 2, m_size.height() / 2, skgpu::Mipmapped::kNo, externalTexture);
-            break;
-        case Format::YUV444:
-            subsampling = SkYUVAInfo::Subsampling::k444;
-
-            externalTexture.fID = m_planes[m_yuvPlane[1]];
-            backendTextures[1] = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
-            externalTexture.fID = m_planes[m_yuvPlane[2]];
-            backendTextures[2] = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
-            break;
-        case Format::YUV411:
-            subsampling = SkYUVAInfo::Subsampling::k411;
-
-            externalTexture.fID = m_planes[m_yuvPlane[1]];
-            backendTextures[1] = GrBackendTextures::MakeGL(m_size.width() / 4, m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
-            externalTexture.fID = m_planes[m_yuvPlane[2]];
-            backendTextures[2] = GrBackendTextures::MakeGL(m_size.width() / 4, m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
-            break;
-        case Format::YUV422:
-            subsampling = SkYUVAInfo::Subsampling::k422;
-
-            externalTexture.fID = m_planes[m_yuvPlane[1]];
-            backendTextures[1] = GrBackendTextures::MakeGL(m_size.width() / 2, m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
-            externalTexture.fID = m_planes[m_yuvPlane[2]];
-            backendTextures[2] = GrBackendTextures::MakeGL(m_size.width() / 2, m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
-            break;
-        default:
-            RELEASE_ASSERT_NOT_REACHED();
-        }
-        break;
-    case 4:
-        RELEASE_ASSERT(m_format == Format::A420);
-        planeConfig = SkYUVAInfo::PlaneConfig::kY_U_V_A;
-        subsampling = SkYUVAInfo::Subsampling::k420;
-        externalTexture.fFormat = GL_R8;
-        externalTexture.fID = m_planes[m_yuvPlane[0]];
-        backendTextures[0] = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
-        externalTexture.fID = m_planes[m_yuvPlane[1]];
-        backendTextures[1] = GrBackendTextures::MakeGL(m_size.width() / 2, m_size.height() / 2, skgpu::Mipmapped::kNo, externalTexture);
-        externalTexture.fID = m_planes[m_yuvPlane[2]];
-        backendTextures[2] = GrBackendTextures::MakeGL(m_size.width() / 2, m_size.height() / 2, skgpu::Mipmapped::kNo, externalTexture);
-        externalTexture.fID = m_planes[m_yuvPlane[3]];
-        backendTextures[3] = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
-        break;
-    }
-
-    if (planeConfig == SkYUVAInfo::PlaneConfig::kUnknown)
-        return nullptr;
-
-    SkYUVColorSpace yuvaColorSpace = [&] {
-        switch (m_yuvToRgbColorSpace) {
-        case YuvToRgbColorSpace::Bt601:
-            return kRec601_Limited_SkYUVColorSpace;
-        case YuvToRgbColorSpace::Bt709:
-            return kRec709_Full_SkYUVColorSpace;
-        case YuvToRgbColorSpace::Bt2020:
-            return kBT2020_8bit_Full_SkYUVColorSpace;
-        case YuvToRgbColorSpace::Smpte240M:
-            return kSMPTE240_Full_SkYUVColorSpace;
-        }
-        RELEASE_ASSERT_NOT_REACHED();
-    }();
-
-    SkYUVAInfo info(SkISize::Make(m_size.width(), m_size.height()), planeConfig, subsampling, yuvaColorSpace);
-    auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
-    GrYUVABackendTextures yuvaBackendTextures(info, backendTextures.data(), origin);
-    if (!yuvaBackendTextures.isValid())
-        return nullptr;
-
-    sk_sp<SkColorSpace> colorSpace = [&] {
-        switch (m_transferFunction) {
-        case TransferFunction::Bt709:
-            return SkColorSpace::MakeRGB(SkNamedTransferFn::kRec709, SkNamedGamut::kSRGB);
-        case TransferFunction::Pq:
-            return SkColorSpace::MakeRGB(SkNamedTransferFn::kPQ, SkNamedGamut::kRec2020);
-        }
-        RELEASE_ASSERT_NOT_REACHED();
-    }();
-
-    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
-    ASSERT(grContext);
-    return SkImages::TextureFromYUVATextures(grContext, yuvaBackendTextures, colorSpace);
-}
-#endif
-
 } // namespace WebCore
 
-#endif // USE(COORDINATED_GRAPHICS)
+#endif // USE(COORDINATED_GRAPHICS) && USE(TEXTURE_MAPPER)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.h
@@ -37,21 +37,24 @@ public:
     enum class Format : uint8_t { AYUV, NV12, NV21, P010, YUV420, YVU420, YUV444, YUV411, YUV422, A420 };
     enum class YuvToRgbColorSpace : uint8_t { Bt601, Bt709, Bt2020, Smpte240M };
     enum class TransferFunction : uint8_t { Bt709, Pq };
+    // FIXME: stop building CoordinatedPlatformLayerBufferYUV when texture mapper
+    // is disabled once these enums are no longer used by skia compositor.
+#if USE(TEXTURE_MAPPER)
     static std::unique_ptr<CoordinatedPlatformLayerBufferYUV> create(Format, unsigned planeCount, std::array<unsigned, 4>&& planes, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace, TransferFunction, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
     static std::unique_ptr<CoordinatedPlatformLayerBufferYUV> create(Format, unsigned planeCount, Vector<RefPtr<BitmapTexture>, 4>&& textures, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace, TransferFunction, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
     CoordinatedPlatformLayerBufferYUV(Format, unsigned planeCount, std::array<unsigned, 4>&& planes, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace, TransferFunction, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
     CoordinatedPlatformLayerBufferYUV(Format, unsigned planeCount, Vector<RefPtr<BitmapTexture>, 4>&& textures, std::array<unsigned, 4>&& yuvPlane, std::array<unsigned, 4>&& yuvPlaneOffset, YuvToRgbColorSpace, TransferFunction, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
     virtual ~CoordinatedPlatformLayerBufferYUV();
-
-    const RefPtr<BitmapTexture>& texture(size_t index) const { RELEASE_ASSERT(index < m_planeCount); return m_textures[index]; }
+#endif
 
 private:
 #if USE(TEXTURE_MAPPER)
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 #else
-    sk_sp<SkImage> skiaImage() override;
+    sk_sp<SkImage> skiaImage() override { RELEASE_ASSERT_NOT_REACHED(); };
 #endif
 
+#if USE(TEXTURE_MAPPER)
     Format m_format { Format::AYUV };
     unsigned m_planeCount { 0 };
     Vector<RefPtr<BitmapTexture>, 4> m_textures;
@@ -60,10 +63,13 @@ private:
     std::array<unsigned, 4> m_yuvPlaneOffset;
     YuvToRgbColorSpace m_yuvToRgbColorSpace { YuvToRgbColorSpace::Bt601 };
     TransferFunction m_transferFunction { TransferFunction::Bt709 };
+#endif
 };
 
 } // namespace WebCore
 
+#if USE(TEXTURE_MAPPER)
 SPECIALIZE_TYPE_TRAITS_COORDINATED_PLATFORM_LAYER_BUFFER_TYPE(CoordinatedPlatformLayerBufferYUV, Type::YUV)
+#endif
 
 #endif // USE(COORDINATED_GRAPHICS)


### PR DESCRIPTION
#### cd04e05d1a61d6f90939d3c2cd1f0cd019796f9e
<pre>
[GTK][WPE] Skia compositor: use promise images for video buffers using GL memory
<a href="https://bugs.webkit.org/show_bug.cgi?id=323752">https://bugs.webkit.org/show_bug.cgi?id=323752</a>

Reviewed by Nikolas Zimmermann.

Stop using inner buffers for video buffers and use SkImage directly.
We only use an inner buffer for the case of qualcom video that will be
handled in the folow up commit. After this patch
CoordinatedPlatformLayerBufferYUV is no lnger used by the skia
compositor, but we still need to build it conditionally because we are
stil using a few class enums for the qualcom case.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::GstMappedFrame::glMemory const):
(WebCore::GstMappedFrame::textureID const):
(WebCore::GstMappedFrame::textureSize const):
(WebCore::GstMappedFrame::textureFormat const):
(WebCore::GstMappedFrame::waitSyncCPUIfNeeded const):
(WebCore::GstMappedFrame::waitForCPUSyncIfNeeded const):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
(WebCore::GstMappedFrame::setNeedsCPUSync):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp:
(WebCore::CoordinatedPlatformLayerBufferVideo::CoordinatedPlatformLayerBufferVideo):
(WebCore::CoordinatedPlatformLayerBufferVideo::createBufferIfNeeded):
(WebCore::CoordinatedPlatformLayerBufferVideo::createBufferFromDMABufMemory):
(WebCore::CoordinatedPlatformLayerBufferVideo::createBufferFromGLMemory):
(WebCore::CoordinatedPlatformLayerBufferVideo::createBufferFromMappedFrameIfNeeded):
(WebCore::PromiseGLVideoPlaneContext::PromiseGLVideoPlaneContext):
(WebCore::isSinglePlaneGLMemory):
(WebCore::CoordinatedPlatformLayerBufferVideo::createSkiaImageIfNeeded):
(WebCore::CoordinatedPlatformLayerBufferVideo::skiaImage):
(WebCore::CoordinatedPlatformLayerBufferVideo::createSkiaImageForQualcommDecoder):
(WebCore::CoordinatedPlatformLayerBufferVideo::createSkiaImageForDMABufMemory):
(WebCore::CoordinatedPlatformLayerBufferVideo::createSkiaImageForMainMemory):
(WebCore::CoordinatedPlatformLayerBufferVideo::createSkiaImageForGLMemory):
(WebCore::CoordinatedPlatformLayerBufferVideo::createSkiaImageForSinglePlaneGLMemory):
(WebCore::buildYUVAInfoFromMappedFrame):
(WebCore::CoordinatedPlatformLayerBufferVideo::createSkiaImageForYUVGLMemory):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp:
(WebCore::CoordinatedPlatformLayerBufferYUV::skiaImage): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.h:

Canonical link: <a href="https://commits.webkit.org/320901@main">https://commits.webkit.org/320901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d359cd4d50f168cbd7da69a638817df1982bab8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196300 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150625 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187868 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145356 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100756 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49025 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165893 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125671 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47763 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45760 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158117 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45477 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7371 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198277 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59560 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154903 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60269 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154548 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28273 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48993 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132596 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129651 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58716 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20477 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58107 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58337 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58165 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->