### PR TITLE
Media controls scrubber never draws the buffered time range

### DIFF
--- a/LayoutTests/media/modern-media-controls/slider/slider-secondary-value-expected.txt
+++ b/LayoutTests/media/modern-media-controls/slider/slider-secondary-value-expected.txt
@@ -1,0 +1,19 @@
+Testing that the Slider draws its secondary value (e.g. the buffered time range).
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+The primary fill covers the played portion (value = 0.5):
+PASS primaryStyle.width is "100px"
+
+The track covers the remaining portion:
+PASS trackStyle.width is "100px"
+
+The secondary fill is drawn inside the track, spanning from the value (0.5) to the secondary value (0.75):
+PASS secondaryStyle.width is "50px"
+PASS secondaryStyle.height is "5px"
+PASS secondaryStyle.backgroundColor is "rgba(255, 255, 255, 0.08)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/slider/slider-secondary-value.html
+++ b/LayoutTests/media/modern-media-controls/slider/slider-secondary-value.html
@@ -1,0 +1,45 @@
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/media-controls-utils.js" type="text/javascript"></script>
+<script src="../resources/media-controls-loader.js" type="text/javascript"></script>
+<body>
+<script type="text/javascript">
+
+description("Testing that the <code>Slider</code> draws its secondary value (e.g. the buffered time range).");
+
+window.jsTestIsAsync = true;
+
+const layoutDelegate = null;
+
+const slider = new Slider(layoutDelegate);
+slider.width = 200;
+slider.height = 25;
+slider.value = 0.5;
+slider.secondaryValue = 0.75;
+
+let primaryStyle, trackStyle, secondaryStyle;
+scheduler.frameDidFire = function()
+{
+    document.body.appendChild(slider.element);
+
+    primaryStyle = window.getComputedStyle(slider.element.querySelector(".primary"));
+    trackStyle = window.getComputedStyle(slider.element.querySelector(".track"));
+    secondaryStyle = window.getComputedStyle(slider.element.querySelector(".track > .secondary"));
+
+    debug("The primary fill covers the played portion (value = 0.5):");
+    shouldBeEqualToString("primaryStyle.width", "100px");
+
+    debug("");
+    debug("The track covers the remaining portion:");
+    shouldBeEqualToString("trackStyle.width", "100px");
+
+    debug("");
+    debug("The secondary fill is drawn inside the track, spanning from the value (0.5) to the secondary value (0.75):");
+    shouldBeEqualToString("secondaryStyle.width", "50px");
+    shouldBeEqualToString("secondaryStyle.height", "5px");
+    shouldBeEqualToString("secondaryStyle.backgroundColor", "rgba(255, 255, 255, 0.08)");
+
+    finishMediaControlsTest();
+}
+
+</script>
+</body>

--- a/Source/WebCore/Modules/modern-media-controls/controls/slider.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/slider.css
@@ -93,7 +93,8 @@
     background-color: rgb(102, 102, 102);
 }
 
-.slider.default > .appearance > .fill > .secondary {
+.slider.default > .appearance > .fill > .track > .secondary {
+    height: 100%;
     background-color: rgba(255, 255, 255, 0.08);
 }
 
@@ -127,6 +128,6 @@
 /* When disabled, we only want to show the track and turn off interaction. */
 
 .slider.default.disabled > .appearance > .fill > .primary,
-.slider.default.disabled > .appearance > .fill > .secondary {
+.slider.default.disabled > .appearance > .fill > .track > .secondary {
     display: none;
 }

--- a/Source/WebCore/Modules/modern-media-controls/controls/slider.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/slider.js
@@ -71,8 +71,21 @@ class Slider extends SliderBase
     {
         super.commit();
 
-        this._primaryFill.element.style.flexGrow = 100 * this.value;
-        this._trackFill.element.style.flexGrow = 100 * (1 - this.value);
+        const value = this.value;
+        const secondaryValue = this.secondaryValue;
+
+        if (value === this._committedValue && secondaryValue === this._committedSecondaryValue)
+            return;
+
+        this._committedValue = value;
+        this._committedSecondaryValue = secondaryValue;
+
+        this._primaryFill.element.style.flexGrow = 100 * value;
+        this._trackFill.element.style.flexGrow = 100 * (1 - value);
+
+        const remaining = 1 - value;
+        const secondaryFraction = remaining > 0 ? Math.max(0, Math.min(1, (secondaryValue - value) / remaining)) : 0;
+        this._secondaryFill.element.style.width = `${100 * secondaryFraction}%`;
     }
 
 }

--- a/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css
@@ -76,7 +76,7 @@
 }
 
 .media-controls.fullscreen.tvos .slider.default.disabled > .appearance > .fill > .primary,
-.media-controls.fullscreen.tvos .slider.default.disabled > .appearance > .fill > .secondary {
+.media-controls.fullscreen.tvos .slider.default.disabled > .appearance > .fill > .track > .secondary {
     display: initial;
 }
 


### PR DESCRIPTION
#### 676a4d6ab743efb237c67f9db21d6e7d7f85e5c6
<pre>
Media controls scrubber never draws the buffered time range
<a href="https://bugs.webkit.org/show_bug.cgi?id=323847">https://bugs.webkit.org/show_bug.cgi?id=323847</a>
<a href="https://rdar.apple.com/187083940">rdar://187083940</a>

Reviewed by NOBODY (OOPS!).

ScrubbingSupport computes the buffered time range and stores it on the
scrubber via Slider.secondaryValue, but the buffered bar is never drawn.
The flexbox refactor in <a href="https://commits.webkit.org/299348@main">299348@main</a> moved the secondary fill element
inside the track, dropped the code in Slider.commit() that sized it, and
left the &quot;&gt; .fill &gt; .secondary&quot; style rules matching the old sibling
position, so they no longer match the now-nested element. As a result
the secondary fill has no width, no height, and no background, and every
secondaryValue change schedules a layout that produces no visible output.

Size the secondary fill in Slider.commit() to cover the region between
the current value and the secondary value as a fraction of the track&apos;s
width, and retarget the &quot;&gt; .fill &gt; .track &gt; .secondary&quot; style rules to
match the element&apos;s actual position. Also cache the committed value and
secondary value so the fill styles are only rewritten when one of them
actually changes.

* Source/WebCore/Modules/modern-media-controls/controls/slider.css:
(.slider.default &gt; .appearance &gt; .fill &gt; .track &gt; .secondary):
(.slider.default.disabled &gt; .appearance &gt; .fill &gt; .primary,):
(.slider.default &gt; .appearance &gt; .fill &gt; .secondary): Deleted.
* Source/WebCore/Modules/modern-media-controls/controls/slider.js:
(Slider.prototype.commit):
* Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css:
(.media-controls.fullscreen.tvos .slider.default.disabled &gt; .appearance &gt; .fill &gt; .primary,):
* LayoutTests/media/modern-media-controls/slider/slider-secondary-value-expected.txt: Added.
* LayoutTests/media/modern-media-controls/slider/slider-secondary-value.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/676a4d6ab743efb237c67f9db21d6e7d7f85e5c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196275 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150608 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e32d9d08-7986-45a4-a395-0772c30dde54) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187843 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59599 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145326 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100747 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0e7734bd-1413-42a6-bd1b-6e98773a6a9c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165873 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125641 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9f330e9d-c67f-431c-9f23-4504f88f1fa1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47740 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45748 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158095 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45463 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7346 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198252 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59535 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154885 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60244 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154530 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48980 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132580 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129602 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58692 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20466 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58082 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58312 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58140 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->