### PR TITLE
[cleanup] Compute inline box repaint rects through localRectsForRepaint like every other renderer

### DIFF
--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -460,8 +460,10 @@ LayoutRect RenderInline::linesVisualOverflowBoundingBox() const
     return rect;
 }
 
-LayoutRect RenderInline::clippedOverflowRect(const RenderLayerModelObject* repaintContainer, const VisibleRectContext& context) const
+auto RenderInline::localRectsForRepaint(RepaintOutlineBounds) const -> RepaintRects
 {
+    // RepaintOutlineBounds is unused for inlines.
+
     // Only first-letter renderers are allowed in here during layout. They mutate the tree triggering repaints.
 #ifndef NDEBUG
     auto insideSelfPaintingInlineBox = [&] {
@@ -477,61 +479,12 @@ LayoutRect RenderInline::clippedOverflowRect(const RenderLayerModelObject* repai
     ASSERT_UNUSED(insideSelfPaintingInlineBox, !view().frameView().layoutContext().isPaintOffsetCacheEnabled() || style().pseudoElementType() == PseudoElementType::FirstLetter || insideSelfPaintingInlineBox());
 #endif
 
-    auto knownEmpty = [&] {
-        if (firstLegacyInlineBoxFor(*this))
-            return false;
-        if (LayoutIntegration::LineLayout::containing(*this))
-            return false;
-        return true;
-    };
-
-    if (knownEmpty())
-        return LayoutRect();
+    if (!firstLegacyInlineBoxFor(*this) && !LayoutIntegration::LineLayout::containing(*this))
+        return { };
 
     auto repaintRect = linesVisualOverflowBoundingBox();
-    bool hitRepaintContainer = false;
-
-    // We need to add in the in-flow position offsets of any inlines (including us) up to our
-    // containing block.
-    RenderBlock* containingBlock = this->containingBlock();
-    for (const RenderElement* inlineFlow = this; inlineFlow; inlineFlow = inlineFlow->parent()) {
-        auto* renderInline = dynamicDowncast<RenderInline>(*inlineFlow);
-        if (!renderInline || inlineFlow == containingBlock)
-            break;
-        if (inlineFlow == repaintContainer) {
-            hitRepaintContainer = true;
-            break;
-        }
-        if (inlineFlow->style().hasInFlowPosition() && inlineFlow->hasLayer())
-            repaintRect.move(renderInline->layer()->offsetForInFlowPosition());
-    }
-
-    LayoutUnit outlineSize { style().usedOutlineSize(style().usedZoomForLength(), style().deviceScaleFactor()) };
-    repaintRect.inflate(outlineSize);
-
-    if (hitRepaintContainer || !containingBlock)
-        return repaintRect;
-
-    auto rects = RepaintRects { repaintRect };
-
-    if (containingBlock->hasNonVisibleOverflow())
-        containingBlock->applyCachedClipAndScrollPosition(rects, repaintContainer, context);
-
-    rects = containingBlock->computeRects(rects, repaintContainer, context);
-    repaintRect = rects.clippedOverflowRect;
-
-    if (outlineSize) {
-        for (auto& child : childrenOfType<RenderElement>(*this))
-            repaintRect.unite(child.rectWithOutlineForRepaint(repaintContainer, outlineSize));
-    }
-
-    return repaintRect;
-}
-
-auto RenderInline::rectsForRepaintingAfterLayout(const RenderLayerModelObject* repaintContainer, RepaintOutlineBounds) const -> RepaintRects
-{
-    // RepaintOutlineBounds is unused for inlines.
-    return { clippedOverflowRect(repaintContainer, visibleRectContextForRepaint()) };
+    repaintRect.inflate(LayoutUnit { style().usedOutlineSize(style().usedZoomForLength(), style().deviceScaleFactor()) });
+    return { repaintRect };
 }
 
 LayoutRect RenderInline::rectWithOutlineForRepaint(const RenderLayerModelObject* repaintContainer, LayoutUnit outlineWidth) const

--- a/Source/WebCore/rendering/RenderInline.h
+++ b/Source/WebCore/rendering/RenderInline.h
@@ -103,8 +103,7 @@ private:
     LayoutUnit offsetHeight() const final { return linesBoundingBox().height(); }
 
 protected:
-    LayoutRect clippedOverflowRect(const RenderLayerModelObject* repaintContainer, const VisibleRectContext&) const override;
-    RepaintRects rectsForRepaintingAfterLayout(const RenderLayerModelObject* repaintContainer, RepaintOutlineBounds) const override;
+    RepaintRects localRectsForRepaint(RepaintOutlineBounds) const override;
     LayoutRect rectWithOutlineForRepaint(const RenderLayerModelObject* repaintContainer, LayoutUnit outlineWidth) const final;
 
     std::optional<RepaintRects> computeVisibleRectsInContainer(const RepaintRects&, const RenderLayerModelObject* container, const VisibleRectContext&, VisibleRectState) const final;


### PR DESCRIPTION
#### 00e08007284d12603b41f85ccca61ceea6c1398b
<pre>
[cleanup] Compute inline box repaint rects through localRectsForRepaint like every other renderer
<a href="https://bugs.webkit.org/show_bug.cgi?id=323755">https://bugs.webkit.org/show_bug.cgi?id=323755</a>
&lt;<a href="https://rdar.apple.com/problem/187016759">rdar://problem/187016759</a>&gt;

Reviewed by Antti Koivisto.

A renderer returns its repaint rect in its own coordinates from localRectsForRepaint(), and
RenderObject maps it up to the repaint container through computeVisibleRectsInContainer().

RenderInline did both, so the mapping was written twice, once by hand in clippedOverflowRect() and
once in its own computeVisibleRectsInContainer(), and both copies had to be kept in sync.

Implement localRectsForRepaint() instead, returning the lines visual overflow rect inflated by the used outline size, and let the shared code do the mapping.

* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::localRectsForRepaint):
(WebCore::RenderInline::clippedOverflowRect): Deleted.
(WebCore::RenderInline::rectsForRepaintingAfterLayout): Deleted.
* Source/WebCore/rendering/RenderInline.h:

Canonical link: <a href="https://commits.webkit.org/320923@main">https://commits.webkit.org/320923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58072573339b29a2978c86fd4f7ceacc9d13c5fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196516 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150781 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61502 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145509 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125845 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47917 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45895 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158270 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45630 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7588 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52617 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198503 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59778 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155078 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41561 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60488 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154721 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49153 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132744 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129901 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58915 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20609 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58317 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58535 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58381 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->