### PR TITLE
Factor out duplicated convertToColorSpace function

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp
@@ -305,6 +305,25 @@ WGPUPowerPreference ConvertToBackingContext::convertToBacking(PowerPreference po
     }
 }
 
+WGPUColorSpace ConvertToBackingContext::convertToBacking(PredefinedColorSpace colorSpace)
+{
+    switch (colorSpace) {
+    case PredefinedColorSpace::SRGB:
+        return WGPUColorSpace::SRGB;
+    case PredefinedColorSpace::SRGBLinear:
+        return WGPUColorSpace::SRGBLinear;
+#if ENABLE(PREDEFINED_COLOR_SPACE_DISPLAY_P3)
+    case PredefinedColorSpace::DisplayP3:
+        return WGPUColorSpace::DisplayP3;
+    case PredefinedColorSpace::DisplayP3Linear:
+        return WGPUColorSpace::DisplayP3Linear;
+#endif
+    }
+
+    ASSERT_NOT_REACHED();
+    return WGPUColorSpace::SRGB;
+}
+
 WGPUPrimitiveTopology ConvertToBackingContext::convertToBacking(PrimitiveTopology primitiveTopology)
 {
     switch (primitiveTopology) {

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.h
@@ -34,6 +34,7 @@
 #include "WebGPUMapMode.h"
 #include "WebGPUOrigin2D.h"
 #include "WebGPUOrigin3D.h"
+#include "WebGPUPredefinedColorSpace.h"
 #include "WebGPUShaderStage.h"
 #include "WebGPUTextureUsage.h"
 #include <WebGPU/WebGPU.h>
@@ -123,6 +124,7 @@ public:
     WGPUIndexFormat convertToBacking(IndexFormat);
     WGPULoadOp convertToBacking(LoadOp);
     WGPUPowerPreference convertToBacking(PowerPreference);
+    WGPUColorSpace NODELETE convertToBacking(PredefinedColorSpace);
     WGPUPrimitiveTopology convertToBacking(PrimitiveTopology);
     WGPUQueryType convertToBacking(QueryType);
     WGPUSamplerBindingType convertToBacking(SamplerBindingType);

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -167,25 +167,6 @@ RefPtr<Sampler> DeviceImpl::createSampler(const SamplerDescriptor& descriptor)
     return SamplerImpl::create(adoptWebGPU(wgpuDeviceCreateSampler(m_backing.get(), &backingDescriptor)), convertToBackingContext);
 }
 
-static WGPUColorSpace NODELETE convertToWGPUColorSpace(const PredefinedColorSpace& colorSpace)
-{
-    switch (colorSpace) {
-    case PredefinedColorSpace::SRGB:
-        return WGPUColorSpace::SRGB;
-    case PredefinedColorSpace::SRGBLinear:
-        return WGPUColorSpace::SRGBLinear;
-#if ENABLE(PREDEFINED_COLOR_SPACE_DISPLAY_P3)
-    case PredefinedColorSpace::DisplayP3:
-        return WGPUColorSpace::DisplayP3;
-    case PredefinedColorSpace::DisplayP3Linear:
-        return WGPUColorSpace::DisplayP3Linear;
-#endif
-    }
-
-    ASSERT_NOT_REACHED();
-    return WGPUColorSpace::SRGB;
-}
-
 void DeviceImpl::updateExternalTexture(const WebCore::WebGPU::ExternalTexture&, const WebCore::MediaPlayerIdentifier&)
 {
     RELEASE_ASSERT_NOT_REACHED();
@@ -199,7 +180,7 @@ RefPtr<ExternalTexture> DeviceImpl::importExternalTexture(const ExternalTextureD
     WGPUExternalTextureDescriptor backingDescriptor {
         .label = label.data(),
         .pixelBuffer = pixelBuffer ? pixelBuffer->get() : nullptr,
-        .colorSpace = convertToWGPUColorSpace(descriptor.colorSpace),
+        .colorSpace = m_convertToBackingContext->convertToBacking(descriptor.colorSpace),
     };
     return ExternalTextureImpl::create(adoptWebGPU(wgpuDeviceImportExternalTexture(m_backing.get(), &backingDescriptor)), descriptor, m_convertToBackingContext);
 }

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp
@@ -83,25 +83,6 @@ static WGPUCompositeAlphaMode NODELETE convertToAlphaMode(WebCore::WebGPU::Canva
     return WGPUCompositeAlphaMode_Premultiplied;
 }
 
-static WGPUColorSpace NODELETE convertToColorSpace(PredefinedColorSpace colorSpace)
-{
-    switch (colorSpace) {
-    case PredefinedColorSpace::SRGB:
-        return WGPUColorSpace::SRGB;
-    case PredefinedColorSpace::SRGBLinear:
-        return WGPUColorSpace::SRGBLinear;
-#if ENABLE(PREDEFINED_COLOR_SPACE_DISPLAY_P3)
-    case PredefinedColorSpace::DisplayP3:
-        return WGPUColorSpace::DisplayP3;
-    case PredefinedColorSpace::DisplayP3Linear:
-        return WGPUColorSpace::DisplayP3Linear;
-#endif
-    }
-
-    ASSERT_NOT_REACHED();
-    return WGPUColorSpace::SRGB;
-}
-
 bool PresentationContextImpl::configure(const CanvasConfiguration& canvasConfiguration)
 {
     m_swapChain = nullptr;
@@ -120,7 +101,7 @@ bool PresentationContextImpl::configure(const CanvasConfiguration& canvasConfigu
         .viewFormats = canvasConfiguration.viewFormats.map([&](auto colorFormat) {
             return convertToBackingContext->convertToBacking(colorFormat);
         }),
-        .colorSpace = convertToColorSpace(canvasConfiguration.colorSpace),
+        .colorSpace = convertToBackingContext->convertToBacking(canvasConfiguration.colorSpace),
         .toneMappingMode = convertToToneMappingMode(canvasConfiguration.toneMappingMode),
         .compositeAlphaMode = convertToAlphaMode(canvasConfiguration.compositingAlphaMode),
         .reportValidationErrors = canvasConfiguration.reportValidationErrors

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
@@ -261,30 +261,12 @@ void QueueImpl::copyExternalImageToTexture(
         backingSource.colorSpace = sourceImageBuffer->colorSpace() == ColorSpace::DisplayP3() ? WGPUColorSpace::DisplayP3 : WGPUColorSpace::SRGB;
     }
 
-    auto convertToColorSpace = [] (PredefinedColorSpace colorSpace) {
-        switch (colorSpace) {
-        case PredefinedColorSpace::SRGB:
-            return WGPUColorSpace::SRGB;
-        case PredefinedColorSpace::SRGBLinear:
-            return WGPUColorSpace::SRGBLinear;
-#if ENABLE(PREDEFINED_COLOR_SPACE_DISPLAY_P3)
-        case PredefinedColorSpace::DisplayP3:
-            return WGPUColorSpace::DisplayP3;
-        case PredefinedColorSpace::DisplayP3Linear:
-            return WGPUColorSpace::DisplayP3Linear;
-#endif
-        }
-
-        ASSERT_NOT_REACHED();
-        return WGPUColorSpace::SRGB;
-    };
-
     WGPUImageCopyTextureTagged backingDestination {
         .texture = convertToBackingContext->convertToBacking(protect(destination.texture)),
         .mipLevel = destination.mipLevel,
         .origin = destination.origin ? convertToBackingContext->convertToBacking(*destination.origin) : WGPUOrigin3D { 0, 0, 0 },
         .aspect = convertToBackingContext->convertToBacking(destination.aspect),
-        .colorSpace = convertToColorSpace(destination.colorSpace),
+        .colorSpace = convertToBackingContext->convertToBacking(destination.colorSpace),
         .premultipliedAlpha = destination.premultipliedAlpha,
     };
 


### PR DESCRIPTION
#### 965bde9fd2a8a6aba855793ba4a94816228b56f3
<pre>
Factor out duplicated convertToColorSpace function
<a href="https://bugs.webkit.org/show_bug.cgi?id=323837">https://bugs.webkit.org/show_bug.cgi?id=323837</a>
<a href="https://rdar.apple.com/187072036">rdar://187072036</a>

Reviewed by David Kilzer.

Factor out duplicated code into ConvertToBackingContext

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.cpp:
(WebCore::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUConvertToBackingContext.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUPresentationContextImpl.cpp:
(WebCore::WebGPU::PresentationContextImpl::configure):
(WebCore::WebGPU::convertToColorSpace): Deleted.
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp:
(WebCore::WebGPU::QueueImpl::copyExternalImageToTexture):

Canonical link: <a href="https://commits.webkit.org/320793@main">https://commits.webkit.org/320793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1893414834aef45f1c459d36197722b29abd9922

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59850 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53644 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196248 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187813 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59571 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48992 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/125618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47720 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/158076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/45444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7320 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/50162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198223 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59509 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/165379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154865 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41466 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60218 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/154511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48960 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129564 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58056 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58286 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58114 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->