### PR TITLE
Add a fast path for premultiplying/unpremultiplying small pixel buffers

### DIFF
--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -40,6 +40,9 @@
 
 #if USE(ACCELERATE) && USE(CG)
 #include <Accelerate/Accelerate.h>
+#if HAVE(ARM_NEON_INTRINSICS)
+#include <arm_neon.h>
+#endif
 #elif USE(SKIA)
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkPixmap.h>
@@ -182,6 +185,61 @@ static bool convertImagePixelsAcceleratedAnyToAny(const ConstPixelBufferConversi
     return true;
 }
 
+#if HAVE(ARM_NEON_INTRINSICS)
+template<bool shouldUnpremultiply>
+static bool convertSmallImageAlpha(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& size)
+{
+    if (size.width() <= 0 || size.height() <= 0)
+        return false;
+    auto pixelCount = static_cast<uint64_t>(size.width()) * size.height();
+    if (pixelCount > 16384 || static_cast<uint64_t>(size.width()) * 4 != source.bytesPerRow || source.bytesPerRow != destination.bytesPerRow)
+        return false;
+
+    auto sourceBytes = source.rows.first(pixelCount * 4);
+    auto destinationBytes = destination.rows.first(pixelCount * 4);
+    size_t offset = 0;
+    if constexpr (!shouldUnpremultiply) {
+        for (; offset + 32 <= sourceBytes.size(); offset += 32) {
+            auto pixels = vld4_u8(sourceBytes.subspan(offset).data());
+            auto premultiply = [&](uint8x8_t channel) {
+                // This produces exactly the same results as (channel * alpha + 127) / 255 in vImagePremultiplyData_ARGB8888().
+                auto product = vmlal_u8(vdupq_n_u16(128), channel, pixels.val[3]);
+                return vshrn_n_u16(vaddq_u16(product, vshrq_n_u16(product, 8)), 8);
+            };
+            pixels.val[0] = premultiply(pixels.val[0]);
+            pixels.val[1] = premultiply(pixels.val[1]);
+            pixels.val[2] = premultiply(pixels.val[2]);
+            vst4_u8(destinationBytes.subspan(offset).data(), pixels);
+        }
+        for (; offset < sourceBytes.size(); offset += 4) {
+            unsigned alpha = sourceBytes[offset + 3];
+            for (unsigned channel = 0; channel < 3; ++channel)
+                destinationBytes[offset + channel] = (sourceBytes[offset + channel] * alpha + 127) / 255;
+            destinationBytes[offset + 3] = alpha;
+        }
+    } else {
+        for (; offset + 64 <= sourceBytes.size(); offset += 64) {
+            auto pixels = vld4q_u8(sourceBytes.subspan(offset).data());
+            auto alpha = pixels.val[3];
+            auto binaryAlpha = vorrq_u8(vceqq_u8(alpha, vdupq_n_u8(0)), vceqq_u8(alpha, vdupq_n_u8(255)));
+            if (vminvq_u8(binaryAlpha) != 255)
+                break;
+            pixels.val[0] = vandq_u8(pixels.val[0], alpha);
+            pixels.val[1] = vandq_u8(pixels.val[1], alpha);
+            pixels.val[2] = vandq_u8(pixels.val[2], alpha);
+            vst4q_u8(destinationBytes.subspan(offset).data(), pixels);
+        }
+        if (offset != sourceBytes.size()) {
+            auto remainingBytes = sourceBytes.size() - offset;
+            vImage_Buffer sourceBuffer { const_cast<uint8_t*>(sourceBytes.subspan(offset).data()), 1, remainingBytes / 4, remainingBytes };
+            vImage_Buffer destinationBuffer { destinationBytes.subspan(offset).data(), 1, remainingBytes / 4, remainingBytes };
+            vImageUnpremultiplyData_RGBA8888(&sourceBuffer, &destinationBuffer, kvImageNoFlags);
+        }
+    }
+    return true;
+}
+#endif
+
 static bool convertImagePixelsAcceleratedMatchingSize(const ConstPixelBufferConversionView& sourceView, const PixelBufferConversionView& destinationView, const IntSize& destinationSize)
 {
     auto sourceVImageBuffer = makeVImageBuffer(sourceView, destinationSize);
@@ -204,28 +262,38 @@ static bool convertImagePixelsAcceleratedMatchingSize(const ConstPixelBufferConv
 
     if (isAlphaApplied(sourceAlphaFormat) != isAlphaApplied(destinationAlphaFormat)) {
         bool shouldUnpremultiply = !isAlphaApplied(destinationAlphaFormat);
-        switch (sourceView.format.pixelFormat) {
-#if ENABLE(PIXEL_FORMAT_RGBA16F)
-        case PixelFormat::RGBA16F:
-            if (shouldUnpremultiply)
-                vImageUnpremultiplyData_RGBA16F(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
-            else
-                vImagePremultiplyData_RGBA16F(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
-            break;
+        bool converted = false;
+#if HAVE(ARM_NEON_INTRINSICS)
+        if (PixelBuffer::bytesPerPixelComponent(sourceView.format.pixelFormat) == 1) {
+            converted = shouldUnpremultiply
+                ? convertSmallImageAlpha<true>(sourceView, destinationView, destinationSize)
+                : convertSmallImageAlpha<false>(sourceView, destinationView, destinationSize);
+        }
 #endif
-        case PixelFormat::RGBA8:
-            if (shouldUnpremultiply)
-                vImageUnpremultiplyData_RGBA8888(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
-            else
-                vImagePremultiplyData_RGBA8888(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
-            break;
-        default:
-            ASSERT(sourceView.format.pixelFormat == PixelFormat::BGRA8);
-            if (shouldUnpremultiply)
-                vImageUnpremultiplyData_BGRA8888(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
-            else
-                vImagePremultiplyData_BGRA8888(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
-            break;
+        if (!converted) {
+            switch (sourceView.format.pixelFormat) {
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+            case PixelFormat::RGBA16F:
+                if (shouldUnpremultiply)
+                    vImageUnpremultiplyData_RGBA16F(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
+                else
+                    vImagePremultiplyData_RGBA16F(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
+                break;
+#endif
+            case PixelFormat::RGBA8:
+                if (shouldUnpremultiply)
+                    vImageUnpremultiplyData_RGBA8888(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
+                else
+                    vImagePremultiplyData_RGBA8888(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
+                break;
+            default:
+                ASSERT(sourceView.format.pixelFormat == PixelFormat::BGRA8);
+                if (shouldUnpremultiply)
+                    vImageUnpremultiplyData_BGRA8888(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
+                else
+                    vImagePremultiplyData_BGRA8888(&sourceVImageBuffer, &destinationVImageBuffer, kvImageNoFlags);
+                break;
+            }
         }
 
         sourceVImageBuffer = destinationVImageBuffer;


### PR DESCRIPTION
#### 1c5f54f324d1e0e3e15d9a7f75dc2911b0473e70
<pre>
Add a fast path for premultiplying/unpremultiplying small pixel buffers
<a href="https://bugs.webkit.org/show_bug.cgi?id=323817">https://bugs.webkit.org/show_bug.cgi?id=323817</a>
<a href="https://rdar.apple.com/187057865">rdar://187057865</a>

Reviewed by Gerald Squelart.

vImagePremultiplyData/vImageUnpremultiplyData pay a per-call setup and multithreading overhead that
dominates for the small buffers canvas getImageData()/putImageData() hands them.

Add convertSmallImageAlpha(), a NEON implementation used on arm64 when the pixel format is 8 bits
per component, the source and destination rows are tightly packed with a matching stride, and the
buffer is at most 16384 pixels. The cap is approximate, chosen to keep the working set in L1 on AS.
Anything that does not qualify keeps the existing vImage path.

I also considered passing the kvImageDoNotTile flag to vImage, which turns off multithreading, but
performance A/B testing indicates the added function performs better.

~3-4% improvement on MotionMark’s Canvas Lines, Design, Images, and Paths.

* Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
(WebCore::convertSmallImageAlpha):
(WebCore::convertImagePixelsAcceleratedMatchingSize):

Canonical link: <a href="https://commits.webkit.org/320853@main">https://commits.webkit.org/320853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b30467a473e4c55e8ab0a6998014b37e7d8f4f8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196407 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/15520cf4-0e31-4201-8957-dd06d6cb490d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187978 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59731 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a8b08127-0a04-4de6-b85d-d511abd33443) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189071 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/49104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125753 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4643182c-6207-4641-b55b-6d52b3f82275) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/47837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/158191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45549 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7478 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/50277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198385 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59668 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41507 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60380 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/154629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49068 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129794 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58819 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58212 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58441 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58271 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->