### PR TITLE
`-apple-color-filter` should not appear in computed styles

### DIFF
--- a/LayoutTests/animations/resources/animation-test-helpers.js
+++ b/LayoutTests/animations/resources/animation-test-helpers.js
@@ -421,7 +421,9 @@ function getPropertyValue(property, elementId, iframeId)
         elementDocument = document.getElementById(iframeId).contentDocument;
     const element = elementDocument.getElementById(elementId);
     const propertyPrefix = property.split(".")[0];
-    const value = getComputedStyle(element)[propertyPrefix];
+    const value = propertyPrefix == "-apple-color-filter"
+        ? internals.computedAppleColorFilter(element)
+        : getComputedStyle(element)[propertyPrefix];
     if (value == "auto")
         return "auto";
     if (property == "font-stretch")

--- a/LayoutTests/css3/color-filters/color-filter-exposure-expected.txt
+++ b/LayoutTests/css3/color-filters/color-filter-exposure-expected.txt
@@ -1,4 +1,4 @@
-Tests that -apple-color-filter is exposed when the feature is enabled
+Tests that -apple-color-filter is exposed when the feature is enabled but is not reported in computed styles.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
@@ -12,17 +12,21 @@ PASS document.documentElement.style.getPropertyValue('-apple-color-filter') is "
 PASS document.documentElement.style.setProperty('-apple-color-filter', 'contrast(1)', '') is undefined.
 PASS document.documentElement.style.getPropertyValue('-apple-color-filter') is 'contrast(1)'
 PASS '-apple-color-filter' in getComputedStyle(document.documentElement) is true
-PASS getComputedStyle(document.documentElement)['-apple-color-filter'] is not undefined
-PASS getComputedStyle(document.documentElement).getPropertyValue('-apple-color-filter') is 'contrast(1)'
+PASS getComputedStyle(document.documentElement)['-apple-color-filter'] is ""
+PASS getComputedStyle(document.documentElement).getPropertyValue('-apple-color-filter') is ""
+PASS getComputedStyle(document.documentElement)['-apple-color-filter'] is ""
 PASS getComputedStyle(document.documentElement).getPropertyPriority('-apple-color-filter') is ""
 PASS getComputedStyle(document.documentElement).removeProperty('-apple-color-filter') threw exception NoModificationAllowedError: The object can not be modified..
-PASS getComputedStyle(document.documentElement).getPropertyValue('-apple-color-filter') is 'contrast(1)'
 PASS getComputedStyle(document.documentElement).setProperty('-apple-color-filter', 'contrast(1)', '') threw exception NoModificationAllowedError: The object can not be modified..
-PASS getComputedStyle(document.documentElement).getPropertyValue('-apple-color-filter') is 'contrast(1)'
+PASS computedPropertyNames().includes('-apple-color-filter') is false
+PASS document.documentElement.computedStyleMap().get('-apple-color-filter') is undefined.
+PASS document.documentElement.computedStyleMap().has('-apple-color-filter') is false
+PASS computedStyleMapKeys().includes('-apple-color-filter') is false
+PASS internals.computedAppleColorFilter(document.documentElement) is 'contrast(1)'
 PASS 'AppleColorFilter' in document.documentElement.style is true
 PASS document.documentElement.style['AppleColorFilter'] is not undefined
 PASS 'AppleColorFilter' in getComputedStyle(document.documentElement) is true
-PASS getComputedStyle(document.documentElement)['AppleColorFilter'] is not undefined
+PASS getComputedStyle(document.documentElement)['AppleColorFilter'] is ""
 PASS CSS.supports('-apple-color-filter: contrast(1)') is true
 PASS CSS.supports('-apple-color-filter: inherit') is true
 PASS CSS.supports('-apple-color-filter', 'contrast(1)') is true

--- a/LayoutTests/css3/color-filters/color-filter-exposure.html
+++ b/LayoutTests/css3/color-filters/color-filter-exposure.html
@@ -23,7 +23,7 @@
 <div id=test1></div>
 <div id=test2></div>
 <script>
-description("Tests that -apple-color-filter is exposed when the feature is enabled");
+description("Tests that -apple-color-filter is exposed when the feature is enabled but is not reported in computed styles.");
 
 shouldBeTrue("'-apple-color-filter' in document.documentElement.style");
 shouldNotBe("document.documentElement.style['-apple-color-filter']", "undefined");
@@ -37,23 +37,41 @@ shouldBeUndefined("document.documentElement.style.setProperty('-apple-color-filt
 shouldBe("document.documentElement.style.getPropertyValue('-apple-color-filter')", "'contrast(1)'");
 document.documentElement.removeAttribute("style");
 
+function computedPropertyNames()
+{
+    var style = getComputedStyle(document.documentElement);
+    var names = [];
+    for (var i = 0; i < style.length; ++i)
+        names.push(style.item(i));
+    return names;
+}
+
+function computedStyleMapKeys()
+{
+    return Array.from(document.documentElement.computedStyleMap().keys());
+}
+
 shouldBeTrue("'-apple-color-filter' in getComputedStyle(document.documentElement)");
-shouldNotBe("getComputedStyle(document.documentElement)['-apple-color-filter']", "undefined");
+shouldBeEmptyString("getComputedStyle(document.documentElement)['-apple-color-filter']");
 
 document.documentElement.setAttribute("style", "-apple-color-filter: contrast(1) !important");
-shouldBe("getComputedStyle(document.documentElement).getPropertyValue('-apple-color-filter')", "'contrast(1)'");
+shouldBeEmptyString("getComputedStyle(document.documentElement).getPropertyValue('-apple-color-filter')");
+shouldBeEmptyString("getComputedStyle(document.documentElement)['-apple-color-filter']");
 shouldBeEmptyString("getComputedStyle(document.documentElement).getPropertyPriority('-apple-color-filter')");
 shouldThrowErrorName("getComputedStyle(document.documentElement).removeProperty('-apple-color-filter')", "NoModificationAllowedError");
-shouldBe("getComputedStyle(document.documentElement).getPropertyValue('-apple-color-filter')", "'contrast(1)'");
 shouldThrowErrorName("getComputedStyle(document.documentElement).setProperty('-apple-color-filter', 'contrast(1)', '')", "NoModificationAllowedError");
-shouldBe("getComputedStyle(document.documentElement).getPropertyValue('-apple-color-filter')", "'contrast(1)'");
+shouldBeFalse("computedPropertyNames().includes('-apple-color-filter')");
+shouldBeUndefined("document.documentElement.computedStyleMap().get('-apple-color-filter')");
+shouldBeFalse("document.documentElement.computedStyleMap().has('-apple-color-filter')");
+shouldBeFalse("computedStyleMapKeys().includes('-apple-color-filter')");
+shouldBe("internals.computedAppleColorFilter(document.documentElement)", "'contrast(1)'");
 document.documentElement.removeAttribute("style");
 
 shouldBeTrue("'AppleColorFilter' in document.documentElement.style");
 shouldNotBe("document.documentElement.style['AppleColorFilter']", "undefined");
 
 shouldBeTrue("'AppleColorFilter' in getComputedStyle(document.documentElement)");
-shouldNotBe("getComputedStyle(document.documentElement)['AppleColorFilter']", "undefined");
+shouldBeEmptyString("getComputedStyle(document.documentElement)['AppleColorFilter']");
 
 shouldBeTrue("CSS.supports('-apple-color-filter: contrast(1)')");
 shouldBeTrue("CSS.supports('-apple-color-filter: inherit')");

--- a/LayoutTests/css3/color-filters/color-filter-parsing.html
+++ b/LayoutTests/css3/color-filters/color-filter-parsing.html
@@ -12,10 +12,12 @@ var testDiv = document.querySelector('#test');
 
 function testColorFilterParsing(value, expected, name)
 {
+    if (!window.internals)
+        return;
     test(() => {
         testDiv.style.setProperty("-apple-color-filter", "");
         testDiv.style.setProperty("-apple-color-filter", value);
-        var computedStyle = getComputedStyle(testDiv).getPropertyValue("-apple-color-filter");
+        var computedStyle = internals.computedAppleColorFilter(testDiv);
         assert_equals(computedStyle, expected);
     }, name);
 }

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -10420,6 +10420,7 @@
             ],
             "codegen-properties": {
                 "settings-flag": "colorFilterEnabled",
+                "skip-style-extractor": true,
                 "computed-style-storage-path": ["m_inheritedRareData", "appleColorFilter"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::AppleColorFilter",

--- a/Source/WebCore/style/StyleExtractor.cpp
+++ b/Source/WebCore/style/StyleExtractor.cpp
@@ -43,12 +43,15 @@
 #include "RenderObjectInlines.h"
 #include "SVGElement.h"
 #include "ShorthandSerializer.h"
+#include "StyleAppleColorFilter.h"
+#include "StyleComputedStyle+GettersInlines.h"
 #include "StyleCustomProperty.h"
 #include "StyleCustomPropertyRegistry.h"
 #include "StyleDocumentScope.h"
 #include "StyleExtractorGenerated.h"
 #include "StyleInterpolation.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
+#include "StylePrimitiveNumericTypes+Serialization.h"
 #include "StylePropertyShorthand.h"
 #include "StyleResolver.h"
 #include "StyleZoomPrimitivesInlines.h"
@@ -610,6 +613,15 @@ Ref<MutableStyleProperties> Extractor::copyProperties() const
             return std::nullopt;
         return { { property, value.releaseNonNull() } };
     }).span());
+}
+
+WTF::String Extractor::appleColorFilterSerializationForTesting(Element& element)
+{
+    updateStyleIfNeededForProperty(element, CSSPropertyAppleColorFilter);
+
+    if (CheckedPtr style = element.computedStyle())
+        return serializationForCSS(CSS::defaultSerializationContext(), *style, style->appleColorFilter());
+    return { };
 }
 
 } // namespace Style

--- a/Source/WebCore/style/StyleExtractor.h
+++ b/Source/WebCore/style/StyleExtractor.h
@@ -102,6 +102,8 @@ public:
 
     static bool updateStyleIfNeededForProperty(Element&, CSSPropertyID);
 
+    WEBCORE_EXPORT static WTF::String appleColorFilterSerializationForTesting(Element&);
+
 private:
     // The renderer we should use for resolving layout-dependent properties.
     const RenderElement* computeRenderer() const;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -254,6 +254,7 @@
 #include "StreamTransferUtilities.h"
 #include "StringCallback.h"
 #include "StyleDocumentScope.h"
+#include "StyleExtractor.h"
 #include "StyleGridPosition.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StyleResolver.h"
@@ -1657,6 +1658,11 @@ float Internals::usedOutlineOffset(Element& element)
     if (!style)
         return 0;
     return Style::evaluate<float>(style->usedOutlineOffset(), style->usedZoomForLength(), style->deviceScaleFactor());
+}
+
+String Internals::computedAppleColorFilter(Element& element)
+{
+    return Style::Extractor::appleColorFilterSerializationForTesting(element);
 }
 
 Node& Internals::ensureUserAgentShadowRoot(Element& host)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -307,6 +307,8 @@ public:
 
     float usedOutlineOffset(Element&);
 
+    String computedAppleColorFilter(Element&);
+
     Node& ensureUserAgentShadowRoot(Element& host);
     Node* shadowRoot(Element& host);
     ExceptionOr<String> shadowRootType(const Node&) const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -560,6 +560,8 @@ enum ContentsFormat {
 
     float usedOutlineOffset(Element element);
 
+    DOMString computedAppleColorFilter(Element element);
+
     Node ensureUserAgentShadowRoot(Element host);
     Node? shadowRoot(Element host);
 


### PR DESCRIPTION
#### 40ca828343d649c6bc1d5ee8cd652a315b1a3cff
<pre>
`-apple-color-filter` should not appear in computed styles
<a href="https://bugs.webkit.org/show_bug.cgi?id=323822">https://bugs.webkit.org/show_bug.cgi?id=323822</a>
<a href="https://rdar.apple.com/187061168">rdar://187061168</a>

Reviewed by Simon Fraser.

Stop exposing `-apple-color-filter` in computed styles and update
tests accordingly.

Test: css3/color-filters/color-filter-exposure.html

* LayoutTests/animations/resources/animation-test-helpers.js:
(getPropertyValue):
* LayoutTests/css3/color-filters/color-filter-exposure-expected.txt: Renamed from LayoutTests/css3/color-filters/color-filter-exposed-if-enabled-expected.txt.
* LayoutTests/css3/color-filters/color-filter-exposure.html: Renamed from LayoutTests/css3/color-filters/color-filter-exposed-if-enabled.html.
* LayoutTests/css3/color-filters/color-filter-parsing.html:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/StyleExtractor.cpp:
(WebCore::Style::Extractor::appleColorFilterSerializationForTesting):
* Source/WebCore/style/StyleExtractor.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::computedAppleColorFilter):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/320885@main">https://commits.webkit.org/320885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e45ac2e1575322e426168f407acc12d08339a92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196253 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150598 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61228 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59576 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145313 "Found 1 new test failure: fast/dom/lazy-image-loading-document-leak.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100744 "Exiting early after 60 failures. 60 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125627 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47725 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45737 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158081 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45448 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7325 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52443 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50165 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198228 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59514 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165383 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154869 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41534 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60223 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154515 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48966 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132567 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129569 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58674 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20454 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58061 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58291 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58118 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->