### PR TITLE
[WPE] WebDriver cannot type shifted or unmapped characters

### DIFF
--- a/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
+++ b/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
@@ -225,21 +225,24 @@ static void doKeyStrokeEvent(WebPageProxy &page, bool pressed, uint32_t keyVal, 
     GUniqueOutPtr<GError> error;
     auto* keymap = WPE_KEYMAP(wpe_display_get_keymap(display));
 
+    unsigned keyCode = 0;
+    auto remainingModifiers = static_cast<WPEModifiers>(modifiers);
+
     GUniqueOutPtr<WPEKeymapEntry> entries;
     guint entriesCount;
-    if (!wpe_keymap_get_entries_for_keyval(keymap, keyVal, &entries.outPtr(), &entriesCount)) {
-        LOG(Automation, "WebAutomationSession::doKeyStrokeEvent: Failed to get keymap entries for keyval %u. Ignoring event.", keyVal);
-        return;
-    }
-    unsigned keyCode = entries.get()[0].keycode;
+    if (wpe_keymap_get_entries_for_keyval(keymap, keyVal, &entries.outPtr(), &entriesCount) && entriesCount) {
+        keyCode = entries.get()[0].keycode;
 
-    WPEModifiers consumedModifiers;
-    if (!wpe_keymap_translate_keyboard_state(keymap, keyCode, static_cast<WPEModifiers>(modifiers), entries.get()[0].group, &keyVal, nullptr, nullptr, &consumedModifiers)) {
-        LOG(Automation, "WebAutomationSession::doKeyStrokeEvent: Failed to translate keyboard state for keycode %u. Ignoring event.", keyCode);
-        return;
-    }
+        if (entries.get()[0].level > 0)
+            modifiers |= WPE_MODIFIER_KEYBOARD_SHIFT;
 
-    auto remainingModifiers = static_cast<WPEModifiers>(modifiers & ~consumedModifiers);
+        WPEModifiers consumedModifiers;
+        if (wpe_keymap_translate_keyboard_state(keymap, keyCode, static_cast<WPEModifiers>(modifiers), entries.get()[0].group, &keyVal, nullptr, nullptr, &consumedModifiers))
+            remainingModifiers = static_cast<WPEModifiers>(modifiers & ~consumedModifiers);
+        else
+            LOG(Automation, "WebAutomationSession::doKeyStrokeEvent: Failed to translate keyboard state for keycode %u. Sending the keyval as requested.", keyCode);
+    } else
+        LOG(Automation, "WebAutomationSession::doKeyStrokeEvent: No keymap entry for keyval %u. Sending it without a keycode.", keyVal);
 
     GRefPtr<WPEEvent> event = adoptGRef(wpe_event_keyboard_new(pressed ? WPE_EVENT_KEYBOARD_KEY_DOWN : WPE_EVENT_KEYBOARD_KEY_UP, view, WPE_INPUT_SOURCE_KEYBOARD, 0,
     remainingModifiers, keyCode, keyVal));

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -419,17 +419,6 @@
         }
     },
 
-    "imported/selenium/py/test/selenium/webdriver/common/form_handling_tests.py": {
-        "subtests": {
-            "test_should_be_able_to_enter_text_into_atext_area_by_setting_its_value": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279342"}}
-            },
-            "test_sending_keyboard_events_should_append_text_in_inputs": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279342"}}
-            }
-        }
-    },
-
     "imported/selenium/py/test/selenium/webdriver/common/frame_switching_tests.py": {
         "subtests": {
             "test_should_focus_on_the_replacement_when_aframe_follows_alink_to_a_top_targeted_page": {
@@ -559,36 +548,6 @@
 
     "imported/selenium/py/test/selenium/webdriver/common/typing_tests.py": {
         "subtests": {
-            "test_should_be_able_to_mix_upper_and_lower_case_letters": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
-            },
-            "test_should_be_able_to_type_capital_letters": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
-            },
-            "test_should_be_able_to_type_quote_marks": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
-            },
-            "test_should_be_able_to_type_the_at_character": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
-            },
-            "test_should_be_able_to_use_arrow_keys": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
-            },
-            "test_should_type_into_input_elements_that_have_no_type_attribute": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
-            },
-            "test_will_simulate_akey_down_when_entering_text_into_input_elements": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
-            },
-            "test_will_simulate_akey_down_when_entering_text_into_text_areas": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
-            },
-            "test_will_simulate_akey_up_when_entering_text_into_input_elements": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
-            },
-            "test_will_simulate_akey_up_when_entering_text_into_text_areas": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
-            },
             "test_numeric_shift_keys": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/182333"}}
             },
@@ -609,14 +568,12 @@
             },
             "test_will_simulate_akey_press_when_entering_text_into_input_elements" : {
                 "expected": {
-                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"},
-                    "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}
                 }
             },
             "test_will_simulate_akey_press_when_entering_text_into_text_areas" : {
                 "expected": {
-                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"},
-                    "wpe": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}
+                    "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}
                 }
             }
         }
@@ -1012,9 +969,6 @@
 
     "imported/w3c/webdriver/tests/classic/perform_actions/key_events.py": {
         "subtests": {
-            "test_special_key_sends_keydown[CLEAR-expected4]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
-            },
             "test_special_key_sends_keydown[F11-expected16]": {
                 "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
             },
@@ -1056,24 +1010,6 @@
             },
             "test_printable_key_sends_correct_events[,-Comma]": {
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
-            },
-            "test_printable_key_sends_correct_events[@-Digit2]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279342"}}
-            },
-            "test_printable_key_sends_correct_events[\"-Quote]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/279342"}}
-            },
-            "test_printable_key_sends_correct_events[\\u0416-]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/303836"}}
-            },
-            "test_printable_key_sends_correct_events[\\u2603-]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/303836"}}
-            },
-            "test_printable_key_sends_correct_events[\\uf6c2-]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/303836"}}
-            },
-            "test_printable_key_sends_correct_events[\\xe0-]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/303836"}}
             },
             "test_special_key_sends_keydown[ADD-expected0]": {
                 "expected": {"gtk": {"status": ["FAIL"], "bug": "webkit.org/b/224736"}}
@@ -1187,12 +1123,6 @@
     },
     "imported/w3c/webdriver/tests/classic/perform_actions/key_special_keys.py": {
         "subtests": {
-            "test_codepoint_keys_behave_correctly[\\U0001f604]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
-            },
-            "test_codepoint_keys_behave_correctly[\\U0001f60d]": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
-            },
             "test_codepoint_keys_behave_correctly[\\u0ba8\\u0bbf]": {
                 "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/184967"}}
             },


### PR DESCRIPTION
#### 6307bfc19c3c851e7111b98b858683697b96e37b
<pre>
[WPE] WebDriver cannot type shifted or unmapped characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=323765">https://bugs.webkit.org/show_bug.cgi?id=323765</a>

Reviewed by Carlos Garcia Campos.

doKeyStrokeEvent() looks the requested keysym in the keymap, takes the
keycode of the first entry and it overwrites the keysym with the result of
translating that keycode with the modifiers. Nothing adds shift for a
keysym that is shifted, since modifiersForKeyVal() only maps modifier
keys, so the entry&apos;s level is ignored and the translation maps the keycode
back to its unshifted keysym. Typing &quot;World1!&quot; produces &quot;world11&quot;. Add
shift when the matched entry needs it, so the requested character survives
the round trip.

A character the layout cannot produce, an accented letter or an emoji, has no
entry in the keymap at all, and the event was dropped. Send it with a keycode
of 0 instead: WebDriver is expected to be able to type any character, and
discarding the event leaves the caller waiting for a key that never arrives.
A failed keymap translation no longer drops the event either; the keysym is
sent as requested.

This makes 24 WebDriver subtests pass on WPE, mostly in typing_tests.py,
form_handling_tests.py, key_events.py and key_special_keys.py, whose
expectations are removed here.

* Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp:
(WebKit::doKeyStrokeEvent):
* WebDriverTests/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/320915@main">https://commits.webkit.org/320915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8dce742b84f98e680a80212d4a142b01752a8660

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196471 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150741 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61450 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59788 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145466 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100833 "3 flakes 16 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125798 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47874 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45858 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158228 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45592 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7541 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198449 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59732 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155035 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41556 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60443 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154679 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49118 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132706 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129855 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58872 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20571 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58272 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58492 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58333 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->