### PR TITLE
[Site Isolation] Web Inspector: Closing inspector during a breakpoint action doesn't stop remaining actions, and page stays paused

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/debugger/breakpoint-action-detach-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/debugger/breakpoint-action-detach-cross-origin-iframe-expected.txt
@@ -1,0 +1,16 @@
+Test that disconnecting a cross-origin iframe's inspector target from inside one of its breakpoint actions abandons the remaining actions and lets the frame keep running.
+
+
+
+== Running test suite: SiteIsolation.Debugger.BreakpointActionDetach
+-- Running test case: SiteIsolation.Debugger.BreakpointActionDetach.Setup
+PASS: Should find the cross-origin frame target.
+
+-- Running test case: SiteIsolation.Debugger.BreakpointActionDetach.RemainingActionsAbandoned
+PASS: Should find the frame's script.
+iframe: first breakpoint action ran, disconnecting this frame's inspector target
+iframe: breakpoint line ran
+iframe: execution continued after the breakpoint
+PASS: Breakpoint actions after the disconnecting one should not run.
+PASS: Frame should keep executing instead of staying paused.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/debugger/breakpoint-action-detach-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/debugger/breakpoint-action-detach-cross-origin-iframe.html
@@ -1,0 +1,50 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="resources/site-isolation-debugger-test-utilities.js"></script>
+<script src="resources/breakpoint-detach-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Debugger.BreakpointActionDetach");
+
+    let crossOriginTarget;
+
+    suite.addTestCase({
+        name: "SiteIsolation.Debugger.BreakpointActionDetach.Setup",
+        description: "Find the cross-origin frame target.",
+        async test() {
+            crossOriginTarget = await frameTargetForURLContaining("breakpoint-action-detach-frame.html");
+            InspectorTest.expectNotNull(crossOriginTarget, "Should find the cross-origin frame target.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Debugger.BreakpointActionDetach.RemainingActionsAbandoned",
+        description: "Disconnecting a frame target from inside a breakpoint action should abandon the remaining actions and leave the frame running.",
+        async test() {
+            await setBreakpointInFrameScript(crossOriginTarget, {
+                actions: [
+                    {type: "evaluate", data: "firstBreakpointAction()"},
+                    {type: "evaluate", data: "secondBreakpointAction()"},
+                ],
+            });
+
+            await InspectorTest.evaluateInPage("runFunctionWithBreakpointInFrame()");
+
+            await waitForExpressionInTarget(WI.assumingMainTarget(), `messagesFromFrameJoined().includes("execution continued")`);
+
+            let messages = await InspectorTest.evaluateInPage("messagesFromFrameJoined()");
+            InspectorTest.log(messages);
+
+            InspectorTest.expectFalse(messages.includes("second breakpoint action ran"), "Breakpoint actions after the disconnecting one should not run.");
+            InspectorTest.expectThat(messages.includes("execution continued after the breakpoint"), "Frame should keep executing instead of staying paused.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Test that disconnecting a cross-origin iframe's inspector target from inside one of its breakpoint actions abandons the remaining actions and lets the frame keep running.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/debugger/resources/breakpoint-action-detach-frame.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/debugger/breakpoint-condition-detach-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/debugger/breakpoint-condition-detach-cross-origin-iframe-expected.txt
@@ -1,0 +1,16 @@
+Test that a cross-origin iframe's breakpoint condition that disconnects the frame's inspector target and then throws neither pauses the frame nor reports the exception.
+
+
+
+== Running test suite: SiteIsolation.Debugger.BreakpointConditionDetach
+-- Running test case: SiteIsolation.Debugger.BreakpointConditionDetach.Setup
+PASS: Should find the cross-origin frame target.
+
+-- Running test case: SiteIsolation.Debugger.BreakpointConditionDetach.ConditionExceptionAbandoned
+PASS: Should find the frame's script.
+iframe: breakpoint condition ran, disconnecting this frame's inspector target
+iframe: breakpoint line ran
+iframe: execution continued after the breakpoint
+PASS: Frame should run to completion.
+PASS: The condition's exception should be abandoned instead of reported.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/debugger/breakpoint-condition-detach-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/debugger/breakpoint-condition-detach-cross-origin-iframe.html
@@ -1,0 +1,51 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="resources/site-isolation-debugger-test-utilities.js"></script>
+<script src="resources/breakpoint-detach-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Debugger.BreakpointConditionDetach");
+
+    let crossOriginTarget;
+
+    suite.addTestCase({
+        name: "SiteIsolation.Debugger.BreakpointConditionDetach.Setup",
+        description: "Find the cross-origin frame target.",
+        async test() {
+            crossOriginTarget = await frameTargetForURLContaining("breakpoint-condition-detach-frame.html");
+            InspectorTest.expectNotNull(crossOriginTarget, "Should find the cross-origin frame target.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.Debugger.BreakpointConditionDetach.ConditionExceptionAbandoned",
+        description: "A breakpoint condition that disconnects the frame target and then throws should neither pause the frame nor report the exception.",
+        async test() {
+            await setBreakpointInFrameScript(crossOriginTarget, {condition: "disconnectFrameInspectorTargetAndThrow()"});
+
+            await InspectorTest.evaluateInPage("runFunctionWithBreakpointInFrame()");
+
+            await waitForExpressionInTarget(WI.assumingMainTarget(), `messagesFromFrameJoined().includes("execution continued")`);
+
+            let messages = await InspectorTest.evaluateInPage("messagesFromFrameJoined()");
+            InspectorTest.log(messages);
+
+            // The condition path never pauses -- evaluateBreakpointCondition() bails out once the
+            // exception is abandoned -- so this only confirms the frame ran to completion, which is
+            // what makes the message list below complete. The exception assertion covers the fix.
+            InspectorTest.expectThat(messages.includes("execution continued after the breakpoint"), "Frame should run to completion.");
+
+            // A reported exception also shows up as a leading CONSOLE MESSAGE line in this test's
+            // output, but the frame's own 'error' event is what this asserts on.
+            InspectorTest.expectFalse(messages.includes("exception was reported"), "The condition's exception should be abandoned instead of reported.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Test that a cross-origin iframe's breakpoint condition that disconnects the frame's inspector target and then throws neither pauses the frame nor reports the exception.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/debugger/resources/breakpoint-condition-detach-frame.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/inspector/debugger/resources/breakpoint-action-detach-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/debugger/resources/breakpoint-action-detach-frame.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Cross-origin frame that disconnects its own inspector target from a breakpoint action</title>
+<script src="breakpoint-detach-frame-script.js"></script>
+<script>
+function report(message)
+{
+    parent.postMessage(message, "*");
+}
+
+function firstBreakpointAction()
+{
+    report("iframe: first breakpoint action ran, disconnecting this frame's inspector target");
+    testRunner.disconnectFrameInspectorTarget();
+}
+
+function secondBreakpointAction()
+{
+    report("iframe: FAIL: second breakpoint action ran");
+}
+
+window.addEventListener("message", (event) => {
+    if (event.data !== "run")
+        return;
+
+    functionWithBreakpoint();
+    report("iframe: execution continued after the breakpoint");
+});
+</script>

--- a/LayoutTests/http/tests/site-isolation/inspector/debugger/resources/breakpoint-condition-detach-frame.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/debugger/resources/breakpoint-condition-detach-frame.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Cross-origin frame that disconnects its own inspector target from a breakpoint condition</title>
+<script src="breakpoint-detach-frame-script.js"></script>
+<script>
+function report(message)
+{
+    parent.postMessage(message, "*");
+}
+
+// A reported exception reaches this listener synchronously, before it is logged to the console, so
+// this is the frame's own view of whether the condition's exception was abandoned or reported.
+// Deliberately does not cancel the event, which would suppress the console logging as well.
+window.addEventListener("error", (event) => {
+    report("iframe: exception was reported: " + event.message);
+});
+
+function disconnectFrameInspectorTargetAndThrow()
+{
+    report("iframe: breakpoint condition ran, disconnecting this frame's inspector target");
+    testRunner.disconnectFrameInspectorTarget();
+
+    // The throw leaves the debugger finishing a condition whose inspector connection is already
+    // gone. It must abandon the exception rather than report it to a console nobody is listening to.
+    throw new Error("breakpoint condition threw");
+}
+
+window.addEventListener("message", (event) => {
+    if (event.data !== "run")
+        return;
+
+    functionWithBreakpoint();
+    report("iframe: execution continued after the breakpoint");
+});
+</script>

--- a/LayoutTests/http/tests/site-isolation/inspector/debugger/resources/breakpoint-detach-frame-script.js
+++ b/LayoutTests/http/tests/site-isolation/inspector/debugger/resources/breakpoint-detach-frame-script.js
@@ -1,0 +1,10 @@
+// report() is provided by whichever page loads this script. The frames that use it lose their
+// inspector connection partway through breakpoint evaluation, so they report by postMessage to
+// their parent rather than over the protocol.
+//
+// setBreakpointInFrameScript() in breakpoint-detach-test-utilities.js breaks on the report() line
+// below and addresses it by line number, so keep the two in sync when editing this file.
+function functionWithBreakpoint()
+{
+    report("iframe: breakpoint line ran");
+}

--- a/LayoutTests/http/tests/site-isolation/inspector/debugger/resources/breakpoint-detach-test-utilities.js
+++ b/LayoutTests/http/tests/site-isolation/inspector/debugger/resources/breakpoint-detach-test-utilities.js
@@ -1,0 +1,39 @@
+// The frames these tests drive lose their inspector connection in the middle of breakpoint
+// evaluation, so they report what happened by postMessage to this page instead. The frontend reads
+// it back over the page target, whose own connection is untouched.
+
+let messagesFromFrame = [];
+
+window.addEventListener("message", (event) => {
+    messagesFromFrame.push(event.data);
+});
+
+function messagesFromFrameJoined()
+{
+    return messagesFromFrame.join("\n");
+}
+
+function runFunctionWithBreakpointInFrame()
+{
+    frames[0].postMessage("run", "*");
+}
+
+TestPage.registerInitializer(function() {
+
+// Both tests break on the same line of the same frame script, and each can only do it once: the
+// frame target's connection is gone afterwards, so no further breakpoint can be set on it.
+window.setBreakpointInFrameScript = async function setBreakpointInFrameScript(target, options) {
+    let script = WI.debuggerManager.dataForTarget(target).scripts.find((script) => script.url && script.url.includes("breakpoint-detach-frame-script.js"));
+    InspectorTest.expectNotNull(script, "Should find the frame's script.");
+    if (!script)
+        return;
+
+    await target.DebuggerAgent.setBreakpointsActive.invoke({active: true});
+    await target.DebuggerAgent.setBreakpoint.invoke({
+        // The report() line in breakpoint-detach-frame-script.js; see the note at the top of it.
+        location: {scriptId: script.id, lineNumber: 8, columnNumber: 0},
+        options,
+    });
+};
+
+});

--- a/Source/WebCore/inspector/FrameDebugger.cpp
+++ b/Source/WebCore/inspector/FrameDebugger.cpp
@@ -78,6 +78,17 @@ void FrameDebugger::detachDebugger(bool isBeingDestroyed)
 {
     JSC::Debugger::detachDebugger(isBeingDestroyed);
 
+    // Mirrors attachDebugger(). isAttached() guards the call because detach() asserts membership,
+    // and attachDebugger() skips global objects that already have a debugger.
+    if (RefPtr frame = m_frame.get()) {
+        Ref windowProxy = frame->windowProxy();
+        for (auto& jsWindowProxy : windowProxy->jsWindowProxiesAsVector()) {
+            auto* globalObject = jsWindowProxy->window();
+            if (globalObject && isAttached(globalObject))
+                detach(globalObject, JSC::Debugger::TerminatingDebuggingSession);
+        }
+    }
+
     if (!isBeingDestroyed)
         recompileAllJSFunctions();
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -293,6 +293,14 @@ void WKBundleFrameFocus(WKBundleFrameRef frameRef)
     protect(coreFrame->page()->focusController())->setFocusedFrame(coreFrame.get());
 }
 
+void WKBundleFrameDisconnectInspectorTargetForTest(WKBundleFrameRef frameRef)
+{
+    if (!frameRef)
+        return;
+
+    protect(WebKit::toImpl(frameRef))->disconnectInspector();
+}
+
 void _WKBundleFrameGenerateTestReport(WKBundleFrameRef frameRef, WKStringRef message, WKStringRef group)
 {
     if (!frameRef)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h
@@ -54,6 +54,8 @@ WK_EXPORT bool WKBundleFrameHandlesPageScaleGesture(WKBundleFrameRef frame);
 
 WK_EXPORT void WKBundleFrameFocus(WKBundleFrameRef frame);
 
+WK_EXPORT void WKBundleFrameDisconnectInspectorTargetForTest(WKBundleFrameRef frame);
+
 WK_EXPORT void _WKBundleFrameGenerateTestReport(WKBundleFrameRef, WKStringRef message, WKStringRef group);
 
 WK_EXPORT void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frame);

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -141,6 +141,7 @@ interface TestRunner {
     // For Web Inspector tests
     undefined showWebInspector();
     undefined closeWebInspector();
+    undefined disconnectFrameInspectorTarget();
     undefined evaluateInWebInspector(DOMString script);
     readonly attribute DOMString inspectorTestStubURL;
 

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -482,6 +482,11 @@ void TestRunner::closeWebInspector()
     WKBundlePageCloseInspectorForTest(page());
 }
 
+void TestRunner::disconnectFrameInspectorTarget(JSContextRef context)
+{
+    WKBundleFrameDisconnectInspectorTargetForTest(WKBundleFrameForJavaScriptContext(context));
+}
+
 void TestRunner::evaluateInWebInspector(JSStringRef script)
 {
     WKBundlePageEvaluateScriptInInspectorForTest(page(), toWK(script).get());

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -253,6 +253,7 @@ public:
 
     void showWebInspector();
     void closeWebInspector();
+    void disconnectFrameInspectorTarget(JSContextRef);
     void evaluateInWebInspector(JSStringRef script);
     JSRetainPtr<JSStringRef> inspectorTestStubURL();
 


### PR DESCRIPTION
#### fa4f05117f627967ce815faf4162414f81bf4233
<pre>
[Site Isolation] Web Inspector: Closing inspector during a breakpoint action doesn&apos;t stop remaining actions, and page stays paused
<a href="https://bugs.webkit.org/show_bug.cgi?id=323797">https://bugs.webkit.org/show_bug.cgi?id=323797</a>
<a href="https://rdar.apple.com/187046297">rdar://187046297</a>

Reviewed by NOBODY (OOPS!).

Under Site Isolation, closing Web Inspector while a breakpoint&apos;s
condition or actions were still running left the pause standing. From a
breakpoint action, the remaining actions kept running and the frame
stayed paused in a nested run loop with no frontend left to resume it.
From a breakpoint condition the frame did not stay paused, but the
condition&apos;s exception was reported to a console nobody was listening to
instead of being abandoned.

detach() is what unwinds the pause. It clears m_currentCallFrame, and it
clears the global object&apos;s debugger pointer, which makes isAttached()
false. evaluateBreakpointActions() checks isAttached() after every
action and returns there, which is what drops the remaining actions.
pauseIfNeeded() checks m_currentCallFrame once
evaluateBreakpointActions() returns and skips handlePause() when it is
null, which is why the frame does not stay paused.
evaluateBreakpointCondition() uses that same m_currentCallFrame check to
abandon the condition&apos;s exception instead of reporting it.

Every Debugger subclass has to undo in detachDebugger() what its
attachDebugger() did. PageDebugger releases its global objects through
Page::setDebugger(nullptr), and WorkerDebugger through
WorkerOrWorkletScriptController::detachDebugger(). FrameDebugger&apos;s
detachDebugger() only recompiled JS functions and never released
anything, so detach() never ran and none of the guards above fired.
PageDebugger does not cover for it either, since its attachDebugger()
early-returns under Site Isolation.

This gives FrameDebugger::detachDebugger() the same loop as its
attachDebugger(), guarded by isAttached() so that it only releases
global objects this debugger owns -- attachDebugger() deliberately skips
any that already have a debugger. It passes TerminatingDebuggingSession
rather than switching to GlobalObjectIsDestructing when isBeingDestroyed
the way JSGlobalObjectDebugger does, because isBeingDestroyed here means
the inspected frame is going away, not that the JSGlobalObject is
destructing; skipping clearDebuggerRequests() would leave stale debugger
requests on CodeBlocks that are still live. Page and WorkerDebugger pass
the same reason for the same event, and like them the loop is not
guarded by isBeingDestroyed -- only the recompile is.

Tests: http/tests/site-isolation/inspector/debugger/breakpoint-action-detach-cross-origin-iframe.html
       http/tests/site-isolation/inspector/debugger/breakpoint-condition-detach-cross-origin-iframe.html

inspector/debugger/breakpoint-action-detach.html and
breakpoint-condition-detach.html cover the fix in the main frame, but
not for a cross-origin iframe&apos;s own FrameDebugger, which is the shape
Site Isolation actually produces. Two new tests,
breakpoint-{action,condition}-detach-cross-origin-iframe.html, mirror
that pair inside an iframe: disconnecting the frame target ends its
inspector connection, so each test can only do it once, and the frame
reports results by postMessage to its parent instead of over the
protocol. The condition test also listens for the frame&apos;s own window
&apos;error&apos; event -- where a reported exception lands before the console --
to assert that it stays silent. Both fail on a build without the
FrameDebugger fix and pass with it.

Reaching that frame target needed a new hook: a protocol test tears the
frontend down synchronously but cannot address an out-of-process frame,
since InspectorStubFrontend only knows the local main frame; an
inspector-test reaches frame targets but closes asynchronously, landing
a run loop turn after breakpoint evaluation has already finished. This
adds testRunner.disconnectFrameInspectorTarget(), which runs
WebFrame::disconnectInspector() on the calling frame -- the same handler
the UI process&apos;s DisconnectInspector message runs -- scoped to just that
target, so the page target&apos;s connection, which the test harness reports
results over, stays untouched. Going through WebFrame also keeps
FrameInspectorTarget&apos;s m_channel in step; disconnecting at the WebCore
level instead would leave it stale and trip
FrontendRouter::disconnectFrontend()&apos;s assertion when the inspector
later closes for real.

* LayoutTests/http/tests/site-isolation/inspector/debugger/breakpoint-action-detach-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/debugger/breakpoint-action-detach-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/debugger/breakpoint-condition-detach-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/debugger/breakpoint-condition-detach-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/debugger/resources/breakpoint-action-detach-frame.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/debugger/resources/breakpoint-condition-detach-frame.html: Added.
* LayoutTests/http/tests/site-isolation/inspector/debugger/resources/breakpoint-detach-frame-script.js: Added.
(functionWithBreakpoint):
* LayoutTests/http/tests/site-isolation/inspector/debugger/resources/breakpoint-detach-test-utilities.js: Added.
(messagesFromFrameJoined):
(runFunctionWithBreakpointInFrame):
(TestPage.registerInitializer.window.setBreakpointInFrameScript.async setBreakpointInFrameScript):
* Source/WebCore/inspector/FrameDebugger.cpp:
(WebCore::FrameDebugger::detachDebugger):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(WKBundleFrameDisconnectInspectorTargetForTest):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::disconnectFrameInspectorTarget):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa4f05117f627967ce815faf4162414f81bf4233

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196173 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150536 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4099d46-4274-4e6a-8d0a-a4a1e037af15) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59496 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145245 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100695 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e8a67c26-b706-4461-90f3-307b6823f12a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48931 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165806 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125552 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f5478394-4b77-4a84-b050-c7b694a09e70) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47658 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45679 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158018 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45387 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7244 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198147 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59432 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165323 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154804 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60141 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/41992 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154449 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48898 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132484 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129482 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58602 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20410 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57981 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58215 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58045 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->