### PR TITLE
MediaStream video-layer KVO bounds observer is not removed from the old root layer when the layer is recreated

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -97,6 +97,7 @@
 - (void)begin:(CALayer*) layer
 {
     ASSERT(_callback);
+    [self stop];
     _rootLayer = layer;
     [_rootLayer addObserver:self forKeyPath:@"bounds" options:NSKeyValueObservingOptionNew context:nil];
 }


### PR DESCRIPTION
#### 7fcc238713a47d2e0634069b9edd92b8c2bc5a02
<pre>
MediaStream video-layer KVO bounds observer is not removed from the old root layer when the layer is recreated
<a href="https://bugs.webkit.org/show_bug.cgi?id=323843">https://bugs.webkit.org/show_bug.cgi?id=323843</a>
<a href="https://rdar.apple.com/187081705">rdar://187081705</a>

Reviewed by NOBODY (OOPS!).

WebRootSampleBufferBoundsChangeListener adds a KVO observer for the root
layer&apos;s &quot;bounds&quot; in -begin: and removes it in -stop. On layer recreation
-begin: is reached again without an intervening -stop, so the observer on
the previous root layer is never removed:

  - layersAreInitialized() calls [m_boundsChangeListener begin:layerA].
  - destroyLayers() clears m_sampleBufferDisplayLayer but does not stop
    the listener; the observer stays registered and _rootLayer keeps
    layerA alive.
  - The next begin: overwrites _rootLayer with layerB without removing
    the observer from layerA, so dropping layerA&apos;s last reference
    deallocates it while still observed.

This leaks the KVO registration and, when layerA deallocates, yields
Foundation&apos;s &quot;deallocated while key value observers were still
registered&quot; and a potential crash. The path runs on ordinary
MediaStream/WebRTC layer churn (track enable/disable).

Fix by making -begin: self-balancing: call -stop before overwriting
_rootLayer. -stop&apos;s null check keeps the first -begin: a no-op, so
add/remove are paired on every path. Balancing in -begin: (rather than
destroyLayers()) suffices: the _rootLayer RetainPtr keeps the old layer
alive until the next -begin:, and pure-teardown is covered by the
destructor&apos;s -invalidate.

No new test: a KVO-registration leak internal to a Cocoa-only Obj-C
helper with no script- or API-visible surface.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(-[WebRootSampleBufferBoundsChangeListener begin:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fcc238713a47d2e0634069b9edd92b8c2bc5a02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196271 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150606 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/77e769bf-42f6-4ea4-ba6b-49695d9396bf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145321 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100745 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c1cc0b66-94fb-4b70-82cd-224f3231e10b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125636 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8ce4ab6d-4adc-418e-ac8e-4ed4ad963060) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47737 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45746 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158093 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45456 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7343 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52454 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50180 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198249 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59532 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154883 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60241 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154528 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48976 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132578 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129595 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58689 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20461 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58079 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58309 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58137 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->