### PR TITLE
Replace references to ComputedStyle's "specifiedLineHeight" with "lineHeight"

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -5486,7 +5486,6 @@
                 "animation-wrapper-requires-setter": "setLineHeightFromAnimation",
                 "style-builder-custom": "All",
                 "style-extractor-custom": true,
-                "computed-style-name-for-methods": "SpecifiedLineHeight",
                 "computed-style-storage-path": ["m_inheritedData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::LineHeight",

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -2393,8 +2393,8 @@ Style::ComputedStyle HTMLInputElement::createInnerTextStyle(const Style::Compute
         return isText() && !style.logicalHeight().isAuto() && !hasAutofillStrongPasswordButton();
     };
     if (shouldUseInitialLineHeight()) {
-        textBlockStyle.setSpecifiedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
-        textBlockStyle.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
+        textBlockStyle.setLineHeight(Style::ComputedStyle::initialLineHeight());
+        textBlockStyle.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialLineHeight());
     }
 
     return textBlockStyle;

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1498,8 +1498,8 @@ void RenderTheme::adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle
     // Font
     if (auto controlFont = this->controlFont(appearance, fontCascade.get(), style.usedZoom())) {
         // If overriding the specified font with the theme font, also override the line height with the standard line height.
-        style.setSpecifiedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
-        style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
+        style.setLineHeight(Style::ComputedStyle::initialLineHeight());
+        style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialLineHeight());
 
         style.setFontDescription(WTF::move(controlFont.value()));
     }

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -120,7 +120,7 @@ unsigned TextAutoSizingHashTranslator::hash(const Style::ComputedStyle& style)
     hash ^= std::to_underlying(style.nbspMode());
     hash ^= std::to_underlying(style.lineBreak());
     hash ^= std::to_underlying(style.textSecurity());
-    hash ^= style.specifiedLineHeight().valueForHash();
+    hash ^= style.lineHeight().valueForHash();
     hash ^= computeFontHash(style.fontCascade());
     hash ^= WTF::FloatHash<float>::hash(style.borderHorizontalSpacing().unresolvedValue());
     hash ^= WTF::FloatHash<float>::hash(style.borderVerticalSpacing().unresolvedValue());
@@ -150,7 +150,7 @@ bool TextAutoSizingHashTranslator::equal(const Style::ComputedStyle& styleA, con
         && styleA.nbspMode() == styleB.nbspMode()
         && styleA.lineBreak() == styleB.lineBreak()
         && styleA.textSecurity() == styleB.textSecurity()
-        && styleA.specifiedLineHeight() == styleB.specifiedLineHeight()
+        && styleA.lineHeight() == styleB.lineHeight()
         && styleA.fontCascade().equalForTextAutoSizing(styleB.fontCascade())
         && styleA.borderHorizontalSpacing() == styleB.borderHorizontalSpacing()
         && styleA.borderVerticalSpacing() == styleB.borderVerticalSpacing()
@@ -252,9 +252,9 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
 
         // Resize the line height of the parent.
         auto& parentStyle = parentRenderer->style();
-        auto& lineHeightLength = parentStyle.specifiedLineHeight();
+        auto& parentLineHeight = parentStyle.lineHeight();
 
-        int specifiedLineHeight = WTF::switchOn(lineHeightLength,
+        int parentEvaluatedLineHeight = WTF::switchOn(parentLineHeight,
             [&](const CSS::Keyword::Normal&) {
                 return 0;
             },
@@ -265,15 +265,18 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
                 return LayoutUnit { number.value * LayoutUnit { fontDescription.computedSize() } }.toInt();
             }
         );
+        parentEvaluatedLineHeight *= scaleChange;
 
         // This calculation matches the line-height computed size calculation in StyleBuilderCustom::applyValueLineHeight().
-        int lineHeight = specifiedLineHeight * scaleChange;
-        if (auto fixedLineHeight = lineHeightLength.tryLength(); fixedLineHeight && fixedLineHeight->resolveZoom(Style::ZoomFactor::none()) == lineHeight)
+        if (auto fixedLineHeight = parentLineHeight.tryLength(); fixedLineHeight && fixedLineHeight->resolveZoom(Style::ZoomFactor::none()) == parentEvaluatedLineHeight)
             continue;
 
         auto newParentStyle = cloneRenderStyleWithState(parentStyle);
-        newParentStyle.setTextAutosizingAdjustedLineHeight(lineHeightLength.isNormal() ? Style::LineHeight { lineHeightLength } : Style::LineHeight { Style::LineHeight::Length { static_cast<float>(lineHeight) } });
-        newParentStyle.setSpecifiedLineHeight(Style::LineHeight { lineHeightLength });
+        newParentStyle.setTextAutosizingAdjustedLineHeight(parentLineHeight.isNormal()
+            ? Style::LineHeight { parentLineHeight }
+            : Style::LineHeight { Style::LineHeight::Length { static_cast<float>(parentEvaluatedLineHeight) } }
+        );
+        newParentStyle.setLineHeight(Style::LineHeight { parentLineHeight });
         newParentStyle.setFontDescription(WTF::move(fontDescription));
         parentRenderer->setStyle(WTF::move(newParentStyle));
 
@@ -336,7 +339,7 @@ void TextAutoSizingValue::reset()
             parentRenderer = parentRenderer->parent();
 
         auto& parentStyle = parentRenderer->style();
-        auto& originalLineHeight = parentStyle.specifiedLineHeight();
+        auto& originalLineHeight = parentStyle.lineHeight();
         if (originalLineHeight == parentStyle.textAutosizingAdjustedLineHeight())
             continue;
 

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -343,8 +343,8 @@ void RenderThemeAdwaita::adjustSearchFieldStyle(Style::ComputedStyle& style, con
 void RenderThemeAdwaita::adjustMenuListStyle(Style::ComputedStyle& style, const Element* element) const
 {
     RenderTheme::adjustMenuListStyle(style, element);
-    style.setSpecifiedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
-    style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
+    style.setLineHeight(Style::ComputedStyle::initialLineHeight());
+    style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialLineHeight());
 }
 
 void RenderThemeAdwaita::adjustMenuListButtonStyle(Style::ComputedStyle& style, const Element* element) const

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -3214,8 +3214,8 @@ static void adjustSelectListButtonStyleForVectorBasedControls(Style::ComputedSty
     applyCommonButtonPaddingToStyleForVectorBasedControls(style);
 #endif
 
-    style.setSpecifiedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
-    style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
+    style.setLineHeight(Style::ComputedStyle::initialLineHeight());
+    style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialLineHeight());
 }
 
 bool RenderThemeCocoa::adjustMenuListStyleForVectorBasedControls(Style::ComputedStyle& style, const Element* element) const
@@ -3236,7 +3236,7 @@ bool RenderThemeCocoa::adjustMenuListStyleForVectorBasedControls(Style::Computed
 
     // Enforce "line-height: normal" as long as this element isn't a non-select element using `-webkit-appearance: menulist`.
     if (element && is<HTMLSelectElement>(*element)) {
-        style.setSpecifiedLineHeight(CSS::Keyword::Normal { });
+        style.setLineHeight(CSS::Keyword::Normal { });
         style.setTextAutosizingAdjustedLineHeight(CSS::Keyword::Normal { });
     }
 

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -471,8 +471,8 @@ static void adjustSelectListButtonStyle(Style::ComputedStyle& style)
     // Enforce "padding: 0 0.5em".
     applyCommonButtonPaddingToStyle(style);
 
-    style.setSpecifiedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
-    style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
+    style.setLineHeight(Style::ComputedStyle::initialLineHeight());
+    style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialLineHeight());
 }
 
 class RenderThemeMeasureTextClient : public MeasureTextClient {

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1228,8 +1228,8 @@ static void setFontFromControlSize(Style::ComputedStyle& style, NSControlSize co
     fontDescription.setComputedSize([font pointSize]);
 
     // Reset line height
-    style.setSpecifiedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
-    style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
+    style.setLineHeight(Style::ComputedStyle::initialLineHeight());
+    style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialLineHeight());
 
     style.setFontDescription(WTF::move(fontDescription));
 }
@@ -1424,8 +1424,8 @@ void RenderThemeMac::adjustMenuListButtonStyle(Style::ComputedStyle& style, cons
 
     style.setMinHeight(18_css_px);
 
-    style.setSpecifiedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
-    style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialSpecifiedLineHeight());
+    style.setLineHeight(Style::ComputedStyle::initialLineHeight());
+    style.setTextAutosizingAdjustedLineHeight(Style::ComputedStyle::initialLineHeight());
 }
 
 std::span<const IntSize, 4> RenderThemeMac::menuListSizes() const

--- a/Source/WebCore/rendering/style/AutosizeStatus.cpp
+++ b/Source/WebCore/rendering/style/AutosizeStatus.cpp
@@ -40,7 +40,7 @@ auto AutosizeStatus::compute(const Style::ComputedStyle& style) -> AutosizeStatu
             return true;
 
         const float maximumDifferenceBetweenFixedLineHeightAndFontSize = 5;
-        auto& lineHeight = style.specifiedLineHeight();
+        auto& lineHeight = style.lineHeight();
         if (auto fixedLineHeight = lineHeight.tryFixed(); fixedLineHeight && fixedLineHeight->resolveZoom(style.usedZoomForLength()) - style.fontSize() > maximumDifferenceBetweenFixedLineHeightAndFontSize)
             return false;
 
@@ -84,22 +84,22 @@ auto AutosizeStatus::isIdempotentTextAutosizingCandidate(const Style::ComputedSt
             if (style.whiteSpaceCollapse() == WhiteSpaceCollapse::Collapse && style.textWrapMode() == TextWrapMode::NoWrap) {
                 if (style.width().isFixed())
                     return false;
-                if (auto fixedHeight = style.height().tryFixed(); fixedHeight && style.specifiedLineHeight().isFixed()) {
-                    if (auto fixedSpecifiedLineHeight = style.specifiedLineHeight().tryFixed()) {
+                if (auto fixedHeight = style.height().tryFixed(); fixedHeight && style.lineHeight().isFixed()) {
+                    if (auto fixedLineHeight = style.lineHeight().tryFixed()) {
                         auto size = style.fontSize();
                         auto zoomFactor = style.usedZoomForLength();
-                        if (fixedHeight->resolveZoom(zoomFactor) == size && fixedSpecifiedLineHeight->resolveZoom(zoomFactor) == size)
+                        if (fixedHeight->resolveZoom(zoomFactor) == size && fixedLineHeight->resolveZoom(zoomFactor) == size)
                             return false;
                     }
                 }
                 return true;
             }
             if (fields.contains(AutosizeStatus::Fields::Floating)) {
-                if (auto fixedHeight = style.height().tryFixed(); style.specifiedLineHeight().isFixed() && fixedHeight) {
-                    if (auto fixedSpecifiedLineHeight = style.specifiedLineHeight().tryFixed()) {
+                if (auto fixedHeight = style.height().tryFixed(); style.lineHeight().isFixed() && fixedHeight) {
+                    if (auto fixedLineHeight = style.lineHeight().tryFixed()) {
                         auto size = style.fontSize();
                         auto zoomFactor = style.usedZoomForLength();
-                        if (fixedSpecifiedLineHeight->resolveZoom(Style::ZoomFactor { 1.0f }) - size > smallMinimumDifferenceThresholdBetweenLineHeightAndComputedFontSizeForBoostingText
+                        if (fixedLineHeight->resolveZoom(Style::ZoomFactor { 1.0f }) - size > smallMinimumDifferenceThresholdBetweenLineHeightAndComputedFontSizeForBoostingText
                             && fixedHeight->resolveZoom(zoomFactor) - size > smallMinimumDifferenceThresholdBetweenLineHeightAndComputedFontSizeForBoostingText)
                             return true;
                     }
@@ -129,7 +129,7 @@ auto AutosizeStatus::isIdempotentTextAutosizingCandidate(const Style::ComputedSt
             return true;
         if (fields.contains(AutosizeStatus::Fields::FixedWidth))
             return true;
-        if (auto fixedSpecifiedLineHeight = style.specifiedLineHeight().tryFixed(); fixedSpecifiedLineHeight && fixedSpecifiedLineHeight->resolveZoom(style.usedZoomForLength()) - style.fontSize() > largeMinimumDifferenceThresholdBetweenLineHeightAndComputedFontSizeForBoostingText)
+        if (auto fixedLineHeight = style.lineHeight().tryFixed(); fixedLineHeight && fixedLineHeight->resolveZoom(style.usedZoomForLength()) - style.fontSize() > largeMinimumDifferenceThresholdBetweenLineHeightAndComputedFontSizeForBoostingText)
             return true;
         return false;
     }
@@ -142,9 +142,9 @@ auto AutosizeStatus::isIdempotentTextAutosizingCandidate(const Style::ComputedSt
 
 bool AutosizeStatus::probablyContainsASmallFixedNumberOfLines(const Style::ComputedStyle& style)
 {
-    auto& specifiedLineHeight = style.specifiedLineHeight();
-    auto lineHeightAsLength = specifiedLineHeight.tryLength();
-    auto lineHeightAsNumber = specifiedLineHeight.tryNumber();
+    auto& lineHeight = style.lineHeight();
+    auto lineHeightAsLength = lineHeight.tryLength();
+    auto lineHeightAsNumber = lineHeight.tryNumber();
     if (!lineHeightAsLength && !lineHeightAsNumber)
         return false;
 

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1378,7 +1378,7 @@ auto Adjuster::adjustmentForTextAutosizing(const Style::ComputedStyle& style, co
 
     float initialScale = document->page() ? document->page()->initialScaleIgnoringContentSize() : 1;
     auto adjustLineHeightIfNeeded = [&](auto usedFontSize) {
-        auto lineHeight = style.specifiedLineHeight();
+        auto lineHeight = style.lineHeight();
         constexpr static unsigned eligibleFontSize = 12;
         if (usedFontSize * initialScale >= eligibleFontSize)
             return;

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -305,13 +305,13 @@ inline void BuilderCustom::applyValueLetterSpacing(BuilderState& builderState, C
 inline void BuilderCustom::applyInheritLineHeight(BuilderState& builderState)
 {
     builderState.style().setTextAutosizingAdjustedLineHeight(forwardInheritedValue(builderState.parentStyle().textAutosizingAdjustedLineHeight()));
-    builderState.style().setSpecifiedLineHeight(forwardInheritedValue(builderState.parentStyle().specifiedLineHeight()));
+    builderState.style().setLineHeight(forwardInheritedValue(builderState.parentStyle().lineHeight()));
 }
 
 inline void BuilderCustom::applyInitialLineHeight(BuilderState& builderState)
 {
-    builderState.style().setTextAutosizingAdjustedLineHeight(ComputedStyle::initialSpecifiedLineHeight());
-    builderState.style().setSpecifiedLineHeight(ComputedStyle::initialSpecifiedLineHeight());
+    builderState.style().setTextAutosizingAdjustedLineHeight(ComputedStyle::initialLineHeight());
+    builderState.style().setLineHeight(ComputedStyle::initialLineHeight());
 }
 
 static inline float computeBaseComputedFontSize(const Document& document, const ComputedStyle& style)
@@ -377,7 +377,7 @@ inline void BuilderCustom::applyValueLineHeight(BuilderState& builderState, CSSV
     }();
 
     builderState.style().setTextAutosizingAdjustedLineHeight(WTF::move(textAutosizingAdjustedLineHeight));
-    builderState.style().setSpecifiedLineHeight(WTF::move(lineHeight));
+    builderState.style().setLineHeight(WTF::move(lineHeight));
 }
 
 inline void BuilderCustom::applyValueWebkitLocale(BuilderState& builderState, CSSValue& value)

--- a/Source/WebCore/style/StyleDifference.cpp
+++ b/Source/WebCore/style/StyleDifference.cpp
@@ -473,7 +473,7 @@ public:
 
         if (&a.inheritedData() != &b.inheritedData()) {
             if (a.inheritedData().textAutosizingAdjustedLineHeight != b.inheritedData().textAutosizingAdjustedLineHeight
-                || a.inheritedData().specifiedLineHeight != b.inheritedData().specifiedLineHeight
+                || a.inheritedData().lineHeight != b.inheritedData().lineHeight
                 || a.inheritedData().borderHorizontalSpacing != b.inheritedData().borderHorizontalSpacing
                 || a.inheritedData().borderVerticalSpacing != b.inheritedData().borderVerticalSpacing)
                 return true;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -281,12 +281,12 @@ void ComputedStyleBase::setTextAutosizingAdjustedLineHeight(LineHeight&& lineHei
 
 void ComputedStyleBase::setLineHeightFromAnimation(LineHeight&& lineHeight)
 {
-    bool specifiedLineHeightChanged = m_inheritedData->specifiedLineHeight != lineHeight;
+    bool lineHeightChanged = m_inheritedData->lineHeight != lineHeight;
     bool textAutosizingAdjustedLineHeightChanged = m_inheritedData->textAutosizingAdjustedLineHeight != lineHeight;
-    if (specifiedLineHeightChanged || textAutosizingAdjustedLineHeightChanged) {
+    if (lineHeightChanged || textAutosizingAdjustedLineHeightChanged) {
         auto& access = m_inheritedData.access();
-        if (specifiedLineHeightChanged)
-            access.specifiedLineHeight = lineHeight;
+        if (lineHeightChanged)
+            access.lineHeight = lineHeight;
         if (textAutosizingAdjustedLineHeightChanged)
             access.textAutosizingAdjustedLineHeight = WTF::move(lineHeight);
     }

--- a/Source/WebCore/style/computed/data/StyleInheritedData.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedData.cpp
@@ -36,8 +36,8 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(InheritedData);
 InheritedData::InheritedData()
     : borderHorizontalSpacing(ComputedStyle::initialBorderHorizontalSpacing())
     , borderVerticalSpacing(ComputedStyle::initialBorderVerticalSpacing())
-    , specifiedLineHeight(ComputedStyle::initialSpecifiedLineHeight())
-    , textAutosizingAdjustedLineHeight(ComputedStyle::initialSpecifiedLineHeight())
+    , lineHeight(ComputedStyle::initialLineHeight())
+    , textAutosizingAdjustedLineHeight(ComputedStyle::initialLineHeight())
     , fontData(FontData::create())
     , color(WebCore::Color::black)
     , visitedLinkColor(WebCore::Color::black)
@@ -48,7 +48,7 @@ inline InheritedData::InheritedData(const InheritedData& o)
     : RefCounted<InheritedData>()
     , borderHorizontalSpacing(o.borderHorizontalSpacing)
     , borderVerticalSpacing(o.borderVerticalSpacing)
-    , specifiedLineHeight(o.specifiedLineHeight)
+    , lineHeight(o.lineHeight)
     , textAutosizingAdjustedLineHeight(o.textAutosizingAdjustedLineHeight)
     , fontData(o.fontData)
     , color(o.color)
@@ -79,7 +79,7 @@ bool InheritedData::fastPathInheritedEqual(const InheritedData& other) const
 
 bool InheritedData::nonFastPathInheritedEqual(const InheritedData& other) const
 {
-    return specifiedLineHeight == other.specifiedLineHeight
+    return lineHeight == other.lineHeight
         && textAutosizingAdjustedLineHeight == other.textAutosizingAdjustedLineHeight
         && fontData == other.fontData
         && borderHorizontalSpacing == other.borderHorizontalSpacing
@@ -99,7 +99,7 @@ void InheritedData::dumpDifferences(TextStream& ts, const InheritedData& other) 
 
     LOG_IF_DIFFERENT(borderHorizontalSpacing);
     LOG_IF_DIFFERENT(borderVerticalSpacing);
-    LOG_IF_DIFFERENT(specifiedLineHeight);
+    LOG_IF_DIFFERENT(lineHeight);
     LOG_IF_DIFFERENT(textAutosizingAdjustedLineHeight);
     LOG_IF_DIFFERENT(color);
     LOG_IF_DIFFERENT(visitedLinkColor);

--- a/Source/WebCore/style/computed/data/StyleInheritedData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedData.h
@@ -58,7 +58,7 @@ public:
     WebkitBorderSpacing borderHorizontalSpacing;
     WebkitBorderSpacing borderVerticalSpacing;
 
-    LineHeight specifiedLineHeight;
+    LineHeight lineHeight;
     LineHeight textAutosizingAdjustedLineHeight;
 
     DataRef<FontData> fontData;

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -124,7 +124,7 @@ static double resolveLh(const ComputedStyle* style, const FontCascade& fallbackF
         auto& fontDescription = fontCascade.fontDescription();
 
         return evaluate<float>(
-            style->specifiedLineHeight(),
+            style->lineHeight(),
             LineHeightEvaluationContext {
                 fontDescription.computedSize(),
                 static_cast<float>(unzoomFontMetric(fontCascade.metricsOfPrimaryFont().lineSpacing(), fontDescription)),
@@ -715,7 +715,7 @@ bool equalForLengthResolution(const ComputedStyle& styleA, const ComputedStyle& 
         return false;
     if (styleA.metricsOfPrimaryFont().lineSpacing() != styleB.metricsOfPrimaryFont().lineSpacing())
         return false;
-    if (styleA.specifiedLineHeight() != styleB.specifiedLineHeight())
+    if (styleA.lineHeight() != styleB.lineHeight())
         return false;
     if (styleA.zoom() != styleB.zoom())
         return false;


### PR DESCRIPTION
#### b007d6d34b1cd8903527f2c60cb1371d28d4e0fc
<pre>
Replace references to ComputedStyle&apos;s &quot;specifiedLineHeight&quot; with &quot;lineHeight&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=323764">https://bugs.webkit.org/show_bug.cgi?id=323764</a>

Reviewed by Alan Baradlay.

Part 2 of <a href="https://bugs.webkit.org/show_bug.cgi?id=323630">https://bugs.webkit.org/show_bug.cgi?id=323630</a>

In this step we make the following renames:

  - specifiedLineHeight() -&gt; lineHeight()

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/html/HTMLInputElement.cpp:
* Source/WebCore/rendering/RenderTheme.cpp:
* Source/WebCore/rendering/TextAutoSizing.cpp:
* Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
* Source/WebCore/rendering/style/AutosizeStatus.cpp:
* Source/WebCore/style/StyleAdjuster.cpp:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleDifference.cpp:
* Source/WebCore/style/computed/StyleComputedStyleBase.cpp:
* Source/WebCore/style/computed/data/StyleInheritedData.cpp:
* Source/WebCore/style/computed/data/StyleInheritedData.h:
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:

Canonical link: <a href="https://commits.webkit.org/320758@main">https://commits.webkit.org/320758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14ebaa09dea70d1738842721c7ac38b0386a6e32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196121 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187678 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145212 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188771 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165770 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125515 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47618 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157978 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45350 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7186 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52350 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198089 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59381 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154765 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41443 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60090 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41957 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154409 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48861 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129428 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58556 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20373 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57934 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58169 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/57999 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->