### PR TITLE
[JSC] Reject Date components that do not fit in the ECMAScript time range

### DIFF
--- a/JSTests/stress/date-constructor-out-of-range-components.js
+++ b/JSTests/stress/date-constructor-out-of-range-components.js
@@ -1,0 +1,20 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+shouldBe(Number.isNaN(new Date(1000000000, 0, 1).valueOf()), true);
+shouldBe(Number.isNaN(new Date(-1000000000, 0, 1).valueOf()), true);
+shouldBe(Number.isNaN(Date.UTC(1000000000, 0, 1)), true);
+shouldBe(Date.UTC(275760, 8, 13), 8.64e15);
+shouldBe(new Date(2020, 0, 1).getFullYear(), 2020);
+shouldBe(Date.UTC(2020, 0, 1), Date.parse("2020-01-01T00:00:00.000Z"));
+shouldBe(new Date(8.64e15).valueOf(), 8.64e15);
+shouldBe(Number.isFinite(new Date(8.64e15).getFullYear()), true);
+
+const clipOffsetMinutes = new Date(8.64e15).getTimezoneOffset();
+if (clipOffsetMinutes < 0) {
+    const pulledBack = new Date(275760, 8, 13, 1).valueOf();
+    shouldBe(Number.isNaN(pulledBack), false);
+    shouldBe(pulledBack <= 8.64e15, true);
+}

--- a/Source/JavaScriptCore/runtime/JSDateMath.cpp
+++ b/Source/JavaScriptCore/runtime/JSDateMath.cpp
@@ -92,6 +92,11 @@
 namespace JSC {
 namespace JSDateMathInternal {
 static constexpr bool verbose = false;
+
+static bool canNarrowToInt64Milliseconds(double milliseconds)
+{
+    return std::isfinite(milliseconds) && std::abs(milliseconds) <= WTF::maxECMAScriptTime + WTF::msPerDay;
+}
 }
 
 class OpaqueICUTimeZone {
@@ -328,14 +333,14 @@ double DateCache::gregorianDateTimeToMS(int32_t year, int32_t month, int32_t mon
     double ms = timeToMS(hour, minute, second, milliseconds);
     double localTimeResult = (day * WTF::msPerDay) + ms;
 
-    if (inputTimeType == TimeType::LocalTime && std::isfinite(localTimeResult))
+    if (inputTimeType == TimeType::LocalTime && JSDateMathInternal::canNarrowToInt64Milliseconds(localTimeResult))
         return localTimeResult - localTimeOffset(static_cast<int64_t>(localTimeResult), inputTimeType).offset;
     return localTimeResult;
 }
 
 double DateCache::localTimeToMS(double milliseconds, TimeType inputTimeType)
 {
-    if (inputTimeType == TimeType::LocalTime && std::isfinite(milliseconds))
+    if (inputTimeType == TimeType::LocalTime && JSDateMathInternal::canNarrowToInt64Milliseconds(milliseconds))
         return milliseconds - localTimeOffset(static_cast<int64_t>(milliseconds), inputTimeType).offset;
     return milliseconds;
 }
@@ -363,11 +368,11 @@ ALWAYS_INLINE std::tuple<int32_t, int32_t, int32_t> DateCache::yearMonthDayFromD
 ALWAYS_INLINE PlainGregorianDateTime DateCache::computeGregorianDateTime(double millisecondsFromEpoch, TimeType outputTimeType)
 {
     LocalTimeOffset localTime;
-    if (outputTimeType == TimeType::LocalTime && std::isfinite(millisecondsFromEpoch)) {
+    if (outputTimeType == TimeType::LocalTime && JSDateMathInternal::canNarrowToInt64Milliseconds(millisecondsFromEpoch)) {
         localTime = localTimeOffset(static_cast<int64_t>(millisecondsFromEpoch));
         millisecondsFromEpoch += localTime.offset;
     }
-    if (!std::isfinite(millisecondsFromEpoch))
+    if (!JSDateMathInternal::canNarrowToInt64Milliseconds(millisecondsFromEpoch))
         return { };
 
     WTF::Int64Milliseconds timeClipped(static_cast<int64_t>(millisecondsFromEpoch));
@@ -424,7 +429,7 @@ double DateCache::parseDate(JSGlobalObject* globalObject, VM& vm, const String& 
         if (std::isnan(value))
             value = WTF::parseDate(dateString, isLocalTime);
 
-        if (isLocalTime && std::isfinite(value))
+        if (isLocalTime && JSDateMathInternal::canNarrowToInt64Milliseconds(value))
             value -= localTimeOffset(static_cast<int64_t>(value), TimeType::LocalTime).offset;
 
         return value;


### PR DESCRIPTION
#### d5ba0ecec9c4681b9800c4a59d423357c4217d8d
<pre>
[JSC] Reject Date components that do not fit in the ECMAScript time range
<a href="https://bugs.webkit.org/show_bug.cgi?id=323443">https://bugs.webkit.org/show_bug.cgi?id=323443</a>

Reviewed by Yusuke Suzuki.

localTimeToMS and the other Date math sinks only checked isfinite
before narrowing milliseconds to int64_t. A finite year such as
1000000000 produces a time far outside that type. Release already
TimeClipped that to NaN. UBSan reported the conversion.

Skip the narrowing when the value is outside ±8.64e15 plus one day.
TimeClip is still the spec gate. The extra day covers local offset
around the clip so getters on new Date(8.64e15) stay valid.

* Source/JavaScriptCore/runtime/JSDateMath.cpp:
* JSTests/stress/date-constructor-out-of-range-components.js: Added.

Canonical link: <a href="https://commits.webkit.org/320788@main">https://commits.webkit.org/320788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10698867b5439e4138f38450dd3737ee576d3dc3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196141 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150512 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145222 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100681 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165782 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125526 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47633 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45657 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7409 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14294 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/157993 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45362 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7210 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47087 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198114 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59401 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154775 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41463 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60110 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41968 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154419 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48873 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129451 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58572 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20385 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57951 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58015 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->