### PR TITLE
[Swift Testing] Add some image/color utility functions

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/CocoaTypes.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/CocoaTypes.swift
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if WTF_PLATFORM_IOS_FAMILY
+public import UIKit
+
+/// The platform image type.
+public typealias CocoaImage = UIImage
+
+/// The platform color type.
+public typealias CocoaColor = UIColor
+#else
+public import AppKit
+
+/// The platform image type.
+public typealias CocoaImage = NSImage
+
+/// The platform color type.
+public typealias CocoaColor = NSColor
+#endif

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoa.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoa.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#ifdef __cplusplus
+#if defined(__cplusplus) && !defined(__swift__)
 
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"
@@ -73,4 +73,4 @@ constexpr CGFloat whiteColorComponents[4] = { 1, 1, 1, 1 };
 
 #endif
 
-#endif // __cplusplus
+#endif // defined(__cplusplus) && !defined(__swift__)

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageAndCocoaColor.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageAndCocoaColor.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#ifdef __cplusplus
+#if defined(__cplusplus) && !defined(__swift__)
 
 #if USE(APPKIT)
 OBJC_CLASS NSImage;
@@ -43,9 +43,8 @@ namespace TestWebKitAPI::Util {
 
 CocoaColor *pixelColor(CocoaImage *, CGPoint = CGPointZero);
 NSData *makePDFData(CGSize, SEL colorSelector);
-CocoaColor *toSRGBColor(CocoaColor *);
 bool compareColors(CocoaColor *, CocoaColor *, float tolerance = 0.01);
 
 } // namespace TestWebKitAPI::Util
 
-#endif // __cplusplus
+#endif // defined(__cplusplus) && !defined(__swift__)

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageAndCocoaColor.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageAndCocoaColor.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 #import "Helpers/cocoa/TestCocoaImageAndCocoaColor.h"
+#import "Helpers/cocoa/TestCocoaImageUtilities.h"
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
@@ -32,59 +33,12 @@ namespace TestWebKitAPI::Util {
 
 CocoaColor *pixelColor(CocoaImage *image, CGPoint point)
 {
-#if USE(APPKIT)
-    auto imageRef = [image CGImageForProposedRect:nullptr context:nil hints:nil];
-    auto *bitmap = [[NSBitmapImageRep alloc] initWithCGImage:imageRef];
-    auto *color = [bitmap colorAtX:point.x y:point.y];
-    return color;
-#else
-    image = [image.imageAsset imageWithTraitCollection:UITraitCollection.currentTraitCollection];
-
-    UIGraphicsBeginImageContext(image.size);
-
-    [image drawAtPoint:CGPointZero];
-
-    auto context = UIGraphicsGetCurrentContext();
-    auto *data = (unsigned char *)CGBitmapContextGetData(context);
-    if (!data)
-        return nil;
-
-    unsigned offset = ((image.size.width * point.y) + point.x) * 4;
-    auto *color = [UIColor colorWithRed:data[offset] / 255.0 green:data[offset + 1] / 255.0 blue:data[offset + 2] / 255.0 alpha:data[offset + 3] / 255.0];
-
-    UIGraphicsEndImageContext();
-
-    return color;
-#endif
-}
-
-CocoaColor *toSRGBColor(CocoaColor *color)
-{
-#if USE(APPKIT)
-    return [color colorUsingColorSpace:NSColorSpace.sRGBColorSpace];
-#else
-    return color;
-#endif
+    return [TestCocoaImageUtilities pixelColorOfImage:image atPoint:point];
 }
 
 bool compareColors(CocoaColor *color1, CocoaColor *color2, float tolerance)
 {
-    if (color1 == color2 || [color1 isEqual:color2])
-        return true;
-
-    if (!color1 || !color2)
-        return false;
-
-    color1 = toSRGBColor(color1);
-    color2 = toSRGBColor(color2);
-
-    CGFloat red1, green1, blue1, alpha1;
-    [color1 getRed:&red1 green:&green1 blue:&blue1 alpha:&alpha1];
-
-    CGFloat red2, green2, blue2, alpha2;
-    [color2 getRed:&red2 green:&green2 blue:&blue2 alpha:&alpha2];
-
-    return fabs(red1 - red2) < tolerance && fabs(green1 - green2) < tolerance && fabs(blue1 - blue2) < tolerance && fabs(alpha1 - alpha2) < tolerance;
+    return [TestCocoaImageUtilities compareColor:color1 toColor:color2 tolerance:tolerance];
 }
 
 NSData *makePDFData(CGSize size, SEL colorSelector)

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageUtilities.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,76 +25,39 @@
 
 #pragma once
 
+#ifdef __OBJC__
+
+#import <CoreGraphics/CoreGraphics.h>
 #import <wtf/Platform.h>
 
-#if HAVE(PDFKIT)
-
-#import <Foundation/Foundation.h>
-#import <PDFKit/PDFKit.h>
-
 #if PLATFORM(IOS_FAMILY)
-@class UIColor;
+#import <UIKit/UIKit.h>
 #else
-@class NSColor;
+#import <AppKit/AppKit.h>
 #endif
 
-NS_ASSUME_NONNULL_BEGIN
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 NS_SWIFT_UI_ACTOR
-@interface TestPDFAnnotation : NSObject
+@interface TestCocoaImageUtilities : NSObject
 
-@property (nonatomic, readonly) BOOL isLink;
-
-@property (nonatomic, readonly) CGRect bounds;
-
-@property (nonatomic, readonly, nullable) NSURL *linkURL;
-
++ (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithPDFAnnotation:(PDFAnnotation *)annotation;
-
-@end
-
-NS_SWIFT_UI_ACTOR
-@interface TestPDFPage : NSObject
-
-@property (nonatomic, readonly) CGRect bounds;
-
-@property (nonatomic, readonly) NSArray<TestPDFAnnotation *> *annotations;
-
-@property (nonatomic, readonly) NSString *text;
-
-@property (nonatomic, readonly) NSInteger characterCount;
-
-- (instancetype)init NS_UNAVAILABLE;
-
-- (instancetype)initWithPDFPage:(PDFPage *)page;
-
-- (CGRect)rectForCharacterAtIndex:(NSInteger)index;
-
-- (NSInteger)characterIndexAtPoint:(CGPoint)point;
++ (void)performWithDarkAppearance:(BOOL)darkAppearance block:(void (NS_NOESCAPE ^)(void))block NS_SWIFT_NAME(perform(darkAppearance:block:));
 
 #if PLATFORM(IOS_FAMILY)
-- (UIColor *)colorAtPoint:(CGPoint)point;
++ (NSData *)pngDataWithSize:(CGSize)size color:(UIColor *)color NS_SWIFT_NAME(pngData(size:color:));
++ (nullable UIColor *)pixelColorOfImage:(UIImage *)image atPoint:(CGPoint)point NS_SWIFT_NAME(pixelColor(of:at:));
++ (BOOL)compareColor:(nullable UIColor *)color toColor:(nullable UIColor *)otherColor tolerance:(CGFloat)tolerance NS_SWIFT_NAME(compareColors(_:_:tolerance:));
 #else
-- (NSColor *)colorAtPoint:(CGPoint)point;
++ (NSData *)pngDataWithSize:(CGSize)size color:(NSColor *)color NS_SWIFT_NAME(pngData(size:color:));
++ (nullable NSColor *)pixelColorOfImage:(NSImage *)image atPoint:(CGPoint)point NS_SWIFT_NAME(pixelColor(of:at:));
++ (BOOL)compareColor:(nullable NSColor *)color toColor:(nullable NSColor *)otherColor tolerance:(CGFloat)tolerance NS_SWIFT_NAME(compareColors(_:_:tolerance:));
 #endif
 
 @end
 
-NS_SWIFT_UI_ACTOR
-@interface TestPDFDocument : NSObject
+NS_HEADER_AUDIT_END(nullability, sendability)
 
-@property (nonatomic, readonly) NSInteger pageCount;
-
-- (nullable TestPDFPage *)pageAtIndex:(NSInteger)index;
-
-- (instancetype)init NS_UNAVAILABLE;
-
-- (instancetype)initFromData:(NSData *)data;
-
-@end
-
-NS_ASSUME_NONNULL_END
-
-#endif // HAVE(PDFKIT)
+#endif // __OBJC__

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageUtilities.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageUtilities.swift
@@ -1,0 +1,309 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+public import CoreGraphics
+public import Foundation
+private import TestWebKitAPILibrary.Helpers.cocoa.TestCocoaImageUtilities
+
+#if WTF_PLATFORM_IOS_FAMILY
+public import UIKit
+#else
+public import AppKit
+#endif
+
+/// A system appearance to draw with.
+public enum Appearance: Sendable {
+    /// The standard light appearance.
+    case light
+
+    /// The standard dark appearance.
+    case dark
+}
+
+/// Runs a closure with the given appearance current for drawing.
+///
+/// - Parameters:
+///   - appearance: The appearance to make current.
+///   - body: The work to perform, typically sampling an appearance-sensitive image.
+/// - Returns: Whatever `body` returns.
+/// - Throws: Whatever `body` throws.
+@MainActor
+public func withAppearance<T, E: Error>(_ appearance: Appearance, _ body: () throws(E) -> T) throws(E) -> T {
+    var result: Result<T, E>?
+
+    TestCocoaImageUtilities.perform(darkAppearance: appearance == .dark) {
+        result = Result { () throws(E) in try body() }
+    }
+
+    // swift-format-ignore: NeverForceUnwrap
+    return try result!.get()
+}
+
+/// PNG data for an image of the given size, filled with a single color.
+///
+/// - Parameters:
+///   - size: The size of the image, in points.
+///   - color: The color to fill the image with.
+/// - Returns: The encoded PNG data.
+@MainActor
+public func makePNGData(size: CGSize, color: CocoaColor) -> Data {
+    TestCocoaImageUtilities.pngData(size: size, color: color)
+}
+
+/// The color of a single pixel of an image.
+///
+/// - Parameters:
+///   - image: The image to sample.
+///   - point: The pixel to sample, in points from the top-left corner of the image.
+/// - Returns: The color of that pixel, or `nil` if the image could not be sampled or the point
+///   lies outside of it.
+@MainActor
+public func pixelColor(of image: CocoaImage, at point: CGPoint = .zero) -> CocoaColor? {
+    TestCocoaImageUtilities.pixelColor(of: image, at: point)
+}
+
+/// Whether two colors match on every sRGB component, within a tolerance.
+///
+/// - Parameters:
+///   - color: The first color.
+///   - otherColor: The second color.
+///   - tolerance: The largest per-component difference that still counts as a match.
+/// - Returns: Whether the colors match.
+@MainActor
+public func compareColors(_ color: CocoaColor?, _ otherColor: CocoaColor?, tolerance: CGFloat = 0.01) -> Bool {
+    TestCocoaImageUtilities.compareColors(color, otherColor, tolerance: tolerance)
+}
+
+@MainActor
+private func makeBitmap(size: CGSize, draw: () -> Void) -> CGImage? {
+    guard
+        let width = Int(exactly: size.width.rounded(.up)), width > 0,
+        let height = Int(exactly: size.height.rounded(.up)), height > 0,
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)
+    else {
+        return nil
+    }
+
+    #if HAVE_CGCONTEXT_INIT_WITH_BITMAP_INFO_AND_NULLABLE_COLORSPACE
+    let context = unsafe CGContext(
+        data: nil,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: 0,
+        space: colorSpace,
+        bitmapInfo: CGBitmapInfo(alpha: .premultipliedLast, byteOrder: .order32Big)
+    )
+    #else
+    let context = unsafe CGContext(
+        data: nil,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: 0,
+        space: colorSpace,
+        bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue).union(.byteOrder32Big).rawValue
+    )
+    #endif
+
+    guard let context else {
+        return nil
+    }
+
+    context.translateBy(x: 0, y: CGFloat(height))
+    context.scaleBy(x: 1, y: -1)
+
+    #if WTF_PLATFORM_IOS_FAMILY
+    UIGraphicsPushContext(context)
+    defer { UIGraphicsPopContext() }
+    #else
+    NSGraphicsContext.saveGraphicsState()
+    defer { NSGraphicsContext.restoreGraphicsState() }
+
+    NSGraphicsContext.current = NSGraphicsContext(cgContext: context, flipped: true)
+    #endif
+
+    draw()
+
+    return context.makeImage()
+}
+
+private func sampleColor(of bitmap: CGImage, atX x: Int, y: Int) -> CocoaColor? {
+    guard
+        (0..<bitmap.width).contains(x), (0..<bitmap.height).contains(y),
+        let pixels = bitmap.dataProvider?.data
+    else {
+        return nil
+    }
+
+    let data = pixels as Data
+    let offset = data.startIndex + y * bitmap.bytesPerRow + x * 4
+
+    guard data.indices.contains(offset + 3) else {
+        return nil
+    }
+
+    let alpha = CGFloat(data[offset + 3]) / 255
+
+    guard alpha > 0 else {
+        return .clear
+    }
+
+    // The bitmap is premultiplied, so divide the alpha back out of each color component.
+    func component(_ value: UInt8) -> CGFloat {
+        min(CGFloat(value) / 255 / alpha, 1)
+    }
+
+    return CocoaColor(
+        red: component(data[offset]),
+        green: component(data[offset + 1]),
+        blue: component(data[offset + 2]),
+        alpha: alpha
+    )
+}
+
+private func sRGBComponents(of color: CocoaColor) -> [CGFloat]? {
+    #if WTF_PLATFORM_IOS_FAMILY
+    let cgColor = color.cgColor
+    #else
+    guard let cgColor = color.usingColorSpace(.sRGB)?.cgColor else {
+        return nil
+    }
+    #endif
+
+    guard
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB),
+        let converted = cgColor.converted(to: colorSpace, intent: .defaultIntent, options: nil),
+        let components = converted.components, components.count == 4
+    else {
+        return nil
+    }
+
+    return components
+}
+
+@objc
+@implementation
+extension TestCocoaImageUtilities {
+    @objc(performWithDarkAppearance:block:)
+    class func perform(darkAppearance: Bool, block: () -> Void) {
+        #if WTF_PLATFORM_IOS_FAMILY
+        let style: UIUserInterfaceStyle = darkAppearance ? .dark : .light
+
+        UITraitCollection(userInterfaceStyle: style).performAsCurrent(block)
+        #else
+        let name: NSAppearance.Name = darkAppearance ? .darkAqua : .aqua
+
+        guard let appearance = NSAppearance(named: name) else {
+            preconditionFailure("Could not create the \(name.rawValue) appearance.")
+        }
+
+        appearance.performAsCurrentDrawingAppearance(block)
+        #endif
+    }
+
+    class func pngData(size: CGSize, color: CocoaColor) -> Data {
+        #if WTF_PLATFORM_IOS_FAMILY
+        let format = UIGraphicsImageRendererFormat.preferred()
+        format.scale = 1
+        format.opaque = false
+        format.preferredRange = .standard
+
+        return UIGraphicsImageRenderer(size: size, format: format)
+            .pngData { context in
+                color.setFill()
+                context.fill(CGRect(origin: .zero, size: size))
+            }
+        #else
+        let image = NSImage(size: size)
+
+        image.lockFocus()
+        color.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        image.unlockFocus()
+
+        guard let cgImage = unsafe image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            preconditionFailure("Could not get a bitmap for a \(size) image that was just drawn.")
+        }
+
+        let representation = NSBitmapImageRep(cgImage: cgImage)
+        representation.size = size
+
+        guard let data = representation.representation(using: .png, properties: [:]) else {
+            preconditionFailure("Could not encode a \(size) image that was just drawn.")
+        }
+
+        return data
+        #endif
+    }
+
+    @objc(pixelColorOfImage:atPoint:)
+    class func pixelColor(of image: CocoaImage, at point: CGPoint) -> CocoaColor? {
+        #if WTF_PLATFORM_IOS_FAMILY
+        let image = image.imageAsset?.image(with: .current) ?? image
+        #endif
+
+        guard
+            let x = Int(exactly: point.x.rounded(.down)),
+            let y = Int(exactly: point.y.rounded(.down)),
+            let bitmap = makeBitmap(
+                size: image.size,
+                draw: {
+                    #if WTF_PLATFORM_IOS_FAMILY
+                    image.draw(at: .zero)
+                    #else
+                    image.draw(in: CGRect(origin: .zero, size: image.size))
+                    #endif
+                }
+            )
+        else {
+            return nil
+        }
+
+        return sampleColor(of: bitmap, atX: x, y: y)
+    }
+
+    @objc(compareColor:toColor:tolerance:)
+    class func compareColors(_ color: CocoaColor?, _ otherColor: CocoaColor?, tolerance: CGFloat) -> Bool {
+        if color === otherColor {
+            return true
+        }
+
+        guard let color, let otherColor else {
+            return false
+        }
+
+        if color.isEqual(otherColor) {
+            return true
+        }
+
+        guard
+            let components = sRGBComponents(of: color),
+            let otherComponents = sRGBComponents(of: otherColor)
+        else {
+            return false
+        }
+
+        return zip(components, otherComponents).allSatisfy { abs($0.0 - $0.1) < tolerance }
+    }
+}

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestPDFDocument.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestPDFDocument.swift
@@ -34,10 +34,8 @@ private import TestWebKitAPILibrary.Helpers.cocoa.TestPDFDocument
 
 #if WTF_PLATFORM_IOS_FAMILY
 import UIKit
-typealias CocoaColor = UIColor
 #else
 import AppKit
-typealias CocoaColor = NSColor
 #endif
 
 @objc

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm
@@ -31,6 +31,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#import "Helpers/cocoa/TestCocoaImageUtilities.h"
 #import "Helpers/cocoa/TestWebExtensionsDelegate.h"
 #import "Helpers/cocoa/WebExtensionUtilities.h"
 #import <WebKit/WKPreferencesPrivate.h>
@@ -1041,44 +1042,15 @@ void loadAndRunExtension(NSDictionary *manifest, NSDictionary *resources, WKWebE
 NSData *makePNGData(CGSize size, SEL colorSelector)
 {
 #if USE(APPKIT)
-    RetainPtr image = adoptNS([[NSImage alloc] initWithSize:size]);
-
-    [image lockFocus];
-
-    [[NSColor performSelector:colorSelector] setFill];
-    NSRectFill(NSMakeRect(0, 0, size.width, size.height));
-
-    [image unlockFocus];
-
-    auto cgImageRef = [image CGImageForProposedRect:NULL context:nil hints:nil];
-    RetainPtr newImageRep = adoptNS([[NSBitmapImageRep alloc] initWithCGImage:cgImageRef]);
-    newImageRep.get().size = size;
-
-    return [newImageRep representationUsingType:NSBitmapImageFileTypePNG properties:@{ }];
+    return [TestCocoaImageUtilities pngDataWithSize:size color:[NSColor performSelector:colorSelector]];
 #else
-    UIGraphicsBeginImageContextWithOptions(size, NO, 1.0);
-
-    [[UIColor performSelector:colorSelector] setFill];
-    UIRectFill(CGRectMake(0, 0, size.width, size.height));
-
-    auto *image = UIGraphicsGetImageFromCurrentImageContext();
-
-    UIGraphicsEndImageContext();
-
-    return UIImagePNGRepresentation(image);
+    return [TestCocoaImageUtilities pngDataWithSize:size color:[UIColor performSelector:colorSelector]];
 #endif
 }
 
 void performWithAppearance(Appearance appearance, void (^block)(void))
 {
-#if USE(APPKIT)
-    auto *appearanceName = appearance == Appearance::Dark ? NSAppearanceNameDarkAqua : NSAppearanceNameAqua;
-    [[NSAppearance appearanceNamed:appearanceName] performAsCurrentDrawingAppearance:block];
-#else
-    auto *traitCollection = appearance == Appearance::Dark ? [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark]
-        : [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight];
-    [traitCollection performAsCurrentTraitCollection:block];
-#endif
+    [TestCocoaImageUtilities performWithDarkAppearance:appearance == Appearance::Dark block:block];
 }
 
 } // namespace Util

--- a/Tools/TestWebKitAPI/Helpers/ios/UserInterfaceSwizzler.h
+++ b/Tools/TestWebKitAPI/Helpers/ios/UserInterfaceSwizzler.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#ifdef __cplusplus
+#if defined(__cplusplus) && !defined(__swift__)
 
 #if PLATFORM(IOS_FAMILY)
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -608,6 +608,7 @@
 			membershipExceptions = (
 				"cocoa/AppKit+Extras.swift",
 				"cocoa/Bundle+Extras.swift",
+				cocoa/CocoaTypes.swift,
 				"cocoa/Foundation+Extras.swift",
 				cocoa/HTTPServer.mm,
 				cocoa/HTTPServer.swift,
@@ -619,6 +620,7 @@
 				cocoa/StdLibExtras.swift,
 				"cocoa/SwiftUI+Extras.swift",
 				cocoa/TestCocoaImageAndCocoaColor.mm,
+				cocoa/TestCocoaImageUtilities.swift,
 				cocoa/TestContextMenuDriver.mm,
 				cocoa/TestElementFullscreenDelegate.mm,
 				cocoa/TestNSBundleExtras.m,


### PR DESCRIPTION
#### 5c19c2e2cbcd3a6dfafb1d0ce0ef48fa940df166
<pre>
[Swift Testing] Add some image/color utility functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=323835">https://bugs.webkit.org/show_bug.cgi?id=323835</a>
<a href="https://rdar.apple.com/187070154">rdar://187070154</a>

Reviewed by Abrar Rahman Protyasha.

Expose some existing C++ helpers in Swift.

* Tools/TestWebKitAPI/Helpers/cocoa/CocoaTypes.swift: Added.
* Tools/TestWebKitAPI/Helpers/cocoa/TestPDFDocument.swift:

Expose CocoaColor and CocoaImage type aliases.

* Tools/TestWebKitAPI/Helpers/cocoa/TestCocoa.h:

Ignore this file in Swift because it causes conflicts and is useless too.

* Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageAndCocoaColor.mm:
(TestWebKitAPI::Util::pixelColor):
(TestWebKitAPI::Util::compareColors):
* Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageUtilities.h: Added.
* Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageUtilities.swift: Added.
(Appearance.withAppearance(_:_:)):
(Appearance.makePNGData(_:color:)):
(Appearance.pixelColor(of:at:)):
(Appearance.compareColors(_:_:tolerance:)):
(CocoaImage.isSymbol):
(TestCocoaImageUtilities.pngData(_:color:)):
(TestCocoaImageUtilities.pixelColor(of:at:)):
(TestCocoaImageUtilities.compareColors(_:_:tolerance:)):

Re-implement and expose these functions in Swift.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/320807@main">https://commits.webkit.org/320807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a238ba84272979bdd187c6d51abf482b838adafa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185959 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196256 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1bd9e5bf-3f23-42ef-986f-a9944c986b69) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187821 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59579 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145311 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1e029d84-b04a-4c88-b048-5afe2623419d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125624 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/926311e7-5979-4c67-8e68-ebcbe5cbbf46) 
| [⏳ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47727 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158083 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45450 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7328 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198231 "Built successfully") | | 
| [⏳ 🧪 services](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59517 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154871 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41478 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60226 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154517 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48965 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129574 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58677 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58064 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58294 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58121 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->