### PR TITLE
A negative stdDeviation asserts when computing filter outsets

### DIFF
--- a/LayoutTests/css3/filters/effect-reference-negative-deviation-expected.html
+++ b/LayoutTests/css3/filters/effect-reference-negative-deviation-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<title>A negative stdDeviation in a referenced filter must not assert while computing filter outsets</title>
+<style>
+div {
+    width: 50px;
+    height: 20px;
+    margin: 10px;
+    background-color: green;
+}
+</style>
+<div></div>
+<div></div>
+<div></div>
+<div></div>
+<div></div>
+<div></div>
+<div></div>
+<div></div>
+</html>

--- a/LayoutTests/css3/filters/effect-reference-negative-deviation.html
+++ b/LayoutTests/css3/filters/effect-reference-negative-deviation.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<title>A negative stdDeviation in a referenced filter must not assert while computing filter outsets</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" version="1.1" style="position: absolute">
+  <defs>
+    <filter id="blur1">
+      <feGaussianBlur stdDeviation="-1"/>
+    </filter>
+    <filter id="blur2">
+      <feGaussianBlur stdDeviation="-1 -1"/>
+    </filter>
+    <filter id="blur3">
+      <feGaussianBlur stdDeviation="1 -1"/>
+    </filter>
+    <filter id="blur4">
+      <feGaussianBlur stdDeviation="-1 1"/>
+    </filter>
+    <filter id="shadow1">
+      <feDropShadow stdDeviation="-1"/>
+    </filter>
+    <filter id="shadow2">
+      <feDropShadow stdDeviation="-1 -1"/>
+    </filter>
+    <filter id="shadow3">
+      <feDropShadow stdDeviation="1 -1"/>
+    </filter>
+    <filter id="shadow4">
+      <feDropShadow stdDeviation="-1 1" dx="20" dy="20"/>
+    </filter>
+  </defs>
+</svg>
+<style>
+div {
+    width: 50px;
+    height: 20px;
+    margin: 10px;
+    background-color: green;
+}
+</style>
+<div style="filter: url(#blur1)"></div>
+<div style="filter: url(#blur2)"></div>
+<div style="filter: url(#blur3)"></div>
+<div style="filter: url(#blur4)"></div>
+<div style="filter: url(#shadow1)"></div>
+<div style="filter: url(#shadow2)"></div>
+<div style="filter: url(#shadow3)"></div>
+<div style="filter: url(#shadow4)"></div>
+</html>

--- a/Source/WebCore/svg/SVGFEDropShadowElement.cpp
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.cpp
@@ -159,6 +159,9 @@ bool SVGFEDropShadowElement::taintsOrigin() const
 
 IntOutsets SVGFEDropShadowElement::outsets(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits) const
 {
+    if (stdDeviationX() < 0 || stdDeviationY() < 0)
+        return { };
+
     auto offset = SVGFilterRenderer::calculateResolvedSize({ dx(), dy() }, targetBoundingBox, primitiveUnits);
     auto stdDeviation = SVGFilterRenderer::calculateResolvedSize({ stdDeviationX(), stdDeviationY() }, targetBoundingBox, primitiveUnits);
     return FEDropShadow::calculateOutsets(offset, stdDeviation);

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
@@ -140,6 +140,9 @@ bool SVGFEGaussianBlurElement::isIdentity() const
 
 IntOutsets SVGFEGaussianBlurElement::outsets(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits) const
 {
+    if (stdDeviationX() < 0 || stdDeviationY() < 0)
+        return { };
+
     auto stdDeviation = SVGFilterRenderer::calculateResolvedSize({ stdDeviationX(), stdDeviationY() }, targetBoundingBox, primitiveUnits);
     return FEGaussianBlur::calculateOutsets(stdDeviation);
 }


### PR DESCRIPTION
#### 6f6d0f82d0e30c560939707413c49f7e6a6c7ad9
<pre>
A negative stdDeviation asserts when computing filter outsets
<a href="https://bugs.webkit.org/show_bug.cgi?id=323810">https://bugs.webkit.org/show_bug.cgi?id=323810</a>

Reviewed by Simon Fraser.

ASSERTION FAILED: stdDeviation.width() &gt;= 0 &amp;&amp; stdDeviation.height() &gt;= 0
Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp(114)

A negative stdDeviation turns a filter primitive off, but outsets() did not
check for it and passed the value on to calculateOutsets(), which asserts.

While this was discovered during LBSE testing, it is reproducible with
plain CSS reference filters too - so add a new reftest to cover this.

* LayoutTests/css3/filters/effect-reference-negative-deviation-expected.html: Added.
* LayoutTests/css3/filters/effect-reference-negative-deviation.html: Added.
* Source/WebCore/svg/SVGFEDropShadowElement.cpp:
(WebCore::SVGFEDropShadowElement::outsets const):
* Source/WebCore/svg/SVGFEGaussianBlurElement.cpp:
(WebCore::SVGFEGaussianBlurElement::outsets const):

Canonical link: <a href="https://commits.webkit.org/320797@main">https://commits.webkit.org/320797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c4b13c6456a02c60fb9b06edb4eebe35f97b3d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196194 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145269 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165822 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125578 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47681 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45697 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158040 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45404 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7265 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198168 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154826 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60162 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42008 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154471 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28232 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48926 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129503 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58623 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58002 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58066 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->