### PR TITLE
Adopt Vector::moveTo in TextTrackCueList::updateCueIndex

### DIFF
--- a/Source/WebCore/html/track/TextTrackCueList.cpp
+++ b/Source/WebCore/html/track/TextTrackCueList.cpp
@@ -128,22 +128,18 @@ void TextTrackCueList::clear()
 
 void TextTrackCueList::updateCueIndex(const TextTrackCue& cue)
 {
-    auto vectorSpan = m_vector.mutableSpan();
+    auto vectorSpan = m_vector.span();
     auto cueIndex = this->cueIndex(cue);
     auto valuesUntilCue = vectorSpan.first(cueIndex);
-    auto cuePosition = vectorSpan.subspan(cueIndex).begin();
+    auto& movedCue = vectorSpan[cueIndex];
     auto valuesAfterCue = vectorSpan.subspan(cueIndex + 1);
     ASSERT_SORTED(valuesUntilCue);
     ASSERT_SORTED(valuesAfterCue);
 
-    auto reinsertionPosition = std::ranges::upper_bound(valuesUntilCue, *cuePosition, cueSortsBefore);
-    if (std::to_address(reinsertionPosition) != std::to_address(cuePosition))
-        std::rotate(reinsertionPosition, cuePosition, valuesAfterCue.begin());
-    else {
-        reinsertionPosition = std::ranges::upper_bound(valuesAfterCue, *cuePosition, cueSortsBefore);
-        if (std::to_address(reinsertionPosition) != valuesAfterCue.data())
-            std::rotate(cuePosition, valuesAfterCue.begin(), reinsertionPosition);
-    }
+    if (auto earlier = std::ranges::upper_bound(valuesUntilCue, movedCue, cueSortsBefore); earlier != valuesUntilCue.end())
+        m_vector.moveTo(cueIndex, earlier - valuesUntilCue.begin());
+    else if (auto later = std::ranges::upper_bound(valuesAfterCue, movedCue, cueSortsBefore); later != valuesAfterCue.begin())
+        m_vector.moveTo(cueIndex, cueIndex + (later - valuesAfterCue.begin()));
 
     ASSERT_SORTED(m_vector);
 }


### PR DESCRIPTION
#### 8379f89080920297b5d796680d647b4319dfbed7
<pre>
Adopt Vector::moveTo in TextTrackCueList::updateCueIndex
<a href="https://bugs.webkit.org/show_bug.cgi?id=323844">https://bugs.webkit.org/show_bug.cgi?id=323844</a>
<a href="https://rdar.apple.com/187081956">rdar://187081956</a>

Reviewed by Chris Dumez.

updateCueIndex() repositions a single cue whose sort key changed back into
its sorted slot. It located the target with two upper_bound probes -- one over
the cues before the moved cue, one over those after -- and then shifted the run
between the old and new positions with std::rotate(), plus std::to_address()
bookkeeping to compare the raw iterators against the cue&apos;s current position.

That is exactly the &quot;relocate the element at one index to another&quot; operation
Vector::moveTo() was added for (320527@main). Rewrite updateCueIndex() to keep
the same two upper_bound probes but perform the reposition with a single
moveTo() call per branch: moveTo(cueIndex, earlier) when the cue moved toward
the front, moveTo(cueIndex, cueIndex + offset) when it moved toward the back.
Both computed positions are in bounds and differ from cueIndex, so moveTo()&apos;s
bounds and same-position handling apply. Since Ref&lt;TextTrackCue&gt; moves with
memcpy, moveTo() collapses to one bounded memmove instead of std::rotate()&apos;s
swap sequence.

Reading is now done through a const span() rather than mutableSpan() with a raw
cuePosition iterator, since moveTo() owns the mutation.

* Source/WebCore/html/track/TextTrackCueList.cpp:
(WebCore::TextTrackCueList::updateCueIndex):

Canonical link: <a href="https://commits.webkit.org/320897@main">https://commits.webkit.org/320897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/859c6cf80ac4e7fd997df493245d7907d5c9344c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196272 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150607 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9c968cbb-1241-4639-8332-99670116f994) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187841 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145323 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100746 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c33f8cf8-f26f-4106-bb66-d7553f4615ae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49010 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125638 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/4ca5eb74-1440-428e-9738-8d087b9cb524) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47738 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45747 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158094 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45458 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7344 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198250 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59533 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154884 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41545 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60242 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154529 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48977 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132579 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129597 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58690 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20463 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58080 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58310 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58138 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->