### PR TITLE
Update css-link-params URL fragment tests to the :~: fragment directive syntax

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/css-linked-parameters-precedence-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/css-linked-parameters-precedence-1.html
@@ -10,4 +10,4 @@
   }
 </style>
 
-<img src="circle-with-parameters.svg#param(--color, green)">
+<img src="circle-with-parameters.svg#:~:param(--color,green)">

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/css-linked-parameters-precedence-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/css-linked-parameters-precedence-2.html
@@ -8,7 +8,7 @@
   .image-with-params {
   width:100px;
   height:100px;
-  background-image: url("circle-with-parameters.svg#param(--color,red)" param(--color, green));
+  background-image: url("circle-with-parameters.svg#:~:param(--color,red)" param(--color, green));
   }
 </style>
 <div class="image-with-params"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/img-with-url-fragment-identifiers-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/img-with-url-fragment-identifiers-1.html
@@ -4,4 +4,4 @@
 <link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
 <link rel="help" href="https://drafts.csswg.org/css-link-params/#url-frag">
 <link rel="match" href="circle-green-ref.html"/>
-<img src="circle-with-parameters.svg#param(--color, green)">
+<img src="circle-with-parameters.svg#:~:param(--color,green)">

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/img-with-url-fragment-identifiers-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/img-with-url-fragment-identifiers-2.html
@@ -4,4 +4,4 @@
 <link rel="author" title="Divyansh Mangal" href="mailto:dmangal@microsoft.com">
 <link rel="help" href="https://drafts.csswg.org/css-link-params/#url-frag">
 <link rel="match" href="circle-green-with-stroke-ref.html"/>
-<img src="circle-with-parameters.svg#param(--color, green), param(--stroke, blue)">
+<img src="circle-with-parameters.svg#:~:param(--color,green)&amp;param(--stroke,blue)">


### PR DESCRIPTION
#### 0d166a4a3d95ca936c7f5476a822e5cad8a67d11
<pre>
Update css-link-params URL fragment tests to the :~: fragment directive syntax
<a href="https://bugs.webkit.org/show_bug.cgi?id=323798">https://bugs.webkit.org/show_bug.cgi?id=323798</a>
<a href="https://rdar.apple.com/187046115">rdar://187046115</a>

Reviewed by Tim Nguyen.

These tests still used the older bare fragment form, image.svg#param(--color,green).
The CSSWG resolved[1] to harmonize link parameters with the fragment directive.

[1]: <a href="https://github.com/w3c/csswg-drafts/issues/14235">https://github.com/w3c/csswg-drafts/issues/14235</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/css-linked-parameters-precedence-1.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/css-linked-parameters-precedence-2.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/img-with-url-fragment-identifiers-1.html:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/img-with-url-fragment-identifiers-2.html:

Canonical link: <a href="https://commits.webkit.org/320771@main">https://commits.webkit.org/320771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/268c237a0d22b8662f6e1e15f65bf7a8f90016a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196172 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [⏳ 🧪 bindings](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61146 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59495 "Hash 268c237a for PR 73603 does not build (failure)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145244 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48935 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125551 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47662 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/59495 "Hash 268c237a for PR 73603 does not build (failure)") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/158022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45383 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7243 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47117 "Build is in progress. Recent messages:") | | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/59495 "Hash 268c237a for PR 73603 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198146 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59431 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165319 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154803 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41449 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60140 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154448 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48897 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129481 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58601 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57980 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58214 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58044 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->