### PR TITLE
[WGSL] shader,validation,parse,comments:* is failing

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/comments-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/comments-expected.txt
@@ -4,85 +4,13 @@ PASS :line_comment_eof:
 PASS :line_comment_terminators:blankspace=["%20","space"]
 PASS :line_comment_terminators:blankspace=["%5Ct","tab"]
 PASS :line_comment_terminators:blankspace=["%5Cn","line_feed"]
-FAIL :line_comment_terminators:blankspace=["%5Cu000b","vertical_tab"] assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    // Line commentconst invalid_outside_comment = should_fail
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:532:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :line_comment_terminators:blankspace=["%5Cf","form_feed"] assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    // Line commentconst invalid_outside_comment = should_fail
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:532:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :line_comment_terminators:blankspace=["%5Cr","carriage_return"] assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    // Line comment\rconst invalid_outside_comment = should_fail
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:532:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :line_comment_terminators:blankspace=["%5Cu000b","vertical_tab"]
+PASS :line_comment_terminators:blankspace=["%5Cf","form_feed"]
+PASS :line_comment_terminators:blankspace=["%5Cr","carriage_return"]
 PASS :line_comment_terminators:blankspace=["%5Cr%5Cn","carriage_return_line_feed"]
-FAIL :line_comment_terminators:blankspace=["%C2%85","next_line"] assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    // Line commentconst invalid_outside_comment = should_fail
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:532:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :line_comment_terminators:blankspace=["%E2%80%A8","line_separator"] assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    // Line comment const invalid_outside_comment = should_fail
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:532:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
-FAIL :line_comment_terminators:blankspace=["%E2%80%A9","paragraph_separator"] assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    // Line comment const invalid_outside_comment = should_fail
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
-    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
-    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:532:28
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :line_comment_terminators:blankspace=["%C2%85","next_line"]
+PASS :line_comment_terminators:blankspace=["%E2%80%A8","line_separator"]
+PASS :line_comment_terminators:blankspace=["%E2%80%A9","paragraph_separator"]
 PASS :unterminated_block_comment:terminated=true
 PASS :unterminated_block_comment:terminated=false
 

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -85,6 +85,14 @@ static unsigned isIdentifierContinue(Latin1Character character, std::span<const 
 
 }
 
+// https://www.w3.org/TR/WGSL/#blankspace-and-line-breaks
+template <typename T>
+static bool isLineBreak(T character)
+{
+    return character == '\n' || character == '\v' || character == '\f' || character == '\r'
+        || character == u'\x85' || character == u'\U00002028' || character == u'\U00002029';
+}
+
 template<typename CharacterType>
 Token Lexer<CharacterType>::makeToken(TokenType type)
 {
@@ -583,7 +591,7 @@ bool Lexer<T>::skipLineComment()
     ASSERT(peek(0) == '/' && peek(1) == '/');
     // Note that in the case of \r\n this makes the comment end on the \r. It is
     // fine, as the \n after that is simple whitespace.
-    while (!isAtEndOfFile() && peek() != '\n') {
+    while (!isAtEndOfFile() && !isLineBreak(peek())) {
         if (peek() == '\0')
             return false;
         shift();


### PR DESCRIPTION
#### 257af3cb70fe470d267072c69f1015d92e78ae73
<pre>
[WGSL] shader,validation,parse,comments:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=323826">https://bugs.webkit.org/show_bug.cgi?id=323826</a>
<a href="https://rdar.apple.com/187062124">rdar://187062124</a>

Reviewed by Mike Wyrzykowski and Dan Glastonbury.

The WGSL spec[1] defines a line break as any of line feed, vertical tab, form
feed, carriage return, next line, line separator or paragraph separator, and a
line-ending comment runs up to but not including the next line break. We only
stopped at line feed, so a comment ended by any of the others swallowed the rest
of the physical line, silently accepting code that should have been rejected.

[1]: <a href="https://www.w3.org/TR/WGSL/#blankspace-and-line-breaks">https://www.w3.org/TR/WGSL/#blankspace-and-line-breaks</a>

* LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/comments-expected.txt:
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::isLineBreak):
(WGSL::Lexer&lt;T&gt;::skipLineComment):

Canonical link: <a href="https://commits.webkit.org/320849@main">https://commits.webkit.org/320849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffc65d4638a02149238a314e870342fe363a41b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53629 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196231 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150577 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/467da56c-ee62-45d9-ac91-467429d0b18e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145291 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100725 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0017f658-2a79-42e1-a413-ec3e7fbe541e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125602 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/88c7f9f0-9a30-4f4b-85e6-4e1c3e78d6b1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47708 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45715 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158064 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45432 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7300 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52429 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198204 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59490 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154849 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41510 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60199 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154496 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48943 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132550 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129542 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58655 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58039 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58270 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58099 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->