### PR TITLE
Add missing validation for overrides

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -142,6 +142,8 @@ private:
     Packing getPacking(AST::IdentityExpression&);
     Packing packingForType(const Type*);
 
+    void addOverrideValidation(ShaderModule::OverrideValidator&&);
+
     AST::IdentifierExpression& getBase(AST::Expression&, unsigned&);
 
     ShaderModule& m_shaderModule;
@@ -172,7 +174,7 @@ private:
     HashSet<AST::Expression*> m_doNotUnpack;
     CheckedUint32 m_combinedFunctionVariablesSize;
     bool m_isTopLevelExpression { true };
-    bool m_suppressOverrideValidation { false };
+    Vector<AST::BinaryExpression*> m_shortCircuitedOperators;
 };
 
 std::optional<Error> RewriteGlobalVariables::run()
@@ -432,10 +434,37 @@ void RewriteGlobalVariables::visit(AST::Expression& expression)
     pack(Packing::Unpacked, expression);
 }
 
+static bool skipsRightHandSide(const ShaderModule& shaderModule, const AST::BinaryExpression& expression, const HashMap<String, ConstantValue>& overrideValues)
+{
+    ASSERT(expression.operation() == AST::BinaryOperation::ShortCircuitAnd || expression.operation() == AST::BinaryOperation::ShortCircuitOr);
+
+    auto value = evaluate(shaderModule, expression.leftExpression(), overrideValues);
+    if (!value || !std::holds_alternative<bool>(*value))
+        return false;
+
+    return std::get<bool>(*value) == (expression.operation() == AST::BinaryOperation::ShortCircuitOr);
+}
+
+void RewriteGlobalVariables::addOverrideValidation(ShaderModule::OverrideValidator&& validator)
+{
+    if (m_shortCircuitedOperators.isEmpty()) {
+        m_shaderModule.addOverrideValidation(WTF::move(validator));
+        return;
+    }
+
+    m_shaderModule.addOverrideValidation([&shaderModule = m_shaderModule, operators = m_shortCircuitedOperators, validator = WTF::move(validator)](const auto& overrideValues) -> std::optional<Error> {
+        for (auto* operation : operators) {
+            if (skipsRightHandSide(shaderModule, *operation, overrideValues))
+                return std::nullopt;
+        }
+        return validator(overrideValues);
+    });
+}
+
 Packing RewriteGlobalVariables::pack(Packing expectedPacking, AST::Expression& expression)
 {
     if (m_isTopLevelExpression && expression.maybeEvaluation().value_or(Evaluation::Runtime) == Evaluation::Override) {
-        m_shaderModule.addOverrideValidation([&shaderModule = m_shaderModule, &expression](auto& overrideValues) -> std::optional<Error> {
+        addOverrideValidation([&shaderModule = m_shaderModule, &expression](const auto& overrideValues) -> std::optional<Error> {
             auto maybeValue = shaderModule.ensureOverrideValue(expression, overrideValues);
             if (!maybeValue)
                 return maybeValue.error();
@@ -613,17 +642,15 @@ Packing RewriteGlobalVariables::getPacking(AST::BinaryExpression& expression)
 
     if (expression.operation() == AST::BinaryOperation::ShortCircuitAnd || expression.operation() == AST::BinaryOperation::ShortCircuitOr) {
         auto leftEval = expression.leftExpression().maybeEvaluation().value_or(Evaluation::Runtime);
-        if (leftEval == Evaluation::Override) {
-            SetForScope suppressScope(m_suppressOverrideValidation, true);
+        if (leftEval < Evaluation::Runtime) {
+            m_shortCircuitedOperators.append(&expression);
             pack(Packing::Unpacked, expression.rightExpression());
+            m_shortCircuitedOperators.removeLast();
             return Packing::Unpacked;
         }
     }
 
     pack(Packing::Unpacked, expression.rightExpression());
-
-    if (m_suppressOverrideValidation)
-        return Packing::Unpacked;
 
     auto operation = toASCIILiteral(expression.operation());
     if (auto* overload = m_shaderModule.lookupOverload(operation)) {
@@ -631,7 +658,7 @@ Packing RewriteGlobalVariables::getPacking(AST::BinaryExpression& expression)
             auto leftEval = expression.leftExpression().maybeEvaluation().value_or(Evaluation::Runtime);
             auto rightEval = expression.rightExpression().maybeEvaluation().value_or(Evaluation::Runtime);
             if (leftEval == Evaluation::Override || rightEval == Evaluation::Override) {
-                m_shaderModule.addOverrideValidation([&shaderModule = m_shaderModule, &expression, validate](auto& overrideValues) -> std::optional<Error> {
+                addOverrideValidation([&shaderModule = m_shaderModule, &expression, validate](const auto& overrideValues) -> std::optional<Error> {
                     FixedVector<std::optional<ConstantValue>> validationArguments(2);
                     if (auto value = evaluate(shaderModule, expression.leftExpression(), overrideValues))
                         validationArguments[0] = { *value };
@@ -750,26 +777,24 @@ Packing RewriteGlobalVariables::getPacking(AST::CallExpression& call)
     for (auto& argument : call.arguments())
         pack(Packing::Unpacked, argument);
 
-    if (!m_suppressOverrideValidation) {
-        if (auto validate = call.validationFunction()) {
-            m_shaderModule.addOverrideValidation([&shaderModule = m_shaderModule, &call, validate](auto& overrideValues) -> std::optional<Error> {
-                unsigned argumentCount = call.arguments().size();
-                FixedVector<std::optional<ConstantValue>> validationArguments(argumentCount);
-                for (unsigned i = 0; i < argumentCount; ++i) {
-                    if (auto value = evaluate(shaderModule, call.arguments()[i], overrideValues))
-                        validationArguments[i] = { *value };
-                }
+    if (auto validate = call.validationFunction()) {
+        addOverrideValidation([&shaderModule = m_shaderModule, &call, validate](const auto& overrideValues) -> std::optional<Error> {
+            unsigned argumentCount = call.arguments().size();
+            FixedVector<std::optional<ConstantValue>> validationArguments(argumentCount);
+            for (unsigned i = 0; i < argumentCount; ++i) {
+                if (auto value = evaluate(shaderModule, call.arguments()[i], overrideValues))
+                    validationArguments[i] = { *value };
+            }
 
-                FixedVector<const Type*> paramTypes(argumentCount);
-                for (unsigned i = 0; i < argumentCount; ++i)
-                    paramTypes[i] = call.arguments()[i].inferredType();
+            FixedVector<const Type*> paramTypes(argumentCount);
+            for (unsigned i = 0; i < argumentCount; ++i)
+                paramTypes[i] = call.arguments()[i].inferredType();
 
-                if (auto error = validate(WTF::move(validationArguments), paramTypes))
-                    return Error(*error, call.span());
+            if (auto error = validate(WTF::move(validationArguments), paramTypes))
+                return Error(*error, call.span());
 
-                return std::nullopt;
-            });
-        }
+            return std::nullopt;
+        });
     }
 
     return Packing::Unpacked;

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -292,6 +292,8 @@ public:
     }
     bool hasFeature(const String& featureName) const { return m_configuration.supportedFeatures.contains(featureName); }
 
+    using OverrideValidator = Function<std::optional<Error>(const HashMap<String, ConstantValue>&)>;
+
     template<typename Validator>
     void addOverrideValidation(Validator&& validator)
     {
@@ -349,7 +351,7 @@ private:
     std::optional<CallGraph> m_callGraph;
     Vector<std::function<void()>> m_replacements;
     HashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_pipelineOverrideIds;
-    Vector<Function<std::optional<Error>(const HashMap<String, ConstantValue>&)>> m_overrideValidations;
+    Vector<OverrideValidator> m_overrideValidations;
     HashMap<String, OverloadedDeclaration> m_overloadedOperations;
     Vector<AST::Variable*> m_overrides;
 };

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm
@@ -111,6 +111,20 @@ static void expectGenerateError(const String& wgsl, const String& errorMessage)
     EXPECT_EQ(error.message(), errorMessage);
 }
 
+static void expectNoGenerateError(const String& wgsl)
+{
+    auto staticCheckResult = staticCheck(wgsl);
+    EXPECT_TRUE(std::holds_alternative<WGSL::SuccessfulCheck>(staticCheckResult));
+    auto& successfulCheck = std::get<WGSL::SuccessfulCheck>(staticCheckResult);
+
+    auto maybePrepareResult = prepare(successfulCheck);
+    EXPECT_TRUE(std::holds_alternative<WGSL::PrepareResult>(maybePrepareResult));
+    auto& prepareResult = std::get<WGSL::PrepareResult>(maybePrepareResult);
+
+    auto generationResult = generate(successfulCheck, prepareResult);
+    EXPECT_TRUE(std::holds_alternative<String>(generationResult));
+}
+
 class WGSLMetalCompilationTests : public testing::Test {
 protected:
     static void SetUpTestSuite()
@@ -566,6 +580,47 @@ TEST_F(WGSLMetalCompilationTests, Override)
 TEST_F(WGSLMetalCompilationTests, OverrideComplexExpression)
 {
     testCompilation(file("override-complex-expression.wgsl"_s));
+}
+
+TEST_F(WGSLMetalCompilationTests, OverrideShortCircuit)
+{
+    auto shader = [](ASCIILiteral condition, ASCIILiteral operation) {
+        return makeString(
+            "override cond = "_s, condition, ";"
+            "override shift = 32u;"
+            "@compute @workgroup_size(1) "
+            "fn main(@builtin(local_invocation_index) tid: u32) {"
+            "    var r = 0u;"
+            "    if (cond "_s, operation, " ((tid << shift) == 0u)) { r = 1u; }"
+            "    _ = r;"
+            "}"_s);
+    };
+    auto shiftError = "shift left value must be less than the bit width of the shifted value, which is 32"_s;
+
+    expectGenerateError(shader("true"_s, "&&"_s), shiftError);
+    expectGenerateError(shader("false"_s, "||"_s), shiftError);
+
+    expectNoGenerateError(shader("false"_s, "&&"_s));
+    expectNoGenerateError(shader("true"_s, "||"_s));
+
+    expectNoGenerateError(
+        "override shift = 32u;"
+        "@compute @workgroup_size(1) "
+        "fn main(@builtin(local_invocation_index) tid: u32) {"
+        "    var r = 0u;"
+        "    if (false && ((tid << shift) == 0u)) { r = 1u; }"
+        "    _ = r;"
+        "}"_s);
+
+    expectGenerateError(
+        "override cond = true;"
+        "override shift = 32u;"
+        "@compute @workgroup_size(1) "
+        "fn main(@builtin(local_invocation_index) tid: u32) {"
+        "    var r = 0u;"
+        "    if (cond && (cond && ((tid << shift) == 0u))) { r = 1u; }"
+        "    _ = r;"
+        "}"_s, shiftError);
 }
 
 TEST_F(WGSLMetalCompilationTests, PackUnpack)


### PR DESCRIPTION
#### ad8fd867b57c4f0c8b63abdd773cca615e434f78
<pre>
Add missing validation for overrides
<a href="https://bugs.webkit.org/show_bug.cgi?id=323806">https://bugs.webkit.org/show_bug.cgi?id=323806</a>
<a href="https://rdar.apple.com/185268723">rdar://185268723</a>

Reviewed by Dan Glastonbury.

Add missing validation to avoid override misuse.

Test: Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::skipsRightHandSide):
(WGSL::RewriteGlobalVariables::addOverrideValidation):
(WGSL::RewriteGlobalVariables::pack):
(WGSL::RewriteGlobalVariables::getPacking):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
* Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm:
(TestWGSLAPI::expectNoGenerateError):
(TestWGSLAPI::TEST_F(WGSLMetalCompilationTests, OverrideShortCircuit)):

Canonical link: <a href="https://commits.webkit.org/320829@main">https://commits.webkit.org/320829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57524ee87acf8763421766234226525c705f8ea9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196354 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1ed2a22d-bac5-4be8-9898-e17e5ced3948) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59681 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145386 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/866ee4de-f9f3-46d5-b459-cd50c1c54e18) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49066 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125706 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4dc7730e-a0cb-421a-8ca5-d9d16435ca33) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47799 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/158153 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45518 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7425 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198332 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59619 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154949 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41493 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60328 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/154589 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49034 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129734 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58774 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58164 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58396 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58222 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->