### PR TITLE
Unreviewed build fix 9-9-2026 due to deprecations

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CodingTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CodingTests.swift
@@ -29,6 +29,7 @@ private import WebKit_Private.WKPreferencesPrivate
 @MainActor
 struct CodingTests {
     @Test
+    @available(*, deprecated, message: "Intentionally uses deprecated API.")
     func wkPreferences() throws {
         let a = WKPreferences()
 
@@ -54,6 +55,7 @@ struct CodingTests {
     }
 
     @Test
+    @available(*, deprecated, message: "Intentionally uses deprecated API.")
     func wkProcessPoolShared() throws {
         let a = try #require(WKProcessPool._shared())
         let b = try encodeAndDecode(a)
@@ -62,12 +64,14 @@ struct CodingTests {
     }
 
     @Test
+    @available(*, deprecated, message: "Intentionally uses deprecated API.")
     func wkProcessPool() throws {
         let pool = try encodeAndDecode(WKProcessPool())
         #expect(pool !== WKProcessPool._shared())
     }
 
     @Test
+    @available(*, deprecated, message: "Intentionally uses deprecated API.")
     func wkWebsiteDataStoreDefault() throws {
         let a = WKWebsiteDataStore.default()
         let b = try encodeAndDecode(a)
@@ -76,12 +80,14 @@ struct CodingTests {
     }
 
     @Test
+    @available(*, deprecated, message: "Intentionally uses deprecated API.")
     func wkWebsiteDataStoreNonPersistent() throws {
         let store = try encodeAndDecode(WKWebsiteDataStore.nonPersistent())
         #expect(!store.isPersistent)
     }
 
     @Test
+    @available(*, deprecated, message: "Intentionally uses deprecated API.")
     func wkWebViewConfiguration() throws {
         let a = WKWebViewConfiguration()
 
@@ -114,6 +120,7 @@ struct CodingTests {
     }
 
     @Test
+    @available(*, deprecated, message: "Intentionally uses deprecated API.")
     func wkWebView() throws {
         let a = WKWebView()
 
@@ -149,6 +156,7 @@ struct CodingTests {
     }
 
     @Test
+    @available(*, deprecated, message: "Intentionally uses deprecated API.")
     func wkWebViewSameConfiguration() throws {
         // First, encode two WKWebViews sharing the same configuration.
         let data = try {
@@ -176,6 +184,7 @@ struct CodingTests {
     }
 }
 
+@available(*, deprecated, message: "Intentionally uses deprecated API.")
 private func encodeAndDecode<T>(_ value: T) throws -> T where T: NSCoding, T: NSObject {
     if let secureCoding = value as? any NSSecureCoding {
         let data = try NSKeyedArchiver.archivedData(withRootObject: secureCoding, requiringSecureCoding: true)


### PR DESCRIPTION
#### 362f419658ae8def26524afeda1fffeb11a5436c
<pre>
Unreviewed build fix 9-9-2026 due to deprecations
<a href="https://bugs.webkit.org/show_bug.cgi?id=323762">https://bugs.webkit.org/show_bug.cgi?id=323762</a>
<a href="https://rdar.apple.com/187019943">rdar://187019943</a>

Unreviewed, suppress deprecations

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CodingTests.swift:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/362f419658ae8def26524afeda1fffeb11a5436c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53512 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/196105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61073 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/196105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188755 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/48879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/196105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/47606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/196105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/157966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/45334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-gcc~~](https://ews-build.webkit.org/#/builders/284/builds/7170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/198073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59365 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/165270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/198073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60074 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/198073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/48847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/57918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/57983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->