### PR TITLE
[cleanup] Ask isInlineBox() instead of downcasting to RenderInline where the type is not needed

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1912,7 +1912,7 @@ void AXObjectCache::setDirtyStitchGroups(const RenderBlock& renderBlock)
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 void AXObjectCache::onTextRunsChanged(const RenderObject& renderer)
 {
-    if (is<RenderInline>(renderer) || is<RenderListOutsideMarker>(renderer)) {
+    if (renderer.isInlineBox() || is<RenderListOutsideMarker>(renderer)) {
         // Fast-path exit for common renderers that will never produce text runs.
         return;
     }

--- a/Source/WebCore/accessibility/AccessibilityObjectInlines.h
+++ b/Source/WebCore/accessibility/AccessibilityObjectInlines.h
@@ -109,7 +109,8 @@ inline SRGBA<uint8_t> AccessibilityObject::colorValue() const
 
 inline bool AccessibilityObject::isInlineText() const
 {
-    return is<RenderInline>(renderer());
+    auto* renderer = this->renderer();
+    return renderer && renderer->isInlineBox();
 }
 
 inline Element* AccessibilityObject::element() const

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2583,7 +2583,7 @@ AccessibilityRole AccessibilityRenderObject::determineAccessibilityRole()
     if (m_renderer->isRenderTableSection())
         return AccessibilityRole::Ignored;
 
-    auto treatStyleFormatGroupAsInline = is<RenderInline>(*m_renderer) ? TreatStyleFormatGroupAsInline::Yes : TreatStyleFormatGroupAsInline::No;
+    auto treatStyleFormatGroupAsInline = m_renderer->isInlineBox() ? TreatStyleFormatGroupAsInline::Yes : TreatStyleFormatGroupAsInline::No;
     auto roleFromNode = determineAccessibilityRoleFromNode(treatStyleFormatGroupAsInline);
 
     // Table cells (by default) return a TextGroup role from determineAccessibilityRoleFromNode.
@@ -2606,7 +2606,7 @@ AccessibilityRole AccessibilityRenderObject::determineAccessibilityRole()
     // InlineRole is the final fallback before assigning AccessibilityRole::Unknown to an object. It makes it
     // possible to distinguish truly unknown objects from non-focusable inline text elements
     // which have an event handler or attribute suggesting possible inclusion by the platform.
-    if (is<RenderInline>(*m_renderer)
+    if (m_renderer->isInlineBox()
         && (hasAttributesRequiredForInclusion()
             || (node && node->hasEventListeners())
             || (supportsDatetimeAttribute() && !getAttribute(datetimeAttr).isEmpty())))

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -1461,7 +1461,7 @@ AccessibilityObjectInclusion AccessibilityObject::accessibilityPlatformIncludesO
     // We always want to include table cells (layout and CSS) that have rendered text content.
     if (is<RenderTableCell>(renderObject)) {
         for (const auto& child : childrenOfType<RenderObject>(downcast<RenderElement>(*renderObject))) {
-            if (is<RenderInline>(child) || is<RenderText>(child) || is<HTMLSpanElement>(child.node()))
+            if (child.isInlineBox() || is<RenderText>(child) || is<HTMLSpanElement>(child.node()))
                 return AccessibilityObjectInclusion::IncludeObject;
         }
         return AccessibilityObjectInclusion::DefaultBehavior;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3345,7 +3345,7 @@ bool Document::updateLayoutIfDimensionsOutOfDate(Element& element, OptionSet<Dim
             }
 
             // Require the entire container chain to be boxes or SVG or inline box in block-inline-inline case.
-            if (is<RenderInline>(*currentRenderer) && currentBox && currentBox->isBlockLevelBox())
+            if (currentRenderer->isInlineBox() && currentBox && currentBox->isBlockLevelBox())
                 continue;
 
             if (!currentRenderer->isSVGRenderer()) {

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -96,8 +96,8 @@ static bool shouldInvalidateLineLayoutAfterChangeFor(const RenderBlockFlow& root
             return false;
         if (is<RenderReplaced>(renderer))
             return typeOfChange == TypeOfChangeForInvalidation::NodeInsertion;
-        if (auto* inlineRenderer = dynamicDowncast<RenderInline>(renderer))
-            return typeOfChange == TypeOfChangeForInvalidation::NodeInsertion && !inlineRenderer->firstChild();
+        if (renderer.isInlineBox())
+            return typeOfChange == TypeOfChangeForInvalidation::NodeInsertion && !downcast<RenderElement>(renderer).firstChild();
         return false;
     };
     if (!isSupportedRendererWithChange(renderer))
@@ -106,7 +106,7 @@ static bool shouldInvalidateLineLayoutAfterChangeFor(const RenderBlockFlow& root
     auto isSupportedParent = [&] {
         auto* parent = renderer.parent();
         // Content append under existing inline box is not yet supported.
-        return is<RenderBlockFlow>(parent) || (is<RenderInline>(parent) && !parent->everHadLayout());
+        return is<RenderBlockFlow>(parent) || (parent && parent->isInlineBox() && !parent->everHadLayout());
     };
     if (!isSupportedParent())
         return true;
@@ -124,8 +124,8 @@ static bool shouldInvalidateLineLayoutAfterChangeFor(const RenderBlockFlow& root
             }
             return *hasStrongDirectionalityContent;
         }
-        if (auto* renderInline = dynamicDowncast<RenderInline>(renderer)) {
-            auto& style = renderInline->style();
+        if (renderer.isInlineBox()) {
+            auto& style = renderer.style();
             return style.writingMode().isBidiRTL() || (style.rtlOrdering() == Order::Logical && style.unicodeBidi() != UnicodeBidi::Normal);
         }
         return false;
@@ -159,7 +159,7 @@ static bool shouldInvalidateLineLayoutAfterChangeFor(const RenderBlockFlow& root
 
     auto rootHasNonSupportedRenderer = [&] (bool shouldOnlyCheckForRelativeDimension = false) {
         for (CheckedPtr sibling = rootBlockContainer.firstChild(); sibling; sibling = sibling->nextSibling()) {
-            if (auto* inlineBox = dynamicDowncast<RenderInline>(*sibling); inlineBox && !inlineBox->style().textAutospace().isNoAutospace())
+            if (sibling->isInlineBox() && !sibling->style().textAutospace().isNoAutospace())
                 return true;
 
             auto siblingHasRelativeDimensions = false;
@@ -294,7 +294,7 @@ LineLayout* LineLayout::containing(RenderObject& renderer)
             if (renderer.isOutOfFlowPositioned()) {
                 // Here we are looking for the containing block as if the out-of-flow box was inflow (for static position purpose).
                 CheckedPtr containingBlock = renderer.parent();
-                if (is<RenderInline>(containingBlock))
+                if (containingBlock && containingBlock->isInlineBox())
                     containingBlock = containingBlock->containingBlock();
                 return dynamicDowncast<RenderBlockFlow>(containingBlock.unsafeGet());
             }
@@ -302,9 +302,8 @@ LineLayout* LineLayout::containing(RenderObject& renderer)
                 // Note that containigBlock() on boxes in top layer (i.e. dialog) may return incorrect result during style change even with not-yet-updated style.
                 return dynamicDowncast<RenderBlockFlow>(RenderObject::containingBlockForPositionType(downcast<RenderBox>(renderer).style().position(), renderer));
             }
-            if (CheckedPtr parentInlineBox = dynamicDowncast<RenderInline>(renderer.parent())) {
-                return dynamicDowncast<RenderBlockFlow>(parentInlineBox->containingBlock());
-            }
+            if (CheckedPtr parent = renderer.parent(); parent && parent->isInlineBox())
+                return dynamicDowncast<RenderBlockFlow>(parent->containingBlock());
             if (auto* parentBlock = dynamicDowncast<RenderBlockFlow>(renderer.parent())) {
                 if (parentBlock->childrenInline()) {
                     ASSERT(parentBlock->settings().anonymousBlockGenerationDisabled());

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -566,7 +566,7 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
         if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(*targetRenderer))
             return renderBox->borderBoundingBox();
 
-        if (is<RenderInline>(targetRenderer)) {
+        if (targetRenderer->isInlineBox()) {
             Vector<LayoutRect> rects;
             targetRenderer->boundingRects(rects, { });
             return unionRect(rects);

--- a/Source/WebCore/rendering/InlineWalker.h
+++ b/Source/WebCore/rendering/InlineWalker.h
@@ -43,7 +43,7 @@ public:
 
     void advance()
     {
-        if (is<RenderInline>(*m_iterator))
+        if (m_iterator->isInlineBox())
             m_iterator.traverseNext();
         else
             m_iterator.traverseNextSkippingChildren();

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
@@ -261,7 +261,7 @@ void LegacyInlineFlowBox::computeOverflow(LayoutUnit lineTop, LayoutUnit lineBot
             LayoutRect textBoxOverflow(enclosingLayoutRect(textBox.logicalFrameRect()));
             addTextBoxVisualOverflow(textBox, textBoxDataMap, textBoxOverflow);
             logicalVisualOverflow.unite(textBoxOverflow);
-        } else if (is<RenderInline>(child->renderer())) {
+        } else if (child->renderer().isInlineBox()) {
             auto& flow = downcast<LegacyInlineFlowBox>(*child);
             flow.computeOverflow(lineTop, lineBottom, textBoxDataMap);
             if (!flow.renderer().hasSelfPaintingLayer())

--- a/Source/WebCore/rendering/LegacyInlineIterator.cpp
+++ b/Source/WebCore/rendering/LegacyInlineIterator.cpp
@@ -27,6 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "config.h"
 #include "LegacyInlineIterator.h"
 
+#include "RenderObjectInlines.h"
 #include "StyleComputedStyle+GettersInlines.h"
 
 namespace WebCore {

--- a/Source/WebCore/rendering/LegacyInlineIterator.h
+++ b/Source/WebCore/rendering/LegacyInlineIterator.h
@@ -144,7 +144,7 @@ static inline void notifyObserverEnteredObject(Observer* observer, RenderObject*
     if (!observer || !object || !object->isInlineBox())
         return;
 
-    auto& style = downcast<RenderInline>(*object).style();
+    auto& style = object->style();
     auto unicodeBidi = style.unicodeBidi();
     if (unicodeBidi == UnicodeBidi::Normal) {
         // http://dev.w3.org/csswg/css3-writing-modes/#unicode-bidi
@@ -171,7 +171,7 @@ static inline void notifyObserverWillExitObject(Observer* observer, RenderObject
     if (!observer || !object || !object->isInlineBox())
         return;
 
-    auto unicodeBidi = downcast<RenderInline>(*object).style().unicodeBidi();
+    auto unicodeBidi = object->style().unicodeBidi();
     if (unicodeBidi == UnicodeBidi::Normal)
         return; // Nothing to do for unicode-bidi: normal
     if (isIsolated(unicodeBidi)) {
@@ -376,9 +376,7 @@ inline void InlineBidiResolver::incrementInternal()
 
 static inline bool isIsolatedInline(RenderObject& object)
 {
-    if (auto* inlineBox = dynamicDowncast<RenderInline>(object))
-        return isIsolated(inlineBox->style().unicodeBidi());
-    return false;
+    return object.isInlineBox() && isIsolated(object.style().unicodeBidi());
 }
 
 static inline RenderObject* highestContainingIsolateWithinRoot(RenderObject& initialObject, RenderObject* root)

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -730,7 +730,7 @@ static LayoutPoint staticDistance(const RenderBoxModelObject& container, const R
         hasSeenNonInlineBoxContainer = true;
     }
 
-    if (!hasSeenNonInlineBoxContainer && is<RenderInline>(container)) {
+    if (!hasSeenNonInlineBoxContainer && container.isInlineBox()) {
         // This is a simple case of when the containing block is formed by a positioned inline box with no block boxes in-between (e.g <span style="position: relative">)
         return initialStaticPosition();
     }

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4172,7 +4172,7 @@ bool RenderBlockFlow::layoutSimpleBlockContentInInline(MarginInfo& marginInfo)
                 auto isContentfulInline = [&] {
                     if (CheckedPtr text = dynamicDowncast<RenderText>(renderer.get()))
                         return text->hasRenderedText();
-                    return !is<RenderInline>(renderer.get()) && !renderer->isFloatingOrOutOfFlowPositioned();
+                    return !renderer->isInlineBox() && !renderer->isFloatingOrOutOfFlowPositioned();
                 };
                 if (isContentfulInline()) {
                     marginInfo.setMargin({ }, { });
@@ -4867,7 +4867,7 @@ RenderObject* InlineMinMaxIterator::next()
     m_isEndOfInline = false;
     do {
 
-        if (!oldEndOfInline && is<RenderInline>(m_current))
+        if (!oldEndOfInline && m_current && m_current->isInlineBox())
             candidate = m_current->firstChildSlow();
 
         if (!candidate) {
@@ -4900,7 +4900,7 @@ RenderObject* InlineMinMaxIterator::next()
             continue;
         }
 
-        if (is<RenderInline>(*candidate) || candidate->isRenderTextOrLineBreak() || candidate->isFloating() || candidate->isBlockLevelReplacedOrAtomicInline())
+        if (candidate->isInlineBox() || candidate->isRenderTextOrLineBreak() || candidate->isFloating() || candidate->isBlockLevelReplacedOrAtomicInline())
             break;
 
         if (candidate->style().display().isBlockType()) {
@@ -4968,7 +4968,7 @@ static inline std::optional<std::pair<const RenderText&, const RenderText&>> tra
     auto shouldSkip = [&](auto& renderer) {
         if (is<RenderText>(renderer))
             return false;
-        if (is<RenderInline>(renderer))
+        if (renderer.isInlineBox())
             return true;
         auto& renderBox = downcast<RenderBoxModelObject>(renderer);
         return !renderBox.isInFlow() || renderBox.style().display() == Style::DisplayType::RubyText;
@@ -5249,7 +5249,7 @@ std::pair<LayoutUnit, LayoutUnit> RenderBlockFlow::computeInlineIntrinsicLogical
             }
         }
 
-        if (!is<RenderInline>(*child) && !is<RenderText>(*child)) {
+        if (!child->isInlineBox() && !is<RenderText>(*child)) {
             // Case (2). Inline replaced boxes and floats.
             // Terminate the current line as far as minwidth is concerned.
             LayoutUnit childMinContentInParentInlineAxis;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -310,7 +310,7 @@ Style::Difference RenderElement::adjustStyleDifference(Style::Difference diff) c
         if (isRenderTextControl())
             return false;
         // Let's still trigger layout on content with legacy line layout.
-        if (is<RenderInline>(*this) && !LayoutIntegration::LineLayout::containing(*this))
+        if (isInlineBox() && !LayoutIntegration::LineLayout::containing(*this))
             return false;
         return true;
     };
@@ -1226,7 +1226,7 @@ void RenderElement::styleDidChange(Style::Difference diff, const Style::Computed
     }
 
     // FIXME: First line change on the block comes in as equal on inline boxes.
-    auto needsLayoutBoxStyleUpdate = (diff >= Style::DifferenceResult::Repaint || (is<RenderInline>(*this) && &style() != &firstLineStyle())) && layoutBox();
+    auto needsLayoutBoxStyleUpdate = (diff >= Style::DifferenceResult::Repaint || (isInlineBox() && &style() != &firstLineStyle())) && layoutBox();
     if (needsLayoutBoxStyleUpdate)
         LayoutIntegration::LineLayout::updateStyle(*this);
 }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -742,7 +742,7 @@ RenderBlock* RenderObject::containingBlockForPositionType(PositionType positionT
 
     if (positionType == PositionType::Absolute) {
         auto containingBlockForAbsolutePosition = [&] {
-            if (CheckedPtr renderInline = dynamicDowncast<RenderInline>(renderer); renderInline && renderInline->style().position() == PositionType::Relative) {
+            if (renderer.isInlineBox() && renderer.style().position() == PositionType::Relative) {
                 // A relatively positioned RenderInline forwards its absolute positioned descendants to
                 // its nearest non-anonymous containing block (to avoid having positioned objects list in RenderInlines).
                 return nearestNonAnonymousContainingBlockIncludingSelf(renderer.parent());

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1628,7 +1628,7 @@ void RenderText::setSelectionState(HighlightState state)
 
 static inline bool NODELETE isInlineFlowOrEmptyText(const RenderObject& renderer)
 {
-    if (is<RenderInline>(renderer))
+    if (renderer.isInlineBox())
         return true;
     auto* textRenderer = dynamicDowncast<RenderText>(renderer);
     return textRenderer && textRenderer->text().isEmpty();

--- a/Source/WebCore/rendering/RenderTextFragment.cpp
+++ b/Source/WebCore/rendering/RenderTextFragment.cpp
@@ -75,8 +75,8 @@ bool RenderTextFragment::canBeSelectionLeaf() const
         return firstLetter() || textNode->hasEditableStyle();
     }
     // First-letter is always selectable.
-    CheckedPtr anonymousInlineWrapper = dynamicDowncast<RenderInline>(this->parent());
-    return anonymousInlineWrapper && anonymousInlineWrapper->firstLetterRemainingText();
+    CheckedPtr anonymousInlineWrapper = dynamicDowncast<RenderBoxModelObject>(this->parent());
+    return anonymousInlineWrapper && anonymousInlineWrapper->isInlineBox() && anonymousInlineWrapper->firstLetterRemainingText();
 }
 
 void RenderTextFragment::setTextInternal(const String& newText, bool force)

--- a/Source/WebCore/rendering/RenderVTTCue.cpp
+++ b/Source/WebCore/rendering/RenderVTTCue.cpp
@@ -545,7 +545,7 @@ RenderInline* RenderVTTCue::cueBox() const
 
     auto* firstChild = backdropBox->firstChild();
     ASSERT(firstChild);
-    ASSERT(is<RenderInline>(firstChild));
+    ASSERT(firstChild->isInlineBox());
     return dynamicDowncast<RenderInline>(firstChild);
 }
 

--- a/Source/WebCore/rendering/line/TrailingObjects.cpp
+++ b/Source/WebCore/rendering/line/TrailingObjects.cpp
@@ -26,6 +26,7 @@
 #include "TrailingObjects.h"
 
 #include "LegacyInlineIterator.h"
+#include "RenderObjectInlines.h"
 #include "StyleComputedStyle+GettersInlines.h"
 
 namespace WebCore {

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -584,7 +584,7 @@ void RenderTreeBuilder::move(RenderBoxModelObject& from, RenderBoxModelObject& t
     };
     // When moving a subtree out of a BFC we need to make sure that the line boxes generated for the inline tree are not accessible anymore from the renderers.
     // Let's find the BFC root and nuke the inline tree (At some point we are going to destroy the subtree instead of moving these renderers around.)
-    if (is<RenderInline>(child))
+    if (child.isInlineBox())
         findBFCRootAndDestroyInlineTree();
 }
 
@@ -1066,7 +1066,7 @@ RenderPtr<RenderObject> RenderTreeBuilder::detachFromRenderElement(RenderElement
             addListItemNeedingMarkerUpdate(listItem);
     }
 
-    if (m_tearDownType == RenderTreeBuilder::TearDownType::Root || is<RenderInline>(m_subtreeDestroyRoot)) {
+    if (m_tearDownType == RenderTreeBuilder::TearDownType::Root || (m_subtreeDestroyRoot && m_subtreeDestroyRoot->isInlineBox())) {
         // In case of partial damage on the inline content (the block root is not going away), we need to initiate inline layout invalidation on leaf renderers too.
         invalidateLineLayout(child, IsRemoval::Yes);
     }

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
@@ -103,7 +103,8 @@ static bool isValidColumnSpanner(const RenderMultiColumnFlow& fragmentedFlow, co
     if (descendantBox->isLegend())
         return false;
 
-    if (!is<RenderBlockFlow>(descendantBox->parent()) && !is<RenderInline>(descendantBox->parent()))
+    auto* parent = descendantBox->parent();
+    if (!is<RenderBlockFlow>(parent) && !(parent && parent->isInlineBox()))
         return false;
 
     // We need to have the flow thread as the containing block. A spanner cannot break out of the flow thread.

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -169,7 +169,7 @@ void RenderTreeUpdater::updateRebuildRoots()
             return false;
         };
         auto isBlockInInline = [&] {
-            if (!is<RenderInline>(renderingAncestor->renderer()))
+            if (!renderingAncestor->renderer()->isInlineBox())
                 return false;
             return rootRenderer && rootRenderer->isInFlow() && !rootRenderer->isInline();
         };
@@ -837,7 +837,7 @@ static std::optional<DidRepaintAndMarkContainingBlock> repaintAndMarkContainingB
             if (!destroyRoot.hasLayer() || !destroyRoot.isOutOfFlowPositioned())
                 return false;
             CheckedPtr container = destroyRoot.container();
-            if (!container || !container->isInFlowPositioned() || !is<RenderInline>(*container))
+            if (!container || !container->isInFlowPositioned() || !container->isInlineBox())
                 return false;
             CheckedPtr layer = downcast<RenderLayerModelObject>(destroyRoot).layer();
             auto cachedRepaintRect = layer->cachedClippedOverflowRect();

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -912,7 +912,7 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyGridAutoFlow> {
 template<> struct PropertyExtractorAdaptor<CSSPropertyRotate> {
     template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
     {
-        if (is<RenderInline>(state.renderer))
+        if (state.renderer && state.renderer->isInlineBox())
             return functor(CSS::Keyword::None { });
         return functor(state.style.rotate());
     }
@@ -921,7 +921,7 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyRotate> {
 template<> struct PropertyExtractorAdaptor<CSSPropertyScale> {
     template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
     {
-        if (is<RenderInline>(state.renderer))
+        if (state.renderer && state.renderer->isInlineBox())
             return functor(CSS::Keyword::None { });
         return functor(state.style.scale());
     }
@@ -930,7 +930,7 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyScale> {
 template<> struct PropertyExtractorAdaptor<CSSPropertyTranslate> {
     template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
     {
-        if (is<RenderInline>(state.renderer))
+        if (state.renderer && state.renderer->isInlineBox())
             return functor(CSS::Keyword::None { });
         return functor(state.style.translate());
     }


### PR DESCRIPTION
#### e68d09467c4364aeeed397bdb4f30e142930d39b
<pre>
[cleanup] Ask isInlineBox() instead of downcasting to RenderInline where the type is not needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=323766">https://bugs.webkit.org/show_bug.cgi?id=323766</a>
&lt;<a href="https://rdar.apple.com/problem/187025891">rdar://problem/187025891</a>&gt;

Reviewed by Antti Koivisto.

This is in preparation for removing RenderInline renderer.

Most call sites only want to know whether a renderer is an inline box, and the ones that downcast mostly go on to call style(), parent(), firstChild(),
containingBlock() or firstLetterRemainingText(), all of which RenderObject, RenderElement and RenderBoxModelObject already provide.

* Source/WebCore/accessibility/AXObjectCache.cpp:
* Source/WebCore/accessibility/AccessibilityObjectInlines.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
* Source/WebCore/page/IntersectionObserver.cpp:
* Source/WebCore/rendering/InlineWalker.h:
* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
* Source/WebCore/rendering/LegacyInlineIterator.h:
* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderElement.cpp:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/rendering/RenderText.cpp:
* Source/WebCore/rendering/RenderTextFragment.cpp:
* Source/WebCore/rendering/RenderVTTCue.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
* Source/WebCore/style/StyleExtractorCustom.h:

Canonical link: <a href="https://commits.webkit.org/320950@main">https://commits.webkit.org/320950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64047fbb921f58682faebdbfeb4b9b389689959b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196647 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d0005f06-5155-47b0-a641-4f0fda44e904) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59965 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145601 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cd2eae38-0f50-4f71-9ece-9ce2a25dc8a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166132 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125950 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/75e6b479-7110-4130-973b-6529fd456816) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48013 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158361 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45729 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7721 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52719 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198634 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59911 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155187 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41582 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60622 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154824 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49248 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132831 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130088 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59046 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20708 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58449 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58665 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58514 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->