### PR TITLE
WKWebViewEditActions.CopyMenuItemDisabledInCopyDisallowedPDF test does not load any PDF content

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewEditActions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewEditActions.mm
@@ -443,6 +443,7 @@ TEST(WKWebViewEditActions, CopyMenuItemDisabledInCopyDisallowedPDF)
 {
     validateCopyMenuItem(configurationForWebViewTestingUnifiedPDF(), ^(TestWKWebView *webView) {
         RetainPtr request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"copying-disabled" withExtension:@"pdf"]];
+        [webView synchronouslyLoadRequest:request];
         [webView waitForNextPresentationUpdate];
         [[webView window] makeFirstResponder:webView];
         [[webView window] makeKeyAndOrderFront:nil];


### PR DESCRIPTION
#### e6308a9db7e02636d48d2c7febcdede1441eeb0d
<pre>
WKWebViewEditActions.CopyMenuItemDisabledInCopyDisallowedPDF test does not load any PDF content
<a href="https://bugs.webkit.org/show_bug.cgi?id=323801">https://bugs.webkit.org/show_bug.cgi?id=323801</a>
<a href="https://rdar.apple.com/187047306">rdar://187047306</a>

Reviewed by Aditya Keerthi and Wenson Hsieh.

This is a follow-up to 320534@main, where we introduced the test. Thes
test initialized a NSURLRequest pointing to the copying-disabled.pdf
resource, but it did not actually _load_ this request, and so the test
was being performed on a blank web view and was passing for the wrong
reasons.

To fix this, we add the missing `-synchronouslyLoadRequest:` call.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewEditActions.mm:
(TestWebKitAPI::TEST(WKWebViewEditActions, CopyMenuItemDisabledInCopyDisallowedPDF)):

Canonical link: <a href="https://commits.webkit.org/320806@main">https://commits.webkit.org/320806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c97a408da87709ed17574ec82bdfb6bc8d4b118

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196188 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150550 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145265 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100705 "Exiting early after 60 failures. 60 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48948 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125574 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd456ff6-2391-4c4c-a558-a6a80cc41c22) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47675 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45691 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158034 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45401 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7259 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198162 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59447 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154821 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60156 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154466 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28235 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48916 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129497 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58617 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/57996 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58230 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58060 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->