### PR TITLE
[EWS] determineDefaultCompilerCrossTarget.pl  webkitperl test fails on non-Linux bots

### DIFF
--- a/Tools/Scripts/webkitperl/webkitdirs_unittest/determineDefaultCompilerCrossTarget.pl
+++ b/Tools/Scripts/webkitperl/webkitdirs_unittest/determineDefaultCompilerCrossTarget.pl
@@ -34,6 +34,10 @@ use File::Temp;
 use Test::More;
 use webkitdirs;
 
+if (!webkitdirs::isLinux()) {
+    plan(skip_all => "cross-target builds are only supported on Linux");
+}
+
 my $helper = File::Spec->catfile(webkitdirs::sourceDir(), "Tools", "Scripts", "cross-toolchain-helper");
 chomp(my @targets = `'$helper' --print-available-targets 2>/dev/null`);
 if (!@targets) {


### PR DESCRIPTION
#### 807d76eb55965ee8b0327ecfb989e3c396ce0f32
<pre>
[EWS] determineDefaultCompilerCrossTarget.pl  webkitperl test fails on non-Linux bots
<a href="https://rdar.apple.com/187086366">rdar://187086366</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=323850">https://bugs.webkit.org/show_bug.cgi?id=323850</a>

Reviewed by Ryan Haddad.

Cross-target support in webkitdirs.pm is Linux-only, so the test dies on non-Linux bots. Skip it up front when not on Linux.

* Tools/Scripts/webkitperl/webkitdirs_unittest/determineDefaultCompilerCrossTarget.pl:

Canonical link: <a href="https://commits.webkit.org/320958@main">https://commits.webkit.org/320958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/048c36c41b62880e117a6296f998771967e830b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/185986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196280 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150613 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6720e9b8-c652-4551-9ffb-631937bb2cec) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59604 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145332 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100752 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b18314ec-d499-407d-8b3a-1573047ee48b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125647 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b187030a-79ed-41df-a6e3-4ac8edd69af2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47745 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45753 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158100 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45468 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7351 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198257 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59540 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154890 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41593 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60249 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154535 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/48985 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129618 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58697 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20470 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58087 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58317 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58145 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->