### PR TITLE
[EWS] Cancelled test build is incorrectly reported as green

### DIFF
--- a/Tools/CISupport/Shared/steps.py
+++ b/Tools/CISupport/Shared/steps.py
@@ -108,12 +108,13 @@ class SetBuildSummary(buildstep.BuildStep, AddToLogMixin):
     @defer.inlineCallbacks
     def run(self):
         build_summary = self.getProperty('build_summary', 'build successful')
-        yield self._addToLog('stdio', f'Setting build summary as: {build_summary}')
-        previous_build_summary = self.getProperty('build_summary', '')
-        if self.FAILURE_MSG_IN_STRESS_MODE in previous_build_summary:
+        if self.build.results in (CANCELLED, RETRY):
+            build_summary = f'Build was interrupted ({Results[self.build.results]})'
+        elif self.FAILURE_MSG_IN_STRESS_MODE in build_summary:
             self.build.results = FAILURE
-        elif self.getProperty('force_build_success', False) or any(s in previous_build_summary for s in self.SUCCESS_MSGS):
+        elif self.getProperty('force_build_success', False) or any(s in build_summary for s in self.SUCCESS_MSGS):
             self.build.results = SUCCESS
+        yield self._addToLog('stdio', f'Setting build summary as: {build_summary}')
         self.build.buildFinished([build_summary], self.build.results)
         return defer.returnValue(SUCCESS)
 

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -36,7 +36,7 @@ from unittest.mock import call, create_autospec, patch
 
 from buildbot.process import properties
 from buildbot.process import remotetransfer
-from buildbot.process.results import SUCCESS, FAILURE, WARNINGS, SKIPPED, RETRY
+from buildbot.process.results import SUCCESS, FAILURE, WARNINGS, SKIPPED, RETRY, CANCELLED
 from buildbot.test.fake.fakebuild import FakeBuild
 from buildbot.test.reactor import TestReactorMixin
 from buildbot.test.steps import Expect, ExpectShell
@@ -3916,6 +3916,15 @@ class TestFilterLayoutTestFailuresUsingResultsDB(BuildStepMixinAdditions, unitte
         self.expect_outcome(result=SUCCESS)
         yield self.run_step()
         self.assertEqual(self.build.results, SUCCESS)
+
+    @defer.inlineCallbacks
+    def test_set_build_summary_keeps_a_cancelled_build_cancelled(self):
+        self.setup_step(SetBuildSummary())
+        self.setProperty('build_summary', 'Passed layout tests')
+        self.build.results = CANCELLED
+        self.expect_outcome(result=SUCCESS)
+        yield self.run_step()
+        self.assertEqual(self.build.results, CANCELLED)
 
     def test_ignoring_every_failure_sets_the_property_set_build_summary_reads(self):
         # The other half of the wiring: nothing else tells SetBuildSummary to keep this build green.


### PR DESCRIPTION
#### 86b750ce03c87c313fd9c70593e71efc7e5dd4f3
<pre>
[EWS] Cancelled test build is incorrectly reported as green
<a href="https://bugs.webkit.org/show_bug.cgi?id=323685">https://bugs.webkit.org/show_bug.cgi?id=323685</a>
<a href="https://rdar.apple.com/162612734">rdar://162612734</a>

Reviewed by Ryan Haddad.

SetBuildSummary forced the build result to SUCCESS whenever the build_summary
property matched one of its success messages. That property is set optimistically
by the first test step that passes, and later test steps only overwrite it once
they reach a verdict. Cancelling a build in between (for example after
run-layout-tests-in-stress-mode passed but while layout-tests was still being
retried) left the stale &quot;Passed layout tests&quot; summary in place, and
SetBuildSummary then overrode the CANCELLED build result with SUCCESS, so the
build appeared green even though tests were failing.

Leave the build result alone for builds which were cancelled or are being
retried, since those never reached a verdict, and report the interruption as the
build summary instead.

* Tools/CISupport/Shared/steps.py:
(SetBuildSummary.run):
* Tools/CISupport/ews-build/steps_unittest.py:
(TestFilterLayoutTestFailuresUsingResultsDB.test_set_build_summary_keeps_a_cancelled_build_cancelled):

Canonical link: <a href="https://commits.webkit.org/320761@main">https://commits.webkit.org/320761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7496bc05dfe386da68cd90f11bc946fdceadcc12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185791 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59696 "Build was cancelled. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53503 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196096 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150477 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187653 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/61064 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59422 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145188 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150477 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188746 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/61064 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53503 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/125487 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/61064 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45627 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53503 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/61064 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53503 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/7161 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/50045 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/198064 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/185194 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59356 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53503 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/198064 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60065 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53503 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/198064 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28217 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/48838 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129396 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58531 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53503 "Build was cancelled. Recent messages:OS: Tahoe (26.5.1), Xcode: 26.5; Checked out pull request; Compiled WebKit (cancelled)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57909 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58144 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57974 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->