### PR TITLE
Remove unnecessary temporary String creation at CSS parsing call sites

### DIFF
--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -96,8 +96,7 @@ static std::optional<Color> parseColorValue(StringView string, HTMLInputElement&
     Ref document = context.document();
     auto parserContext = document->cssParserContext();
     parserContext.mode = HTMLStandardMode;
-    auto colorString = string.toString();
-    auto color = parseColorRawSimple(colorString, parserContext);
+    auto color = parseColorRawSimple(string, parserContext);
     if (color.isValid())
         return color;
 
@@ -105,7 +104,7 @@ static std::optional<Color> parseColorValue(StringView string, HTMLInputElement&
     CSS::PlatformColorResolutionState state {
         .resolvedCurrentColor = Color::black
     };
-    color = parseColorRawGeneral(colorString, parserContext, document, options, state);
+    color = parseColorRawGeneral(string, parserContext, document, options, state);
     if (color.isValid())
         return color;
 

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -852,7 +852,7 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
     //  leading and trailing whitespace, to be parsed as a <number-token>. Values that fail to
     //  parse trigger fallback."
     case AttrType::Number: {
-        auto trimmedValue = attributeValue.string().trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        auto trimmedValue = StringView { attributeValue }.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
         CSSTokenizer tokenizer(trimmedValue);
         auto tokenRange = tokenizer.tokenRange();
         tokenRange.consumeWhitespace();
@@ -861,7 +861,7 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
         auto numberToken = tokenRange.consumeIncludingWhitespace();
         if (!tokenRange.atEnd())
             return substituteFailure();
-        m_intermediateTokenStrings.append(WTF::move(trimmedValue));
+        m_intermediateTokenStrings.append(attributeValue.string());
         m_intermediateTokenStrings.appendVector(tokenizer.escapedStringsForAdoption());
         tokens.append(CSSParserToken(numberToken.numericValue(), numberToken.numericValueType(), numberToken.numericSign(), numberToken.value()));
         return true;
@@ -875,7 +875,7 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
         // "If the <attr-unit> does not match a known CSS unit, it triggers fallback."
         if (attrType == AttrType::Unit && parsedAttrType->unitType == CSSUnitType::Unknown)
             return substituteFailure();
-        auto trimmedValue = attributeValue.string().trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        auto trimmedValue = StringView { attributeValue }.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
         CSSTokenizer tokenizer(trimmedValue);
         auto tokenRange = tokenizer.tokenRange();
         tokenRange.consumeWhitespace();
@@ -889,7 +889,7 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
             token.convertToPercentage();
         else
             token.convertToDimensionWithUnit(parsedAttrType->unitType);
-        m_intermediateTokenStrings.append(WTF::move(trimmedValue));
+        m_intermediateTokenStrings.append(attributeValue.string());
         m_intermediateTokenStrings.appendVector(tokenizer.escapedStringsForAdoption());
         tokens.append(token);
         return true;

--- a/Source/WebCore/svg/properties/SVGPropertyTraits.cpp
+++ b/Source/WebCore/svg/properties/SVGPropertyTraits.cpp
@@ -69,7 +69,7 @@ Color SVGPropertyTraits<Color>::fromString(SVGElement& targetElement, const Stri
     Ref document = targetElement.document();
     auto& cssParserContext = document->cssParserContext();
 
-    auto trimmedString = string.trim(deprecatedIsSpaceOrNewline);
+    auto trimmedString = StringView { string }.trim(deprecatedIsSpaceOrNewline);
 
     auto color = parseColorRawSimple(trimmedString, cssParserContext);
     if (color.isValid())

--- a/Source/WebKit/UIProcess/API/wpe/WebKitColor.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitColor.cpp
@@ -109,7 +109,7 @@ gboolean webkit_color_parse(WebKitColor* color, const gchar* colorString)
     g_return_val_if_fail(color, FALSE);
     g_return_val_if_fail(colorString, FALSE);
 
-    auto webCoreColor = WebCore::CSSPropertyParserHelpers::deprecatedParseColorRawWithoutContext(String::fromLatin1(colorString));
+    auto webCoreColor = WebCore::CSSPropertyParserHelpers::deprecatedParseColorRawWithoutContext(StringView::fromLatin1(colorString));
     if (!webCoreColor.isValid())
         return FALSE;
 


### PR DESCRIPTION
#### 1443a4cc2f46901f5576a647e68915dfe13bbc2c
<pre>
Remove unnecessary temporary String creation at CSS parsing call sites
<a href="https://bugs.webkit.org/show_bug.cgi?id=323834">https://bugs.webkit.org/show_bug.cgi?id=323834</a>
<a href="https://rdar.apple.com/187067129">rdar://187067129</a>

Reviewed by Darin Adler and Chris Dumez.

This is a follow-up to 320120@main. This visits all the call sites and gets rid
of unnecessarily created temporary strings.

* Source/WebCore/html/ColorInputType.cpp:
(WebCore::parseColorValue):
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteAttrFunction):
* Source/WebCore/svg/properties/SVGPropertyTraits.cpp:
(WebCore::SVGPropertyTraits&lt;Color&gt;::fromString):
* Source/WebKit/UIProcess/API/wpe/WebKitColor.cpp:
(webkit_color_parse):

Canonical link: <a href="https://commits.webkit.org/320894@main">https://commits.webkit.org/320894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8138f0ecd130fc47bf0177d47ecfb66f82a2040e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196260 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150595 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187825 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145315 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100738 "Exiting early after 60 failures. 60 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125629 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47729 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45740 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158085 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45452 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7332 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50171 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198235 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59521 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154875 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41543 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60230 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154521 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48968 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132666 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129579 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58679 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20458 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58068 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58298 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58125 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->