### PR TITLE
[Swift Testing] Add more Swift Testing friendly annotations to TestWKWebView

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h
@@ -54,15 +54,17 @@
 @protocol BEExtendedTextInputTraits;
 #endif
 
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
+
 @interface WKWebView (AdditionalDeclarations)
 #if PLATFORM(MAC)
-- (void)copy:(id)sender;
-- (void)paste:(id)sender;
-- (void)changeAttributes:(id)sender;
-- (void)changeColor:(id)sender;
-- (void)superscript:(id)sender;
-- (void)subscript:(id)sender;
-- (void)unscript:(id)sender;
+- (void)copy:(nullable id)sender;
+- (void)paste:(nullable id)sender;
+- (void)changeAttributes:(nullable id)sender;
+- (void)changeColor:(nullable id)sender;
+- (void)superscript:(nullable id)sender;
+- (void)subscript:(nullable id)sender;
+- (void)unscript:(nullable id)sender;
 #endif
 @end
 
@@ -91,23 +93,23 @@ class Color;
 @property (nonatomic, readonly) CGRect selectionClipRect;
 @property (nonatomic, readonly) BOOL hasAsyncTextInput;
 #if USE(BROWSERENGINEKIT)
-@property (nonatomic, readonly) id<BETextInput> asyncTextInput;
-@property (nonatomic, readonly) id<BEExtendedTextInputTraits> extendedTextInputTraits;
+@property (nonatomic, readonly, nullable) id<BETextInput> asyncTextInput;
+@property (nonatomic, readonly, nullable) id<BEExtendedTextInputTraits> extendedTextInputTraits;
 #endif
 #if HAVE(UI_WK_DOCUMENT_CONTEXT)
-- (void)synchronouslyAdjustSelectionWithDelta:(NSRange)range;
+- (void)synchronouslyAdjustSelectionWithDelta:(NSRange)range NS_SWIFT_UNAVAILABLE("Spins the run loop");
 #endif
-@property (nonatomic, readonly) id<UITextInputTraits_Private> effectiveTextInputTraits;
+@property (nonatomic, readonly, nullable) id<UITextInputTraits_Private> effectiveTextInputTraits;
 #ifdef __cplusplus
 @property (nonatomic, readonly) TestWebKitAPI::AutocorrectionContext autocorrectionContext;
 - (std::pair<CGRect, CGRect>)autocorrectionRectsForString:(NSString *)string;
 #endif
-- (NSArray<_WKTextInputContext *> *)synchronouslyRequestTextInputContextsInRect:(CGRect)rect;
+- (nullable NSArray<_WKTextInputContext *> *)synchronouslyRequestTextInputContextsInRect:(CGRect)rect NS_SWIFT_UNAVAILABLE("Spins the run loop");
 - (void)replaceText:(NSString *)input withText:(NSString *)correction shouldUnderline:(BOOL)shouldUnderline completion:(void(^)())completion;
 - (void)insertText:(NSString *)primaryString alternatives:(NSArray<NSString *> *)alternatives;
 - (void)handleKeyEvent:(WebEvent *)event completion:(void (^)(WebEvent *theEvent, BOOL handled))completion;
 - (void)selectTextForContextMenuWithLocationInView:(CGPoint)locationInView completion:(void(^)(BOOL shouldPresent))completion;
-- (void)selectTextInGranularity:(UITextGranularity)granularity atPoint:(CGPoint)locationInView;
+- (void)selectTextInGranularity:(UITextGranularity)granularity atPoint:(CGPoint)locationInView NS_SWIFT_UNAVAILABLE("Spins the run loop");
 - (void)defineSelection;
 - (void)shareSelection;
 - (void)moveSelectionToStartOfParagraph;
@@ -117,102 +119,103 @@ class Color;
 - (void)insertTextSuggestion:(UITextSuggestion *)textSuggestion;
 - (void)focusInWindow;
 #if HAVE(UI_WK_DOCUMENT_CONTEXT)
-- (UIWKDocumentContext *)synchronouslyRequestDocumentContext:(UIWKDocumentRequest *)request;
+- (nullable UIWKDocumentContext *)synchronouslyRequestDocumentContext:(UIWKDocumentRequest *)request NS_SWIFT_UNAVAILABLE("Spins the run loop");
 #endif
 #endif // PLATFORM(IOS_FAMILY)
 
-- (CALayer *)firstLayerWithName:(NSString *)layerName;
-- (CALayer *)firstLayerWithNameContaining:(NSString *)layerName;
+- (nullable CALayer *)firstLayerWithName:(NSString *)layerName;
+- (nullable CALayer *)firstLayerWithNameContaining:(NSString *)layerName;
 #ifdef __cplusplus
 - (void)forEachCALayer:(IterationStatus(^)(CALayer *))visitor;
 #endif
 
-@property (nonatomic, readonly) CGImageRef snapshotAfterScreenUpdates;
-@property (nonatomic, readonly) NSUInteger gpuToWebProcessConnectionCount;
-@property (nonatomic, readonly) NSUInteger modelProcessModelPlayerCount;
-@property (nonatomic, readonly) NSString *contentsAsString;
-@property (nonatomic, readonly) NSData *contentsAsWebArchive;
-@property (nonatomic, readonly) NSArray<NSString *> *tagsInBody;
-@property (nonatomic, readonly) NSString *selectedText;
+@property (nonatomic, readonly, nullable) CGImageRef snapshotAfterScreenUpdates NS_SWIFT_UNAVAILABLE("Spins the run loop");
+@property (nonatomic, readonly) NSUInteger gpuToWebProcessConnectionCount NS_SWIFT_UNAVAILABLE("Spins the run loop");
+@property (nonatomic, readonly) NSUInteger modelProcessModelPlayerCount NS_SWIFT_UNAVAILABLE("Spins the run loop");
+@property (nonatomic, readonly, nullable) NSString *contentsAsString NS_SWIFT_UNAVAILABLE("Spins the run loop");
+@property (nonatomic, readonly, nullable) NSData *contentsAsWebArchive NS_SWIFT_UNAVAILABLE("Spins the run loop");
+@property (nonatomic, readonly, nullable) NSArray<NSString *> *tagsInBody NS_SWIFT_UNAVAILABLE("Spins the run loop");
+@property (nonatomic, readonly) NSString *selectedText NS_SWIFT_UNAVAILABLE("Spins the run loop");
 - (void)loadTestPageNamed:(NSString *)pageName;
-- (void)synchronouslyGoBack;
-- (void)synchronouslyGoForward;
-- (void)synchronouslyLoadHTMLString:(NSString *)html;
-- (void)synchronouslyLoadHTMLString:(NSString *)html baseURL:(NSURL *)url;
-- (void)synchronouslyLoadHTMLString:(NSString *)html preferences:(WKWebpagePreferences *)preferences;
-- (void)synchronouslyLoadRequest:(NSURLRequest *)request;
-- (void)synchronouslyLoadSimulatedRequest:(NSURLRequest *)request responseHTMLString:(NSString *)htmlString;
-- (void)synchronouslyLoadRequest:(NSURLRequest *)request preferences:(WKWebpagePreferences *)preferences;
-- (void)synchronouslyLoadRequestIgnoringSSLErrors:(NSURLRequest *)request;
-- (void)synchronouslyLoadTestPageNamed:(NSString *)pageName;
-- (void)synchronouslyLoadTestPageNamed:(NSString *)pageName asStringWithBaseURL:(NSURL *)url;
-- (void)synchronouslyLoadTestPageNamed:(NSString *)pageName preferences:(WKWebpagePreferences *)preferences;
-- (BOOL)_synchronouslyExecuteEditCommand:(NSString *)command argument:(NSString *)argument;
-- (void)expectElementTagsInOrder:(NSArray<NSString *> *)tagNames;
-- (void)expectElementCount:(NSInteger)count querySelector:(NSString *)querySelector;
-- (void)expectElementTag:(NSString *)tagName toComeBefore:(NSString *)otherTagName;
-- (BOOL)evaluateMediaQuery:(NSString *)query;
-- (NSString *)stringByEvaluatingJavaScript:(NSString *)script;
-- (NSString *)stringByEvaluatingJavaScript:(NSString *)script inFrame:(WKFrameInfo *)frame;
-- (id)objectByEvaluatingJavaScriptWithUserGesture:(NSString *)script;
-- (id)objectByEvaluatingJavaScript:(NSString *)script;
-- (id)objectByEvaluatingJavaScript:(NSString *)script inFrame:(WKFrameInfo *)frame;
-- (id)objectByEvaluatingJavaScript:(NSString *)script inFrame:(WKFrameInfo *)frame inContentWorld:(WKContentWorld *)world;
-- (id)objectByEvaluatingJavaScriptWithUserGesture:(NSString *)script inFrame:(WKFrameInfo *)frame;
-- (id)objectByCallingAsyncFunction:(NSString *)script withArguments:(NSDictionary *)arguments;
-- (id)objectByCallingAsyncFunction:(NSString *)script withArguments:(NSDictionary *)arguments error:(NSError **)errorOut;
-- (id)objectByCallingAsyncFunction:(NSString *)script withArguments:(NSDictionary *)arguments inFrame:(WKFrameInfo *)frame inContentWorld:(WKContentWorld *)world;
-- (unsigned)waitUntilClientWidthIs:(unsigned)expectedClientWidth;
-- (CGRect)elementRectFromSelector:(NSString *)selector;
-- (CGPoint)elementMidpointFromSelector:(NSString *)selector;
-- (_WKJSHandle *)querySelector:(NSString *)selector frame:(WKFrameInfo *)frame world:(WKContentWorld *)world;
+- (void)synchronouslyGoBack NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (void)synchronouslyGoForward NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (void)synchronouslyLoadHTMLString:(NSString *)html NS_SWIFT_UNAVAILABLE("Use async load(html:baseURL:) instead");
+- (void)synchronouslyLoadHTMLString:(NSString *)html baseURL:(nullable NSURL *)url NS_SWIFT_UNAVAILABLE("Use async load(html:baseURL:) instead");
+- (void)synchronouslyLoadHTMLString:(NSString *)html preferences:(WKWebpagePreferences *)preferences NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (void)synchronouslyLoadRequest:(NSURLRequest *)request NS_SWIFT_UNAVAILABLE("Use async loadAndWait(_:) instead");
+- (void)synchronouslyLoadSimulatedRequest:(NSURLRequest *)request responseHTMLString:(NSString *)htmlString NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (void)synchronouslyLoadRequest:(NSURLRequest *)request preferences:(WKWebpagePreferences *)preferences NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (void)synchronouslyLoadRequestIgnoringSSLErrors:(NSURLRequest *)request NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (void)synchronouslyLoadTestPageNamed:(NSString *)pageName NS_SWIFT_UNAVAILABLE("Use async load(testPageNamed:) instead");
+- (void)synchronouslyLoadTestPageNamed:(NSString *)pageName asStringWithBaseURL:(nullable NSURL *)url NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (void)synchronouslyLoadTestPageNamed:(NSString *)pageName preferences:(WKWebpagePreferences *)preferences NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (BOOL)_synchronouslyExecuteEditCommand:(NSString *)command argument:(nullable NSString *)argument NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (void)expectElementTagsInOrder:(NSArray<NSString *> *)tagNames NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (void)expectElementCount:(NSInteger)count querySelector:(NSString *)querySelector NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (void)expectElementTag:(NSString *)tagName toComeBefore:(NSString *)otherTagName NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (BOOL)evaluateMediaQuery:(NSString *)query NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (NSString *)stringByEvaluatingJavaScript:(NSString *)script NS_SWIFT_UNAVAILABLE("Use async callJavaScript(returning:_:) instead");
+- (NSString *)stringByEvaluatingJavaScript:(NSString *)script inFrame:(nullable WKFrameInfo *)frame NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (nullable id)objectByEvaluatingJavaScriptWithUserGesture:(NSString *)script NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (nullable id)objectByEvaluatingJavaScript:(NSString *)script NS_SWIFT_UNAVAILABLE("Use async callJavaScript(returning:_:) instead");
+- (nullable id)objectByEvaluatingJavaScript:(NSString *)script inFrame:(nullable WKFrameInfo *)frame NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (nullable id)objectByEvaluatingJavaScript:(NSString *)script inFrame:(nullable WKFrameInfo *)frame inContentWorld:(WKContentWorld *)world NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (nullable id)objectByEvaluatingJavaScriptWithUserGesture:(NSString *)script inFrame:(nullable WKFrameInfo *)frame NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (nullable id)objectByCallingAsyncFunction:(NSString *)script withArguments:(nullable NSDictionary *)arguments NS_SWIFT_UNAVAILABLE("Use async callJavaScript(returning:_:) instead");
+- (nullable id)objectByCallingAsyncFunction:(NSString *)script withArguments:(nullable NSDictionary *)arguments error:(NSError **)errorOut NS_SWIFT_UNAVAILABLE("Use async callJavaScript(returning:_:) instead");
+- (nullable id)objectByCallingAsyncFunction:(NSString *)script withArguments:(nullable NSDictionary *)arguments inFrame:(nullable WKFrameInfo *)frame inContentWorld:(WKContentWorld *)world NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (unsigned)waitUntilClientWidthIs:(unsigned)expectedClientWidth NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (CGRect)elementRectFromSelector:(NSString *)selector NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (CGPoint)elementMidpointFromSelector:(NSString *)selector NS_SWIFT_UNAVAILABLE("Use async elementMidpoint(selector:) instead");
+- (nullable _WKJSHandle *)querySelector:(NSString *)selector frame:(nullable WKFrameInfo *)frame world:(WKContentWorld *)world NS_SWIFT_UNAVAILABLE("Use async querySelector(_:in:frame:) instead");
 - (void)visitUnsafeSite;
 @end
 
 @interface WKWebView (TestWebKitAPI_NonCpp)
 
 #if PLATFORM(IOS_FAMILY)
-@property (nonatomic, readonly) UIView <UITextInputPrivate, UITextInputInternal, UITextInputMultiDocument, UIWKInteractionViewProtocol_Staging_95652872, UITextInputTokenizer> *textInputContentView;
+@property (nonatomic, readonly, nullable) UIView <UITextInputPrivate, UITextInputInternal, UITextInputMultiDocument, UIWKInteractionViewProtocol_Staging_95652872, UITextInputTokenizer> *textInputContentView;
 #endif
 
 @end
 
+NS_SWIFT_UI_ACTOR
 @interface TestMessageHandler : NSObject <WKScriptMessageHandler>
 - (void)addMessage:(NSString *)message withHandler:(dispatch_block_t)handler;
-@property (nonatomic, copy) void (^didReceiveScriptMessage)(NSString *);
-@property (nonatomic, readonly) NSArray<NSString *> *receivedMessages;
+@property (nonatomic, copy, nullable) void (^didReceiveScriptMessage)(NSString *);
+@property (nonatomic, readonly, nullable) NSArray<NSString *> *receivedMessages;
 @end
 
 @interface TestWKWebView : WKWebView
 - (instancetype)initWithFrame:(CGRect)frame configuration:(WKWebViewConfiguration *)configuration processPoolConfiguration:(_WKProcessPoolConfiguration *)processPoolConfiguration;
 - (instancetype)initWithFrame:(CGRect)frame configuration:(WKWebViewConfiguration *)configuration addToWindow:(BOOL)addToWindow;
-- (void)synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:(NSString *)html;
+- (void)synchronouslyLoadHTMLStringAndWaitUntilAllImmediateChildFramesPaint:(NSString *)html NS_SWIFT_UNAVAILABLE("Spins the run loop");
 - (void)clearMessageHandlers:(NSArray *)messageNames;
 - (void)performAfterReceivingMessage:(NSString *)message action:(dispatch_block_t)action;
 - (void)performAfterReceivingAnyMessage:(void (^)(NSString *))action;
-- (void)waitForMessage:(NSString *)message;
-- (void)waitForMessages:(NSArray<NSString *> *)messages;
-- (void)waitForMessagesUnordered:(NSArray<NSString *> *)messages;
+- (void)waitForMessage:(NSString *)message NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (void)waitForMessages:(NSArray<NSString *> *)messages NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (void)waitForMessagesUnordered:(NSArray<NSString *> *)messages NS_SWIFT_UNAVAILABLE("Spins the run loop");
 
 // This function waits until a DOM load event is fired.
 // FIXME: Rename this function to better describe what "after loading" means.
 - (void)performAfterLoading:(dispatch_block_t)actions;
 
-- (void)waitForNextPresentationUpdate;
-- (void)waitForNextVisibleContentRectUpdate;
-- (void)waitUntilActivityStateUpdateDone;
+- (void)waitForNextPresentationUpdate NS_SWIFT_UNAVAILABLE("Use async nextPresentationUpdate() instead");
+- (void)waitForNextVisibleContentRectUpdate NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (void)waitUntilActivityStateUpdateDone NS_SWIFT_UNAVAILABLE("Spins the run loop");
 - (void)forceLightMode;
 - (void)forceDarkMode;
-- (NSString *)stylePropertyAtSelectionStart:(NSString *)propertyName;
-- (NSString *)stylePropertyAtSelectionEnd:(NSString *)propertyName;
+- (NSString *)stylePropertyAtSelectionStart:(NSString *)propertyName NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (NSString *)stylePropertyAtSelectionEnd:(NSString *)propertyName NS_SWIFT_UNAVAILABLE("Spins the run loop");
 - (void)collapseToStart;
 - (void)collapseToEnd;
 - (void)addToTestWindow;
 - (void)removeFromTestWindow;
-- (BOOL)selectionRangeHasStartOffset:(int)start endOffset:(int)end;
-- (BOOL)selectionRangeHasStartOffset:(int)start endOffset:(int)end inFrame:(WKFrameInfo *)frameInfo;
+- (BOOL)selectionRangeHasStartOffset:(int)start endOffset:(int)end NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (BOOL)selectionRangeHasStartOffset:(int)start endOffset:(int)end inFrame:(nullable WKFrameInfo *)frameInfo NS_SWIFT_UNAVAILABLE("Spins the run loop");
 - (void)clickOnElementID:(NSString *)elementID;
-- (void)waitForPendingMouseEvents;
+- (void)waitForPendingMouseEvents NS_SWIFT_UNAVAILABLE("Spins the run loop");
 - (void)focus;
 #ifdef __cplusplus
 - (std::optional<CGPoint>)getElementMidpoint:(NSString *)selector;
@@ -222,13 +225,13 @@ class Color;
 - (RetainPtr<_WKFrameTreeNode>)frameTree;
 #endif
 - (void)typeCharacter:(char)character;
-- (void)setVisibility:(BOOL)isVisible;
+- (void)setVisibility:(BOOL)isVisible NS_SWIFT_UNAVAILABLE("Spins the run loop");
 @end
 
 #if PLATFORM(IOS_FAMILY)
 @interface UIView (WKTestingUIViewUtilities)
-- (UIView *)wkFirstSubviewWithClass:(Class)targetClass;
-- (UIView *)wkFirstSubviewWithBoundsSize:(CGSize)size;
+- (nullable UIView *)wkFirstSubviewWithClass:(Class)targetClass;
+- (nullable UIView *)wkFirstSubviewWithBoundsSize:(CGSize)size;
 @end
 #endif
 
@@ -240,14 +243,14 @@ class Color;
 @property (nonatomic) UIEdgeInsets overrideSafeAreaInset;
 @property (nonatomic, readonly) CGRect caretViewRectInContentCoordinates;
 @property (nonatomic, readonly) NSArray<NSValue *> *selectionViewRectsInContentCoordinates;
-@property (nonatomic, readonly) NSString *textForSpeakSelection;
+@property (nonatomic, readonly, nullable) NSString *textForSpeakSelection NS_SWIFT_UNAVAILABLE("Spins the run loop");
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
-@property (nonatomic, readonly) UIView *selectionHighlightView;
+@property (nonatomic, readonly, nullable) UIView *selectionHighlightView;
 #endif
-- (_WKActivatedElementInfo *)activatedElementAtPosition:(CGPoint)position;
-- (void)evaluateJavaScriptAndWaitForInputSessionToChange:(NSString *)script;
-- (void)evaluateJavaScriptAndWaitForInputSessionToChange:(NSString *)script inFrame:(WKFrameInfo *)frame;
-- (WKContentView *)wkContentView;
+- (nullable _WKActivatedElementInfo *)activatedElementAtPosition:(CGPoint)position NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (void)evaluateJavaScriptAndWaitForInputSessionToChange:(NSString *)script NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (void)evaluateJavaScriptAndWaitForInputSessionToChange:(NSString *)script inFrame:(nullable WKFrameInfo *)frame NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (nullable WKContentView *)wkContentView;
 - (void)setZoomScaleSimulatingUserTriggeredZoom:(CGFloat)zoomScale;
 @end
 #endif
@@ -268,23 +271,23 @@ class Color;
 - (void)wheelEventAtPoint:(CGPoint)pointInWindow wheelDelta:(CGSize)delta;
 - (void)wheelEventAtPoint:(CGPoint)pointInWindow wheelDelta:(CGSize)delta phase:(CGScrollPhase)phase momentumPhase:(CGMomentumScrollPhase)momentumPhase;
 - (BOOL)acceptsFirstMouseAtPoint:(NSPoint)pointInWindow;
-- (NSWindow *)hostWindow;
-- (NSEvent *)_mouseEventWithType:(NSEventType)type atLocation:(NSPoint)pointInWindow;
+- (nullable NSWindow *)hostWindow;
+- (nullable NSEvent *)_mouseEventWithType:(NSEventType)type atLocation:(NSPoint)pointInWindow;
 - (void)typeCharacter:(char)character modifiers:(NSEventModifierFlags)modifiers;
 - (void)sendKey:(NSString *)characters code:(unsigned short)keyCode isDown:(BOOL)isDown modifiers:(NSEventModifierFlags)modifiers;
 - (void)setEventTimestampOffset:(NSTimeInterval)offset;
-@property (nonatomic, readonly) NSArray<NSString *> *collectLogsForNewConnections;
+@property (nonatomic, readonly) NSArray<NSString *> *collectLogsForNewConnections NS_SWIFT_UNAVAILABLE("Spins the run loop");
 @property (nonatomic, readonly) NSTimeInterval eventTimestamp;
 @property (nonatomic) BOOL forceWindowToBecomeKey;
 @end
 #endif
 
 @interface TestWKWebView (SiteIsolation)
-- (_WKFrameTreeNode *)mainFrame;
-- (WKFrameInfo *)firstChildFrame;
-- (WKFrameInfo *)secondChildFrame;
-- (void)evaluateJavaScript:(NSString *)string inFrame:(WKFrameInfo *)frame completionHandler:(void(^)(id, NSError *))completionHandler;
-- (WKFindResult *)findStringAndWait:(NSString *)string withConfiguration:(WKFindConfiguration *)configuration;
+- (_WKFrameTreeNode *)mainFrame NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (nullable WKFrameInfo *)firstChildFrame NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (WKFrameInfo *)secondChildFrame NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (void)evaluateJavaScript:(NSString *)string inFrame:(nullable WKFrameInfo *)frame completionHandler:(nullable void(^)(id _Nullable, NSError * _Nullable))completionHandler;
+- (WKFindResult *)findStringAndWait:(NSString *)string withConfiguration:(WKFindConfiguration *)configuration NS_SWIFT_UNAVAILABLE("Spins the run loop");
 @end
 
 #if PLATFORM(MAC)
@@ -293,7 +296,9 @@ typedef BOOL (^MenuItemFilter)(NSMenuItem *);
 
 @interface TestWKWebView (ContextMenu)
 #if PLATFORM(MAC)
-- (void)rightClick:(NSPoint)clickLocation andSelectItemMatching:(MenuItemFilter)filter;
-- (_WKContextMenuElementInfo *)rightClickAtPointAndWaitForContextMenu:(NSPoint)clickLocation;
+- (void)rightClick:(NSPoint)clickLocation andSelectItemMatching:(MenuItemFilter)filter NS_SWIFT_UNAVAILABLE("Spins the run loop");
+- (nullable _WKContextMenuElementInfo *)rightClickAtPointAndWaitForContextMenu:(NSPoint)clickLocation NS_SWIFT_UNAVAILABLE("Spins the run loop");
 #endif
 @end
+
+NS_HEADER_AUDIT_END(nullability, sendability)

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift
@@ -109,7 +109,7 @@ extension WebPage {
         #if WTF_PLATFORM_MAC
         backingWebView.insertText(text)
         #else
-        backingWebView.textInputContentView.insertText(text)
+        backingWebView.textInputContentView?.insertText(text)
         #endif
         await waitForNextPresentationUpdate()
     }


### PR DESCRIPTION
#### 9815d79412c6a2670bb2b5b47ffe22988b356f89
<pre>
[Swift Testing] Add more Swift Testing friendly annotations to TestWKWebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=323800">https://bugs.webkit.org/show_bug.cgi?id=323800</a>
<a href="https://rdar.apple.com/187047317">rdar://187047317</a>

Reviewed by Abrar Rahman Protyasha.

* Tools/TestWebKitAPI/Helpers/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift:
(insertText(_:)):

Canonical link: <a href="https://commits.webkit.org/320766@main">https://commits.webkit.org/320766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75e8fc09dbd7a260538b385493219ed972be4790

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59776 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53578 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196176 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ed528e3-dfda-44ca-ae6c-f2761acde16a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59499 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1003214b-4edb-433b-a032-ceb75029e119) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48933 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/125555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/31db0bc4-eeec-45c9-b20c-faf711ac849e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47660 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/158020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/45392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7247 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/50106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198150 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59435 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/165328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41447 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60144 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/41997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/154454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48904 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129485 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57984 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58218 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58048 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->