### PR TITLE
PlatformSpeechSynthesizerClient should prevent use-after-free via weak back-reference to client

### DIFF
--- a/Source/WebCore/platform/PlatformSpeechSynthesizer.cpp
+++ b/Source/WebCore/platform/PlatformSpeechSynthesizer.cpp
@@ -52,10 +52,16 @@ void PlatformSpeechSynthesizer::resetVoiceList()
     m_voiceList.clear();
 }
 
+RefPtr<PlatformSpeechSynthesizerClient> PlatformSpeechSynthesizer::client() const
+{
+    return m_speechSynthesizerClient.get();
+}
+
 void PlatformSpeechSynthesizer::voicesDidChange()
 {
     resetVoiceList();
-    m_speechSynthesizerClient.voicesDidChange();
+    if (RefPtr client = m_speechSynthesizerClient.get())
+        client->voicesDidChange();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/PlatformSpeechSynthesizer.h
+++ b/Source/WebCore/platform/PlatformSpeechSynthesizer.h
@@ -29,10 +29,12 @@
 #if ENABLE(SPEECH_SYNTHESIS)
 
 #include <WebCore/PlatformSpeechSynthesisVoice.h>
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 #if PLATFORM(COCOA)
 #include <wtf/RetainPtr.h>
@@ -56,7 +58,7 @@ class GstSpeechSynthesisWrapper;
 #endif
 class PlatformSpeechSynthesisUtterance;
 
-class PlatformSpeechSynthesizerClient {
+class PlatformSpeechSynthesizerClient : public AbstractRefCountedAndCanMakeWeakPtr<PlatformSpeechSynthesizerClient> {
 public:
     virtual void didStartSpeaking(PlatformSpeechSynthesisUtterance&) = 0;
     virtual void didFinishSpeaking(PlatformSpeechSynthesisUtterance&) = 0;
@@ -86,7 +88,7 @@ public:
     virtual void resetState();
     virtual void voicesDidChange();
 
-    PlatformSpeechSynthesizerClient& client() const { return m_speechSynthesizerClient; }
+    RefPtr<PlatformSpeechSynthesizerClient> client() const;
 
 protected:
     explicit PlatformSpeechSynthesizer(PlatformSpeechSynthesizerClient&);
@@ -101,7 +103,7 @@ private:
 #endif
 
     bool m_voiceListIsInitialized { false };
-    PlatformSpeechSynthesizerClient& m_speechSynthesizerClient;
+    WeakPtr<PlatformSpeechSynthesizerClient> m_speechSynthesizerClient;
 
 #if PLATFORM(COCOA)
     RetainPtr<WebSpeechSynthesisWrapper> m_platformSpeechWrapper;

--- a/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm
@@ -179,7 +179,8 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
         if (!protectedSynthesizerObject)
             return;
 
-        protectedSynthesizerObject->client().didStartSpeaking(Ref { *m_utterance });
+        if (RefPtr client = protectedSynthesizerObject->client())
+            client->didStartSpeaking(Ref { *m_utterance });
     }
 #endif
 
@@ -234,7 +235,8 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     if (!protectedSynthesizerObject)
         return;
 
-    protectedSynthesizerObject->client().didStartSpeaking(Ref { *m_utterance });
+    if (RefPtr client = protectedSynthesizerObject->client())
+        client->didStartSpeaking(Ref { *m_utterance });
 }
 
 - (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didFinishSpeechUtterance:(AVSpeechUtterance *)utterance
@@ -251,7 +253,8 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     RefPtr<WebCore::PlatformSpeechSynthesisUtterance> protectedUtterance = m_utterance;
     m_utterance = nullptr;
 
-    protectedSynthesizerObject->client().didFinishSpeaking(*protectedUtterance);
+    if (RefPtr client = protectedSynthesizerObject->client())
+        client->didFinishSpeaking(*protectedUtterance);
 }
 
 - (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didPauseSpeechUtterance:(AVSpeechUtterance *)utterance
@@ -264,7 +267,8 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     if (!protectedSynthesizerObject)
         return;
 
-    protectedSynthesizerObject->client().didPauseSpeaking(Ref { *m_utterance });
+    if (RefPtr client = protectedSynthesizerObject->client())
+        client->didPauseSpeaking(Ref { *m_utterance });
 }
 
 - (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didContinueSpeechUtterance:(AVSpeechUtterance *)utterance
@@ -277,7 +281,8 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     if (!protectedSynthesizerObject)
         return;
 
-    protectedSynthesizerObject->client().didResumeSpeaking(Ref { *m_utterance });
+    if (RefPtr client = protectedSynthesizerObject->client())
+        client->didResumeSpeaking(Ref { *m_utterance });
 }
 
 - (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer didCancelSpeechUtterance:(AVSpeechUtterance *)utterance
@@ -294,7 +299,8 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
     RefPtr<WebCore::PlatformSpeechSynthesisUtterance> protectedUtterance = m_utterance;
     m_utterance = nullptr;
 
-    protectedSynthesizerObject->client().didFinishSpeaking(*protectedUtterance);
+    if (RefPtr client = protectedSynthesizerObject->client())
+        client->didFinishSpeaking(*protectedUtterance);
 }
 
 - (void)speechSynthesizer:(AVSpeechSynthesizer *)synthesizer willSpeakRangeOfSpeechString:(NSRange)characterRange utterance:(AVSpeechUtterance *)utterance
@@ -308,7 +314,8 @@ static float getAVSpeechUtteranceMaximumSpeechRate()
         return;
 
     // AVSpeechSynthesizer only supports word boundaries.
-    protectedSynthesizerObject->client().boundaryEventOccurred(Ref { *m_utterance }, WebCore::SpeechBoundary::SpeechWordBoundary, characterRange.location, characterRange.length);
+    if (RefPtr client = protectedSynthesizerObject->client())
+        client->boundaryEventOccurred(Ref { *m_utterance }, WebCore::SpeechBoundary::SpeechWordBoundary, characterRange.location, characterRange.length);
 }
 
 @end
@@ -360,7 +367,8 @@ void PlatformSpeechSynthesizer::initializeVoiceList()
                 return;
 
             protectedThis->appendVoices(voices.get());
-            protectedThis->m_speechSynthesizerClient.voicesDidChange();
+            if (RefPtr client = protectedThis->client())
+                client->voicesDidChange();
             END_BLOCK_OBJC_EXCEPTIONS
         });
     }];

--- a/Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
@@ -138,7 +138,8 @@ void GstSpeechSynthesisWrapper::pause()
     webkitGstSetElementStateSynchronously(m_pipeline.get(), GST_STATE_PAUSED, [this](GstMessage* message) -> bool {
         return handleMessage(message);
     });
-    m_platformSynthesizer.client().didPauseSpeaking(*m_utterance);
+    if (RefPtr client = m_platformSynthesizer.client())
+        client->didPauseSpeaking(*m_utterance);
 }
 
 void GstSpeechSynthesisWrapper::resume()
@@ -149,7 +150,8 @@ void GstSpeechSynthesisWrapper::resume()
     webkitGstSetElementStateSynchronously(m_pipeline.get(), GST_STATE_PLAYING, [this](GstMessage* message) -> bool {
         return handleMessage(message);
     });
-    m_platformSynthesizer.client().didResumeSpeaking(*m_utterance);
+    if (RefPtr client = m_platformSynthesizer.client())
+        client->didResumeSpeaking(*m_utterance);
 }
 
 void GstSpeechSynthesisWrapper::speakUtterance(RefPtr<PlatformSpeechSynthesisUtterance>&& utterance)
@@ -176,7 +178,8 @@ void GstSpeechSynthesisWrapper::speakUtterance(RefPtr<PlatformSpeechSynthesisUtt
         return handleMessage(message);
     });
 
-    m_platformSynthesizer.client().didStartSpeaking(*m_utterance);
+    if (RefPtr client = m_platformSynthesizer.client())
+        client->didStartSpeaking(*m_utterance);
 }
 
 void GstSpeechSynthesisWrapper::cancel()
@@ -187,7 +190,8 @@ void GstSpeechSynthesisWrapper::cancel()
     webkitGstSetElementStateSynchronously(m_pipeline.get(), GST_STATE_READY, [this](GstMessage* message) -> bool {
         return handleMessage(message);
     });
-    m_platformSynthesizer.client().didFinishSpeaking(*m_utterance);
+    if (RefPtr client = m_platformSynthesizer.client())
+        client->didFinishSpeaking(*m_utterance);
 }
 
 void GstSpeechSynthesisWrapper::resetState()

--- a/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
+++ b/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
@@ -52,7 +52,8 @@ void PlatformSpeechSynthesizerMock::speakingFinished()
     RefPtr<PlatformSpeechSynthesisUtterance> protect(m_utterance);
     m_utterance = nullptr;
 
-    client().didFinishSpeaking(*protect);
+    if (RefPtr client = this->client())
+        client->didFinishSpeaking(*protect);
 }
 
 void PlatformSpeechSynthesizerMock::initializeVoiceList()
@@ -68,11 +69,13 @@ void PlatformSpeechSynthesizerMock::speak(RefPtr<PlatformSpeechSynthesisUtteranc
 {
     ASSERT(!m_utterance);
     m_utterance = utterance;
-    client().didStartSpeaking(*utterance);
+    if (RefPtr client = this->client()) {
+        client->didStartSpeaking(*utterance);
 
-    // Fire a fake word and then sentence boundary event. Since the entire sentence is the full length, pick arbitrary (3) length for the word.
-    client().boundaryEventOccurred(*utterance, SpeechBoundary::SpeechWordBoundary, 0, 3);
-    client().boundaryEventOccurred(*utterance, SpeechBoundary::SpeechSentenceBoundary, 0, utterance->text().length());
+        // Fire a fake word and then sentence boundary event. Since the entire sentence is the full length, pick arbitrary (3) length for the word.
+        client->boundaryEventOccurred(*utterance, SpeechBoundary::SpeechWordBoundary, 0, 3);
+        client->boundaryEventOccurred(*utterance, SpeechBoundary::SpeechSentenceBoundary, 0, utterance->text().length());
+    }
 
     // Give the fake speech job some time so that pause and other functions have time to be called.
     m_speakingFinishedTimer.startOneShot(m_utteranceDuration);
@@ -89,20 +92,25 @@ void PlatformSpeechSynthesizerMock::cancel()
     // This allows new utterances to be queued before the callback fires.
     RefPtr utterance = std::exchange(m_utterance, nullptr);
     callOnMainThread([protectedThis = Ref { *this }, utterance]() {
-        protectedThis->client().speakingErrorOccurred(*utterance);
+        if (RefPtr client = protectedThis->client())
+            client->speakingErrorOccurred(*utterance);
     });
 }
 
 void PlatformSpeechSynthesizerMock::pause()
 {
-    if (RefPtr utterance = m_utterance)
-        client().didPauseSpeaking(*utterance);
+    if (RefPtr utterance = m_utterance) {
+        if (RefPtr client = this->client())
+            client->didPauseSpeaking(*utterance);
+    }
 }
 
 void PlatformSpeechSynthesizerMock::resume()
 {
-    if (RefPtr utterance = m_utterance)
-        client().didResumeSpeaking(*utterance);
+    if (RefPtr utterance = m_utterance) {
+        if (RefPtr client = this->client())
+            client->didResumeSpeaking(*utterance);
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/spiel/PlatformSpeechSynthesizerSpiel.cpp
+++ b/Source/WebCore/platform/spiel/PlatformSpeechSynthesizerSpiel.cpp
@@ -110,35 +110,43 @@ void SpielSpeechWrapper::finishSpeakerInitialization()
     // TODO: Plumb support for boundaryEventOccurred? Using range-started signal?
 
     g_signal_connect_swapped(m_speaker.get(), "utterance-started", G_CALLBACK(+[](SpielSpeechWrapper* self, SpielUtterance*) {
-        self->m_platformSynthesizer.client().didStartSpeaking(*self->m_utterance);
+        if (RefPtr client = self->m_platformSynthesizer.client())
+            client->didStartSpeaking(*self->m_utterance);
     }), this);
 
     g_signal_connect_swapped(m_speaker.get(), "utterance-finished", G_CALLBACK(+[](SpielSpeechWrapper* self, SpielUtterance*) {
-        self->m_platformSynthesizer.client().didFinishSpeaking(*self->m_utterance);
+        if (RefPtr client = self->m_platformSynthesizer.client())
+            client->didFinishSpeaking(*self->m_utterance);
         self->clearUtterance();
     }), this);
 
     g_signal_connect_swapped(m_speaker.get(), "utterance-canceled", G_CALLBACK(+[](SpielSpeechWrapper* self, SpielUtterance*) {
-        self->m_platformSynthesizer.client().didFinishSpeaking(*self->m_utterance);
+        if (RefPtr client = self->m_platformSynthesizer.client())
+            client->didFinishSpeaking(*self->m_utterance);
         self->clearUtterance();
     }), this);
 
     g_signal_connect_swapped(m_speaker.get(), "utterance-error", G_CALLBACK(+[](SpielSpeechWrapper* self, SpielUtterance*) {
-        self->m_platformSynthesizer.client().speakingErrorOccurred(*self->m_utterance);
+        if (RefPtr client = self->m_platformSynthesizer.client())
+            client->speakingErrorOccurred(*self->m_utterance);
         self->clearUtterance();
     }), this);
 
     g_signal_connect_swapped(m_speaker.get(), "notify::paused", G_CALLBACK(+[](SpielSpeechWrapper* self, SpielSpeaker* speaker) {
+        RefPtr client = self->m_platformSynthesizer.client();
+        if (!client)
+            return;
         gboolean isPaused;
         g_object_get(speaker, "paused", &isPaused, nullptr);
         if (isPaused)
-            self->m_platformSynthesizer.client().didPauseSpeaking(*self->m_utterance);
+            client->didPauseSpeaking(*self->m_utterance);
         else
-            self->m_platformSynthesizer.client().didResumeSpeaking(*self->m_utterance);
+            client->didResumeSpeaking(*self->m_utterance);
     }), this);
 
     g_signal_connect_swapped(m_speaker.get(), "notify::voices", G_CALLBACK(+[](SpielSpeechWrapper* self, SpielSpeaker*) {
-        self->m_platformSynthesizer.client().voicesDidChange();
+        if (RefPtr client = self->m_platformSynthesizer.client())
+            client->voicesDidChange();
     }), this);
 
     m_speakerCreatedCallback();
@@ -205,7 +213,8 @@ void SpielSpeechWrapper::speakUtterance(RefPtr<PlatformSpeechSynthesisUtterance>
     }
 
     if (!utterance->voice()) {
-        m_platformSynthesizer.client().didFinishSpeaking(*utterance);
+        if (RefPtr client = m_platformSynthesizer.client())
+            client->didFinishSpeaking(*utterance);
         return;
     }
 
@@ -258,7 +267,8 @@ void PlatformSpeechSynthesizer::initializeVoiceList()
     if (!m_platformSpeechWrapper) {
         m_platformSpeechWrapper = makeUnique<SpielSpeechWrapper>(*this, [&] {
             m_voiceList = m_platformSpeechWrapper->initializeVoiceList();
-            client().voicesDidChange();
+            if (RefPtr speechClient = client())
+                speechClient->voicesDidChange();
         });
         return;
     }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1909,7 +1909,8 @@ void Internals::simulateSpeechSynthesizerVoiceListChange()
     if (m_platformSpeechSynthesizer) {
         m_platformSpeechSynthesizer->setInitialVoiceListToEmpty(false);
         m_platformSpeechSynthesizer->initializeVoiceList();
-        m_platformSpeechSynthesizer->client().voicesDidChange();
+        if (RefPtr client = m_platformSpeechSynthesizer->client())
+            client->voicesDidChange();
         return;
     }
 


### PR DESCRIPTION
#### fb20d4d63ba2a3a5c6618befe58aebaba605dcad
<pre>
PlatformSpeechSynthesizerClient should prevent use-after-free via weak back-reference to client
<a href="https://bugs.webkit.org/show_bug.cgi?id=312793">https://bugs.webkit.org/show_bug.cgi?id=312793</a>
<a href="https://rdar.apple.com/172854014">rdar://172854014</a>

Reviewed by Joshua Hoffman.

PlatformSpeechSynthesizer held a raw C++ reference
(PlatformSpeechSynthesizerClient&amp;) back to its client
(SpeechSynthesis). When cancel() was made asynchronous via
callOnMainThread in 309349@main, the deferred lambda could fire after
SpeechSynthesis had been destroyed, dereferencing freed memory. ASan
caught this as a heap-use-after-free in 131 media/track layout tests.

This commit makes PlatformSpeechSynthesizerClient inherit from
AbstractRefCountedAndCanMakeWeakPtr so it supports both WeakPtr (for
the non-owning back-reference) and RefPtr (for strong promotion at
call sites). Convert the raw reference member to a WeakPtr, and update
all ~29 call sites across all platform implementations to promote to
RefPtr before calling through the client.

This also fixes two latent async bugs with the same pattern: the Cocoa
voicesDidChange async callback and the Spiel initializeVoiceList
lambda both accessed the client in a deferred context without lifetime
protection.

* Source/WebCore/platform/PlatformSpeechSynthesizer.cpp:
(WebCore::PlatformSpeechSynthesizer::voicesDidChange):
* Source/WebCore/platform/PlatformSpeechSynthesizer.h:
* Source/WebCore/platform/cocoa/PlatformSpeechSynthesizerCocoa.mm:
(-[WebSpeechSynthesisWrapper speakUtterance:]):
(-[WebSpeechSynthesisWrapper speechSynthesizer:didStartSpeechUtterance:]):
(-[WebSpeechSynthesisWrapper speechSynthesizer:didFinishSpeechUtterance:]):
(-[WebSpeechSynthesisWrapper speechSynthesizer:didPauseSpeechUtterance:]):
(-[WebSpeechSynthesisWrapper speechSynthesizer:didContinueSpeechUtterance:]):
(-[WebSpeechSynthesisWrapper speechSynthesizer:didCancelSpeechUtterance:]):
(-[WebSpeechSynthesisWrapper speechSynthesizer:willSpeakRangeOfSpeechString:utterance:]):
(WebCore::PlatformSpeechSynthesizer::initializeVoiceList):
* Source/WebCore/platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp:
(WebCore::GstSpeechSynthesisWrapper::pause):
(WebCore::GstSpeechSynthesisWrapper::resume):
(WebCore::GstSpeechSynthesisWrapper::speakUtterance):
(WebCore::GstSpeechSynthesisWrapper::cancel):
* Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp:
(WebCore::PlatformSpeechSynthesizerMock::speakingFinished):
(WebCore::PlatformSpeechSynthesizerMock::speak):
(WebCore::PlatformSpeechSynthesizerMock::cancel):
(WebCore::PlatformSpeechSynthesizerMock::pause):
(WebCore::PlatformSpeechSynthesizerMock::resume):
* Source/WebCore/platform/spiel/PlatformSpeechSynthesizerSpiel.cpp:
(WebCore::SpielSpeechWrapper::finishSpeakerInitialization):
(WebCore::SpielSpeechWrapper::speakUtterance):
(WebCore::PlatformSpeechSynthesizer::initializeVoiceList):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::simulateSpeechSynthesizerVoiceListChange):

Originally-landed-as: 305413.715@safari-7624-branch (71471a83ed2d). <a href="https://rdar.apple.com/184744850">rdar://184744850</a>
Canonical link: <a href="https://commits.webkit.org/320970@main">https://commits.webkit.org/320970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/651e3da75f4099d7cb4864f88cd622b3e71a905f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196217 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150567 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187780 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59538 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145287 "Found 1 new test failure: fast/dom/lazy-image-loading-document-leak.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100719 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48966 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125598 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47694 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45706 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158050 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45428 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7286 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198190 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59476 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154840 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60185 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154487 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28307 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48935 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132537 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129525 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58642 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20439 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58025 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58257 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58085 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->