### PR TITLE
[JSC] `RegExp::deleteCode()` should not clear the pattern's atom

### DIFF
--- a/JSTests/stress/regexp-cached-result-one-character-atom-delete-all-code.js
+++ b/JSTests/stress/regexp-cached-result-one-character-atom-delete-all-code.js
@@ -1,0 +1,39 @@
+//@ requireOptions("--useDollarVM=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`);
+}
+
+let re = /x/g;
+
+let cases = [
+    ["aaxbbxcc", 2, "aaxbb", "cc"],
+    ["aaxbbx\0\0", 2, "aaxbb", "\0\0"],
+    ["aaxbbあxcc", 2, "aaxbbあ", "cc"],
+    [("_".repeat(64) + "aaxbb".repeat(10) + "xcc" + "_".repeat(64)).substring(64, 117), 11, "aaxbb".repeat(10), "cc"],
+];
+
+let index = 0;
+let expected = null;
+
+function step() {
+    if (expected) {
+        let [leftContext, rightContext] = expected;
+        shouldBe(RegExp.$1, "");
+        shouldBe(RegExp.lastParen, "");
+        shouldBe(RegExp.lastMatch, "x");
+        shouldBe(RegExp.leftContext, leftContext);
+        shouldBe(RegExp.rightContext, rightContext);
+    }
+    if (index === cases.length)
+        return;
+    let [input, count, leftContext, rightContext] = cases[index++];
+    re.test("zzx");
+    shouldBe(input.match(re).length, count);
+    expected = [leftContext, rightContext];
+    $vm.deleteAllCodeWhenIdle();
+    setTimeout(step, 0);
+}
+
+step();

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -458,8 +458,6 @@ void RegExp::deleteCode()
         return;
     m_state = NotCompiled;
     m_minimumSize = 0;
-    m_atom = String();
-    m_specificPattern = Yarr::SpecificPattern::None;
 #if ENABLE(YARR_JIT)
     if (m_regExpJITCode)
         m_regExpJITCode->clear(locker);


### PR DESCRIPTION
#### e19f57a779e161677336853feda3360b51802205
<pre>
[JSC] `RegExp::deleteCode()` should not clear the pattern&apos;s atom
<a href="https://bugs.webkit.org/show_bug.cgi?id=323838">https://bugs.webkit.org/show_bug.cgi?id=323838</a>

Reviewed by Yusuke Suzuki.

m_atom and m_specificPattern depend only on the pattern, like
m_numSubpatterns and m_rareData which deleteCode() already keeps, so stop
clearing them.

Test: JSTests/stress/regexp-cached-result-one-character-atom-delete-all-code.js

* JSTests/stress/regexp-cached-result-one-character-atom-delete-all-code.js: Added.
(shouldBe):
(step):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::deleteCode):

Canonical link: <a href="https://commits.webkit.org/320817@main">https://commits.webkit.org/320817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da0e4c6adf507ad19bbcfd47e52fcd53b9ddf324

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196252 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150590 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145308 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100732 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/48995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165856 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125620 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47723 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45736 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7492 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14376 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45445 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7324 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47198 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198227 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59513 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154868 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41483 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60222 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154514 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48962 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129568 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58673 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58060 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58290 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58117 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->