### PR TITLE
SourceBufferPrivate computes evictable frame size on every append even when the buffer has ample headroom

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-evictable-size-headroom-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-evictable-size-headroom-expected.txt
@@ -1,0 +1,45 @@
+
+RUN(video.disableRemotePlayback = true)
+EVENT(sourceopen)
+EVENT(updateend)
+Appending PTS=0
+EVENT(updateend)
+Appending PTS=1
+EVENT(updateend)
+Appending PTS=2
+EVENT(updateend)
+Appending PTS=3
+EVENT(updateend)
+Appending PTS=4
+EVENT(updateend)
+Appending PTS=5
+EVENT(updateend)
+Appending PTS=6
+EVENT(updateend)
+Appending PTS=7
+EVENT(updateend)
+Appending PTS=8
+EVENT(updateend)
+Appending PTS=9
+EVENT(updateend)
+EXPECTED (exception == 'null') OK
+EXPECTED (bufferedRanges() == '[ 0...10 ]') OK
+RUN(video.currentTime = 6)
+EXPECTED (video.currentTime == '6') OK
+Appending PTS=10
+EVENT(updateend)
+EXPECTED (bufferedRanges() == '[ 0...11 ]') OK
+EXPECTED (internals.evictableSize(sourceBuffer) == '0') OK
+Appending PTS=11
+EVENT(updateend)
+Appending PTS=12
+EVENT(updateend)
+Appending PTS=13
+EVENT(updateend)
+Appending PTS=14
+EVENT(updateend)
+EXPECTED (exception == 'null') OK
+EXPECTED (bufferedRanges() == '[ 0...15 ]') OK
+EXPECTED (internals.evictableSize(sourceBuffer) == '216') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-managedmse-evictable-size-headroom.html
+++ b/LayoutTests/media/media-source/media-managedmse-evictable-size-headroom.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>mock-media-source</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+    var initSegment;
+    var exception;
+    var sampleSize = 72;
+
+    function bufferedRanges() {
+        var bufferedRanges = '[ ';
+        var timeRanges = sourceBuffer.buffered;
+        for (var i = 0 ; i < timeRanges.length ; i++) {
+            if (i)
+                bufferedRanges += ', ';
+            bufferedRanges += timeRanges.start(i) + '...' + timeRanges.end(i);
+        }
+        bufferedRanges += ' ]';
+        return bufferedRanges;
+    }
+
+    async function appendPtsRange(firstPts, lastPts) {
+        var resultException = null;
+        for (var pts = firstPts; pts <= lastPts; pts++) {
+            try {
+                consoleWrite('Appending PTS='+pts);
+                sourceBuffer.appendBuffer(makeASample(pts, pts, 1, 1, 1, SAMPLE_FLAG.SYNC, 1));
+                await waitFor(sourceBuffer, 'updateend');
+            } catch (e) {
+                resultException = e;
+                sourceBuffer.abort();
+                break;
+            }
+        }
+        return resultException;
+    }
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    window.addEventListener('load', async() => {
+        findMediaElement();
+        source = new ManagedMediaSource();
+
+        const videoSource = document.createElement('source');
+        videoSource.type = 'video/mock; codecs=mock';
+        videoSource.src = URL.createObjectURL(source);
+        run('video.disableRemotePlayback = true');
+        video.appendChild(videoSource);
+
+        await waitFor(source, 'sourceopen');
+        sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock");
+        initSegment = makeAInit(300, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)]);
+        sourceBuffer.appendBuffer(initSegment);
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Buffer up to 24 samples; the eviction bookkeeping only scans for evictable
+        // content once contentSize reaches half of the maximum (12 samples).
+        await internals.setMaximumSourceBufferSize(sourceBuffer, 24 * sampleSize);
+
+        exception = await appendPtsRange(0, 9);
+        testExpected('exception', null, '==');
+        testExpected('bufferedRanges()', '[ 0...10 ]', '==');
+
+        run('video.currentTime = 6');
+        testExpected('video.currentTime', 6, '==');
+
+        // 11 samples is below half of the maximum. Even though the samples before
+        // currentTime - 3s are evictable, nothing is scanned while there is headroom,
+        // so evictableSize is reported as 0 and no data is evicted.
+        await Promise.all([ waitFor(video, 'seeked', true), appendPtsRange(10, 10) ]);
+        testExpected('bufferedRanges()', '[ 0...11 ]', '==');
+        testExpected('internals.evictableSize(sourceBuffer)', 0, '==');
+
+        // Crossing half of the maximum re-engages the scan, so the samples from the
+        // beginning of the buffer up to currentTime - 3s are now reported as evictable.
+        exception = await appendPtsRange(11, 14);
+        testExpected('exception', null, '==');
+        testExpected('bufferedRanges()', '[ 0...15 ]', '==');
+        testExpected('internals.evictableSize(sourceBuffer)', (6 - 3) * sampleSize, '==');
+
+        endTest();
+     });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -609,9 +609,17 @@ void SourceBufferPrivate::computeEvictionData(ComputeEvictionDataRule rule)
 {
     assertIsCurrent(m_dispatcher.get());
 
+    const uint64_t contentSize = totalTrackBufferSizeInBytes();
+    const uint64_t maximumBufferSize = m_maximumBufferSize;
+
     SourceBufferEvictionData evictionData {
-        .contentSize = totalTrackBufferSizeInBytes(),
+        .contentSize = contentSize,
         .evictableSize = [&]() -> int64_t {
+            // Only scan for evictable content once the buffer is at least half full;
+            // below that the result is unused and eviction cannot be triggered yet.
+            if (contentSize < maximumBufferSize / 2)
+                return 0;
+
             RefPtr mediaSource = m_mediaSource.get();
             if (!mediaSource)
                 return 0;
@@ -659,7 +667,7 @@ void SourceBufferPrivate::computeEvictionData(ComputeEvictionDataRule rule)
             });
             return evictableSize;
         }(),
-        .maximumBufferSize = m_maximumBufferSize,
+        .maximumBufferSize = maximumBufferSize,
         .numMediaSamples = [&]() -> size_t {
             const size_t evictionThreshold = platformEvictionThreshold();
             if (!evictionThreshold)


### PR DESCRIPTION
#### e5335f1d31fd2efa62b24aadd8b3aa29427d960b
<pre>
SourceBufferPrivate computes evictable frame size on every append even when the buffer has ample headroom
<a href="https://bugs.webkit.org/show_bug.cgi?id=323848">https://bugs.webkit.org/show_bug.cgi?id=323848</a>
<a href="https://rdar.apple.com/187086241">rdar://187086241</a>

Reviewed by NOBODY (OOPS!).

computeEvictionData() runs on every append and walks the evictable regions of
every track buffer via TrackBuffer::codedFramesIntervalSize(), which copies a
DecodeOrderSampleMap sub-map - O(evictable samples) with an allocation. That
value is only consumed once the buffer is near maximumBufferSize; the fields
that decide whether eviction runs (contentSize/numMediaSamples) are cheap. So
while there is headroom the scan is pure per-append overhead, most visible
during long playback with a large buffer.

Skip the scan while contentSize is below half of maximumBufferSize. This does
not change what gets evicted or when: eviction still uses the always-updated
contentSize/numMediaSamples, and the scan re-engages as the buffer fills. A
single append larger than the headroom still evicts via the synchronous
fallback in evictCodedFrames(). evictableSize is otherwise observable only
through Internals.

Test: media/media-source/media-managedmse-evictable-size-headroom.html

* LayoutTests/media/media-source/media-managedmse-evictable-size-headroom-expected.txt: Added.
* LayoutTests/media/media-source/media-managedmse-evictable-size-headroom.html: Added.
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::computeEvictionData):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5335f1d31fd2efa62b24aadd8b3aa29427d960b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196279 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150612 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61255 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59603 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145331 "Found 1 new test failure: fast/dom/lazy-image-loading-document-leak.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100751 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49016 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165877 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125645 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47744 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45752 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158099 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45467 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7350 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198256 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165402 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154889 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60248 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154534 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48984 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132583 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129612 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58696 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20469 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58086 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58316 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58144 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->