### PR TITLE
[IFC] Stop adjusting the display, float and clear values of line break boxes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-br-element/br-and-wbr-with-non-inline-display-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-br-element/br-and-wbr-with-non-inline-display-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: br breaks the line, wbr does not</title>
+<style>
+.t { width: 100px; margin-bottom: 10px; font-size: 0; line-height: 0; }
+.t i { display: inline-block; width: 20px; height: 20px; background: green; }
+.t b { display: block; float: left; width: 40px; height: 40px; background: green; }
+</style>
+<div class=t><i></i><br><i></i></div>
+<div class=t><i></i><br><i></i></div>
+<div class=t><i></i><br><i></i></div>
+<div class=t><i></i><br><i></i></div>
+<div class=t><i></i><br><i></i></div>
+<div class=t><i></i><br><i></i></div>
+<div class=t><i></i><wbr><i></i></div>
+<div class=t><b></b><i></i><wbr><i></i></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-br-element/br-and-wbr-with-non-inline-display-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-br-element/br-and-wbr-with-non-inline-display-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: br breaks the line, wbr does not</title>
+<style>
+.t { width: 100px; margin-bottom: 10px; font-size: 0; line-height: 0; }
+.t i { display: inline-block; width: 20px; height: 20px; background: green; }
+.t b { display: block; float: left; width: 40px; height: 40px; background: green; }
+</style>
+<div class=t><i></i><br><i></i></div>
+<div class=t><i></i><br><i></i></div>
+<div class=t><i></i><br><i></i></div>
+<div class=t><i></i><br><i></i></div>
+<div class=t><i></i><br><i></i></div>
+<div class=t><i></i><br><i></i></div>
+<div class=t><i></i><wbr><i></i></div>
+<div class=t><b></b><i></i><wbr><i></i></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-br-element/br-and-wbr-with-non-inline-display.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-br-element/br-and-wbr-with-non-inline-display.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>br keeps breaking the line and wbr keeps not breaking it whatever display, float and clear say</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#phrasing-content-3">
+<link rel="match" href="br-and-wbr-with-non-inline-display-ref.html">
+<style>
+.t { width: 100px; margin-bottom: 10px; font-size: 0; line-height: 0; }
+.t i { display: inline-block; width: 20px; height: 20px; background: green; }
+.t b { display: block; float: left; width: 40px; height: 40px; background: green; }
+</style>
+<div class=t><i></i><br style="display: block"><i></i></div>
+<div class=t><i></i><br style="display: inline-block"><i></i></div>
+<div class=t><i></i><br style="display: table-cell"><i></i></div>
+<div class=t><i></i><br style="display: flex"><i></i></div>
+<div class=t><i></i><br style="display: list-item"><i></i></div>
+<div class=t><i></i><br style="float: left"><i></i></div>
+<div class=t><i></i><wbr style="display: block"><i></i></div>
+<div class=t><b></b><i></i><wbr style="clear: left"><i></i></div>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
@@ -145,7 +145,7 @@ static bool NODELETE cannotConstrainInlineItem(const InlineItem& inlineItem)
     // A block level box takes a line of its own, so it bounds the text we constrain rather than being part of it.
     if (inlineItem.isBlock())
         return false;
-    if (!inlineItem.isText() && !inlineItem.isSoftLineBreak() && !inlineItem.layoutBox().isInlineLevelBox())
+    if (!inlineItem.isText() && !inlineItem.isSoftLineBreak() && !inlineItem.layoutBox().isInlineLevelBox() && !inlineItem.layoutBox().isLineBreakBox())
         return true;
     if (containsTrailingSoftHyphen(inlineItem))
         return true;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -342,7 +342,7 @@ static bool NODELETE requiresVisualReordering(const Box& layoutBox)
 {
     if (auto* inlineTextBox = dynamicDowncast<InlineTextBox>(layoutBox))
         return inlineTextBox->hasStrongDirectionalityContent();
-    if (layoutBox.isInlineBox() && layoutBox.isInFlow()) {
+    if ((layoutBox.isInlineBox() || layoutBox.isLineBreakBox()) && layoutBox.isInFlow()) {
         auto& style = layoutBox.style();
         return style.writingMode().isBidiRTL() || (style.rtlOrdering() == Order::Logical && style.unicodeBidi() != UnicodeBidi::Normal);
     }
@@ -1230,6 +1230,9 @@ void InlineItemsBuilder::handleInlineBoxEnd(const Box& inlineBox, InlineItemList
 
 void InlineItemsBuilder::handleInlineLevelBox(const Box& layoutBox, InlineItemList& inlineItemList)
 {
+    if (layoutBox.isLineBreakBox())
+        return inlineItemList.append({ layoutBox, layoutBox.isWordBreakOpportunity() ? InlineItem::Type::WordBreakOpportunity : InlineItem::Type::HardLineBreak });
+
     if (layoutBox.isRubyAnnotationBox())
         return inlineItemList.append({ layoutBox, InlineItem::Type::OutOfFlow });
 
@@ -1240,9 +1243,6 @@ void InlineItemsBuilder::handleInlineLevelBox(const Box& layoutBox, InlineItemLi
             m_hasWhiteSpaceTrim |= !layoutBox.style().whiteSpaceTrim().isNone();
         return inlineItemList.append({ layoutBox, InlineItem::Type::AtomicInlineBox });
     }
-
-    if (layoutBox.isLineBreakBox())
-        return inlineItemList.append({ layoutBox, layoutBox.isWordBreakOpportunity() ? InlineItem::Type::WordBreakOpportunity : InlineItem::Type::HardLineBreak });
 
     ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -210,20 +210,6 @@ void BoxTreeUpdater::adjustStyleIfNeeded(const RenderElement& renderer, Style::C
                 styleToAdjust.setDisplay(Style::DisplayType::InlineFlow);
             return;
         }
-
-        if (auto* renderLineBreak = dynamicDowncast<RenderLineBreak>(renderer)) {
-            if (!styleToAdjust.hasOutOfFlowPosition()) {
-                // Force in-flow display value to inline (see webkit.org/b/223151).
-                styleToAdjust.setDisplay(Style::DisplayType::InlineFlow);
-            }
-            styleToAdjust.setFloating(Float::None);
-            // Clear property should only apply on block elements, however,
-            // it appears that browsers seem to ignore it on <br> inline elements.
-            // https://drafts.csswg.org/css2/#propdef-clear
-            if (renderLineBreak->isWBR())
-                styleToAdjust.setClear(Clear::None);
-            return;
-        }
     };
     adjustStyle(style);
     if (firstLineStyle)

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -702,7 +702,7 @@ void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdj
 
     if (m_inlineContent) {
         for (auto& box : m_inlineContent->displayContent().boxes) {
-            if (box.isInlineBox() || box.isTextOrSoftLineBreak())
+            if (box.isInlineBox() || box.isText() || box.isLineBreak())
                 continue;
 
             if (box.isBlockLevelBox()) {

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -203,11 +203,15 @@ bool Box::isFloatingPositioned() const
     // FIXME: Rendering code caches values like this. (style="position: absolute; float: left")
     if (isOutOfFlowPositioned())
         return false;
+    if (isLineBreakBox())
+        return false;
     return m_style.floating() != Float::None;
 }
 
 bool Box::hasFloatClear() const
 {
+    if (isWordBreakOpportunity())
+        return false;
     return m_style.clear() != Clear::None && (isBlockLevelBox() || isLineBreakBox());
 }
 
@@ -556,11 +560,11 @@ void Box::setShape(RefPtr<const LayoutShape> shape)
 
 const ElementBox* Box::associatedRubyAnnotationBox() const
 {
-    if (style().display() != Style::DisplayType::RubyBase)
+    if (isLineBreakBox() || style().display() != Style::DisplayType::RubyBase)
         return nullptr;
 
     auto* next = nextSibling();
-    if (!next || next->style().display() != Style::DisplayType::RubyText)
+    if (!next || next->isLineBreakBox() || next->style().display() != Style::DisplayType::RubyText)
         return nullptr;
 
     return dynamicDowncast<ElementBox>(next);


### PR DESCRIPTION
#### 506a7e66512dac3f08eb2b9c22b2882d7ce689b0
<pre>
[IFC] Stop adjusting the display, float and clear values of line break boxes
<a href="https://bugs.webkit.org/show_bug.cgi?id=323782">https://bugs.webkit.org/show_bug.cgi?id=323782</a>
&lt;<a href="https://rdar.apple.com/problem/187042554">rdar://problem/187042554</a>&gt;

Reviewed by Antti Koivisto.

This is in preparation for not adjusting computed style for layout boxes.

&lt;br&gt; and &lt;wbr&gt; in-flow display was forced to inline, float to none and, for &lt;wbr&gt;, clear to none.

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-br-element/br-and-wbr-with-non-inline-display-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-br-element/br-and-wbr-with-non-inline-display-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-br-element/br-and-wbr-with-non-inline-display.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp:
(WebCore::Layout::cannotConstrainInlineItem):
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::requiresVisualReordering):
(WebCore::Layout::InlineItemsBuilder::handleInlineLevelBox):
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::BoxTreeUpdater::adjustStyleIfNeeded):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::updateRenderTreePositions):
* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::isFloatingPositioned const):
(WebCore::Layout::Box::hasFloatClear const):
(WebCore::Layout::Box::associatedRubyAnnotationBox const):

Canonical link: <a href="https://commits.webkit.org/320828@main">https://commits.webkit.org/320828@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c52b5bc388552eca4fab285fd344827a024dda65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196225 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150574 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e31b150e-1a9e-4c42-8b25-94150d4691f7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59546 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145289 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100723 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/334b4c6a-e432-4295-9242-d757b8c2cbd1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125600 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7ec1f13f-8b53-4d3f-84b4-50a589ac5325) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47696 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45713 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158052 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45425 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7294 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198198 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59484 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165360 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154846 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41492 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60193 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42026 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154493 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48942 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132544 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129536 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58649 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58033 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58264 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58093 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->