### PR TITLE
Web Inspector: Debugger.globalObjectCleared from a subframe wipes every target's script map

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js
@@ -981,25 +981,29 @@ WI.DebuggerManager = class DebuggerManager extends WI.Object
 
         WI.Script.resetUniqueDisplayNameNumbers(target);
 
-        this._internalWebKitScripts = [];
-        this._targetDebuggerDataMap.clear();
+        // Only clear state belonging to the target that was cleared. The Debugger domain's
+        // targetTypes includes "frame", so a subframe appearing emits this for its own target.
+        this._internalWebKitScripts = this._internalWebKitScripts.filter((script) => script.target !== target);
+        this._targetDebuggerDataMap.delete(target);
 
         this._ignoreBreakpointDisplayLocationDidChangeEvent = true;
 
-        // Mark all the breakpoints as unresolved. They will be reported as resolved when
+        // Mark this target's breakpoints as unresolved. They will be reported as resolved when
         // breakpointResolved is called as the page loads.
         for (let breakpoint of this._breakpoints) {
-            breakpoint.clearResolvedLocations();
+            if (breakpoint.sourceCodeLocation.sourceCode?.target !== target)
+                continue;
 
-            if (breakpoint.sourceCodeLocation.sourceCode)
-                breakpoint.sourceCodeLocation.sourceCode = null;
+            breakpoint.clearResolvedLocations();
+            breakpoint.sourceCodeLocation.sourceCode = null;
         }
 
         this._ignoreBreakpointDisplayLocationDidChangeEvent = false;
 
         this.dispatchEventToListeners(WI.DebuggerManager.Event.ScriptsCleared);
 
-        if (wasPaused)
+        // `paused` spans every target, so only resume if no other target is still paused.
+        if (wasPaused && !this.paused)
             this.dispatchEventToListeners(WI.DebuggerManager.Event.Resumed);
     }
 


### PR DESCRIPTION
#### cfed8f7c90ddc47e935d9e4d52bd56cccb1eb13b
<pre>
Web Inspector: Debugger.globalObjectCleared from a subframe wipes every target&apos;s script map
<a href="https://bugs.webkit.org/show_bug.cgi?id=323787">https://bugs.webkit.org/show_bug.cgi?id=323787</a>
<a href="https://rdar.apple.com/187042936">rdar://187042936</a>

Reviewed by Devin Rousso.

DebuggerManager.globalObjectCleared() receives the target whose global object was cleared, then
cleared state for every target. That was harmless while only the page emitted the event, but the
Debugger domain&apos;s targetTypes now includes &quot;frame&quot;, so a subframe appearing discards the main
frame&apos;s WI.DebuggerData. A later main-frame pause resolves no call frames and takes the silent
auto-resume path in debuggerDidPause(), so the frontend never reports the pause.

* Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js:
(WI.DebuggerManager.prototype.globalObjectCleared):

Canonical link: <a href="https://commits.webkit.org/320787@main">https://commits.webkit.org/320787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12917f691ea0a5fddf654f618fb23de400dbaa89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196178 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145252 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188835 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Failed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48934 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125559 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47661 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158021 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45393 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7249 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198152 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59437 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154811 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41460 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60146 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154456 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48906 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129487 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58607 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57986 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58220 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58050 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->