### PR TITLE
[WebDriver][BiDi] Support shared-worker realm lifecycle and enumeration

### DIFF
--- a/Source/WebCore/automation/AutomationInstrumentation.cpp
+++ b/Source/WebCore/automation/AutomationInstrumentation.cpp
@@ -105,6 +105,28 @@ void AutomationInstrumentation::scriptRealmDestroyed(FrameIdentifier frameID, DO
     });
 }
 
+void AutomationInstrumentation::scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier, const SecurityOriginData& origin)
+{
+    if (!automationClient()) [[likely]]
+        return;
+
+    WTF::ensureOnMainThread([workerIdentifier = workerIdentifier.isolatedCopy(), ownerFrameIdentifier, origin = origin.isolatedCopy()] {
+        if (RefPtr client = automationClient().get())
+            client->scriptDedicatedWorkerRealmCreated(workerIdentifier, ownerFrameIdentifier, origin);
+    });
+}
+
+void AutomationInstrumentation::scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier)
+{
+    if (!automationClient()) [[likely]]
+        return;
+
+    WTF::ensureOnMainThread([workerIdentifier = workerIdentifier.isolatedCopy(), ownerFrameIdentifier] {
+        if (RefPtr client = automationClient().get())
+            client->scriptDedicatedWorkerRealmDestroyed(workerIdentifier, ownerFrameIdentifier);
+    });
+}
+
 } // namespace WebCore
 
 #endif

--- a/Source/WebCore/automation/AutomationInstrumentation.cpp
+++ b/Source/WebCore/automation/AutomationInstrumentation.cpp
@@ -34,6 +34,9 @@
 #if ENABLE(WEBDRIVER_BIDI)
 
 #include "DOMWrapperWorld.h"
+#include "DocumentPage.h"
+#include "FrameDestructionObserverInlines.h"
+#include "WorkerInspectorProxy.h"
 #include <JavaScriptCore/ConsoleMessage.h>
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <wtf/NeverDestroyed.h>
@@ -125,6 +128,38 @@ void AutomationInstrumentation::scriptDedicatedWorkerRealmDestroyed(const String
         if (RefPtr client = automationClient().get())
             client->scriptDedicatedWorkerRealmDestroyed(workerIdentifier, ownerFrameIdentifier);
     });
+}
+
+Vector<AutomationInstrumentation::DedicatedWorkerRealmData> AutomationInstrumentation::dedicatedWorkerRealms(PageIdentifier pageIdentifier)
+{
+    Vector<DedicatedWorkerRealmData> result;
+
+    for (Ref worker : WorkerInspectorProxy::proxiesForPage(pageIdentifier)) {
+        if (!worker->isExecutionReady())
+            continue;
+
+        const auto& origin = worker->automationSecurityOrigin();
+        if (!origin)
+            continue;
+
+        RefPtr context = worker->scriptExecutionContext();
+        RefPtr document = dynamicDowncast<Document>(context.get());
+        if (!document)
+            continue;
+
+        RefPtr frame = document->frame();
+        RefPtr page = document->page();
+        if (!frame || !frame->isMainFrame() || !page || !page->isControlledByAutomation())
+            continue;
+
+        result.append(DedicatedWorkerRealmData {
+            worker->identifier().isolatedCopy(),
+            frame->frameID(),
+            origin->isolatedCopy()
+        });
+    }
+
+    return result;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/automation/AutomationInstrumentation.cpp
+++ b/Source/WebCore/automation/AutomationInstrumentation.cpp
@@ -36,6 +36,8 @@
 #include "DOMWrapperWorld.h"
 #include "DocumentPage.h"
 #include "FrameDestructionObserverInlines.h"
+#include "SharedWorkerContextManager.h"
+#include "SharedWorkerThreadProxy.h"
 #include "WorkerInspectorProxy.h"
 #include <JavaScriptCore/ConsoleMessage.h>
 #include <JavaScriptCore/ConsoleTypes.h>
@@ -155,6 +157,41 @@ Vector<AutomationInstrumentation::DedicatedWorkerRealmData> AutomationInstrument
         result.append(DedicatedWorkerRealmData {
             worker->identifier().isolatedCopy(),
             frame->frameID(),
+            origin->isolatedCopy()
+        });
+    }
+
+    return result;
+}
+
+void AutomationInstrumentation::scriptSharedWorkerRealmStateChanged(SharedWorkerIdentifier workerIdentifier, const Vector<FrameIdentifier>& activeOwnerFrameIdentifiers, const Vector<FrameIdentifier>& attachedOwnerFrameIdentifiers, const SecurityOriginData& origin)
+{
+    ASSERT(isMainThread());
+    if (RefPtr client = automationClient().get())
+        client->scriptSharedWorkerRealmStateChanged(workerIdentifier, activeOwnerFrameIdentifiers, attachedOwnerFrameIdentifiers, origin);
+}
+
+void AutomationInstrumentation::scriptSharedWorkerRealmDestroyed(SharedWorkerIdentifier workerIdentifier)
+{
+    ASSERT(isMainThread());
+    if (RefPtr client = automationClient().get())
+        client->scriptSharedWorkerRealmDestroyed(workerIdentifier);
+}
+
+Vector<AutomationInstrumentation::SharedWorkerRealmData> AutomationInstrumentation::sharedWorkerRealms()
+{
+    ASSERT(isMainThread());
+    Vector<SharedWorkerRealmData> result;
+
+    for (Ref worker : SharedWorkerContextManager::singleton().sharedWorkers()) {
+        const auto& origin = worker->automationSecurityOrigin();
+        if (!origin)
+            continue;
+
+        result.append(SharedWorkerRealmData {
+            worker->identifier(),
+            worker->activeOwnerFrameIdentifiers(),
+            worker->attachedOwnerFrameIdentifiers(),
             origin->isolatedCopy()
         });
     }

--- a/Source/WebCore/automation/AutomationInstrumentation.h
+++ b/Source/WebCore/automation/AutomationInstrumentation.h
@@ -59,6 +59,8 @@ public:
     virtual void addMessageToConsole(const JSC::MessageSource&, const JSC::MessageLevel&, const String&, const JSC::MessageType&, const WallTime&) = 0;
     virtual void scriptRealmCreated(FrameIdentifier, const SecurityOriginData&) = 0;
     virtual void scriptRealmDestroyed(FrameIdentifier) = 0;
+    virtual void scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier, const SecurityOriginData&) = 0;
+    virtual void scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier) = 0;
 };
 
 
@@ -70,6 +72,8 @@ public:
     static void addMessageToConsole(const std::unique_ptr<Inspector::ConsoleMessage>&);
     static void scriptRealmCreated(FrameIdentifier, const SecurityOriginData&, DOMWrapperWorld&);
     static void scriptRealmDestroyed(FrameIdentifier, DOMWrapperWorld&);
+    static void scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier, const SecurityOriginData&);
+    static void scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/automation/AutomationInstrumentation.h
+++ b/Source/WebCore/automation/AutomationInstrumentation.h
@@ -35,13 +35,16 @@
 #include <JavaScriptCore/ConsoleMessage.h>
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <WebCore/FrameIdentifier.h>
+#include <WebCore/PageIdentifier.h>
 #include <WebCore/SecurityOriginData.h>
+#include <tuple>
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Function.h>
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/RefPtr.h>
+#include <wtf/Vector.h>
 #include <wtf/WallTime.h>
 
 namespace Inspector {
@@ -66,6 +69,8 @@ public:
 
 class WEBCORE_EXPORT AutomationInstrumentation {
 public:
+    using DedicatedWorkerRealmData = std::tuple<String, FrameIdentifier, SecurityOriginData>;
+
     static void NODELETE setClient(const AutomationInstrumentationClient&);
     static void NODELETE clearClient();
 
@@ -74,6 +79,7 @@ public:
     static void scriptRealmDestroyed(FrameIdentifier, DOMWrapperWorld&);
     static void scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier, const SecurityOriginData&);
     static void scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier);
+    static Vector<DedicatedWorkerRealmData> dedicatedWorkerRealms(PageIdentifier);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/automation/AutomationInstrumentation.h
+++ b/Source/WebCore/automation/AutomationInstrumentation.h
@@ -37,6 +37,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/SecurityOriginData.h>
+#include <WebCore/SharedWorkerIdentifier.h>
 #include <tuple>
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/CompletionHandler.h>
@@ -64,6 +65,8 @@ public:
     virtual void scriptRealmDestroyed(FrameIdentifier) = 0;
     virtual void scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier, const SecurityOriginData&) = 0;
     virtual void scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier) = 0;
+    virtual void scriptSharedWorkerRealmStateChanged(SharedWorkerIdentifier, const Vector<FrameIdentifier>& activeOwnerFrameIdentifiers, const Vector<FrameIdentifier>& attachedOwnerFrameIdentifiers, const SecurityOriginData&) = 0;
+    virtual void scriptSharedWorkerRealmDestroyed(SharedWorkerIdentifier) = 0;
 };
 
 
@@ -71,6 +74,7 @@ class WEBCORE_EXPORT AutomationInstrumentation {
 public:
     using DedicatedWorkerRealmData = std::tuple<String, FrameIdentifier, SecurityOriginData>;
 
+    using SharedWorkerRealmData = std::tuple<SharedWorkerIdentifier, Vector<FrameIdentifier>, Vector<FrameIdentifier>, SecurityOriginData>;
     static void NODELETE setClient(const AutomationInstrumentationClient&);
     static void NODELETE clearClient();
 
@@ -80,6 +84,9 @@ public:
     static void scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier, const SecurityOriginData&);
     static void scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, FrameIdentifier ownerFrameIdentifier);
     static Vector<DedicatedWorkerRealmData> dedicatedWorkerRealms(PageIdentifier);
+    static void scriptSharedWorkerRealmStateChanged(SharedWorkerIdentifier, const Vector<FrameIdentifier>& activeOwnerFrameIdentifiers, const Vector<FrameIdentifier>& attachedOwnerFrameIdentifiers, const SecurityOriginData&);
+    static void scriptSharedWorkerRealmDestroyed(SharedWorkerIdentifier);
+    static Vector<SharedWorkerRealmData> sharedWorkerRealms();
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerInspectorProxy.cpp
+++ b/Source/WebCore/workers/WorkerInspectorProxy.cpp
@@ -26,7 +26,9 @@
 #include "config.h"
 #include "WorkerInspectorProxy.h"
 
+#include "AutomationInstrumentation.h"
 #include "DocumentPage.h"
+#include "FrameDestructionObserverInlines.h"
 #include "InspectorInstrumentation.h"
 #include "ScriptExecutionContext.h"
 #include "WorkerGlobalScope.h"
@@ -146,6 +148,25 @@ auto WorkerInspectorProxy::pageOrWorkerGlobalScopeIdentifier(ScriptExecutionCont
     return context.identifier();
 }
 
+#if ENABLE(WEBDRIVER_BIDI)
+static std::optional<FrameIdentifier> automationOwnerFrameIdentifier(const WorkerInspectorProxy& worker)
+{
+    // FIXME: Support dedicated workers owned by iframes and other workers once
+    // those owner realms are registered with the BiDi script agent.
+    RefPtr context = worker.scriptExecutionContext();
+    RefPtr document = dynamicDowncast<Document>(context.get());
+    if (!document)
+        return std::nullopt;
+
+    RefPtr frame = document->frame();
+    RefPtr page = document->page();
+    if (!frame || !frame->isMainFrame() || !page || !page->isControlledByAutomation())
+        return std::nullopt;
+
+    return frame->frameID();
+}
+#endif
+
 void WorkerInspectorProxy::workerStarted(ScriptExecutionContext& scriptExecutionContext, WorkerThread* thread, const URL& url, const String& name)
 {
     ASSERT(!m_workerThread);
@@ -155,9 +176,41 @@ void WorkerInspectorProxy::workerStarted(ScriptExecutionContext& scriptExecution
     m_workerThread = thread;
     m_url = url;
     m_name = name;
+    m_isExecutionReady = false;
+    m_wasTerminatedBeforeExecutionReady = false;
+    m_automationOwnerFrameIdentifier = std::nullopt;
+#if ENABLE(WEBDRIVER_BIDI)
+    m_automationOwnerFrameIdentifier = automationOwnerFrameIdentifier(*this);
+#endif
     addToProxyMap();
 
     InspectorInstrumentation::workerStarted(*this);
+}
+
+void WorkerInspectorProxy::workerBecameExecutionReady(const SecurityOriginData& origin)
+{
+    ASSERT(!m_scriptExecutionContext || m_scriptExecutionContext->isContextThread());
+    ASSERT(m_workerThread || m_wasTerminatedBeforeExecutionReady);
+    if (m_isExecutionReady)
+        return;
+
+    m_isExecutionReady = true;
+
+#if ENABLE(WEBDRIVER_BIDI)
+    if (m_automationOwnerFrameIdentifier) {
+        AutomationInstrumentation::scriptDedicatedWorkerRealmCreated(m_identifier, *m_automationOwnerFrameIdentifier, origin);
+        if (m_wasTerminatedBeforeExecutionReady)
+            AutomationInstrumentation::scriptDedicatedWorkerRealmDestroyed(m_identifier, *m_automationOwnerFrameIdentifier);
+    }
+#else
+    UNUSED_PARAM(origin);
+#endif
+
+    if (m_wasTerminatedBeforeExecutionReady) {
+        m_isExecutionReady = false;
+        m_wasTerminatedBeforeExecutionReady = false;
+        m_automationOwnerFrameIdentifier = std::nullopt;
+    }
 }
 
 void WorkerInspectorProxy::workerTerminated()
@@ -165,6 +218,17 @@ void WorkerInspectorProxy::workerTerminated()
     if (!m_workerThread)
         return;
 
+#if ENABLE(WEBDRIVER_BIDI)
+    if (m_isExecutionReady && m_automationOwnerFrameIdentifier)
+        AutomationInstrumentation::scriptDedicatedWorkerRealmDestroyed(m_identifier, *m_automationOwnerFrameIdentifier);
+#endif
+
+    if (!m_isExecutionReady)
+        m_wasTerminatedBeforeExecutionReady = true;
+
+    m_isExecutionReady = false;
+    if (!m_wasTerminatedBeforeExecutionReady)
+        m_automationOwnerFrameIdentifier = std::nullopt;
     InspectorInstrumentation::workerTerminated(*this);
     removeFromProxyMap();
 

--- a/Source/WebCore/workers/WorkerInspectorProxy.cpp
+++ b/Source/WebCore/workers/WorkerInspectorProxy.cpp
@@ -179,6 +179,7 @@ void WorkerInspectorProxy::workerStarted(ScriptExecutionContext& scriptExecution
     m_isExecutionReady = false;
     m_wasTerminatedBeforeExecutionReady = false;
     m_automationOwnerFrameIdentifier = std::nullopt;
+    m_automationSecurityOrigin = std::nullopt;
 #if ENABLE(WEBDRIVER_BIDI)
     m_automationOwnerFrameIdentifier = automationOwnerFrameIdentifier(*this);
 #endif
@@ -194,22 +195,28 @@ void WorkerInspectorProxy::workerBecameExecutionReady(const SecurityOriginData& 
     if (m_isExecutionReady)
         return;
 
+#if ENABLE(WEBDRIVER_BIDI)
+    if (m_automationOwnerFrameIdentifier)
+        m_automationSecurityOrigin = origin.isolatedCopy();
+#else
+    UNUSED_PARAM(origin);
+#endif
+
     m_isExecutionReady = true;
 
 #if ENABLE(WEBDRIVER_BIDI)
     if (m_automationOwnerFrameIdentifier) {
-        AutomationInstrumentation::scriptDedicatedWorkerRealmCreated(m_identifier, *m_automationOwnerFrameIdentifier, origin);
+        AutomationInstrumentation::scriptDedicatedWorkerRealmCreated(m_identifier, *m_automationOwnerFrameIdentifier, *m_automationSecurityOrigin);
         if (m_wasTerminatedBeforeExecutionReady)
             AutomationInstrumentation::scriptDedicatedWorkerRealmDestroyed(m_identifier, *m_automationOwnerFrameIdentifier);
     }
-#else
-    UNUSED_PARAM(origin);
 #endif
 
     if (m_wasTerminatedBeforeExecutionReady) {
         m_isExecutionReady = false;
         m_wasTerminatedBeforeExecutionReady = false;
         m_automationOwnerFrameIdentifier = std::nullopt;
+        m_automationSecurityOrigin = std::nullopt;
     }
 }
 
@@ -227,8 +234,10 @@ void WorkerInspectorProxy::workerTerminated()
         m_wasTerminatedBeforeExecutionReady = true;
 
     m_isExecutionReady = false;
-    if (!m_wasTerminatedBeforeExecutionReady)
+    if (!m_wasTerminatedBeforeExecutionReady) {
         m_automationOwnerFrameIdentifier = std::nullopt;
+        m_automationSecurityOrigin = std::nullopt;
+    }
     InspectorInstrumentation::workerTerminated(*this);
     removeFromProxyMap();
 

--- a/Source/WebCore/workers/WorkerInspectorProxy.h
+++ b/Source/WebCore/workers/WorkerInspectorProxy.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "FrameIdentifier.h"
 #include "PageIdentifier.h"
 #include "ScriptExecutionContextIdentifier.h"
 #include <wtf/CheckedPtr.h>
@@ -43,6 +44,7 @@
 namespace WebCore {
 
 class ScriptExecutionContext;
+class SecurityOriginData;
 class WorkerThread;
 
 enum class WorkerThreadStartMode;
@@ -81,7 +83,9 @@ public:
 
     WorkerThreadStartMode workerStartMode(ScriptExecutionContext&);
     void workerStarted(ScriptExecutionContext&, WorkerThread*, const URL&, const String& name);
+    void workerBecameExecutionReady(const SecurityOriginData&);
     void workerTerminated();
+    bool isExecutionReady() const { return m_isExecutionReady; }
 
     void resumeWorkerIfPaused();
     void connectToWorkerInspectorController(PageChannel&);
@@ -105,6 +109,9 @@ private:
     URL m_url;
     String m_name;
     CheckedPtr<PageChannel> m_pageChannel;
+    bool m_isExecutionReady { false };
+    bool m_wasTerminatedBeforeExecutionReady { false };
+    std::optional<FrameIdentifier> m_automationOwnerFrameIdentifier;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerInspectorProxy.h
+++ b/Source/WebCore/workers/WorkerInspectorProxy.h
@@ -28,6 +28,7 @@
 #include "FrameIdentifier.h"
 #include "PageIdentifier.h"
 #include "ScriptExecutionContextIdentifier.h"
+#include "SecurityOriginData.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/FastMalloc.h>
@@ -86,6 +87,7 @@ public:
     void workerBecameExecutionReady(const SecurityOriginData&);
     void workerTerminated();
     bool isExecutionReady() const { return m_isExecutionReady; }
+    const std::optional<SecurityOriginData>& automationSecurityOrigin() const { return m_automationSecurityOrigin; }
 
     void resumeWorkerIfPaused();
     void connectToWorkerInspectorController(PageChannel&);
@@ -112,6 +114,7 @@ private:
     bool m_isExecutionReady { false };
     bool m_wasTerminatedBeforeExecutionReady { false };
     std::optional<FrameIdentifier> m_automationOwnerFrameIdentifier;
+    std::optional<SecurityOriginData> m_automationSecurityOrigin;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -49,6 +49,7 @@
 #include "Page.h"
 #include "PlatformStrategies.h"
 #include "ScriptExecutionContext.h"
+#include "SecurityOriginData.h"
 #include "Settings.h"
 #include "SocketProvider.h"
 #include "StorageConnection.h"
@@ -186,7 +187,9 @@ void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::Ses
     }
 
     workerThreadCreated(thread.get());
-    thread->start();
+    thread->WorkerOrWorkletThread::start({ }, [this](SecurityOriginData&& origin) {
+        workerGlobalScopeCreated(WTF::move(origin));
+    });
 
     m_inspectorProxy->workerStarted(*scriptExecutionContext, thread.ptr(), scriptURL, name);
 }
@@ -459,6 +462,16 @@ void WorkerMessagingProxy::workerGlobalScopeDestroyed()
 
     ScriptExecutionContext::postTaskTo(*m_scriptExecutionContextIdentifier, [this](auto&) {
         workerGlobalScopeDestroyedInternal();
+    });
+}
+
+void WorkerMessagingProxy::workerGlobalScopeCreated(SecurityOriginData&& origin)
+{
+    if (!m_scriptExecutionContextIdentifier)
+        return;
+
+    ScriptExecutionContext::postTaskTo(*m_scriptExecutionContextIdentifier, [this, protectedThis = Ref { *this }, origin = WTF::move(origin).isolatedCopy()](auto&) {
+        m_inspectorProxy->workerBecameExecutionReady(origin);
     });
 }
 

--- a/Source/WebCore/workers/WorkerMessagingProxy.h
+++ b/Source/WebCore/workers/WorkerMessagingProxy.h
@@ -39,6 +39,7 @@
 namespace WebCore {
 
 class DedicatedWorkerThread;
+class SecurityOriginData;
 class WeakPtrImplWithEventTargetData;
 class WorkerInspectorProxy;
 class WorkerUserGestureForwarder;
@@ -76,6 +77,7 @@ private:
     void reportErrorToWorkerObject(const String&) final;
     void workerGlobalScopeClosed() final;
     void workerGlobalScopeDestroyed() final;
+    void workerGlobalScopeCreated(SecurityOriginData&&);
 
     // Implementation of WorkerDebuggerProxy.
     // (Only use these functions in the worker context thread.)

--- a/Source/WebCore/workers/WorkerOrWorkletThread.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WorkerOrWorkletThread.h"
 
+#include "SecurityOrigin.h"
 #include "ThreadGlobalData.h"
 #include "WorkerEventLoop.h"
 #include "WorkerLoaderProxy.h"
@@ -121,6 +122,9 @@ void WorkerOrWorkletThread::workerOrWorkletThread()
 
         downcast<WorkerMainRunLoop>(m_runLoop.get()).setGlobalScope(*globalScope());
 
+        if (auto callback = WTF::move(m_globalScopeCreatedCallback))
+            callback(protect(globalScope())->securityOrigin()->data().isolatedCopy());
+
         String exceptionMessage;
         evaluateScriptIfNecessary(exceptionMessage);
 
@@ -164,6 +168,9 @@ void WorkerOrWorkletThread::workerOrWorkletThread()
             scriptController->forbidExecution();
         }
     }
+
+    if (auto callback = WTF::move(m_globalScopeCreatedCallback))
+        callback(protect(globalScope())->securityOrigin()->data().isolatedCopy());
 
     if (shouldWaitForWebInspectorOnStartup()) {
         startRunningDebuggerTasks();
@@ -237,7 +244,7 @@ void WorkerOrWorkletThread::destroyWorkerGlobalScope(Ref<WorkerOrWorkletThread>&
     protector->detach();
 }
 
-void WorkerOrWorkletThread::start(Function<void(const String&)>&& evaluateCallback)
+void WorkerOrWorkletThread::start(Function<void(const String&)>&& evaluateCallback, Function<void(SecurityOriginData&&)>&& globalScopeCreatedCallback)
 {
     // Mutex protection is necessary to ensure that m_thread is initialized when the thread starts.
     Locker locker { m_threadCreationAndGlobalScopeLock };
@@ -246,6 +253,7 @@ void WorkerOrWorkletThread::start(Function<void(const String&)>&& evaluateCallba
         return;
 
     m_evaluateCallback = WTF::move(evaluateCallback);
+    m_globalScopeCreatedCallback = WTF::move(globalScopeCreatedCallback);
 
     auto thread = createThread();
 

--- a/Source/WebCore/workers/WorkerOrWorkletThread.h
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.h
@@ -44,6 +44,7 @@ class Thread;
 
 namespace WebCore {
 
+class SecurityOriginData;
 class WorkerDebuggerProxy;
 class WorkerLoaderProxy;
 
@@ -65,7 +66,7 @@ public:
     WorkerOrWorkletGlobalScope* globalScope() const { return m_globalScope.get(); }
     WorkerRunLoop& runLoop() LIFETIME_BOUND { return m_runLoop; }
 
-    void start(Function<void(const String&)>&& evaluateCallback = { });
+    void start(Function<void(const String&)>&& evaluateCallback = { }, Function<void(SecurityOriginData&&)>&& globalScopeCreatedCallback = { });
     void stop(Function<void()>&& terminatedCallback = { });
 
     void startRunningDebuggerTasks();
@@ -108,6 +109,7 @@ private:
     RefPtr<Thread> m_thread;
     const UniqueRef<WorkerRunLoop> m_runLoop;
     Function<void(const String&)> m_evaluateCallback;
+    Function<void(SecurityOriginData&&)> m_globalScopeCreatedCallback;
     Function<void()> m_stoppedCallback;
     BinarySemaphore m_suspensionSemaphore;
     ThreadSafeWeakHashSet<WorkerOrWorkletThread> m_childThreads;

--- a/Source/WebCore/workers/shared/SharedWorker.cpp
+++ b/Source/WebCore/workers/shared/SharedWorker.cpp
@@ -89,6 +89,10 @@ ExceptionOr<Ref<SharedWorker>> SharedWorker::create(Document& document, Variant<
     if (!document.hasBrowsingContext())
         return Exception { ExceptionCode::InvalidStateError, "No browsing context"_s };
 
+    auto ownerFrameIdentifier = document.frameID();
+    if (!ownerFrameIdentifier)
+        return Exception { ExceptionCode::InvalidStateError, "No owner frame"_s };
+
     auto url = document.encodingParseURL(compliantScriptURLString.releaseReturnValue());
     if (!url.isValid())
         return Exception { ExceptionCode::SyntaxError, "Invalid script URL"_s };
@@ -121,7 +125,7 @@ ExceptionOr<Ref<SharedWorker>> SharedWorker::create(Document& document, Variant<
         return sharedWorker;
     }
 
-    protect(sharedWorkerMainThreadConnection())->requestSharedWorker(key, sharedWorker->identifier(), WTF::move(transferredPort), options);
+    protect(sharedWorkerMainThreadConnection())->requestSharedWorker(key, sharedWorker->identifier(), *ownerFrameIdentifier, WTF::move(transferredPort), options);
     return sharedWorker;
 }
 

--- a/Source/WebCore/workers/shared/SharedWorkerObjectConnection.h
+++ b/Source/WebCore/workers/shared/SharedWorkerObjectConnection.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/SharedWorkerObjectIdentifier.h>
 #include <WebCore/TransferredMessagePort.h>
 #include <wtf/Forward.h>
@@ -46,7 +47,7 @@ class SharedWorkerObjectConnection : public RefCounted<SharedWorkerObjectConnect
 public:
     WEBCORE_EXPORT virtual ~SharedWorkerObjectConnection();
 
-    virtual void requestSharedWorker(const SharedWorkerKey&, SharedWorkerObjectIdentifier, TransferredMessagePort&&, const WorkerOptions&) = 0;
+    virtual void requestSharedWorker(const SharedWorkerKey&, SharedWorkerObjectIdentifier, FrameIdentifier ownerFrameIdentifier, TransferredMessagePort&&, const WorkerOptions&) = 0;
     virtual void sharedWorkerObjectIsGoingAway(const SharedWorkerKey&, SharedWorkerObjectIdentifier) = 0;
     virtual void suspendForBackForwardCache(const SharedWorkerKey&, SharedWorkerObjectIdentifier) = 0;
     virtual void resumeForBackForwardCache(const SharedWorkerKey&, SharedWorkerObjectIdentifier) = 0;

--- a/Source/WebCore/workers/shared/context/SharedWorkerContextManager.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerContextManager.cpp
@@ -49,6 +49,15 @@ SharedWorkerThreadProxy* SharedWorkerContextManager::sharedWorker(SharedWorkerId
     return m_workerMap.get(sharedWorkerIdentifier);
 }
 
+Vector<Ref<SharedWorkerThreadProxy>> SharedWorkerContextManager::sharedWorkers() const
+{
+    Vector<Ref<SharedWorkerThreadProxy>> result;
+    result.reserveInitialCapacity(m_workerMap.size());
+    for (Ref worker : m_workerMap.values())
+        result.append(WTF::move(worker));
+    return result;
+}
+
 void SharedWorkerContextManager::stopSharedWorker(SharedWorkerIdentifier sharedWorkerIdentifier)
 {
     auto worker = m_workerMap.take(sharedWorkerIdentifier);
@@ -61,14 +70,16 @@ void SharedWorkerContextManager::stopSharedWorker(SharedWorkerIdentifier sharedW
     // FIXME: We should be able to deal with the thread being unresponsive here.
 
     Ref thread = worker->thread();
-    thread->stop([worker = WTF::move(worker)]() mutable {
+    thread->stop([worker = WTF::move(worker), sharedWorkerIdentifier]() mutable {
+        ASSERT(isMainThread());
+        worker->workerTerminated();
+        if (RefPtr connection = SharedWorkerContextManager::singleton().connection())
+            connection->sharedWorkerTerminated(sharedWorkerIdentifier);
+
         // Spin the runloop before releasing the shared worker thread proxy, as there would otherwise be
         // a race towards its destruction.
         callOnMainThread([worker = WTF::move(worker)] { });
     });
-
-    if (RefPtr connection = SharedWorkerContextManager::singleton().connection())
-        connection->sharedWorkerTerminated(sharedWorkerIdentifier);
 }
 
 void SharedWorkerContextManager::suspendSharedWorker(SharedWorkerIdentifier sharedWorkerIdentifier)
@@ -112,7 +123,13 @@ void SharedWorkerContextManager::registerSharedWorkerThread(Ref<SharedWorkerThre
     auto result = m_workerMap.add(proxy->identifier(), proxy.copyRef());
     ASSERT_UNUSED(result, result.isNewEntry);
 
-    proxy->thread().start([](const String& /*exceptionMessage*/) { });
+    auto weakProxy = ThreadSafeWeakPtr { proxy.get() };
+    proxy->thread().start([](const String& /* exceptionMessage */) { }, [weakProxy = WTF::move(weakProxy)](SecurityOriginData&& origin) mutable {
+        callOnMainThread([weakProxy = WTF::move(weakProxy), origin = WTF::move(origin)]() mutable {
+            if (RefPtr proxy = weakProxy.get())
+                proxy->workerBecameExecutionReady(WTF::move(origin));
+        });
+    });
 }
 
 void SharedWorkerContextManager::Connection::postConnectEvent(SharedWorkerIdentifier sharedWorkerIdentifier, TransferredMessagePort&& transferredPort, const SecurityOriginData& sourceOrigin, CompletionHandler<void(bool)>&& completionHandler)
@@ -128,6 +145,13 @@ void SharedWorkerContextManager::Connection::postConnectEvent(SharedWorkerIdenti
         downcast<SharedWorkerGlobalScope>(scriptExecutionContext).postConnectEvent(WTF::move(transferredPort), sourceOrigin);
     });
     completionHandler(true);
+}
+
+void SharedWorkerContextManager::Connection::setSharedWorkerOwnerFrameIdentifiers(SharedWorkerIdentifier sharedWorkerIdentifier, Vector<FrameIdentifier>&& activeOwnerFrameIdentifiers, Vector<FrameIdentifier>&& attachedOwnerFrameIdentifiers)
+{
+    ASSERT(isMainThread());
+    if (RefPtr proxy = SharedWorkerContextManager::singleton().sharedWorker(sharedWorkerIdentifier))
+        proxy->setOwnerFrameIdentifiers(WTF::move(activeOwnerFrameIdentifiers), WTF::move(attachedOwnerFrameIdentifiers));
 }
 
 void SharedWorkerContextManager::Connection::terminateSharedWorker(SharedWorkerIdentifier sharedWorkerIdentifier)

--- a/Source/WebCore/workers/shared/context/SharedWorkerContextManager.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerContextManager.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/SharedWorkerIdentifier.h>
 #include <WebCore/TransferredMessagePort.h>
 #include <wtf/AbstractRefCounted.h>
@@ -43,6 +44,7 @@ public:
     WEBCORE_EXPORT static SharedWorkerContextManager& NODELETE singleton();
 
     SharedWorkerThreadProxy* sharedWorker(SharedWorkerIdentifier) const;
+    Vector<Ref<SharedWorkerThreadProxy>> sharedWorkers() const;
     void stopSharedWorker(SharedWorkerIdentifier);
     void suspendSharedWorker(SharedWorkerIdentifier);
     void resumeSharedWorker(SharedWorkerIdentifier);
@@ -63,6 +65,7 @@ public:
 
         // IPC message handlers.
         WEBCORE_EXPORT void postConnectEvent(SharedWorkerIdentifier, TransferredMessagePort&&, const SecurityOriginData& sourceOrigin, CompletionHandler<void(bool)>&&);
+        WEBCORE_EXPORT void setSharedWorkerOwnerFrameIdentifiers(SharedWorkerIdentifier, Vector<FrameIdentifier>&& activeOwnerFrameIdentifiers, Vector<FrameIdentifier>&& attachedOwnerFrameIdentifiers);
         WEBCORE_EXPORT void terminateSharedWorker(SharedWorkerIdentifier);
         WEBCORE_EXPORT void suspendSharedWorker(SharedWorkerIdentifier);
         WEBCORE_EXPORT void resumeSharedWorker(SharedWorkerIdentifier);

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "SharedWorkerThreadProxy.h"
 
+#include "AutomationInstrumentation.h"
 #include "BadgeClient.h"
 #include "CacheStorageProvider.h"
 #include "Chrome.h"
@@ -104,12 +105,14 @@ bool SharedWorkerThreadProxy::hasInstances()
     return !allSharedWorkerThreadProxies().isEmpty();
 }
 
-SharedWorkerThreadProxy::SharedWorkerThreadProxy(Ref<Page>&& page, SharedWorkerIdentifier sharedWorkerIdentifier, const ClientOrigin& clientOrigin, WorkerFetchResult&& workerFetchResult, WorkerOptions&& workerOptions, WorkerInitializationData&& initializationData, CacheStorageProvider& cacheStorageProvider)
+SharedWorkerThreadProxy::SharedWorkerThreadProxy(Ref<Page>&& page, SharedWorkerIdentifier sharedWorkerIdentifier, const ClientOrigin& clientOrigin, WorkerFetchResult&& workerFetchResult, WorkerOptions&& workerOptions, WorkerInitializationData&& initializationData, Vector<FrameIdentifier>&& activeOwnerFrameIdentifiers, Vector<FrameIdentifier>&& attachedOwnerFrameIdentifiers, CacheStorageProvider& cacheStorageProvider)
     : m_page(WTF::move(page))
     , m_document(*m_page->localTopDocument())
     , m_contextIdentifier(*initializationData.clientIdentifier)
     , m_workerThread(SharedWorkerThread::create(sharedWorkerIdentifier, generateWorkerParameters(workerFetchResult, WTF::move(workerOptions), WTF::move(initializationData), m_document), WTF::move(workerFetchResult.script), *this, *this, *this, *this, WorkerThreadStartMode::Normal, clientOrigin.topOrigin.securityOrigin(), protect(m_document->idbConnectionProxy()).get(), protect(m_document->socketProvider()).get(), JSC::RuntimeFlags::createAllEnabled()))
     , m_cacheStorageProvider(cacheStorageProvider)
+    , m_activeOwnerFrameIdentifiers(WTF::move(activeOwnerFrameIdentifiers))
+    , m_attachedOwnerFrameIdentifiers(WTF::move(attachedOwnerFrameIdentifiers))
     , m_clientOrigin(clientOrigin)
 {
     ASSERT(!allSharedWorkerThreadProxies().contains(m_contextIdentifier));
@@ -136,6 +139,39 @@ SharedWorkerThreadProxy::~SharedWorkerThreadProxy()
 SharedWorkerIdentifier SharedWorkerThreadProxy::identifier() const
 {
     return m_workerThread->identifier();
+}
+
+void SharedWorkerThreadProxy::setOwnerFrameIdentifiers(Vector<FrameIdentifier>&& activeOwnerFrameIdentifiers, Vector<FrameIdentifier>&& attachedOwnerFrameIdentifiers)
+{
+    ASSERT(isMainThread());
+    m_activeOwnerFrameIdentifiers = WTF::move(activeOwnerFrameIdentifiers);
+    m_attachedOwnerFrameIdentifiers = WTF::move(attachedOwnerFrameIdentifiers);
+#if ENABLE(WEBDRIVER_BIDI)
+    if (isExecutionReady())
+        AutomationInstrumentation::scriptSharedWorkerRealmStateChanged(identifier(), m_activeOwnerFrameIdentifiers, m_attachedOwnerFrameIdentifiers, *m_automationSecurityOrigin);
+#endif
+}
+
+void SharedWorkerThreadProxy::workerBecameExecutionReady(SecurityOriginData&& origin)
+{
+    ASSERT(isMainThread());
+    if (isExecutionReady() || isTerminatingOrTerminated())
+        return;
+
+    m_automationSecurityOrigin = WTF::move(origin);
+#if ENABLE(WEBDRIVER_BIDI)
+    AutomationInstrumentation::scriptSharedWorkerRealmStateChanged(identifier(), m_activeOwnerFrameIdentifiers, m_attachedOwnerFrameIdentifiers, *m_automationSecurityOrigin);
+#endif
+}
+
+void SharedWorkerThreadProxy::workerTerminated()
+{
+    ASSERT(isMainThread());
+#if ENABLE(WEBDRIVER_BIDI)
+    if (isExecutionReady())
+        AutomationInstrumentation::scriptSharedWorkerRealmDestroyed(identifier());
+#endif
+    m_automationSecurityOrigin = std::nullopt;
 }
 
 void SharedWorkerThreadProxy::notifyNetworkStateChange(bool isOnline)

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include <WebCore/ClientOrigin.h>
+#include <WebCore/FrameIdentifier.h>
+#include <WebCore/SecurityOriginData.h>
 #include <WebCore/SharedWorkerIdentifier.h>
 #include <WebCore/WorkerBadgeProxy.h>
 #include <WebCore/WorkerDebuggerProxy.h>
@@ -34,6 +36,7 @@
 #include <WebCore/WorkerOptions.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/Vector.h>
 
 namespace WebCore {
 
@@ -58,6 +61,15 @@ public:
     SharedWorkerIdentifier NODELETE identifier() const;
     SharedWorkerThread& thread() { return m_workerThread; }
 
+    const Vector<FrameIdentifier>& activeOwnerFrameIdentifiers() const { return m_activeOwnerFrameIdentifiers; }
+    const Vector<FrameIdentifier>& attachedOwnerFrameIdentifiers() const { return m_attachedOwnerFrameIdentifiers; }
+    void setOwnerFrameIdentifiers(Vector<FrameIdentifier>&&, Vector<FrameIdentifier>&&);
+
+    bool isExecutionReady() const { return !!m_automationSecurityOrigin; }
+    const std::optional<SecurityOriginData>& automationSecurityOrigin() const { return m_automationSecurityOrigin; }
+    void workerBecameExecutionReady(SecurityOriginData&&);
+    void workerTerminated();
+
     bool isTerminatingOrTerminated() const { return m_isTerminatingOrTerminated; }
     void setAsTerminatingOrTerminated() { m_isTerminatingOrTerminated = true; }
 
@@ -68,7 +80,7 @@ public:
     void setDidBeginCheckedPtrDeletion() final { CanMakeThreadSafeCheckedPtr<SharedWorkerThreadProxy>::setDidBeginCheckedPtrDeletion(); }
 
 private:
-    WEBCORE_EXPORT SharedWorkerThreadProxy(Ref<Page>&&, SharedWorkerIdentifier, const ClientOrigin&, WorkerFetchResult&&, WorkerOptions&&, WorkerInitializationData&&, CacheStorageProvider&);
+    WEBCORE_EXPORT SharedWorkerThreadProxy(Ref<Page>&&, SharedWorkerIdentifier, const ClientOrigin&, WorkerFetchResult&&, WorkerOptions&&, WorkerInitializationData&&, Vector<FrameIdentifier>&& activeOwnerFrameIdentifiers, Vector<FrameIdentifier>&& attachedOwnerFrameIdentifiers, CacheStorageProvider&);
 
     bool postTaskForModeToWorkerOrWorkletGlobalScope(ScriptExecutionContext::Task&&, const String& mode);
 
@@ -106,6 +118,9 @@ private:
     WeakRef<CacheStorageProvider> m_cacheStorageProvider;
     RefPtr<CacheStorageConnection> m_cacheStorageConnection;
     bool m_isTerminatingOrTerminated { false };
+    Vector<FrameIdentifier> m_activeOwnerFrameIdentifiers;
+    Vector<FrameIdentifier> m_attachedOwnerFrameIdentifiers;
+    std::optional<SecurityOriginData> m_automationSecurityOrigin;
     ClientOrigin m_clientOrigin;
 };
 

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
@@ -30,6 +30,7 @@
 #include "WebSharedWorkerServerToContextConnection.h"
 #include <WebCore/Site.h>
 #include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -107,19 +108,22 @@ void WebSharedWorker::launch(WebSharedWorkerServerToContextConnection& connectio
         connection.suspendSharedWorker(identifier());
 }
 
-void WebSharedWorker::addSharedWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, const WebCore::TransferredMessagePort& port)
+void WebSharedWorker::addSharedWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, const WebCore::TransferredMessagePort& port)
 {
-    ASSERT(!m_sharedWorkerObjects.contains({ sharedWorkerObjectIdentifier, { false, port } }));
-    m_sharedWorkerObjects.add({ sharedWorkerObjectIdentifier, { false, port } });
+    ASSERT(!m_sharedWorkerObjects.contains({ sharedWorkerObjectIdentifier, { } }));
+    m_sharedWorkerObjects.add({ sharedWorkerObjectIdentifier, { ownerFrameIdentifier, false, port } });
     if (RefPtr connection = contextConnection())
         connection->addSharedWorkerObject(sharedWorkerObjectIdentifier);
+    sendOwnerFrameIdentifiers();
 
     resumeIfNeeded();
 }
 
 void WebSharedWorker::removeSharedWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier)
 {
-    m_sharedWorkerObjects.remove({ sharedWorkerObjectIdentifier, { } });
+    bool didRemove = m_sharedWorkerObjects.remove({ sharedWorkerObjectIdentifier, { } });
+    ASSERT_UNUSED(didRemove, didRemove);
+    sendOwnerFrameIdentifiers();
     if (RefPtr connection = contextConnection())
         connection->removeSharedWorkerObject(sharedWorkerObjectIdentifier);
 
@@ -132,7 +136,12 @@ void WebSharedWorker::suspend(WebCore::SharedWorkerObjectIdentifier sharedWorker
     if (iterator == m_sharedWorkerObjects.end())
         return;
 
+    if (iterator->state.isSuspended)
+        return;
+
     iterator->state.isSuspended = true;
+    sendOwnerFrameIdentifiers();
+
     ASSERT(!m_isSuspended);
     suspendIfNeeded();
 }
@@ -158,7 +167,12 @@ void WebSharedWorker::resume(WebCore::SharedWorkerObjectIdentifier sharedWorkerO
     if (iterator == m_sharedWorkerObjects.end())
         return;
 
+    if (!iterator->state.isSuspended)
+        return;
+
     iterator->state.isSuspended = false;
+    sendOwnerFrameIdentifiers();
+
     resumeIfNeeded();
 }
 
@@ -176,6 +190,26 @@ void WebSharedWorker::forEachSharedWorkerObject(NOESCAPE const Function<void(Web
 {
     for (auto& object : m_sharedWorkerObjects)
         apply(object.identifier, *object.state.port);
+}
+
+Vector<WebCore::FrameIdentifier> WebSharedWorker::ownerFrameIdentifiers(OwnerFrameFilter ownerFrameFilter) const
+{
+    Vector<WebCore::FrameIdentifier> result;
+    HashSet<WebCore::FrameIdentifier> seenFrameIdentifiers;
+    for (auto& object : m_sharedWorkerObjects) {
+        if (ownerFrameFilter == OwnerFrameFilter::ActiveOnly && object.state.isSuspended)
+            continue;
+        RELEASE_ASSERT(object.state.ownerFrameIdentifier);
+        if (seenFrameIdentifiers.add(*object.state.ownerFrameIdentifier).isNewEntry)
+            result.append(*object.state.ownerFrameIdentifier);
+    }
+    return result;
+}
+
+void WebSharedWorker::sendOwnerFrameIdentifiers() const
+{
+    if (RefPtr connection = contextConnection(); connection && isRunning())
+        connection->updateSharedWorkerOwnerFrameIdentifiers(*this);
 }
 
 std::optional<WebCore::ProcessIdentifier> WebSharedWorker::firstSharedWorkerObjectProcess() const

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/SharedWorkerIdentifier.h>
 #include <WebCore/SharedWorkerKey.h>
 #include <WebCore/SharedWorkerObjectIdentifier.h>
@@ -37,6 +38,7 @@
 #include <wtf/ListHashSet.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebKit {
@@ -70,12 +72,14 @@ public:
     WebCore::Site topSite() const;
     WebSharedWorkerServerToContextConnection* contextConnection() const;
 
-    void addSharedWorkerObject(WebCore::SharedWorkerObjectIdentifier, const WebCore::TransferredMessagePort&);
+    void addSharedWorkerObject(WebCore::SharedWorkerObjectIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, const WebCore::TransferredMessagePort&);
     void removeSharedWorkerObject(WebCore::SharedWorkerObjectIdentifier);
     void suspend(WebCore::SharedWorkerObjectIdentifier);
     void resume(WebCore::SharedWorkerObjectIdentifier);
     unsigned sharedWorkerObjectsCount() const { return m_sharedWorkerObjects.size(); }
     void forEachSharedWorkerObject(NOESCAPE const Function<void(WebCore::SharedWorkerObjectIdentifier, const WebCore::TransferredMessagePort&)>&) const;
+    Vector<WebCore::FrameIdentifier> activeOwnerFrameIdentifiers() const { return ownerFrameIdentifiers(OwnerFrameFilter::ActiveOnly); }
+    Vector<WebCore::FrameIdentifier> attachedOwnerFrameIdentifiers() const { return ownerFrameIdentifiers(OwnerFrameFilter::AllAttached); }
     std::optional<WebCore::ProcessIdentifier> NODELETE firstSharedWorkerObjectProcess() const;
 
     void didCreateContextConnection(WebSharedWorkerServerToContextConnection&);
@@ -93,6 +97,7 @@ public:
     void launch(WebSharedWorkerServerToContextConnection&);
 
     struct SharedWorkerObjectState {
+        std::optional<WebCore::FrameIdentifier> ownerFrameIdentifier;
         bool isSuspended { false };
         std::optional<WebCore::TransferredMessagePort> port;
     };
@@ -112,6 +117,9 @@ private:
 
     void suspendIfNeeded();
     void resumeIfNeeded();
+    enum class OwnerFrameFilter : bool { ActiveOnly, AllAttached };
+    Vector<WebCore::FrameIdentifier> ownerFrameIdentifiers(OwnerFrameFilter) const;
+    void sendOwnerFrameIdentifiers() const;
 
     WeakPtr<WebSharedWorkerServer> m_server;
     WebCore::SharedWorkerKey m_key;

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
@@ -57,7 +57,7 @@ PAL::SessionID WebSharedWorkerServer::sessionID()
     return m_session->sessionID();
 }
 
-void WebSharedWorkerServer::requestSharedWorker(WebCore::SharedWorkerKey&& sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::TransferredMessagePort&& port, WebCore::WorkerOptions&& workerOptions)
+void WebSharedWorkerServer::requestSharedWorker(WebCore::SharedWorkerKey&& sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, WebCore::TransferredMessagePort&& port, WebCore::WorkerOptions&& workerOptions)
 {
     Ref sharedWorker = m_sharedWorkers.ensure(sharedWorkerKey, [&] {
         return WebSharedWorker::create(*this, sharedWorkerKey, workerOptions);
@@ -71,7 +71,7 @@ void WebSharedWorkerServer::requestSharedWorker(WebCore::SharedWorkerKey&& share
         return;
     }
 
-    sharedWorker->addSharedWorkerObject(sharedWorkerObjectIdentifier, port);
+    sharedWorker->addSharedWorkerObject(sharedWorkerObjectIdentifier, ownerFrameIdentifier, port);
 
     if (sharedWorker->sharedWorkerObjectsCount() > 1) {
         RELEASE_LOG(SharedWorker, "WebSharedWorkerServer::requestSharedWorker: A shared worker with this URL already exists (now shared by %u shared worker objects)", sharedWorker->sharedWorkerObjectsCount());
@@ -83,7 +83,7 @@ void WebSharedWorkerServer::requestSharedWorker(WebCore::SharedWorkerKey&& share
             RefPtr contextConnection = sharedWorker->contextConnection();
             ASSERT(contextConnection);
             if (contextConnection) {
-                contextConnection->postConnectEvent(sharedWorker.get(), port, [weakThis = WeakPtr { *this }, sharedWorkerKey, sharedWorkerObjectIdentifier, sharedWorkerIdentifier = sharedWorker->identifier(), port, workerOptions](bool success) mutable {
+                contextConnection->postConnectEvent(sharedWorker.get(), port, [weakThis = WeakPtr { *this }, sharedWorkerKey, sharedWorkerObjectIdentifier, ownerFrameIdentifier, sharedWorkerIdentifier = sharedWorker->identifier(), port, workerOptions](bool success) mutable {
                     if (success)
                         return;
                     CheckedPtr checkedThis = weakThis.get();
@@ -93,7 +93,7 @@ void WebSharedWorkerServer::requestSharedWorker(WebCore::SharedWorkerKey&& share
                     RELEASE_LOG_ERROR(SharedWorker, "WebSharedWorkerServer::requestSharedWorker: Failed to connect to existing shared worker %" PRIu64 ", will create a new one instead.", sharedWorkerIdentifier.toUInt64());
                     if (auto it = checkedThis->m_sharedWorkers.find(sharedWorkerKey); it != checkedThis->m_sharedWorkers.end() && it->value->identifier() == sharedWorkerIdentifier)
                         checkedThis->m_sharedWorkers.remove(it);
-                    checkedThis->requestSharedWorker(WTF::move(sharedWorkerKey), sharedWorkerObjectIdentifier, WTF::move(port), WTF::move(workerOptions));
+                    checkedThis->requestSharedWorker(WTF::move(sharedWorkerKey), sharedWorkerObjectIdentifier, ownerFrameIdentifier, WTF::move(port), WTF::move(workerOptions));
                 });
             }
         }

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/CrossOriginEmbedderPolicyValue.h>
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
@@ -71,7 +72,7 @@ public:
     using ContextConnectionKey = std::pair<WebCore::RegistrableDomain, WebCore::CrossOriginEmbedderPolicyValue>;
     WebSharedWorkerServerToContextConnection* contextConnectionForRegistrableDomain(const WebCore::RegistrableDomain&, WebCore::CrossOriginEmbedderPolicyValue) const;
 
-    void requestSharedWorker(WebCore::SharedWorkerKey&&, WebCore::SharedWorkerObjectIdentifier, WebCore::TransferredMessagePort&&, WebCore::WorkerOptions&&);
+    void requestSharedWorker(WebCore::SharedWorkerKey&&, WebCore::SharedWorkerObjectIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, WebCore::TransferredMessagePort&&, WebCore::WorkerOptions&&);
     void sharedWorkerObjectIsGoingAway(const WebCore::SharedWorkerKey&, WebCore::SharedWorkerObjectIdentifier);
     void suspendForBackForwardCache(const WebCore::SharedWorkerKey&, WebCore::SharedWorkerObjectIdentifier);
     void resumeForBackForwardCache(const WebCore::SharedWorkerKey&, WebCore::SharedWorkerObjectIdentifier);

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
@@ -89,7 +89,7 @@ NetworkSession* WebSharedWorkerServerConnection::session()
     return m_networkProcess->networkSession(server->sessionID());
 }
 
-void WebSharedWorkerServerConnection::requestSharedWorker(WebCore::SharedWorkerKey&& sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::TransferredMessagePort&& port, WebCore::WorkerOptions&& workerOptions)
+void WebSharedWorkerServerConnection::requestSharedWorker(WebCore::SharedWorkerKey&& sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, WebCore::TransferredMessagePort&& port, WebCore::WorkerOptions&& workerOptions)
 {
     MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, WebCore::RegistrableDomain::uncheckedCreateFromHost(sharedWorkerKey.origin.topOrigin.host())) != NetworkProcess::AllowCookieAccess::Terminate);
     MESSAGE_CHECK(sharedWorkerObjectIdentifier.processIdentifier() == m_webProcessIdentifier);
@@ -98,7 +98,7 @@ void WebSharedWorkerServerConnection::requestSharedWorker(WebCore::SharedWorkerK
     MESSAGE_CHECK(sharedWorkerKey.name == workerOptions.name);
     CONNECTION_RELEASE_LOG("requestSharedWorker: sharedWorkerObjectIdentifier=%" PUBLIC_LOG_STRING, sharedWorkerObjectIdentifier.toString().utf8().data());
     if (CheckedPtr session = this->session())
-        session->ensureSharedWorkerServer().requestSharedWorker(WTF::move(sharedWorkerKey), sharedWorkerObjectIdentifier, WTF::move(port), WTF::move(workerOptions));
+        session->ensureSharedWorkerServer().requestSharedWorker(WTF::move(sharedWorkerKey), sharedWorkerObjectIdentifier, ownerFrameIdentifier, WTF::move(port), WTF::move(workerOptions));
 }
 
 void WebSharedWorkerServerConnection::sharedWorkerObjectIsGoingAway(WebCore::SharedWorkerKey&& sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier)

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
@@ -28,6 +28,7 @@
 #include "MessageReceiver.h"
 #include "MessageSender.h"
 #include "SharedPreferencesForWebProcess.h"
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <WebCore/SharedWorkerObjectIdentifier.h>
 #include <WebCore/TransferredMessagePort.h>
@@ -91,7 +92,7 @@ private:
     uint64_t messageSenderDestinationID() const final { return 0; }
 
     // IPC messages.
-    void requestSharedWorker(WebCore::SharedWorkerKey&&, WebCore::SharedWorkerObjectIdentifier, WebCore::TransferredMessagePort&&, WebCore::WorkerOptions&&);
+    void requestSharedWorker(WebCore::SharedWorkerKey&&, WebCore::SharedWorkerObjectIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, WebCore::TransferredMessagePort&&, WebCore::WorkerOptions&&);
     void sharedWorkerObjectIsGoingAway(WebCore::SharedWorkerKey&&, WebCore::SharedWorkerObjectIdentifier);
     void suspendForBackForwardCache(WebCore::SharedWorkerKey&&, WebCore::SharedWorkerObjectIdentifier);
     void resumeForBackForwardCache(WebCore::SharedWorkerKey&&, WebCore::SharedWorkerObjectIdentifier);

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.messages.in
@@ -27,7 +27,7 @@
     DispatchedTo=Networking
 ]
 messages -> WebSharedWorkerServerConnection {
-    RequestSharedWorker(struct WebCore::SharedWorkerKey sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::TransferredMessagePort port, struct WebCore::WorkerOptions workerOptions)
+    RequestSharedWorker(struct WebCore::SharedWorkerKey sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, WebCore::TransferredMessagePort port, struct WebCore::WorkerOptions workerOptions)
     SharedWorkerObjectIsGoingAway(struct WebCore::SharedWorkerKey sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier)
     SuspendForBackForwardCache(struct WebCore::SharedWorkerKey sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier)
     ResumeForBackForwardCache(struct WebCore::SharedWorkerKey sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier)

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp
@@ -143,7 +143,7 @@ void WebSharedWorkerServerToContextConnection::launchSharedWorker(WebSharedWorke
             }
         }
     }
-    send(Messages::WebSharedWorkerContextManagerConnection::LaunchSharedWorker { sharedWorker.origin(), sharedWorker.identifier(), sharedWorker.workerOptions(), sharedWorker.fetchResult(), initializationData });
+    send(Messages::WebSharedWorkerContextManagerConnection::LaunchSharedWorker { sharedWorker.origin(), sharedWorker.identifier(), sharedWorker.workerOptions(), sharedWorker.fetchResult(), initializationData, sharedWorker.activeOwnerFrameIdentifiers(), sharedWorker.attachedOwnerFrameIdentifiers() });
     sharedWorker.forEachSharedWorkerObject([protectedThis = Ref { *this }, sharedWorker = Ref { sharedWorker }](auto, auto& port) {
         protectedThis->postConnectEvent(sharedWorker, port, [](bool) { });
     });
@@ -171,6 +171,11 @@ void WebSharedWorkerServerToContextConnection::postConnectEvent(const WebSharedW
         registry->recordPendingTransferDestination(port.first, connection->webProcessIdentifier());
     }
     sendWithAsyncReply(Messages::WebSharedWorkerContextManagerConnection::PostConnectEvent { sharedWorker.identifier(), port, sharedWorker.origin().clientOrigin }, WTF::move(completionHandler));
+}
+
+void WebSharedWorkerServerToContextConnection::updateSharedWorkerOwnerFrameIdentifiers(const WebSharedWorker& sharedWorker)
+{
+    send(Messages::WebSharedWorkerContextManagerConnection::SetSharedWorkerOwnerFrameIdentifiers { sharedWorker.identifier(), sharedWorker.activeOwnerFrameIdentifiers(), sharedWorker.attachedOwnerFrameIdentifiers() });
 }
 
 void WebSharedWorkerServerToContextConnection::terminateSharedWorker(const WebSharedWorker& sharedWorker)

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h
@@ -79,6 +79,7 @@ public:
     void launchSharedWorker(WebSharedWorker&);
     void postConnectEvent(const WebSharedWorker&, const WebCore::TransferredMessagePort&, CompletionHandler<void(bool)>&&);
     void terminateSharedWorker(const WebSharedWorker&);
+    void updateSharedWorkerOwnerFrameIdentifiers(const WebSharedWorker&);
 
     void suspendSharedWorker(WebCore::SharedWorkerIdentifier);
     void resumeSharedWorker(WebCore::SharedWorkerIdentifier);

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
@@ -849,6 +849,51 @@ String BidiScriptAgent::originStringFromSecurityOriginData(const WebCore::Securi
     return originData.toString();
 }
 
+std::optional<RealmIdentifier> BidiScriptAgent::registerDedicatedWorkerRealm(const DedicatedWorkerRealmKey& key, const BrowsingContext& ownerBrowsingContext, const WebCore::SecurityOriginData& origin, bool emitCreatedEvent)
+{
+    auto ownerRealmIterator = m_browsingContextToRealmId.find(ownerBrowsingContext);
+    if (ownerRealmIterator == m_browsingContextToRealmId.end()) {
+        m_pendingDedicatedWorkerRealms.set(key, PendingDedicatedWorkerRealmInfo { origin.isolatedCopy(), ownerBrowsingContext.isolatedCopy() });
+        return std::nullopt;
+    }
+
+    m_pendingDedicatedWorkerRealms.remove(key);
+
+    auto workerRealmIterator = m_dedicatedWorkerRealmIdentifiers.find(key);
+    auto realmIdentifier = workerRealmIterator == m_dedicatedWorkerRealmIdentifiers.end() ? RealmIdentifier::generate() : workerRealmIterator->value;
+    if (workerRealmIterator == m_dedicatedWorkerRealmIdentifiers.end())
+        m_dedicatedWorkerRealmIdentifiers.set(key, realmIdentifier);
+
+    auto activeRealmIterator = m_activeRealms.find(realmIdentifier);
+    if (activeRealmIterator != m_activeRealms.end()) {
+        if (emitCreatedEvent && !activeRealmIterator->value.creationNotified) {
+            activeRealmIterator->value.creationNotified = true;
+            sendRealmCreatedEvent(realmIdentifier, activeRealmIterator->value);
+        }
+        return realmIdentifier;
+    }
+
+    RealmInfo realmInfo {
+        originStringFromSecurityOriginData(origin),
+        Inspector::Protocol::BidiScript::RealmType::DedicatedWorker,
+        std::nullopt,
+        { },
+        { },
+        emitCreatedEvent
+    };
+    realmInfo.owners.append(ownerRealmIterator->value);
+    realmInfo.associatedBrowsingContexts.add(ownerBrowsingContext);
+    m_activeRealms.set(realmIdentifier, WTF::move(realmInfo));
+
+    if (emitCreatedEvent) {
+        activeRealmIterator = m_activeRealms.find(realmIdentifier);
+        ASSERT(activeRealmIterator != m_activeRealms.end());
+        sendRealmCreatedEvent(realmIdentifier, activeRealmIterator->value);
+    }
+
+    return realmIdentifier;
+}
+
 void BidiScriptAgent::processRealmsForPagesAsync(Deque<Ref<WebPageProxy>>&& pagesToProcess, std::optional<Inspector::Protocol::BidiScript::RealmType>&& optionalRealmType, std::optional<String>&& contextHandleFilter, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>&& accumulated, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>>>&& callback)
 {
     if (pagesToProcess.isEmpty()) {
@@ -951,49 +996,138 @@ void BidiScriptAgent::collectExecutionReadyFrameRealms(const FrameTreeNodeData& 
     }
 }
 
-void BidiScriptAgent::sendRealmCreatedEvent(const String& realmID, const WebCore::SecurityOriginData& origin, Inspector::Protocol::BidiScript::RealmType type, Inspector::Protocol::BidiBrowsingContext::BrowsingContext context)
+void BidiScriptAgent::sendRealmCreatedEvent(RealmIdentifier realmIdentifier, const RealmInfo& realmInfo)
 {
     RefPtr session = m_session.get();
     if (!session)
         return;
 
-    session->bidiProcessor().emitEventIfEnabled(BidiEventNames::Script::RealmCreated, { context }, [&]() {
-        session->bidiProcessor().scriptDomainNotifier().realmCreated(realmID, originStringFromSecurityOriginData(origin), type, context);
+    session->bidiProcessor().emitEventIfEnabled(BidiEventNames::Script::RealmCreated, realmInfo.associatedBrowsingContexts, [&]() {
+        RefPtr<JSON::ArrayOf<String>> owners;
+        if (!realmInfo.owners.isEmpty()) {
+            owners = JSON::ArrayOf<String>::create();
+            for (auto owner : realmInfo.owners)
+                owners->addItem(makeString("realm-"_s, owner.loggingString()));
+        }
+
+        session->bidiProcessor().scriptDomainNotifier().realmCreated(
+            makeString("realm-"_s, realmIdentifier.loggingString()),
+            realmInfo.origin,
+            realmInfo.type,
+            realmInfo.context.value_or(nullString()),
+            WTF::move(owners)
+        );
+    });
+}
+
+void BidiScriptAgent::sendRealmDestroyedEvent(RealmIdentifier realmIdentifier, const RealmInfo& realmInfo)
+{
+    RefPtr session = m_session.get();
+    if (!session)
+        return;
+
+    session->bidiProcessor().emitEventIfEnabled(BidiEventNames::Script::RealmDestroyed, realmInfo.associatedBrowsingContexts, [&]() {
+        session->bidiProcessor().scriptDomainNotifier().realmDestroyed(
+            makeString("realm-"_s, realmIdentifier.loggingString()),
+            realmInfo.context.value_or(nullString())
+        );
     });
 }
 
 void BidiScriptAgent::notifyRealmCreated(RealmIdentifier realmIdentifier, Inspector::Protocol::BidiBrowsingContext::BrowsingContext browsingContext, const WebCore::SecurityOriginData& origin)
 {
-    // The WebProcess owns realm identifier creation and passes the identifier across IPC.
-    String realmID = makeString("realm-"_s, realmIdentifier.loggingString());
-
-    // Track the current realm for this browsing context.
     m_browsingContextToRealmId.set(browsingContext, realmIdentifier);
 
-    RealmInfo realmInfo { origin.isolatedCopy(), Inspector::Protocol::BidiScript::RealmType::Window, browsingContext };
+    RealmInfo realmInfo {
+        originStringFromSecurityOriginData(origin),
+        Inspector::Protocol::BidiScript::RealmType::Window,
+        browsingContext,
+        { },
+        { },
+        true
+    };
+    realmInfo.associatedBrowsingContexts.add(browsingContext);
     m_activeRealms.set(realmIdentifier, WTF::move(realmInfo));
 
-    sendRealmCreatedEvent(realmID, origin, Inspector::Protocol::BidiScript::RealmType::Window, browsingContext);
+    auto activeRealmIterator = m_activeRealms.find(realmIdentifier);
+    ASSERT(activeRealmIterator != m_activeRealms.end());
+    sendRealmCreatedEvent(realmIdentifier, activeRealmIterator->value);
+
+    Vector<std::pair<DedicatedWorkerRealmKey, PendingDedicatedWorkerRealmInfo>> pendingWorkers;
+    for (const auto& entry : m_pendingDedicatedWorkerRealms) {
+        if (entry.value.ownerBrowsingContext == browsingContext)
+            pendingWorkers.append({ entry.key, entry.value });
+    }
+    for (const auto& [key, pendingWorker] : pendingWorkers) {
+        m_pendingDedicatedWorkerRealms.remove(key);
+        registerDedicatedWorkerRealm(key, pendingWorker.ownerBrowsingContext, pendingWorker.origin, true);
+    }
 }
 
 void BidiScriptAgent::notifyRealmDestroyed(RealmIdentifier realmIdentifier, Inspector::Protocol::BidiBrowsingContext::BrowsingContext browsingContext)
 {
-    RefPtr session = m_session.get();
-    if (!session)
+    removeDedicatedWorkerRealmsForBrowsingContext(browsingContext);
+
+    auto activeRealmIterator = m_activeRealms.find(realmIdentifier);
+    if (activeRealmIterator == m_activeRealms.end())
         return;
 
-    // Match the realm identifier that the WebProcess reported for this realm.
-    String realmID = makeString("realm-"_s, realmIdentifier.loggingString());
+    RealmInfo realmInfo = WTF::move(activeRealmIterator->value);
+    m_activeRealms.remove(activeRealmIterator);
 
-    // Remove the realm from active realms.
-    m_activeRealms.remove(realmIdentifier);
+    auto browsingContextIterator = m_browsingContextToRealmId.find(browsingContext);
+    if (browsingContextIterator != m_browsingContextToRealmId.end() && browsingContextIterator->value == realmIdentifier)
+        m_browsingContextToRealmId.remove(browsingContextIterator);
 
-    // Remove the browsing context mapping (realm will be regenerated on next navigation).
-    m_browsingContextToRealmId.remove(browsingContext);
+    sendRealmDestroyedEvent(realmIdentifier, realmInfo);
+}
 
-    session->bidiProcessor().emitEventIfEnabled(BidiEventNames::Script::RealmDestroyed, { browsingContext }, [&]() {
-        session->bidiProcessor().scriptDomainNotifier().realmDestroyed(realmID, browsingContext);
-    });
+void BidiScriptAgent::notifyDedicatedWorkerRealmCreated(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, BrowsingContext ownerBrowsingContext, const WebCore::SecurityOriginData& origin)
+{
+    DedicatedWorkerRealmKey key { ownerFrameIdentifier, workerIdentifier };
+    registerDedicatedWorkerRealm(key, ownerBrowsingContext, origin, true);
+}
+
+void BidiScriptAgent::notifyDedicatedWorkerRealmDestroyed(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier)
+{
+    DedicatedWorkerRealmKey key { ownerFrameIdentifier, workerIdentifier };
+    m_pendingDedicatedWorkerRealms.remove(key);
+
+    auto workerRealmIterator = m_dedicatedWorkerRealmIdentifiers.find(key);
+    if (workerRealmIterator == m_dedicatedWorkerRealmIdentifiers.end())
+        return;
+
+    auto realmIdentifier = workerRealmIterator->value;
+    m_dedicatedWorkerRealmIdentifiers.remove(workerRealmIterator);
+
+    auto activeRealmIterator = m_activeRealms.find(realmIdentifier);
+    if (activeRealmIterator == m_activeRealms.end())
+        return;
+
+    RealmInfo realmInfo = WTF::move(activeRealmIterator->value);
+    m_activeRealms.remove(activeRealmIterator);
+    sendRealmDestroyedEvent(realmIdentifier, realmInfo);
+}
+
+void BidiScriptAgent::removeDedicatedWorkerRealmsForBrowsingContext(const BrowsingContext& browsingContext)
+{
+    Vector<DedicatedWorkerRealmKey> workerKeys;
+    for (const auto& entry : m_dedicatedWorkerRealmIdentifiers) {
+        auto activeRealmIterator = m_activeRealms.find(entry.value);
+        if (activeRealmIterator != m_activeRealms.end() && activeRealmIterator->value.associatedBrowsingContexts.contains(browsingContext))
+            workerKeys.append(entry.key);
+    }
+
+    for (const auto& key : workerKeys)
+        notifyDedicatedWorkerRealmDestroyed(key.second, key.first);
+
+    Vector<DedicatedWorkerRealmKey> pendingWorkerKeys;
+    for (const auto& entry : m_pendingDedicatedWorkerRealms) {
+        if (entry.value.ownerBrowsingContext == browsingContext)
+            pendingWorkerKeys.append(entry.key);
+    }
+    for (const auto& key : pendingWorkerKeys)
+        m_pendingDedicatedWorkerRealms.remove(key);
 }
 
 std::optional<RealmIdentifier> BidiScriptAgent::realmIdentifierForBrowsingContext(const String& browsingContext) const
@@ -1008,15 +1142,24 @@ void BidiScriptAgent::emitEventsForActiveRealms(const HashSet<String>& contextFi
 {
     // Per W3C BiDi spec: when subscribing to script.realmCreated with subscribe priority 2,
     // emit events for all currently active realms.
-    for (const auto& entry : m_activeRealms) {
-        const RealmIdentifier& realmIdentifier = entry.key;
-        const RealmInfo& realmInfo = entry.value;
+    for (auto& entry : m_activeRealms) {
+        RealmIdentifier realmIdentifier = entry.key;
+        RealmInfo& realmInfo = entry.value;
 
-        if (!contextFilter.isEmpty() && !contextFilter.contains(realmInfo.context))
-            continue;
+        if (!contextFilter.isEmpty()) {
+            bool matchesContextFilter = false;
+            for (const auto& browsingContext : realmInfo.associatedBrowsingContexts) {
+                if (contextFilter.contains(browsingContext)) {
+                    matchesContextFilter = true;
+                    break;
+                }
+            }
+            if (!matchesContextFilter)
+                continue;
+        }
 
-        String realmID = makeString("realm-"_s, realmIdentifier.loggingString());
-        sendRealmCreatedEvent(realmID, realmInfo.origin, realmInfo.type, realmInfo.context);
+        sendRealmCreatedEvent(realmIdentifier, realmInfo);
+        realmInfo.creationNotified = true;
     }
 }
 

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
@@ -35,6 +35,7 @@
 #include "PageLoadState.h"
 #include "WebAutomationSession.h"
 #include "WebAutomationSessionMacros.h"
+#include "WebAutomationSessionProxyMessages.h"
 #include "WebDriverBidiProcessor.h"
 #include "WebDriverBidiProtocolObjects.h"
 #include "WebFrameMetrics.h"
@@ -573,10 +574,9 @@ void BidiScriptAgent::getRealms(const BrowsingContext& optionalBrowsingContext, 
 {
     // https://w3c.github.io/webdriver-bidi/#command-script-getRealms
 
-    // FIXME: Implement worker realm support (dedicated-worker, shared-worker, service-worker, worker).
-    // https://bugs.webkit.org/show_bug.cgi?id=304300
-    // Currently only window realms (main frames and iframes) are supported.
-    // Worker realm types require tracking worker global scopes and their owner sets.
+    // Dedicated workers owned directly by a top-level document are supported.
+    // FIXME: Implement iframe-owned and nested dedicated workers, shared workers,
+    // service workers, and generic worker realms.
 
     // FIXME: Implement worklet realm support (paint-worklet, audio-worklet, worklet).
     // https://bugs.webkit.org/show_bug.cgi?id=304301
@@ -601,8 +601,8 @@ void BidiScriptAgent::getRealms(const BrowsingContext& optionalBrowsingContext, 
         ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!resolvedPageForContext, WindowNotFound);
     }
 
-    // Early short-circuit: if a non-window realm type is requested, return empty (we currently only support window realms).
-    if (optionalRealmType && *optionalRealmType != Inspector::Protocol::BidiScript::RealmType::Window) {
+    // Unsupported realm types are valid filters, but there are no matching realms yet.
+    if (optionalRealmType && *optionalRealmType != Inspector::Protocol::BidiScript::RealmType::Window && *optionalRealmType != Inspector::Protocol::BidiScript::RealmType::DedicatedWorker) {
         auto realmsArray = JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>::create();
         callback(WTF::move(realmsArray));
         return;
@@ -849,6 +849,27 @@ String BidiScriptAgent::originStringFromSecurityOriginData(const WebCore::Securi
     return originData.toString();
 }
 
+RefPtr<Inspector::Protocol::BidiScript::RealmInfo> BidiScriptAgent::createProtocolRealmInfo(RealmIdentifier realmIdentifier, const RealmInfo& realm)
+{
+    auto protocolRealm = Inspector::Protocol::BidiScript::RealmInfo::create()
+        .setRealm(makeString("realm-"_s, realmIdentifier.loggingString()))
+        .setOrigin(realm.origin)
+        .setType(realm.type)
+        .release();
+
+    if (realm.context)
+        protocolRealm->setContext(*realm.context);
+
+    if (!realm.owners.isEmpty()) {
+        auto owners = JSON::ArrayOf<String>::create();
+        for (auto owner : realm.owners)
+            owners->addItem(makeString("realm-"_s, owner.loggingString()));
+        protocolRealm->setOwners(WTF::move(owners));
+    }
+
+    return protocolRealm;
+}
+
 std::optional<RealmIdentifier> BidiScriptAgent::registerDedicatedWorkerRealm(const DedicatedWorkerRealmKey& key, const BrowsingContext& ownerBrowsingContext, const WebCore::SecurityOriginData& origin, bool emitCreatedEvent)
 {
     auto ownerRealmIterator = m_browsingContextToRealmId.find(ownerBrowsingContext);
@@ -897,17 +918,12 @@ std::optional<RealmIdentifier> BidiScriptAgent::registerDedicatedWorkerRealm(con
 void BidiScriptAgent::processRealmsForPagesAsync(Deque<Ref<WebPageProxy>>&& pagesToProcess, std::optional<Inspector::Protocol::BidiScript::RealmType>&& optionalRealmType, std::optional<String>&& contextHandleFilter, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>&& accumulated, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>>>&& callback)
 {
     if (pagesToProcess.isEmpty()) {
-        // Assemble final array with window realms only.
         auto realmsArray = JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>::create();
         for (auto& realmInfo : accumulated) {
             if (!realmInfo)
                 continue;
-            if (optionalRealmType && *optionalRealmType != Inspector::Protocol::BidiScript::RealmType::Window)
-                continue; // Only window realms supported currently.
-
             realmsArray->addItem(realmInfo.releaseNonNull());
         }
-
         callback(WTF::move(realmsArray));
         return;
     }
@@ -915,19 +931,67 @@ void BidiScriptAgent::processRealmsForPagesAsync(Deque<Ref<WebPageProxy>>&& page
     Ref<WebPageProxy> currentPage = pagesToProcess.first();
     pagesToProcess.removeFirst();
 
-    currentPage->getAllFrameTrees([weakThis = WeakPtr { *this }, pagesToProcess = WTF::move(pagesToProcess), optionalRealmType = WTF::move(optionalRealmType), contextHandleFilter = WTF::move(contextHandleFilter), accumulated = WTF::move(accumulated), callback = WTF::move(callback)](Vector<FrameTreeNodeData>&& frameTrees) mutable {
+    currentPage->getAllFrameTrees([weakThis = WeakPtr { *this }, currentPage = currentPage.copyRef(), pagesToProcess = WTF::move(pagesToProcess), optionalRealmType = WTF::move(optionalRealmType), contextHandleFilter = WTF::move(contextHandleFilter), accumulated = WTF::move(accumulated), callback = WTF::move(callback)](Vector<FrameTreeNodeData>&& frameTrees) mutable {
         CheckedPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-        // Collect realms from main frames only (no iframes in this PR).
-        Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>> candidateRealms;
-        for (const auto& frameTree : frameTrees)
-            protectedThis->collectExecutionReadyFrameRealms(frameTree, candidateRealms, contextHandleFilter, false);
 
-        for (auto& realmInfo : candidateRealms)
-            accumulated.append(WTF::move(realmInfo));
+        bool includeWindowRealms = !optionalRealmType || *optionalRealmType == Inspector::Protocol::BidiScript::RealmType::Window;
+        if (includeWindowRealms) {
+            Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>> candidateRealms;
+            for (const auto& frameTree : frameTrees)
+                protectedThis->collectExecutionReadyFrameRealms(frameTree, candidateRealms, contextHandleFilter, false);
 
-        protectedThis->processRealmsForPagesAsync(WTF::move(pagesToProcess), WTF::move(optionalRealmType), WTF::move(contextHandleFilter), WTF::move(accumulated), WTF::move(callback));
+            for (auto& realmInfo : candidateRealms)
+                accumulated.append(WTF::move(realmInfo));
+        }
+
+        bool includeDedicatedWorkerRealms = !optionalRealmType || *optionalRealmType == Inspector::Protocol::BidiScript::RealmType::DedicatedWorker;
+        if (!includeDedicatedWorkerRealms) {
+            protectedThis->processRealmsForPagesAsync(WTF::move(pagesToProcess), WTF::move(optionalRealmType), WTF::move(contextHandleFilter), WTF::move(accumulated), WTF::move(callback));
+            return;
+        }
+
+        RefPtr session = protectedThis->m_session.get();
+        if (!session)
+            return;
+
+        auto ownerBrowsingContext = session->handleForWebPageProxy(currentPage);
+        if (ownerBrowsingContext.isEmpty()) {
+            protectedThis->processRealmsForPagesAsync(WTF::move(pagesToProcess), WTF::move(optionalRealmType), WTF::move(contextHandleFilter), WTF::move(accumulated), WTF::move(callback));
+            return;
+        }
+
+        protect(currentPage->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebAutomationSessionProxy::GetDedicatedWorkerRealms(currentPage->webPageIDInMainFrameProcess()), [weakThis, currentPage = currentPage.copyRef(), ownerBrowsingContext = ownerBrowsingContext.isolatedCopy(), pagesToProcess = WTF::move(pagesToProcess), optionalRealmType = WTF::move(optionalRealmType), contextHandleFilter = WTF::move(contextHandleFilter), accumulated = WTF::move(accumulated), callback = WTF::move(callback)](Vector<std::tuple<String, WebCore::FrameIdentifier, WebCore::SecurityOriginData>>&& workerRealms) mutable {
+            CheckedPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+
+            RefPtr session = protectedThis->m_session.get();
+            RefPtr currentOwnerPage = session ? session->webPageProxyForHandle(ownerBrowsingContext) : nullptr;
+            if (currentOwnerPage != currentPage.ptr()) {
+                protectedThis->processRealmsForPagesAsync(WTF::move(pagesToProcess), WTF::move(optionalRealmType), WTF::move(contextHandleFilter), WTF::move(accumulated), WTF::move(callback));
+                return;
+            }
+
+            for (auto& [workerIdentifier, ownerFrameIdentifier, origin] : workerRealms) {
+                RefPtr ownerFrame = WebFrameProxy::webFrame(ownerFrameIdentifier);
+                if (!ownerFrame || ownerFrame->page() != currentPage.ptr())
+                    continue;
+
+                DedicatedWorkerRealmKey key { ownerFrameIdentifier, workerIdentifier };
+                auto realmIdentifier = protectedThis->registerDedicatedWorkerRealm(key, ownerBrowsingContext, origin, false);
+                if (!realmIdentifier)
+                    continue;
+
+                auto activeRealmIterator = protectedThis->m_activeRealms.find(*realmIdentifier);
+                if (activeRealmIterator == protectedThis->m_activeRealms.end())
+                    continue;
+                accumulated.append(protectedThis->createProtocolRealmInfo(*realmIdentifier, activeRealmIterator->value));
+            }
+
+            protectedThis->processRealmsForPagesAsync(WTF::move(pagesToProcess), WTF::move(optionalRealmType), WTF::move(contextHandleFilter), WTF::move(accumulated), WTF::move(callback));
+        });
     });
 }
 
@@ -972,10 +1036,6 @@ std::optional<String> BidiScriptAgent::contextHandleForFrame(const FrameInfoData
 
 void BidiScriptAgent::collectExecutionReadyFrameRealms(const FrameTreeNodeData& frameTree, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>& realms, const std::optional<String>& contextHandleFilter, bool recurseSubframes)
 {
-    // FIXME: Per W3C BiDi spec, when contextHandleFilter is present, we should also include
-    // worker realms whose owner set includes the active document of that context.
-    // Currently only collecting window realms (frames).
-
     // Check if frame is execution ready per W3C BiDi spec step 1:
     // "Let environment settings be a list of all the environment settings objects that have their execution ready flag set."
     if (isFrameExecutionReady(frameTree.info)) {

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
@@ -42,6 +42,7 @@
 #include "WebFrameProxy.h"
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
+#include "WebProcessProxy.h"
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/SecurityOriginData.h>
@@ -574,9 +575,9 @@ void BidiScriptAgent::getRealms(const BrowsingContext& optionalBrowsingContext, 
 {
     // https://w3c.github.io/webdriver-bidi/#command-script-getRealms
 
-    // Dedicated workers owned directly by a top-level document are supported.
-    // FIXME: Implement iframe-owned and nested dedicated workers, shared workers,
-    // service workers, and generic worker realms.
+    // Dedicated workers owned directly by a top-level document and shared workers are supported.
+    // FIXME: Implement iframe-owned and nested dedicated workers, service workers,
+    // and generic worker realms.
 
     // FIXME: Implement worklet realm support (paint-worklet, audio-worklet, worklet).
     // https://bugs.webkit.org/show_bug.cgi?id=304301
@@ -602,7 +603,7 @@ void BidiScriptAgent::getRealms(const BrowsingContext& optionalBrowsingContext, 
     }
 
     // Unsupported realm types are valid filters, but there are no matching realms yet.
-    if (optionalRealmType && *optionalRealmType != Inspector::Protocol::BidiScript::RealmType::Window && *optionalRealmType != Inspector::Protocol::BidiScript::RealmType::DedicatedWorker) {
+    if (optionalRealmType && *optionalRealmType != Inspector::Protocol::BidiScript::RealmType::Window && *optionalRealmType != Inspector::Protocol::BidiScript::RealmType::DedicatedWorker && *optionalRealmType != Inspector::Protocol::BidiScript::RealmType::SharedWorker) {
         auto realmsArray = JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>::create();
         callback(WTF::move(realmsArray));
         return;
@@ -624,11 +625,6 @@ void BidiScriptAgent::getRealms(const BrowsingContext& optionalBrowsingContext, 
         }
     }
 
-    if (pagesToProcess.isEmpty()) {
-        auto realmsArray = JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>::create();
-        callback(WTF::move(realmsArray));
-        return;
-    }
 
     // Process pages asynchronously using getAllFrameTrees.
     processRealmsForPagesAsync(WTF::move(pagesToProcess), WTF::move(optionalRealmType), WTF::move(contextHandleFilter), { }, WTF::move(callback));
@@ -900,10 +896,12 @@ std::optional<RealmIdentifier> BidiScriptAgent::registerDedicatedWorkerRealm(con
         std::nullopt,
         { },
         { },
+        { },
         emitCreatedEvent
     };
     realmInfo.owners.append(ownerRealmIterator->value);
     realmInfo.associatedBrowsingContexts.add(ownerBrowsingContext);
+    realmInfo.retainedBrowsingContextsForDestruction.add(ownerBrowsingContext);
     m_activeRealms.set(realmIdentifier, WTF::move(realmInfo));
 
     if (emitCreatedEvent) {
@@ -915,16 +913,66 @@ std::optional<RealmIdentifier> BidiScriptAgent::registerDedicatedWorkerRealm(con
     return realmIdentifier;
 }
 
+HashSet<BrowsingContext> BidiScriptAgent::controlledBrowsingContexts(const Vector<WebCore::FrameIdentifier>& frameIdentifiers) const
+{
+    HashSet<BrowsingContext> result;
+    RefPtr session = m_session.get();
+    if (!session)
+        return result;
+
+    for (auto frameIdentifier : frameIdentifiers) {
+        RefPtr frame = WebFrameProxy::webFrame(frameIdentifier);
+        RefPtr page = frame ? frame->page() : nullptr;
+        if (!page || !page->isControlledByAutomation())
+            continue;
+
+        auto browsingContext = session->effectiveHandleForWebFrameProxy(*frame);
+        if (!browsingContext.isEmpty())
+            result.add(WTF::move(browsingContext));
+    }
+    return result;
+}
+
+std::optional<RealmIdentifier> BidiScriptAgent::synchronizeSharedWorkerRealm(WebCore::SharedWorkerIdentifier workerIdentifier, const Vector<WebCore::FrameIdentifier>& activeOwnerFrameIdentifiers, const Vector<WebCore::FrameIdentifier>& attachedOwnerFrameIdentifiers, const WebCore::SecurityOriginData& origin, bool emitCreatedEvent)
+{
+    if (m_destroyedSharedWorkerIdentifiers.contains(workerIdentifier))
+        return std::nullopt;
+
+    auto activeOwnerBrowsingContexts = controlledBrowsingContexts(activeOwnerFrameIdentifiers);
+    auto attachedOwnerBrowsingContexts = controlledBrowsingContexts(attachedOwnerFrameIdentifiers);
+
+    if (activeOwnerBrowsingContexts.isEmpty() && attachedOwnerBrowsingContexts.isEmpty() && !m_sharedWorkerRealmIdentifiers.contains(workerIdentifier))
+        return std::nullopt;
+
+    auto realmIdentifier = m_sharedWorkerRealmIdentifiers.ensure(workerIdentifier, [] {
+        return RealmIdentifier::generate();
+    }).iterator->value;
+    auto& realmInfo = m_activeRealms.ensure(realmIdentifier, [&] {
+        return RealmInfo {
+            originStringFromSecurityOriginData(origin),
+            Inspector::Protocol::BidiScript::RealmType::SharedWorker,
+            std::nullopt,
+            { },
+            { },
+            { },
+            false
+        };
+    }).iterator->value;
+    realmInfo.associatedBrowsingContexts = WTF::move(activeOwnerBrowsingContexts);
+    for (const auto& browsingContext : attachedOwnerBrowsingContexts)
+        realmInfo.retainedBrowsingContextsForDestruction.add(browsingContext);
+    if (emitCreatedEvent && !realmInfo.creationNotified) {
+        realmInfo.creationNotified = true;
+        sendRealmCreatedEvent(realmIdentifier, realmInfo);
+    }
+
+    return realmIdentifier;
+}
+
 void BidiScriptAgent::processRealmsForPagesAsync(Deque<Ref<WebPageProxy>>&& pagesToProcess, std::optional<Inspector::Protocol::BidiScript::RealmType>&& optionalRealmType, std::optional<String>&& contextHandleFilter, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>&& accumulated, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>>>&& callback)
 {
     if (pagesToProcess.isEmpty()) {
-        auto realmsArray = JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>::create();
-        for (auto& realmInfo : accumulated) {
-            if (!realmInfo)
-                continue;
-            realmsArray->addItem(realmInfo.releaseNonNull());
-        }
-        callback(WTF::move(realmsArray));
+        collectSharedWorkerRealms(WTF::move(optionalRealmType), WTF::move(contextHandleFilter), WTF::move(accumulated), WTF::move(callback));
         return;
     }
 
@@ -993,6 +1041,54 @@ void BidiScriptAgent::processRealmsForPagesAsync(Deque<Ref<WebPageProxy>>&& page
             protectedThis->processRealmsForPagesAsync(WTF::move(pagesToProcess), WTF::move(optionalRealmType), WTF::move(contextHandleFilter), WTF::move(accumulated), WTF::move(callback));
         });
     });
+}
+
+void BidiScriptAgent::collectSharedWorkerRealms(std::optional<Inspector::Protocol::BidiScript::RealmType>&& optionalRealmType, std::optional<String>&& contextHandleFilter, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>&& accumulated, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>>>&& callback)
+{
+    auto realmsArray = JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>::create();
+    for (auto& realmInfo : accumulated) {
+        if (realmInfo)
+            realmsArray->addItem(realmInfo.releaseNonNull());
+    }
+    if (optionalRealmType && *optionalRealmType != Inspector::Protocol::BidiScript::RealmType::SharedWorker) {
+        callback(WTF::move(realmsArray));
+        return;
+    }
+
+    RefPtr session = m_session.get();
+    RefPtr processPool = session ? session->processPool() : nullptr;
+    if (!processPool) {
+        callback(WTF::move(realmsArray));
+        return;
+    }
+
+    Ref callbackAggregator = CallbackAggregator::create([weakThis = WeakPtr { *this }, realmsArray, callback = WTF::move(callback)]() mutable {
+        if (weakThis)
+            callback(WTF::move(realmsArray));
+    });
+    for (Ref process : borrow(processPool->processes()).get()) {
+        process->sendWithAsyncReply(Messages::WebAutomationSessionProxy::GetSharedWorkerRealms(), [weakThis = WeakPtr { *this }, process = process.copyRef(), contextHandleFilter, realmsArray, callbackAggregator](Vector<std::tuple<WebCore::SharedWorkerIdentifier, Vector<WebCore::FrameIdentifier>, Vector<WebCore::FrameIdentifier>, WebCore::SecurityOriginData>>&& workerRealms) mutable {
+            CheckedPtr protectedThis = weakThis.get();
+            RefPtr session = protectedThis ? protectedThis->m_session.get() : nullptr;
+            if (!session || process->processPoolIfExists() != session->processPool())
+                return;
+
+            for (auto& [workerIdentifier, activeOwnerFrameIdentifiers, attachedOwnerFrameIdentifiers, origin] : workerRealms) {
+                auto realmIdentifier = protectedThis->synchronizeSharedWorkerRealm(workerIdentifier, activeOwnerFrameIdentifiers, attachedOwnerFrameIdentifiers, origin, false);
+                if (!realmIdentifier)
+                    continue;
+
+                auto activeRealmIterator = protectedThis->m_activeRealms.find(*realmIdentifier);
+                if (activeRealmIterator == protectedThis->m_activeRealms.end())
+                    continue;
+
+                const auto& realmInfo = activeRealmIterator->value;
+                if (contextHandleFilter && !realmInfo.associatedBrowsingContexts.contains(*contextHandleFilter))
+                    continue;
+                realmsArray->addItem(protectedThis->createProtocolRealmInfo(*realmIdentifier, realmInfo).releaseNonNull());
+            }
+        });
+    }
 }
 
 bool BidiScriptAgent::isFrameExecutionReady(const FrameInfoData& frameInfo)
@@ -1086,7 +1182,7 @@ void BidiScriptAgent::sendRealmDestroyedEvent(RealmIdentifier realmIdentifier, c
     if (!session)
         return;
 
-    session->bidiProcessor().emitEventIfEnabled(BidiEventNames::Script::RealmDestroyed, realmInfo.associatedBrowsingContexts, [&]() {
+    session->bidiProcessor().emitEventIfEnabled(BidiEventNames::Script::RealmDestroyed, realmInfo.retainedBrowsingContextsForDestruction, [&]() {
         session->bidiProcessor().scriptDomainNotifier().realmDestroyed(
             makeString("realm-"_s, realmIdentifier.loggingString()),
             realmInfo.context.value_or(nullString())
@@ -1104,9 +1200,11 @@ void BidiScriptAgent::notifyRealmCreated(RealmIdentifier realmIdentifier, Inspec
         browsingContext,
         { },
         { },
+        { },
         true
     };
     realmInfo.associatedBrowsingContexts.add(browsingContext);
+    realmInfo.retainedBrowsingContextsForDestruction.add(browsingContext);
     m_activeRealms.set(realmIdentifier, WTF::move(realmInfo));
 
     auto activeRealmIterator = m_activeRealms.find(realmIdentifier);
@@ -1190,6 +1288,26 @@ void BidiScriptAgent::removeDedicatedWorkerRealmsForBrowsingContext(const Browsi
         m_pendingDedicatedWorkerRealms.remove(key);
 }
 
+void BidiScriptAgent::notifySharedWorkerRealmStateChanged(WebCore::SharedWorkerIdentifier workerIdentifier, const Vector<WebCore::FrameIdentifier>& activeOwnerFrameIdentifiers, const Vector<WebCore::FrameIdentifier>& attachedOwnerFrameIdentifiers, const WebCore::SecurityOriginData& origin)
+{
+    synchronizeSharedWorkerRealm(workerIdentifier, activeOwnerFrameIdentifiers, attachedOwnerFrameIdentifiers, origin, true);
+}
+
+void BidiScriptAgent::notifySharedWorkerRealmDestroyed(WebCore::SharedWorkerIdentifier workerIdentifier)
+{
+    m_destroyedSharedWorkerIdentifiers.add(workerIdentifier);
+
+    auto realmIdentifier = m_sharedWorkerRealmIdentifiers.takeOptional(workerIdentifier);
+    if (!realmIdentifier)
+        return;
+
+    auto realmInfo = m_activeRealms.takeOptional(*realmIdentifier);
+    if (!realmInfo)
+        return;
+
+    sendRealmDestroyedEvent(*realmIdentifier, *realmInfo);
+}
+
 std::optional<RealmIdentifier> BidiScriptAgent::realmIdentifierForBrowsingContext(const String& browsingContext) const
 {
     auto it = m_browsingContextToRealmId.find(browsingContext);
@@ -1207,6 +1325,10 @@ void BidiScriptAgent::emitEventsForActiveRealms(const HashSet<String>& contextFi
         RealmInfo& realmInfo = entry.value;
 
         if (!contextFilter.isEmpty()) {
+            // A shared-worker realm has no associated Document, so the subscription replay steps include
+            // them only for global subscriptions.
+            if (realmInfo.type == Inspector::Protocol::BidiScript::RealmType::SharedWorker)
+                continue;
             bool matchesContextFilter = false;
             for (const auto& browsingContext : realmInfo.associatedBrowsingContexts) {
                 if (contextFilter.contains(browsingContext)) {

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
@@ -35,6 +35,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/SecurityOriginData.h>
 #include <optional>
+#include <utility>
 #include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
@@ -63,9 +64,12 @@ class BidiScriptAgent final : public Inspector::BidiScriptBackendDispatcherHandl
 
 public:
     struct RealmInfo {
-        WebCore::SecurityOriginData origin;
+        String origin;
         Inspector::Protocol::BidiScript::RealmType type;
-        Inspector::Protocol::BidiBrowsingContext::BrowsingContext context;
+        std::optional<Inspector::Protocol::BidiBrowsingContext::BrowsingContext> context;
+        Vector<RealmIdentifier> owners;
+        HashSet<String> associatedBrowsingContexts;
+        bool creationNotified { false };
     };
 
 
@@ -83,6 +87,9 @@ public:
     // Realm lifecycle events.
     void notifyRealmCreated(RealmIdentifier, Inspector::Protocol::BidiBrowsingContext::BrowsingContext, const WebCore::SecurityOriginData&);
     void notifyRealmDestroyed(RealmIdentifier, Inspector::Protocol::BidiBrowsingContext::BrowsingContext);
+    void notifyDedicatedWorkerRealmCreated(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, Inspector::Protocol::BidiBrowsingContext::BrowsingContext ownerBrowsingContext, const WebCore::SecurityOriginData&);
+    void notifyDedicatedWorkerRealmDestroyed(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier);
+    void removeDedicatedWorkerRealmsForBrowsingContext(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&);
 
     // Lookup RealmIdentifier from browsing context (for UIProcess-initiated realm destruction).
     std::optional<RealmIdentifier> realmIdentifierForBrowsingContext(const String& browsingContext) const;
@@ -106,12 +113,21 @@ private:
         std::optional<Vector<String>> userContexts;
     };
 
-    void sendRealmCreatedEvent(const String& realmID, const WebCore::SecurityOriginData&, Inspector::Protocol::BidiScript::RealmType, Inspector::Protocol::BidiBrowsingContext::BrowsingContext);
+    using DedicatedWorkerRealmKey = std::pair<WebCore::FrameIdentifier, String>;
+
+    struct PendingDedicatedWorkerRealmInfo {
+        WebCore::SecurityOriginData origin;
+        Inspector::Protocol::BidiBrowsingContext::BrowsingContext ownerBrowsingContext;
+    };
+
+    void sendRealmCreatedEvent(RealmIdentifier, const RealmInfo&);
+    void sendRealmDestroyedEvent(RealmIdentifier, const RealmInfo&);
 
     void processRealmsForPagesAsync(Deque<Ref<WebPageProxy>>&& pagesToProcess, std::optional<Inspector::Protocol::BidiScript::RealmType>&& optionalRealmType, std::optional<String>&& contextHandleFilter, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>&& accumulated, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>>>&&);
     void collectExecutionReadyFrameRealms(const FrameTreeNodeData&, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>& realms, const std::optional<String>& contextHandleFilter, bool recurseSubframes = true);
     bool NODELETE isFrameExecutionReady(const FrameInfoData&);
     RefPtr<Inspector::Protocol::BidiScript::RealmInfo> createRealmInfoForFrame(const FrameInfoData&);
+    std::optional<RealmIdentifier> registerDedicatedWorkerRealm(const DedicatedWorkerRealmKey&, const Inspector::Protocol::BidiBrowsingContext::BrowsingContext& ownerBrowsingContext, const WebCore::SecurityOriginData&, bool emitCreatedEvent);
     std::optional<String> contextHandleForFrame(const FrameInfoData&);
     RealmIdentifier generateRealmIdForFrame(const FrameInfoData&);
     String generateRealmIdForBrowsingContext(const String& browsingContext);
@@ -132,6 +148,8 @@ private:
 
     // Track realm counters for navigation detection: frame ID -> counter
 
+    HashMap<DedicatedWorkerRealmKey, RealmIdentifier> m_dedicatedWorkerRealmIdentifiers;
+    HashMap<DedicatedWorkerRealmKey, PendingDedicatedWorkerRealmInfo> m_pendingDedicatedWorkerRealms;
     Vector<std::pair<PreloadScriptIdentifier, PreloadScriptInfo>> m_preloadScripts;
 };
 

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
@@ -128,6 +128,7 @@ private:
     bool NODELETE isFrameExecutionReady(const FrameInfoData&);
     RefPtr<Inspector::Protocol::BidiScript::RealmInfo> createRealmInfoForFrame(const FrameInfoData&);
     std::optional<RealmIdentifier> registerDedicatedWorkerRealm(const DedicatedWorkerRealmKey&, const Inspector::Protocol::BidiBrowsingContext::BrowsingContext& ownerBrowsingContext, const WebCore::SecurityOriginData&, bool emitCreatedEvent);
+    RefPtr<Inspector::Protocol::BidiScript::RealmInfo> createProtocolRealmInfo(RealmIdentifier, const RealmInfo&);
     std::optional<String> contextHandleForFrame(const FrameInfoData&);
     RealmIdentifier generateRealmIdForFrame(const FrameInfoData&);
     String generateRealmIdForBrowsingContext(const String& browsingContext);

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
@@ -34,6 +34,7 @@
 #include <JavaScriptCore/InspectorBackendDispatcher.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/SecurityOriginData.h>
+#include <WebCore/SharedWorkerIdentifier.h>
 #include <optional>
 #include <utility>
 #include <wtf/CanMakeWeakPtr.h>
@@ -69,6 +70,7 @@ public:
         std::optional<Inspector::Protocol::BidiBrowsingContext::BrowsingContext> context;
         Vector<RealmIdentifier> owners;
         HashSet<String> associatedBrowsingContexts;
+        HashSet<String> retainedBrowsingContextsForDestruction;
         bool creationNotified { false };
     };
 
@@ -90,6 +92,8 @@ public:
     void notifyDedicatedWorkerRealmCreated(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, Inspector::Protocol::BidiBrowsingContext::BrowsingContext ownerBrowsingContext, const WebCore::SecurityOriginData&);
     void notifyDedicatedWorkerRealmDestroyed(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier);
     void removeDedicatedWorkerRealmsForBrowsingContext(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&);
+    void notifySharedWorkerRealmStateChanged(WebCore::SharedWorkerIdentifier, const Vector<WebCore::FrameIdentifier>& activeOwnerFrameIdentifiers, const Vector<WebCore::FrameIdentifier>& attachedOwnerFrameIdentifiers, const WebCore::SecurityOriginData&);
+    void notifySharedWorkerRealmDestroyed(WebCore::SharedWorkerIdentifier);
 
     // Lookup RealmIdentifier from browsing context (for UIProcess-initiated realm destruction).
     std::optional<RealmIdentifier> realmIdentifierForBrowsingContext(const String& browsingContext) const;
@@ -124,10 +128,15 @@ private:
     void sendRealmDestroyedEvent(RealmIdentifier, const RealmInfo&);
 
     void processRealmsForPagesAsync(Deque<Ref<WebPageProxy>>&& pagesToProcess, std::optional<Inspector::Protocol::BidiScript::RealmType>&& optionalRealmType, std::optional<String>&& contextHandleFilter, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>&& accumulated, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>>>&&);
+    void collectSharedWorkerRealms(std::optional<Inspector::Protocol::BidiScript::RealmType>&&, std::optional<String>&& contextHandleFilter, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>&&, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>>>&&);
+
     void collectExecutionReadyFrameRealms(const FrameTreeNodeData&, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>& realms, const std::optional<String>& contextHandleFilter, bool recurseSubframes = true);
     bool NODELETE isFrameExecutionReady(const FrameInfoData&);
     RefPtr<Inspector::Protocol::BidiScript::RealmInfo> createRealmInfoForFrame(const FrameInfoData&);
     std::optional<RealmIdentifier> registerDedicatedWorkerRealm(const DedicatedWorkerRealmKey&, const Inspector::Protocol::BidiBrowsingContext::BrowsingContext& ownerBrowsingContext, const WebCore::SecurityOriginData&, bool emitCreatedEvent);
+    std::optional<RealmIdentifier> synchronizeSharedWorkerRealm(WebCore::SharedWorkerIdentifier, const Vector<WebCore::FrameIdentifier>& activeOwnerFrameIdentifiers, const Vector<WebCore::FrameIdentifier>& attachedOwnerFrameIdentifiers, const WebCore::SecurityOriginData&, bool emitCreatedEvent);
+    HashSet<Inspector::Protocol::BidiBrowsingContext::BrowsingContext> controlledBrowsingContexts(const Vector<WebCore::FrameIdentifier>&) const;
+
     RefPtr<Inspector::Protocol::BidiScript::RealmInfo> createProtocolRealmInfo(RealmIdentifier, const RealmInfo&);
     std::optional<String> contextHandleForFrame(const FrameInfoData&);
     RealmIdentifier generateRealmIdForFrame(const FrameInfoData&);
@@ -152,6 +161,8 @@ private:
     HashMap<DedicatedWorkerRealmKey, RealmIdentifier> m_dedicatedWorkerRealmIdentifiers;
     HashMap<DedicatedWorkerRealmKey, PendingDedicatedWorkerRealmInfo> m_pendingDedicatedWorkerRealms;
     Vector<std::pair<PreloadScriptIdentifier, PreloadScriptInfo>> m_preloadScripts;
+    HashMap<WebCore::SharedWorkerIdentifier, RealmIdentifier> m_sharedWorkerRealmIdentifiers;
+    HashSet<WebCore::SharedWorkerIdentifier> m_destroyedSharedWorkerIdentifiers;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -1334,6 +1334,7 @@ void WebAutomationSession::contextDestroyedForPage(const WebPageProxy& page)
     auto [clientWindow, userContext] = getClientWindowAndUserContext(page);
 
     // Ensure the active realm is destroyed even if the WebProcess terminates first.
+    m_bidiProcessor->scriptAgent().removeDedicatedWorkerRealmsForBrowsingContext(contextHandle);
     if (auto realmID = m_bidiProcessor->scriptAgent().realmIdentifierForBrowsingContext(contextHandle))
         m_bidiProcessor->scriptAgent().notifyRealmDestroyed(*realmID, contextHandle);
 
@@ -3251,8 +3252,36 @@ void WebAutomationSession::scriptRealmDestroyed(WebCore::FrameIdentifier frameID
     if (it == scriptAgent.activeRealms().end())
         return; // Realm not found or already destroyed.
 
-    auto browsingContext = it->value.context;
-    scriptAgent.notifyRealmDestroyed(realmIdentifier, browsingContext);
+    if (!it->value.context)
+        return;
+    scriptAgent.notifyRealmDestroyed(realmIdentifier, *it->value.context);
+}
+
+void WebAutomationSession::scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, IPC::Untrusted<WebCore::SecurityOriginData>&& untrustedOrigin)
+{
+    auto origin = WTF::move(untrustedOrigin).unsafeExtractWithoutValidation(IPC::UnvalidatedReason::NeedsReview);
+
+    RefPtr ownerFrame = WebFrameProxy::webFrame(ownerFrameIdentifier);
+    if (!ownerFrame)
+        return;
+
+    if (!ownerFrame->isMainFrame())
+        return;
+
+    RefPtr page = ownerFrame->page();
+    if (!page || !page->isControlledByAutomation())
+        return;
+
+    auto ownerBrowsingContextIterator = m_webPageHandleMap.find(page->identifier());
+    if (ownerBrowsingContextIterator == m_webPageHandleMap.end())
+        return;
+
+    m_bidiProcessor->scriptAgent().notifyDedicatedWorkerRealmCreated(workerIdentifier, ownerFrameIdentifier, ownerBrowsingContextIterator->value, origin);
+}
+
+void WebAutomationSession::scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier)
+{
+    m_bidiProcessor->scriptAgent().notifyDedicatedWorkerRealmDestroyed(workerIdentifier, ownerFrameIdentifier);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -3283,6 +3283,17 @@ void WebAutomationSession::scriptDedicatedWorkerRealmDestroyed(const String& wor
 {
     m_bidiProcessor->scriptAgent().notifyDedicatedWorkerRealmDestroyed(workerIdentifier, ownerFrameIdentifier);
 }
+
+void WebAutomationSession::scriptSharedWorkerRealmStateChanged(WebCore::SharedWorkerIdentifier workerIdentifier, Vector<WebCore::FrameIdentifier>&& activeOwnerFrameIdentifiers, Vector<WebCore::FrameIdentifier>&& attachedOwnerFrameIdentifiers, IPC::Untrusted<WebCore::SecurityOriginData>&& untrustedOrigin)
+{
+    auto origin = WTF::move(untrustedOrigin).unsafeExtractWithoutValidation(IPC::UnvalidatedReason::NeedsReview);
+    m_bidiProcessor->scriptAgent().notifySharedWorkerRealmStateChanged(workerIdentifier, activeOwnerFrameIdentifiers, attachedOwnerFrameIdentifiers, origin);
+}
+
+void WebAutomationSession::scriptSharedWorkerRealmDestroyed(WebCore::SharedWorkerIdentifier workerIdentifier)
+{
+    m_bidiProcessor->scriptAgent().notifySharedWorkerRealmDestroyed(workerIdentifier);
+}
 #endif
 
 #if !PLATFORM(COCOA) && !USE(CAIRO) && !USE(SKIA)

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -378,6 +378,8 @@ private:
 #if ENABLE(WEBDRIVER_BIDI)
     void scriptRealmCreated(WebCore::FrameIdentifier, RealmIdentifier, IPC::Untrusted<WebCore::SecurityOriginData>&&);
     void scriptRealmDestroyed(WebCore::FrameIdentifier, RealmIdentifier);
+    void scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, IPC::Untrusted<WebCore::SecurityOriginData>&&);
+    void scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier);
 #endif
 
     // Platform-dependent implementations.

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -42,6 +42,7 @@
 #include <WebCore/NavigationIdentifier.h>
 #include <WebCore/SecurityOriginData.h>
 #include <WebCore/ShareableBitmap.h>
+#include <WebCore/SharedWorkerIdentifier.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
@@ -380,6 +381,8 @@ private:
     void scriptRealmDestroyed(WebCore::FrameIdentifier, RealmIdentifier);
     void scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, IPC::Untrusted<WebCore::SecurityOriginData>&&);
     void scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier);
+    void scriptSharedWorkerRealmStateChanged(WebCore::SharedWorkerIdentifier, Vector<WebCore::FrameIdentifier>&& activeOwnerFrameIdentifiers, Vector<WebCore::FrameIdentifier>&& attachedOwnerFrameIdentifiers, IPC::Untrusted<WebCore::SecurityOriginData>&&);
+    void scriptSharedWorkerRealmDestroyed(WebCore::SharedWorkerIdentifier);
 #endif
 
     // Platform-dependent implementations.

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.messages.in
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.messages.in
@@ -30,5 +30,7 @@ messages -> WebAutomationSession {
 #if ENABLE(WEBDRIVER_BIDI)
     ScriptRealmCreated(WebCore::FrameIdentifier frameID, WebKit::RealmIdentifier realmIdentifier, IPC::Untrusted<WebCore::SecurityOriginData> origin)
     ScriptRealmDestroyed(WebCore::FrameIdentifier frameID, WebKit::RealmIdentifier realmIdentifier)
+    ScriptDedicatedWorkerRealmCreated(String workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, IPC::Untrusted<WebCore::SecurityOriginData> origin)
+    ScriptDedicatedWorkerRealmDestroyed(String workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier)
 #endif
 }

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.messages.in
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.messages.in
@@ -32,5 +32,7 @@ messages -> WebAutomationSession {
     ScriptRealmDestroyed(WebCore::FrameIdentifier frameID, WebKit::RealmIdentifier realmIdentifier)
     ScriptDedicatedWorkerRealmCreated(String workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, IPC::Untrusted<WebCore::SecurityOriginData> origin)
     ScriptDedicatedWorkerRealmDestroyed(String workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier)
+    ScriptSharedWorkerRealmStateChanged(WebCore::SharedWorkerIdentifier workerIdentifier, Vector<WebCore::FrameIdentifier> activeOwnerFrameIdentifiers, Vector<WebCore::FrameIdentifier> attachedOwnerFrameIdentifiers, IPC::Untrusted<WebCore::SecurityOriginData> origin)
+    ScriptSharedWorkerRealmDestroyed(WebCore::SharedWorkerIdentifier workerIdentifier)
 #endif
 }

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiScript.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiScript.json
@@ -76,16 +76,24 @@
                 { "name": "realm", "$ref": "BidiScript.Realm", "description": "Unique identifier of the realm." },
                 { "name": "origin", "type": "string", "description": "The serialized origin of the realm." },
                 { "name": "type", "$ref": "BidiScript.RealmType", "description": "The type of the realm." },
-                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true, "description": "Browsing context of the realm. Not present for worklet/worker realms." }
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true, "description": "Browsing context of the realm. Not present for worklet/worker realms." },
+                { "name": "owners", "type": "array", "items": { "$ref": "BidiScript.Realm" }, "optional": true, "description": "Owner realms of a dedicated worker realm." }
             ]
         },
         {
             "id": "RealmType",
-            "description": "The type of a JavaScript realm. Currently only 'window' is supported; worker and worklet types will be added in future implementations.",
+            "description": "The type of a JavaScript realm.",
             "spec": "https://w3c.github.io/webdriver-bidi/#type-script-RealmType",
             "type": "string",
             "enum": [
-                "window"
+                "window",
+                "dedicated-worker",
+                "shared-worker",
+                "service-worker",
+                "worker",
+                "paint-worklet",
+                "audio-worklet",
+                "worklet"
             ]
         },
         {
@@ -292,7 +300,8 @@
                 { "name": "realm", "$ref": "BidiScript.Realm", "description": "Unique identifier of the realm." },
                 { "name": "origin", "type": "string", "description": "The serialized origin of the realm." },
                 { "name": "type", "$ref": "BidiScript.RealmType", "description": "The type of the realm." },
-                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true, "description": "Browsing context of the realm. Not present for worklet/worker realms." }
+                { "name": "context", "$ref": "BidiBrowsingContext.BrowsingContext", "optional": true, "description": "Browsing context of the realm. Not present for worklet/worker realms." },
+                { "name": "owners", "type": "array", "items": { "$ref": "BidiScript.Realm" }, "optional": true, "description": "Owner realms of a dedicated worker realm." }
             ]
         },
         {

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -1231,6 +1231,16 @@ void WebAutomationSessionProxy::scriptRealmDestroyed(WebCore::FrameIdentifier fr
     protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebAutomationSession::ScriptRealmDestroyed(frameID, realmIdentifier), 0);
 }
 
+void WebAutomationSessionProxy::scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, const WebCore::SecurityOriginData& origin)
+{
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebAutomationSession::ScriptDedicatedWorkerRealmCreated(workerIdentifier, ownerFrameIdentifier, origin), 0);
+}
+
+void WebAutomationSessionProxy::scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier)
+{
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebAutomationSession::ScriptDedicatedWorkerRealmDestroyed(workerIdentifier, ownerFrameIdentifier), 0);
+}
+
 void WebAutomationSessionProxy::ensureRealmForInitialEmptyDocument(WebCore::PageIdentifier pageID)
 {
     RefPtr page = WebProcess::singleton().webPage(pageID);

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -1241,6 +1241,22 @@ void WebAutomationSessionProxy::scriptDedicatedWorkerRealmDestroyed(const String
     protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebAutomationSession::ScriptDedicatedWorkerRealmDestroyed(workerIdentifier, ownerFrameIdentifier), 0);
 }
 
+void WebAutomationSessionProxy::getDedicatedWorkerRealms(WebCore::PageIdentifier pageID, CompletionHandler<void(Vector<DedicatedWorkerRealmData>&&)>&& completionHandler)
+{
+    Vector<DedicatedWorkerRealmData> result;
+
+    RefPtr page = WebProcess::singleton().webPage(pageID);
+    RefPtr corePage = page ? page->corePage() : nullptr;
+    if (!corePage || !corePage->isControlledByAutomation()) {
+        completionHandler(WTF::move(result));
+        return;
+    }
+
+    result = AutomationInstrumentation::dedicatedWorkerRealms(pageID);
+
+    completionHandler(WTF::move(result));
+}
+
 void WebAutomationSessionProxy::ensureRealmForInitialEmptyDocument(WebCore::PageIdentifier pageID)
 {
     RefPtr page = WebProcess::singleton().webPage(pageID);

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -1257,6 +1257,21 @@ void WebAutomationSessionProxy::getDedicatedWorkerRealms(WebCore::PageIdentifier
     completionHandler(WTF::move(result));
 }
 
+void WebAutomationSessionProxy::scriptSharedWorkerRealmStateChanged(WebCore::SharedWorkerIdentifier workerIdentifier, const Vector<WebCore::FrameIdentifier>& activeOwnerFrameIdentifiers, const Vector<WebCore::FrameIdentifier>& attachedOwnerFrameIdentifiers, const WebCore::SecurityOriginData& origin)
+{
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebAutomationSession::ScriptSharedWorkerRealmStateChanged(workerIdentifier, activeOwnerFrameIdentifiers, attachedOwnerFrameIdentifiers, origin), 0);
+}
+
+void WebAutomationSessionProxy::scriptSharedWorkerRealmDestroyed(WebCore::SharedWorkerIdentifier workerIdentifier)
+{
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebAutomationSession::ScriptSharedWorkerRealmDestroyed(workerIdentifier), 0);
+}
+
+void WebAutomationSessionProxy::getSharedWorkerRealms(CompletionHandler<void(Vector<SharedWorkerRealmData>&&)>&& completionHandler)
+{
+    completionHandler(AutomationInstrumentation::sharedWorkerRealms());
+}
+
 void WebAutomationSessionProxy::ensureRealmForInitialEmptyDocument(WebCore::PageIdentifier pageID)
 {
     RefPtr page = WebProcess::singleton().webPage(pageID);

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
@@ -117,6 +117,8 @@ private:
     void addMessageToConsole(const JSC::MessageSource&, const JSC::MessageLevel&, const String&, const JSC::MessageType&, const WallTime&) override;
     void scriptRealmCreated(WebCore::FrameIdentifier, const WebCore::SecurityOriginData&) override;
     void scriptRealmDestroyed(WebCore::FrameIdentifier) override;
+    void scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, const WebCore::SecurityOriginData&) override;
+    void scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier) override;
     void ensureRealmForInitialEmptyDocument(WebCore::PageIdentifier);
 #endif
 

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
@@ -33,6 +33,7 @@
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/PageIdentifier.h>
+#include <tuple>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
@@ -41,6 +42,7 @@
 #include "IdentifierTypes.h"
 #include <JavaScriptCore/ConsoleMessage.h>
 #include <WebCore/AutomationInstrumentation.h>
+#include <WebCore/SecurityOriginData.h>
 #endif
 
 namespace WebCore {
@@ -120,6 +122,9 @@ private:
     void scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, const WebCore::SecurityOriginData&) override;
     void scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier) override;
     void ensureRealmForInitialEmptyDocument(WebCore::PageIdentifier);
+
+    using DedicatedWorkerRealmData = std::tuple<String, WebCore::FrameIdentifier, WebCore::SecurityOriginData>;
+    void getDedicatedWorkerRealms(WebCore::PageIdentifier, CompletionHandler<void(Vector<DedicatedWorkerRealmData>&&)>&&);
 #endif
 
     String m_sessionIdentifier;

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
@@ -121,10 +121,14 @@ private:
     void scriptRealmDestroyed(WebCore::FrameIdentifier) override;
     void scriptDedicatedWorkerRealmCreated(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, const WebCore::SecurityOriginData&) override;
     void scriptDedicatedWorkerRealmDestroyed(const String& workerIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier) override;
+    void scriptSharedWorkerRealmStateChanged(WebCore::SharedWorkerIdentifier, const Vector<WebCore::FrameIdentifier>& activeOwnerFrameIdentifiers, const Vector<WebCore::FrameIdentifier>& attachedOwnerFrameIdentifiers, const WebCore::SecurityOriginData&) override;
+    void scriptSharedWorkerRealmDestroyed(WebCore::SharedWorkerIdentifier) override;
     void ensureRealmForInitialEmptyDocument(WebCore::PageIdentifier);
 
     using DedicatedWorkerRealmData = std::tuple<String, WebCore::FrameIdentifier, WebCore::SecurityOriginData>;
     void getDedicatedWorkerRealms(WebCore::PageIdentifier, CompletionHandler<void(Vector<DedicatedWorkerRealmData>&&)>&&);
+    using SharedWorkerRealmData = std::tuple<WebCore::SharedWorkerIdentifier, Vector<WebCore::FrameIdentifier>, Vector<WebCore::FrameIdentifier>, WebCore::SecurityOriginData>;
+    void getSharedWorkerRealms(CompletionHandler<void(Vector<SharedWorkerRealmData>&&)>&&);
 #endif
 
     String m_sessionIdentifier;

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.messages.in
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.messages.in
@@ -52,5 +52,6 @@ messages -> WebAutomationSessionProxy {
 
 #if ENABLE(WEBDRIVER_BIDI)
     EnsureRealmForInitialEmptyDocument(WebCore::PageIdentifier pageID)
+    GetDedicatedWorkerRealms(WebCore::PageIdentifier pageID) -> (Vector<std::tuple<String, WebCore::FrameIdentifier, WebCore::SecurityOriginData>> realms) Async
 #endif
 }

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.messages.in
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.messages.in
@@ -53,5 +53,6 @@ messages -> WebAutomationSessionProxy {
 #if ENABLE(WEBDRIVER_BIDI)
     EnsureRealmForInitialEmptyDocument(WebCore::PageIdentifier pageID)
     GetDedicatedWorkerRealms(WebCore::PageIdentifier pageID) -> (Vector<std::tuple<String, WebCore::FrameIdentifier, WebCore::SecurityOriginData>> realms) Async
+    GetSharedWorkerRealms() -> (Vector<std::tuple<WebCore::SharedWorkerIdentifier, Vector<WebCore::FrameIdentifier>, Vector<WebCore::FrameIdentifier>, WebCore::SecurityOriginData>> realms) Async
 #endif
 }

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -104,7 +104,7 @@ void WebSharedWorkerContextManagerConnection::updatePreferencesStore(const WebPr
     m_preferencesStore = store;
 }
 
-void WebSharedWorkerContextManagerConnection::launchSharedWorker(WebCore::ClientOrigin&& origin, WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, WebCore::WorkerOptions&& workerOptions, WebCore::WorkerFetchResult&& workerFetchResult, WebCore::WorkerInitializationData&& initializationData)
+void WebSharedWorkerContextManagerConnection::launchSharedWorker(WebCore::ClientOrigin&& origin, WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, WebCore::WorkerOptions&& workerOptions, WebCore::WorkerFetchResult&& workerFetchResult, WebCore::WorkerInitializationData&& initializationData, Vector<WebCore::FrameIdentifier>&& activeOwnerFrameIdentifiers, Vector<WebCore::FrameIdentifier>&& attachedOwnerFrameIdentifiers)
 {
     RELEASE_LOG(SharedWorker, "WebSharedWorkerContextManagerConnection::launchSharedWorker: sharedWorkerIdentifier=%" PRIu64, sharedWorkerIdentifier.toUInt64());
     auto pageConfiguration = WebCore::pageConfigurationWithEmptyClients(m_pageID, WebProcess::singleton().sessionID());
@@ -138,7 +138,7 @@ void WebSharedWorkerContextManagerConnection::launchSharedWorker(WebCore::Client
 
     page->setupForRemoteWorker(workerFetchResult.responseURL, origin.topOrigin, workerFetchResult.referrerPolicy, initializationData.advancedPrivacyProtections, initializationData.globalPrivacyControlEnabled);
 
-    auto sharedWorkerThreadProxy = WebCore::SharedWorkerThreadProxy::create(Ref { page }, sharedWorkerIdentifier, origin, WTF::move(workerFetchResult), WTF::move(workerOptions), WTF::move(initializationData), WebProcess::singleton().cacheStorageProvider());
+    auto sharedWorkerThreadProxy = WebCore::SharedWorkerThreadProxy::create(Ref { page }, sharedWorkerIdentifier, origin, WTF::move(workerFetchResult), WTF::move(workerOptions), WTF::move(initializationData), WTF::move(activeOwnerFrameIdentifiers), WTF::move(attachedOwnerFrameIdentifiers), WebProcess::singleton().cacheStorageProvider());
 
     Ref thread = sharedWorkerThreadProxy->thread();
     auto workerClient = WebWorkerClient::create(WTF::move(page), thread);

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.h
@@ -70,7 +70,7 @@ private:
     WebSharedWorkerContextManagerConnection(Ref<IPC::Connection>&&, WebCore::Site&&, PageGroupIdentifier, WebPageProxyIdentifier, WebCore::PageIdentifier, const WebPreferencesStore&, RemoteWorkerInitializationData&&, WebCore::CrossOriginEmbedderPolicyValue);
 
     // IPC Messages.
-    void launchSharedWorker(WebCore::ClientOrigin&&, WebCore::SharedWorkerIdentifier, WebCore::WorkerOptions&&, WebCore::WorkerFetchResult&&, WebCore::WorkerInitializationData&&);
+    void launchSharedWorker(WebCore::ClientOrigin&&, WebCore::SharedWorkerIdentifier, WebCore::WorkerOptions&&, WebCore::WorkerFetchResult&&, WebCore::WorkerInitializationData&&, Vector<WebCore::FrameIdentifier>&& activeOwnerFrameIdentifiers, Vector<WebCore::FrameIdentifier>&& attachedOwnerFrameIdentifiers);
     void updatePreferencesStore(const WebPreferencesStore&);
     void setUserAgent(String&& userAgent) { m_userAgent = WTF::move(userAgent); }
     void close();

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.messages.in
@@ -26,8 +26,9 @@
     DispatchedTo=WebContent
 ]
 messages -> WebSharedWorkerContextManagerConnection {
-    LaunchSharedWorker(struct WebCore::ClientOrigin origin, WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, struct WebCore::WorkerOptions workerOptions, struct WebCore::WorkerFetchResult workerFetchResult, struct WebCore::WorkerInitializationData workerInitializationData)
+    LaunchSharedWorker(struct WebCore::ClientOrigin origin, WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, struct WebCore::WorkerOptions workerOptions, struct WebCore::WorkerFetchResult workerFetchResult, struct WebCore::WorkerInitializationData workerInitializationData, Vector<WebCore::FrameIdentifier> activeOwnerFrameIdentifiers, Vector<WebCore::FrameIdentifier> attachedOwnerFrameIdentifiers)
     PostConnectEvent(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, WebCore::TransferredMessagePort port, WebCore::SecurityOriginData sourceOrigin) -> (bool success)
+    SetSharedWorkerOwnerFrameIdentifiers(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, Vector<WebCore::FrameIdentifier> activeOwnerFrameIdentifiers, Vector<WebCore::FrameIdentifier> attachedOwnerFrameIdentifiers)
     TerminateSharedWorker(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier)
     UpdatePreferencesStore(struct WebKit::WebPreferencesStore store)
     SetUserAgent(String userAgent)

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.cpp
@@ -55,11 +55,11 @@ IPC::Connection* WebSharedWorkerObjectConnection::messageSenderConnection() cons
     return &WebProcess::singleton().ensureNetworkProcessConnection().connection();
 }
 
-void WebSharedWorkerObjectConnection::requestSharedWorker(const WebCore::SharedWorkerKey& sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::TransferredMessagePort&& port, const WebCore::WorkerOptions& workerOptions)
+void WebSharedWorkerObjectConnection::requestSharedWorker(const WebCore::SharedWorkerKey& sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, WebCore::TransferredMessagePort&& port, const WebCore::WorkerOptions& workerOptions)
 {
     CONNECTION_RELEASE_LOG("requestSharedWorker: sharedWorkerObjectIdentifier=%" PUBLIC_LOG_STRING, sharedWorkerObjectIdentifier.toString().utf8().data());
     WebMessagePortChannelProvider::singleton().messagePortSentToRemote(port.first);
-    send(Messages::WebSharedWorkerServerConnection::RequestSharedWorker { sharedWorkerKey, sharedWorkerObjectIdentifier, WTF::move(port), workerOptions });
+    send(Messages::WebSharedWorkerServerConnection::RequestSharedWorker { sharedWorkerKey, sharedWorkerObjectIdentifier, ownerFrameIdentifier, WTF::move(port), workerOptions });
 }
 
 void WebSharedWorkerObjectConnection::sharedWorkerObjectIsGoingAway(const WebCore::SharedWorkerKey& sharedWorkerKey, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier)

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.h
@@ -45,7 +45,7 @@ private:
     WebSharedWorkerObjectConnection();
 
     // WebCore::SharedWorkerObjectConnection.
-    void requestSharedWorker(const WebCore::SharedWorkerKey&, WebCore::SharedWorkerObjectIdentifier, WebCore::TransferredMessagePort&&, const WebCore::WorkerOptions&) final;
+    void requestSharedWorker(const WebCore::SharedWorkerKey&, WebCore::SharedWorkerObjectIdentifier, WebCore::FrameIdentifier ownerFrameIdentifier, WebCore::TransferredMessagePort&&, const WebCore::WorkerOptions&) final;
     void sharedWorkerObjectIsGoingAway(const WebCore::SharedWorkerKey&, WebCore::SharedWorkerObjectIdentifier) final;
     void suspendForBackForwardCache(const WebCore::SharedWorkerKey&, WebCore::SharedWorkerObjectIdentifier) final;
     void resumeForBackForwardCache(const WebCore::SharedWorkerKey&, WebCore::SharedWorkerObjectIdentifier) final;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestAutomationSession.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestAutomationSession.cpp
@@ -20,10 +20,46 @@
 #include "config.h"
 
 #include "TestMain.h"
+#include "WebKitTestServer.h"
 #include <gio/gio.h>
+#include <wtf/JSONValues.h>
 #include <wtf/UUID.h>
+#include <wtf/Vector.h>
 #include <wtf/glib/SocketConnection.h>
 #include <wtf/text/StringBuilder.h>
+
+#if ENABLE(WEBDRIVER_BIDI)
+static WebKitTestServer* s_server;
+
+static void serverCallback(SoupServer*, SoupServerMessage* message, const char* path, GHashTable*, gpointer)
+{
+    static constexpr auto page = R"HTML(
+        <title>loading</title>
+        <script>
+            window.worker = new SharedWorker('shared-worker.js', 'automation-shared-worker');
+            worker.port.onmessage = () => document.title = 'ready';
+            worker.port.start();
+        </script>
+    )HTML";
+    static constexpr auto worker = "onconnect = event => event.ports[0].postMessage('ready');";
+
+    const char* content;
+    const char* contentType;
+    if (g_str_equal(path, "/shared-worker.html")) {
+        content = page;
+        contentType = "text/html";
+    } else if (g_str_equal(path, "/shared-worker.js")) {
+        content = worker;
+        contentType = "application/javascript";
+    } else {
+        soup_server_message_set_status(message, SOUP_STATUS_NOT_FOUND, nullptr);
+        return;
+    }
+
+    soup_server_message_set_response(message, contentType, SOUP_MEMORY_STATIC, content, strlen(content));
+    soup_server_message_set_status(message, SOUP_STATUS_OK, nullptr);
+}
+#endif
 
 class AutomationTest: public Test {
 public:
@@ -76,6 +112,17 @@ public:
     {
         g_assert_cmpuint(connectionID, ==, m_connectionID);
         g_assert_cmpuint(targetID, ==, m_target.id);
+#if ENABLE(WEBDRIVER_BIDI)
+        auto transportValue = JSON::Value::parseJSON(String::fromUTF8(message));
+        auto transportMessage = transportValue ? transportValue->asObject() : nullptr;
+        if (transportMessage && transportMessage->getString("method"_s) == "Automation.bidiMessageSent"_s) {
+            if (auto parameters = transportMessage->getObject("params"_s)) {
+                auto bidiValue = JSON::Value::parseJSON(parameters->getString("message"_s));
+                if (auto bidiMessage = bidiValue ? bidiValue->asObject() : nullptr)
+                    m_bidiMessages.append(bidiMessage.releaseNonNull());
+            }
+        }
+#endif
         m_message = message;
         g_main_loop_quit(m_mainLoop.get());
     }
@@ -90,6 +137,74 @@ public:
         messageBuilder.append('}');
         m_connection->sendMessage("SendMessageToBackend", g_variant_new("(tts)", m_connectionID, m_target.id, messageBuilder.toString().utf8().data()));
     }
+#if ENABLE(WEBDRIVER_BIDI)
+    String browsingContextHandleFromLastResponse() const
+    {
+        auto messageValue = JSON::Value::parseJSON(String::fromUTF8(m_message.data()));
+        g_assert_true(!!messageValue);
+        auto messageObject = messageValue->asObject();
+        g_assert_true(!!messageObject);
+        auto result = messageObject->getObject("result"_s);
+        g_assert_true(!!result);
+        auto handle = result->getString("handle"_s);
+        g_assert_false(handle.isEmpty());
+        return handle;
+    }
+
+    void loadSharedWorkerPage(WebKitWebView* webView)
+    {
+        auto titleChangedHandler = g_signal_connect(webView, "notify::title", G_CALLBACK(+[](WebKitWebView* webView, GParamSpec*, AutomationTest* test) {
+            if (!g_strcmp0(webkit_web_view_get_title(webView), "ready"))
+                g_main_loop_quit(test->m_mainLoop.get());
+        }), this);
+        webkit_web_view_load_uri(webView, s_server->getURIForPath("/shared-worker.html").data());
+        while (g_strcmp0(webkit_web_view_get_title(webView), "ready"))
+            g_main_loop_run(m_mainLoop.get());
+        g_signal_handler_disconnect(webView, titleChangedHandler);
+    }
+
+    Ref<JSON::Object> sendBidiCommandAndWait(int identifier, const String& method, Ref<JSON::Object>&& parameters)
+    {
+        auto command = JSON::Object::create();
+        command->setInteger("id"_s, identifier);
+        command->setString("method"_s, method);
+        command->setObject("params"_s, WTF::move(parameters));
+
+        auto automationParameters = JSON::Object::create();
+        automationParameters->setString("message"_s, command->toJSONString());
+        sendCommandToBackend("processBidiMessage"_s, automationParameters->toJSONString());
+
+        auto response = waitForBidiMessage([identifier](const JSON::Object& message) {
+            auto messageIdentifier = message.getInteger("id"_s);
+            return messageIdentifier && *messageIdentifier == identifier;
+        });
+        g_assert_true(response->getString("type"_s) == "success"_s);
+        return response;
+    }
+
+    template<typename Predicate>
+    RefPtr<JSON::Object> takeBidiMessage(Predicate&& predicate)
+    {
+        for (size_t index = 0; index < m_bidiMessages.size(); ++index) {
+            if (!predicate(m_bidiMessages[index].get()))
+                continue;
+            auto message = m_bidiMessages[index].copyRef();
+            m_bidiMessages.removeAt(index);
+            return message;
+        }
+        return nullptr;
+    }
+
+    template<typename Predicate>
+    Ref<JSON::Object> waitForBidiMessage(Predicate&& predicate)
+    {
+        while (true) {
+            if (auto message = takeBidiMessage(predicate))
+                return message.releaseNonNull();
+            g_main_loop_run(m_mainLoop.get());
+        }
+    }
+#endif
 
     static WebKitWebView* createWebViewCallback(WebKitAutomationSession* session, AutomationTest* test)
     {
@@ -249,6 +364,9 @@ public:
     bool m_createWebViewInWindowWasCalled { false };
     bool m_createWebViewInTabWasCalled { false };
     CString m_message;
+#if ENABLE(WEBDRIVER_BIDI)
+    Vector<Ref<JSON::Object>> m_bidiMessages;
+#endif
 };
 
 const SocketConnection::MessageHandlers AutomationTest::s_messageHandlers = {
@@ -293,6 +411,10 @@ const SocketConnection::MessageHandlers AutomationTest::s_messageHandlers = {
         }}
     }
 };
+#if ENABLE(WEBDRIVER_BIDI)
+static void verifySharedWorkerRealmLifecycle(AutomationTest&, GRefPtr<WebKitWebView>&, const String&, GRefPtr<WebKitWebView>&, const String&);
+#endif
+
 
 static void testAutomationSessionRequestSession(AutomationTest* test, gconstpointer)
 {
@@ -348,6 +470,9 @@ static void testAutomationSessionRequestSession(AutomationTest* test, gconstpoin
     g_assert_true(webkit_web_view_get_network_session(webView.get()) == networkSession);
 #endif
     g_assert_true(test->createTopLevelBrowsingContext(webView.get()));
+#if ENABLE(WEBDRIVER_BIDI)
+    auto firstBrowsingContext = test->browsingContextHandleFromLastResponse();
+#endif
 
     auto newWebViewInWindow = test->createWebView(
         "is-controlled-by-automation", TRUE,
@@ -362,6 +487,9 @@ static void testAutomationSessionRequestSession(AutomationTest* test, gconstpoin
     g_assert_true(webkit_web_view_get_network_session(newWebViewInWindow.get()) == networkSession);
 #endif
     g_assert_true(test->createNewWindow(newWebViewInWindow.get()));
+#if ENABLE(WEBDRIVER_BIDI)
+    auto secondBrowsingContext = test->browsingContextHandleFromLastResponse();
+#endif
 
     auto newWebViewInTab = test->createWebView(
         "is-controlled-by-automation", TRUE,
@@ -370,10 +498,116 @@ static void testAutomationSessionRequestSession(AutomationTest* test, gconstpoin
     g_assert_true(webkit_web_view_is_controlled_by_automation(newWebViewInTab.get()));
     g_assert_cmpuint(webkit_web_view_get_automation_presentation_type(newWebViewInTab.get()), ==, WEBKIT_AUTOMATION_BROWSING_CONTEXT_PRESENTATION_TAB);
     g_assert_true(test->createNewTab(newWebViewInTab.get()));
+#if ENABLE(WEBDRIVER_BIDI)
+    verifySharedWorkerRealmLifecycle(*test, webView, firstBrowsingContext, newWebViewInWindow, secondBrowsingContext);
+#endif
 
     webkit_web_context_set_automation_allowed(test->m_webContext.get(), FALSE);
 }
 
+#if ENABLE(WEBDRIVER_BIDI)
+static String assertSharedWorkerRealmAndGetIdentifier(const JSON::Object& realm, const String& expectedOrigin)
+{
+    g_assert_true(realm.getString("type"_s) == "shared-worker"_s);
+    g_assert_true(realm.getString("origin"_s) == expectedOrigin);
+    g_assert_false(!!realm.getValue("context"_s));
+    g_assert_false(!!realm.getValue("owners"_s));
+
+    auto realmIdentifier = realm.getString("realm"_s);
+    g_assert_true(realmIdentifier.startsWith("realm-"_s));
+    return realmIdentifier;
+}
+
+static Ref<JSON::Array> getRealms(AutomationTest& test, int commandIdentifier, Ref<JSON::Object>&& parameters)
+{
+    auto response = test.sendBidiCommandAndWait(commandIdentifier, "script.getRealms"_s, WTF::move(parameters));
+    auto result = response->getObject("result"_s);
+    g_assert_true(!!result);
+    auto realms = result->getArray("realms"_s);
+    g_assert_true(!!realms);
+    return realms.releaseNonNull();
+}
+
+static String getSharedWorkerRealmIdentifier(AutomationTest& test, int commandIdentifier, const String& browsingContext, const String& expectedOrigin)
+{
+    auto parameters = JSON::Object::create();
+    parameters->setString("context"_s, browsingContext);
+    parameters->setString("type"_s, "shared-worker"_s);
+    auto realms = getRealms(test, commandIdentifier, WTF::move(parameters));
+    g_assert_cmpuint(realms->length(), ==, 1);
+
+    auto realm = realms->get(0)->asObject();
+    g_assert_true(!!realm);
+    return assertSharedWorkerRealmAndGetIdentifier(*realm, expectedOrigin);
+}
+
+static void verifySharedWorkerRealmLifecycle(AutomationTest& test, GRefPtr<WebKitWebView>& firstWebView, const String& firstBrowsingContext, GRefPtr<WebKitWebView>& secondWebView, const String& secondBrowsingContext)
+{
+    g_assert_true(firstBrowsingContext != secondBrowsingContext);
+    test.loadSharedWorkerPage(firstWebView.get());
+    test.loadSharedWorkerPage(secondWebView.get());
+
+    auto subscriptionParameters = JSON::Object::create();
+    auto events = JSON::Array::create();
+    events->pushString("script.realmCreated"_s);
+    subscriptionParameters->setArray("events"_s, WTF::move(events));
+    test.sendBidiCommandAndWait(1, "session.subscribe"_s, WTF::move(subscriptionParameters));
+
+    auto realmCreatedEvent = test.takeBidiMessage([](const JSON::Object& message) {
+        if (message.getString("method"_s) != "script.realmCreated"_s)
+            return false;
+        auto parameters = message.getObject("params"_s);
+        return parameters && parameters->getString("type"_s) == "shared-worker"_s;
+    });
+    g_assert_true(!!realmCreatedEvent);
+    auto expectedOrigin = s_server->baseURL().protocolHostAndPort();
+    auto createdRealm = realmCreatedEvent->getObject("params"_s);
+    g_assert_true(!!createdRealm);
+    auto realmIdentifier = assertSharedWorkerRealmAndGetIdentifier(*createdRealm, expectedOrigin);
+
+    g_assert_true(getSharedWorkerRealmIdentifier(test, 2, firstBrowsingContext, expectedOrigin) == realmIdentifier);
+    g_assert_true(getSharedWorkerRealmIdentifier(test, 3, secondBrowsingContext, expectedOrigin) == realmIdentifier);
+
+    auto allRealms = getRealms(test, 4, JSON::Object::create());
+    unsigned sharedWorkerRealmCount = 0;
+    for (size_t index = 0; index < allRealms->length(); ++index) {
+        auto realm = allRealms->get(index)->asObject();
+        if (!realm || realm->getString("type"_s) != "shared-worker"_s)
+            continue;
+        ++sharedWorkerRealmCount;
+        g_assert_true(assertSharedWorkerRealmAndGetIdentifier(*realm, expectedOrigin) == realmIdentifier);
+    }
+    g_assert_cmpuint(sharedWorkerRealmCount, ==, 1);
+
+    auto destructionSubscriptionParameters = JSON::Object::create();
+    auto destructionEvents = JSON::Array::create();
+    destructionEvents->pushString("script.realmDestroyed"_s);
+    destructionSubscriptionParameters->setArray("events"_s, WTF::move(destructionEvents));
+    auto destructionContexts = JSON::Array::create();
+    destructionContexts->pushString(secondBrowsingContext);
+    destructionSubscriptionParameters->setArray("contexts"_s, WTF::move(destructionContexts));
+    test.sendBidiCommandAndWait(5, "session.subscribe"_s, WTF::move(destructionSubscriptionParameters));
+
+    firstWebView = nullptr;
+    g_assert_true(getSharedWorkerRealmIdentifier(test, 6, secondBrowsingContext, expectedOrigin) == realmIdentifier);
+
+    secondWebView = nullptr;
+
+    auto realmDestroyedEvent = test.waitForBidiMessage([&realmIdentifier](const JSON::Object& message) {
+        if (message.getString("method"_s) != "script.realmDestroyed"_s)
+            return false;
+        auto parameters = message.getObject("params"_s);
+        return parameters && parameters->getString("realm"_s) == realmIdentifier;
+    });
+    auto destroyedRealm = realmDestroyedEvent->getObject("params"_s);
+    g_assert_true(!!destroyedRealm);
+    g_assert_false(!!destroyedRealm->getValue("context"_s));
+
+    auto sharedWorkerParameters = JSON::Object::create();
+    sharedWorkerParameters->setString("type"_s, "shared-worker"_s);
+    g_assert_cmpuint(getRealms(test, 7, WTF::move(sharedWorkerParameters))->length(), ==, 0);
+}
+#endif
 static void testAutomationSessionApplicationInfo(Test* test, gconstpointer)
 {
     WebKitApplicationInfo* info = webkit_application_info_new();
@@ -400,11 +634,19 @@ void beforeAll()
 {
     g_setenv("WEBKIT_INSPECTOR_SERVER", "127.0.0.1:2229", TRUE);
 
+#if ENABLE(WEBDRIVER_BIDI)
+    s_server = new WebKitTestServer();
+    s_server->run(serverCallback);
+#endif
+
     AutomationTest::add("WebKitAutomationSession", "request-session", testAutomationSessionRequestSession);
     Test::add("WebKitAutomationSession", "application-info", testAutomationSessionApplicationInfo);
 }
 
 void afterAll()
 {
+#if ENABLE(WEBDRIVER_BIDI)
+    delete s_server;
+#endif
     g_unsetenv("WEBKIT_INSPECTOR_SERVER");
 }

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -5473,7 +5473,7 @@
                 "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/304062"}}
             },
             "test_dedicated_worker": {
-                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/282981"}}
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/304300", "note": "The imported WPT expects the worker script URL instead of the serialized worker origin"}}
             },
             "test_shared_worker": {
                 "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/282981"}}
@@ -5520,7 +5520,7 @@
                 "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288067"}}
             },
             "test_dedicated_worker": {
-                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/282981"}}
+                "expected": { "all": { "status": ["PASS"]}}
             },
             "test_shared_worker": {
                 "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/282981"}}


### PR DESCRIPTION
[WebDriver][BiDi] Support shared worker realm lifecycle and enumeration
https://bugs.webkit.org/show_bug.cgi?id=304300

Reviewed by NOBODY (OOPS!).

WebDriver BiDi does not currently expose shared worker realms through
script.getRealms or report their lifecycle events. Expose each execution-ready
shared worker as one BiDi realm shared by its automated owner documents.

A shared worker can have multiple SharedWorker objects, and an owner document
can enter the back/forward cache without detaching. Store the owner frame for
each object in WebSharedWorker and derive two deduplicated sets. Active owners
exclude suspended objects and determine context filtering and realmCreated
event routing. Attached owners include suspended objects and preserve the
routing information needed when the realm is finally destroyed.

Send both sets to the WebProcess hosting the worker at launch and whenever an
object is added, removed, suspended, or resumed. SharedWorkerContextManager
registers the ref-counted SharedWorkerThreadProxy before starting its thread.
The proxy reports readiness only after the worker global scope exists and
reports destruction only after the stop callback completes. The readiness
callback crosses threads with a ThreadSafeWeakPtr and isolated origin data,
while the stop callback keeps the proxy alive. IPC carries identifiers and
value snapshots rather than object pointers.

BidiScriptAgent assigns one stable RealmIdentifier to each
SharedWorkerIdentifier. It uses active owner contexts for current filtering
and creation event routing, retains attached owner contexts for final
destruction event routing, and records terminated workers so late
script.getRealms replies cannot recreate destroyed realms. script.getRealms
queries every WebProcess in the process pool and applies realm-type and
active-owner context filters. Shared worker realm information contains only
the realm identifier, serialized origin, and type; it has no context or owners
field.

Add a WebKit API regression covering late global subscription replay, exact
payload shape and canonical origin, a stable realm identifier across two
owners, all enumeration filters, survival after the first owner closes,
context-routed final destruction, and removal after the final owner closes.

Leave imported WPT files and expectations unchanged. The creation test still
fails its existing script URL origin assertion. The destruction test keeps the
worker alive because its owner is suspended in the back/forward cache. The
WebKit API regression closes the final owner directly and verifies the
resulting teardown.

This change covers orderly owner and worker-thread teardown. Rehosting a
shared worker after its hosting WebProcess crashes remains follow-up work.

* Source/WebCore/automation/AutomationInstrumentation.cpp:
(WebCore::AutomationInstrumentation::scriptSharedWorkerRealmStateChanged):
(WebCore::AutomationInstrumentation::scriptSharedWorkerRealmDestroyed):
(WebCore::AutomationInstrumentation::sharedWorkerRealms):
* Source/WebCore/automation/AutomationInstrumentation.h:
* Source/WebCore/workers/shared/SharedWorker.cpp:
(WebCore::SharedWorker::create):
* Source/WebCore/workers/shared/SharedWorkerObjectConnection.h:
* Source/WebCore/workers/shared/context/SharedWorkerContextManager.cpp:
(WebCore::SharedWorkerContextManager::sharedWorkers const):
(WebCore::SharedWorkerContextManager::stopSharedWorker):
(WebCore::SharedWorkerContextManager::registerSharedWorkerThread):
(WebCore::SharedWorkerContextManager::Connection::setSharedWorkerOwnerFrameIdentifiers):
* Source/WebCore/workers/shared/context/SharedWorkerContextManager.h:
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::SharedWorkerThreadProxy::SharedWorkerThreadProxy):
(WebCore::SharedWorkerThreadProxy::setOwnerFrameIdentifiers):
(WebCore::SharedWorkerThreadProxy::workerBecameExecutionReady):
(WebCore::SharedWorkerThreadProxy::workerTerminated):
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp:
(WebKit::WebSharedWorker::addSharedWorkerObject):
(WebKit::WebSharedWorker::removeSharedWorkerObject):
(WebKit::WebSharedWorker::suspend):
(WebKit::WebSharedWorker::resume):
(WebKit::WebSharedWorker::ownerFrameIdentifiers const):
(WebKit::WebSharedWorker::sendOwnerFrameIdentifiers const):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h:
(WebKit::WebSharedWorker::activeOwnerFrameIdentifiers const):
(WebKit::WebSharedWorker::attachedOwnerFrameIdentifiers const):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp:
(WebKit::WebSharedWorkerServer::requestSharedWorker):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp:
(WebKit::WebSharedWorkerServerConnection::requestSharedWorker):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.messages.in:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.cpp:
(WebKit::WebSharedWorkerServerToContextConnection::launchSharedWorker):
(WebKit::WebSharedWorkerServerToContextConnection::updateSharedWorkerOwnerFrameIdentifiers):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerToContextConnection.h:
* Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp:
(WebKit::BidiScriptAgent::getRealms):
(WebKit::BidiScriptAgent::registerDedicatedWorkerRealm):
(WebKit::BidiScriptAgent::controlledBrowsingContexts const):
(WebKit::BidiScriptAgent::synchronizeSharedWorkerRealm):
(WebKit::BidiScriptAgent::processRealmsForPagesAsync):
(WebKit::BidiScriptAgent::collectSharedWorkerRealms):
(WebKit::BidiScriptAgent::sendRealmDestroyedEvent):
(WebKit::BidiScriptAgent::notifyRealmCreated):
(WebKit::BidiScriptAgent::notifySharedWorkerRealmStateChanged):
(WebKit::BidiScriptAgent::notifySharedWorkerRealmDestroyed):
(WebKit::BidiScriptAgent::emitEventsForActiveRealms):
* Source/WebKit/UIProcess/Automation/BidiScriptAgent.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::scriptSharedWorkerRealmStateChanged):
(WebKit::WebAutomationSession::scriptSharedWorkerRealmDestroyed):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.messages.in:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::scriptSharedWorkerRealmStateChanged):
(WebKit::WebAutomationSessionProxy::scriptSharedWorkerRealmDestroyed):
(WebKit::WebAutomationSessionProxy::getSharedWorkerRealms):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.messages.in:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp:
(WebKit::WebSharedWorkerContextManagerConnection::launchSharedWorker):
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.h:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.messages.in:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.cpp:
(WebKit::WebSharedWorkerObjectConnection::requestSharedWorker):
* Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestAutomationSession.cpp:
(serverCallback):
(AutomationTest::receivedMessage):
(AutomationTest::browsingContextHandleFromLastResponse const):
(AutomationTest::loadSharedWorkerPage):
(AutomationTest::sendBidiCommandAndWait):
(AutomationTest::takeBidiMessage):
(AutomationTest::waitForBidiMessage):
(testAutomationSessionRequestSession):
(assertSharedWorkerRealmAndGetIdentifier):
(getRealms):
(getSharedWorkerRealmIdentifier):
(verifySharedWorkerRealmLifecycle):
(beforeAll):
(afterAll):
.<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97189ffe54ea3ba4d21d94e394565e957c741ca5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196298 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150623 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59622 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145341 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100758 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49026 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165894 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125658 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47764 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45759 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158118 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45478 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7369 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198275 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59558 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154900 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60267 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154545 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48995 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132594 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129648 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58714 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20478 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58105 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->