### PR TITLE
[Site Isolation] Expand about:blank process/origin checks to include about:srcdoc

### DIFF
--- a/LayoutTests/http/tests/site-isolation/srcdoc-in-cross-origin-iframe-inherits-parent-origin-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/srcdoc-in-cross-origin-iframe-inherits-parent-origin-expected.txt
@@ -1,0 +1,17 @@
+Setting srcdoc on an already cross-site (out-of-process) iframe must bring the frame back into the parent's origin.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS childDoc is not null
+PASS childDoc.URL is "about:srcdoc"
+PASS targetElem is not null
+PASS targetElem && targetElem.textContent is "mutated by parent"
+PASS iframeElem.contentWindow.parentIsReachable is true
+PASS iframeElem.contentWindow.origin === window.origin is true
+PASS childDoc.baseURI === document.baseURI is true
+PASS iframeElem.contentWindow.internals.processIdentifier === window.internals.processIdentifier is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/srcdoc-in-cross-origin-iframe-inherits-parent-origin.html
+++ b/LayoutTests/http/tests/site-isolation/srcdoc-in-cross-origin-iframe-inherits-parent-origin.html
@@ -1,0 +1,57 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Setting srcdoc on an already cross-site (out-of-process) iframe must bring the frame back into the parent's origin.");
+window.jsTestIsAsync = true;
+
+var iframeElem;
+var childDoc;
+var targetElem;
+function checkSrcdocInheritance()
+{
+    iframeElem = document.getElementById('test-iframe');
+    childDoc = iframeElem.contentDocument;
+    shouldNotBe("childDoc", "null");
+    if (!childDoc)
+        return;
+
+    shouldBeEqualToString("childDoc.URL", "about:srcdoc");
+
+    targetElem = childDoc.querySelector("#target");
+    shouldNotBe("targetElem", "null");
+    if (targetElem)
+        targetElem.textContent = "mutated by parent";
+    shouldBeEqualToString("targetElem && targetElem.textContent", "mutated by parent");
+
+    shouldBeTrue("iframeElem.contentWindow.parentIsReachable");
+    shouldBeTrue("iframeElem.contentWindow.origin === window.origin");
+    shouldBeTrue("childDoc.baseURI === document.baseURI");
+    shouldBeTrue("iframeElem.contentWindow.internals.processIdentifier === window.internals.processIdentifier");
+}
+
+async function runTest()
+{
+    const testIframe = document.getElementById('test-iframe');
+    testIframe.srcdoc = '<body><p id="target">original</p><script>window.parentIsReachable = !!parent.document;<\/script></body>';
+    await new Promise((resolve) => {
+        testIframe.addEventListener("load", () => { resolve(); }, { once: true } ); 
+    });
+    checkSrcdocInheritance();
+}
+
+onload = async () => {
+    await runTest();
+    finishJSTest();
+};
+
+</script>
+
+<iframe id="test-iframe" src="http://localhost:8000/site-isolation/resources/green-background.html"></iframe>
+
+</body>
+</html>

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6484,7 +6484,7 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
 
     RefPtr websitePolicies = navigation.websitePolicies();
     bool isServerSideRedirect = shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision && navigation.currentRequestIsRedirect();
-    bool shouldInheritOriginFromInitiator = currentRequestURL.isAboutBlank() && navigation.originatingFrameInfo();
+    bool shouldInheritOriginFromInitiator = (currentRequestURL.isAboutBlank() || currentRequestURL.isAboutSrcDoc()) && navigation.originatingFrameInfo();
     Site navigationSite { shouldInheritOriginFromInitiator ? Site { navigation.originatingFrameInfo()->securityOrigin } : Site { currentRequestURL } };
 
     if (siteIsolationEnabled && (!frame.isMainFrame() || newProcess->coreProcessIdentifier() == frame.process().coreProcessIdentifier())) {

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2378,10 +2378,10 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
         return { WTF::move(sourceProcess), nullptr, "Process has not yet committed any provisional loads"_s };
     }
 
-    if (siteIsolationEnabled && targetURL.isAboutBlank()) {
+    if (siteIsolationEnabled && (targetURL.isAboutBlank() || targetURL.isAboutSrcDoc())) {
         RefPtr navigationOriginatorFrame = navigation.originatingFrameInfo() ? WebFrameProxy::webFrame(navigation.originatingFrameInfo()->frameID) : nullptr;
         if (navigationOriginatorFrame)
-            return { navigationOriginatorFrame->process(), nullptr, "Frame is navigating to about:blank from a cross site origin. Switching to process that originated navigation."_s };
+            return { navigationOriginatorFrame->process(), nullptr, "Frame is navigating to about:blank or about:srcdoc from a cross site origin. Switching to process that originated navigation."_s };
     }
 
     // FIXME: We should support process swap when a window has been opened via window.open() without 'noopener'.


### PR DESCRIPTION
#### a1457f792eed5fa20b8deb4f92f47fa5c0ca4043
<pre>
[Site Isolation] Expand about:blank process/origin checks to include about:srcdoc
<a href="https://bugs.webkit.org/show_bug.cgi?id=323829">https://bugs.webkit.org/show_bug.cgi?id=323829</a>
<a href="https://rdar.apple.com/187064736">rdar://187064736</a>

Reviewed by Alex Christensen.

When a cross-site iframe navigates to an about:srcdoc URL, the iframe&apos;s process should transition from the
cross-site source process to the originating process because per spec, any about:srcdoc or about:blank content
should inherit the origin of the frame that initiated navigation to about:srcdoc. Currently, navigating to about:srcdoc
from a cross-site iframe results in the iframe remaining in the cross-site source process rather than returning to the
originating process. Consequently, the iframe&apos;s contentDocument is null. The fix is to add an additional check to
cover cases for about:srcdoc to WebKit&apos;s existing check for about:blank when determining the process in
WebProcessPool::processForNavigationInternal or the origin in WebPageProxy::continueNavigationInNewProcess.

Test: http/tests/site-isolation/srcdoc-in-cross-origin-iframe-inherits-parent-origin.html

* LayoutTests/http/tests/site-isolation/srcdoc-in-cross-origin-iframe-inherits-parent-origin-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/srcdoc-in-cross-origin-iframe-inherits-parent-origin.html: Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueNavigationInNewProcess):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigationInternal):

Canonical link: <a href="https://commits.webkit.org/320845@main">https://commits.webkit.org/320845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/695f6c78e0beedb4d0ba0d60e60104c3738893f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196232 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150578 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/620d00b4-a238-47a0-934c-573d7104fd9b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145292 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100726 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d718107a-8c88-4983-9d78-d7fde95a33ce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48977 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125603 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/53ff2537-bfcf-4388-81cd-39a1dc4867c5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47705 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45716 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158061 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45434 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7302 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198205 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165369 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154851 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60200 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42033 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154498 "Found 1 new API test failure: TestGeolocationManager:/webkit/WebKitGeolocationManager/current-position (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28255 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48944 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132551 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129543 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58656 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58040 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58271 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58100 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->