### PR TITLE
[IFC] Stop adjusting display: inline to inline-block on block container boxes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-inline-on-block-container-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-inline-on-block-container-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: a block container with an inline outside display is an atomic inline level box</title>
+<style>
+.t { width: 200px; margin-bottom: 10px; font-size: 0; line-height: 0; }
+.t i { display: inline-block; width: 20px; height: 20px; background: green; }
+.t .box { width: 40px; height: 40px; margin: 0; padding: 0; border: none; background: green; }
+</style>
+<div class=t><i></i><fieldset class=box style="display: inline-block"></fieldset><i></i></div>
+<div class=t><i></i><button class=box style="display: inline-block"></button><i></i></div>
+<div class=t><i></i><textarea class=box style="display: inline-block"></textarea><i></i></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-inline-on-block-container-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-inline-on-block-container-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: a block container with an inline outside display is an atomic inline level box</title>
+<style>
+.t { width: 200px; margin-bottom: 10px; font-size: 0; line-height: 0; }
+.t i { display: inline-block; width: 20px; height: 20px; background: green; }
+.t .box { width: 40px; height: 40px; margin: 0; padding: 0; border: none; background: green; }
+</style>
+<div class=t><i></i><fieldset class=box style="display: inline-block"></fieldset><i></i></div>
+<div class=t><i></i><button class=box style="display: inline-block"></button><i></i></div>
+<div class=t><i></i><textarea class=box style="display: inline-block"></textarea><i></i></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-inline-on-block-container.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-inline-on-block-container.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>An element whose box is always a block container generates an atomic inline level box for display: inline</title>
+<link rel="help" href="https://drafts.csswg.org/css-display/#outer-role">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements">
+<link rel="match" href="display-inline-on-block-container-ref.html">
+<style>
+.t { width: 200px; margin-bottom: 10px; font-size: 0; line-height: 0; }
+.t i { display: inline-block; width: 20px; height: 20px; background: green; }
+.t .box { width: 40px; height: 40px; margin: 0; padding: 0; border: none; background: green; }
+</style>
+<div class=t><i></i><fieldset class=box style="display: inline"></fieldset><i></i></div>
+<div class=t><i></i><button class=box style="display: inline"></button><i></i></div>
+<div class=t><i></i><textarea class=box style="display: inline"></textarea><i></i></div>

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -185,9 +185,6 @@ void BoxTreeUpdater::adjustStyleIfNeeded(const RenderElement& renderer, Style::C
         }
 
         if (is<RenderBlock>(renderer)) {
-            if (styleToAdjust.display() == Style::DisplayType::InlineFlow)
-                styleToAdjust.setDisplay(Style::DisplayType::InlineFlowRoot);
-
             if (renderer.isAnonymousBlock()) {
                 CheckedRef anonBlockParentStyle = renderer.parent()->style();
                 // overflow and text-overflow property values don't get forwarded to anonymous block boxes.

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -225,7 +225,10 @@ bool Box::isFloatAvoider() const
 
 bool Box::isInlineBlockBox() const
 {
-    return m_style.display() == Style::DisplayType::InlineFlowRoot;
+    auto display = m_style.display();
+    if (display == Style::DisplayType::InlineFlowRoot)
+        return true;
+    return display == Style::DisplayType::InlineFlow && is<ElementBox>(*this) && !isInlineBox() && !isReplacedBox() && !isIFrame();
 }
 
 bool Box::isInlineTableBox() const


### PR DESCRIPTION
#### df01582880ad31a1d13a43c20cbb814f8bce50fb
<pre>
[IFC] Stop adjusting display: inline to inline-block on block container boxes
<a href="https://bugs.webkit.org/show_bug.cgi?id=323802">https://bugs.webkit.org/show_bug.cgi?id=323802</a>
&lt;<a href="https://rdar.apple.com/problem/187048839">rdar://problem/187048839</a>&gt;

Reviewed by Antti Koivisto.

This is in preparation for not adjusting computed style for layout boxes.

Some elements always get a block container renderer, whatever their computed
display value is (e.g. &lt;input style=&quot;display: inline&quot;&gt; or
&lt;fieldset style=&quot;display: inline&quot;&gt;).

* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-inline-on-block-container-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-inline-on-block-container-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-inline-on-block-container.html: Added.
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::BoxTreeUpdater::adjustStyleIfNeeded):
* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::isInlineBlockBox const):

Canonical link: <a href="https://commits.webkit.org/320872@main">https://commits.webkit.org/320872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aed8c60f020d153e97addcdeac9eda906354d064

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196411 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150704 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f6dc7147-d1a9-4cce-8400-5de045169a98) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59735 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145430 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100808 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb59e50f-b76a-4e64-a339-466c29357fcc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189075 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125756 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f08e62d9-cc74-4566-85da-f2dd0f369b12) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47840 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158194 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45551 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7482 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198389 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59672 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154996 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41527 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60384 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154633 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49071 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129798 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58823 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58216 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58445 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58275 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->