### PR TITLE
SampleMap size accounting drifts on a duplicate presentation timestamp

### DIFF
--- a/Source/WebCore/Modules/mediasource/SampleMap.cpp
+++ b/Source/WebCore/Modules/mediasource/SampleMap.cpp
@@ -112,9 +112,13 @@ void SampleMap::addSample(Ref<MediaSample>&& sample)
 {
     MediaTime presentationTime = sample->presentationTime();
 
-    m_totalSize += sample->sizeInBytes();
+    // Bail if a sample is already occupying this presentation time; accounting
+    // for it would drift m_totalSize and desync the presentation and decode maps.
+    auto insertResult = presentationOrder().m_samples.insert(PresentationOrderSampleMap::MapType::value_type(presentationTime, sample));
+    if (!insertResult.second)
+        return;
 
-    presentationOrder().m_samples.insert(PresentationOrderSampleMap::MapType::value_type(presentationTime, sample));
+    m_totalSize += sample->sizeInBytes();
 
     auto decodeKey = DecodeOrderSampleMap::KeyType(sample->decodeTime(), presentationTime);
     decodeOrder().m_samples.insert(DecodeOrderSampleMap::MapType::value_type(decodeKey, WTF::move(sample)));

--- a/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp
@@ -48,9 +48,9 @@ namespace TestWebKitAPI {
 
 class TestSample : public MediaSample {
 public:
-    static Ref<TestSample> create(const MediaTime& presentationTime, const MediaTime& decodeTime, const MediaTime& duration, SampleFlags flags)
+    static Ref<TestSample> create(const MediaTime& presentationTime, const MediaTime& decodeTime, const MediaTime& duration, SampleFlags flags, size_t sizeInBytes = 0)
     {
-        return adoptRef(*new TestSample(presentationTime, decodeTime, duration, flags));
+        return adoptRef(*new TestSample(presentationTime, decodeTime, duration, flags, sizeInBytes));
     }
 
     MediaTime presentationTime() const final { return m_presentationTime; }
@@ -74,10 +74,11 @@ public:
     void dump(PrintStream&) const final { }
 
 private:
-    TestSample(const MediaTime& presentationTime, const MediaTime& decodeTime, const MediaTime& duration, SampleFlags flags)
+    TestSample(const MediaTime& presentationTime, const MediaTime& decodeTime, const MediaTime& duration, SampleFlags flags, size_t sizeInBytes)
         : m_presentationTime(presentationTime)
         , m_decodeTime(decodeTime)
         , m_duration(duration)
+        , m_sizeInBytes(sizeInBytes)
         , m_flags(flags)
     {
     }
@@ -373,6 +374,39 @@ TEST_F(SampleMapTest, findSamplesBetweenDecodeKeysWithNaN)
 
     auto samplesWithHigherDecodeTimes = decodeMap.findSamplesBetweenDecodeKeys(decodeKey, mapWithNan.decodeOrder().rbegin()->first);
     EXPECT_TRUE(samplesWithHigherDecodeTimes.isEmpty());
+}
+
+TEST_F(SampleMapTest, addSampleRejectsDuplicatePresentationTime)
+{
+    SampleMap localMap;
+    localMap.addSample(TestSample::create(MediaTime(0, 1), MediaTime(0, 1), MediaTime(1, 1), MediaSample::IsSync, 100));
+    localMap.addSample(TestSample::create(MediaTime(1, 1), MediaTime(1, 1), MediaTime(1, 1), MediaSample::None, 200));
+
+    EXPECT_EQ(2u, localMap.size());
+    EXPECT_EQ(2u, localMap.presentationOrder().size());
+    EXPECT_EQ(2u, localMap.decodeOrder().size());
+    EXPECT_EQ(300u, localMap.sizeInBytes());
+
+    // A second sample sharing an existing presentation time must be rejected
+    // wholesale: neither map may grow and the byte total must not drift.
+    localMap.addSample(TestSample::create(MediaTime(1, 1), MediaTime(5, 1), MediaTime(1, 1), MediaSample::None, 999));
+
+    EXPECT_EQ(2u, localMap.size());
+    EXPECT_EQ(2u, localMap.presentationOrder().size());
+    EXPECT_EQ(2u, localMap.decodeOrder().size());
+    EXPECT_EQ(300u, localMap.sizeInBytes());
+
+    // The originally-stored sample (decode time 1) must be the one retained.
+    auto iterator = localMap.presentationOrder().findSampleWithPresentationTime(MediaTime(1, 1));
+    ASSERT_TRUE(localMap.presentationOrder().end() != iterator);
+    EXPECT_EQ(MediaTime(1, 1), iterator->second->decodeTime());
+
+    // Removing a stored sample balances the accounting back out; no residual drift.
+    localMap.removeSample(iterator->second.get());
+    EXPECT_EQ(1u, localMap.size());
+    EXPECT_EQ(1u, localMap.presentationOrder().size());
+    EXPECT_EQ(1u, localMap.decodeOrder().size());
+    EXPECT_EQ(100u, localMap.sizeInBytes());
 }
 
 }


### PR DESCRIPTION
#### 21f5592d43e74580b6885078801a3091ee71e334
<pre>
SampleMap size accounting drifts on a duplicate presentation timestamp
<a href="https://bugs.webkit.org/show_bug.cgi?id=323840">https://bugs.webkit.org/show_bug.cgi?id=323840</a>
<a href="https://rdar.apple.com/187079069">rdar://187079069</a>

Reviewed by NOBODY (OOPS!).

SampleMap::addSample() incremented m_totalSize and then inserted into two
unique-key maps whose insert() is a silent no-op on a duplicate key. A
colliding presentation timestamp therefore left m_totalSize (and the
decode map) counting a sample that was never fully stored, desynchronizing
the two maps and permanently inflating sizeInBytes().

Guard on the presentation-map insert: only account for and store the
sample when it is actually inserted. Because the decode key embeds the
presentation time, guarding the presentation insert keeps both maps
consistent.

Test: Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp

* Source/WebCore/Modules/mediasource/SampleMap.cpp:
(WebCore::SampleMap::addSample):
* Tools/TestWebKitAPI/Tests/WebCore/SampleMap.cpp:
(TestWebKitAPI::TestSample::create):
(TestWebKitAPI::TestSample::TestSample):
(TestWebKitAPI::TEST_F(SampleMapTest, addSampleRejectsDuplicatePresentationTime)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21f5592d43e74580b6885078801a3091ee71e334

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196262 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150596 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/dd97a07b-4254-426d-bb54-a3e5b4a1a31d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187827 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145318 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100739 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ca5013ee-7372-46cf-8128-3df67678a7d4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125632 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d1801093-1a38-495b-a974-831a26e7ed0f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47730 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45739 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45455 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7334 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52448 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198237 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59523 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154873 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60232 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42053 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154519 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48970 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132572 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129581 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58680 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20460 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58070 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58300 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58127 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->