### PR TITLE
Ignore messages to RemoteObjectRegistry if destination can't be found

### DIFF
--- a/LayoutTests/ipc/remote-object-registry-invoke-method-stale-page-expected.txt
+++ b/LayoutTests/ipc/remote-object-registry-invoke-method-stale-page-expected.txt
@@ -1,0 +1,3 @@
+Tests that a RemoteObjectRegistry message addressed to a page that no longer exists is dropped instead of terminating the WebContent process.
+
+PASS if no crash.

--- a/LayoutTests/ipc/remote-object-registry-invoke-method-stale-page.html
+++ b/LayoutTests/ipc/remote-object-registry-invoke-method-stale-page.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=false ] -->
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function done()
+{
+    document.getElementById("result").textContent = "PASS if no crash.";
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+async function main()
+{
+    if (!window.IPC)
+        return done();
+
+    const stalePageProxyID = IPC.webPageProxyID + 1000000n;
+
+    for (const messageName of ["RemoteObjectRegistry_InvokeMethod", "RemoteObjectRegistry_CallReplyBlock", "RemoteObjectRegistry_ReleaseUnusedReplyBlock"]) {
+        IPC.sendMessage("UI", stalePageProxyID, IPC.messages[messageName].name, new Uint8Array(0));
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 500));
+    done();
+}
+
+window.onload = () => { main().catch(done); };
+</script>
+</head>
+<body>
+<p>Tests that a RemoteObjectRegistry message addressed to a page that no longer exists is dropped instead of terminating the WebContent process.</p>
+<p id="result">FAIL</p>
+</body>
+</html>

--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
@@ -187,9 +187,9 @@ static uint64_t NODELETE generateReplyIdentifier()
     remoteObjectRegistry->sendInvocation(WebKit::RemoteObjectInvocation(interface.identifier, [encoder rootObjectDictionary], WTF::move(replyInfo)));
 }
 
-- (WebKit::RemoteObjectRegistry&)remoteObjectRegistry
+- (WebKit::RemoteObjectRegistry*)remoteObjectRegistry
 {
-    return *_remoteObjectRegistry;
+    return _remoteObjectRegistry.get();
 }
 
 static NSString *replyBlockSignature(Protocol *protocol, SEL selector, NSUInteger blockIndex)

--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistryInternal.h
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistryInternal.h
@@ -39,7 +39,7 @@ class WebPageProxy;
 
 @interface _WKRemoteObjectRegistry ()
 
-@property (nonatomic, readonly) WebKit::RemoteObjectRegistry& remoteObjectRegistry;
+@property (nonatomic, readonly) WebKit::RemoteObjectRegistry* remoteObjectRegistry;
 
 - (id)_initWithWebPage:(std::reference_wrapper<WebKit::WebPage>)messageSender;
 - (id)_initWithWebPageProxy:(std::reference_wrapper<WebKit::WebPageProxy>)messageSender;

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -659,7 +659,7 @@ _WKRemoteObjectRegistry *WebPageProxy::remoteObjectRegistry()
 RemoteObjectRegistry* WebPageProxy::uiRemoteObjectRegistry()
 {
     if (RetainPtr registry = remoteObjectRegistry())
-        return &[registry remoteObjectRegistry];
+        return [registry remoteObjectRegistry];
     return nullptr;
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1607,16 +1607,17 @@ bool WebProcessProxy::handleRemoteObjectRegistryMessage(IPC::Connection& connect
         return false;
 
     WebPageProxyIdentifier pageID(decoder.destinationID());
-    if (!isAssociatedWithPage(pageID))
-        return false;
 
     RefPtr page = WebPageProxy::fromIdentifier(pageID);
     if (!page)
+        return true;
+
+    if (!isAssociatedWithPage(pageID))
         return false;
 
     RefPtr registry = page->uiRemoteObjectRegistry();
     if (!registry)
-        return false;
+        return true;
 
     registry->didReceiveMessage(connection, decoder);
     return true;


### PR DESCRIPTION
#### 48b9b5b5fcd3aea3a9d9eaca4648354db3b6301d
<pre>
Ignore messages to RemoteObjectRegistry if destination can&apos;t be found
<a href="https://bugs.webkit.org/show_bug.cgi?id=323811">https://bugs.webkit.org/show_bug.cgi?id=323811</a>
<a href="https://rdar.apple.com/184175210">rdar://184175210</a>

Reviewed by Brady Eidson.

This fixes a regression from 316400@main.

Before 316400@main, if a message was sent to a RemoteObjectRegistry that
had been destroyed in the UI process, WebProcessProxy::dispatchMessage
would fall through to the final return true; and we would ignore the message
and move on.  Since that change, we return handleRemoteObjectRegistryMessage
which, to match behavior, needs to return true if we can&apos;t find the
RemoteObjectRegistry.  Since the RemoteObjectRegistry&apos;s lifetime is tied to
the WKWebView and not the WebPageProxy, it is not uncommon for it to be destroyed
before the WebPageProxy during teardown, hence the radar.

Test: ipc/remote-object-registry-invoke-method-stale-page.html

* LayoutTests/ipc/remote-object-registry-invoke-method-stale-page-expected.txt: Added.
* LayoutTests/ipc/remote-object-registry-invoke-method-stale-page.html: Added.
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm:
(-[_WKRemoteObjectRegistry remoteObjectRegistry]):
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistryInternal.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::uiRemoteObjectRegistry):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::handleRemoteObjectRegistryMessage):

Canonical link: <a href="https://commits.webkit.org/320837@main">https://commits.webkit.org/320837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/355bd01076f2f362f60cba38b0725ac6d6b7a668

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196196 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150557 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5c07f990-56e0-4224-9795-d87a27ad0b31) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59519 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145271 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100710 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0137d813-cd7e-45b8-9745-b3c4e2d7339a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125580 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a583dc5-fbb4-4ae7-a734-643dc52d7047) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47683 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45698 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45406 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7267 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50124 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198170 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154828 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41500 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60164 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154484 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48920 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132524 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129505 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58625 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58004 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58238 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58068 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->