### PR TITLE
[css-values-5 calc-size()] Add SizeOrKeyword<> style type base

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3477,6 +3477,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/primitives/StylePrimitiveNumericTypes+Rounding.h
     style/values/primitives/StylePrimitiveNumericTypes.h
     style/values/primitives/StyleRatio.h
+    style/values/primitives/StyleSizeOrKeyword.h
     style/values/primitives/StyleSnapLengthAsBorderWidth.h
     style/values/primitives/StyleString.h
     style/values/primitives/StyleURL.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -5557,6 +5557,7 @@
 		BCA088F5264E1C08003E2A6C /* ImageDataSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA088F2264E1BF9003E2A6C /* ImageDataSettings.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCA088F5264E1C09003E2A6C /* ImageDataPixelFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA088F2264E1BFA003E2A6C /* ImageDataPixelFormat.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCA169A30BFD55B40019CA76 /* JSHTMLTableCaptionElement.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA169A10BFD55B40019CA76 /* JSHTMLTableCaptionElement.h */; };
+		BCA1C6000000000000000002 /* StyleSizeOrKeyword.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA1C6000000000000000001 /* StyleSizeOrKeyword.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCA2B061105047600043BD1C /* UserScript.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA2B0601050475F0043BD1C /* UserScript.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCA2B08B10505BCD0043BD1C /* UserScriptTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA2B08A10505BCD0043BD1C /* UserScriptTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCA407FD2C9FBAC9006B037F /* CSSValueTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA407F12C9F26C6006B037F /* CSSValueTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -19467,6 +19468,7 @@
 		BC2C0C902D32F3F200FCFBA0 /* CSSPrimitiveNumericOrKeyword.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSPrimitiveNumericOrKeyword.h; sourceTree = "<group>"; };
 		BC2C0C912D32F46F00FCFBA0 /* StylePrimitiveNumeric.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StylePrimitiveNumeric.h; sourceTree = "<group>"; };
 		BC2C0C922D32F54500FCFBA0 /* StylePrimitiveNumericOrKeyword.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StylePrimitiveNumericOrKeyword.h; sourceTree = "<group>"; };
+		BCA1C6000000000000000001 /* StyleSizeOrKeyword.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleSizeOrKeyword.h; sourceTree = "<group>"; };
 		BC2CBF4B140F1A65003879BE /* JSWebGLContextEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebGLContextEvent.h; sourceTree = "<group>"; };
 		BC2CBF7A140F1D58003879BE /* JSWebGLContextEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebGLContextEvent.cpp; sourceTree = "<group>"; };
 		BC2CCA0E2655DDB200B8C035 /* ColorSpace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ColorSpace.h; sourceTree = "<group>"; };
@@ -20287,6 +20289,7 @@
 		BCA088F4264E1BFA003E2A6C /* ImageDataPixelFormat.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = ImageDataPixelFormat.idl; sourceTree = "<group>"; };
 		BCA169A00BFD55B40019CA76 /* JSHTMLTableCaptionElement.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = JSHTMLTableCaptionElement.cpp; sourceTree = "<group>"; };
 		BCA169A10BFD55B40019CA76 /* JSHTMLTableCaptionElement.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = JSHTMLTableCaptionElement.h; sourceTree = "<group>"; };
+		BCA1C6000000000000000003 /* StyleSizeOrKeyword+CSSValueConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StyleSizeOrKeyword+CSSValueConversion.h"; sourceTree = "<group>"; };
 		BCA2B0601050475F0043BD1C /* UserScript.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserScript.h; sourceTree = "<group>"; };
 		BCA2B0601050485F0043BD1C /* UserScript.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserScript.cpp; sourceTree = "<group>"; };
 		BCA2B08A10505BCD0043BD1C /* UserScriptTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserScriptTypes.h; sourceTree = "<group>"; };
@@ -39399,6 +39402,8 @@
 				BCB271EE2CC0156E00265123 /* StylePrimitiveNumericTypes.h */,
 				BCD9F05B2E1C297600D1C3DF /* StyleRatio.cpp */,
 				BC23875F2D84A59400698102 /* StyleRatio.h */,
+				BCA1C6000000000000000003 /* StyleSizeOrKeyword+CSSValueConversion.h */,
+				BCA1C6000000000000000001 /* StyleSizeOrKeyword.h */,
 				28A097C6302E767800E50E45 /* StyleSnapLengthAsBorderWidth.cpp */,
 				28A097C5302E767800E50E45 /* StyleSnapLengthAsBorderWidth.h */,
 				BC66AF5A2F7D8E4000345E91 /* StyleString.cpp */,
@@ -49505,6 +49510,7 @@
 				BCCE02912E766AA30028EA38 /* StyleSingleTransitionDelay.h in Headers */,
 				BCCE02922E766AAA0028EA38 /* StyleSingleTransitionDuration.h in Headers */,
 				BC7320022E732F3F00A6584F /* StyleSingleTransitionProperty.h in Headers */,
+				BCA1C6000000000000000002 /* StyleSizeOrKeyword.h in Headers */,
 				214FAAB5DFD52EFEDBCC69DA /* StyleSizing.h in Headers */,
 				BC4F32B52E89C4DA00F6AEC1 /* StyleSkewTransformFunction.h in Headers */,
 				28A097C7302E767800E50E45 /* StyleSnapLengthAsBorderWidth.h in Headers */,

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -59,6 +59,7 @@
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StyleResolveForFont.h"
 #include "StyleResolver.h"
+#include "StyleSizeOrKeyword+CSSValueConversion.h"
 #include "StyleTextEdge+CSSValueConversion.h"
 #include "StyleValueTypes+CSSValueConversion.h"
 #include "TextSpacing.h"

--- a/Source/WebCore/style/values/flexbox/StyleFlexBasis.h
+++ b/Source/WebCore/style/values/flexbox/StyleFlexBasis.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <WebCore/StylePrimitiveNumericOrKeyword.h>
+#include <WebCore/StyleSizeOrKeyword.h>
 
 namespace WebCore {
 namespace Style {
@@ -33,7 +33,7 @@ struct PreferredSize;
 
 // <'flex-basis'> = content | <‘width’>
 // https://drafts.csswg.org/css-flexbox/#propdef-flex-basis
-struct FlexBasis : PrimitiveNumericOrKeyword<LengthPercentage<CSS::NonnegativeLayoutUnitClamped>, CSS::Keyword::Content, CSS::Keyword::Auto, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::Stretch, CSS::Keyword::WebkitFillAvailable, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
+struct FlexBasis : SizeOrKeyword<CSS::Keyword::Content, CSS::Keyword::Auto, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::Stretch, CSS::Keyword::WebkitFillAvailable, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
     using Base::Base;
 
     // `FlexBasis` is a superset of `PreferredSize` and therefore this conversion can fail when type is `content`.

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericOrKeyword+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericOrKeyword+CSSValueConversion.h
@@ -24,13 +24,11 @@
 
 #pragma once
 
-#include "CSSCalcSizeValue.h"
-#include "CSSCalcTree+Copy.h"
-#include "CSSCalcValue.h"
 #include "CSSKeywordValue.h"
 #include "StyleBuilderChecking.h"
 #include "StylePrimitiveNumericOrKeyword.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
+#include "StyleSizeOrKeyword.h"
 
 namespace WebCore {
 namespace Style {
@@ -87,35 +85,6 @@ template<PrimitiveNumericOrKeywordDerived StyleType, typename... Rest>
 auto convertPrimitiveNumericOrKeywordFromCSSValue(const CSSKeywordValue& value, Rest&&...) -> std::optional<StyleType>
 {
     return convertKeywordIDForCSSValueConversion<StyleType>(value.valueID());
-}
-
-// MARK: <calc-size()> conversion
-
-// FIXME: Stub until calc-size() resolves at used value time. The size types will move to their own
-// base type, and this will construct a calc-size() alternative rather than degrade.
-template<LengthPercentageOrKeywordDerived StyleType, typename ConversionState, typename... Rest>
-auto convertCalcSizeForCSSValueConversion(ConversionState& conversionState, const CSS::CalcSizeParameters& parameters, Rest&&... rest) -> std::optional<StyleType>
-{
-    using CSSRaw = typename StyleType::Specified::CSS::Raw;
-
-    auto convertCalculation = [&](const CSS::CalcSizeCalculation& calculation) -> std::optional<StyleType> {
-        return StyleType { toStyle(CSS::UnevaluatedCalc<CSSRaw> { CSSCalc::Value::create(CSS::Category::LengthPercentage, CSS::All, CSSCalc::copy(calculation)) }, conversionState, std::forward<Rest>(rest)...) };
-    };
-
-    return WTF::switchOn(parameters.basis,
-        [&](const CSS::Keyword::Any&) -> std::optional<StyleType> {
-            return convertCalculation(parameters.calculation);
-        },
-        [&]<CSSValueID Id>(const Constant<Id>&) -> std::optional<StyleType> {
-            return convertKeywordIDForCSSValueConversion<StyleType>(Id);
-        },
-        [&](const CSS::CalcSizeCalculation& basis) -> std::optional<StyleType> {
-            return convertCalculation(basis);
-        },
-        [&](const UniqueRef<CSS::CalcSizeFunction>& nested) -> std::optional<StyleType> {
-            return convertCalcSizeForCSSValueConversion<StyleType>(conversionState, nested->value.parameters, std::forward<Rest>(rest)...);
-        }
-    );
 }
 
 template<PrimitiveNumericOrKeywordDerived StyleType, typename... Rest>
@@ -205,9 +174,6 @@ auto convertPrimitiveNumericOrKeywordFromCSSValue(const CSSToLengthConversionDat
         if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
             return convertPrimitiveNumericOrKeywordFromCSSValue<StyleType>(conversionData, *primitiveValue, std::forward<Rest>(rest)...);
 
-        if (RefPtr calcSizeValue = dynamicDowncast<CSSCalcSizeValue>(value))
-            return convertCalcSizeForCSSValueConversion<StyleType>(conversionData, calcSizeValue->calcSize()->parameters, std::forward<Rest>(rest)...);
-
         RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(value);
         if (!keywordValue)
             return std::nullopt;
@@ -229,13 +195,6 @@ auto convertPrimitiveNumericOrKeywordFromCSSValue(BuilderState& state, const CSS
         if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value))
             return convertPrimitiveNumericOrKeywordFromCSSValue<StyleType>(state, *primitiveValue, std::forward<Rest>(rest)...);
 
-        if (RefPtr calcSizeValue = dynamicDowncast<CSSCalcSizeValue>(value)) {
-            if (auto result = convertCalcSizeForCSSValueConversion<StyleType>(state, calcSizeValue->calcSize()->parameters, std::forward<Rest>(rest)...))
-                return *result;
-            state.setCurrentPropertyInvalidAtComputedValueTime();
-            return 0_css_px;
-        }
-
         RefPtr keywordValue = requiredDowncast<CSSKeywordValue>(state, value);
         if (!keywordValue)
             return 0_css_px;
@@ -243,24 +202,21 @@ auto convertPrimitiveNumericOrKeywordFromCSSValue(BuilderState& state, const CSS
     }
 }
 
-template<LengthPercentageOrKeywordDerived StyleType> struct CSSValueConversion<StyleType> {
+// Split out so that specializations can reuse the overloads they do not change.
+template<LengthPercentageOrKeywordDerived StyleType> struct NumericOrKeywordCSSValueConversion {
+    static StyleType invalidValue() { return StyleType { CSS::px(0) }; }
+
     template<typename... Rest> auto operator()(const CSSToLengthConversionData& conversionData, const CSSPrimitiveValue& value, Rest&&... rest) -> StyleType
     {
-        using namespace CSS::Literals;
-
-        return convertPrimitiveNumericOrKeywordFromCSSValue<StyleType>(conversionData, value, std::forward<Rest>(rest)...).value_or(StyleType { 0_css_px });
+        return convertPrimitiveNumericOrKeywordFromCSSValue<StyleType>(conversionData, value, std::forward<Rest>(rest)...).value_or(invalidValue());
     }
     template<typename... Rest> auto operator()(const CSSToLengthConversionData& conversionData, const CSSKeywordValue& value, Rest&&... rest) -> StyleType
     {
-        using namespace CSS::Literals;
-
-        return convertPrimitiveNumericOrKeywordFromCSSValue<StyleType>(conversionData, value, std::forward<Rest>(rest)...).value_or(StyleType { 0_css_px });
+        return convertPrimitiveNumericOrKeywordFromCSSValue<StyleType>(conversionData, value, std::forward<Rest>(rest)...).value_or(invalidValue());
     }
     template<typename... Rest> auto operator()(const CSSToLengthConversionData& conversionData, const CSSValue& value, Rest&&... rest) -> StyleType
     {
-        using namespace CSS::Literals;
-
-        return convertPrimitiveNumericOrKeywordFromCSSValue<StyleType>(conversionData, value, std::forward<Rest>(rest)...).value_or(StyleType { 0_css_px });
+        return convertPrimitiveNumericOrKeywordFromCSSValue<StyleType>(conversionData, value, std::forward<Rest>(rest)...).value_or(invalidValue());
     }
 
     template<typename... Rest> auto operator()(BuilderState& state, const CSSPrimitiveValue& value, Rest&&... rest) -> StyleType
@@ -276,6 +232,10 @@ template<LengthPercentageOrKeywordDerived StyleType> struct CSSValueConversion<S
         return convertPrimitiveNumericOrKeywordFromCSSValue<StyleType>(state, value, std::forward<Rest>(rest)...);
     }
 };
+
+// The sizing properties have their own specialization.
+template<LengthPercentageOrKeywordDerived StyleType> requires (!SizeOrKeywordDerived<StyleType>)
+struct CSSValueConversion<StyleType> : NumericOrKeywordCSSValueConversion<StyleType> { };
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StyleSizeOrKeyword+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StyleSizeOrKeyword+CSSValueConversion.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSCalcSizeValue.h"
+#include "CSSCalcTree+Copy.h"
+#include "CSSCalcValue.h"
+#include "StylePrimitiveNumericOrKeyword+CSSValueConversion.h"
+#include "StyleSizeOrKeyword.h"
+
+namespace WebCore {
+namespace Style {
+
+// MARK: - <calc-size()> conversion
+
+// FIXME: Stub until calc-size() resolves at used value time, when this will construct a calc-size()
+// alternative rather than degrade to what the function is based on.
+template<SizeOrKeywordDerived StyleType, typename ConversionState, typename... Rest>
+auto convertCalcSizeForCSSValueConversion(ConversionState& conversionState, const CSS::CalcSizeParameters& parameters, Rest&&... rest) -> std::optional<StyleType>
+{
+    using CSSRaw = typename StyleType::Specified::CSS::Raw;
+
+    auto convertCalculation = [&](const CSS::CalcSizeCalculation& calculation) -> std::optional<StyleType> {
+        return StyleType { toStyle(CSS::UnevaluatedCalc<CSSRaw> { CSSCalc::Value::create(CSS::Category::LengthPercentage, CSS::All, CSSCalc::copy(calculation)) }, conversionState, std::forward<Rest>(rest)...) };
+    };
+
+    return WTF::switchOn(parameters.basis,
+        [&](const CSS::Keyword::Any&) -> std::optional<StyleType> {
+            return convertCalculation(parameters.calculation);
+        },
+        [&]<CSSValueID Id>(const Constant<Id>&) -> std::optional<StyleType> {
+            return convertKeywordIDForCSSValueConversion<StyleType>(Id);
+        },
+        [&](const CSS::CalcSizeCalculation& basis) -> std::optional<StyleType> {
+            return convertCalculation(basis);
+        },
+        [&](const UniqueRef<CSS::CalcSizeFunction>& nested) -> std::optional<StyleType> {
+            return convertCalcSizeForCSSValueConversion<StyleType>(conversionState, nested->value.parameters, std::forward<Rest>(rest)...);
+        }
+    );
+}
+
+// MARK: - Conversion
+
+// Only the CSSValue overloads need calc-size() handling.
+template<SizeOrKeywordDerived StyleType> struct CSSValueConversion<StyleType> : NumericOrKeywordCSSValueConversion<StyleType> {
+    using Base = NumericOrKeywordCSSValueConversion<StyleType>;
+    using Base::operator();
+    using Base::invalidValue;
+
+    template<typename... Rest> auto operator()(const CSSToLengthConversionData& conversionData, const CSSValue& value, Rest&&... rest) -> StyleType
+    {
+        if (RefPtr calcSizeValue = dynamicDowncast<CSSCalcSizeValue>(value))
+            return convertCalcSizeForCSSValueConversion<StyleType>(conversionData, calcSizeValue->calcSize()->parameters, std::forward<Rest>(rest)...).value_or(invalidValue());
+
+        return Base::operator()(conversionData, value, std::forward<Rest>(rest)...);
+    }
+
+    template<typename... Rest> auto operator()(BuilderState& state, const CSSValue& value, Rest&&... rest) -> StyleType
+    {
+        if (RefPtr calcSizeValue = dynamicDowncast<CSSCalcSizeValue>(value)) {
+            if (auto result = convertCalcSizeForCSSValueConversion<StyleType>(state, calcSizeValue->calcSize()->parameters, std::forward<Rest>(rest)...))
+                return *result;
+            state.setCurrentPropertyInvalidAtComputedValueTime();
+            return invalidValue();
+        }
+
+        return Base::operator()(state, value, std::forward<Rest>(rest)...);
+    }
+};
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StyleSizeOrKeyword.h
+++ b/Source/WebCore/style/values/primitives/StyleSizeOrKeyword.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/StylePrimitiveNumericOrKeyword.h>
+
+namespace WebCore {
+namespace Style {
+
+// Base for the sizing properties, which accept `calc-size()` in addition to a <length-percentage>
+// and their keywords. Being a distinct base keeps the calc-size() handling off the other
+// <length-percentage>-or-keyword types.
+template<CSS::SpecificKeyword... Ks>
+struct SizeOrKeyword : PrimitiveNumericOrKeyword<LengthPercentage<CSS::NonnegativeLayoutUnitClamped>, Ks...> {
+    using NumericOrKeyword = PrimitiveNumericOrKeyword<LengthPercentage<CSS::NonnegativeLayoutUnitClamped>, Ks...>;
+    using Base = SizeOrKeyword<Ks...>;
+
+    using NumericOrKeyword::NumericOrKeyword;
+};
+
+template<typename T> concept SizeOrKeywordDerived = WTF::IsBaseOfTemplate<SizeOrKeyword, T>::value && VariantLike<T>;
+
+} // namespace Style
+} // namespace WebCore

--- a/Source/WebCore/style/values/sizing/StyleMaximumSize.h
+++ b/Source/WebCore/style/values/sizing/StyleMaximumSize.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <WebCore/StylePrimitiveNumericOrKeyword.h>
+#include <WebCore/StyleSizeOrKeyword.h>
 
 namespace WebCore {
 namespace Style {
@@ -46,7 +46,7 @@ namespace Style {
 //
 // https://drafts.csswg.org/css-sizing-3/#max-size-properties
 // https://drafts.csswg.org/css-sizing-4/#sizing-values (additional values added)
-struct MaximumSize : PrimitiveNumericOrKeyword<LengthPercentage<CSS::NonnegativeLayoutUnitClamped>, CSS::Keyword::None, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::Stretch, CSS::Keyword::WebkitFillAvailable, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
+struct MaximumSize : SizeOrKeyword<CSS::Keyword::None, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::Stretch, CSS::Keyword::WebkitFillAvailable, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
     using Base::Base;
 
     ALWAYS_INLINE bool isNone() const { return holdsAlternative<CSS::Keyword::None>(); }

--- a/Source/WebCore/style/values/sizing/StyleMinimumSize.h
+++ b/Source/WebCore/style/values/sizing/StyleMinimumSize.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <WebCore/StylePrimitiveNumericOrKeyword.h>
+#include <WebCore/StyleSizeOrKeyword.h>
 
 namespace WebCore {
 namespace Style {
@@ -48,7 +48,7 @@ struct PreferredSize;
 //
 // https://drafts.csswg.org/css-sizing-3/#min-size-properties
 // https://drafts.csswg.org/css-sizing-4/#sizing-values (additional values added)
-struct MinimumSize : PrimitiveNumericOrKeyword<LengthPercentage<CSS::NonnegativeLayoutUnitClamped>, CSS::Keyword::Auto, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::Stretch, CSS::Keyword::WebkitFillAvailable, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
+struct MinimumSize : SizeOrKeyword<CSS::Keyword::Auto, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::Stretch, CSS::Keyword::WebkitFillAvailable, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
     using Base::Base;
 
     ALWAYS_INLINE bool isAuto() const { return holdsAlternative<CSS::Keyword::Auto>(); }

--- a/Source/WebCore/style/values/sizing/StylePreferredSize.h
+++ b/Source/WebCore/style/values/sizing/StylePreferredSize.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <WebCore/StylePrimitiveNumericOrKeyword.h>
+#include <WebCore/StyleSizeOrKeyword.h>
 
 namespace WebCore {
 namespace Style {
@@ -49,7 +49,7 @@ struct MinimumSize;
 //
 // https://drafts.csswg.org/css-sizing-3/#preferred-size-properties
 // https://drafts.csswg.org/css-sizing-4/#sizing-values (additional values added)
-struct PreferredSize : PrimitiveNumericOrKeyword<LengthPercentage<CSS::NonnegativeLayoutUnitClamped>, CSS::Keyword::Auto, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::Stretch, CSS::Keyword::WebkitFillAvailable, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
+struct PreferredSize : SizeOrKeyword<CSS::Keyword::Auto, CSS::Keyword::MinContent, CSS::Keyword::MaxContent, CSS::Keyword::FitContent, CSS::Keyword::Stretch, CSS::Keyword::WebkitFillAvailable, CSS::Keyword::Intrinsic, CSS::Keyword::MinIntrinsic> {
     using Base::Base;
 
     // `PreferredSize` is a structural twin to `MinimumSize` and therefore can be losslessly converted.


### PR DESCRIPTION
#### a86a48dc43ceb3a4c3faab7c7504288462cf159d
<pre>
[css-values-5 calc-size()] Add SizeOrKeyword&lt;&gt; style type base
<a href="https://bugs.webkit.org/show_bug.cgi?id=323759">https://bugs.webkit.org/show_bug.cgi?id=323759</a>
<a href="https://rdar.apple.com/187019453">rdar://187019453</a>

Reviewed by Sam Weinig.

Only size style types like Style::PreferredSize support calc-size(). Introduce
SizeOrKeyword&lt;&gt; base type to use for those and remove the code from
PrimitiveNumericOrKeyword&lt;&gt;.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/values/flexbox/StyleFlexBasis.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericOrKeyword+CSSValueConversion.h:
(WebCore::Style::convertPrimitiveNumericOrKeywordFromCSSValue):
(WebCore::Style::NumericOrKeywordCSSValueConversion::invalidValue):
(WebCore::Style::NumericOrKeywordCSSValueConversion::operator()):
(WebCore::Style::convertCalcSizeForCSSValueConversion): Deleted.
(WebCore::Style::CSSValueConversion&lt;StyleType&gt;::operator()): Deleted.

IsBaseOfTemplate follows indirect bases, so the size types still satisfy
LengthPercentageOrKeywordDerived and this specialization has to exclude them
explicitly.

* Source/WebCore/style/values/primitives/StyleSizeOrKeyword+CSSValueConversion.h: Added.
(WebCore::Style::convertCalcSizeForCSSValueConversion):
(WebCore::Style::CSSValueConversion&lt;StyleType&gt;::operator()):
* Source/WebCore/style/values/primitives/StyleSizeOrKeyword.h: Added.
* Source/WebCore/style/values/sizing/StyleMaximumSize.h:
* Source/WebCore/style/values/sizing/StyleMinimumSize.h:
* Source/WebCore/style/values/sizing/StylePreferredSize.h:

Canonical link: <a href="https://commits.webkit.org/320763@main">https://commits.webkit.org/320763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9eaa7513390f5e8c589df47fa14555215eb9a40f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59766 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53569 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196166 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6a8cd840-d51a-47fa-84b1-74864256fd1d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59489 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a03afa20-4482-42e5-a710-a661e4512f40) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188823 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/48936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/125553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fff7018a-2c72-41cb-83b6-ea4337f32046) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/47663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/158023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/45386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7237 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50102 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198140 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59426 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/165322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154801 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41446 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60134 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154445 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48900 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129476 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58596 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57975 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58209 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58039 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->