### PR TITLE
[IFC] Stop adjusting the display value of inline boxes with a non-inline display

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-on-svg-text-content-element-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-on-svg-text-content-element-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: SVG text content child elements are laid out inline</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<svg width="200" height="40">
+  <text x="0" y="20" style="font: 20px/1 Ahem; fill: green">
+    <tspan>A</tspan><tspan>B</tspan><tspan>C</tspan><tspan>D</tspan>
+  </text>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-on-svg-text-content-element-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-on-svg-text-content-element-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: SVG text content child elements are laid out inline</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<svg width="200" height="40">
+  <text x="0" y="20" style="font: 20px/1 Ahem; fill: green">
+    <tspan>A</tspan><tspan>B</tspan><tspan>C</tspan><tspan>D</tspan>
+  </text>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-on-svg-text-content-element.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-on-svg-text-content-element.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>display on an SVG text content child element does not change how it is laid out</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/render.html#VisibilityControl">
+<link rel="help" href="https://drafts.csswg.org/css-display/#unbox-svg">
+<link rel="match" href="display-on-svg-text-content-element-ref.html">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<svg width="200" height="40">
+  <text x="0" y="20" style="font: 20px/1 Ahem; fill: green">
+    <tspan style="display: block">A</tspan><tspan style="display: inline-block">B</tspan><tspan style="display: table-cell">C</tspan><tspan style="display: flex">D</tspan>
+  </text>
+</svg>

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -41,12 +41,12 @@
 #include "RenderFlexibleBox.h"
 #include "RenderGrid.h"
 #include "RenderImage.h"
+#include "RenderInline.h"
 #include "RenderLineBreak.h"
 #include "RenderListItem.h"
 #include "RenderListOutsideMarker.h"
 #include "RenderMenuList.h"
 #include "RenderObjectInlines.h"
-#include "RenderSVGInline.h"
 #include "RenderSlider.h"
 #include "RenderTable.h"
 #include "RenderTextControl.h"
@@ -89,6 +89,8 @@ static Layout::Box::ElementAttributes elementAttributes(const RenderElement& ren
             return renderLineBreak->isWBR() ? Layout::Box::NodeType::WordBreakOpportunity : Layout::Box::NodeType::LineBreak;
         if (is<RenderTable>(renderer))
             return Layout::Box::NodeType::TableBox;
+        if (is<RenderInline>(renderer))
+            return Layout::Box::NodeType::InlineBox;
         return Layout::Box::NodeType::GenericElement;
     }();
 
@@ -194,20 +196,6 @@ void BoxTreeUpdater::adjustStyleIfNeeded(const RenderElement& renderer, Style::C
                 styleToAdjust.setOverflowX(anonBlockParentStyle->overflowX());
                 styleToAdjust.setOverflowY(anonBlockParentStyle->overflowY());
             }
-            return;
-        }
-
-        if (auto* renderInline = dynamicDowncast<RenderInline>(renderer)) {
-            auto isSupportedInlineDisplay = [&] {
-                auto display = styleToAdjust.display();
-                if (display == Style::DisplayType::RubyBase || display == Style::DisplayType::RubyText)
-                    return renderInline->parent()->style().display() == Style::DisplayType::InlineRuby;
-                if (is<RenderSVGInline>(*renderInline))
-                    return display == Style::DisplayType::InlineFlow;
-                return display.isInlineType();
-            };
-            if (!isSupportedInlineDisplay())
-                styleToAdjust.setDisplay(Style::DisplayType::InlineFlow);
             return;
         }
     };

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -235,6 +235,9 @@ bool Box::isInlineTableBox() const
 
 bool Box::isBlockLevelBox() const
 {
+    if (isInlineBox())
+        return false;
+
     // Block level elements generate block level boxes.
     auto display = m_style.display();
     return display == Style::DisplayType::BlockFlow
@@ -255,6 +258,9 @@ bool Box::isBlockBox() const
 
 bool Box::isInlineLevelBox() const
 {
+    if (isInlineBox())
+        return true;
+
     // Inline level elements generate inline level boxes.
     auto display = m_style.display();
     return is<ElementBox>(*this) &&
@@ -273,12 +279,7 @@ bool Box::isInlineLevelBox() const
 bool Box::isInlineBox() const
 {
     // An inline box is one that is both inline-level and whose contents participate in its containing inline formatting context.
-    // A non-replaced element with a 'display' value of 'inline' generates an inline box.
-    auto display = m_style.display();
-    return is<ElementBox>(*this) &&
-          (display == Style::DisplayType::InlineFlow
-        || display == Style::DisplayType::InlineRuby
-        || display == Style::DisplayType::RubyBase) && !isReplacedBox();
+    return m_nodeType == NodeType::InlineBox || isLineBreakBox();
 }
 
 bool Box::isAtomicInlineBox() const
@@ -301,6 +302,9 @@ bool Box::isGridItem() const
 
 bool Box::isBlockContainer() const
 {
+    if (isInlineBox())
+        return false;
+
     auto display = m_style.display();
     return display == Style::DisplayType::BlockFlow
         || display == Style::DisplayType::BlockFlowRoot
@@ -329,7 +333,7 @@ bool Box::isLayoutContainmentBox() const
 
 bool Box::isRubyAnnotationBox() const
 {
-    return m_style.display() == Style::DisplayType::RubyText;
+    return m_style.display() == Style::DisplayType::RubyText && m_parent && m_parent->isRuby();
 }
 
 bool Box::isInterlinearRubyAnnotationBox() const
@@ -339,8 +343,7 @@ bool Box::isInterlinearRubyAnnotationBox() const
 
 bool Box::isInternalRubyBox() const
 {
-    return m_style.display() == Style::DisplayType::RubyBase
-        || m_style.display() == Style::DisplayType::RubyText;
+    return isRubyBase() || isRubyAnnotationBox();
 }
 
 bool Box::isSizeContainmentBox() const
@@ -375,7 +378,7 @@ bool Box::isInternalTableBox() const
 
 bool Box::isRubyBase() const
 {
-    return style().display() == Style::DisplayType::RubyBase;
+    return style().display() == Style::DisplayType::RubyBase && m_parent && m_parent->isRuby();
 }
 
 const Box* Box::nextInFlowSibling() const

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -52,6 +52,7 @@ public:
     enum class NodeType : uint8_t {
         Text,
         GenericElement,
+        InlineBox,
         ReplacedElement,
         DocumentElement,
         Body,

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
@@ -156,6 +156,8 @@ std::unique_ptr<Box> TreeBuilder::createLayoutBox(const ElementBox& parentContai
             return { Box::NodeType::DocumentElement, isAnonymous };
         if (auto* renderLineBreak = dynamicDowncast<RenderLineBreak>(renderer))
             return { renderLineBreak->isWBR() ? Box::NodeType::WordBreakOpportunity : Box::NodeType::LineBreak, isAnonymous };
+        if (is<RenderInline>(renderer))
+            return { Box::NodeType::InlineBox, isAnonymous };
         if (auto* element = renderer.element()) {
             if (element->hasTagName(HTMLNames::bodyTag))
                 return { Box::NodeType::Body, isAnonymous };


### PR DESCRIPTION
#### 7d3d84c508b1eb04e26fa1bd3ebb6e191ccb64ab
<pre>
[IFC] Stop adjusting the display value of inline boxes with a non-inline display
<a href="https://bugs.webkit.org/show_bug.cgi?id=323799">https://bugs.webkit.org/show_bug.cgi?id=323799</a>
&lt;<a href="https://rdar.apple.com/problem/187046402">rdar://problem/187046402</a>&gt;

Reviewed by Antti Koivisto.

This is in preparation for not adjusting computed style for layout boxes.

* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-on-svg-text-content-element-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-on-svg-text-content-element-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-on-svg-text-content-element.html: Added.
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::elementAttributes):
(WebCore::LayoutIntegration::BoxTreeUpdater::adjustStyleIfNeeded):
* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::isBlockLevelBox const):
(WebCore::Layout::Box::isInlineLevelBox const):
(WebCore::Layout::Box::isInlineBox const):
(WebCore::Layout::Box::isBlockContainer const):
(WebCore::Layout::Box::isRubyAnnotationBox const):
(WebCore::Layout::Box::isInternalRubyBox const):
(WebCore::Layout::Box::isRubyBase const):
* Source/WebCore/layout/layouttree/LayoutBox.h:
* Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp:
(WebCore::Layout::TreeBuilder::createLayoutBox):

Canonical link: <a href="https://commits.webkit.org/320833@main">https://commits.webkit.org/320833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96aeea20be8d56711a64c600f239a4017f216bf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196355 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150666 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e7fdde25-7f36-4b0a-b02f-728cc15e2031) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187926 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145390 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4071d793-2e94-4e88-9a45-1634cf2211d2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165932 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125710 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a73787ad-3d8f-4d80-9ce1-6cb7859f5c58) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47803 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158157 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45519 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7426 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198333 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59620 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154951 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41496 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60329 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154591 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49036 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132630 "Build is in progress. Recent messages:") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129735 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58775 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58165 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58397 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58223 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->