### PR TITLE
[Site Isolation] Disconnect remote intersection observers when owning document is destroyed

### DIFF
--- a/LayoutTests/http/tests/site-isolation/intersection-observer/remote-observer-document-leak-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/intersection-observer/remote-observer-document-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that an IntersectionObserver in a remote frame does not leak its document when the frame is removed before the first observation is delivered.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Document did not leak
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/intersection-observer/remote-observer-document-leak.html
+++ b/LayoutTests/http/tests/site-isolation/intersection-observer/remote-observer-document-leak.html
@@ -1,0 +1,18 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that an IntersectionObserver in a remote frame does not leak its document when the frame is removed before the first observation is delivered.");
+jsTestIsAsync = true;
+
+window.addEventListener("message", event => {
+    if (event.data.passed)
+        testPassed(event.data.message);
+    else
+        testFailed(event.data.message);
+    finishJSTest();
+});
+</script>
+<body>
+<iframe src="http://localhost:8000/site-isolation/intersection-observer/resources/remote-observer-document-leak-frame.html"></iframe>
+</body>

--- a/LayoutTests/http/tests/site-isolation/intersection-observer/resources/remote-observer-document-leak-frame.html
+++ b/LayoutTests/http/tests/site-isolation/intersection-observer/resources/remote-observer-document-leak-frame.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<script src="/resources/gc.js"></script>
+<body>
+<script>
+
+let frameIdentifiers = [];
+let framesLeftToRemove = 0;
+let allFramesRemoved;
+
+// Ensure that each subframe is removed before any rendering update can deliver an observation.
+function subframeDidStartObserving(subframeWindow)
+{
+    frameIdentifiers.push(internals.documentIdentifier(subframeWindow.document));
+    subframeWindow.frameElement.remove();
+    if (!--framesLeftToRemove)
+        allFramesRemoved();
+}
+
+function report(passed, message)
+{
+    parent.postMessage({ passed, message }, "*");
+}
+
+onload = async () => {
+    if (!window.internals) {
+        report(false, "Test requires internals");
+        return;
+    }
+
+    try {
+        let message = await testDocumentIsNotLeaked(async documentCount => {
+            framesLeftToRemove = documentCount;
+            let removed = new Promise(resolve => allFramesRemoved = resolve);
+            for (let i = 0; i < documentCount; ++i) {
+                let frame = document.createElement("iframe");
+                frame.src = "remote-observer-document-leak-subframe.html";
+                document.body.appendChild(frame);
+            }
+            await removed;
+            return frameIdentifiers;
+        }, { documentCount: 20 });
+        report(true, message);
+    } catch (error) {
+        report(false, error.message);
+    }
+};
+</script>

--- a/LayoutTests/http/tests/site-isolation/intersection-observer/resources/remote-observer-document-leak-subframe.html
+++ b/LayoutTests/http/tests/site-isolation/intersection-observer/resources/remote-observer-document-leak-subframe.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<body>
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+    let observer = new IntersectionObserver(() => { });
+    observer.observe(document.createElement("div"));
+    parent.subframeDidStartObserving(window);
+});
+</script>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -834,6 +834,9 @@ Document::~Document()
         ASSERT(m_intersectionObserverData->registrations.isEmpty());
     }
 
+    ASSERT(m_localIntersectionObservers.isEmpty());
+    ASSERT(m_remoteIntersectionObservers.isEmpty());
+
     removeFromDocumentsMap();
 
     // We need to remove from the contexts map very early in the destructor so that calling postTask() on this Document from another thread is safe.
@@ -1016,6 +1019,12 @@ void Document::commonTeardown()
     for (auto& weakLocalIntersectionObserver : localIntersectionObservers) {
         if (RefPtr localIntersectionObserver = weakLocalIntersectionObserver.get())
             localIntersectionObserver->disconnect();
+    }
+
+    auto remoteIntersectionObservers = m_remoteIntersectionObservers;
+    for (auto& weakRemoteIntersectionObserver : remoteIntersectionObservers) {
+        if (RefPtr remoteIntersectionObserver = weakRemoteIntersectionObserver.get())
+            remoteIntersectionObserver->disconnect();
     }
 
     auto resizeObservers = m_resizeObservers;


### PR DESCRIPTION
#### 7737c68ff27119f121322fb9d7f745584315d922
<pre>
[Site Isolation] Disconnect remote intersection observers when owning document is destroyed
<a href="https://bugs.webkit.org/show_bug.cgi?id=323814">https://bugs.webkit.org/show_bug.cgi?id=323814</a>
<a href="https://rdar.apple.com/187055922">rdar://187055922</a>

Reviewed by Kiet Ho.

308143@main split the document&apos;s vector of IntersectionObservers in to a local and a remote
vector. However, it only disconnected the local observers when the document was destroyed. We should
also disconnect the remote observers.

Test: http/tests/site-isolation/intersection-observer/remote-observer-document-leak.html

* LayoutTests/http/tests/site-isolation/intersection-observer/remote-observer-document-leak-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/intersection-observer/remote-observer-document-leak.html: Added.
* LayoutTests/http/tests/site-isolation/intersection-observer/resources/remote-observer-document-leak-frame.html: Added.
* LayoutTests/http/tests/site-isolation/intersection-observer/resources/remote-observer-document-leak-subframe.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::~Document):
(WebCore::Document::commonTeardown):

Canonical link: <a href="https://commits.webkit.org/320838@main">https://commits.webkit.org/320838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5226a03713a5a508ace195b659d62994d6a7d501

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196198 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150559 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bbd4a03b-638f-4cb9-a124-18d4d59ab940) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187762 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145273 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100712 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/14e106f4-3280-44fa-ba1b-3c69177f8b1f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165829 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125582 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3df25792-51b9-456c-baf1-d435cda91841) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47685 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45700 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158044 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45414 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7269 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198172 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59457 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165349 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154830 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41499 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60166 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154475 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48922 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132525 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129507 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58627 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58006 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58240 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58070 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->