### PR TITLE
[Site Isolation] Video in cross-origin iframe is sometimes not rendering after navigating back

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -38,6 +38,7 @@
 #import <WebCore/EventRegion.h>
 #import <WebCore/GraphicsContext.h>
 #import <WebCore/GraphicsLayerCA.h>
+#import <WebCore/HTMLVideoElement.h>
 #import <WebCore/IOSurface.h>
 #import <WebCore/PlatformCAFilters.h>
 #import <WebCore/PlatformCALayerCocoa.h>
@@ -144,12 +145,20 @@ PlatformCALayerRemote::~PlatformCALayerRemote()
 
 void PlatformCALayerRemote::moveToContext(RemoteLayerTreeContext& context)
 {
-    if (RefPtr oldContext = m_context.get())
+    RefPtr oldContext = m_context.get();
+
+#if HAVE(AVKIT)
+    RefPtr videoElement = oldContext ? oldContext->videoElementForLayer(layerID()) : nullptr;
+    if (videoElement)
+        context.layerDidEnterContext(*this, layerType(), *videoElement);
+    else
+#endif // HAVE(AVKIT)
+        context.layerDidEnterContext(*this, layerType());
+
+    if (oldContext)
         oldContext->layerWillLeaveContext(*this);
 
     m_context = context;
-
-    context.layerDidEnterContext(*this, layerType());
 
     m_properties.notePropertiesChanged(m_properties.everChangedProperties);
 }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -67,6 +67,8 @@ public:
     void layerDidEnterContext(PlatformCALayerRemote&, WebCore::PlatformCALayer::LayerType);
 #if HAVE(AVKIT)
     void layerDidEnterContext(PlatformCALayerRemote&, WebCore::PlatformCALayer::LayerType, WebCore::HTMLVideoElement&);
+
+    RefPtr<WebCore::HTMLVideoElement> videoElementForLayer(WebCore::PlatformLayerIdentifier) const;
 #endif
     void layerWillLeaveContext(PlatformCALayerRemote&);
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -146,6 +146,19 @@ void RemoteLayerTreeContext::layerDidEnterContext(PlatformCALayerRemote& layer, 
     m_createdLayers.add(layerID, WTF::move(creationProperties));
     m_livePlatformLayers.add(layerID, &layer);
 }
+
+RefPtr<HTMLVideoElement> RemoteLayerTreeContext::videoElementForLayer(PlatformLayerIdentifier layerID) const
+{
+    auto it = m_videoLayers.find(layerID);
+    if (it == m_videoLayers.end())
+        return nullptr;
+
+    RefPtr videoElement = protect(protect(webPage())->videoPresentationManager())->videoElementForContext(it->value);
+    if (!videoElement)
+        RELEASE_LOG_ERROR(RemoteLayerTree, "RemoteLayerTreeContext::videoElementForLayer: layer %" PRIu64 " is registered as a video layer but has no video element; remote layer hosting will not be set up", layerID.object().toUInt64());
+
+    return videoElement;
+}
 #endif
 
 WebPage& RemoteLayerTreeContext::webPage() const

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -157,6 +157,8 @@ public:
     void setupRemoteLayerHosting(WebCore::HTMLVideoElement&);
     void willRemoveLayerForID(WebCore::MediaPlayerClientIdentifier);
 
+    RefPtr<WebCore::HTMLVideoElement> videoElementForContext(WebCore::MediaPlayerClientIdentifier) const;
+
     void swapFullscreenModes(WebCore::HTMLVideoElement&, WebCore::HTMLVideoElement&);
 
     // Interface to WebChromeClient

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -267,6 +267,15 @@ void VideoPresentationManager::removeContext(WebCore::MediaPlayerClientIdentifie
     m_videoElements.remove(*videoElement);
 }
 
+RefPtr<WebCore::HTMLVideoElement> VideoPresentationManager::videoElementForContext(WebCore::MediaPlayerClientIdentifier contextId) const
+{
+    auto it = m_contextMap.find(contextId);
+    if (it == m_contextMap.end())
+        return nullptr;
+
+    return std::get<0>(it->value)->videoElement();
+}
+
 void VideoPresentationManager::addClientForContext(WebCore::MediaPlayerClientIdentifier contextId)
 {
     auto addResult = m_clientCounts.add(contextId, 1);


### PR DESCRIPTION
#### d58d0a3ae2a04845ab8b975e917d5685c8b67611
<pre>
[Site Isolation] Video in cross-origin iframe is sometimes not rendering after navigating back
<a href="https://bugs.webkit.org/show_bug.cgi?id=323760">https://bugs.webkit.org/show_bug.cgi?id=323760</a>
<a href="https://rdar.apple.com/187019361">rdar://187019361</a>

Reviewed by Sihui Liu.

When navigating back to a page with a cross-origin iframe, the drawing area will in some cases
change, and we need to move PlatformCALayerRemote objects to the new context in
PlatformCALayerRemote::moveToContext. For the layer hosting to be set up correctly, we need
to call the layerDidEnterContext method in RemoteLayerTreeContext that takes the
HTMLVideoElement as argument.

No new tests, since we currently don&apos;t have a way to verify that the hosting is correctly set up.

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::moveToContext):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::videoElementForLayer const):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::videoElementForContext const):

Canonical link: <a href="https://commits.webkit.org/320926@main">https://commits.webkit.org/320926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8032ca327379fac554e9b1315962c17e5835082a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196497 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150763 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c04a79f1-91fc-48ba-a216-b2990091952c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59813 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145492 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100849 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca99a412-2420-41f9-88b2-5b69cbeda3dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125827 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4f60213c-f90c-44b2-a4e4-6e041bcf62eb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47901 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45879 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158254 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45616 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7567 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52599 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50343 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198479 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59758 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155060 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60469 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42190 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154703 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28286 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49136 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132726 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129882 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58896 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20595 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58298 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58516 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58359 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->