### PR TITLE
Replace references to ComputedStyle and FontDescription "computedLocale" with "usedLocale"

### DIFF
--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -342,7 +342,7 @@ void CSSFontSelector::fontCacheInvalidated()
 
 std::optional<AtomString> CSSFontSelector::resolveGenericFamily(const FontDescription& fontDescription, const AtomString& familyName)
 {
-    auto platformResult = FontDescription::platformResolveGenericFamily(fontDescription.script(), fontDescription.computedLocale(), familyName);
+    auto platformResult = FontDescription::platformResolveGenericFamily(fontDescription.script(), fontDescription.usedLocale(), familyName);
     if (!platformResult.isNull())
         return platformResult;
 

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -667,8 +667,8 @@ bool BaseDateAndTimeInputType::setupDateTimeChooserParameters(DateTimeChooserPar
     if (!document->settings().langAttributeAwareFormControlUIEnabled())
         parameters.locale = AtomString { defaultLanguage() };
     else {
-        AtomString computedLocale = element->effectiveLang();
-        parameters.locale = computedLocale.isEmpty() ? AtomString(defaultLanguage()) : computedLocale;
+        AtomString locale = element->effectiveLang();
+        parameters.locale = locale.isEmpty() ? AtomString { defaultLanguage() } : locale;
     }
 
     auto stepRange = createStepRange(AnyStepHandling::Reject);

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp
@@ -475,7 +475,7 @@ static std::optional<size_t> firstHyphenPosition(StringView content, const Style
     auto candidatePosition = std::min(contentLength, contentLength - limitAfterValue(style) + 1);
     auto firstHyphenLocation = std::optional<size_t> { };
     while (true) {
-        auto hyphenIndex = lastHyphenLocation(content, candidatePosition, Style::toPlatform(style.computedLocale()));
+        auto hyphenIndex = lastHyphenLocation(content, candidatePosition, Style::toPlatform(style.usedLocale()));
         if (!hyphenIndex || hyphenIndex < limitBefore)
             return firstHyphenLocation;
         if (hyphenIndex >= candidatePosition) {
@@ -494,7 +494,7 @@ static std::optional<size_t> lastHyphenPosition(StringView content, const Style:
     if (!hasEnoughContentForHyphenation(contentLength, style))
         return { };
 
-    if (auto hyphenIndex = lastHyphenLocation(content, std::min(contentLength, contentLength - limitAfterValue(style) + 1), Style::toPlatform(style.computedLocale())))
+    if (auto hyphenIndex = lastHyphenLocation(content, std::min(contentLength, contentLength - limitAfterValue(style) + 1), Style::toPlatform(style.usedLocale())))
         return hyphenIndex >= limitBeforeValue(style) ? std::make_optional(hyphenIndex) : std::nullopt;
     return { };
 }
@@ -508,7 +508,7 @@ static std::optional<size_t> hyphenPositionBefore(StringView content, const Styl
     if (beforePosition < limitBeforeValue(style) || !hasEnoughContentForHyphenation(contentLength, style))
         return { };
 
-    if (auto hyphenIndex = lastHyphenLocation(content, std::min(beforePosition, contentLength - limitAfterValue(style)) + 1, Style::toPlatform(style.computedLocale())))
+    if (auto hyphenIndex = lastHyphenLocation(content, std::min(beforePosition, contentLength - limitAfterValue(style)) + 1, Style::toPlatform(style.usedLocale())))
         return hyphenIndex >= limitBeforeValue(style) ? std::make_optional(hyphenIndex) : std::nullopt;
     return { };
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -358,7 +358,7 @@ static inline bool endsWithSoftWrapOpportunity(const InlineTextItem& previousInl
         // The bidi boundary may or may not be the reason for splitting the inline text box content.
         // FIXME: We could add a "reason flag" to InlineTextItem to tell why the split happened.
         CheckedRef style = previousInlineTextItem.style();
-        auto lineBreakIteratorFactory = CachedLineBreakIteratorFactory { previousInlineTextItem.inlineTextBox().content(), Style::toPlatform(style->computedLocale()), TextUtil::lineBreakIteratorMode(style->lineBreak()), TextUtil::contentAnalysis(style->wordBreak()) };
+        auto lineBreakIteratorFactory = CachedLineBreakIteratorFactory { previousInlineTextItem.inlineTextBox().content(), Style::toPlatform(style->usedLocale()), TextUtil::lineBreakIteratorMode(style->lineBreak()), TextUtil::contentAnalysis(style->wordBreak()) };
         auto softWrapOpportunityCandidate = nextInlineTextItem.start();
         return TextUtil::findNextBreakablePosition(lineBreakIteratorFactory, softWrapOpportunityCandidate, style.get()) == softWrapOpportunityCandidate;
     }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -1109,7 +1109,7 @@ void InlineItemsBuilder::handleTextContent(const InlineTextBox& inlineTextBox, I
     auto singleSpaceWidth = !deferWhitespaceMeasurement ? std::optional(std::max(0.f, TextUtil::singleSpaceWidth(fontCascade.get(), inlineTextBox.canUseSimplifiedContentMeasuring()))) : std::nullopt;
     auto shouldPreserveSpacesAndTabs = TextUtil::shouldPreserveSpacesAndTabs(inlineTextBox);
     auto shouldPreserveNewline = TextUtil::shouldPreserveNewline(inlineTextBox);
-    auto lineBreakIteratorFactory = CachedLineBreakIteratorFactory { text, Style::toPlatform(style->computedLocale()), TextUtil::lineBreakIteratorMode(style->lineBreak()), TextUtil::contentAnalysis(style->wordBreak()) };
+    auto lineBreakIteratorFactory = CachedLineBreakIteratorFactory { text, Style::toPlatform(style->usedLocale()), TextUtil::lineBreakIteratorMode(style->lineBreak()), TextUtil::contentAnalysis(style->wordBreak()) };
     auto currentPosition = partialContentOffset.value_or(0lu);
     ASSERT(currentPosition <= contentLength);
 

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionContext.h
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionContext.h
@@ -81,7 +81,7 @@ inline TextBreakingPositionContext::TextBreakingPositionContext(const Style::Com
     , lineBreak(style.lineBreak())
     , wordBreak(style.wordBreak())
     , nbspMode(style.nbspMode())
-    , locale(Style::toPlatform(style.computedLocale()))
+    , locale(Style::toPlatform(style.usedLocale()))
 {
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -391,7 +391,7 @@ bool TextUtil::mayBreakInBetween(String previousContent, const Style::ComputedSt
         // See the templated CharacterType in nextBreakablePosition for last and lastlast characters.
         nextContent.convertTo16Bit();
     }
-    auto lineBreakIteratorFactory = CachedLineBreakIteratorFactory { nextContent, Style::toPlatform(nextContentStyle.computedLocale()), TextUtil::lineBreakIteratorMode(nextContentStyle.lineBreak()), TextUtil::contentAnalysis(nextContentStyle.wordBreak()) };
+    auto lineBreakIteratorFactory = CachedLineBreakIteratorFactory { nextContent, Style::toPlatform(nextContentStyle.usedLocale()), TextUtil::lineBreakIteratorMode(nextContentStyle.lineBreak()), TextUtil::contentAnalysis(nextContentStyle.wordBreak()) };
     auto previousContentLength = previousContent.length();
     // FIXME: We should look into the entire uncommitted content for more text context.
     char16_t lastCharacter = previousContentLength ? previousContent[previousContentLength - 1] : 0;
@@ -464,7 +464,7 @@ EnumSet<TextUtil::WordBreakRule> TextUtil::wordBreakBehavior(const Style::Comput
         return { WordBreakRule::AtArbitraryPositionWithinWords };
 
     auto includeHyphenationIfAllowed = [&](std::optional<WordBreakRule> wordBreakRule) -> EnumSet<WordBreakRule> {
-        auto hyphenationIsAllowed = hyphenationIsDisabled == HyphenationIsDisabled::No && style.hyphens() == Hyphens::Auto && canHyphenate(Style::toPlatform(style.computedLocale()));
+        auto hyphenationIsAllowed = hyphenationIsDisabled == HyphenationIsDisabled::No && style.hyphens() == Hyphens::Auto && canHyphenate(Style::toPlatform(style.usedLocale()));
         if (hyphenationIsAllowed) {
             if (wordBreakRule)
                 return { *wordBreakRule, WordBreakRule::AtHyphenationOpportunities };

--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -384,7 +384,7 @@ void ComplexTextController::collectComplexTextRuns()
     RefPtr<const Font> smallSynthesizedFont;
     RefPtr<const Font> halfWidthFont;
 
-    CachedTextBreakIterator graphemeClusterIterator(m_run->text(), { }, TextBreakIterator::CharacterMode { }, m_fontCascade->fontDescription().computedLocale());
+    CachedTextBreakIterator graphemeClusterIterator(m_run->text(), { }, TextBreakIterator::CharacterMode { }, m_fontCascade->fontDescription().usedLocale());
 
     char32_t baseCharacter;
     advanceByCombiningCharacterSequence(graphemeClusterIterator, currentIndex, baseCharacter);

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -400,7 +400,7 @@ NEVER_INLINE float FontCascade::widthForSimpleTextSlow(StringView text, TextDire
     else
         addGlyphsFromText(glyphBuffer, font, text.span16());
 
-    auto initialAdvance = font->applyTransforms(glyphBuffer, 0, 0, enableKerning(), requiresShaping(), fontDescription().computedLocale(), text, textDirection);
+    auto initialAdvance = font->applyTransforms(glyphBuffer, 0, 0, enableKerning(), requiresShaping(), fontDescription().usedLocale(), text, textDirection);
     auto result = 0.f;
     for (size_t i = 0; i < glyphBuffer.size(); ++i)
         result += WebCore::width(glyphBuffer.advanceAt(i));

--- a/Source/WebCore/platform/graphics/FontCascadeCache.h
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.h
@@ -114,7 +114,7 @@ struct FontDescriptionKey {
         : m_size(description.usedSize())
         , m_fontSelectionRequest(description.fontSelectionRequest())
         , m_flags(makeFlagsKey(description))
-        , m_locale(description.computedLocale())
+        , m_locale(description.usedLocale())
     {
         auto featureSettings = description.featureSettings();
         auto variationSettings = description.variationSettings();

--- a/Source/WebCore/platform/graphics/FontDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontDescription.cpp
@@ -108,7 +108,7 @@ void FontDescription::setSpecifiedLocale(const AtomString& locale)
     ASSERT(isMainThread());
     m_specifiedLocale = locale;
     m_script = localeToScriptCode(m_specifiedLocale);
-    m_locale = m_script == USCRIPT_HAN ? specializedChineseLocale() : m_specifiedLocale;
+    m_usedLocale = m_script == USCRIPT_HAN ? specializedChineseLocale() : m_specifiedLocale;
 }
 
 #if !PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/FontDescription.h
+++ b/Source/WebCore/platform/graphics/FontDescription.h
@@ -59,7 +59,7 @@ public:
     TextSpacingTrim textSpacingTrim() const { return m_textSpacingTrim; }
     TextAutospace textAutospace() const { return m_textAutospace; }
     UScriptCode script() const { return static_cast<UScriptCode>(m_script); }
-    const AtomString& computedLocale() const { return m_locale; } // This is what you should be using for things like text shaping and font fallback
+    const AtomString& usedLocale() const { return m_usedLocale; } // This is what you should be using for things like text shaping and font fallback
     const AtomString& specifiedLocale() const { return m_specifiedLocale; } // This is what you should be using for web-exposed things like -webkit-locale
 
     FontOrientation orientation() const { return static_cast<FontOrientation>(m_orientation); }
@@ -165,7 +165,7 @@ private:
     FontVariantAlternates m_variantAlternates;
     FontPalette m_fontPalette;
     FontSizeAdjust m_sizeAdjust;
-    AtomString m_locale;
+    AtomString m_usedLocale;
     AtomString m_specifiedLocale;
 
     FontSelectionRequest m_fontSelectionRequest;

--- a/Source/WebCore/platform/graphics/SystemFallbackFontCache.cpp
+++ b/Source/WebCore/platform/graphics/SystemFallbackFontCache.cpp
@@ -55,7 +55,7 @@ RefPtr<Font> SystemFallbackFontCache::systemFallbackFontForCharacterCluster(cons
 {
     auto fontAddResult = m_characterFallbackMaps.add(font, CharacterFallbackMap());
 
-    auto key = CharacterFallbackMapKey { description.computedLocale(), characterCluster.toString(), isForPlatformFont != IsForPlatformFont::No, resolvedEmojiPolicy };
+    auto key = CharacterFallbackMapKey { description.usedLocale(), characterCluster.toString(), isForPlatformFont != IsForPlatformFont::No, resolvedEmojiPolicy };
     return fontAddResult.iterator->value.ensure(WTF::move(key), [&] {
         StringBuilder stringBuilder;
         stringBuilder.append(FontCascade::normalizeSpaces(characterCluster));

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -93,7 +93,7 @@ inline auto WidthIterator::applyFontTransforms(GlyphBuffer& glyphBuffer, unsigne
     for (unsigned i = lastGlyphCount; i < glyphBufferSize; ++i)
         beforeWidth += width(advances[i]);
 
-    auto initialAdvance = font.applyTransforms(glyphBuffer, lastGlyphCount, m_currentCharacterIndex, m_enableKerning, m_requiresShaping, m_fontCascade->fontDescription().computedLocale(), m_run->text(), direction());
+    auto initialAdvance = font.applyTransforms(glyphBuffer, lastGlyphCount, m_currentCharacterIndex, m_enableKerning, m_requiresShaping, m_fontCascade->fontDescription().usedLocale(), m_run->text(), direction());
 
     glyphBufferSize = glyphBuffer.size();
     advances = glyphBuffer.advances();

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -582,7 +582,7 @@ static std::optional<SpecialCaseFontLookupResult> fontDescriptorWithFamilySpecia
     if (family.startsWith("UICTFontTextStyle"_s)) {
         const auto& request = fontDescription.fontSelectionRequest();
         CTFontSymbolicTraits traits = (isFontWeightBold(request.weight) ? kCTFontTraitBold : 0) | (isItalic(request.slope) ? kCTFontTraitItalic : 0);
-        auto descriptor = adoptCF(CTFontDescriptorCreateWithTextStyle(family.string().createCFString().get(), protect(contentSizeCategory()).get(), fontDescription.computedLocale().string().createCFString().get()));
+        auto descriptor = adoptCF(CTFontDescriptorCreateWithTextStyle(family.string().createCFString().get(), protect(contentSizeCategory()).get(), fontDescription.usedLocale().string().createCFString().get()));
         if (traits) {
             // FIXME: rdar://105369379 As far as I can tell, there's no modification to the attributes dictionary that has the same effect as CTFontDescriptorCreateCopyWithSymbolicTraits(),
             // because there doesn't seem to be a place to specify the bitmask. That's the reason we're creating the derived CTFontDescriptor here, rather than in UnrealizedCoreTextFont::realize().
@@ -592,16 +592,16 @@ static std::optional<SpecialCaseFontLookupResult> fontDescriptorWithFamilySpecia
     }
 
     if (equalLettersIgnoringASCIICase(family, "-apple-menu"_s))
-        return { { adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontMenuItem, size, fontDescription.computedLocale().string().createCFString().get())), FontTypeForPreparation::SystemFont } };
+        return { { adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontMenuItem, size, fontDescription.usedLocale().string().createCFString().get())), FontTypeForPreparation::SystemFont } };
 
     if (equalLettersIgnoringASCIICase(family, "-apple-status-bar"_s))
-        return { { adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontSystem, size, fontDescription.computedLocale().string().createCFString().get())), FontTypeForPreparation::SystemFont } };
+        return { { adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontSystem, size, fontDescription.usedLocale().string().createCFString().get())), FontTypeForPreparation::SystemFont } };
 
     if (equalLettersIgnoringASCIICase(family, "lastresort"_s))
         return { { adoptCF(CTFontDescriptorCreateLastResort()), FontTypeForPreparation::NonSystemFont } };
 
     if (equalLettersIgnoringASCIICase(family, "-apple-system-monospaced-numbers"_s)) {
-        auto systemFontDescriptor = UnrealizedCoreTextFont { adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontSystem, size, fontDescription.computedLocale().string().createCFString().get())) };
+        auto systemFontDescriptor = UnrealizedCoreTextFont { adoptCF(CTFontDescriptorCreateForUIType(kCTFontUIFontSystem, size, fontDescription.usedLocale().string().createCFString().get())) };
         systemFontDescriptor.modify([](CFMutableDictionaryRef attributes) {
             int numberSpacingType = kNumberSpacingType;
             int monospacedNumbersSelector = kMonospacedNumbersSelector;
@@ -815,7 +815,7 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
     if (!fullName.isEmpty())
         m_fontNamesRequiringSystemFallbackForPrewarming.add(fullName);
 
-    auto result = lookupFallbackFont(ctFont.get(), description.weight(), description.computedLocale(), description.shouldAllowUserInstalledFonts(), characterCluster);
+    auto result = lookupFallbackFont(ctFont.get(), description.weight(), description.usedLocale(), description.shouldAllowUserInstalledFonts(), characterCluster);
     result = preparePlatformFont(UnrealizedCoreTextFont { WTF::move(result) }, description, { });
 
     if (!result)

--- a/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp
@@ -233,7 +233,7 @@ static CGFloat NODELETE mapWidth(FontSelectionValue width)
 SystemFontDatabaseCoreText::CascadeListParameters SystemFontDatabaseCoreText::systemFontParameters(const FontDescription& description, const AtomString& familyName, SystemFontKind systemFontKind, AllowUserInstalledFonts allowUserInstalledFonts)
 {
     CascadeListParameters result;
-    result.locale = description.computedLocale();
+    result.locale = description.usedLocale();
     result.size = description.usedSize();
     result.italic = isItalic(description.fontStyleSlope());
     result.allowUserInstalledFonts = allowUserInstalledFonts;

--- a/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
+++ b/Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm
@@ -196,11 +196,11 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
         effectiveFont = m_fontCascade->fallbackRangesAt(0).fontForCharacter(baseCharacter);
         if (!effectiveFont)
             effectiveFont = &m_fontCascade->fallbackRangesAt(0).fontForFirstRange();
-        stringAttributes = adoptCF(CFDictionaryCreateMutableCopy(kCFAllocatorDefault, 0, getCFStringAttributes(*effectiveFont, m_fontCascade->enableKerning(), effectiveFont->platformData().orientation(), m_fontCascade->fontDescription().computedLocale()).get()));
+        stringAttributes = adoptCF(CFDictionaryCreateMutableCopy(kCFAllocatorDefault, 0, getCFStringAttributes(*effectiveFont, m_fontCascade->enableKerning(), effectiveFont->platformData().orientation(), m_fontCascade->fontDescription().usedLocale()).get()));
         // We don't know which font should be used to render this grapheme cluster, so enable CoreText's fallback mechanism by using the CTFont which doesn't have CoreText's fallback disabled.
         CFDictionarySetValue(const_cast<CFMutableDictionaryRef>(stringAttributes.get()), kCTFontAttributeName, effectiveFont->platformData().ctFont());
     } else
-        stringAttributes = getCFStringAttributes(*effectiveFont, m_fontCascade->enableKerning(), effectiveFont->platformData().orientation(), m_fontCascade->fontDescription().computedLocale());
+        stringAttributes = getCFStringAttributes(*effectiveFont, m_fontCascade->enableKerning(), effectiveFont->platformData().orientation(), m_fontCascade->fontDescription().usedLocale());
 
     RetainPtr<CTLineRef> line;
 

--- a/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
@@ -252,7 +252,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
     // The computed "locale" equals the "lang" attribute. The latter must be a valid BCP 47 language tag,
     // according to <https://html.spec.whatwg.org/multipage/dom.html#attr-lang>.
     // This is exactly what hb_language_from_string() expects, so we can pass directly.
-    auto language = hb_language_from_string(m_fontCascade->fontDescription().computedLocale().string().utf8().data(), -1);
+    auto language = hb_language_from_string(m_fontCascade->fontDescription().usedLocale().string().utf8().data(), -1);
 
     auto shapeFunction = [&](const HBRun& run) {
         hb_buffer_set_cluster_level(buffer.get(), HB_BUFFER_CLUSTER_LEVEL_CHARACTERS);

--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -141,7 +141,7 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
         bcp47.append("und-Zsye");
     auto typeface = fontManager().matchFamilyStyleCharacter(nullptr, { }, bcp47.mutableSpan().data(), bcp47.size(), baseCharacter);
 #else
-    auto typeface = m_skiaSystemFallbackFontCache.fontForCharacterCluster(isEmoji ? "und-Zsye"_s : description.computedLocale(), stringView);
+    auto typeface = m_skiaSystemFallbackFontCache.fontForCharacterCluster(isEmoji ? "und-Zsye"_s : description.usedLocale(), stringView);
 #endif
     if (!typeface)
         return nullptr;

--- a/Source/WebCore/rendering/RenderQuote.cpp
+++ b/Source/WebCore/rendering/RenderQuote.cpp
@@ -473,7 +473,7 @@ String RenderQuote::computeText() const
     case QuoteType::CloseQuote:
         if (!style().quotes().isAuto())
             return isOpenQuote ? style().quotes().openQuote(m_depth).impl() : style().quotes().closeQuote(m_depth).impl();
-        if (const auto* quotes = quotesForLanguage(Style::toPlatform(style().computedLocale())))
+        if (const auto* quotes = quotesForLanguage(Style::toPlatform(style().usedLocale())))
             return stringForQuoteCharacter(isOpenQuote ? (m_depth ? quotes->open2 : quotes->open1) : (m_depth ? quotes->close2 : quotes->close1));
         // FIXME: Should the default be the quotes for "en" rather than straight quotes?
         // (According to https://html.spec.whatwg.org/multipage/rendering.html#quotes, the answer is "yes".)

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -548,7 +548,7 @@ void RenderText::styleDidChange(Style::Difference diff, const Style::ComputedSty
             return true;
         if (oldStyle->textSecurity() != newStyle.textSecurity())
             return true;
-        return !newStyle.textTransform().isNone() && oldStyle->computedLocale() != newStyle.computedLocale();
+        return !newStyle.textTransform().isNone() && oldStyle->usedLocale() != newStyle.usedLocale();
     };
     if (needsRenderedTextUpdateOnly())
         updateRenderedText();
@@ -1278,7 +1278,7 @@ float RenderText::maxWordFragmentWidth(const Style::ComputedStyle& style, const 
     Vector<int, 8> hyphenLocations;
     ASSERT(word.length() >= minimumSuffixLength);
     unsigned hyphenLocation = word.length() - minimumSuffixLength;
-    while ((hyphenLocation = lastHyphenLocation(word, hyphenLocation, Style::toPlatform(style.computedLocale()))) >= std::max(minimumPrefixLength, 1U))
+    while ((hyphenLocation = lastHyphenLocation(word, hyphenLocation, Style::toPlatform(style.usedLocale()))) >= std::max(minimumPrefixLength, 1U))
         hyphenLocations.append(hyphenLocation);
 
     if (hyphenLocations.isEmpty())
@@ -1345,7 +1345,7 @@ void RenderText::computeMinMaxIntrinsicLogicalWidths(float leadingWidth, SingleT
     unsigned length = string.length();
     auto iteratorMode = mapLineBreakToIteratorMode(style.lineBreak());
     auto contentAnalysis = mapWordBreakToContentAnalysis(style.wordBreak());
-    CachedLineBreakIteratorFactory lineBreakIteratorFactory(string, Style::toPlatform(style.computedLocale()), iteratorMode, contentAnalysis);
+    CachedLineBreakIteratorFactory lineBreakIteratorFactory(string, Style::toPlatform(style.usedLocale()), iteratorMode, contentAnalysis);
     bool needsWordSpacing = false;
     bool ignoringSpaces = false;
     bool isSpace = false;
@@ -1360,7 +1360,7 @@ void RenderText::computeMinMaxIntrinsicLogicalWidths(float leadingWidth, SingleT
     float maxWordWidth = std::numeric_limits<float>::max();
     unsigned minimumPrefixLength = 0;
     unsigned minimumSuffixLength = 0;
-    if (style.hyphens() == Hyphens::Auto && canHyphenate(Style::toPlatform(style.computedLocale()))) {
+    if (style.hyphens() == Hyphens::Auto && canHyphenate(Style::toPlatform(style.usedLocale()))) {
         maxWordWidth = 0;
 
         // Map 'hyphenate-limit-{before,after}: auto;' to 2.
@@ -1768,11 +1768,11 @@ String applyTextTransform(const Style::ComputedStyle& style, const String& text,
     // https://w3c.github.io/csswg-drafts/css-text/#text-transform-order
     auto modified = text;
     if (transform.contains(Style::TextTransformValue::Capitalize))
-        modified = capitalize(modified, previousCharacter, Style::toPlatform(style.computedLocale()));
+        modified = capitalize(modified, previousCharacter, Style::toPlatform(style.usedLocale()));
     else if (transform.contains(Style::TextTransformValue::Uppercase))
-        modified = modified.convertToUppercaseWithLocale(Style::toPlatform(style.computedLocale()));
+        modified = modified.convertToUppercaseWithLocale(Style::toPlatform(style.usedLocale()));
     else if (transform.contains(Style::TextTransformValue::Lowercase))
-        modified = modified.convertToLowercaseWithLocale(Style::toPlatform(style.computedLocale()));
+        modified = modified.convertToLowercaseWithLocale(Style::toPlatform(style.usedLocale()));
 
     if (transform.contains(Style::TextTransformValue::FullWidth))
         modified = transformToFullWidth(modified);

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -521,7 +521,7 @@ static void updateApplePayButtonPartForRenderer(ApplePayButtonPart& applePayButt
     CheckedRef style = renderer.style();
 
     auto platformLocale = [&] -> String {
-        auto locale = style->computedLocale();
+        auto locale = style->usedLocale();
         if (locale.isAuto())
             return defaultLanguage(ShouldMinimizeLanguages::No);
         return Style::toPlatform(locale);

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -375,7 +375,7 @@ inline bool BreakingContext::handleText()
         m_renderTextInfo.text = &renderer;
         m_renderTextInfo.font = &font;
         m_renderTextInfo.layout = font.createLayout(renderer, m_width.currentWidth(), m_collapseWhiteSpace);
-        m_renderTextInfo.lineBreakIteratorFactory.resetStringAndReleaseIterator(renderer.text(), Style::toPlatform(style->computedLocale()), iteratorMode, contentAnalysis);
+        m_renderTextInfo.lineBreakIteratorFactory.resetStringAndReleaseIterator(renderer.text(), Style::toPlatform(style->usedLocale()), iteratorMode, contentAnalysis);
     } else if (m_renderTextInfo.layout && m_renderTextInfo.font != &font) {
         m_renderTextInfo.font = &font;
         m_renderTextInfo.layout = font.createLayout(renderer, m_width.currentWidth(), m_collapseWhiteSpace);

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -356,9 +356,9 @@ inline const FontCascade& ComputedStyleBase::fontCascade() const
     return m_inheritedData->fontData->fontCascade;
 }
 
-inline WebkitLocale ComputedStyleBase::computedLocale() const
+inline WebkitLocale ComputedStyleBase::usedLocale() const
 {
-    return fontDescription().computedLocale();
+    return fontDescription().usedLocale();
 }
 
 inline float ComputedStyleBase::usedLetterSpacing() const

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -651,7 +651,7 @@ public:
     WEBCORE_EXPORT const FontMetrics& metricsOfPrimaryFont() const LIFETIME_BOUND;
     std::pair<FontOrientation, NonCJKGlyphOrientation> NODELETE fontAndGlyphOrientation();
     float NODELETE usedFontSize() const;
-    inline WebkitLocale computedLocale() const;
+    inline WebkitLocale usedLocale() const;
 
     const LineHeight& NODELETE textAutosizingAdjustedLineHeight() const;
     void setTextAutosizingAdjustedLineHeight(LineHeight&&);


### PR DESCRIPTION
#### 5176adcf576863ada609fbeda6c2aec842bfa0d2
<pre>
Replace references to ComputedStyle and FontDescription &quot;computedLocale&quot; with &quot;usedLocale&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=323769">https://bugs.webkit.org/show_bug.cgi?id=323769</a>

Reviewed by Antti Koivisto.

Part 1 of <a href="https://bugs.webkit.org/show_bug.cgi?id=323768">https://bugs.webkit.org/show_bug.cgi?id=323768</a>

In this step we make the following renames:

  - ComputedStyleBase::computedLocale() -&gt; ComputedStyleBase::usedLocale()
  - FontDescription::computedLocale() -&gt; FontDescription::usedLocale()

* Source/WebCore/css/CSSFontSelector.cpp:
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
* Source/WebCore/layout/formattingContexts/inline/text/TextBreakingPositionContext.h:
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
* Source/WebCore/platform/graphics/FontCascade.cpp:
* Source/WebCore/platform/graphics/FontCascadeCache.h:
* Source/WebCore/platform/graphics/FontDescription.cpp:
* Source/WebCore/platform/graphics/FontDescription.h:
* Source/WebCore/platform/graphics/SystemFallbackFontCache.cpp:
* Source/WebCore/platform/graphics/WidthIterator.cpp:
* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
* Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp:
* Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm:
* Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp:
* Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp:
* Source/WebCore/rendering/RenderQuote.cpp:
* Source/WebCore/rendering/RenderText.cpp:
* Source/WebCore/rendering/RenderTheme.cpp:
* Source/WebCore/rendering/line/BreakingContext.h:
* Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h:
* Source/WebCore/style/computed/StyleComputedStyleBase.h:

Canonical link: <a href="https://commits.webkit.org/320779@main">https://commits.webkit.org/320779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d411e08f618885cc74658713260ec6b72409717

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185821 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196126 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150502 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145213 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100677 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165774 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125516 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47623 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45649 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157983 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45354 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7191 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198094 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59385 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154767 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41455 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60095 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154411 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48865 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129433 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58560 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20377 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57938 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58173 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->