### PR TITLE
scrollWidth and clientWidth are inconsistent when zoomed in/out due to rounding issues

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-not-scrollable-fractional-zoom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-not-scrollable-fractional-zoom-expected.txt
@@ -1,0 +1,7 @@
+
+PASS scrollWidth equals clientWidth for a non-scrollable 203.2px box with 'zoom: 1.25'
+PASS scrollWidth equals clientWidth for a non-scrollable 307.2px box with 'zoom: 1.25'
+PASS scrollWidth equals clientWidth for a non-scrollable 202.30769231px box with 'zoom: 1.3'
+PASS scrollWidth equals clientWidth for a non-scrollable 203.33333333px box with 'zoom: 1.5'
+PASS scrollWidth equals clientWidth for a non-scrollable 202.66666667px box with 'zoom: 0.75'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-not-scrollable-fractional-zoom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-not-scrollable-fractional-zoom.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>scrollWidth equals clientWidth for a non-scrollable element with a fractional used width under CSS zoom</title>
+<link rel="author" title="Brent Fulgham" href="mailto:bfulgham@apple.com">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollwidth">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-clientwidth">
+<meta name="assert" content="An element with no overflow reports the same integer for scrollWidth and clientWidth, even when CSS zoom makes its used border-box width fractional in unzoomed CSS pixels.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+/* Each width is chosen so that width * zoom is an exact integer: the used
+   border-box width is device-pixel aligned, while the unzoomed CSS-pixel value
+   is fractional. That is what exposes a size getter that rounds differently
+   from its siblings. See subpixel-sizes-and-offsets.tentative.html for the
+   unzoomed form of the same rule. */
+.box {
+  box-sizing: border-box;
+  height: 20px;
+  background: silver;
+}
+#zoom125a { zoom: 1.25; width: 203.2px; }
+#zoom125b { zoom: 1.25; width: 307.2px; }
+#zoom130  { zoom: 1.3;  width: 202.30769231px; }
+#zoom150  { zoom: 1.5;  width: 203.33333333px; }
+#zoom075  { zoom: 0.75; width: 202.66666667px; }
+</style>
+<div id="zoom125a" class="box"></div>
+<div id="zoom125b" class="box"></div>
+<div id="zoom130" class="box"></div>
+<div id="zoom150" class="box"></div>
+<div id="zoom075" class="box"></div>
+<script>
+const cases = [
+  { id: "zoom125a", zoom: "1.25", width: "203.2px" },
+  { id: "zoom125b", zoom: "1.25", width: "307.2px" },
+  { id: "zoom130",  zoom: "1.3",  width: "202.30769231px" },
+  { id: "zoom150",  zoom: "1.5",  width: "203.33333333px" },
+  { id: "zoom075",  zoom: "0.75", width: "202.66666667px" },
+];
+
+for (const testCase of cases) {
+  test(() => {
+    const box = document.getElementById(testCase.id);
+    // Pages detect scrollability with `elm.scrollWidth !== elm.clientWidth`.
+    assert_equals(box.scrollWidth, box.clientWidth,
+                  "scrollWidth must equal clientWidth when there is nothing to overflow");
+  }, `scrollWidth equals clientWidth for a non-scrollable ${testCase.width} box with 'zoom: ${testCase.zoom}'`);
+}
+</script>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1850,8 +1850,10 @@ int Element::scrollWidth()
         return 0;
     }
 
-    if (CheckedPtr renderer = renderBox())
-        return Style::unapplyingZoom<int>(renderer->scrollWidth(), *renderer);
+    if (CheckedPtr renderer = renderBox()) {
+        auto scrollWidth = LayoutUnit { renderer->scrollWidth() };
+        return convertToNonSubpixelValue(Style::unapplyingZoom<LayoutUnit>(scrollWidth, *renderer).toDouble());
+    }
     return 0;
 }
 
@@ -1868,8 +1870,10 @@ int Element::scrollHeight()
         return 0;
     }
 
-    if (CheckedPtr renderer = renderBox())
-        return Style::unapplyingZoom<int>(renderer->scrollHeight(), *renderer);
+    if (CheckedPtr renderer = renderBox()) {
+        auto scrollHeight = LayoutUnit { renderer->scrollHeight() };
+        return convertToNonSubpixelValue(Style::unapplyingZoom<LayoutUnit>(scrollHeight, *renderer).toDouble());
+    }
     return 0;
 }
 


### PR DESCRIPTION
#### dab9e9d6d6f03bae4f252f04e3eb90d7c4f620c5
<pre>
scrollWidth and clientWidth are inconsistent when zoomed in/out due to rounding issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=268275">https://bugs.webkit.org/show_bug.cgi?id=268275</a>
<a href="https://rdar.apple.com/121879134">rdar://121879134</a>

Reviewed by Simon Fraser.

Element::clientWidth/offsetWidth and Element::scrollWidth/scrollHeight use slightly
different computations on the same layout content, resulting in small differences caused
by rounding.

Element::clientWidth and Element::offsetWidth take the padding-box integer out
of the zoomed layout space with Style::unapplyingZoom&lt;LayoutUnit&gt; and round the
quotient to nearest integer. Element::scrollWidth and Element::scrollHeight take the
same measurement through the Style::unapplyingZoom&lt;int&gt;, which increments the
value before truncating when the zoom factor is above one. The two operators
disagree by a pixel whenever the quotient lands near a half.

This creates problems with page detection of scrollability, since web authors often use
elm.scrollWidth !== elm.clientWidth for this purpose. The rounding errors described
above can cause the page to believe the region is scrollable (e.g., on Shopify content).

This patch makes scrollWidth and scrollHeight consistent with the conversion used in
clientWidth and clientHeight already use.

Test: imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-not-scrollable-fractional-zoom.html

* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-not-scrollable-fractional-zoom-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollWidthHeight-not-scrollable-fractional-zoom.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::scrollWidth):
(WebCore::Element::scrollHeight):

Canonical link: <a href="https://commits.webkit.org/320773@main">https://commits.webkit.org/320773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8089540dd4b55b2dddd3dfda6cb09915b950876b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59759 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196159 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/be26f116-62f2-46dc-bc57-9c319e0ae614) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145234 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d9163666-59a4-454e-ae07-c183d5b71215) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48925 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125539 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/397a54f9-3fac-4436-b95a-c01518afa8a1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47652 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158012 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45380 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7230 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198133 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154793 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41453 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60127 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154437 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48886 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129469 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58589 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57968 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58202 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58032 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->