### PR TITLE
[JSC][Wasm] Reject a final parent in isSubRTT with a pointer check

### DIFF
--- a/JSTests/wasm/stress/call-indirect-final-signature.js
+++ b/JSTests/wasm/stress/call-indirect-final-signature.js
@@ -1,0 +1,28 @@
+import * as assert from "../assert.js"
+import { instantiate } from "../gc/wast-wrapper.js"
+
+const { ok, bad, subtype } = instantiate(`
+(module
+  (type $retI32 (func (result i32)))
+  (type $retI64 (func (result i64)))
+  (type $base (sub (func (result i32))))
+  (type $child (sub $base (func (result i32))))
+  (table 3 funcref)
+  (func $one (type $retI32) (i32.const 1))
+  (func $two (type $retI64) (i64.const 2))
+  (func $from-child (type $child) (i32.const 3))
+  (elem (i32.const 0) $one $two $from-child)
+  (func (export "ok") (result i32)
+    (call_indirect (type $retI32) (i32.const 0)))
+  (func (export "bad") (result i32)
+    (call_indirect (type $retI32) (i32.const 1)))
+  (func (export "subtype") (result i32)
+    (call_indirect (type $base) (i32.const 2)))
+)
+`).exports
+
+for (let i = 0; i < wasmTestLoopCount; ++i) {
+    assert.eq(ok(), 1)
+    assert.eq(subtype(), 3)
+    assert.throws(bad, WebAssembly.RuntimeError, "signature")
+}

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -121,22 +121,6 @@ RefPtr<RTT> RTT::tryCreateArray(const RTT& supertype, bool isFinalType, RTTArray
     return adoptRef(new (NotNull, memory) RTT(RTTKind::Array, supertype, isFinalType, /*fieldCount*/ 0, WTF::move(payload)));
 }
 
-bool RTT::isSubRTT(const RTT& parent) const
-{
-    if (this == &parent)
-        return true;
-    if (displaySizeExcludingThis() < parent.displaySizeExcludingThis())
-        return false;
-    return &parent == displayEntry(parent.displaySizeExcludingThis());
-}
-
-bool RTT::isStrictSubRTT(const RTT& parent) const
-{
-    if (displaySizeExcludingThis() <= parent.displaySizeExcludingThis())
-        return false;
-    return &parent == displayEntry(parent.displaySizeExcludingThis());
-}
-
 String RTT::toString() const
 {
     return WTF::toString(*this);

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -852,8 +852,26 @@ public:
         return static_cast<uint64_t>(ptr | (maskedFieldIndex & 0b1111) | (static_cast<uint64_t>(maskedFieldIndex >> 4) << 48));
     }
 
-    bool NODELETE isSubRTT(const RTT& other) const;
-    bool NODELETE isStrictSubRTT(const RTT& other) const;
+    bool isSubRTT(const RTT& parent) const
+    {
+        if (this == &parent)
+            return true;
+        if (parent.isFinalType())
+            return false;
+        if (displaySizeExcludingThis() < parent.displaySizeExcludingThis())
+            return false;
+        return &parent == displayEntry(parent.displaySizeExcludingThis());
+    }
+
+    bool isStrictSubRTT(const RTT& parent) const
+    {
+        if (parent.isFinalType())
+            return false;
+        if (displaySizeExcludingThis() <= parent.displaySizeExcludingThis())
+            return false;
+        return &parent == displayEntry(parent.displaySizeExcludingThis());
+    }
+
     bool isFinalType() const { return m_isFinalType; }
 
     // Print this RTT for debugging.


### PR DESCRIPTION
#### 24b40653ec9c39a3396123fcac89e533765e1b0c
<pre>
[JSC][Wasm] Reject a final parent in isSubRTT with a pointer check
<a href="https://bugs.webkit.org/show_bug.cgi?id=177962">https://bugs.webkit.org/show_bug.cgi?id=177962</a>

Reviewed by NOBODY (OOPS!).

A final type has no subtypes. isSubRTT already returned false after
the display walk. Check isFinalType first so IPInt call_indirect and
other C++ callers skip that walk.

* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
* JSTests/wasm/stress/call-indirect-final-signature.js: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24b40653ec9c39a3396123fcac89e533765e1b0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186019 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/196312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/61290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/196312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/188974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/61290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/196312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/61290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/196312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/61290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/7383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/47259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/198290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/198290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/60284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/198290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/60284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/58120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/58178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->