### PR TITLE
[IFC] Stop adjusting internal table and table caption display values to block

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/table-display-on-fieldset-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/table-display-on-fieldset-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: a fieldset with an internal table display value is a block level box</title>
+<style>
+.t { width: 200px; margin-bottom: 10px; font-size: 0; line-height: 0; }
+.t i { display: inline-block; width: 20px; height: 20px; background: green; }
+.t fieldset { width: 40px; height: 20px; margin: 0; padding: 0; border: none; background: green; }
+</style>
+<div class=t><span><fieldset style="display: block"></fieldset></span><i></i></div>
+<div class=t><span><fieldset style="display: block"></fieldset></span><i></i></div>
+<div class=t><span><fieldset style="display: block"></fieldset></span><i></i></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/table-display-on-fieldset-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/table-display-on-fieldset-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: a fieldset with an internal table display value is a block level box</title>
+<style>
+.t { width: 200px; margin-bottom: 10px; font-size: 0; line-height: 0; }
+.t i { display: inline-block; width: 20px; height: 20px; background: green; }
+.t fieldset { width: 40px; height: 20px; margin: 0; padding: 0; border: none; background: green; }
+</style>
+<div class=t><span><fieldset style="display: block"></fieldset></span><i></i></div>
+<div class=t><span><fieldset style="display: block"></fieldset></span><i></i></div>
+<div class=t><span><fieldset style="display: block"></fieldset></span><i></i></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/table-display-on-fieldset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/table-display-on-fieldset.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>A fieldset with an internal table display value generates a regular block level box</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements">
+<link rel="help" href="https://drafts.csswg.org/css-display/#layout-specific-display">
+<link rel="match" href="table-display-on-fieldset-ref.html">
+<style>
+.t { width: 200px; margin-bottom: 10px; font-size: 0; line-height: 0; }
+.t i { display: inline-block; width: 20px; height: 20px; background: green; }
+.t fieldset { width: 40px; height: 20px; margin: 0; padding: 0; border: none; background: green; }
+</style>
+<div class=t><span><fieldset style="display: table-cell"></fieldset></span><i></i></div>
+<div class=t><span><fieldset style="display: table-caption"></fieldset></span><i></i></div>
+<div class=t><span><fieldset style="display: table-row"></fieldset></span><i></i></div>

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -178,12 +178,6 @@ void BoxTreeUpdater::tearDown()
 void BoxTreeUpdater::adjustStyleIfNeeded(const RenderElement& renderer, Style::ComputedStyle& style, Style::ComputedStyle* firstLineStyle)
 {
     auto adjustStyle = [&](auto& styleToAdjust) {
-        // If we end up here with a box that has a table display type, just treat it as a regular block-level box.
-        if (styleToAdjust.display().isInternalTableBox() || styleToAdjust.display() == Style::DisplayType::TableCaption) {
-            styleToAdjust.setDisplay(Style::DisplayType::BlockFlow);
-            return;
-        }
-
         if (is<RenderBlock>(renderer)) {
             if (renderer.isAnonymousBlock()) {
                 CheckedRef anonBlockParentStyle = renderer.parent()->style();

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -236,6 +236,12 @@ bool Box::isInlineTableBox() const
     return m_style.display() == Style::DisplayType::InlineTable;
 }
 
+static bool NODELETE isInsideTable(const Box& box)
+{
+    auto& parent = box.parent();
+    return parent.isTableBox() || parent.isTableWrapperBox() || parent.style().display().isInternalTableBox();
+}
+
 bool Box::isBlockLevelBox() const
 {
     if (isInlineBox())
@@ -243,6 +249,8 @@ bool Box::isBlockLevelBox() const
 
     // Block level elements generate block level boxes.
     auto display = m_style.display();
+    if (display.isInternalTableBox() || display == Style::DisplayType::TableCaption)
+        return !isInsideTable(*this);
     return display == Style::DisplayType::BlockFlow
         || display == Style::DisplayType::BlockFlowRoot
         || display == Style::DisplayType::BlockTable


### PR DESCRIPTION
#### edced46cadb17690d7ea22e112e40eeda067a9ae
<pre>
[IFC] Stop adjusting internal table and table caption display values to block
<a href="https://bugs.webkit.org/show_bug.cgi?id=323803">https://bugs.webkit.org/show_bug.cgi?id=323803</a>
&lt;<a href="https://rdar.apple.com/problem/187049545">rdar://problem/187049545</a>&gt;

Reviewed by Antti Koivisto.

This is in preparation for not adjusting computing style for layout boxes.

* LayoutTests/imported/w3c/web-platform-tests/css/css-display/table-display-on-fieldset-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/table-display-on-fieldset-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/table-display-on-fieldset.html: Added.
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::BoxTreeUpdater::adjustStyleIfNeeded):
* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::isInsideTable):
(WebCore::Layout::Box::isBlockLevelBox const):

Canonical link: <a href="https://commits.webkit.org/320891@main">https://commits.webkit.org/320891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc63f3f3d2e9db495e0371a3700010e072f19482

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196470 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/22a51e8b-aa42-4f6e-bd2f-eca0c04426d4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145465 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/932f3428-e05b-4399-a9ed-a9e86607dc35) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165999 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125797 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/71ebcbef-2bbd-404e-9f26-36db9d0ab7ae) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47880 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158234 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45591 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7540 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198448 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155032 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41541 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60442 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154676 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49113 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129854 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58871 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20570 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58271 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58491 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58332 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->