### PR TITLE
[WPE] SkiaCompositingLayer: SIGSEGV in isColorFilterNode

### DIFF
--- a/LayoutTests/compositing/filters/repeated-filter-transitions-expected.txt
+++ b/LayoutTests/compositing/filters/repeated-filter-transitions-expected.txt
@@ -1,0 +1,1 @@
+PASS: Repeated filter transitions did not crash.

--- a/LayoutTests/compositing/filters/repeated-filter-transitions.html
+++ b/LayoutTests/compositing/filters/repeated-filter-transitions.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.target { transition: filter 0.1s; }
+.dim { filter: brightness(0.95); }
+</style>
+</head>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+async function runTest()
+{
+    const targets = Array.from({ length: 10 }, () => {
+        const target = document.createElement("div");
+        target.className = "target";
+        target.textContent = "hello";
+        document.body.appendChild(target);
+        return target;
+    });
+    document.body.offsetHeight;
+
+    for (let iteration = 0; iteration < 10; ++iteration) {
+        for (const dimmed of [true, false]) {
+            const finished = Promise.all(targets.map(target => new Promise(resolve => {
+                target.addEventListener("transitionend", resolve, { once: true });
+            })));
+            targets.forEach(target => target.classList.toggle("dim", dimmed));
+            await finished;
+        }
+    }
+
+    targets.forEach(target => target.remove());
+    document.body.append("PASS: Repeated filter transitions did not crash.");
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+runTest();
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -1333,7 +1333,7 @@ void SkiaCompositingLayer::paintWithMaskAndBackdrop(SkCanvas& canvas, PaintConte
 void SkiaCompositingLayer::paintWithFilterAndMask(SkCanvas& canvas, PaintContext& context)
 {
     auto filter = this->filter();
-    if (!filter) {
+    if (!filter || !filter->filter) {
         paintSelfAndChildren(canvas, context);
         return;
     }


### PR DESCRIPTION
#### 361bf1bd5adf181adf676f5b2b412a7310c83e93
<pre>
[WPE] SkiaCompositingLayer: SIGSEGV in isColorFilterNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=323720">https://bugs.webkit.org/show_bug.cgi?id=323720</a>

Reviewed by Carlos Garcia Campos.

Add a check for the underlying `sk_sp&lt;SkImageFilter&gt;` before using it.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paintWithFilterAndMask):

* LayoutTests/compositing/filters/repeated-filter-transitions.html: Added.
* LayoutTests/compositing/filters/repeated-filter-transitions-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/320824@main">https://commits.webkit.org/320824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/789d2dd803ece543007d4f5e46daa1027df0f5bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196215 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150565 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187778 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59536 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145282 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100717 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48965 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165834 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125592 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47693 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45705 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158049 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45419 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7284 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198188 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/185319 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165354 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154839 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41490 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60183 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42021 "Too many flaky failures: http/tests/cookies/same-site/popup-same-site-via-same-site-redirect.html, http/tests/cookies/same-site/post-from-cross-site-popup.html, http/tests/misc/resource-timing-navigation-in-restored-iframe-2.html, http/tests/misc/script-no-store.html, http/tests/navigation/post-redirect-get-reload.py, http/tests/security/canvas-remote-read-remote-image-blocked-no-crossorigin.html, http/tests/security/mixedContent/redirect-http-to-https-script-in-iframe-UpgradeMixedContent.html, http/tests/security/mixedContent/secure-redirect-to-secure-redirect-to-basic-auth-insecure-image-UpgradeMixedContent.https.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss.html, http/tests/web-locks/web-lock-in-third-party-sharedworker-site-isolation.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154485 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48934 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132535 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129523 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58640 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58023 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58255 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58083 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->