### PR TITLE
[IFC] Stop forwarding overflow and text-overflow to anonymous block boxes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-in-anonymous-block-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-in-anonymous-block-expected.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: the first line of the block container is ellipsed</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+div.clipped { overflow: hidden; text-overflow: ellipsis; width: 100px; white-space: pre; font: 10px/1 Ahem; }
+</style>
+<div class=clipped>this text should have ellipsis</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-in-anonymous-block-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-in-anonymous-block-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: the first line of the block container is ellipsed</title>
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+div.clipped { overflow: hidden; text-overflow: ellipsis; width: 100px; white-space: pre; font: 10px/1 Ahem; }
+</style>
+<div class=clipped>this text should have ellipsis</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-in-anonymous-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-in-anonymous-block.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>text-overflow applies to the lines of the anonymous block boxes of a block container</title>
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#text-overflow">
+<link rel="help" href="https://drafts.csswg.org/css-display/#anonymous">
+<link rel="match" href="text-overflow-in-anonymous-block-ref.html">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<style>
+div.clipped { overflow: hidden; text-overflow: ellipsis; width: 100px; white-space: pre; font: 10px/1 Ahem; }
+</style>
+<!-- The inline content ends up in an anonymous block box, which does not inherit overflow or text-overflow. -->
+<div class=clipped>this text should have ellipsis<div style="height: 0"></div></div>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp
@@ -468,7 +468,8 @@ InlineRect InlineFormattingContext::createDisplayContentForInlineContent(const L
     // When a block line is clamped, its content gets clamped and not this line itself.
     if (!lineLayoutResult.isBlockContent()) {
         auto isLegacyLineClamp = lineClamp && lineClamp->isLegacy;
-        auto truncationPolicy = InlineFormattingUtils::lineEndingTruncationPolicy(root().style(), numberOfLinesWithInlineContent, numberOfVisibleLinesAllowed, lineLayoutResult.hasContentfulInFlowContent());
+        CheckedRef styleForTruncation = root().isAnonymous() ? IntegrationUtils::firstNonAnonymousAncestorStyle(root()) : root().style();
+        auto truncationPolicy = InlineFormattingUtils::lineEndingTruncationPolicy(styleForTruncation, numberOfLinesWithInlineContent, numberOfVisibleLinesAllowed, lineLayoutResult.hasContentfulInFlowContent());
         ellipsis = InlineDisplayLineBuilder::applyEllipsisIfNeeded(truncationPolicy, displayLine, boxes.mutableSpan(), isLegacyLineClamp);
         if (ellipsis) {
             displayLine.setHasEllipsis();

--- a/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
@@ -28,6 +28,7 @@
 
 #include "InlineContentCache.h"
 #include "InlineFormattingContext.h"
+#include "LayoutIntegrationUtils.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StyleComputedStyle+InitialInlines.h"
 
@@ -545,7 +546,8 @@ bool TextOnlySimpleLineBuilder::isEligibleForSimplifiedDisplayBuild(const Elemen
         return false;
 
     auto& rootStyle = rootBlockContainer.style();
-    if (rootStyle.textOverflow() != Style::ComputedStyle::initialTextOverflow())
+    CheckedRef styleForTruncation = rootBlockContainer.isAnonymous() ? IntegrationUtils::firstNonAnonymousAncestorStyle(rootBlockContainer) : rootStyle;
+    if (styleForTruncation->textOverflow() != Style::ComputedStyle::initialTextOverflow())
         return false;
     if (!rootStyle.writingMode().isHorizontal())
         return false;

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp
@@ -28,6 +28,7 @@
 
 #include "InlineDisplayContentBuilder.h"
 #include "LayoutBoxGeometry.h"
+#include "LayoutIntegrationUtils.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "TextUtil.h"
 
@@ -498,9 +499,12 @@ std::optional<InlineDisplay::Line::Ellipsis> InlineDisplayLineBuilder::applyElli
     if (truncationPolicy == LineEndingTruncationPolicy::NoTruncation || !displayBoxes.size())
         return { };
 
+    CheckedRef rootBox = displayBoxes[0].layoutBox();
+    CheckedRef styleForTruncation = rootBox->isAnonymous() ? IntegrationUtils::firstNonAnonymousAncestorStyle(rootBox) : rootBox->style();
+
     auto ellipsisText = [&] -> AtomString {
         if (truncationPolicy == LineEndingTruncationPolicy::WhenContentOverflowsInInlineDirection) {
-            return WTF::switchOn(displayBoxes[0].layoutBox().style().textOverflow(),
+            return WTF::switchOn(styleForTruncation->textOverflow(),
                 [&](const CSS::Keyword::Clip&) -> AtomString {
                     return nullAtom();
                 },
@@ -516,7 +520,7 @@ std::optional<InlineDisplay::Line::Ellipsis> InlineDisplayLineBuilder::applyElli
             // Legacy line clamp always uses ...
             return TextUtil::ellipsisTextInInlineDirection(displayLine.isHorizontal());
         }
-        return WTF::switchOn(displayBoxes[0].layoutBox().style().blockEllipsis(),
+        return WTF::switchOn(styleForTruncation->blockEllipsis(),
             [&](const CSS::Keyword::NoEllipsis&) -> AtomString {
                 return nullAtom();
             },

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -178,17 +178,8 @@ void BoxTreeUpdater::tearDown()
 void BoxTreeUpdater::adjustStyleIfNeeded(const RenderElement& renderer, Style::ComputedStyle& style, Style::ComputedStyle* firstLineStyle)
 {
     auto adjustStyle = [&](auto& styleToAdjust) {
-        if (is<RenderBlock>(renderer)) {
-            if (renderer.isAnonymousBlock()) {
-                CheckedRef anonBlockParentStyle = renderer.parent()->style();
-                // overflow and text-overflow property values don't get forwarded to anonymous block boxes.
-                // e.g. <div style="overflow: hidden; text-overflow: ellipsis; width: 100px; white-space: pre;">this text should have ellipsis<div></div></div>
-                styleToAdjust.setTextOverflow(Style::TextOverflow { anonBlockParentStyle->textOverflow() });
-                styleToAdjust.setOverflowX(anonBlockParentStyle->overflowX());
-                styleToAdjust.setOverflowY(anonBlockParentStyle->overflowY());
-            }
-            return;
-        }
+        UNUSED_PARAM(renderer);
+        UNUSED_PARAM(styleToAdjust);
     };
     adjustStyle(style);
     if (firstLineStyle)

--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp
@@ -31,11 +31,20 @@
 #include "LayoutIntegrationFormattingContextLayout.h"
 #include "LayoutState.h"
 #include "RenderBoxInlines.h"
+#include "RenderElementInlines.h"
 #include "RenderObject.h"
 #include "RenderObjectInlines.h"
 
 namespace WebCore {
 namespace Layout {
+
+const Style::ComputedStyle& IntegrationUtils::firstNonAnonymousAncestorStyle(const Box& box)
+{
+    CheckedPtr renderer = box.rendererForIntegration();
+    if (auto* ancestor = renderer ? renderer->firstNonAnonymousAncestor() : nullptr)
+        return ancestor->style();
+    return box.style();
+}
 
 // https://drafts.csswg.org/css-grid-2/#item-margins
 // Percent/Calc padding and sizing resolves against the gridAreaInlineSize, not the block size of the grid container.

--- a/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationUtils.h
@@ -59,6 +59,7 @@ public:
     LayoutUnit minContentLogicalWidthContribution(const ElementBox&) const;
     LayoutUnit maxContentLogicalWidthContribution(const ElementBox&) const;
     void layoutWithFormattingContextForBlockInInline(const ElementBox& block, LayoutPoint blockLineLogicalTopLeft, const InlineLayoutState&) const;
+    static const Style::ComputedStyle& firstNonAnonymousAncestorStyle(const Box&);
 
     static BlockLayoutState::MarginState NODELETE toMarginState(const RenderBlockFlow::MarginInfo&);
     static RenderBlockFlow::MarginInfo toMarginInfo(const Layout::BlockLayoutState::MarginState&);


### PR DESCRIPTION
#### feb8e0dbf2cc3b8cbd9e8bd3740440d4cfdbe08d
<pre>
[IFC] Stop forwarding overflow and text-overflow to anonymous block boxes
<a href="https://bugs.webkit.org/show_bug.cgi?id=323818">https://bugs.webkit.org/show_bug.cgi?id=323818</a>
&lt;<a href="https://rdar.apple.com/problem/187058237">rdar://problem/187058237</a>&gt;

Reviewed by Antti Koivisto.

This is preparation for not adjusting computed style for layout boxes.

overflow and text-overflow are not inherited, so an anonymous block box holding
the inline content of a block container gets the initial values while the block
container is the one asking for the truncation.

* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-in-anonymous-block-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-in-anonymous-block-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/text-overflow-in-anonymous-block.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp:
(WebCore::Layout::InlineFormattingContext::layout):
(WebCore::Layout::InlineFormattingContext::createDisplayContentForInlineContent):
* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp:
(WebCore::Layout::TextOnlySimpleLineBuilder::isEligibleForSimplifiedDisplayBuild):
* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.cpp:
(WebCore::Layout::InlineDisplayLineBuilder::applyEllipsisIfNeeded):
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.h:
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::BoxTreeUpdater::adjustStyleIfNeeded):
* Source/WebCore/layout/integration/LayoutIntegrationUtils.cpp:
(WebCore::Layout::IntegrationUtils::styleForLineEndingTruncation):
* Source/WebCore/layout/integration/LayoutIntegrationUtils.h:

Canonical link: <a href="https://commits.webkit.org/320922@main">https://commits.webkit.org/320922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c6694b6ddc4e294386a9bd3d78ee3c2286e2c5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196517 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150782 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d2b26bb2-5acc-4101-9bd2-7f04137978ce) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188099 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59833 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145508 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/19cafbee-e320-4d41-861c-da762a857889) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49190 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125843 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b0b0ab18-f53c-47a8-80e8-155d1f859e98) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47919 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45896 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158272 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45632 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7589 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52618 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198504 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155079 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41562 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60489 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154722 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49152 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132745 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129902 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58916 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20611 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58318 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58536 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58382 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->