### PR TITLE
[libpas] Replace MTE enablement bool with a tri-state

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.c
@@ -74,6 +74,11 @@ extern const pas_heap_config iso_heap_config;
 #endif // PAS_ENABLE_ISO
 extern const pas_heap_config pas_utility_heap_config;
 
+static inline bool pas_mte_is_mte_enabled_unchecked(void)
+{
+    return PAS_RUNTIME_CONFIG_PTR->mte_state == pas_mte_state_enabled;
+}
+
 #if defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE
 #if PAS_ENABLE_MTE
 
@@ -110,20 +115,24 @@ static void pas_mte_do_initialization(void)
 {
     pas_runtime_config* config = PAS_RUNTIME_CONFIG_PTR;
 
+    bool enabled = false;
+
     struct proc_bsdinfo info;
     int rc = proc_pidinfo(getpid(), PROC_PIDTBSDINFO, 0, &info, sizeof(info));
     if (rc == sizeof(info) && info.pbi_flags & PAS_MTE_PROC_FLAG_SEC_ENABLED)
-        config->enabled = true;
+        enabled = true;
 
     if (is_env_true("MTE_overrideEnablementForJavaScriptCore")) {
         PAS_ASSERT(!is_env_false("MTE_overrideEnablementForJavaScriptCore"));
-        config->enabled = true;
+        enabled = true;
     }
     if (is_env_false("MTE_overrideEnablementForJavaScriptCore"))
-        config->enabled = false;
+        enabled = false;
 
-    if (!config->enabled)
+    if (!enabled) {
+        pas_atomic_store_uint8(&config->mte_state, pas_mte_state_disabled);
         return;
+    }
 
     uint64_t ldmState = 0;
     size_t sysCtlLen = sizeof(ldmState);
@@ -161,7 +170,7 @@ static void pas_mte_do_initialization(void)
             wcp_is_hardened = true;
 
         if (wcp_is_hardened) {
-            config->enabled = true;
+            enabled = true;
             config->is_hardened = true;
 
             pas_mte_force_nontaggable_user_allocations_into_large_heap();
@@ -169,26 +178,32 @@ static void pas_mte_do_initialization(void)
             config->is_hardened = false;
 #if !PAS_USE_MTE_IN_WEBCONTENT
             // Disable tagging in libpas by default in WebContent process
-            config->enabled = false;
+            enabled = false;
 #else
-            config->enabled = true;
+            enabled = true;
 #endif
         }
 
 #ifndef NDEBUG
         if (is_env_true("MTE_disableForWebContent")) {
             PAS_ASSERT(!is_env_true("MTE_overrideEnablementForWebContent"));
-            config->enabled = false;
+            enabled = false;
         }
 #endif
         if (is_env_true("MTE_overrideEnablementForWebContent")) {
-            config->enabled = true;
+            enabled = true;
         } else if (is_env_false("MTE_overrideEnablementForWebContent")) {
-            config->enabled = false;
+            enabled = false;
         }
     } else {
         config->is_hardened = true;
     }
+
+    /* We must publish here at the latest,
+       since the tail may read the enablement bits via
+       pas_bmalloc_force_allocations_into_biftit_heaps_where_available() */
+    pas_atomic_store_uint8(&config->mte_state,
+        enabled ? pas_mte_state_enabled : pas_mte_state_disabled);
 
     PAS_IGNORE_WARNINGS_BEGIN("unreachable-code");
     // Retag-on-scavenge functionally supports both segregated and bitfit heaps.
@@ -213,10 +228,10 @@ static void pas_mte_do_initialization(void)
 
 static bool pas_mte_is_enabled(void)
 {
-    const pas_runtime_config* config = PAS_RUNTIME_CONFIG_PTR;
     struct proc_bsdinfo info;
     int rc = proc_pidinfo(getpid(), PROC_PIDTBSDINFO, 0, &info, sizeof(info));
-    return (rc == sizeof(info) && (info.pbi_flags & PAS_MTE_PROC_FLAG_SEC_ENABLED) && config->enabled);
+    return (rc == sizeof(info) && (info.pbi_flags & PAS_MTE_PROC_FLAG_SEC_ENABLED)
+        && pas_mte_is_mte_enabled_unchecked());
 }
 
 #else // !PAS_ENABLE_MTE
@@ -224,7 +239,7 @@ static bool pas_mte_is_enabled(void)
 static PAS_UNUSED void pas_mte_do_initialization(void)
 {
     pas_runtime_config* config = PAS_RUNTIME_CONFIG_PTR;
-    config->enabled = false;
+    config->mte_state = pas_mte_state_disabled;
 }
 
 static PAS_UNUSED bool pas_mte_is_enabled(void)
@@ -299,7 +314,7 @@ static void pas_report_config(void)
         progname, pid, (int)threadno,
         (size_t)PAS_DEALLOCATION_LOG_SIZE, (size_t)PAS_DEALLOCATION_LOG_MAX_BYTES,
         pas_scavenger_period_in_milliseconds, pas_scavenger_deep_sleep_timeout_in_milliseconds, pas_scavenger_max_epoch_delta,
-        config->enabled, config->is_lockdown_mode, config->is_hardened,
+        pas_mte_is_mte_enabled_unchecked(), config->is_lockdown_mode, config->is_hardened,
         config->mode_bits.adjacent_tag_exclusion, config->mode_bits.retag_on_scavenge, config->mode_bits.zero_tag_all,
 #if PAS_ENABLE_BMALLOC
         pas_system_heap_should_supplant_bmalloc(pas_heap_config_kind_bmalloc),
@@ -382,11 +397,11 @@ void pas_bmalloc_force_allocations_into_bitfit_heaps_where_available(void)
     PAS_IGNORE_WARNINGS_END;
 }
 
-bool pas_mte_is_mte_enabled(void)
+bool pas_mte_is_mte_enabled_slow(void)
 {
     pas_mte_ensure_initialized();
 #if PAS_ENABLE_MTE
-    return PAS_RUNTIME_CONFIG_PTR->enabled;
+    return pas_mte_is_mte_enabled_unchecked();
 #else
     return false;
 #endif

--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
@@ -67,7 +67,7 @@
 #if defined(PAS_USE_OPENSOURCE_MTE) && PAS_USE_OPENSOURCE_MTE
 #if PAS_ENABLE_MTE
 
-#define PAS_USE_MTE (PAS_RUNTIME_CONFIG_PTR->enabled)
+#define PAS_USE_MTE (PAS_RUNTIME_CONFIG_PTR->mte_state == pas_mte_state_enabled)
 #ifndef PAS_USE_MTE_IN_WEBCONTENT
 #define PAS_USE_MTE_IN_WEBCONTENT 1
 #endif
@@ -198,7 +198,32 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-bool pas_mte_is_mte_enabled(void);
+
+bool pas_mte_is_mte_enabled_slow(void);
+
+#if PAS_ENABLE_MTE
+/* mte_state is safe to read with a relaxed load because in the case that a
+   stale value is observed, it would necessarily be a value of 0 (from the
+   original static initialization) as it will only ever be changed once,
+   inside the first call to pas_mte_is_mte_enabled_slow(); and the result of
+   such a stale read is to fall through to pas_mte_is_mte_enabled_slow(),
+   which ensures single initialization. */
+static inline __attribute__((__always_inline__)) bool pas_mte_is_mte_enabled(void)
+{
+    uint8_t state = PAS_RUNTIME_CONFIG_PTR->mte_state;
+    if (state == pas_mte_state_disabled)
+        return false;
+    if (state == pas_mte_state_enabled)
+        return true;
+    return pas_mte_is_mte_enabled_slow();
+}
+#else /* !PAS_ENABLE_MTE */
+static inline __attribute__((__always_inline__)) bool pas_mte_is_mte_enabled(void)
+{
+    return false;
+}
+#endif /* PAS_ENABLE_MTE */
+
 void pas_mte_ensure_initialized(void);
 void pas_mte_force_nontaggable_user_allocations_into_large_heap(void);
 void pas_bmalloc_force_allocations_into_bitfit_heaps_where_available(void);

--- a/Source/bmalloc/libpas/src/libpas/pas_runtime_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_runtime_config.h
@@ -63,8 +63,14 @@ extern Slot g_config[];
 #define PAS_RUNTIME_CONFIG_RESERVED_SLOTS 2
 #define PAS_RUNTIME_CONFIG_RESERVED_BYTES (PAS_RUNTIME_CONFIG_RESERVED_SLOTS * sizeof(Slot))
 
+typedef enum {
+    pas_mte_state_undetermined = 0,
+    pas_mte_state_disabled = 1,
+    pas_mte_state_enabled = 2
+} pas_mte_state;
+
 typedef struct {
-    uint8_t enabled;
+    uint8_t mte_state; /* One of pas_mte_state. */
 
     struct {
         uint8_t retag_on_scavenge : 1;


### PR DESCRIPTION
#### 86f52ba2f2c1597d4d4c7450c370c8b77c38cd9f
<pre>
[libpas] Replace MTE enablement bool with a tri-state
<a href="https://bugs.webkit.org/show_bug.cgi?id=323820">https://bugs.webkit.org/show_bug.cgi?id=323820</a>
<a href="https://rdar.apple.com/187058868">rdar://187058868</a>

Reviewed by Yusuke Suzuki.

pas_runtime_config lives in the reserved slots at the start of WTF&apos;s
g_config, which is zero-initialized at load time. Previously the MTE
enablement bit was a bool with 0 meaning either uninitialized or
not enabled. However, this means that in order to ensure that the
enablement-state was initialized, a consumer would need to call through
the out-of-line pas_mte_is_mte_enabled function which calls into
dispatch_once_f and is thus too heavy to have on the malloc hot path.

This patch replaces the enablement bool with a tristate so that
consumers can perform a relaxed load to determine whether or not they
need to go down the slow path, now appropriately renamed
pas_mte_is_mte_enabled_slow(). The tristate can be read with a relaxed
load because the slow-path uses dispatch_once_f to ensure that multiple
callers don&apos;t actually initialize libpas more than once, and the state
will only be set once.

In the new model, the consumer-facing pas_mte_is_mte_enabled() function
is an inlineable hot-path, while pas_mte_is_mte_enabled_slow() handles
the dispatch_once_f.

* Source/bmalloc/libpas/src/libpas/pas_runtime_config.h: add pas_mte_state,
  replace pas_runtime_config::enabled with mte_state
* Source/bmalloc/libpas/src/libpas/pas_mte_config.h:
(pas_mte_is_mte_enabled_unchecked): report the field as-is, for libpas&apos; own use
(pas_mte_is_mte_disabled_unchecked):
(pas_mte_is_mte_enabled): new inlineable entry point handling all three states
* Source/bmalloc/libpas/src/libpas/pas_mte_config.c:
(pas_mte_do_initialization): accumulate locally, publish with a release store
(pas_mte_is_enabled):
(pas_report_config):
(pas_mte_is_mte_enabled_slow): Renamed from pas_mte_is_mte_enabled.
(pas_mte_is_mte_enabled): Deleted.

Canonical link: <a href="https://commits.webkit.org/320852@main">https://commits.webkit.org/320852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbab872af8114187a456391ef15da659738f3d37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196224 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150573 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2f2717fa-495c-48d0-a42a-2b5f1a25e3da) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145285 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100724 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6f8dfa6f-3d50-4c24-a4e8-0aca6135aa22) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165843 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125595 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ac447a8-2921-4236-8f63-a56a1bc99cf4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47700 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45710 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7469 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14360 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45429 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7293 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47168 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198197 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59483 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154845 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41512 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60192 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154492 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48945 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129535 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58648 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58032 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58263 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58092 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->