### PR TITLE
Make String::utf8(), StringImpl::utf8() and StringView::utf8() return a UTF8CString

### DIFF
--- a/LayoutTests/ipc/serialized-type-info.html
+++ b/LayoutTests/ipc/serialized-type-info.html
@@ -124,6 +124,7 @@
 
         const fundamentalTypes = [
             "char",
+            "char8_t",
             "char16_t",
             "char32_t",
             "short",

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1461,7 +1461,7 @@ static bool fetchModuleFromLocalFileSystem(const URL& fileURL, Vector& buffer)
     if ((status.st_mode & S_IFMT) != S_IFREG)
         return false;
 
-    FILE* f = fopen(pathName.data(), "r");
+    FILE* f = fopen(pathName.legacyCStringPointer(), "r");
 #endif
     if (!f) {
         SAFE_FPRINTF(stderr, "Could not open file: %s\n", fileName.utf8());
@@ -2125,8 +2125,7 @@ JSC_DEFINE_HOST_FUNCTION(functionWriteFile, (JSGlobalObject* globalObject, CallF
         return throwVMError(globalObject, scope, "Could not open file."_s);
 
     auto size = WTF::visit(WTF::makeVisitor([&](const String& string) {
-        CString utf8 = string.utf8();
-        return handle.write(byteCast<uint8_t>(utf8.span()));
+        return handle.write(byteCast<uint8_t>(string.utf8().span()));
     }, [&] (const std::span<const uint8_t>& data) {
         return handle.write(data);
     }), data);
@@ -2984,8 +2983,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDumpBytecodeProfile, (JSGlobalObject* globalObj
     String path = callFrame->argument(0).toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto pathUtf8 = path.utf8();
-    bool ok = vm.m_perBytecodeProfiler->save(pathUtf8.data());
+    bool ok = vm.m_perBytecodeProfiler->save(path.utf8().legacyCStringPointer());
     return JSValue::encode(jsBoolean(ok));
 }
 
@@ -4371,8 +4369,12 @@ void CommandLine::parseArguments(int argc, char** argv, int start)
         if (!strncmp(arg, singleStringSubArgList.characters(), singleStringSubArgList.length())) {
             // We just assume input is utf-8 (probably ascii)
             String subArgList = String::fromLatin1(arg + singleStringSubArgList.length());
-            Vector<CString> splitArgs = subArgList.split(" "_s).map([](const String& arg) { return arg.impl()->utf8(); });
-            Vector<char*> buffer = splitArgs.map([](const CString& arg) { return const_cast<char*>(arg.data()); });
+            auto splitArgs = subArgList.split(" "_s).map([](const String& arg) {
+                return arg.impl()->utf8();
+            });
+            Vector<char*> buffer = splitArgs.map([](const UTF8CString& arg) {
+                return const_cast<char*>(arg.legacyCStringPointer());
+            });
 
             parseArguments(buffer.mutableSpan().size(), buffer.mutableSpan().data(), 0);
             continue;

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -99,7 +99,7 @@ public:
     int length() const { return m_string.length(); }
 
     CString ascii() const { return m_string.string().ascii(); }
-    CString utf8() const { return m_string.string().utf8(); }
+    UTF8CString utf8() const { return m_string.string().utf8(); }
 
     // There's 2 functions to construct Identifier from string, (1) fromString and (2) fromUid.
     // They have different meanings in keeping or discarding symbol-ness of strings.

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -1751,12 +1751,12 @@ UDateIntervalFormat* IntlDateTimeFormat::createDateIntervalFormatIfNecessary(JSG
         if (m_impl->m_hourCycle != HourCycle::None)
             localeBuilder.append("-hc-"_s, hourCycleString(m_impl->m_hourCycle));
     }
-    CString dataLocaleWithExtensions = localeBuilder.toString().utf8();
+    auto dataLocaleWithExtensions = localeBuilder.toString().utf8();
 
     UErrorCode status = U_ZERO_ERROR;
     String timeZoneForICU = m_impl->m_timeZone.toICUString();
     StringView timeZoneView(timeZoneForICU);
-    m_dateIntervalFormat = std::unique_ptr<UDateIntervalFormat, UDateIntervalFormatDeleter>(udtitvfmt_open(dataLocaleWithExtensions.data(), skeleton.span().data(), skeleton.size(), timeZoneView.upconvertedCharacters(), timeZoneView.length(), &status));
+    m_dateIntervalFormat = std::unique_ptr<UDateIntervalFormat, UDateIntervalFormatDeleter>(udtitvfmt_open(dataLocaleWithExtensions.legacyCStringPointer(), skeleton.span().data(), skeleton.size(), timeZoneView.upconvertedCharacters(), timeZoneView.length(), &status));
     if (U_FAILURE(status)) [[unlikely]] {
         throwTypeError(globalObject, scope, "failed to initialize DateIntervalFormat"_s);
         return nullptr;
@@ -2636,10 +2636,10 @@ IntlDateTimeFormat::createTemporalIntervalFormat(UDateFormat* tempFormat, Tempor
     localeBuilder.append(m_impl->m_dataLocale, "-u-ca-"_s, ensureCalendar(), "-nu-"_s, ensureNumberingSystem());
     if (m_impl->m_hourCycle != HourCycle::None)
         localeBuilder.append("-hc-"_s, hourCycleString(m_impl->m_hourCycle));
-    CString localeWithExt = localeBuilder.toString().utf8();
+    auto localeWithExt = localeBuilder.toString().utf8();
 
     return std::unique_ptr<UDateIntervalFormat, UDateIntervalFormatDeleter>(
-        udtitvfmt_open(localeWithExt.data(), tempSkeleton.span().data(), tempSkeleton.size(),
+        udtitvfmt_open(localeWithExt.legacyCStringPointer(), tempSkeleton.span().data(), tempSkeleton.size(),
         tzView.upconvertedCharacters(), tzView.length(), &status));
 }
 

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -409,7 +409,7 @@ void IntlNumberFormat::initializeNumberFormat(JSGlobalObject* globalObject, JSVa
     m_signDisplay = intlOption<SignDisplay>(globalObject, options, Identifier::fromString(vm, "signDisplay"_s), { { "auto"_s, SignDisplay::Auto }, { "never"_s, SignDisplay::Never }, { "always"_s, SignDisplay::Always }, { "exceptZero"_s, SignDisplay::ExceptZero }, { "negative"_s, SignDisplay::Negative } }, "signDisplay must be either \"auto\", \"never\", \"always\", \"exceptZero\", or \"negative\""_s, SignDisplay::Auto);
     RETURN_IF_EXCEPTION(scope, void());
 
-    CString dataLocaleWithExtensions = m_numberingSystem.isNull() ? m_dataLocale.utf8() : makeString(m_dataLocale, "-u-nu-"_s, m_numberingSystem).utf8();
+    auto dataLocaleWithExtensions = m_numberingSystem.isNull() ? m_dataLocale.utf8() : makeString(m_dataLocale, "-u-nu-"_s, m_numberingSystem).utf8();
     dataLogLnIf(IntlNumberFormatInternal::verbose, "dataLocaleWithExtensions:(", dataLocaleWithExtensions , ")");
 
     // Options are obtained. Configure formatter here.
@@ -540,7 +540,7 @@ void IntlNumberFormat::initializeNumberFormat(JSGlobalObject* globalObject, JSVa
     auto upconverted = skeletonView.upconvertedCharacters();
 
     UErrorCode status = U_ZERO_ERROR;
-    m_numberFormatter = std::unique_ptr<UNumberFormatter, UNumberFormatterDeleter>(unumf_openForSkeletonAndLocale(upconverted.get(), skeletonView.length(), dataLocaleWithExtensions.data(), &status));
+    m_numberFormatter = std::unique_ptr<UNumberFormatter, UNumberFormatterDeleter>(unumf_openForSkeletonAndLocale(upconverted.get(), skeletonView.length(), dataLocaleWithExtensions.legacyCStringPointer(), &status));
     if (U_FAILURE(status)) {
         throwTypeError(globalObject, scope, "Failed to initialize NumberFormat"_s);
         return;

--- a/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
@@ -145,7 +145,7 @@ void IntlPluralRules::initializePluralRules(JSGlobalObject* globalObject, JSValu
     StringView skeletonView { skeletonBuilder };
     auto upconverted = skeletonView.upconvertedCharacters();
 
-    m_numberFormatter = std::unique_ptr<UNumberFormatter, UNumberFormatterDeleter>(unumf_openForSkeletonAndLocale(upconverted.get(), skeletonView.length(), locale.data(), &status));
+    m_numberFormatter = std::unique_ptr<UNumberFormatter, UNumberFormatterDeleter>(unumf_openForSkeletonAndLocale(upconverted.get(), skeletonView.length(), locale.legacyCStringPointer(), &status));
     if (U_FAILURE(status)) {
         throwTypeError(globalObject, scope, "failed to initialize PluralRules"_s);
         return;
@@ -153,7 +153,7 @@ void IntlPluralRules::initializePluralRules(JSGlobalObject* globalObject, JSValu
 
     vm.heap.reportExtraMemoryAllocated(this, estimatedUNumberFormatterSize);
 
-    m_numberRangeFormatter = std::unique_ptr<UNumberRangeFormatter, UNumberRangeFormatterDeleter>(unumrf_openForSkeletonWithCollapseAndIdentityFallback(upconverted.get(), skeletonView.length(), UNUM_RANGE_COLLAPSE_NONE, UNUM_IDENTITY_FALLBACK_RANGE, locale.data(), nullptr, &status));
+    m_numberRangeFormatter = std::unique_ptr<UNumberRangeFormatter, UNumberRangeFormatterDeleter>(unumrf_openForSkeletonWithCollapseAndIdentityFallback(upconverted.get(), skeletonView.length(), UNUM_RANGE_COLLAPSE_NONE, UNUM_IDENTITY_FALLBACK_RANGE, locale.legacyCStringPointer(), nullptr, &status));
     if (U_FAILURE(status)) {
         throwTypeError(globalObject, scope, "failed to initialize PluralRules"_s);
         return;
@@ -161,7 +161,7 @@ void IntlPluralRules::initializePluralRules(JSGlobalObject* globalObject, JSValu
 
     vm.heap.reportExtraMemoryAllocated(this, estimatedUNumberRangeFormatterSize);
 
-    m_pluralRules = std::unique_ptr<UPluralRules, UPluralRulesDeleter>(uplrules_openForType(locale.data(), m_type == Type::Ordinal ? UPLURAL_TYPE_ORDINAL : UPLURAL_TYPE_CARDINAL, &status));
+    m_pluralRules = std::unique_ptr<UPluralRules, UPluralRulesDeleter>(uplrules_openForType(locale.legacyCStringPointer(), m_type == Type::Ordinal ? UPLURAL_TYPE_ORDINAL : UPLURAL_TYPE_CARDINAL, &status));
     if (U_FAILURE(status)) {
         throwTypeError(globalObject, scope, "failed to initialize PluralRules"_s);
         return;

--- a/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
@@ -114,7 +114,7 @@ void IntlRelativeTimeFormat::initializeRelativeTimeFormat(JSGlobalObject* global
 
     m_numberingSystem = resolved.extensions[static_cast<unsigned>(RelevantExtensionKey::Nu)];
     m_dataLocale = resolved.dataLocale;
-    CString dataLocaleWithExtensions = m_numberingSystem.isNull() ? m_dataLocale.utf8() : makeString(m_dataLocale, "-u-nu-"_s, m_numberingSystem).utf8();
+    auto dataLocaleWithExtensions = m_numberingSystem.isNull() ? m_dataLocale.utf8() : makeString(m_dataLocale, "-u-nu-"_s, m_numberingSystem).utf8();
 
     m_style = intlOption<Style>(globalObject, options, vm.propertyNames->style, { { "long"_s, Style::Long }, { "short"_s, Style::Short }, { "narrow"_s, Style::Narrow } }, "style must be either \"long\", \"short\", or \"narrow\""_s, Style::Long);
     RETURN_IF_EXCEPTION(scope, void());
@@ -135,7 +135,7 @@ void IntlRelativeTimeFormat::initializeRelativeTimeFormat(JSGlobalObject* global
     RETURN_IF_EXCEPTION(scope, void());
 
     UErrorCode status = U_ZERO_ERROR;
-    auto numberFormat = std::unique_ptr<UNumberFormat, ICUDeleter<unum_close>>(unum_open(UNUM_DECIMAL, nullptr, 0, dataLocaleWithExtensions.data(), nullptr, &status));
+    auto numberFormat = std::unique_ptr<UNumberFormat, ICUDeleter<unum_close>>(unum_open(UNUM_DECIMAL, nullptr, 0, dataLocaleWithExtensions.legacyCStringPointer(), nullptr, &status));
     if (U_FAILURE(status)) [[unlikely]] {
         throwTypeError(globalObject, scope, "failed to initialize RelativeTimeFormat"_s);
         return;
@@ -161,7 +161,7 @@ void IntlRelativeTimeFormat::initializeRelativeTimeFormat(JSGlobalObject* global
     unum_setAttribute(numberFormat.get(), UNUM_MINIMUM_GROUPING_DIGITS, useLocaleDefault);
 
     // ureldatefmt_open adopts the UNumberFormat, so we release ownership here.
-    m_relativeDateTimeFormatter = std::unique_ptr<URelativeDateTimeFormatter, URelativeDateTimeFormatterDeleter>(ureldatefmt_open(dataLocaleWithExtensions.data(), numberFormat.release(), icuStyle, UDISPCTX_CAPITALIZATION_FOR_STANDALONE, &status));
+    m_relativeDateTimeFormatter = std::unique_ptr<URelativeDateTimeFormatter, URelativeDateTimeFormatterDeleter>(ureldatefmt_open(dataLocaleWithExtensions.legacyCStringPointer(), numberFormat.release(), icuStyle, UDISPCTX_CAPITALIZATION_FOR_STANDALONE, &status));
     if (U_FAILURE(status)) [[unlikely]] {
         throwTypeError(globalObject, scope, "failed to initialize RelativeTimeFormat"_s);
         return;

--- a/Source/JavaScriptCore/runtime/JSDateMath.cpp
+++ b/Source/JavaScriptCore/runtime/JSDateMath.cpp
@@ -452,16 +452,16 @@ String DateCache::timeZoneDisplayName(bool isDST)
 {
     if (m_timeZoneStandardDisplayNameCache.isNull()) {
         auto& timeZoneCache = *this->timeZoneCache();
-        CString language = defaultLanguage().utf8();
+        auto language = defaultLanguage().utf8();
         {
             Vector<char16_t, 32> standardDisplayNameBuffer;
-            auto status = callBufferProducingFunction(ucal_getTimeZoneDisplayName, timeZoneCache.m_calendar.get(), UCAL_STANDARD, language.data(), standardDisplayNameBuffer);
+            auto status = callBufferProducingFunction(ucal_getTimeZoneDisplayName, timeZoneCache.m_calendar.get(), UCAL_STANDARD, language.legacyCStringPointer(), standardDisplayNameBuffer);
             if (U_SUCCESS(status))
                 m_timeZoneStandardDisplayNameCache = String::adopt(WTF::move(standardDisplayNameBuffer));
         }
         {
             Vector<char16_t, 32> dstDisplayNameBuffer;
-            auto status = callBufferProducingFunction(ucal_getTimeZoneDisplayName, timeZoneCache.m_calendar.get(), UCAL_DST, language.data(), dstDisplayNameBuffer);
+            auto status = callBufferProducingFunction(ucal_getTimeZoneDisplayName, timeZoneCache.m_calendar.get(), UCAL_DST, language.legacyCStringPointer(), dstDisplayNameBuffer);
             if (U_SUCCESS(status))
                 m_timeZoneDSTDisplayNameCache = String::adopt(WTF::move(dstDisplayNameBuffer));
         }

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -530,7 +530,7 @@ JSC_DEFINE_HOST_FUNCTION(dumpAndClearSamplingProfilerSamples, (JSGlobalObject* g
             return JSValue::encode(jsUndefined());
         }
 
-        CString utf8String = jsonData.utf8();
+        auto utf8String = jsonData.utf8();
 
         fileHandle.write(byteCast<uint8_t>(utf8String.span()));
         dataLogLn("Dumped sampling profiler samples to ", tempFilePath);

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -555,7 +555,7 @@ void RegExp::printTraceData()
     formattedRegExp[SameLineFormatedRegExpnWidth] = '\0';
 
     auto patternCStr = pattern().utf8(); // Hold a reference so it doesn't get destroyed.
-    auto patternStr = patternCStr.data();
+    auto patternStr = patternCStr.legacyCStringPointer();
     auto patternLength = pattern().length();
 
     auto appendRawPatternBuffer = [&] (size_t& index) {

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
@@ -50,7 +50,7 @@ StreamingCompiler::StreamingCompiler(VM& vm, CompilerMode compilerMode, JSGlobal
     , m_parser(m_info.get(), *this)
     , m_source(source)
 {
-    m_info->sourceURL = Name(byteCast<char8_t>(wasmSourceURL.utf8().span()));
+    m_info->sourceURL = Name(wasmSourceURL.utf8().span());
     m_info->requestIdentifier = requestIdentifier;
     Vector<JSCell*> dependencies;
     dependencies.append(globalObject);

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
@@ -59,9 +59,9 @@ WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(StopData);
 String stringToHex(StringView str)
 {
     StringBuilder result;
-    CString utf8 = str.utf8();
-    for (size_t i = 0; i < utf8.length(); ++i)
-        result.append(hex(static_cast<uint8_t>(utf8.data()[i]), 2, Lowercase));
+    auto utf8 = str.utf8();
+    for (auto c : utf8.span())
+        result.append(hex(byteCast<uint8_t>(c), 2, Lowercase));
     return result.toString();
 }
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -888,13 +888,13 @@ void ExecutionHandler::sendReplyImpl(AbstractLocker&, StringView reply) WTF_REQU
     }
 #endif
 
-    CString packetData = packet.utf8();
-    int sent = static_cast<int>(send(m_debugServer.m_clientSocket, packetData.data(), packetData.length(), 0));
+    auto packetData = packet.utf8();
+    int sent = static_cast<int>(send(m_debugServer.m_clientSocket, packetData.legacyCStringPointer(), packetData.length(), 0));
     if (sent < 0)
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Failed to send packet: ", packetData.data(), " sent: ", sent);
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Failed to send packet: ", packetData.legacyCStringPointer(), " sent: ", sent);
     else {
         m_debuggerState = DebuggerState::Replied;
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Sent reply: ", packetData.data());
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Sent reply: ", packetData.legacyCStringPointer());
     }
 }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
@@ -298,7 +298,7 @@ static void compileAndInstantiate(VM& vm, JSGlobalObject* globalObject, JSPromis
     Wasm::Name sourceURL;
     if (creationMode == Wasm::CreationMode::FromModuleLoader && sourceProvider) {
         auto sourceURLString = sourceProvider->sourceOrigin().url().string();
-        sourceURL = Wasm::Name(byteCast<char8_t>(sourceURLString.utf8().span()));
+        sourceURL = Wasm::Name(sourceURLString.utf8().span());
     }
     Wasm::Module::validateAsync(vm, WTF::move(source), WTF::move(sourceURL), createSharedTask<Wasm::Module::CallbackType>([weakTicket = WTF::move(weakTicket), importObject, sourceProvider = WTF::move(sourceProvider), compileOptions = WTF::move(compileOptions), resolveKind, creationMode, &vm] (Wasm::Module::ValidationResult&& result) mutable {
         vm.deferredWorkTimer->scheduleWorkSoonIfActive(weakTicket, [importObject, sourceProvider = WTF::move(sourceProvider), compileOptions = WTF::move(compileOptions), result = WTF::move(result), resolveKind, creationMode, &vm](DeferredWorkTimer::Ticket& ticket) mutable {

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -63,7 +63,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     return std::filesystem::u8path(path.utf8().legacyCStringPointer());
 ALLOW_DEPRECATED_DECLARATIONS_END
 #else
-    return { std::u8string(byteCast<char8_t>(path.utf8().legacyCStringPointer())) };
+    return { std::u8string(path.utf8().data()) };
 #endif
 }
 

--- a/Source/WTF/wtf/FormattedLogging.h
+++ b/Source/WTF/wtf/FormattedLogging.h
@@ -29,6 +29,7 @@
 #include <format>
 #include <type_traits>
 #include <wtf/Assertions.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/TextStream.h>
 
 namespace WTF {
@@ -48,7 +49,7 @@ struct std::formatter<T> : std::formatter<std::string_view> {
         WTF::TextStream stream(WTF::TextStream::LineMode::SingleLine);
         stream << value;
         auto utf8 = stream.release().utf8();
-        return std::formatter<std::string_view>::format(std::string_view(utf8.data(), utf8.length()), ctx);
+        return std::formatter<std::string_view>::format(std::string_view(byteCast<char>(utf8.span())), ctx);
     }
 };
 

--- a/Source/WTF/wtf/cf/URLCF.cpp
+++ b/Source/WTF/wtf/cf/URLCF.cpp
@@ -49,7 +49,7 @@ RetainPtr<CFURLRef> URL::createCFURL(const String& string)
         auto characters = string.span8();
         return adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, byteCast<UInt8>(characters.data()), characters.size(), kCFStringEncodingUTF8, nullptr, true));
     }
-    CString utf8 = string.utf8();
+    auto utf8 = string.utf8();
     auto utf8Span = utf8.span();
     return adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, byteCast<UInt8>(utf8Span.data()), utf8Span.size(), kCFStringEncodingUTF8, nullptr, true));
 }

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -166,7 +166,7 @@ std::pair<String, FileHandle> openTemporaryFile(StringView prefix, StringView su
     temporaryFilePath.append("XXXXXX"_span);
     
     // Append the file name suffix.
-    CString suffixUTF8 = suffix.utf8();
+    auto suffixUTF8 = suffix.utf8();
     temporaryFilePath.append(suffixUTF8.spanIncludingNullTerminator());
 
     auto fileHandle = FileHandle::adopt(mkostemps(temporaryFilePath.mutableSpan().data(), suffixUTF8.length(), O_CLOEXEC));

--- a/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
+++ b/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
@@ -102,7 +102,7 @@ void LibraryPathDiagnosticsLogger::logJSONPayload(const JSON::Object &object)
 {
     auto textRepresentation = object.toJSONString();
     auto utf8 = textRepresentation.utf8();
-    auto span = utf8.span();
+    auto span = byteCast<char>(utf8.span());
     os_log(m_osLog, "%{public}.*s", static_cast<int>(span.size()), span.data());
 }
 
@@ -180,7 +180,7 @@ void LibraryPathDiagnosticsLogger::logDynamicLibraryInfo(const String& installNa
     const struct mach_header *header = _dyld_get_dlopen_image_header(handle);
     if (!header) {
         auto utf8 = installName.utf8();
-        auto span = utf8.span();
+        auto span = byteCast<char>(utf8.span());
         logError("Unable to locate mach header for %.*s", static_cast<int>(span.size()), span.data());
         return;
     }
@@ -189,7 +189,7 @@ void LibraryPathDiagnosticsLogger::logDynamicLibraryInfo(const String& installNa
     int dladdr_ret = dladdr(header, &info);
     if (!dladdr_ret) {
         auto utf8 = installName.utf8();
-        auto span = utf8.span();
+        auto span = byteCast<char>(utf8.span());
         logError("No info returned from dladdr() for %.*s", static_cast<int>(span.size()), span.data());
         return;
     }
@@ -197,7 +197,7 @@ void LibraryPathDiagnosticsLogger::logDynamicLibraryInfo(const String& installNa
     uuid_t uuid = { 0 };
     if (!_dyld_get_image_uuid(header, uuid)) {
         auto utf8 = installName.utf8();
-        auto span = utf8.span();
+        auto span = byteCast<char>(utf8.span());
         logError("No UUID found for %.*s", static_cast<int>(span.size()), span.data());
         return;
     }
@@ -263,7 +263,7 @@ void LibraryPathDiagnosticsLogger::logCryptexCanaryInfo(canary_cryptex_t which, 
 
     if (!metadata) {
         auto utf8 = description.utf8();
-        auto span = utf8.span();
+        auto span = byteCast<char>(utf8.span());
         logError("Unable to load canary metadata for '%.*s' cryptex", static_cast<int>(span.size()), span.data());
         return;
     }

--- a/Source/WTF/wtf/glib/FilePathWatcher.cpp
+++ b/Source/WTF/wtf/glib/FilePathWatcher.cpp
@@ -41,11 +41,11 @@ FilePathWatcher::FilePathWatcher(const String& path, Function<void()>&& handler)
         return;
 
     auto pathUtf8 = path.utf8();
-    GRefPtr file = adoptGRef(g_file_new_for_path(pathUtf8.data()));
+    GRefPtr file = adoptGRef(g_file_new_for_path(pathUtf8.legacyCStringPointer()));
     GUniqueOutPtr<GError> error;
     m_monitor = adoptGRef(g_file_monitor_file(file.get(), G_FILE_MONITOR_WATCH_HARD_LINKS, nullptr, &error.outPtr()));
     if (!m_monitor) {
-        LOG_ERROR("FilePathWatcher: failed to monitor %s: %s", pathUtf8.data(), error.get() ? error->message : "unknown error");
+        LOG_ERROR("FilePathWatcher: failed to monitor %s: %s", pathUtf8.legacyCStringPointer(), error.get() ? error->message : "unknown error");
         return;
     }
     // GFileMonitor coalesces events within a rate-limit window that defaults to

--- a/Source/WTF/wtf/module.modulemap
+++ b/Source/WTF/wtf/module.modulemap
@@ -1,4 +1,4 @@
-// FIXME (rdar://173516139): When you add a header to WTF, touch this line to invalidate the module cache. Touch count: 1.
+// FIXME (rdar://173516139): When you add a header to WTF, touch this line to invalidate the module cache. Touch count: 2.
 
 module wtf [system] {
     explicit module Assertions {

--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -179,20 +179,15 @@ std::pair<String, FileHandle> openTemporaryFile(StringView prefix, StringView su
     // This is OK for now since the code using it is built on macOS only.
     ASSERT_UNUSED(suffix, suffix.isEmpty());
 
-    const auto temporaryDirectoryUtf8 = temporaryDirectory.utf8();
-    IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
-    const char* directory = !temporaryDirectory.isEmpty() ? temporaryDirectoryUtf8.data() : temporaryFileDirectory();
-    CString prefixUTF8 = prefix.utf8();
-    size_t length = strlen(directory) + 1 + prefixUTF8.length() + 1 + 6 + 1;
-    auto buffer = MallocSpan<char>::malloc(length);
-    snprintf(buffer.mutableSpan().data(), length, "%s/%s-XXXXXX", directory, prefixUTF8.data());
-    IGNORE_CLANG_WARNINGS_END
+    auto directory = !temporaryDirectory.isEmpty() ? temporaryDirectory : String::fromUTF8(temporaryFileDirectory());
+    // mkostemp overwrites the XXXXXX in place, so this needs to be a mutable buffer.
+    auto path = makeString(directory, '/', prefix, "-XXXXXX"_s).utf8();
 
-    auto handle = FileHandle::adopt(mkostemp(buffer.mutableSpan().data(), O_CLOEXEC));
+    auto handle = FileHandle::adopt(mkostemp(byteCast<char>(path.mutableSpan()).data(), O_CLOEXEC));
     if (!handle)
         return { String(), FileHandle() };
 
-    return { String::fromUTF8(buffer.span().data()), WTF::move(handle) };
+    return { String { path }, WTF::move(handle) };
 }
 #endif // !PLATFORM(COCOA)
 

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -218,6 +218,20 @@ public:
             ASSERT(charactersAreAllASCII(byteCast<Latin1Character>(characters)));
     }
 
+    // std::string does not know its encoding, so this asserts that its bytes are in CharacterType's.
+    explicit CStringWithEncoding(const std::string& string)
+        : CStringWithEncoding(byteCast<CharacterType>(std::span { string }))
+    {
+    }
+
+    // Null-terminated, like CString(const char*), and likewise asserts the encoding of its bytes.
+    explicit CStringWithEncoding(const CharacterType* string)
+        : CString(byteCast<char>(string))
+    {
+        if constexpr (std::same_as<CharacterType, char>)
+            ASSERT(charactersAreAllASCII(byteCast<Latin1Character>(CString::span())));
+    }
+
     static CStringWithEncoding newUninitialized(size_t length, std::span<CharacterType>& characterBuffer)
     {
         std::span<char> bytes;

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -66,6 +66,11 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
+inline std::span<const char8_t> unsafeSpan(const char8_t* string)
+{
+    return byteCast<char8_t>(unsafeSpan(byteCast<char>(string)));
+}
+
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 inline std::span<const char16_t> unsafeSpan(const char16_t* string)
 {

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -1637,7 +1637,7 @@ std::expected<UTF8CString, UTF8ConversionError> StringImpl::tryGetUTF8(Conversio
     return utf8ForCharacters(span16(), mode);
 }
 
-CString StringImpl::utf8(ConversionMode mode) const
+UTF8CString StringImpl::utf8(ConversionMode mode) const
 {
     auto expectedString = tryGetUTF8(mode);
     RELEASE_ASSERT(expectedString);

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -347,8 +347,7 @@ public:
     template<typename Func>
     std::expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> tryGetUTF8(NOESCAPE const Func&, ConversionMode = LenientConversion) const;
     WTF_EXPORT_PRIVATE std::expected<UTF8CString, UTF8ConversionError> tryGetUTF8(ConversionMode = LenientConversion) const;
-    // FIXME: Should return a UTF8CString, like tryGetUTF8() above already does.
-    WTF_EXPORT_PRIVATE CString utf8(ConversionMode = LenientConversion) const;
+    WTF_EXPORT_PRIVATE UTF8CString utf8(ConversionMode = LenientConversion) const;
 
 private:
     // The high bits of 'hash' are always empty, but we prefer to store our flags

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -115,7 +115,7 @@ std::expected<UTF8CString, UTF8ConversionError> StringView::tryGetUTF8(Conversio
     return StringImpl::utf8ForCharacters(span16(), mode);
 }
 
-CString StringView::utf8(ConversionMode mode) const
+UTF8CString StringView::utf8(ConversionMode mode) const
 {
     auto expectedString = tryGetUTF8(mode);
     RELEASE_ASSERT(expectedString);

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -128,8 +128,7 @@ public:
 #endif
 
     WTF_EXPORT_PRIVATE std::expected<UTF8CString, UTF8ConversionError> tryGetUTF8(ConversionMode = LenientConversion) const;
-    // FIXME: Should return a UTF8CString, like tryGetUTF8() above already does.
-    WTF_EXPORT_PRIVATE CString utf8(ConversionMode = LenientConversion) const;
+    WTF_EXPORT_PRIVATE UTF8CString utf8(ConversionMode = LenientConversion) const;
 
     template<typename Func>
     std::expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> tryGetUTF8(const Func&, ConversionMode = LenientConversion) const;

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -458,7 +458,7 @@ std::expected<UTF8CString, UTF8ConversionError> String::tryGetUTF8() const
     return tryGetUTF8(LenientConversion);
 }
 
-CString String::utf8(ConversionMode mode) const
+UTF8CString String::utf8(ConversionMode mode) const
 {
     auto expectedString = tryGetUTF8(mode);
     RELEASE_ASSERT(expectedString);

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -74,6 +74,11 @@ public:
     // Construct a string with UTF-8 data, null string if it contains invalid UTF-8 sequences.
     WTF_EXPORT_PRIVATE String(std::span<const char8_t>);
 
+    // Construct a string from a CString that knows its encoding, decoding it as that encoding.
+    // Unlike CString, which would have to be decoded by the caller, and unlike fromUTF8(), which
+    // will happily reinterpret Latin-1 bytes as UTF-8, the character type picks the decoding.
+    template<OneByteCharacterType CharacterType> String(const CStringWithEncoding<CharacterType>&);
+
     // Construct a string referencing an existing StringImpl.
     String(StringImpl&);
     String(StringImpl*);
@@ -123,10 +128,7 @@ public:
     WTF_EXPORT_PRIVATE ASCIICString ascii() const;
     WTF_EXPORT_PRIVATE Latin1CString latin1() const;
 
-    // FIXME: Should return a UTF8CString, like tryGetUTF8() below already does. The call sites that
-    // hand the result to a %s or a C API now use legacyCStringPointer(), which keeps returning
-    // const char* once this is retyped, so the remaining work is the retype itself.
-    WTF_EXPORT_PRIVATE CString utf8(ConversionMode = LenientConversion) const;
+    WTF_EXPORT_PRIVATE UTF8CString utf8(ConversionMode = LenientConversion) const;
 
     template<typename Func>
     std::expected<std::invoke_result_t<Func, std::span<const char8_t>>, UTF8ConversionError> tryGetUTF8(NOESCAPE const Func&, ConversionMode = LenientConversion) const;
@@ -447,6 +449,11 @@ inline String::String(StaticStringImpl& string)
 
 inline String::String(StaticStringImpl* string)
     : m_impl(reinterpret_cast<StringImpl*>(string))
+{
+}
+
+template<OneByteCharacterType CharacterType> inline String::String(const CStringWithEncoding<CharacterType>& string)
+    : String(string.span())
 {
 }
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp
@@ -278,7 +278,7 @@ void AdapterImpl::requestDevice(const DeviceDescriptor& descriptor, CompletionHa
     WGPURequiredLimits requiredLimits { .limits = WTF::move(limits) };
 
     WGPUDeviceDescriptor backingDescriptor {
-        .label = label.data(),
+        .label = label.legacyCStringPointer(),
         .requiredFeatureCount = features.size(),
         .requiredFeatures = features.size() ? features.span().data() : nullptr,
         .requiredLimits = &requiredLimits,

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
@@ -113,7 +113,7 @@ RefPtr<RenderPassEncoder> CommandEncoderImpl::beginRenderPass(const RenderPassDe
 
     WGPURenderPassDescriptor backingDescriptor {
         .maxDrawCount = descriptor.maxDrawCount.value_or(UINT64_MAX),
-        .label = label.data(),
+        .label = label.legacyCStringPointer(),
         .colorAttachmentCount = colorAttachments.size(),
         .colorAttachments = colorAttachments.size() ? colorAttachments.span().data() : nullptr,
         .depthStencilAttachment = depthStencilAttachment ? &depthStencilAttachment.value() : nullptr,

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -72,12 +72,20 @@ namespace WebCore::WebGPU {
 
 static auto invalidEntryPointName()
 {
-    return CString(""_s);
+    return UTF8CString(""_s);
+}
+
+// WGPU takes entry point and constant names as a const char*, so a name holding a null character
+// would be silently truncated to the part before it. Reject such a name instead of compiling
+// against a different one than was asked for.
+static bool hasNullCharacter(const UTF8CString& name)
+{
+    return WTF::contains(name.span(), u8'\0');
 }
 
 static auto invalidConstantName()
 {
-    return CString(""_s);
+    return UTF8CString(""_s);
 }
 
 static bool containsOnlyValidUTF8Characters(StringView string)
@@ -122,7 +130,7 @@ RefPtr<Buffer> DeviceImpl::createBuffer(const BufferDescriptor& descriptor)
     Ref convertToBackingContext = m_convertToBackingContext;
 
     WGPUBufferDescriptor backingDescriptor {
-        .label = label.data(),
+        .label = label.legacyCStringPointer(),
         .usage = convertToBackingContext->convertBufferUsageFlagsToBacking(descriptor.usage),
         .size = descriptor.size,
         .mappedAtCreation = descriptor.mappedAtCreation,
@@ -142,7 +150,7 @@ RefPtr<Texture> DeviceImpl::createTexture(const TextureDescriptor& descriptor)
     });
 
     WGPUTextureDescriptor backingDescriptor {
-        .label = label.data(),
+        .label = label.legacyCStringPointer(),
         .usage = convertToBackingContext->convertTextureUsageFlagsToBacking(descriptor.usage),
         .dimension = convertToBackingContext->convertToBacking(descriptor.dimension),
         .size = convertToBackingContext->convertToBacking(descriptor.size),
@@ -188,7 +196,7 @@ RefPtr<ExternalTexture> DeviceImpl::importExternalTexture(const ExternalTextureD
 
     auto pixelBuffer = std::get_if<RetainPtr<CVPixelBufferRef>>(&descriptor.videoBacking);
     WGPUExternalTextureDescriptor backingDescriptor {
-        .label = label.data(),
+        .label = label.legacyCStringPointer(),
         .pixelBuffer = pixelBuffer ? pixelBuffer->get() : nullptr,
         .colorSpace = m_convertToBackingContext->convertToBacking(descriptor.colorSpace),
     };
@@ -227,7 +235,7 @@ RefPtr<BindGroupLayout> DeviceImpl::createBindGroupLayout(const BindGroupLayoutD
     });
 
     WGPUBindGroupLayoutDescriptor backingDescriptor {
-        .label = label.data(),
+        .label = label.legacyCStringPointer(),
         .entryCount = backingEntries.size(),
         .entries = backingEntries.size() ? backingEntries.span().data() : nullptr,
     };
@@ -247,7 +255,7 @@ RefPtr<PipelineLayout> DeviceImpl::createPipelineLayout(const PipelineLayoutDesc
     }
 
     WGPUPipelineLayoutDescriptor backingDescriptor {
-        .label = label.data(),
+        .label = label.legacyCStringPointer(),
         .bindGroupLayoutCount = descriptor.bindGroupLayouts ? backingBindGroupLayouts.size() : 0,
         .bindGroupLayouts = descriptor.bindGroupLayouts ? backingBindGroupLayouts.span().data() : nullptr,
     };
@@ -275,7 +283,7 @@ RefPtr<BindGroup> DeviceImpl::createBindGroup(const BindGroupDescriptor& descrip
     });
 
     WGPUBindGroupDescriptor backingDescriptor {
-        .label = label.data(),
+        .label = label.legacyCStringPointer(),
         .layout = convertToBackingContext->convertToBacking(protect(descriptor.layout)),
         .entryCount = backingEntries.size(),
         .entries = backingEntries.size() ? backingEntries.span().data() : nullptr,
@@ -299,14 +307,14 @@ RefPtr<ShaderModule> DeviceImpl::createShaderModule(const ShaderModuleDescriptor
     for (size_t i = 0; i < descriptor.hints.size(); ++i) {
         const auto& hint = descriptor.hints[i].value;
         hintsEntries.append(WGPUShaderModuleCompilationHint {
-            .entryPoint = entryPoints[i].data(),
+            .entryPoint = entryPoints[i].legacyCStringPointer(),
             .layout = convertToBackingContext->convertToBacking(protect(hint.pipelineLayout))
         });
     }
 
     WGPUShaderModuleDescriptor backingDescriptor {
         .wgslDescriptor = descriptor.code,
-        .label = label.data(),
+        .label = label.legacyCStringPointer(),
         .hintCount = hintsEntries.size(),
         .hints = hintsEntries.size() ? &hintsEntries[0] : nullptr,
     };
@@ -319,10 +327,10 @@ static auto convertToBacking(const ComputePipelineDescriptor& descriptor, Conver
 {
     auto label = descriptor.label.utf8();
 
-    std::optional<CString> entryPoint;
+    std::optional<UTF8CString> entryPoint;
     if (!descriptor.compute.entryPoint.isNull()) {
         entryPoint = descriptor.compute.entryPoint.utf8();
-        if (descriptor.compute.entryPoint.length() != String::fromUTF8(entryPoint->data()).length())
+        if (hasNullCharacter(*entryPoint))
             entryPoint = invalidEntryPointName();
     }
 
@@ -333,17 +341,17 @@ static auto convertToBacking(const ComputePipelineDescriptor& descriptor, Conver
     Vector<WGPUConstantEntry> backingConstantEntries(descriptor.compute.constants.size(), [&](size_t i) {
         const auto& constant = descriptor.compute.constants[i];
         return WGPUConstantEntry {
-            .key = constantNames[i].data(),
+            .key = constantNames[i].legacyCStringPointer(),
             .value = constant.value
         };
     });
 
     WGPUComputePipelineDescriptor backingDescriptor {
-        .label = label.data(),
+        .label = label.legacyCStringPointer(),
         .layout = descriptor.layout ? convertToBackingContext.convertToBacking(*protect(descriptor.layout)) : nullptr,
         .compute = WGPUProgrammableStageDescriptor {
             .module = convertToBackingContext.convertToBacking(protect(descriptor.compute.module)),
-            .entryPoint = entryPoint ? entryPoint->data() : nullptr,
+            .entryPoint = entryPoint ? entryPoint->legacyCStringPointer() : nullptr,
             .constantCount = backingConstantEntries.size(),
             .constants = backingConstantEntries.size() ? backingConstantEntries.span().data() : nullptr,
         }
@@ -364,10 +372,10 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
 {
     auto label = descriptor.label.utf8();
 
-    std::optional<CString> vertexEntryPoint;
+    std::optional<UTF8CString> vertexEntryPoint;
     if (!descriptor.vertex.entryPoint.isNull()) {
         vertexEntryPoint = descriptor.vertex.entryPoint.utf8();
-        if (descriptor.vertex.entryPoint.length() != String::fromUTF8(vertexEntryPoint->data()).length())
+        if (hasNullCharacter(*vertexEntryPoint))
             vertexEntryPoint = invalidEntryPointName();
     }
 
@@ -378,7 +386,7 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
     Vector<WGPUConstantEntry> vertexConstantEntries(descriptor.vertex.constants.size(), [&](size_t i) {
         const auto& constant = descriptor.vertex.constants[i];
         return WGPUConstantEntry {
-            .key = vertexConstantNames[i].data(),
+            .key = vertexConstantNames[i].legacyCStringPointer(),
             .value = constant.value
         };
     });
@@ -429,12 +437,12 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
         .depthBiasClamp = descriptor.depthStencil ? descriptor.depthStencil->depthBiasClamp : 0,
     };
 
-    std::optional<CString> fragmentEntryPoint;
-    Vector<CString> fragmentConstantNames;
+    std::optional<UTF8CString> fragmentEntryPoint;
+    Vector<UTF8CString> fragmentConstantNames;
     if (descriptor.fragment) {
         if (!descriptor.fragment->entryPoint.isNull()) {
             fragmentEntryPoint = descriptor.fragment->entryPoint.utf8();
-            if (descriptor.fragment->entryPoint.length() != String::fromUTF8(fragmentEntryPoint->data()).length())
+            if (hasNullCharacter(*fragmentEntryPoint))
                 fragmentEntryPoint = invalidEntryPointName();
         }
 
@@ -448,7 +456,7 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
         fragmentConstantEntries = Vector<WGPUConstantEntry>(descriptor.fragment->constants.size(), [&](size_t i) {
             const auto& constant = descriptor.fragment->constants[i];
             return WGPUConstantEntry {
-                .key = fragmentConstantNames[i].data(),
+                .key = fragmentConstantNames[i].legacyCStringPointer(),
                 .value = constant.value,
             };
         });
@@ -494,7 +502,7 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
 
     WGPUFragmentState fragmentState {
         .module = descriptor.fragment ? convertToBackingContext.convertToBacking(protect(descriptor.fragment->module)) : nullptr,
-        .entryPoint = fragmentEntryPoint ? fragmentEntryPoint->data() : nullptr,
+        .entryPoint = fragmentEntryPoint ? fragmentEntryPoint->legacyCStringPointer() : nullptr,
         .constantCount = fragmentConstantEntries.size(),
         .constants = fragmentConstantEntries.size() ? fragmentConstantEntries.span().data() : nullptr,
         .targetCount = colorTargets.size(),
@@ -502,11 +510,11 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
     };
 
     WGPURenderPipelineDescriptor backingDescriptor {
-        .label = label.data(),
+        .label = label.legacyCStringPointer(),
         .layout = descriptor.layout ? convertToBackingContext.convertToBacking(*protect(descriptor.layout)) : nullptr,
         .vertex = {
             .module = convertToBackingContext.convertToBacking(protect(descriptor.vertex.module)),
-            .entryPoint = vertexEntryPoint ? vertexEntryPoint->data() : nullptr,
+            .entryPoint = vertexEntryPoint ? vertexEntryPoint->legacyCStringPointer() : nullptr,
             .constantCount = vertexConstantEntries.size(),
             .constants = vertexConstantEntries.size() ? vertexConstantEntries.span().data() : nullptr,
             .bufferCount = backingBuffers.size(),
@@ -606,10 +614,10 @@ void DeviceImpl::createRenderPipelineWithPipelineLayoutFromPipelineAsync(const R
 
 RefPtr<CommandEncoder> DeviceImpl::createCommandEncoder(const std::optional<CommandEncoderDescriptor>& descriptor)
 {
-    CString label = descriptor ? descriptor->label.utf8() : CString(""_s);
+    auto label = descriptor ? descriptor->label.utf8() : UTF8CString(""_s);
 
     WGPUCommandEncoderDescriptor backingDescriptor {
-        .label = label.data(),
+        .label = label.legacyCStringPointer(),
     };
 
     return CommandEncoderImpl::create(adoptWebGPU(wgpuDeviceCreateCommandEncoder(m_backing.get(), &backingDescriptor)), m_convertToBackingContext);
@@ -625,7 +633,7 @@ RefPtr<RenderBundleEncoder> DeviceImpl::createRenderBundleEncoder(const RenderBu
     });
 
     WGPURenderBundleEncoderDescriptor backingDescriptor {
-        .label = label.data(),
+        .label = label.legacyCStringPointer(),
         .colorFormatCount = backingColorFormats.size(),
         .colorFormats = backingColorFormats.size() ? backingColorFormats.span().data() : nullptr,
         .depthStencilFormat = descriptor.depthStencilFormat ? convertToBackingContext->convertToBacking(*descriptor.depthStencilFormat) : WGPUTextureFormat_Undefined,
@@ -643,7 +651,7 @@ RefPtr<QuerySet> DeviceImpl::createQuerySet(const QuerySetDescriptor& descriptor
     Ref convertToBackingContext = m_convertToBackingContext;
 
     WGPUQuerySetDescriptor backingDescriptor {
-        .label = label.data(),
+        .label = label.legacyCStringPointer(),
         .type = convertToBackingContext->convertToBacking(descriptor.type),
         .count = descriptor.count,
     };

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.cpp
@@ -122,7 +122,7 @@ RefPtr<RenderBundle> RenderBundleEncoderImpl::finish(const RenderBundleDescripto
     auto label = descriptor.label.utf8();
 
     WGPURenderBundleDescriptor backingDescriptor {
-        .label = label.data(),
+        .label = label.legacyCStringPointer(),
     };
 
     return RenderBundleImpl::create(adoptWebGPU(wgpuRenderBundleEncoderFinish(m_backing.get(), &backingDescriptor)), m_convertToBackingContext);

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
@@ -49,12 +49,12 @@ TextureImpl::~TextureImpl() = default;
 
 RefPtr<TextureView> TextureImpl::createView(const std::optional<TextureViewDescriptor>& descriptor)
 {
-    CString label = descriptor ? descriptor->label.utf8() : CString(""_s);
+    auto label = descriptor ? descriptor->label.utf8() : UTF8CString(""_s);
 
     Ref convertToBackingContext = m_convertToBackingContext;
 
     WGPUTextureViewDescriptor backingDescriptor {
-        .label = label.data(),
+        .label = label.legacyCStringPointer(),
         .format = descriptor && descriptor->format ? convertToBackingContext->convertToBacking(*descriptor->format) : WGPUTextureFormat_Undefined,
         .dimension = descriptor && descriptor->dimension ? convertToBackingContext->convertToBacking(*descriptor->dimension) : WGPUTextureViewDimension_Undefined,
         .baseMipLevel = descriptor ? descriptor->baseMipLevel : 0,

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -204,10 +204,10 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
     auto mimeType = parseMIMEType(contentType);
     if (auto multipartBoundary = parseMultipartBoundary(mimeType)) {
         auto boundaryWithDashes = makeString("--"_s, *multipartBoundary);
-        CString boundary = boundaryWithDashes.utf8();
+        auto boundary = boundaryWithDashes.utf8();
         size_t boundaryLength = boundary.length();
 
-        size_t currentBoundaryIndex = find(data, boundary.span());
+        size_t currentBoundaryIndex = find(data, byteCast<uint8_t>(boundary.span()));
         if (currentBoundaryIndex == notFound)
             return nullptr;
 
@@ -221,7 +221,7 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
             return nullptr;
 
         size_t nextBoundaryIndex;
-        while ((nextBoundaryIndex = find(data, boundary.span())) != notFound) {
+        while ((nextBoundaryIndex = find(data, byteCast<uint8_t>(boundary.span()))) != notFound) {
             parseMultipartPart(data.first(nextBoundaryIndex - oneNewLine.length()), form.get());
             currentBoundaryIndex = nextBoundaryIndex;
             skip(data, nextBoundaryIndex + boundaryLength);

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -449,7 +449,7 @@ ExceptionOr<void> WebSocket::close(std::optional<unsigned short> optionalCode, c
         LOG(Network, "WebSocket %p close() code=%d reason='%s'", this, code, reason.utf8().legacyCStringPointer());
         if (!(code == ThreadableWebSocketChannel::CloseEventCodeNormalClosure || (ThreadableWebSocketChannel::CloseEventCodeMinimumUserDefined <= code && code <= ThreadableWebSocketChannel::CloseEventCodeMaximumUserDefined)))
             return Exception { ExceptionCode::InvalidAccessError };
-        CString utf8 = reason.utf8(StrictConversionReplacingUnpairedSurrogatesWithFFFD);
+        auto utf8 = reason.utf8(StrictConversionReplacingUnpairedSurrogatesWithFFFD);
         if (utf8.length() > maxReasonSizeInBytes) {
             protect(scriptExecutionContext())->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "WebSocket close message is too long."_s);
             return Exception { ExceptionCode::SyntaxError };

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp
@@ -94,7 +94,7 @@ bool WebSocketExtensionDispatcher::processHeaderValue(const String& headerValue)
         return false;
     }
 
-    const CString headerValueData = headerValue.utf8();
+    const auto headerValueData = headerValue.utf8();
     // FIXME: Is UTF-8 the encoding that WebSocketExtensionParser expects? It doesn't specify.
     WebSocketExtensionParser parser(byteCast<uint8_t>(headerValueData.span()));
     while (!parser.finished()) {

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -333,7 +333,7 @@ CString AccessibilityObjectAtspi::text(int startOffset, int endOffset) const
     if (utf8Text.isNull())
         return { };
 
-    auto length = static_cast<int>(g_utf8_strlen(utf8Text.data(), -1));
+    auto length = static_cast<int>(g_utf8_strlen(utf8Text.legacyCStringPointer(), -1));
     if (endOffset == -1)
         endOffset = length;
 
@@ -346,7 +346,7 @@ CString AccessibilityObjectAtspi::text(int startOffset, int endOffset) const
     if (!startOffset && endOffset == length)
         return utf8Text;
 
-    GUniquePtr<char> substring(g_utf8_substring(utf8Text.data(), startOffset, endOffset));
+    GUniquePtr<char> substring(g_utf8_substring(utf8Text.legacyCStringPointer(), startOffset, endOffset));
     return substring.get();
 }
 
@@ -372,7 +372,7 @@ void AccessibilityObjectAtspi::textInserted(const String& insertedText, const Vi
     auto mapping = offsetMapping(utf16Text);
     auto offset = UTF16OffsetToUTF8(mapping, utf16Offset);
     auto utf8InsertedText = maskedText.isNull() ? insertedText.utf8() : maskedText.utf8();
-    auto insertedTextLength = g_utf8_strlen(utf8InsertedText.data(), -1);
+    auto insertedTextLength = g_utf8_strlen(utf8InsertedText.legacyCStringPointer(), -1);
     AccessibilityAtspi::singleton().textChanged(*this, "insert", WTF::move(utf8InsertedText), offset - insertedTextLength, insertedTextLength);
 }
 
@@ -387,7 +387,7 @@ void AccessibilityObjectAtspi::textDeleted(const String& deletedText, const Visi
     auto mapping = offsetMapping(utf16Text);
     auto offset = UTF16OffsetToUTF8(mapping, utf16Offset);
     auto utf8DeletedText = deletedText.utf8();
-    auto deletedTextLength = g_utf8_strlen(utf8DeletedText.data(), -1);
+    auto deletedTextLength = g_utf8_strlen(utf8DeletedText.legacyCStringPointer(), -1);
     AccessibilityAtspi::singleton().textChanged(*this, "delete", WTF::move(utf8DeletedText), offset, deletedTextLength);
 }
 
@@ -469,7 +469,7 @@ CString AccessibilityObjectAtspi::textAtOffset(int offset, TextGranularity granu
     if (utf8Text.isNull())
         return { };
 
-    auto length = static_cast<int>(g_utf8_strlen(utf8Text.data(), -1));
+    auto length = static_cast<int>(g_utf8_strlen(utf8Text.legacyCStringPointer(), -1));
     if (offset < 0 || offset > length)
         return { };
 
@@ -484,7 +484,7 @@ CString AccessibilityObjectAtspi::textAtOffset(int offset, TextGranularity granu
         endOffset = UTF16OffsetToUTF8(mapping, std::min<int>(boundaryOffset.y(), utf16Text.length()));
     }
 
-    GUniquePtr<char> substring(g_utf8_substring(utf8Text.data(), startOffset, endOffset));
+    GUniquePtr<char> substring(g_utf8_substring(utf8Text.legacyCStringPointer(), startOffset, endOffset));
     return substring.get();
 }
 
@@ -494,11 +494,11 @@ int AccessibilityObjectAtspi::characterAtOffset(int offset) const
     if (utf8Text.isNull())
         return 0;
 
-    auto length = static_cast<int>(g_utf8_strlen(utf8Text.data(), -1));
+    auto length = static_cast<int>(g_utf8_strlen(utf8Text.legacyCStringPointer(), -1));
     if (offset < 0 || offset >= length)
         return 0;
 
-    return g_utf8_get_char(g_utf8_offset_to_pointer(utf8Text.data(), offset));
+    return g_utf8_get_char(g_utf8_offset_to_pointer(utf8Text.legacyCStringPointer(), offset));
 }
 
 std::optional<unsigned> AccessibilityObjectAtspi::characterOffset(char16_t character, int index) const
@@ -527,7 +527,7 @@ std::optional<unsigned> AccessibilityObjectAtspi::characterIndex(char16_t charac
     if (utf8Text.isNull())
         return std::nullopt;
 
-    auto length = static_cast<unsigned>(g_utf8_strlen(utf8Text.data(), -1));
+    auto length = static_cast<unsigned>(g_utf8_strlen(utf8Text.legacyCStringPointer(), -1));
     if (offset >= length)
         return std::nullopt;
 
@@ -582,7 +582,7 @@ IntRect AccessibilityObjectAtspi::textExtents(int startOffset, int endOffset, At
     if (utf8Text.isNull())
         return { };
 
-    auto length = static_cast<int>(g_utf8_strlen(utf8Text.data(), -1));
+    auto length = static_cast<int>(g_utf8_strlen(utf8Text.legacyCStringPointer(), -1));
     startOffset = std::clamp(startOffset, 0, length);
     if (endOffset == -1)
         endOffset = length;
@@ -690,7 +690,7 @@ bool AccessibilityObjectAtspi::selectionBounds(int& startOffset, int& endOffset)
     startOffset = UTF16OffsetToUTF8(mapping, bounds.x());
     endOffset = UTF16OffsetToUTF8(mapping, bounds.y());
 
-    auto length = static_cast<int>(g_utf8_strlen(utf8Text.data(), -1));
+    auto length = static_cast<int>(g_utf8_strlen(utf8Text.legacyCStringPointer(), -1));
     endOffset = std::clamp(endOffset, 0, length);
     if (endOffset < startOffset) {
         startOffset = endOffset = 0;
@@ -717,7 +717,7 @@ bool AccessibilityObjectAtspi::selectRange(int startOffset, int endOffset)
     if (utf8Text.isNull())
         return false;
 
-    auto length = static_cast<int>(g_utf8_strlen(utf8Text.data(), -1));
+    auto length = static_cast<int>(g_utf8_strlen(utf8Text.legacyCStringPointer(), -1));
     startOffset = std::clamp(startOffset, 0, length);
     if (endOffset == -1)
         endOffset = length;
@@ -749,7 +749,7 @@ void AccessibilityObjectAtspi::selectionChanged(const VisibleSelection& selectio
     if (bounds.y() < 0)
         return;
 
-    auto length = static_cast<unsigned>(g_utf8_strlen(utf8Text.data(), -1));
+    auto length = static_cast<unsigned>(g_utf8_strlen(utf8Text.legacyCStringPointer(), -1));
     auto mapping = offsetMapping(utf16Text);
     auto caretOffset = UTF16OffsetToUTF8(mapping, bounds.y());
     if (caretOffset <= length)
@@ -930,7 +930,7 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
     auto mapping = offsetMapping(utf16Text);
     std::optional<unsigned> utf16Offset;
     if (offset) {
-        auto length = static_cast<int>(g_utf8_strlen(utf8Text.data(), -1));
+        auto length = static_cast<int>(g_utf8_strlen(utf8Text.legacyCStringPointer(), -1));
         if (*offset < 0 || *offset >= length)
             return { };
 
@@ -961,7 +961,7 @@ bool AccessibilityObjectAtspi::scrollToMakeVisible(int startOffset, int endOffse
     if (utf8Text.isNull())
         return false;
 
-    auto length = static_cast<int>(g_utf8_strlen(utf8Text.data(), -1));
+    auto length = static_cast<int>(g_utf8_strlen(utf8Text.legacyCStringPointer(), -1));
     if (startOffset < 0 || startOffset > length)
         return false;
     if (endOffset < 0 || endOffset > length)
@@ -1022,7 +1022,7 @@ bool AccessibilityObjectAtspi::scrollToPoint(int startOffset, int endOffset, Ats
     if (utf8Text.isNull())
         return false;
 
-    auto length = static_cast<int>(g_utf8_strlen(utf8Text.data(), -1));
+    auto length = static_cast<int>(g_utf8_strlen(utf8Text.legacyCStringPointer(), -1));
     if (startOffset < 0 || startOffset > length)
         return false;
     if (endOffset < 0 || endOffset > length)

--- a/Source/WebCore/bindings/js/GarbageCollectionController.cpp
+++ b/Source/WebCore/bindings/js/GarbageCollectionController.cpp
@@ -137,7 +137,7 @@ void GarbageCollectionController::dumpHeapForVM(VM& vm)
         jsonData = snapshotBuilder.json();
     }
 
-    CString utf8String = jsonData.utf8();
+    auto utf8String = jsonData.utf8();
 
     fileHandle.write(byteCast<uint8_t>(utf8String.span()));
     WTFLogAlways("Dumped GC heap to %s%s", tempFilePath.utf8().legacyCStringPointer(), isMainThread() ? "" : " for Worker");

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1508,7 +1508,7 @@ inline SelectorCodeGenerator::SelectorCodeGenerator(const CSSSelector& rootSelec
 {
     if (shouldDumpCSSJITDisassembly()) [[unlikely]] {
         auto selectorTextUTF8 = m_originalSelector.selectorText().utf8();
-        auto selectorTextSpan = selectorTextUTF8.span();
+        auto selectorTextSpan = byteCast<char>(selectorTextUTF8.span());
         dataLogF("Compiling \"%.*s\"\n", static_cast<int>(selectorTextSpan.size()), selectorTextSpan.data());
     }
 

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -2545,8 +2545,7 @@ String WebGL2RenderingContext::getActiveUniformBlockName(WebGLProgram& program, 
     }
     // Index not validated because the error will be set by the GraphicsContextGL and the return value will be
     // the expected null.
-    CString name = protect(graphicsContextGL())->getActiveUniformBlockName(program.object(), index);
-    return String::fromUTF8(name.span());
+    return protect(graphicsContextGL())->getActiveUniformBlockName(program.object(), index);
 }
 
 void WebGL2RenderingContext::uniformBlockBinding(WebGLProgram& program, GCGLuint uniformBlockIndex, GCGLuint uniformBlockBinding)

--- a/Source/WebCore/html/canvas/WebGLProgram.cpp
+++ b/Source/WebCore/html/canvas/WebGLProgram.cpp
@@ -178,7 +178,7 @@ const HashMap<String, int>& WebGLProgram::uniformLocations() LIFETIME_BOUND
         for (auto& activeUniform : activeUniforms()) {
             if (activeUniform.blockIndex != -1)
                 continue;
-            auto name = String::fromUTF8(activeUniform.name.data());
+            String name { activeUniform.name };
             if (activeUniform.locations[0] != -1)
                 locations.add(name, activeUniform.locations[0]);
             if (name.endsWith("[0]"_s)) {
@@ -202,7 +202,7 @@ const HashMap<String, unsigned>& WebGLProgram::uniformIndices() LIFETIME_BOUND
         auto activeUniforms = this->activeUniforms();
         for (unsigned i = 0; i < activeUniforms.size(); ++i) {
             auto& activeUniform = activeUniforms[i];
-            auto name = String::fromUTF8(activeUniform.name.data());
+            String name { activeUniform.name };
             indices.add(name, i);
             if (name.endsWith("[0]"_s)) {
                 auto baseName = name.left(name.length() - 3);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -413,13 +413,13 @@ static constexpr GCGLErrorCode NODELETE glEnumToErrorCode(GCGLenum error)
 }
 
 // Conversion function converting GraphicsContextGL member function results that are directly
-// CStrings. The returned values might be null on implementation error or context loss during
+// UTF8CStrings. The returned values might be null on implementation error or context loss during
 // that function.
-static String ensureNotNull(const CString& text)
+static String toNonNullString(const UTF8CString& text)
 {
     if (text.isNull())
         return emptyString();
-    return String::fromUTF8(text.span());
+    return text;
 }
 
 static GraphicsContextGL::SurfaceBuffer NODELETE toGCGLSurfaceBuffer(CanvasRenderingContext::SurfaceBuffer buffer)
@@ -2303,7 +2303,7 @@ String WebGLRenderingContextBase::getProgramInfoLog(WebGLProgram& program)
         return { };
     if (!validateWebGLObject("getProgramInfoLog"_s, program))
         return { };
-    return ensureNotNull(protect(graphicsContextGL())->getProgramInfoLog(program.object()));
+    return toNonNullString(protect(graphicsContextGL())->getProgramInfoLog(program.object()));
 }
 
 WebGLAny WebGLRenderingContextBase::getRenderbufferParameter(GCGLenum target, GCGLenum pname)
@@ -2411,7 +2411,7 @@ String WebGLRenderingContextBase::getShaderInfoLog(WebGLShader& shader)
         return { };
     if (!validateWebGLObject("getShaderInfoLog"_s, shader))
         return { };
-    return ensureNotNull(protect(graphicsContextGL())->getShaderInfoLog(shader.object()));
+    return toNonNullString(protect(graphicsContextGL())->getShaderInfoLog(shader.object()));
 }
 
 RefPtr<WebGLShaderPrecisionFormat> WebGLRenderingContextBase::getShaderPrecisionFormat(GCGLenum shaderType, GCGLenum precisionType)
@@ -5693,7 +5693,7 @@ static ASCIILiteral debugMessageSeverityToString(GCGLenum severity)
     }
 }
 
-void WebGLRenderingContextBase::addDebugMessage(GCGLenum type, GCGLenum id, GCGLenum severity, const CString& message)
+void WebGLRenderingContextBase::addDebugMessage(GCGLenum type, GCGLenum id, GCGLenum severity, const UTF8CString& message)
 {
     if (!shouldPrintToConsole())
         return;
@@ -5707,9 +5707,9 @@ void WebGLRenderingContextBase::addDebugMessage(GCGLenum type, GCGLenum id, GCGL
 
     if (type == GraphicsContextGL::DEBUG_TYPE_ERROR) {
         level = MessageLevel::Error;
-        formattedMessage = makeString("WebGL: "_s, errorCodeToString(glEnumToErrorCode(id)), ": "_s, String::fromUTF8(message.span()));
+        formattedMessage = makeString("WebGL: "_s, errorCodeToString(glEnumToErrorCode(id)), ": "_s, message);
     } else
-        formattedMessage = makeString("WebGL debug message: type:"_s, debugMessageTypeToString(type), ", id:"_s, id, " severity: "_s, debugMessageSeverityToString(severity), ": "_s, String::fromUTF8(message.span()));
+        formattedMessage = makeString("WebGL debug message: type:"_s, debugMessageTypeToString(type), ", id:"_s, id, " severity: "_s, debugMessageSeverityToString(severity), ": "_s, message);
 
     auto consoleMessage = makeUnique<Inspector::ConsoleMessage>(MessageSource::Rendering, MessageType::Log, level, WTF::move(formattedMessage));
     scriptExecutionContext->addConsoleMessage(WTF::move(consoleMessage));

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -467,7 +467,7 @@ public:
 
     // GraphicsContextGL::Client
     void forceContextLost() final;
-    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const CString&) final;
+    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const UTF8CString&) final;
     void didChangeMemoryCost() final;
 
     void recycleContext();

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1805,7 +1805,7 @@ SubstituteData FrameLoader::defaultSubstituteDataForURL(const URL& url)
 
     auto& srcdoc = iframeElement->attributeWithoutSynchronization(srcdocAttr);
     ASSERT(!srcdoc.isNull());
-    CString encodedSrcdoc = srcdoc.string().utf8();
+    auto encodedSrcdoc = srcdoc.string().utf8();
 
     ResourceResponse response(URL(), String { textHTMLContentTypeAtom() }, encodedSrcdoc.length(), "UTF-8"_s);
     return SubstituteData(SharedBuffer::create(encodedSrcdoc.span()), URL(), WTF::move(response), iframeElement->srcdocSessionHistoryVisibility());

--- a/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
@@ -157,7 +157,7 @@ Ref<FragmentedSharedBuffer> MHTMLArchive::generateMHTMLData(Page* page)
     stringBuilder.append("\";\r\n\tboundary=\""_s, boundary, "\"\r\n\r\n"_s);
 
     ASSERT(stringBuilder.toString().containsOnlyASCII());
-    CString asciiString = stringBuilder.toString().utf8();
+    auto asciiString = stringBuilder.toString().utf8();
     SharedBufferBuilder mhtmlData;
     mhtmlData.append(asciiString.span());
 

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -558,8 +558,8 @@ ExceptionOr<Ref<PerformanceMeasure>> Performance::measure(JSC::JSGlobalObject& g
             if (correctedStartTime != correctedEndTime)
                 correctedEndTime -= 1;
 
-            WTFBeginSignpostAlwaysWithSpecificTime(entry.ptr(), WebKitPerformance, correctedStartTime, "%" PUBLIC_LOG_STRING, message.data());
-            WTFEndSignpostAlwaysWithSpecificTime(entry.ptr(), WebKitPerformance, correctedEndTime, "%" PUBLIC_LOG_STRING, message.data());
+            WTFBeginSignpostAlwaysWithSpecificTime(entry.ptr(), WebKitPerformance, correctedStartTime, "%" PUBLIC_LOG_STRING, message.legacyCStringPointer());
+            WTFEndSignpostAlwaysWithSpecificTime(entry.ptr(), WebKitPerformance, correctedEndTime, "%" PUBLIC_LOG_STRING, message.legacyCStringPointer());
         }
 #endif
         {

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -423,7 +423,7 @@ static Vector<ContentSecurityPolicyHash> generateHashesForContent(const StringVi
     if (algorithms.isEmpty())
         return { };
 
-    CString utf8Content = content.utf8(StrictConversionReplacingUnpairedSurrogatesWithFFFD);
+    auto utf8Content = content.utf8(StrictConversionReplacingUnpairedSurrogatesWithFFFD);
     Vector<ContentSecurityPolicyHash> hashes;
     for (auto algorithm : algorithms) {
         auto hash = cryptographicDigestForBytes(algorithm, byteCast<uint8_t>(utf8Content.span()));

--- a/Source/WebCore/platform/audio/AudioBus.h
+++ b/Source/WebCore/platform/audio/AudioBus.h
@@ -34,6 +34,7 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Vector.h>
+#include <wtf/text/StringView.h>
 
 namespace WebCore {
 
@@ -146,7 +147,7 @@ public:
     // Makes maximum absolute value == 1.0 (if possible).
     void normalize();
 
-    static RefPtr<AudioBus> loadPlatformResource(const char* name, float sampleRate);
+    static RefPtr<AudioBus> loadPlatformResource(StringView name, float sampleRate);
 
 private:
     AudioBus() { }

--- a/Source/WebCore/platform/audio/HRTFElevation.cpp
+++ b/Source/WebCore/platform/audio/HRTFElevation.cpp
@@ -84,7 +84,7 @@ static RefPtr<AudioBus> getConcatenatedImpulseResponsesForSubject(const String& 
         auto& cache = concatenatedImpulseResponsesMap();
         bus = cache.get(subjectName);
         if (!bus) {
-            bus = AudioBus::loadPlatformResource(subjectName.utf8().legacyCStringPointer(), ResponseSampleRate);
+            bus = AudioBus::loadPlatformResource(subjectName, ResponseSampleRate);
             ASSERT(bus);
             if (!bus)
                 return nullptr;
@@ -182,9 +182,9 @@ bool HRTFElevation::calculateKernelsForAzimuthElevation(int azimuth, int elevati
     AudioChannel* leftEarImpulseResponse = response->channel(AudioBus::ChannelLeft);
     AudioChannel* rightEarImpulseResponse = response->channel(AudioBus::ChannelRight);
 #else
-    auto resourceName = makeString("IRC_"_s, subjectName, "_C_R0195_T"_s, pad('0', 3, azimuth), "_P"_s, pad('0', 3, positiveElevation)).utf8();
+    auto resourceName = makeString("IRC_"_s, subjectName, "_C_R0195_T"_s, pad('0', 3, azimuth), "_P"_s, pad('0', 3, positiveElevation));
 
-    RefPtr<AudioBus> impulseResponse(AudioBus::loadPlatformResource(resourceName.data(), sampleRate));
+    RefPtr<AudioBus> impulseResponse(AudioBus::loadPlatformResource(resourceName, sampleRate));
 
     ASSERT(impulseResponse.get());
     if (!impulseResponse.get())

--- a/Source/WebCore/platform/audio/cocoa/AudioBusCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/AudioBusCocoa.mm
@@ -39,11 +39,11 @@
 
 namespace WebCore {
 
-RefPtr<AudioBus> AudioBus::loadPlatformResource(const char* name, float sampleRate)
+RefPtr<AudioBus> AudioBus::loadPlatformResource(StringView name, float sampleRate)
 {
     @autoreleasepool {
         RetainPtr<NSBundle> bundle = [NSBundle bundleForClass:[WebCoreAudioBundleClass class]];
-        RetainPtr<NSURL> audioFileURL = [bundle URLForResource:[NSString stringWithUTF8String:name] withExtension:@"wav" subdirectory:@"audio"];
+        RetainPtr<NSURL> audioFileURL = [bundle URLForResource:name.createNSString().get() withExtension:@"wav" subdirectory:@"audio"];
         if (NSData *audioData = [NSData dataWithContentsOfURL:audioFileURL.get() options:NSDataReadingMappedIfSafe error:nil])
             return createBusFromInMemoryAudioFile(span(audioData), false, sampleRate);
     }

--- a/Source/WebCore/platform/audio/glib/AudioBusGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/AudioBusGLib.cpp
@@ -26,7 +26,7 @@
 #include <gio/gio.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GSpanExtras.h>
-#include <wtf/glib/GUniquePtr.h>
+#include <wtf/text/MakeString.h>
 
 #if PLATFORM(GTK)
 #define AUDIO_GRESOURCE_PATH "/org/webkitgtk/resources/audio"
@@ -36,10 +36,10 @@
 
 namespace WebCore {
 
-RefPtr<AudioBus> AudioBus::loadPlatformResource(const char* name, float sampleRate)
+RefPtr<AudioBus> AudioBus::loadPlatformResource(StringView name, float sampleRate)
 {
-    GUniquePtr<char> path(g_strdup_printf(AUDIO_GRESOURCE_PATH "/%s", name));
-    GRefPtr<GBytes> data = adoptGRef(g_resources_lookup_data(path.get(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
+    auto path = makeString(AUDIO_GRESOURCE_PATH "/"_s, name).utf8();
+    GRefPtr<GBytes> data = adoptGRef(g_resources_lookup_data(path.legacyCStringPointer(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
     ASSERT(data);
     return createBusFromInMemoryAudioFile(span(data), false, sampleRate);
 }

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -87,7 +87,7 @@ public:
     RefPtr<NativeImage> nativeImageAtIndex(unsigned index) final { return m_source->nativeImageAtIndex(index); }
 
     // Testing support.
-    CString sourceUTF8() const { return sourceURL().string().utf8(); }
+    UTF8CString sourceUTF8() const { return sourceURL().string().utf8(); }
     void setAsyncDecodingEnabledForTesting(bool enabled) { m_source->setAsyncDecodingEnabledForTesting(enabled); }
     bool isAsyncDecodingEnabledForTesting() const { return m_source->isAsyncDecodingEnabledForTesting(); }
     void setMinimumDecodingDurationForTesting(Seconds duration) { m_source->setMinimumDecodingDurationForTesting(duration); }

--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -116,7 +116,7 @@ EncodedDataStatus BitmapImageSource::dataChanged(FragmentedSharedBuffer* data, b
 
 void BitmapImageSource::destroyDecodedFrames(bool destroyAll)
 {
-    LOG(Images, "BitmapImageSource::%s - %p - url: %s. Decoded data with destroyAll = %d will be destroyed.", __FUNCTION__, this, sourceUTF8().data(), destroyAll);
+    LOG(Images, "BitmapImageSource::%s - %p - url: %s. Decoded data with destroyAll = %d will be destroyed.", __FUNCTION__, this, sourceUTF8().legacyCStringPointer(), destroyAll);
 
     bool canDestroyDecodedData = destroyAll && this->canDestroyDecodedData();
 
@@ -352,7 +352,7 @@ bool BitmapImageSource::isDecoderWorkQueueIdle() const
 
 void BitmapImageSource::stopDecoderWorkQueue()
 {
-    LOG(Images, "BitmapImageSource::%s - %p - url: %s. Decoding work queue will be stopped.", __FUNCTION__, this, sourceUTF8().data());
+    LOG(Images, "BitmapImageSource::%s - %p - url: %s. Decoding work queue will be stopped.", __FUNCTION__, this, sourceUTF8().legacyCStringPointer());
 
     if (!m_decoder || !m_decoder->isWorkQueueIdle())
         return;
@@ -379,7 +379,7 @@ void BitmapImageSource::decode(Function<void(DecodingStatus)>&& decodeCallback)
     unsigned index = currentFrameIndex();
 
     if (isPendingDecodingAtIndex(index, SubsamplingLevel::Default, DecodingMode::Asynchronous)) {
-        LOG(Images, "BitmapImageSource::%s - %p - url: %s. Frame at index = %d is being decoded.", __FUNCTION__, this, sourceUTF8().data(), index);
+        LOG(Images, "BitmapImageSource::%s - %p - url: %s. Frame at index = %d is being decoded.", __FUNCTION__, this, sourceUTF8().legacyCStringPointer(), index);
         return;
     }
 
@@ -392,18 +392,18 @@ void BitmapImageSource::decode(Function<void(DecodingStatus)>&& decodeCallback)
         // startAnimation() always decodes the nextFrame which is currentFrameIndex + 1.
         // If primaryFrameIndex = 0, then the sequence of decoding is { 1, 2, .., n, 0, 1, ...}.
         if (startAnimation(SubsamplingLevel::Default, DecodingMode::Asynchronous)) {
-            LOG(Images, "BitmapImageSource::%s - %p - url: %s. Animator has requested decoding next frame at index = %d.", __FUNCTION__, this, sourceUTF8().data(), index);
+            LOG(Images, "BitmapImageSource::%s - %p - url: %s. Animator has requested decoding next frame at index = %d.", __FUNCTION__, this, sourceUTF8().legacyCStringPointer(), index);
             return;
         }
     }
 
     if (!compatibleDecodingDestination) {
-        LOG(Images, "BitmapImageSource::%s - %p - url: %s. Decoding for frame at index = %d will be requested.", __FUNCTION__, this, sourceUTF8().data(), index);
+        LOG(Images, "BitmapImageSource::%s - %p - url: %s. Decoding for frame at index = %d will be requested.", __FUNCTION__, this, sourceUTF8().legacyCStringPointer(), index);
         requestNativeImageAtIndex(index, SubsamplingLevel::Default, ImageAnimatingState::No, { DecodingMode::Asynchronous, preferredDecodingDestination });
         return;
     }
 
-    LOG(Images, "BitmapImageSource::%s - %p - url: %s. Frame at index = %d was decoded for natural size.", __FUNCTION__, this, sourceUTF8().data(), index);
+    LOG(Images, "BitmapImageSource::%s - %p - url: %s. Frame at index = %d was decoded for natural size.", __FUNCTION__, this, sourceUTF8().legacyCStringPointer(), index);
     callDecodeCallbacks(DecodingStatus::Complete);
 }
 
@@ -445,12 +445,12 @@ void BitmapImageSource::imageFrameDecodeAtIndexHasFinished(unsigned index, Subsa
     ASSERT(index < m_frames.size());
 
     if (!nativeImage || !m_decoder) {
-        LOG(Images, "BitmapImageSource::%s - %p - url: %s. Frame at index = %d has failed.", __FUNCTION__, this, sourceUTF8().data(), index);
+        LOG(Images, "BitmapImageSource::%s - %p - url: %s. Frame at index = %d has failed.", __FUNCTION__, this, sourceUTF8().legacyCStringPointer(), index);
 
         destroyNativeImageAtIndex(index, options.decodingDestination());
         imageFrameDecodeAtIndexHasFinished(index, animatingState, DecodingStatus::Invalid);
     } else {
-        LOG(Images, "BitmapImageSource::%s - %p - url: %s. Frame at index = %d has been decoded.", __FUNCTION__, this, sourceUTF8().data(), index);
+        LOG(Images, "BitmapImageSource::%s - %p - url: %s. Frame at index = %d has been decoded.", __FUNCTION__, this, sourceUTF8().legacyCStringPointer(), index);
 
         cacheNativeImageAtIndex(index, subsamplingLevel, options, nativeImage.releaseNonNull());
 
@@ -567,7 +567,7 @@ DecodingStatus BitmapImageSource::requestNativeImageAtIndex(unsigned index, Subs
     if (!m_decoder)
         return DecodingStatus::Invalid;
 
-    LOG(Images, "BitmapImageSource::%s - %p - url: %s. Decoding for frame at index = %d will be requested.", __FUNCTION__, this, sourceUTF8().data(), index);
+    LOG(Images, "BitmapImageSource::%s - %p - url: %s. Decoding for frame at index = %d will be requested.", __FUNCTION__, this, sourceUTF8().legacyCStringPointer(), index);
 
     protect(m_decoder)->requestNativeImageAtIndex(index, subsamplingLevel, animatingState, options);
 
@@ -584,7 +584,7 @@ std::expected<DecodingDestination, DecodingStatus> BitmapImageSource::requestNat
 
     // Never decode the same frame from two different threads.
     if (isPendingDecodingAtIndex(index, subsamplingLevel, options)) {
-        LOG(Images, "BitmapImageSource::%s - %p - url: %s. Frame at index = %d is being decoded.", __FUNCTION__, this, sourceUTF8().data(), index);
+        LOG(Images, "BitmapImageSource::%s - %p - url: %s. Frame at index = %d is being decoded.", __FUNCTION__, this, sourceUTF8().legacyCStringPointer(), index);
         ++m_blankDrawCountForTesting;
         return makeUnexpected(DecodingStatus::Decoding);
     }
@@ -607,7 +607,7 @@ std::expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::nativeImageAt
     // FIXME: Remove this for CG; ImageIO should be thread safe when decoding the same frame from multiple threads.
     // Never decode the same frame from two different threads.
     if (isPendingDecodingAtIndex(index, subsamplingLevel, options)) {
-        LOG(Images, "BitmapImageSource::%s - %p - url: %s. Frame at index = %d is being decoded.", __FUNCTION__, this, sourceUTF8().data(), index);
+        LOG(Images, "BitmapImageSource::%s - %p - url: %s. Frame at index = %d is being decoded.", __FUNCTION__, this, sourceUTF8().legacyCStringPointer(), index);
         ++m_blankDrawCountForTesting;
         return makeUnexpected(DecodingStatus::Decoding);
     }

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1223,7 +1223,7 @@ public:
         WEBCORE_EXPORT Client();
         WEBCORE_EXPORT virtual ~Client();
         virtual void forceContextLost() = 0;
-        virtual void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const CString&) = 0;
+        virtual void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const UTF8CString&) = 0;
         virtual void didChangeMemoryCost() = 0;
     };
 
@@ -1237,7 +1237,7 @@ public:
     // ========== WebGL 1 entry points.
     virtual void activeTexture(GCGLenum texture) = 0;
     virtual void attachShader(PlatformGLObject program, PlatformGLObject shader) = 0;
-    virtual void bindAttribLocation(PlatformGLObject, GCGLuint index, const CString& name) = 0;
+    virtual void bindAttribLocation(PlatformGLObject, GCGLuint index, const UTF8CString& name) = 0;
     virtual void bindBuffer(GCGLenum target, PlatformGLObject) = 0;
     virtual void bindFramebuffer(GCGLenum target, PlatformGLObject) = 0;
     virtual void bindRenderbuffer(GCGLenum target, PlatformGLObject) = 0;
@@ -1300,7 +1300,7 @@ public:
     virtual GCGLint getBufferParameteri(GCGLenum target, GCGLenum pname) = 0;
 
     // getParameter
-    virtual CString getString(GCGLenum name) = 0;
+    virtual UTF8CString getString(GCGLenum name) = 0;
     virtual void getFloatv(GCGLenum pname, std::span<GCGLfloat> value) = 0;
     virtual void getIntegerv(GCGLenum pname, std::span<GCGLint> value) = 0;
     virtual void getIntegeri_v(GCGLenum pname, GCGLuint index, std::span<GCGLint, 4> value) = 0; // NOLINT
@@ -1315,7 +1315,7 @@ public:
     virtual GCGLint getFramebufferAttachmentParameteri(GCGLenum target, GCGLenum attachment, GCGLenum pname) = 0;
 
     // getProgramParameter
-    virtual CString getProgramInfoLog(PlatformGLObject) = 0;
+    virtual UTF8CString getProgramInfoLog(PlatformGLObject) = 0;
 
     // getRenderbufferParameter
     virtual GCGLint getRenderbufferParameteri(GCGLenum target, GCGLenum pname) = 0;
@@ -1323,7 +1323,7 @@ public:
     // getShaderParameter
     virtual GCGLint getShaderi(PlatformGLObject, GCGLenum pname) = 0;
 
-    virtual CString getShaderInfoLog(PlatformGLObject) = 0;
+    virtual UTF8CString getShaderInfoLog(PlatformGLObject) = 0;
     virtual void getShaderPrecisionFormat(GCGLenum shaderType, GCGLenum precisionType, std::span<GCGLint, 2> range, GCGLint* precision) = 0;
 
     // getTexParameter
@@ -1354,7 +1354,7 @@ public:
     virtual void sampleCoverage(GCGLclampf value, GCGLboolean invert) = 0;
     virtual void scissor(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height) = 0;
 
-    virtual void shaderSource(PlatformGLObject shader, const CString& source) = 0;
+    virtual void shaderSource(PlatformGLObject shader, const UTF8CString& source) = 0;
 
     virtual void stencilFunc(GCGLenum func, GCGLint ref, GCGLuint mask) = 0;
     virtual void stencilFuncSeparate(GCGLenum face, GCGLenum func, GCGLint ref, GCGLuint mask) = 0;
@@ -1456,7 +1456,7 @@ public:
     virtual void compressedTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, std::span<const uint8_t> data) = 0;
     virtual void compressedTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLsizei imageSize, GCGLintptr offset) = 0;
 
-    virtual GCGLint getFragDataLocation(PlatformGLObject program, const CString& name) = 0;
+    virtual GCGLint getFragDataLocation(PlatformGLObject program, const UTF8CString& name) = 0;
 
     virtual void uniform1ui(GCGLint location, GCGLuint v0) = 0;
     virtual void uniform2ui(GCGLint location, GCGLuint v0, GCGLuint v1) = 0;
@@ -1519,7 +1519,7 @@ public:
     virtual void bindTransformFeedback(GCGLenum target, PlatformGLObject id) = 0;
     virtual void beginTransformFeedback(GCGLenum primitiveMode) = 0;
     virtual void endTransformFeedback() = 0;
-    virtual void transformFeedbackVaryings(PlatformGLObject program, const Vector<CString>& varyings, GCGLenum bufferMode) = 0;
+    virtual void transformFeedbackVaryings(PlatformGLObject program, const Vector<UTF8CString>& varyings, GCGLenum bufferMode) = 0;
     virtual std::optional<GCGLTransformFeedbackActiveInfo> getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index) = 0;
     virtual void pauseTransformFeedback() = 0;
     virtual void resumeTransformFeedback() = 0;
@@ -1527,9 +1527,9 @@ public:
     virtual void bindBufferBase(GCGLenum target, GCGLuint index, PlatformGLObject buffer) = 0;
     virtual void bindBufferRange(GCGLenum target, GCGLuint index, PlatformGLObject buffer, GCGLintptr offset, GCGLsizeiptr size) = 0;
 
-    virtual GCGLuint getUniformBlockIndex(PlatformGLObject program, const CString& uniformBlockName) = 0;
+    virtual GCGLuint getUniformBlockIndex(PlatformGLObject program, const UTF8CString& uniformBlockName) = 0;
     // getActiveUniformBlockParameter
-    virtual CString getActiveUniformBlockName(PlatformGLObject program, GCGLuint uniformBlockIndex) = 0;
+    virtual UTF8CString getActiveUniformBlockName(PlatformGLObject program, GCGLuint uniformBlockIndex) = 0;
     virtual void uniformBlockBinding(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLuint uniformBlockBinding) = 0;
 
     virtual void getActiveUniformBlockiv(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLenum pname, std::span<GCGLint> params) = 0;
@@ -1579,7 +1579,7 @@ public:
 #endif
 
     // GL_ANGLE_translated_shader_source
-    virtual CString getTranslatedShaderSourceANGLE(PlatformGLObject) = 0;
+    virtual UTF8CString getTranslatedShaderSourceANGLE(PlatformGLObject) = 0;
 
     // GL_ARB_draw_buffers / GL_EXT_draw_buffers
     virtual void drawBuffersEXT(std::span<const GCGLenum> bufs) = 0;

--- a/Source/WebCore/platform/graphics/GraphicsContextGLActiveInfo.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGLActiveInfo.h
@@ -35,7 +35,7 @@ namespace WebCore {
 
 class GCGLUniformActiveInfo {
 public:
-    CString name;
+    UTF8CString name;
     GCGLenum type { 0 };
     int size { -1 };
     // WebGL2 properties.
@@ -50,14 +50,14 @@ public:
 
 class GCGLAttribActiveInfo {
 public:
-    CString name;
+    UTF8CString name;
     GCGLenum type;
     int location;
 };
 
 class GCGLTransformFeedbackActiveInfo {
 public:
-    CString name;
+    UTF8CString name;
     GCGLenum type;
     int size { 0 };
 };

--- a/Source/WebCore/platform/graphics/ImageFrameAnimator.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrameAnimator.cpp
@@ -134,10 +134,10 @@ bool ImageFrameAnimator::startAnimation(SubsamplingLevel subsamplingLevel, const
     m_nextFrameSubsamplingLevel = subsamplingLevel;
     m_nextFrameOptions = options;
 
-    LOG(Images, "ImageFrameAnimator::%s - %p - url: %s. Animation at index = %d will be started.", __FUNCTION__, this, sourceUTF8().data(), m_currentFrameIndex);
+    LOG(Images, "ImageFrameAnimator::%s - %p - url: %s. Animation at index = %d will be started.", __FUNCTION__, this, sourceUTF8().legacyCStringPointer(), m_currentFrameIndex);
 
     if (options.decodingMode() == DecodingMode::Asynchronous) {
-        LOG(Images, "ImageFrameAnimator::%s - %p - url: %s. Decoding for frame at index = %d will be requested.", __FUNCTION__, this, sourceUTF8().data(), nextFrameIndex());
+        LOG(Images, "ImageFrameAnimator::%s - %p - url: %s. Decoding for frame at index = %d will be requested.", __FUNCTION__, this, sourceUTF8().legacyCStringPointer(), nextFrameIndex());
         std::ignore = source->requestNativeImageAtIndexIfNeeded(nextFrameIndex(), subsamplingLevel, ImageAnimatingState::Yes, options);
     }
 
@@ -158,11 +158,11 @@ bool ImageFrameAnimator::startAnimation(SubsamplingLevel subsamplingLevel, const
 
 void ImageFrameAnimator::advanceAnimation()
 {
-    LOG(Images, "ImageFrameAnimator::%s - %p - url: %s. Animation at index = %d will be advanced.", __FUNCTION__, this, sourceUTF8().data(), m_currentFrameIndex);
+    LOG(Images, "ImageFrameAnimator::%s - %p - url: %s. Animation at index = %d will be advanced.", __FUNCTION__, this, sourceUTF8().legacyCStringPointer(), m_currentFrameIndex);
 
     m_currentFrameIndex = nextFrameIndex();
     if (m_currentFrameIndex == m_frameCount - 1) {
-        LOG(Images, "ImageFrameAnimator::%s - %p - url: %s. Animation loop %d has ended.", __FUNCTION__, this, sourceUTF8().data(), m_repetitionsComplete);
+        LOG(Images, "ImageFrameAnimator::%s - %p - url: %s. Animation loop %d has ended.", __FUNCTION__, this, sourceUTF8().legacyCStringPointer(), m_repetitionsComplete);
         ++m_repetitionsComplete;
     }
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -164,9 +164,9 @@ static ASCIILiteral NODELETE extensionName(GCGLExtension extension)
     return name.literal;
 }
 
-static std::optional<GCGLExtension> extensionEnum(const CString& extension)
+static std::optional<GCGLExtension> extensionEnum(const UTF8CString& extension)
 {
-    if (auto* result = extensionsMapping.tryGet(extension.span()))
+    if (auto* result = extensionsMapping.tryGet(byteCast<char>(extension.span())))
         return *result;
     return std::nullopt;
 }
@@ -197,12 +197,12 @@ bool GraphicsContextGLANGLE::initialize()
     {
         StringView extensionsString { unsafeSpan(byteCast<char>(GL_GetString(GL_EXTENSIONS))) };
         for (auto extension : extensionsString.split(' '))
-            m_extensions.add(extension.span8());
+            m_extensions.add(extension.utf8());
     }
     {
         StringView extensionsString { unsafeSpan(byteCast<char>(GL_GetString(GL_REQUESTABLE_EXTENSIONS_ANGLE))) };
         for (auto extension : extensionsString.split(' '))
-            m_allRequestableExtensions.add(extension.span8());
+            m_allRequestableExtensions.add(extension.utf8());
     }
 
     validateAttributes();
@@ -291,7 +291,7 @@ bool GraphicsContextGLANGLE::initialize()
     auto debugMessageCallback = [](GCGLenum, GCGLenum type, GCGLenum id, GCGLenum severity, GCGLsizei length, const GCGLchar* message, const void* context) {
         auto* gl = reinterpret_cast<const GraphicsContextGLANGLE*>(context);
         if (gl->m_client)
-            gl->m_client->addDebugMessage(type, id, severity, CString { unsafeMakeSpan(message, length) });
+            gl->m_client->addDebugMessage(type, id, severity, UTF8CString { byteCast<char8_t>(unsafeMakeSpan(message, length)) });
     };
     GL_DebugMessageCallbackKHR(debugMessageCallback, this);
 
@@ -988,13 +988,13 @@ void GraphicsContextGLANGLE::attachShader(PlatformGLObject program, PlatformGLOb
     GL_AttachShader(program, shader);
 }
 
-void GraphicsContextGLANGLE::bindAttribLocation(PlatformGLObject program, GCGLuint index, const CString& name)
+void GraphicsContextGLANGLE::bindAttribLocation(PlatformGLObject program, GCGLuint index, const UTF8CString& name)
 {
     ASSERT(program);
     if (!makeContextCurrent())
         return;
 
-    GL_BindAttribLocation(program, index, name.data());
+    GL_BindAttribLocation(program, index, name.legacyCStringPointer());
 }
 
 void GraphicsContextGLANGLE::bindBuffer(GCGLenum target, PlatformGLObject buffer)
@@ -1535,7 +1535,7 @@ Vector<GCGLAttribActiveInfo> GraphicsContextGLANGLE::activeAttribs(PlatformGLObj
             return { };
         }
         name.resize(length);
-        result.append(GCGLAttribActiveInfo { name.data(), type, GL_GetAttribLocation(program, name.data()) });
+        result.append(GCGLAttribActiveInfo { UTF8CString { name }, type, GL_GetAttribLocation(program, name.data()) });
     }
     return result;
 }
@@ -1564,7 +1564,7 @@ Vector<GCGLUniformActiveInfo> GraphicsContextGLANGLE::activeUniforms(PlatformGLO
             return { };
         }
         name.resize(length);
-        info.name = name;
+        info.name = UTF8CString { name };
         if (m_isForWebGL2) {
             GL_GetActiveUniformsiv(program, 1, &index, GL_UNIFORM_BLOCK_INDEX, &info.blockIndex);
             GL_GetActiveUniformsiv(program, 1, &index, GL_UNIFORM_OFFSET, &info.offset);
@@ -1621,11 +1621,11 @@ GCGLErrorCodeSet GraphicsContextGLANGLE::getErrors()
     return std::exchange(m_errors, { });
 }
 
-CString GraphicsContextGLANGLE::getString(GCGLenum name)
+UTF8CString GraphicsContextGLANGLE::getString(GCGLenum name)
 {
     if (!makeContextCurrent())
         return { };
-    return CString { byteCast<char>(GL_GetString(name)) };
+    return UTF8CString { byteCast<char8_t>(GL_GetString(name)) };
 }
 
 void GraphicsContextGLANGLE::hint(GCGLenum target, GCGLenum mode)
@@ -1771,14 +1771,14 @@ void GraphicsContextGLANGLE::scissor(GCGLint x, GCGLint y, GCGLsizei width, GCGL
     GL_Scissor(x, y, width, height);
 }
 
-void GraphicsContextGLANGLE::shaderSource(PlatformGLObject shader, const CString& source)
+void GraphicsContextGLANGLE::shaderSource(PlatformGLObject shader, const UTF8CString& source)
 {
     ASSERT(shader);
 
     if (!makeContextCurrent())
         return;
 
-    const char* sources = source.data();
+    const char* sources = source.legacyCStringPointer();
     int lengths = source.length();
     GL_ShaderSource(shader, 1, &sources, &lengths);
 }
@@ -2223,19 +2223,19 @@ GCGLint GraphicsContextGLANGLE::getProgrami(PlatformGLObject program, GCGLenum p
     return value;
 }
 
-CString GraphicsContextGLANGLE::getProgramInfoLog(PlatformGLObject program)
+UTF8CString GraphicsContextGLANGLE::getProgramInfoLog(PlatformGLObject program)
 {
     if (!makeContextCurrent())
         return { };
     GLint maxLength = 0;
     GL_GetProgramiv(program, GL_INFO_LOG_LENGTH, &maxLength);
     if (!maxLength)
-        return "";
-    Vector<char, 64> buffer(maxLength); // GL_INFO_LOG_LENGTH includes nul termination.
+        return ""_s;
+    Vector<char8_t, 64> buffer(maxLength); // GL_INFO_LOG_LENGTH includes nul termination.
     GLsizei length = 0;
-    GL_GetProgramInfoLog(program, maxLength, &length, buffer.mutableSpan().data());
+    GL_GetProgramInfoLog(program, maxLength, &length, byteCast<char>(buffer.mutableSpan()).data());
     ASSERT(length == maxLength - 1);
-    return buffer.subspan(0, length);
+    return UTF8CString { buffer.subspan(0, length) };
 }
 
 GCGLint GraphicsContextGLANGLE::getRenderbufferParameteri(GCGLenum target, GCGLenum pname)
@@ -2257,19 +2257,19 @@ GCGLint GraphicsContextGLANGLE::getShaderi(PlatformGLObject shader, GCGLenum pna
     return value;
 }
 
-CString GraphicsContextGLANGLE::getShaderInfoLog(PlatformGLObject shader)
+UTF8CString GraphicsContextGLANGLE::getShaderInfoLog(PlatformGLObject shader)
 {
     if (!makeContextCurrent())
         return { };
     GLint maxLength = 0;
     GL_GetShaderiv(shader, GL_INFO_LOG_LENGTH, &maxLength);
     if (!maxLength)
-        return "";
-    Vector<char, 64> buffer(maxLength); // GL_INFO_LOG_LENGTH includes nul termination.
+        return ""_s;
+    Vector<char8_t, 64> buffer(maxLength); // GL_INFO_LOG_LENGTH includes nul termination.
     GLsizei length = 0;
-    GL_GetShaderInfoLog(shader, maxLength, &length, buffer.mutableSpan().data());
+    GL_GetShaderInfoLog(shader, maxLength, &length, byteCast<char>(buffer.mutableSpan()).data());
     ASSERT(length == maxLength - 1);
-    return buffer.subspan(0, length);
+    return UTF8CString { buffer.subspan(0, length) };
 }
 
 GCGLfloat GraphicsContextGLANGLE::getTexParameterf(GCGLenum target, GCGLenum pname)
@@ -2481,16 +2481,16 @@ void GraphicsContextGLANGLE::vertexAttribDivisor(GCGLuint index, GCGLuint diviso
         GL_VertexAttribDivisorANGLE(index, divisor);
 }
 
-GCGLuint GraphicsContextGLANGLE::getUniformBlockIndex(PlatformGLObject program, const CString& uniformBlockName)
+GCGLuint GraphicsContextGLANGLE::getUniformBlockIndex(PlatformGLObject program, const UTF8CString& uniformBlockName)
 {
     ASSERT(program);
     if (!makeContextCurrent())
         return GL_INVALID_INDEX;
 
-    return GL_GetUniformBlockIndex(program, uniformBlockName.data());
+    return GL_GetUniformBlockIndex(program, uniformBlockName.legacyCStringPointer());
 }
 
-CString GraphicsContextGLANGLE::getActiveUniformBlockName(PlatformGLObject program, GCGLuint uniformBlockIndex)
+UTF8CString GraphicsContextGLANGLE::getActiveUniformBlockName(PlatformGLObject program, GCGLuint uniformBlockIndex)
 {
     ASSERT(program);
     if (!makeContextCurrent())
@@ -2498,12 +2498,12 @@ CString GraphicsContextGLANGLE::getActiveUniformBlockName(PlatformGLObject progr
     GLint maxLength = 0;
     GL_GetProgramiv(program, GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH, &maxLength);
     // maxLength == 0 is ok, trying to access uniformBlockIndex in below call sets the consistent error.
-    Vector<char, 64> buffer(maxLength); // GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH includes nul termination.
+    Vector<char8_t, 64> buffer(maxLength); // GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH includes nul termination.
     GLsizei length = 0;
-    GL_GetActiveUniformBlockName(program, uniformBlockIndex, maxLength, &length, buffer.mutableSpan().data());
+    GL_GetActiveUniformBlockName(program, uniformBlockIndex, maxLength, &length, byteCast<char>(buffer.mutableSpan()).data());
     if (!length)
         return { };
-    return buffer.subspan(0, length);
+    return UTF8CString { buffer.subspan(0, length) };
 }
 
 void GraphicsContextGLANGLE::uniformBlockBinding(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLuint uniformBlockBinding)
@@ -2604,12 +2604,12 @@ void GraphicsContextGLANGLE::endTransformFeedback()
     GL_EndTransformFeedback();
 }
 
-void GraphicsContextGLANGLE::transformFeedbackVaryings(PlatformGLObject program, const Vector<CString>& varyings, GCGLenum bufferMode)
+void GraphicsContextGLANGLE::transformFeedbackVaryings(PlatformGLObject program, const Vector<UTF8CString>& varyings, GCGLenum bufferMode)
 {
     if (!makeContextCurrent())
         return;
-    Vector<const char*> pointersToVaryings = varyings.map([](const CString& varying) {
-        return varying.data();
+    Vector<const char*> pointersToVaryings = varyings.map([](const UTF8CString& varying) {
+        return varying.legacyCStringPointer();
     });
     GL_TransformFeedbackVaryings(program, pointersToVaryings.size(), pointersToVaryings.span().data(), bufferMode);
 }
@@ -2621,14 +2621,14 @@ std::optional<GCGLTransformFeedbackActiveInfo> GraphicsContextGLANGLE::getTransf
     GLsizei maxLength = 0;
     GL_GetProgramiv(program, GL_TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH, &maxLength);
     // maxLength == 0 is ok, trying to access index in below call sets the consistent error.
-    Vector<char, 64> buffer(maxLength); // GL_TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH includes nul termination.
+    Vector<char8_t, 64> buffer(maxLength); // GL_TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH includes nul termination.
     GLsizei length = 0;
     GLsizei size = 0;
     GLenum type = 0;
-    GL_GetTransformFeedbackVarying(program, index, maxLength, &length, &size, &type, buffer.mutableSpan().data());
+    GL_GetTransformFeedbackVarying(program, index, maxLength, &length, &size, &type, byteCast<char>(buffer.mutableSpan()).data());
     if (!length)
         return std::nullopt;
-    return GCGLTransformFeedbackActiveInfo { buffer.subspan(0, length), type, size };
+    return GCGLTransformFeedbackActiveInfo { UTF8CString { buffer.subspan(0, length) }, type, size };
 }
 
 void GraphicsContextGLANGLE::bindBufferBase(GCGLenum target, GCGLuint index, PlatformGLObject buffer)
@@ -2699,12 +2699,12 @@ void GraphicsContextGLANGLE::copyTexSubImage3D(GCGLenum target, GCGLint level, G
         GL_BindFramebuffer(framebufferTarget, m_multisampleFBO);
 }
 
-GCGLint GraphicsContextGLANGLE::getFragDataLocation(PlatformGLObject program, const CString& name)
+GCGLint GraphicsContextGLANGLE::getFragDataLocation(PlatformGLObject program, const UTF8CString& name)
 {
     if (!makeContextCurrent())
         return -1;
 
-    return GL_GetFragDataLocation(program, name.data());
+    return GL_GetFragDataLocation(program, name.legacyCStringPointer());
 }
 
 void GraphicsContextGLANGLE::uniform1ui(GCGLint location, GCGLuint v0)
@@ -3222,19 +3222,19 @@ bool GraphicsContextGLANGLE::isExtensionEnabledImpl(ASCIILiteral name) const
     return m_extensions.contains(name) || m_allEnabledRequestableExtensions.contains(name);
 }
 
-CString GraphicsContextGLANGLE::getTranslatedShaderSourceANGLE(PlatformGLObject shader)
+UTF8CString GraphicsContextGLANGLE::getTranslatedShaderSourceANGLE(PlatformGLObject shader)
 {
     if (!makeContextCurrent())
         return { };
     GLint maxLength = 0;
     GL_GetShaderivRobustANGLE(shader, GL_TRANSLATED_SHADER_SOURCE_LENGTH_ANGLE, 1, nullptr, &maxLength);
     if (!maxLength)
-        return "";
-    Vector<char, 64> buffer(maxLength); // GL_TRANSLATED_SHADER_SOURCE_LENGTH_ANGLE includes nul termination.
+        return ""_s;
+    Vector<char8_t, 64> buffer(maxLength); // GL_TRANSLATED_SHADER_SOURCE_LENGTH_ANGLE includes nul termination.
     GLsizei length = 0;
-    GL_GetTranslatedShaderSourceANGLE(shader, maxLength, &length, buffer.mutableSpan().data());
+    GL_GetTranslatedShaderSourceANGLE(shader, maxLength, &length, byteCast<char>(buffer.mutableSpan()).data());
     ASSERT(length == maxLength - 1);
-    return buffer.subspan(0, length);
+    return UTF8CString { buffer.subspan(0, length) };
 }
 
 void GraphicsContextGLANGLE::drawBuffersEXT(std::span<const GCGLenum> bufs)

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -62,7 +62,7 @@ public:
     // GraphicsContextGL overrides.
     void activeTexture(GCGLenum texture) final;
     void attachShader(PlatformGLObject program, PlatformGLObject shader) final;
-    void bindAttribLocation(PlatformGLObject, GCGLuint index, const CString& name) final;
+    void bindAttribLocation(PlatformGLObject, GCGLuint index, const UTF8CString& name) final;
     void bindBuffer(GCGLenum target, PlatformGLObject) final;
     void bindFramebuffer(GCGLenum target, PlatformGLObject) final;
     void bindRenderbuffer(GCGLenum target, PlatformGLObject) final;
@@ -126,12 +126,12 @@ public:
     GCGLint max3DTextureSize() final;
     GCGLint maxArrayTextureLayers() final;
     GCGLint getProgrami(PlatformGLObject program, GCGLenum pname) final;
-    CString getProgramInfoLog(PlatformGLObject) final;
+    UTF8CString getProgramInfoLog(PlatformGLObject) final;
     GCGLint getRenderbufferParameteri(GCGLenum target, GCGLenum pname) final;
     GCGLint getShaderi(PlatformGLObject, GCGLenum pname) final;
-    CString getShaderInfoLog(PlatformGLObject) final;
+    UTF8CString getShaderInfoLog(PlatformGLObject) final;
     void getShaderPrecisionFormat(GCGLenum shaderType, GCGLenum precisionType, std::span<GCGLint, 2> range, GCGLint* precision) final;
-    CString getString(GCGLenum name) final;
+    UTF8CString getString(GCGLenum name) final;
     GCGLfloat getTexParameterf(GCGLenum target, GCGLenum pname) final;
     GCGLint getTexParameteri(GCGLenum target, GCGLenum pname) final;
     void getUniformfv(PlatformGLObject program, GCGLint location, std::span<GCGLfloat> value) final;
@@ -155,7 +155,7 @@ public:
     void renderbufferStorage(GCGLenum target, GCGLenum internalformat, GCGLsizei width, GCGLsizei height) final;
     void sampleCoverage(GCGLclampf value, GCGLboolean invert) final;
     void scissor(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height) final;
-    void shaderSource(PlatformGLObject, const CString&) final;
+    void shaderSource(PlatformGLObject, const UTF8CString&) final;
     void stencilFunc(GCGLenum func, GCGLint ref, GCGLuint mask) final;
     void stencilFuncSeparate(GCGLenum face, GCGLenum func, GCGLint ref, GCGLuint mask) final;
     void stencilMask(GCGLuint mask) final;
@@ -231,7 +231,7 @@ public:
     void compressedTexImage3D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLsizei imageSize, GCGLintptr offset) final;
     void compressedTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, std::span<const uint8_t> data) final;
     void compressedTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLsizei imageSize, GCGLintptr offset) final;
-    GCGLint getFragDataLocation(PlatformGLObject program, const CString& name) final;
+    GCGLint getFragDataLocation(PlatformGLObject program, const UTF8CString& name) final;
     void uniform1ui(GCGLint location, GCGLuint v0) final;
     void uniform2ui(GCGLint location, GCGLuint v0, GCGLuint v1) final;
     void uniform3ui(GCGLint location, GCGLuint v0, GCGLuint v1, GCGLuint v2) final;
@@ -284,14 +284,14 @@ public:
     void bindTransformFeedback(GCGLenum target, PlatformGLObject id) final;
     void beginTransformFeedback(GCGLenum primitiveMode) final;
     void endTransformFeedback() final;
-    void transformFeedbackVaryings(PlatformGLObject program, const Vector<CString>& varyings, GCGLenum bufferMode) final;
+    void transformFeedbackVaryings(PlatformGLObject program, const Vector<UTF8CString>& varyings, GCGLenum bufferMode) final;
     std::optional<GCGLTransformFeedbackActiveInfo> getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index) final;
     void pauseTransformFeedback() final;
     void resumeTransformFeedback() final;
     void bindBufferBase(GCGLenum target, GCGLuint index, PlatformGLObject buffer) final;
     void bindBufferRange(GCGLenum target, GCGLuint index, PlatformGLObject buffer, GCGLintptr offset, GCGLsizeiptr) final;
-    GCGLuint getUniformBlockIndex(PlatformGLObject program, const CString& uniformBlockName) final;
-    CString getActiveUniformBlockName(PlatformGLObject program, GCGLuint uniformBlockIndex) final;
+    GCGLuint getUniformBlockIndex(PlatformGLObject program, const UTF8CString& uniformBlockName) final;
+    UTF8CString getActiveUniformBlockName(PlatformGLObject program, GCGLuint uniformBlockIndex) final;
     void uniformBlockBinding(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLuint uniformBlockBinding) final;
     void getActiveUniformBlockiv(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLenum pname, std::span<GCGLint> params) final;
 #if ENABLE(WEBXR)
@@ -307,7 +307,7 @@ public:
     void multiDrawElementsInstancedANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLsizei, const GCGLsizei, const GCGLsizei> countsOffsetsAndInstanceCounts, GCGLenum type) final;
     bool enableExtension(GCGLExtension) override;
     void drawBuffersEXT(std::span<const GCGLenum>) override;
-    CString getTranslatedShaderSourceANGLE(PlatformGLObject) override;
+    UTF8CString getTranslatedShaderSourceANGLE(PlatformGLObject) override;
     PlatformGLObject createQueryEXT() final;
     void deleteQueryEXT(PlatformGLObject query) final;
     GCGLboolean isQueryEXT(PlatformGLObject query) final;
@@ -423,9 +423,9 @@ protected:
     void setPackParameters(GCGLint alignment, GCGLint rowLength, GCGLboolean reverseRowOrder);
     bool NODELETE validateClearBufferv(GCGLenum buffer, size_t valuesSize);
 
-    HashSet<CString> m_allRequestableExtensions;
-    HashSet<CString> m_allEnabledRequestableExtensions;
-    HashSet<CString> m_extensions;
+    HashSet<UTF8CString> m_allRequestableExtensions;
+    HashSet<UTF8CString> m_allEnabledRequestableExtensions;
+    HashSet<UTF8CString> m_extensions;
     GCGLuint m_texture { 0 };
     GCGLuint m_fbo { 0 };
     GCGLuint m_depthStencilBuffer { 0 };

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1445,8 +1445,8 @@ void MediaPlayerPrivateGStreamer::elementIdChanged(const String& elementId) cons
     auto tokens = currentName.split('-');
     auto newName = makeString(tokens[0], '-', elementId, '-', tokens.last());
     auto nameCString = newName.utf8();
-    GST_DEBUG_OBJECT(m_pipeline.get(), "Renaming to %s", nameCString.data());
-    gst_object_set_name(GST_OBJECT_CAST(m_pipeline.get()), nameCString.data());
+    GST_DEBUG_OBJECT(m_pipeline.get(), "Renaming to %s", nameCString.legacyCStringPointer());
+    gst_object_set_name(GST_OBJECT_CAST(m_pipeline.get()), nameCString.legacyCStringPointer());
 }
 
 void MediaPlayerPrivateGStreamer::handleTextSample(GRefPtr<GstSample>&& sample, TrackID streamId)

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
@@ -337,8 +337,8 @@ bool GStreamerInternalVideoEncoder::encode(VideoEncoder::RawFrame&& rawFrame, bo
     auto orientation = makeString(gstVideoFrame.isMirrored() ? "flip-"_s : ""_s, "rotate-"_s, gstVideoFrame.rotation());
     if (orientation != m_orientation) {
         auto orientationCString = orientation.utf8();
-        GST_DEBUG_OBJECT(m_harness->element(), "New orientation: %s", orientationCString.data());
-        GRefPtr tags = adoptGRef(gst_tag_list_new(GST_TAG_IMAGE_ORIENTATION, orientationCString.data(), nullptr));
+        GST_DEBUG_OBJECT(m_harness->element(), "New orientation: %s", orientationCString.legacyCStringPointer());
+        GRefPtr tags = adoptGRef(gst_tag_list_new(GST_TAG_IMAGE_ORIENTATION, orientationCString.legacyCStringPointer(), nullptr));
         GRefPtr event = adoptGRef(gst_event_new_tag(tags.leakRef()));
         m_harness->storeStickyEvent(event);
         m_orientation = WTF::move(orientation);

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
@@ -820,8 +820,8 @@ TextureMapperShaderProgram::TextureMapperShaderProgram(const String& vertex, con
 {
     m_vertexShader = glCreateShader(GL_VERTEX_SHADER);
     {
-        CString vertexCString = vertex.utf8();
-        const char* data = vertexCString.data();
+        auto vertexCString = vertex.utf8();
+        const char* data = vertexCString.legacyCStringPointer();
         int length = vertexCString.length();
         glShaderSource(m_vertexShader, 1, &data, &length);
     }
@@ -829,8 +829,8 @@ TextureMapperShaderProgram::TextureMapperShaderProgram(const String& vertex, con
 
     m_fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
     {
-        CString fragmentCString = fragment.utf8();
-        const char* data = fragmentCString.data();
+        auto fragmentCString = fragment.utf8();
+        const char* data = fragmentCString.legacyCStringPointer();
         int length = fragmentCString.length();
         glShaderSource(m_fragmentShader, 1, &data, &length);
     }

--- a/Source/WebCore/platform/libwpe/PlatformPasteboardLibWPE.cpp
+++ b/Source/WebCore/platform/libwpe/PlatformPasteboardLibWPE.cpp
@@ -88,8 +88,8 @@ void PlatformPasteboard::write(const PasteboardWebContent& content)
     static constexpr auto plainText = "text/plain;charset=utf-8"_s;
     static constexpr auto htmlText = "text/html"_s;
 
-    CString textString = content.text.utf8();
-    CString markupString = content.markup.utf8();
+    auto textString = content.text.utf8();
+    auto markupString = content.markup.utf8();
 
     IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
     std::array<struct wpe_pasteboard_string_pair, 2> pairs = { {
@@ -97,9 +97,9 @@ void PlatformPasteboard::write(const PasteboardWebContent& content)
         { { nullptr, 0 }, { nullptr, 0 } },
     } };
     wpe_pasteboard_string_initialize(&pairs[0].type, plainText, strlen(plainText));
-    wpe_pasteboard_string_initialize(&pairs[0].string, textString.data(), textString.length());
+    wpe_pasteboard_string_initialize(&pairs[0].string, textString.legacyCStringPointer(), textString.length());
     wpe_pasteboard_string_initialize(&pairs[1].type, htmlText, strlen(htmlText));
-    wpe_pasteboard_string_initialize(&pairs[1].string, markupString.data(), markupString.length());
+    wpe_pasteboard_string_initialize(&pairs[1].string, markupString.legacyCStringPointer(), markupString.length());
     struct wpe_pasteboard_string_map map = { pairs.data(), pairs.size() };
     IGNORE_CLANG_WARNINGS_END
 
@@ -120,8 +120,8 @@ void PlatformPasteboard::write(const String& type, const String& string)
 
     auto typeUTF8 = type.utf8();
     auto stringUTF8 = string.utf8();
-    wpe_pasteboard_string_initialize(&pairs[0].type, typeUTF8.data(), typeUTF8.length());
-    wpe_pasteboard_string_initialize(&pairs[0].string, stringUTF8.data(), stringUTF8.length());
+    wpe_pasteboard_string_initialize(&pairs[0].type, typeUTF8.legacyCStringPointer(), typeUTF8.length());
+    wpe_pasteboard_string_initialize(&pairs[0].string, stringUTF8.legacyCStringPointer(), stringUTF8.length());
     struct wpe_pasteboard_string_map map = { pairs, 1 };
 
     wpe_pasteboard_write(m_pasteboard, &map);

--- a/Source/WebCore/platform/network/curl/PublicSuffixStoreCurl.cpp
+++ b/Source/WebCore/platform/network/curl/PublicSuffixStoreCurl.cpp
@@ -57,17 +57,18 @@ String PublicSuffixStore::platformTopPrivatelyControlledDomain(StringView domain
 
     // This function is expected to work with the format used by cookies, so skip any leading dots.
     auto domainUTF8 = domain.utf8();
+    auto characters = domainUTF8.span();
 
     unsigned position = 0;
-    while (domainUTF8.data()[position] == '.')
+    while (position < characters.size() && characters[position] == u8'.')
         position++;
 
-    if (position == domainUTF8.length())
+    if (position == characters.size())
         return String();
 
     const psl_ctx_t* psl = psl_builtin();
     ASSERT(psl);
-    return topPrivatelyControlledDomainInternal(psl, domainUTF8.data() + position);
+    return topPrivatelyControlledDomainInternal(psl, domainUTF8.legacyCStringPointer() + position);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/soup/PublicSuffixStoreSoup.cpp
+++ b/Source/WebCore/platform/soup/PublicSuffixStoreSoup.cpp
@@ -72,7 +72,7 @@ String PublicSuffixStore::platformTopPrivatelyControlledDomain(StringView domain
     const auto tldCString = tldView.utf8();
 
     GUniqueOutPtr<GError> error;
-    if (const char* baseDomain = soup_tld_get_base_domain(tldCString.data(), &error.outPtr()))
+    if (const char* baseDomain = soup_tld_get_base_domain(tldCString.legacyCStringPointer(), &error.outPtr()))
         return String::fromUTF8(baseDomain);
 
     if (g_error_matches(error.get(), SOUP_TLD_ERROR, SOUP_TLD_ERROR_NO_BASE_DOMAIN))

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -802,9 +802,9 @@ static std::expected<sqlite3_stmt*, int> constructAndPrepareStatement(SQLiteData
 std::unique_ptr<SQLiteStatement> SQLiteDatabase::prepareStatementSlow(StringView queryString)
 {
     auto query = queryString.trim(isUnicodeCompatibleASCIIWhitespace<char16_t>).utf8();
-    auto sqlStatement = constructAndPrepareStatement(*this, query.spanIncludingNullTerminator());
+    auto sqlStatement = constructAndPrepareStatement(*this, byteCast<char>(query.spanIncludingNullTerminator()));
     if (!sqlStatement) {
-        RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareStatement: Failed to prepare statement %" PUBLIC_LOG_STRING, query.data());
+        RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareStatement: Failed to prepare statement %" PUBLIC_LOG_STRING, query.legacyCStringPointer());
         return nullptr;
     }
     return std::unique_ptr<SQLiteStatement>(new SQLiteStatement(*this, sqlStatement.value()));

--- a/Source/WebCore/platform/text/enchant/TextCheckerEnchant.cpp
+++ b/Source/WebCore/platform/text/enchant/TextCheckerEnchant.cpp
@@ -54,22 +54,22 @@ void TextCheckerEnchant::ignoreWord(const String& word)
 {
     auto utf8Word = word.utf8();
     for (auto& dictionary : m_enchantDictionaries)
-        enchant_dict_add_to_session(dictionary.get(), utf8Word.data(), utf8Word.length());
+        enchant_dict_add_to_session(dictionary.get(), utf8Word.legacyCStringPointer(), utf8Word.length());
 }
 
 void TextCheckerEnchant::learnWord(const String& word)
 {
     auto utf8Word = word.utf8();
     for (auto& dictionary : m_enchantDictionaries)
-        enchant_dict_add(dictionary.get(), utf8Word.data(), utf8Word.length());
+        enchant_dict_add(dictionary.get(), utf8Word.legacyCStringPointer(), utf8Word.length());
 }
 
 void TextCheckerEnchant::checkSpellingOfWord(const String& word, int start, int end, int& misspellingLocation, int& misspellingLength)
 {
-    CString string = word.substring(start, end - start).utf8();
+    auto string = word.substring(start, end - start).utf8();
 
     for (auto& dictionary : m_enchantDictionaries) {
-        if (!enchant_dict_check(dictionary.get(), string.data(), string.length())) {
+        if (!enchant_dict_check(dictionary.get(), string.legacyCStringPointer(), string.length())) {
             // Stop checking, this word is ok in at least one dict.
             misspellingLocation = -1;
             misspellingLength = 0;
@@ -118,7 +118,7 @@ Vector<String> TextCheckerEnchant::getGuessesForWord(const String& word)
     for (auto& dictionary : m_enchantDictionaries) {
         size_t numberOfSuggestions;
 
-        char** suggestions = enchant_dict_suggest(dictionary.get(), utf8Word.data(), utf8Word.length(), &numberOfSuggestions);
+        char** suggestions = enchant_dict_suggest(dictionary.get(), utf8Word.legacyCStringPointer(), utf8Word.length(), &numberOfSuggestions);
         if (numberOfSuggestions <= 0)
             continue;
 
@@ -139,17 +139,17 @@ void TextCheckerEnchant::updateSpellCheckingLanguages(const Vector<String>& lang
     Vector<UniqueEnchantDict> spellDictionaries;
     if (!languages.isEmpty()) {
         for (auto& language : languages) {
-            CString currentLanguage = language.utf8();
-            if (enchant_broker_dict_exists(m_broker, currentLanguage.data())) {
-                if (auto* dict = enchant_broker_request_dict(m_broker, currentLanguage.data()))
+            auto currentLanguage = language.utf8();
+            if (enchant_broker_dict_exists(m_broker, currentLanguage.legacyCStringPointer())) {
+                if (auto* dict = enchant_broker_request_dict(m_broker, currentLanguage.legacyCStringPointer()))
                     spellDictionaries.append(dict);
             }
         }
     } else {
         // Languages are not specified by user, try to get default language.
-        CString language = defaultLanguage().utf8();
-        if (enchant_broker_dict_exists(m_broker, language.data())) {
-            if (auto* dict = enchant_broker_request_dict(m_broker, language.data()))
+        auto language = defaultLanguage().utf8();
+        if (enchant_broker_dict_exists(m_broker, language.legacyCStringPointer())) {
+            if (auto* dict = enchant_broker_request_dict(m_broker, language.legacyCStringPointer()))
                 spellDictionaries.append(dict);
         } else {
             // No dictionaries selected, we get the first one from the list.

--- a/Source/WebCore/platform/text/hyphen/HyphenationLibHyphen.cpp
+++ b/Source/WebCore/platform/text/hyphen/HyphenationLibHyphen.cpp
@@ -209,7 +209,7 @@ size_t lastHyphenLocation(StringView string, size_t beforeIndex, const AtomStrin
     // which stores either UTF-16 or Latin1 data. This is unfortunate for performance
     // reasons and we should consider switching to a more flexible hyphenation library
     // if it is available.
-    CString utf8StringCopy = string.utf8();
+    auto utf8StringCopy = string.utf8();
 
     // WebCore often passes strings like " wordtohyphenate" to the platform layer. Since
     // libhyphen isn't advanced enough to deal with leading spaces (presumably CoreFoundation
@@ -239,7 +239,7 @@ size_t lastHyphenLocation(StringView string, size_t beforeIndex, const AtomStrin
         int* positions = nullptr;
         int* removedCharacterCounts = nullptr;
         hnj_hyphen_hyphenate2(dictionary->libhyphenDictionary(),
-            utf8StringCopy.data() + leadingSpaceBytes,
+            utf8StringCopy.legacyCStringPointer() + leadingSpaceBytes,
             utf8StringCopy.length() - leadingSpaceBytes,
             hyphenArrayData,
             nullptr, /* output parameter for hyphenated word */

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -259,8 +259,8 @@ void markupToCFHTML(const String& markup, const String& srcURL, Vector<char>& re
     const char* startMarkup = "<HTML>\n<BODY>\n<!--StartFragment-->\n";
     const char* endMarkup = "\n<!--EndFragment-->\n</BODY>\n</HTML>";
 
-    CString sourceURLUTF8 = srcURL == aboutBlankURL() ? "" : srcURL.utf8();
-    CString markupUTF8 = markup.utf8();
+    auto sourceURLUTF8 = srcURL == aboutBlankURL() ? ""_s : srcURL.utf8();
+    auto markupUTF8 = markup.utf8();
 
     // calculate offsets
     unsigned startHTMLOffset = strlen(header) - strlen(NUMBER_FORMAT) * 4 + MAX_DIGITS * 4;
@@ -757,13 +757,13 @@ void setUTF8Data(IDataObject* data, FORMATETC* format, const Vector<String>& dat
     STGMEDIUM medium { };
     medium.tymed = TYMED_HGLOBAL;
 
-    CString charString = dataStrings.first().utf8();
+    auto charString = dataStrings.first().utf8();
     size_t stringLength = charString.length();
     medium.hGlobal = ::GlobalAlloc(GPTR, stringLength + 1);
     if (!medium.hGlobal)
         return;
-    char* buffer = static_cast<char*>(GlobalLock(medium.hGlobal));
-    memcpy(buffer, charString.data(), stringLength);
+    auto buffer = unsafeMakeSpan(static_cast<char*>(GlobalLock(medium.hGlobal)), stringLength + 1);
+    memcpySpan(buffer, charString.span());
     buffer[stringLength] = 0;
     GlobalUnlock(medium.hGlobal);
     data->SetData(format, &medium, FALSE);

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -252,13 +252,13 @@ static size_t capitalizeWordWithLocale(StringView textContent, unsigned startOff
 
     Vector<char16_t, 32> titlecased(wordLength + 4);
     UErrorCode status = U_ZERO_ERROR;
-    auto realLength = u_strToTitle(titlecased.mutableSpan().data(), titlecased.size(), wordData, wordLength, nullptr, localeUTF8.data(), &status);
+    auto realLength = u_strToTitle(titlecased.mutableSpan().data(), titlecased.size(), wordData, wordLength, nullptr, localeUTF8.legacyCStringPointer(), &status);
     if (U_FAILURE(status)) {
         if (status != U_BUFFER_OVERFLOW_ERROR)
             return 0;
         titlecased.grow(realLength);
         status = U_ZERO_ERROR;
-        u_strToTitle(titlecased.mutableSpan().data(), titlecased.size(), wordData, wordLength, nullptr, localeUTF8.data(), &status);
+        u_strToTitle(titlecased.mutableSpan().data(), titlecased.size(), wordData, wordLength, nullptr, localeUTF8.legacyCStringPointer(), &status);
         if (U_FAILURE(status))
             return 0;
     }

--- a/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
+++ b/Source/WebCore/xml/XSLStyleSheetLibxslt.cpp
@@ -302,9 +302,9 @@ xmlDocPtr XSLStyleSheet::locateStylesheetSubResource(xmlDocPtr parentDoc, const 
             // In order to ensure that libxml canonicalized both URLs, we get the original href
             // string from the import rule and canonicalize it using libxml before comparing it
             // with the URI argument.
-            CString importHref = import->href().utf8();
+            auto importHref = import->href().utf8();
             xmlChar* base = xmlNodeGetBase(parentDoc, (xmlNodePtr)parentDoc);
-            xmlChar* childURI = xmlBuildURI((const xmlChar*)importHref.data(), base);
+            xmlChar* childURI = xmlBuildURI((const xmlChar*)importHref.legacyCStringPointer(), base);
             bool equalURIs = xmlStrEqual(uri, childURI);
             xmlFree(base);
             xmlFree(childURI);

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -1669,7 +1669,7 @@ bool XMLDocumentParser::appendFragmentSource(const String& chunk)
     ASSERT(!m_context);
     ASSERT(m_parsingFragment);
 
-    CString chunkAsUTF8 = chunk.utf8();
+    auto chunkAsUTF8 = chunk.utf8();
     
     // libxml2 takes an int for a length, and therefore can't handle XML chunks larger than 2 GiB.
     if (chunkAsUTF8.length() > INT_MAX)

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -206,7 +206,7 @@ int WebDriverService::run(int argc, char** argv)
 
     WTF::initializeMainThread();
 
-    CString hostStr = host && !host->isNull() ? host->utf8() : "local";
+    auto hostStr = host && !host->isNull() ? host->utf8() : "local"_s;
     auto programName = FileSystem::lastComponentOfPathIgnoringTrailingSlash(String::fromLatin1(argv[0]));
     if (programName.isEmpty())
         programName = "WebDriver"_s;
@@ -214,27 +214,27 @@ int WebDriverService::run(int argc, char** argv)
 
 #if ENABLE(WEBDRIVER_BIDI)
     if (m_targetAddress.isEmpty())
-        RELEASE_LOG_INFO(WebDriverClassic, "%s starting: http=%s:%d bidi=%d", programNameStr.data(), hostStr.data(), *port, *bidiPort);
+        RELEASE_LOG_INFO(WebDriverClassic, "%s starting: http=%s:%d bidi=%d", programNameStr.legacyCStringPointer(), hostStr.legacyCStringPointer(), *port, *bidiPort);
     else
-        RELEASE_LOG_INFO(WebDriverClassic, "%s starting: http=%s:%d bidi=%d target=%s:%d", programNameStr.data(), hostStr.data(), *port, *bidiPort, m_targetAddress.utf8().legacyCStringPointer(), m_targetPort);
+        RELEASE_LOG_INFO(WebDriverClassic, "%s starting: http=%s:%d bidi=%d target=%s:%d", programNameStr.legacyCStringPointer(), hostStr.legacyCStringPointer(), *port, *bidiPort, m_targetAddress.utf8().legacyCStringPointer(), m_targetPort);
 #else
     if (m_targetAddress.isEmpty())
-        RELEASE_LOG_INFO(WebDriverClassic, "%s starting: http=%s:%d", programNameStr.data(), hostStr.data(), *port);
+        RELEASE_LOG_INFO(WebDriverClassic, "%s starting: http=%s:%d", programNameStr.legacyCStringPointer(), hostStr.legacyCStringPointer(), *port);
     else
-        RELEASE_LOG_INFO(WebDriverClassic, "%s starting: http=%s:%d target=%s:%d", programNameStr.data(), hostStr.data(), *port, m_targetAddress.utf8().legacyCStringPointer(), m_targetPort);
+        RELEASE_LOG_INFO(WebDriverClassic, "%s starting: http=%s:%d target=%s:%d", programNameStr.legacyCStringPointer(), hostStr.legacyCStringPointer(), *port, m_targetAddress.utf8().legacyCStringPointer(), m_targetPort);
 #endif
 
     if (!m_server.listen(host, *port)) {
-        RELEASE_LOG_ERROR(WebDriverClassic, "Unable to listen for HTTP server at host %s and port %d", hostStr.data(), *port);
-        fprintf(stderr, "FATAL: Unable to listen for HTTP server at host %s and port %d.\n", hostStr.data(), *port);
+        RELEASE_LOG_ERROR(WebDriverClassic, "Unable to listen for HTTP server at host %s and port %d", hostStr.legacyCStringPointer(), *port);
+        SAFE_FPRINTF(stderr, "FATAL: Unable to listen for HTTP server at host %s and port %d.\n", hostStr, *port);
         return EXIT_FAILURE;
     }
-    RELEASE_LOG_INFO(WebDriverClassic, "Started HTTP server with host %s and port %d", hostStr.data(), *port);
+    RELEASE_LOG_INFO(WebDriverClassic, "Started HTTP server with host %s and port %d", hostStr.legacyCStringPointer(), *port);
 #if ENABLE(WEBDRIVER_BIDI)
     auto bidiServerURL = m_bidiServer->listen(host ? *host : nullString(), *bidiPort);
     if (!bidiServerURL) {
-        RELEASE_LOG_ERROR(WebDriverBiDi, "Unable to listen for WebSocket BiDi server at host %s and port %d", hostStr.data(), *bidiPort);
-        fprintf(stderr, "FATAL: Unable to listen for WebSocket BiDi server at host %s and port %d.\n", hostStr.data(), *bidiPort);
+        RELEASE_LOG_ERROR(WebDriverBiDi, "Unable to listen for WebSocket BiDi server at host %s and port %d", hostStr.legacyCStringPointer(), *bidiPort);
+        SAFE_FPRINTF(stderr, "FATAL: Unable to listen for WebSocket BiDi server at host %s and port %d.\n", hostStr, *bidiPort);
         return EXIT_FAILURE;
     }
     RELEASE_LOG_INFO(WebDriverBiDi, "Started WebSocket BiDi server at %s", bidiServerURL->utf8().legacyCStringPointer());

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -195,7 +195,7 @@ void RemoteGraphicsContextGL::forceContextLost()
     send(Messages::RemoteGraphicsContextGLProxy::WasLost());
 }
 
-void RemoteGraphicsContextGL::addDebugMessage(GCGLenum type, GCGLenum id, GCGLenum severity, const CString& message)
+void RemoteGraphicsContextGL::addDebugMessage(GCGLenum type, GCGLenum id, GCGLenum severity, const UTF8CString& message)
 {
     assertIsCurrent(workQueue());
     send(Messages::RemoteGraphicsContextGLProxy::addDebugMessage(type, id, severity, message));

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -114,7 +114,7 @@ protected:
 
     // GraphicsContextGL::Client overrides.
     void forceContextLost() final;
-    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const CString&) final;
+    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const UTF8CString&) final;
     void didChangeMemoryCost() final;
 
     // Messages to be received.

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -76,7 +76,7 @@ messages -> RemoteGraphicsContextGL Stream {
 
     void ActiveTexture(uint32_t texture) StreamBatched
     void AttachShader(uint32_t program, uint32_t shader) StreamBatched
-    void BindAttribLocation(uint32_t arg0, uint32_t index, CString name) StreamBatched
+    void BindAttribLocation(uint32_t arg0, uint32_t index, UTF8CString name) StreamBatched
     void BindBuffer(uint32_t target, uint32_t arg1) StreamBatched
     void BindFramebuffer(uint32_t target, uint32_t arg1) StreamBatched
     void BindRenderbuffer(uint32_t target, uint32_t arg1) StreamBatched
@@ -127,7 +127,7 @@ messages -> RemoteGraphicsContextGL Stream {
     void ActiveAttribs(uint32_t program) -> (Vector<WebCore::GCGLAttribActiveInfo> returnValue) Synchronous
     void ActiveUniforms(uint32_t program) -> (Vector<WebCore::GCGLUniformActiveInfo> returnValue) Synchronous
     void GetBufferParameteri(uint32_t target, uint32_t pname) -> (int32_t returnValue) Synchronous
-    void GetString(uint32_t name) -> (CString returnValue) Synchronous
+    void GetString(uint32_t name) -> (UTF8CString returnValue) Synchronous
     void GetFloatv(uint32_t pname, uint64_t valueSize) -> (std::span<const float> value) Synchronous
     void GetIntegerv(uint32_t pname, uint64_t valueSize) -> (std::span<const int32_t> value) Synchronous
     void GetIntegeri_v(uint32_t pname, uint32_t index) -> (std::span<const int32_t, 4> value) Synchronous
@@ -136,10 +136,10 @@ messages -> RemoteGraphicsContextGL Stream {
     void GetProgrami(uint32_t program, uint32_t pname) -> (int32_t returnValue) Synchronous
     void GetBooleanv(uint32_t pname, uint64_t valueSize) -> (std::span<const bool> value) Synchronous
     void GetFramebufferAttachmentParameteri(uint32_t target, uint32_t attachment, uint32_t pname) -> (int32_t returnValue) Synchronous
-    void GetProgramInfoLog(uint32_t arg0) -> (CString returnValue) Synchronous
+    void GetProgramInfoLog(uint32_t arg0) -> (UTF8CString returnValue) Synchronous
     void GetRenderbufferParameteri(uint32_t target, uint32_t pname) -> (int32_t returnValue) Synchronous
     void GetShaderi(uint32_t arg0, uint32_t pname) -> (int32_t returnValue) Synchronous
-    void GetShaderInfoLog(uint32_t arg0) -> (CString returnValue) Synchronous
+    void GetShaderInfoLog(uint32_t arg0) -> (UTF8CString returnValue) Synchronous
     void GetShaderPrecisionFormat(uint32_t shaderType, uint32_t precisionType) -> (std::span<const int32_t, 2> range, GCGLint precision) Synchronous
     void GetTexParameterf(uint32_t target, uint32_t pname) -> (float returnValue) Synchronous
     void GetTexParameteri(uint32_t target, uint32_t pname) -> (int32_t returnValue) Synchronous
@@ -162,7 +162,7 @@ messages -> RemoteGraphicsContextGL Stream {
     void RenderbufferStorage(uint32_t target, uint32_t internalformat, int32_t width, int32_t height) StreamBatched
     void SampleCoverage(float value, bool invert) StreamBatched
     void Scissor(int32_t x, int32_t y, int32_t width, int32_t height) StreamBatched
-    void ShaderSource(uint32_t arg0, CString arg1) StreamBatched
+    void ShaderSource(uint32_t arg0, UTF8CString arg1) StreamBatched
     void StencilFunc(uint32_t func, int32_t ref, uint32_t mask) StreamBatched
     void StencilFuncSeparate(uint32_t face, uint32_t func, int32_t ref, uint32_t mask) StreamBatched
     void StencilMask(uint32_t mask) StreamBatched
@@ -237,7 +237,7 @@ messages -> RemoteGraphicsContextGL Stream {
     void CompressedTexImage3D1(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t depth, int32_t border, int32_t imageSize, uint64_t offset)
     void CompressedTexSubImage3D0(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, std::span<const uint8_t> data)
     void CompressedTexSubImage3D1(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, int32_t imageSize, uint64_t offset)
-    void GetFragDataLocation(uint32_t program, CString name) -> (int32_t returnValue) Synchronous
+    void GetFragDataLocation(uint32_t program, UTF8CString name) -> (int32_t returnValue) Synchronous
     void Uniform1ui(int32_t location, uint32_t v0) StreamBatched
     void Uniform2ui(int32_t location, uint32_t v0, uint32_t v1) StreamBatched
     void Uniform3ui(int32_t location, uint32_t v0, uint32_t v1, uint32_t v2) StreamBatched
@@ -289,17 +289,17 @@ messages -> RemoteGraphicsContextGL Stream {
     void BindTransformFeedback(uint32_t target, uint32_t id) StreamBatched
     void BeginTransformFeedback(uint32_t primitiveMode)
     void EndTransformFeedback()
-    void TransformFeedbackVaryings(uint32_t program, Vector<CString> varyings, uint32_t bufferMode) StreamBatched
+    void TransformFeedbackVaryings(uint32_t program, Vector<UTF8CString> varyings, uint32_t bufferMode) StreamBatched
     void GetTransformFeedbackVarying(uint32_t program, uint32_t index) -> (std::optional<WebCore::GCGLTransformFeedbackActiveInfo> returnValue) Synchronous
     void PauseTransformFeedback()
     void ResumeTransformFeedback()
     void BindBufferBase(uint32_t target, uint32_t index, uint32_t buffer) StreamBatched
     void BindBufferRange(uint32_t target, uint32_t index, uint32_t buffer, uint64_t offset, uint64_t arg4) StreamBatched
-    void GetUniformBlockIndex(uint32_t program, CString uniformBlockName) -> (uint32_t returnValue) Synchronous
-    void GetActiveUniformBlockName(uint32_t program, uint32_t uniformBlockIndex) -> (CString returnValue) Synchronous
+    void GetUniformBlockIndex(uint32_t program, UTF8CString uniformBlockName) -> (uint32_t returnValue) Synchronous
+    void GetActiveUniformBlockName(uint32_t program, uint32_t uniformBlockIndex) -> (UTF8CString returnValue) Synchronous
     void UniformBlockBinding(uint32_t program, uint32_t uniformBlockIndex, uint32_t uniformBlockBinding) StreamBatched
     void GetActiveUniformBlockiv(uint32_t program, uint32_t uniformBlockIndex, uint32_t pname, uint64_t paramsSize) -> (std::span<const int32_t> params) Synchronous
-    void GetTranslatedShaderSourceANGLE(uint32_t arg0) -> (CString returnValue) Synchronous
+    void GetTranslatedShaderSourceANGLE(uint32_t arg0) -> (UTF8CString returnValue) Synchronous
     void CreateQueryEXT(uint32_t queryEXT) StreamBatched
     void DeleteQueryEXT(uint32_t query)
     void IsQueryEXT(uint32_t query) -> (bool returnValue) Synchronous

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.cpp
@@ -54,7 +54,7 @@ void RemoteGraphicsContextGL::attachShader(uint32_t program, uint32_t shader)
     protect(m_context)->attachShader(program, shader);
 }
 
-void RemoteGraphicsContextGL::bindAttribLocation(uint32_t arg0, uint32_t index, CString&& name)
+void RemoteGraphicsContextGL::bindAttribLocation(uint32_t arg0, uint32_t index, UTF8CString&& name)
 {
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
@@ -446,10 +446,10 @@ void RemoteGraphicsContextGL::getBufferParameteri(uint32_t target, uint32_t pnam
     completionHandler(returnValue);
 }
 
-void RemoteGraphicsContextGL::getString(uint32_t name, CompletionHandler<void(CString&&)>&& completionHandler)
+void RemoteGraphicsContextGL::getString(uint32_t name, CompletionHandler<void(UTF8CString&&)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    CString returnValue = { };
+    UTF8CString returnValue = { };
     returnValue = protect(m_context)->getString(name);
     completionHandler(WTF::move(returnValue));
 }
@@ -527,10 +527,10 @@ void RemoteGraphicsContextGL::getFramebufferAttachmentParameteri(uint32_t target
     completionHandler(returnValue);
 }
 
-void RemoteGraphicsContextGL::getProgramInfoLog(uint32_t arg0, CompletionHandler<void(CString&&)>&& completionHandler)
+void RemoteGraphicsContextGL::getProgramInfoLog(uint32_t arg0, CompletionHandler<void(UTF8CString&&)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    CString returnValue = { };
+    UTF8CString returnValue = { };
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
@@ -557,10 +557,10 @@ void RemoteGraphicsContextGL::getShaderi(uint32_t arg0, uint32_t pname, Completi
     completionHandler(returnValue);
 }
 
-void RemoteGraphicsContextGL::getShaderInfoLog(uint32_t arg0, CompletionHandler<void(CString&&)>&& completionHandler)
+void RemoteGraphicsContextGL::getShaderInfoLog(uint32_t arg0, CompletionHandler<void(UTF8CString&&)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    CString returnValue = { };
+    UTF8CString returnValue = { };
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
@@ -765,7 +765,7 @@ void RemoteGraphicsContextGL::scissor(int32_t x, int32_t y, int32_t width, int32
     protect(m_context)->scissor(x, y, width, height);
 }
 
-void RemoteGraphicsContextGL::shaderSource(uint32_t arg0, CString&& arg1)
+void RemoteGraphicsContextGL::shaderSource(uint32_t arg0, UTF8CString&& arg1)
 {
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
@@ -1242,7 +1242,7 @@ void RemoteGraphicsContextGL::compressedTexSubImage3D1(uint32_t target, int32_t 
     protect(m_context)->compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, static_cast<GCGLintptr>(offset));
 }
 
-void RemoteGraphicsContextGL::getFragDataLocation(uint32_t program, CString&& name, CompletionHandler<void(int32_t)>&& completionHandler)
+void RemoteGraphicsContextGL::getFragDataLocation(uint32_t program, UTF8CString&& name, CompletionHandler<void(int32_t)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
     GCGLint returnValue = { };
@@ -1635,7 +1635,7 @@ void RemoteGraphicsContextGL::endTransformFeedback()
     protect(m_context)->endTransformFeedback();
 }
 
-void RemoteGraphicsContextGL::transformFeedbackVaryings(uint32_t program, Vector<CString>&& varyings, uint32_t bufferMode)
+void RemoteGraphicsContextGL::transformFeedbackVaryings(uint32_t program, Vector<UTF8CString>&& varyings, uint32_t bufferMode)
 {
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(m_objectNames.isValidKey(program));
@@ -1685,7 +1685,7 @@ void RemoteGraphicsContextGL::bindBufferRange(uint32_t target, uint32_t index, u
     protect(m_context)->bindBufferRange(target, index, buffer, static_cast<GCGLintptr>(offset), static_cast<GCGLsizeiptr>(arg4));
 }
 
-void RemoteGraphicsContextGL::getUniformBlockIndex(uint32_t program, CString&& uniformBlockName, CompletionHandler<void(uint32_t)>&& completionHandler)
+void RemoteGraphicsContextGL::getUniformBlockIndex(uint32_t program, UTF8CString&& uniformBlockName, CompletionHandler<void(uint32_t)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
     GCGLuint returnValue = { };
@@ -1696,10 +1696,10 @@ void RemoteGraphicsContextGL::getUniformBlockIndex(uint32_t program, CString&& u
     completionHandler(returnValue);
 }
 
-void RemoteGraphicsContextGL::getActiveUniformBlockName(uint32_t program, uint32_t uniformBlockIndex, CompletionHandler<void(CString&&)>&& completionHandler)
+void RemoteGraphicsContextGL::getActiveUniformBlockName(uint32_t program, uint32_t uniformBlockIndex, CompletionHandler<void(UTF8CString&&)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    CString returnValue = { };
+    UTF8CString returnValue = { };
     MESSAGE_CHECK(m_objectNames.isValidKey(program));
     if (program)
         program = m_objectNames.get(program);
@@ -1729,10 +1729,10 @@ void RemoteGraphicsContextGL::getActiveUniformBlockiv(uint32_t program, uint32_t
     completionHandler(spanReinterpretCast<const int32_t>(params.span()));
 }
 
-void RemoteGraphicsContextGL::getTranslatedShaderSourceANGLE(uint32_t arg0, CompletionHandler<void(CString&&)>&& completionHandler)
+void RemoteGraphicsContextGL::getTranslatedShaderSourceANGLE(uint32_t arg0, CompletionHandler<void(UTF8CString&&)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    CString returnValue = { };
+    UTF8CString returnValue = { };
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -27,7 +27,7 @@
 #pragma once
     void activeTexture(uint32_t texture);
     void attachShader(uint32_t program, uint32_t shader);
-    void bindAttribLocation(uint32_t arg0, uint32_t index, CString&& name);
+    void bindAttribLocation(uint32_t arg0, uint32_t index, UTF8CString&& name);
     void bindBuffer(uint32_t target, uint32_t arg1);
     void bindFramebuffer(uint32_t target, uint32_t arg1);
     void bindRenderbuffer(uint32_t target, uint32_t arg1);
@@ -78,7 +78,7 @@
     void activeAttribs(uint32_t program, CompletionHandler<void(Vector<WebCore::GCGLAttribActiveInfo>&&)>&&);
     void activeUniforms(uint32_t program, CompletionHandler<void(Vector<WebCore::GCGLUniformActiveInfo>&&)>&&);
     void getBufferParameteri(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&&);
-    void getString(uint32_t name, CompletionHandler<void(CString&&)>&&);
+    void getString(uint32_t name, CompletionHandler<void(UTF8CString&&)>&&);
     void getFloatv(uint32_t pname, uint64_t valueSize, CompletionHandler<void(std::span<const float>)>&&);
     void getIntegerv(uint32_t pname, uint64_t valueSize, CompletionHandler<void(std::span<const int32_t>)>&&);
     void getIntegeri_v(uint32_t pname, uint32_t index, CompletionHandler<void(std::span<const int32_t, 4>)>&&); // NOLINT
@@ -87,10 +87,10 @@
     void getProgrami(uint32_t program, uint32_t pname, CompletionHandler<void(int32_t)>&&);
     void getBooleanv(uint32_t pname, uint64_t valueSize, CompletionHandler<void(std::span<const bool>)>&&);
     void getFramebufferAttachmentParameteri(uint32_t target, uint32_t attachment, uint32_t pname, CompletionHandler<void(int32_t)>&&);
-    void getProgramInfoLog(uint32_t arg0, CompletionHandler<void(CString&&)>&&);
+    void getProgramInfoLog(uint32_t arg0, CompletionHandler<void(UTF8CString&&)>&&);
     void getRenderbufferParameteri(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&&);
     void getShaderi(uint32_t arg0, uint32_t pname, CompletionHandler<void(int32_t)>&&);
-    void getShaderInfoLog(uint32_t arg0, CompletionHandler<void(CString&&)>&&);
+    void getShaderInfoLog(uint32_t arg0, CompletionHandler<void(UTF8CString&&)>&&);
     void getShaderPrecisionFormat(uint32_t shaderType, uint32_t precisionType, CompletionHandler<void(std::span<const int32_t, 2>, int32_t)>&&);
     void getTexParameterf(uint32_t target, uint32_t pname, CompletionHandler<void(float)>&&);
     void getTexParameteri(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&&);
@@ -113,7 +113,7 @@
     void renderbufferStorage(uint32_t target, uint32_t internalformat, int32_t width, int32_t height);
     void sampleCoverage(float value, bool invert);
     void scissor(int32_t x, int32_t y, int32_t width, int32_t height);
-    void shaderSource(uint32_t arg0, CString&& arg1);
+    void shaderSource(uint32_t arg0, UTF8CString&& arg1);
     void stencilFunc(uint32_t func, int32_t ref, uint32_t mask);
     void stencilFuncSeparate(uint32_t face, uint32_t func, int32_t ref, uint32_t mask);
     void stencilMask(uint32_t mask);
@@ -188,7 +188,7 @@
     void compressedTexImage3D1(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t depth, int32_t border, int32_t imageSize, uint64_t offset);
     void compressedTexSubImage3D0(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, std::span<const uint8_t>&& data);
     void compressedTexSubImage3D1(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, int32_t imageSize, uint64_t offset);
-    void getFragDataLocation(uint32_t program, CString&& name, CompletionHandler<void(int32_t)>&&);
+    void getFragDataLocation(uint32_t program, UTF8CString&& name, CompletionHandler<void(int32_t)>&&);
     void uniform1ui(int32_t location, uint32_t v0);
     void uniform2ui(int32_t location, uint32_t v0, uint32_t v1);
     void uniform3ui(int32_t location, uint32_t v0, uint32_t v1, uint32_t v2);
@@ -240,17 +240,17 @@
     void bindTransformFeedback(uint32_t target, uint32_t id);
     void beginTransformFeedback(uint32_t primitiveMode);
     void endTransformFeedback();
-    void transformFeedbackVaryings(uint32_t program, Vector<CString>&& varyings, uint32_t bufferMode);
+    void transformFeedbackVaryings(uint32_t program, Vector<UTF8CString>&& varyings, uint32_t bufferMode);
     void getTransformFeedbackVarying(uint32_t program, uint32_t index, CompletionHandler<void(std::optional<WebCore::GCGLTransformFeedbackActiveInfo>&&)>&&);
     void pauseTransformFeedback();
     void resumeTransformFeedback();
     void bindBufferBase(uint32_t target, uint32_t index, uint32_t buffer);
     void bindBufferRange(uint32_t target, uint32_t index, uint32_t buffer, uint64_t offset, uint64_t arg4);
-    void getUniformBlockIndex(uint32_t program, CString&& uniformBlockName, CompletionHandler<void(uint32_t)>&&);
-    void getActiveUniformBlockName(uint32_t program, uint32_t uniformBlockIndex, CompletionHandler<void(CString&&)>&&);
+    void getUniformBlockIndex(uint32_t program, UTF8CString&& uniformBlockName, CompletionHandler<void(uint32_t)>&&);
+    void getActiveUniformBlockName(uint32_t program, uint32_t uniformBlockIndex, CompletionHandler<void(UTF8CString&&)>&&);
     void uniformBlockBinding(uint32_t program, uint32_t uniformBlockIndex, uint32_t uniformBlockBinding);
     void getActiveUniformBlockiv(uint32_t program, uint32_t uniformBlockIndex, uint32_t pname, uint64_t paramsSize, CompletionHandler<void(std::span<const int32_t>)>&&);
-    void getTranslatedShaderSourceANGLE(uint32_t arg0, CompletionHandler<void(CString&&)>&&);
+    void getTranslatedShaderSourceANGLE(uint32_t arg0, CompletionHandler<void(UTF8CString&&)>&&);
     void createQueryEXT(uint32_t name);
     void deleteQueryEXT(uint32_t query);
     void isQueryEXT(uint32_t query, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -1495,16 +1495,16 @@ static void setIBLAssetOwnership(const String& attributionTaskID, REAssetRef ibl
     auto attributionIDString = attributionTaskID.utf8();
 
     if (REPtr<REAssetRef> skyboxTexture = REIBLAssetGetSkyboxTexture(iblAsset)) {
-        RELEASE_LOG_DEBUG(ModelElement, "Attributing skyboxTexture to task ID: %s", attributionIDString.data());
-        REAssetSetMemoryAttributionTarget(skyboxTexture.get(), attributionIDString.data());
+        RELEASE_LOG_DEBUG(ModelElement, "Attributing skyboxTexture to task ID: %s", attributionIDString.legacyCStringPointer());
+        REAssetSetMemoryAttributionTarget(skyboxTexture.get(), attributionIDString.legacyCStringPointer());
     }
     if (REPtr<REAssetRef> diffuseTexture = REIBLAssetGetDiffuseTexture(iblAsset)) {
-        RELEASE_LOG_DEBUG(ModelElement, "Attributing diffuseTexture to task ID: %s", attributionIDString.data());
-        REAssetSetMemoryAttributionTarget(diffuseTexture.get(), attributionIDString.data());
+        RELEASE_LOG_DEBUG(ModelElement, "Attributing diffuseTexture to task ID: %s", attributionIDString.legacyCStringPointer());
+        REAssetSetMemoryAttributionTarget(diffuseTexture.get(), attributionIDString.legacyCStringPointer());
     }
     if (REPtr<REAssetRef> specularTexture = REIBLAssetGetSpecularTexture(iblAsset)) {
-        RELEASE_LOG_DEBUG(ModelElement, "Attributing specularTexture to task ID: %s", attributionIDString.data());
-        REAssetSetMemoryAttributionTarget(specularTexture.get(), attributionIDString.data());
+        RELEASE_LOG_DEBUG(ModelElement, "Attributing specularTexture to task ID: %s", attributionIDString.legacyCStringPointer());
+        REAssetSetMemoryAttributionTarget(specularTexture.get(), attributionIDString.legacyCStringPointer());
     }
 }
 #endif

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -603,7 +603,7 @@ void NetworkDataTaskSoup::completeAuthentication(const AuthenticationChallenge& 
         soup_auth_authenticate(challenge.soupAuth(), credential.user().utf8().legacyCStringPointer(), credential.password().utf8().legacyCStringPointer());
         break;
     case ProtectionSpace::AuthenticationScheme::ClientCertificatePINRequested: {
-        CString password = credential.password().utf8();
+        auto password = credential.password().utf8();
         g_tls_password_set_value(challenge.tlsPassword(), reinterpret_cast<const unsigned char*>(password.data()), password.length());
         soup_message_tls_client_certificate_password_request_complete(m_soupMessage.get());
         break;
@@ -1225,8 +1225,8 @@ void NetworkDataTaskSoup::download()
         return;
     }
 
-    CString downloadDestinationPath = m_pendingDownloadLocation.utf8();
-    m_downloadDestinationFile = adoptGRef(g_file_new_for_path(downloadDestinationPath.data()));
+    auto downloadDestinationPath = m_pendingDownloadLocation.utf8();
+    m_downloadDestinationFile = adoptGRef(g_file_new_for_path(downloadDestinationPath.legacyCStringPointer()));
     GRefPtr<GFileOutputStream> outputStream;
     GUniqueOutPtr<GError> error;
     if (m_allowOverwriteDownload)
@@ -1238,7 +1238,7 @@ void NetworkDataTaskSoup::download()
         return;
     }
 
-    GUniquePtr<char> intermediatePath(g_strdup_printf("%s.wkdownload", downloadDestinationPath.data()));
+    GUniquePtr<char> intermediatePath(g_strdup_printf("%s.wkdownload", downloadDestinationPath.legacyCStringPointer()));
     m_downloadIntermediateFile = adoptGRef(g_file_new_for_path(intermediatePath.get()));
     outputStream = adoptGRef(g_file_replace(m_downloadIntermediateFile.get(), nullptr, TRUE, G_FILE_CREATE_NONE, nullptr, &error.outPtr()));
     if (!outputStream) {
@@ -1306,9 +1306,9 @@ void NetworkDataTaskSoup::didFinishDownload()
     }
 
     GRefPtr<GFileInfo> info = adoptGRef(g_file_info_new());
-    CString uri = m_response.url().string().utf8();
-    g_file_info_set_attribute_string(info.get(), "metadata::download-uri", uri.data());
-    g_file_info_set_attribute_string(info.get(), "xattr::xdg.origin.url", uri.data());
+    auto uri = m_response.url().string().utf8();
+    g_file_info_set_attribute_string(info.get(), "metadata::download-uri", uri.legacyCStringPointer());
+    g_file_info_set_attribute_string(info.get(), "xattr::xdg.origin.url", uri.legacyCStringPointer());
     g_file_set_attributes_async(m_downloadDestinationFile.get(), info.get(), G_FILE_QUERY_INFO_NONE, RunLoopSourcePriority::AsyncIONetwork, nullptr, nullptr, nullptr);
 
     clearRequest();

--- a/Source/WebKit/NetworkProcess/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkStorageSessionSoup.cpp
@@ -327,8 +327,8 @@ void NetworkStorageSession::saveCredentialToPersistentStorage(const ProtectionSp
         return;
 
     g_hash_table_insert(attributes.get(), g_strdup("user"), g_strdup(credential.user().utf8().legacyCStringPointer()));
-    CString utf8Password = credential.password().utf8();
-    GRefPtr<SecretValue> newSecretValue = adoptGRef(secret_value_new(utf8Password.data(), utf8Password.length(), "text/plain"));
+    auto utf8Password = credential.password().utf8();
+    GRefPtr<SecretValue> newSecretValue = adoptGRef(secret_value_new(utf8Password.legacyCStringPointer(), utf8Password.length(), "text/plain"));
     secret_service_store(nullptr, SECRET_SCHEMA_COMPAT_NETWORK, attributes.get(), SECRET_COLLECTION_DEFAULT, _("WebKitGTK password"),
         newSecretValue.get(), nullptr, nullptr, nullptr);
 #else
@@ -432,7 +432,7 @@ void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameS
         // before the day of the month. RFC 6265 section 5.1.1 accepts either ordering.
         auto dayFirst = CookieUtil::cookieStringWithDayFirstExpires(cookieString);
         auto utf8CookieString = (dayFirst ? *dayFirst : cookieString).utf8();
-        GUniquePtr<SoupCookie> cookie(soup_cookie_parse(utf8CookieString.data(), origin.get()));
+        GUniquePtr<SoupCookie> cookie(soup_cookie_parse(utf8CookieString.legacyCStringPointer(), origin.get()));
 
         if (!cookie)
             continue;
@@ -554,7 +554,7 @@ void NetworkStorageSession::deleteCookie(const URL&, const URL& url, const Strin
     if (!cookies)
         return completionHandler();
 
-    CString cookieName = name.utf8();
+    auto cookieName = name.utf8();
     bool wasDeleted = false;
     for (GSList* iter = cookies.get(); iter; iter = g_slist_next(iter)) {
         SoupCookie* cookie = static_cast<SoupCookie*>(iter->data);
@@ -600,7 +600,7 @@ void NetworkStorageSession::deleteCookiesForHostnames(std::span<const String> ho
 {
     SoupCookieJar* cookieJar = cookieStorage();
     for (const auto& hostname : hostnames) {
-        CString hostNameString = hostname.utf8();
+        auto hostNameString = hostname.utf8();
 
         CookieList cookies(soup_cookie_jar_all_cookies(cookieJar));
         for (auto* item = cookies.get(); item; item = g_slist_next(item)) {
@@ -608,7 +608,7 @@ void NetworkStorageSession::deleteCookiesForHostnames(std::span<const String> ho
             if (includeHttpOnlyCookies == IncludeHttpOnlyCookies::No && soup_cookie_get_http_only(cookie))
                 continue;
 
-            if (soup_cookie_domain_matches(cookie, hostNameString.data()))
+            if (soup_cookie_domain_matches(cookie, hostNameString.legacyCStringPointer()))
                 soup_cookie_jar_delete_cookie(cookieJar, cookie);
         }
     }
@@ -777,7 +777,7 @@ Vector<Cookie> NetworkStorageSession::domCookiesForHost(const URL& url)
         auto* soupCookie = static_cast<SoupCookie*>(iter->data);
         if (soup_cookie_get_http_only(soupCookie))
             continue;
-        if (soup_cookie_domain_matches(soupCookie, host.data())) {
+        if (soup_cookie_domain_matches(soupCookie, host.legacyCStringPointer())) {
             // soup_cookie_jar_all_cookies() always returns a reversed list.
             cookies.insert(0, Cookie(soupCookie));
         }

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -1077,9 +1077,9 @@ static RetainPtr<id> decodeObject(WKRemoteObjectDecoder *decoder)
     if (!classNameString)
         [NSException raise:NSInvalidUnarchiveOperationException format:@"Class name missing"];
 
-    CString className = classNameString->string().utf8();
+    auto className = classNameString->string().utf8();
 
-    RetainPtr<Class> objectClass = objc_lookUpClass(className.data());
+    RetainPtr<Class> objectClass = objc_lookUpClass(className.legacyCStringPointer());
     if (!objectClass)
         crashWithClassName(className.span());
 

--- a/Source/WebKit/Shared/RTCNetwork.cpp
+++ b/Source/WebKit/Shared/RTCNetwork.cpp
@@ -28,6 +28,7 @@
 #if USE(LIBWEBRTC)
 #include "RTCNetwork.h"
 
+#include <string_view>
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/posix/SocketPOSIX.h>
@@ -44,6 +45,13 @@ static_assert
  };
 
  */
+
+// libwebrtc takes names and addresses as absl::string_view, which is char-based, so the UTF-8
+// bytes have to be reinterpreted to hand them over.
+static std::string_view toStdStringView(const UTF8CString& string LIFETIME_BOUND)
+{
+    return std::string_view { byteCast<char>(string.span()) };
+}
 
 RTCNetwork::RTCNetwork(String&& name, String&& description, IPAddress prefix, int prefixLength, int type, uint16_t id, int preference, bool active, bool ignored, int scopeID, Vector<InterfaceAddress>&& ips)
     : name(WTF::move(name))
@@ -62,7 +70,7 @@ std::unique_ptr<webrtc::Network> RTCNetwork::value() const
 {
     auto nameUTF8 = name.utf8();
     auto descriptionUTF8 = description.utf8();
-    webrtc::Network network({ nameUTF8.span().data(), nameUTF8.span().size() }, { descriptionUTF8.span().data(), descriptionUTF8.span().size() }, prefix.rtcAddress(), prefixLength, webrtc::AdapterType(type));
+    webrtc::Network network(toStdStringView(nameUTF8), toStdStringView(descriptionUTF8), prefix.rtcAddress(), prefixLength, webrtc::AdapterType(type));
     network.set_id(id);
     network.set_preference(preference);
     network.set_active(active);
@@ -103,7 +111,7 @@ webrtc::SocketAddress SocketAddress::rtcAddress() const
     result.SetPort(port);
     result.SetScopeID(scopeID);
     auto hostnameUTF8 = hostname.utf8();
-    result.SetIP({ hostnameUTF8.span().data(), hostnameUTF8.span().size() });
+    result.SetIP(toStdStringView(hostnameUTF8));
     if (ipAddress)
         result.SetResolvedIP(ipAddress->rtcAddress());
     return result;

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -31,6 +31,10 @@ header: <wtf/text/CString.h>
    std::span<const char> span()
 }
 
+[Alias=class CStringWithEncoding<char8_t>, CustomHeader, WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] alias WTF::UTF8CString {
+   std::span<const char8_t> span()
+}
+
 [AdditionalEncoder=StreamConnectionEncoder] class WTF::MediaTime {
     int64_t timeValue()
     uint32_t timeScale()

--- a/Source/WebKit/Shared/WebGL.serialization.in
+++ b/Source/WebKit/Shared/WebGL.serialization.in
@@ -164,7 +164,7 @@ enum class WebCore::GraphicsContextGLSimulatedEventForTesting : uint8_t {
 
 header: <WebCore/GraphicsContextGLActiveInfo.h>
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] class WebCore::GCGLUniformActiveInfo {
-    CString name;
+    UTF8CString name;
     GCGLenum type;
     int size;
     int blockIndex;
@@ -176,13 +176,13 @@ header: <WebCore/GraphicsContextGLActiveInfo.h>
 };
 header: <WebCore/GraphicsContextGLActiveInfo.h>
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] class WebCore::GCGLAttribActiveInfo {
-    CString name;
+    UTF8CString name;
     GCGLenum type;
     int location;
 };
 header: <WebCore/GraphicsContextGLActiveInfo.h>
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] class WebCore::GCGLTransformFeedbackActiveInfo {
-    CString name;
+    UTF8CString name;
     GCGLenum type;
     int size;
 };

--- a/Source/WebKit/Shared/WebMemorySampler.cpp
+++ b/Source/WebKit/Shared/WebMemorySampler.cpp
@@ -174,7 +174,7 @@ void WebMemorySampler::appendCurrentMemoryUsageToFile()
     }
     statString.append('\n');
 
-    CString utf8String = statString.toString().utf8();
+    auto utf8String = statString.toString().utf8();
     m_sampleLogFile.write(byteCast<uint8_t>(utf8String.span()));
 }
 

--- a/Source/WebKit/Shared/WebPushMessage.cpp
+++ b/Source/WebKit/Shared/WebPushMessage.cpp
@@ -51,9 +51,7 @@ WebCore::NotificationData WebPushMessage::notificationPayloadToCoreData() const
         iconURL = notificationPayload->options->icon;
         direction = notificationPayload->options->dir;
         silent = notificationPayload->options->silent;
-
-        CString dataCString = notificationPayload->options->dataJSONString.utf8();
-        dataJSON = dataCString.span();
+        dataJSON = notificationPayload->options->dataJSONString.utf8().span();
     }
 
     return {

--- a/Source/WebKit/UIProcess/API/glib/InputMethodFilter.cpp
+++ b/Source/WebKit/UIProcess/API/glib/InputMethodFilter.cpp
@@ -253,7 +253,7 @@ void InputMethodFilter::notifySurrounding(const String& text, uint64_t cursorPos
     auto selectionPositionUTF8 = cursorPositionUTF8;
     if (cursorPosition != selectionPosition)
         selectionPositionUTF8 = selectionPosition != text.length() ? StringView(text).left(selectionPosition).utf8().length() : textUTF8.length();
-    webkit_input_method_context_notify_surrounding(m_context.get(), textUTF8.data(), textUTF8.length(), cursorPositionUTF8, selectionPositionUTF8);
+    webkit_input_method_context_notify_surrounding(m_context.get(), textUTF8.legacyCStringPointer(), textUTF8.length(), cursorPositionUTF8, selectionPositionUTF8);
 }
 
 void InputMethodFilter::preeditStarted()

--- a/Source/WebKit/UIProcess/API/glib/WebKitContextMenuClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitContextMenuClient.cpp
@@ -40,8 +40,8 @@ private:
     {
         GRefPtr<GVariant> variant;
         if (userData) {
-            CString userDataString = downcast<API::String>(userData)->string().utf8();
-            const auto userDataSpan = userDataString.spanIncludingNullTerminator();
+            auto userDataString = downcast<API::String>(userData)->string().utf8();
+            const auto userDataSpan = byteCast<char>(userDataString.spanIncludingNullTerminator());
             variant = adoptGRef(g_variant_parse(nullptr, userDataSpan.data(), userDataSpan.last(1).data(), nullptr, nullptr));
         }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -825,7 +825,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request, RenderPro
 
     auto html = htmlBuilder.toString().utf8();
     gsize streamLength = html.length();
-    GRefPtr<GInputStream> stream = adoptGRef(g_memory_input_stream_new_from_data(g_strdup(html.data()), streamLength, g_free));
+    GRefPtr<GInputStream> stream = adoptGRef(g_memory_input_stream_new_from_data(g_strdup(html.legacyCStringPointer()), streamLength, g_free));
     webkit_uri_scheme_request_finish(request, stream.get(), streamLength, "text/html");
 
     if (requestURL.path() == "/stdout"_s)

--- a/Source/WebKit/UIProcess/API/glib/WebKitSecurityOrigin.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSecurityOrigin.cpp
@@ -270,6 +270,6 @@ gchar* webkit_security_origin_to_string(WebKitSecurityOrigin* origin)
 {
     g_return_val_if_fail(origin, nullptr);
 
-    CString cstring = origin->securityOriginData.toString().utf8();
-    return cstring == "null"_s || cstring == ""_s ? nullptr : g_strdup (cstring.data());
+    auto cstring = origin->securityOriginData.toString().utf8();
+    return cstring == "null"_s || cstring == ""_s ? nullptr : g_strdup (cstring.legacyCStringPointer());
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -3317,7 +3317,7 @@ void webkit_settings_set_user_agent(WebKitSettings* settings, const char* userAg
     } else
         userAgentString = WebCore::standardUserAgent(emptyString());
 
-    CString newUserAgent = userAgentString.utf8();
+    auto newUserAgent = userAgentString.utf8();
     if (newUserAgent == priv->userAgent)
         return;
 
@@ -3341,8 +3341,8 @@ void webkit_settings_set_user_agent_with_application_details(WebKitSettings* set
 {
     g_return_if_fail(WEBKIT_IS_SETTINGS(settings));
 
-    CString newUserAgent = WebCore::standardUserAgent(String::fromUTF8(applicationName), String::fromUTF8(applicationVersion)).utf8();
-    webkit_settings_set_user_agent(settings, newUserAgent.data());
+    auto newUserAgent = WebCore::standardUserAgent(String::fromUTF8(applicationName), String::fromUTF8(applicationVersion)).utf8();
+    webkit_settings_set_user_agent(settings, newUserAgent.legacyCStringPointer());
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentFilterStore.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentFilterStore.cpp
@@ -515,7 +515,7 @@ void webkit_user_content_filter_store_fetch_identifiers(WebKitUserContentFilterS
         auto result = GMallocSpan<gchar*>::malloc(bytesToAllocate);
         for (size_t i = 0; i < identifiers.size(); ++i) {
             const auto identifier = identifiers[i].utf8();
-            result[i] = g_strndup(identifier.data(), identifier.length());
+            result[i] = g_strndup(identifier.legacyCStringPointer(), identifier.length());
         }
         result[identifiers.size()] = nullptr;
 

--- a/Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp
@@ -52,12 +52,12 @@ DragSource::DragSource(GtkWidget* webView)
             gtk_selection_data_set_text(data, drag.m_selectionData->text().utf8().legacyCStringPointer(), -1);
             break;
         case DragTargetType::Markup: {
-            CString markup = drag.m_selectionData->markup().utf8();
+            auto markup = drag.m_selectionData->markup().utf8();
             gtk_selection_data_set(data, gdk_atom_intern_static_string("text/html"), 8, reinterpret_cast<const guchar*>(markup.data()), markup.length());
             break;
         }
         case DragTargetType::URIList: {
-            CString uriList = drag.m_selectionData->uriList().utf8();
+            auto uriList = drag.m_selectionData->uriList().utf8();
             gtk_selection_data_set(data, gdk_atom_intern_static_string("text/uri-list"), 8, reinterpret_cast<const guchar*>(uriList.data()), uriList.length());
             break;
         }

--- a/Source/WebKit/UIProcess/API/gtk/DragSourceGtk4.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DragSourceGtk4.cpp
@@ -77,20 +77,20 @@ void DragSource::begin(SelectionData&& selectionData, OptionSet<DragOperation> o
 
     Vector<GdkContentProvider*> providers;
     if (m_selectionData->hasMarkup()) {
-        CString markup = m_selectionData->markup().utf8();
-        GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(markup.data(), markup.length()));
+        auto markup = m_selectionData->markup().utf8();
+        GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(markup.legacyCStringPointer(), markup.length()));
         providers.append(gdk_content_provider_new_for_bytes("text/html", bytes.get()));
     }
 
     if (m_selectionData->hasURIList()) {
-        CString uriList = m_selectionData->uriList().utf8();
-        GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(uriList.data(), uriList.length()));
+        auto uriList = m_selectionData->uriList().utf8();
+        GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(uriList.legacyCStringPointer(), uriList.length()));
         providers.append(gdk_content_provider_new_for_bytes("text/uri-list", bytes.get()));
     }
 
     if (m_selectionData->hasURL()) {
-        CString urlString = m_selectionData->url().string().utf8();
-        gchar* url = g_strdup_printf("%s\n%s", urlString.data(), m_selectionData->hasText() ? m_selectionData->text().utf8().legacyCStringPointer() : urlString.data());
+        auto urlString = m_selectionData->url().string().utf8();
+        gchar* url = g_strdup_printf("%s\n%s", urlString.legacyCStringPointer(), m_selectionData->hasText() ? m_selectionData->text().utf8().legacyCStringPointer() : urlString.legacyCStringPointer());
         IGNORE_CLANG_WARNINGS_BEGIN("unsafe-buffer-usage-in-libc-call")
         GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new_take(url, strlen(url)));
         IGNORE_CLANG_WARNINGS_END

--- a/Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.cpp
@@ -162,7 +162,7 @@ void RemoteInspectorProtocolHandler::updateTargetList(WebKitWebView* webView)
     clientForWebView->appendTargetList(scriptBuilder, RemoteInspectorClient::InspectorType::UI, RemoteInspectorClient::ShouldEscapeSingleQuote::Yes);
     scriptBuilder.append("';"_s);
     auto script = scriptBuilder.toString().utf8();
-    webkit_web_view_evaluate_javascript(webView, script.data(), script.length(), nullptr, nullptr, nullptr, nullptr, nullptr);
+    webkit_web_view_evaluate_javascript(webView, script.legacyCStringPointer(), script.length(), nullptr, nullptr, nullptr, nullptr, nullptr);
 }
 
 void RemoteInspectorProtocolHandler::webViewLoadChanged(WebKitWebView* webView, WebKitLoadEvent event, RemoteInspectorProtocolHandler* handler)

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp
@@ -312,7 +312,7 @@ private:
 
     void inspectedURLChanged(WebInspectorUIProxy&, const String& url) override
     {
-        CString uri = url.utf8();
+        auto uri = url.utf8();
         if (uri == m_inspector->priv->inspectedURI)
             return;
         m_inspector->priv->inspectedURI = uri;

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -3515,11 +3515,11 @@ void webkitWebViewBaseSetPlugID(WebKitWebViewBase* webViewBase, const String& pl
     GUniqueOutPtr<GError> error;
 
     auto plugBusName = tokens[0].utf8();
-    RELEASE_ASSERT(g_dbus_is_name(plugBusName.data()));
+    RELEASE_ASSERT(g_dbus_is_name(plugBusName.legacyCStringPointer()));
 
-    auto* busNamePrefix = !g_dbus_is_unique_name(plugBusName.data()) ? "" : ":";
+    auto* busNamePrefix = !g_dbus_is_unique_name(plugBusName.legacyCStringPointer()) ? "" : ":";
 
-    GUniquePtr<char> busName(g_strdup_printf("%s%s", busNamePrefix, plugBusName.data()));
+    GUniquePtr<char> busName(g_strdup_printf("%s%s", busNamePrefix, plugBusName.legacyCStringPointer()));
 
     priv->socketAccessible = adoptGRef(gtk_at_spi_socket_new(busName.get(), tokens[1].utf8().legacyCStringPointer(), &error.outPtr()));
 

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
@@ -224,7 +224,7 @@ void DownloadProxy::updateQuarantinePropertiesIfPossible()
     if (!file)
         return;
 
-    auto error = qtn_file_init_with_path(file.get(), path.data());
+    auto error = qtn_file_init_with_path(file.get(), path.legacyCStringPointer());
     if (error)
         return;
 
@@ -235,7 +235,7 @@ void DownloadProxy::updateQuarantinePropertiesIfPossible()
     if (error)
         return;
 
-    qtn_file_apply_to_path(file.get(), path.data());
+    qtn_file_apply_to_path(file.get(), path.legacyCStringPointer());
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
@@ -90,7 +90,7 @@ unsigned RemoteInspectorHTTPServer::handleRequest(const char* path, SoupMessageH
     if (CStringView::unsafeFromUTF8(path) == "/"_s) {
         auto html = m_client->buildTargetListPage(RemoteInspectorClient::InspectorType::HTTP).toString().utf8();
         soup_message_headers_append(responseHeaders, "Content-Type", "text/html");
-        soup_message_body_append(responseBody, SOUP_MEMORY_COPY, html.data(), html.length());
+        soup_message_body_append(responseBody, SOUP_MEMORY_COPY, html.legacyCStringPointer(), html.length());
         return SOUP_STATUS_OK;
     }
 
@@ -143,7 +143,7 @@ void RemoteInspectorHTTPServer::sendMessageToFrontend(uint64_t connectionID, uin
 
     auto utf8 = message.utf8();
     // Soup is going to copy the data immediately, so we can use g_bytes_new_static() here to avoid more data copies.
-    GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new_static(utf8.data(), utf8.length()));
+    GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new_static(utf8.legacyCStringPointer(), utf8.length()));
     soup_websocket_connection_send_message(webSocketConnection, SOUP_WEBSOCKET_DATA_TEXT, bytes.get());
 }
 

--- a/Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp
@@ -240,8 +240,8 @@ static String computeContentHash(const String& content, bool base64Encoded)
         if (decoded)
             digest.reset(g_compute_checksum_for_data(G_CHECKSUM_SHA256, decoded->span().data(), decoded->size()));
     } else {
-        CString utf8 = content.utf8();
-        digest.reset(g_compute_checksum_for_string(G_CHECKSUM_SHA256, utf8.data(), utf8.length()));
+        auto utf8 = content.utf8();
+        digest.reset(g_compute_checksum_for_string(G_CHECKSUM_SHA256, utf8.legacyCStringPointer(), utf8.length()));
     }
 
     return String::fromUTF8(digest.get());
@@ -268,7 +268,7 @@ void WebInspectorUIProxy::platformSave(Vector<WebCore::InspectorFrontendClient::
 
     auto updatedFilename = makeString(filename, "-"_s, hash.left(8)).utf8();
 
-    GRefPtr<GFile> file = adoptGRef(g_file_new_build_filename(downloadsDir, updatedFilename.data(), nullptr));
+    GRefPtr<GFile> file = adoptGRef(g_file_new_build_filename(downloadsDir, updatedFilename.legacyCStringPointer(), nullptr));
 
     platformSaveDataToFile(WTF::move(file), saveDatas[0].content, saveDatas[0].base64Encoded);
 }

--- a/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
@@ -509,7 +509,7 @@ static void bindV4l(Vector<CString>& args)
         if (!isV4LNode)
             continue;
 
-        CString path = FileSystem::pathByAppendingComponent("/dev"_s, fileName).utf8();
+        auto path = FileSystem::pathByAppendingComponent("/dev"_s, fileName).utf8();
         args.appendList<CString>({
             "--dev-bind-try", path, path,
         });

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -465,7 +465,7 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForAssertion(const 
             if (prf->evalByCredential) {
                 perCredentialInputValues = adoptNS([[NSMutableDictionary alloc] init]);
                 for (auto& credentialIDAndInputValues : *prf->evalByCredential) {
-                    auto key = base64URLDecode(credentialIDAndInputValues.key.utf8().span());
+                    auto key = base64URLDecode(credentialIDAndInputValues.key);
                     if (!key)
                         continue;
                     [perCredentialInputValues setObject:toASAssertionPRFInputValue(credentialIDAndInputValues.value).get() forKey: toNSData(*key).get()];
@@ -501,7 +501,7 @@ RetainPtr<NSArray> WebAuthenticatorCoordinatorProxy::requestsForAssertion(const 
             if (prf->evalByCredential) {
                 perCredentialInputValues = adoptNS([[NSMutableDictionary alloc] init]);
                 for (auto& credentialIDAndInputValues : *prf->evalByCredential) {
-                    auto key = base64URLDecode(credentialIDAndInputValues.key.utf8().span());
+                    auto key = base64URLDecode(credentialIDAndInputValues.key);
                     if (!key)
                         continue;
                     [perCredentialInputValues setObject:toASAssertionPRFInputValue(credentialIDAndInputValues.value).get() forKey: toNSData(*key).get()];

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -248,7 +248,7 @@ void WebsiteDataStore::platformSetNetworkParameters(WebsiteDataStoreParameters& 
 
     if (m_uiProcessCookieStorageIdentifier.isEmpty()) {
         auto utf8File = cookieFile.utf8();
-        auto url = adoptCF(CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault, (const UInt8 *)utf8File.data(), (CFIndex)utf8File.length(), true));
+        RetainPtr url = adoptCF(CFURLCreateFromFileSystemRepresentation(kCFAllocatorDefault, byteCast<UInt8>(utf8File.span()).data(), static_cast<CFIndex>(utf8File.length()), true));
         RetainPtr cfCookieStorage = adoptCF(CFHTTPCookieStorageCreateFromFile(kCFAllocatorDefault, url.get(), nullptr));
         m_uiProcessCookieStorageIdentifier = identifyingDataFromCookieStorage(cfCookieStorage.get());
     }

--- a/Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp
+++ b/Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp
@@ -223,7 +223,7 @@ void Clipboard::write(WebCore::SelectionData&& selectionData, CompletionHandler<
             auto& data = *static_cast<WriteAsyncData*>(userData);
             switch (info) {
             case ClipboardTargetType::Markup: {
-                CString markup = data.selectionData.markup().utf8();
+                auto markup = data.selectionData.markup().utf8();
                 gtk_selection_data_set(selection, gdk_atom_intern_static_string("text/html"), 8, reinterpret_cast<const guchar*>(markup.data()), markup.length());
                 break;
             }
@@ -238,7 +238,7 @@ void Clipboard::write(WebCore::SelectionData&& selectionData, CompletionHandler<
                 break;
             }
             case ClipboardTargetType::URIList: {
-                CString uriList = data.selectionData.uriList().utf8();
+                auto uriList = data.selectionData.uriList().utf8();
                 gtk_selection_data_set(selection, gdk_atom_intern_static_string("text/uri-list"), 8, reinterpret_cast<const guchar*>(uriList.data()), uriList.length());
                 break;
             }

--- a/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
+++ b/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
@@ -255,14 +255,14 @@ void Clipboard::write(WebCore::SelectionData&& selectionData, CompletionHandler<
 {
     Vector<GdkContentProvider*> providers;
     if (selectionData.hasMarkup()) {
-        CString markup = selectionData.markup().utf8();
-        GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(markup.data(), markup.length()));
+        auto markup = selectionData.markup().utf8();
+        GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(markup.legacyCStringPointer(), markup.length()));
         providers.append(gdk_content_provider_new_for_bytes("text/html", bytes.get()));
     }
 
     if (selectionData.hasURIList()) {
-        CString uriList = selectionData.uriList().utf8();
-        GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(uriList.data(), uriList.length()));
+        auto uriList = selectionData.uriList().utf8();
+        GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(uriList.legacyCStringPointer(), uriList.length()));
         providers.append(gdk_content_provider_new_for_bytes("text/uri-list", bytes.get()));
     }
 

--- a/Source/WebKit/UIProcess/gtk/ValidationBubbleGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ValidationBubbleGtk.cpp
@@ -45,7 +45,7 @@ ValidationBubbleGtk::ValidationBubbleGtk(GtkWidget* webView, String&& message, c
 
     // https://docs.gtk.org/Pango/pango_markup.html
     auto messageUTF8 = m_message.utf8();
-    GUniquePtr<char> escapedMessage(g_markup_escape_text(messageUTF8.data(), messageUTF8.length()));
+    GUniquePtr<char> escapedMessage(g_markup_escape_text(messageUTF8.legacyCStringPointer(), messageUTF8.length()));
     String markup = makeString("<span font='"_s, m_fontSize, "'>"_s, CStringView::unsafeFromUTF8(escapedMessage.get()), "</span>"_s);
     gtk_label_set_markup(GTK_LABEL(label), markup.utf8().legacyCStringPointer());
 

--- a/Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp
@@ -109,7 +109,7 @@ void WebPasteboardProxy::readBuffer(IPC::Connection&, const String&, const Strin
 }
 
 #if ENABLE(WPE_PLATFORM)
-static void setClipboardContentFromSpan(WPEClipboardContent* content, const char* type, const std::span<const char>& text)
+static void setClipboardContentFromSpan(WPEClipboardContent* content, const char* type, std::span<const char8_t> text)
 {
     GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(text.data(), text.size()));
     wpe_clipboard_content_set_bytes(content, type, bytes.get());

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -584,7 +584,7 @@ void RemoteGraphicsContextGLProxy::wasLost()
     markContextLost();
 }
 
-void RemoteGraphicsContextGLProxy::addDebugMessage(GCGLenum type, GCGLenum id, GCGLenum severity, CString&& message)
+void RemoteGraphicsContextGLProxy::addDebugMessage(GCGLenum type, GCGLenum id, GCGLenum severity, UTF8CString&& message)
 {
     if (isContextLost())
         return;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -124,7 +124,7 @@ public:
     // Functions with a generated implementation. This list is used by generate-gpup-webgl script.
     void activeTexture(GCGLenum texture) final;
     void attachShader(PlatformGLObject program, PlatformGLObject shader) final;
-    void bindAttribLocation(PlatformGLObject arg0, GCGLuint index, const CString& name) final;
+    void bindAttribLocation(PlatformGLObject arg0, GCGLuint index, const UTF8CString& name) final;
     void bindBuffer(GCGLenum target, PlatformGLObject arg1) final;
     void bindFramebuffer(GCGLenum target, PlatformGLObject arg1) final;
     void bindRenderbuffer(GCGLenum target, PlatformGLObject arg1) final;
@@ -175,7 +175,7 @@ public:
     Vector<WebCore::GCGLAttribActiveInfo> activeAttribs(PlatformGLObject program) final;
     Vector<WebCore::GCGLUniformActiveInfo> activeUniforms(PlatformGLObject program) final;
     GCGLint getBufferParameteri(GCGLenum target, GCGLenum pname) final;
-    CString getString(GCGLenum name) final;
+    UTF8CString getString(GCGLenum name) final;
     void getFloatv(GCGLenum pname, std::span<GCGLfloat> value) final;
     void getIntegerv(GCGLenum pname, std::span<GCGLint> value) final;
     void getIntegeri_v(GCGLenum pname, GCGLuint index, std::span<GCGLint, 4> value) final; // NOLINT
@@ -184,10 +184,10 @@ public:
     GCGLint getProgrami(PlatformGLObject program, GCGLenum pname) final;
     void getBooleanv(GCGLenum pname, std::span<GCGLboolean> value) final;
     GCGLint getFramebufferAttachmentParameteri(GCGLenum target, GCGLenum attachment, GCGLenum pname) final;
-    CString getProgramInfoLog(PlatformGLObject arg0) final;
+    UTF8CString getProgramInfoLog(PlatformGLObject arg0) final;
     GCGLint getRenderbufferParameteri(GCGLenum target, GCGLenum pname) final;
     GCGLint getShaderi(PlatformGLObject arg0, GCGLenum pname) final;
-    CString getShaderInfoLog(PlatformGLObject arg0) final;
+    UTF8CString getShaderInfoLog(PlatformGLObject arg0) final;
     void getShaderPrecisionFormat(GCGLenum shaderType, GCGLenum precisionType, std::span<GCGLint, 2> range, GCGLint* precision) final;
     GCGLfloat getTexParameterf(GCGLenum target, GCGLenum pname) final;
     GCGLint getTexParameteri(GCGLenum target, GCGLenum pname) final;
@@ -210,7 +210,7 @@ public:
     void renderbufferStorage(GCGLenum target, GCGLenum internalformat, GCGLsizei width, GCGLsizei height) final;
     void sampleCoverage(GCGLclampf value, GCGLboolean invert) final;
     void scissor(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height) final;
-    void shaderSource(PlatformGLObject arg0, const CString&) final;
+    void shaderSource(PlatformGLObject arg0, const UTF8CString&) final;
     void stencilFunc(GCGLenum func, GCGLint ref, GCGLuint mask) final;
     void stencilFuncSeparate(GCGLenum face, GCGLenum func, GCGLint ref, GCGLuint mask) final;
     void stencilMask(GCGLuint mask) final;
@@ -285,7 +285,7 @@ public:
     void compressedTexImage3D(GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLsizei imageSize, GCGLintptr offset) final;
     void compressedTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, std::span<const uint8_t> data) final;
     void compressedTexSubImage3D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLenum format, GCGLsizei imageSize, GCGLintptr offset) final;
-    GCGLint getFragDataLocation(PlatformGLObject program, const CString& name) final;
+    GCGLint getFragDataLocation(PlatformGLObject program, const UTF8CString& name) final;
     void uniform1ui(GCGLint location, GCGLuint v0) final;
     void uniform2ui(GCGLint location, GCGLuint v0, GCGLuint v1) final;
     void uniform3ui(GCGLint location, GCGLuint v0, GCGLuint v1, GCGLuint v2) final;
@@ -337,17 +337,17 @@ public:
     void bindTransformFeedback(GCGLenum target, PlatformGLObject id) final;
     void beginTransformFeedback(GCGLenum primitiveMode) final;
     void endTransformFeedback() final;
-    void transformFeedbackVaryings(PlatformGLObject program, const Vector<CString>& varyings, GCGLenum bufferMode) final;
+    void transformFeedbackVaryings(PlatformGLObject program, const Vector<UTF8CString>& varyings, GCGLenum bufferMode) final;
     std::optional<WebCore::GCGLTransformFeedbackActiveInfo> getTransformFeedbackVarying(PlatformGLObject program, GCGLuint index) final;
     void pauseTransformFeedback() final;
     void resumeTransformFeedback() final;
     void bindBufferBase(GCGLenum target, GCGLuint index, PlatformGLObject buffer) final;
     void bindBufferRange(GCGLenum target, GCGLuint index, PlatformGLObject buffer, GCGLintptr offset, GCGLsizeiptr) final;
-    GCGLuint getUniformBlockIndex(PlatformGLObject program, const CString& uniformBlockName) final;
-    CString getActiveUniformBlockName(PlatformGLObject program, GCGLuint uniformBlockIndex) final;
+    GCGLuint getUniformBlockIndex(PlatformGLObject program, const UTF8CString& uniformBlockName) final;
+    UTF8CString getActiveUniformBlockName(PlatformGLObject program, GCGLuint uniformBlockIndex) final;
     void uniformBlockBinding(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLuint uniformBlockBinding) final;
     void getActiveUniformBlockiv(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLenum pname, std::span<GCGLint> params) final;
-    CString getTranslatedShaderSourceANGLE(PlatformGLObject arg0) final;
+    UTF8CString getTranslatedShaderSourceANGLE(PlatformGLObject arg0) final;
     PlatformGLObject createQueryEXT() final;
     void deleteQueryEXT(PlatformGLObject query) final;
     GCGLboolean isQueryEXT(PlatformGLObject query) final;
@@ -416,7 +416,7 @@ private:
     // Messages to be received.
     void wasCreated(std::optional<RemoteGraphicsContextGLInitializationState>&&);
     void wasLost();
-    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, CString&&);
+    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, UTF8CString&&);
     void memoryCostChanged(std::optional<uint64_t>);
 
     void NODELETE initialize(const RemoteGraphicsContextGLInitializationState&);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.messages.in
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.messages.in
@@ -29,7 +29,7 @@
 messages -> RemoteGraphicsContextGLProxy {
     void WasCreated(struct std::optional<WebKit::RemoteGraphicsContextGLInitializationState> initializationState) CanDispatchOutOfOrder
     void WasLost()
-    void addDebugMessage(unsigned type, unsigned id, unsigned severity, CString message) CanDispatchOutOfOrder
+    void addDebugMessage(unsigned type, unsigned id, unsigned severity, UTF8CString message) CanDispatchOutOfOrder
     void MemoryCostChanged(std::optional<uint64_t> memoryCost)
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -54,7 +54,7 @@ void RemoteGraphicsContextGLProxy::attachShader(PlatformGLObject program, Platfo
     }
 }
 
-void RemoteGraphicsContextGLProxy::bindAttribLocation(PlatformGLObject arg0, GCGLuint index, const CString& name)
+void RemoteGraphicsContextGLProxy::bindAttribLocation(PlatformGLObject arg0, GCGLuint index, const UTF8CString& name)
 {
     if (isContextLost())
         return;
@@ -635,7 +635,7 @@ GCGLint RemoteGraphicsContextGLProxy::getBufferParameteri(GCGLenum target, GCGLe
     return returnValue;
 }
 
-CString RemoteGraphicsContextGLProxy::getString(GCGLenum name)
+UTF8CString RemoteGraphicsContextGLProxy::getString(GCGLenum name)
 {
     if (isContextLost())
         return { };
@@ -752,7 +752,7 @@ GCGLint RemoteGraphicsContextGLProxy::getFramebufferAttachmentParameteri(GCGLenu
     return returnValue;
 }
 
-CString RemoteGraphicsContextGLProxy::getProgramInfoLog(PlatformGLObject arg0)
+UTF8CString RemoteGraphicsContextGLProxy::getProgramInfoLog(PlatformGLObject arg0)
 {
     if (isContextLost())
         return { };
@@ -791,7 +791,7 @@ GCGLint RemoteGraphicsContextGLProxy::getShaderi(PlatformGLObject arg0, GCGLenum
     return returnValue;
 }
 
-CString RemoteGraphicsContextGLProxy::getShaderInfoLog(PlatformGLObject arg0)
+UTF8CString RemoteGraphicsContextGLProxy::getShaderInfoLog(PlatformGLObject arg0)
 {
     if (isContextLost())
         return { };
@@ -1076,7 +1076,7 @@ void RemoteGraphicsContextGLProxy::scissor(GCGLint x, GCGLint y, GCGLsizei width
     }
 }
 
-void RemoteGraphicsContextGLProxy::shaderSource(PlatformGLObject arg0, const CString& arg1)
+void RemoteGraphicsContextGLProxy::shaderSource(PlatformGLObject arg0, const UTF8CString& arg1)
 {
     if (isContextLost())
         return;
@@ -1905,7 +1905,7 @@ void RemoteGraphicsContextGLProxy::compressedTexSubImage3D(GCGLenum target, GCGL
     }
 }
 
-GCGLint RemoteGraphicsContextGLProxy::getFragDataLocation(PlatformGLObject program, const CString& name)
+GCGLint RemoteGraphicsContextGLProxy::getFragDataLocation(PlatformGLObject program, const UTF8CString& name)
 {
     if (isContextLost())
         return { };
@@ -2507,7 +2507,7 @@ void RemoteGraphicsContextGLProxy::endTransformFeedback()
     }
 }
 
-void RemoteGraphicsContextGLProxy::transformFeedbackVaryings(PlatformGLObject program, const Vector<CString>& varyings, GCGLenum bufferMode)
+void RemoteGraphicsContextGLProxy::transformFeedbackVaryings(PlatformGLObject program, const Vector<UTF8CString>& varyings, GCGLenum bufferMode)
 {
     if (isContextLost())
         return;
@@ -2575,7 +2575,7 @@ void RemoteGraphicsContextGLProxy::bindBufferRange(GCGLenum target, GCGLuint ind
     }
 }
 
-GCGLuint RemoteGraphicsContextGLProxy::getUniformBlockIndex(PlatformGLObject program, const CString& uniformBlockName)
+GCGLuint RemoteGraphicsContextGLProxy::getUniformBlockIndex(PlatformGLObject program, const UTF8CString& uniformBlockName)
 {
     if (isContextLost())
         return { };
@@ -2588,7 +2588,7 @@ GCGLuint RemoteGraphicsContextGLProxy::getUniformBlockIndex(PlatformGLObject pro
     return returnValue;
 }
 
-CString RemoteGraphicsContextGLProxy::getActiveUniformBlockName(PlatformGLObject program, GCGLuint uniformBlockIndex)
+UTF8CString RemoteGraphicsContextGLProxy::getActiveUniformBlockName(PlatformGLObject program, GCGLuint uniformBlockIndex)
 {
     if (isContextLost())
         return { };
@@ -2625,7 +2625,7 @@ void RemoteGraphicsContextGLProxy::getActiveUniformBlockiv(PlatformGLObject prog
     memcpySpan(params, paramsReply);
 }
 
-CString RemoteGraphicsContextGLProxy::getTranslatedShaderSourceANGLE(PlatformGLObject arg0)
+UTF8CString RemoteGraphicsContextGLProxy::getTranslatedShaderSourceANGLE(PlatformGLObject arg0)
 {
     if (isContextLost())
         return { };

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebProcessExtensionManager.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebProcessExtensionManager.cpp
@@ -52,8 +52,8 @@ static void parseUserData(API::Object* userData, String& webProcessExtensionsDir
 {
     ASSERT(userData->type() == API::Object::Type::String);
 
-    CString userDataString = downcast<API::String>(userData)->string().utf8();
-    const auto userDataSpan = userDataString.spanIncludingNullTerminator();
+    auto userDataString = downcast<API::String>(userData)->string().utf8();
+    const auto userDataSpan = byteCast<char>(userDataString.spanIncludingNullTerminator());
     GRefPtr<GVariant> variant = adoptGRef(g_variant_parse(nullptr, userDataSpan.data(), userDataSpan.last(1).data(), nullptr, nullptr));
 
     ASSERT(variant);

--- a/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
@@ -231,10 +231,10 @@ void InjectedBundle::extendClassesForParameterCoder(API::Array& classes)
             break;
         }
 
-        CString className = classNameString->string().utf8();
-        RetainPtr objectClass = objc_lookUpClass(className.data());
+        auto className = classNameString->string().utf8();
+        RetainPtr objectClass = objc_lookUpClass(className.legacyCStringPointer());
         if (!objectClass) {
-            RELEASE_LOG_ERROR(Process, "InjectedBundle::extendClassesForParameterCoder - Class %{public}s is not a valid Objective C class", className.data());
+            RELEASE_LOG_ERROR(Process, "InjectedBundle::extendClassesForParameterCoder - Class %{public}s is not a valid Objective C class", className.legacyCStringPointer());
             break;
         }
 

--- a/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp
@@ -287,7 +287,7 @@ void WebPrintOperationGtk::endPrint()
     if (m_printContext) {
         if (auto* document = m_printContext->frame()->document()) {
             auto title = document->title().utf8();
-            metadata.fTitle = SkString(title.data(), title.length());
+            metadata.fTitle = SkString(title.legacyCStringPointer(), title.length());
         }
     }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
@@ -941,7 +941,7 @@ TEST_F(FileSystemTest, readEntireFile)
     auto buffer = FileSystem::readEntireFile(tempFilePath());
     EXPECT_TRUE(buffer);
     auto contents = String { byteCast<Latin1Character>(buffer.value().span()) }.utf8();
-    EXPECT_STREQ(contents.data(), FileSystemTestData);
+    EXPECT_STREQ(contents.legacyCStringPointer(), FileSystemTestData);
 }
 
 TEST_F(FileSystemTest, makeSafeToUseMemoryMapForPath)

--- a/Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp
@@ -523,14 +523,14 @@ TEST(WTF, StringUTF8ConversionInvalidUTF16LenientMode)
 
     auto result = stringWithOrphanHigh.utf8(LenientConversion);
     // U+FFFD in UTF-8 is 0xEF 0xBF 0xBD
-    EXPECT_STREQ("abc\xEF\xBF\xBD" "def", result.data());
+    EXPECT_STREQ("abc\xEF\xBF\xBD" "def", result.legacyCStringPointer());
 
     // Create a string with an orphan low surrogate (0xDC00)
     char16_t orphanLowSurrogate[] = { 'x', 0xDC00, 'y', 0 };
     String stringWithOrphanLow = String(std::span { orphanLowSurrogate, 3 });
 
     auto resultLow = stringWithOrphanLow.utf8(LenientConversion);
-    EXPECT_STREQ("x\xEF\xBF\xBDy", resultLow.data());
+    EXPECT_STREQ("x\xEF\xBF\xBDy", resultLow.legacyCStringPointer());
 
     // Create a string with two consecutive orphan surrogates
     char16_t doubleOrphan[] = { 0xD800, 0xD800, 0 };
@@ -538,7 +538,7 @@ TEST(WTF, StringUTF8ConversionInvalidUTF16LenientMode)
 
     auto resultDouble = stringWithDoubleOrphan.utf8(LenientConversion);
     // Each orphan should become one replacement character
-    EXPECT_STREQ("\xEF\xBF\xBD\xEF\xBF\xBD", resultDouble.data());
+    EXPECT_STREQ("\xEF\xBF\xBD\xEF\xBF\xBD", resultDouble.legacyCStringPointer());
 
     // Create a string with reversed surrogate pair (low then high)
     char16_t reversedPair[] = { 0xDC00, 0xD800, 0 };
@@ -546,7 +546,7 @@ TEST(WTF, StringUTF8ConversionInvalidUTF16LenientMode)
 
     auto resultReversed = stringWithReversed.utf8(LenientConversion);
     // Both are invalid, should become two replacement characters
-    EXPECT_STREQ("\xEF\xBF\xBD\xEF\xBF\xBD", resultReversed.data());
+    EXPECT_STREQ("\xEF\xBF\xBD\xEF\xBF\xBD", resultReversed.legacyCStringPointer());
 }
 
 TEST(WTF, StringUTF8ConversionStrictReplacingMode)
@@ -559,7 +559,7 @@ TEST(WTF, StringUTF8ConversionStrictReplacingMode)
     String stringWithOrphan = String(std::span { orphanHighSurrogate, 4 });
 
     auto result = stringWithOrphan.utf8(StrictConversionReplacingUnpairedSurrogatesWithFFFD);
-    EXPECT_STREQ("ab\xEF\xBF\xBD" "c", result.data());
+    EXPECT_STREQ("ab\xEF\xBF\xBD" "c", result.legacyCStringPointer());
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -178,7 +178,7 @@ TEST(URLExtras, URLExtras_Spoof)
     };
     for (auto& host : punycodedSpoofHosts) {
         auto url = makeString("http://"_s, host, '/').utf8();
-        EXPECT_STREQ(url.data(), userVisibleString(literalURL(url.data())));
+        EXPECT_STREQ(url.legacyCStringPointer(), userVisibleString(literalURL(url.legacyCStringPointer())));
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
@@ -52,7 +52,7 @@ namespace {
 class MockGraphicsContextGLClient final : public GraphicsContextGL::Client {
 public:
     void forceContextLost() final { ++m_contextLostCalls; }
-    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const CString&) final { }
+    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const UTF8CString&) final { }
     void didChangeMemoryCost() final { }
     int contextLostCalls() { return m_contextLostCalls; }
 private:

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
@@ -56,7 +56,7 @@ static RefPtr<TestedGraphicsContextGLTextureMapper> createTestedGraphicsContextG
 class MockGraphicsContextGLClient final : public GraphicsContextGL::Client {
 public:
     void forceContextLost() final { ++m_contextLostCalls; }
-    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const CString&) final { }
+    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const UTF8CString&) final { }
     void didChangeMemoryCost() final { }
     int contextLostCalls() { return m_contextLostCalls; }
 private:

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EventAttribution.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EventAttribution.mm
@@ -252,7 +252,7 @@ static void triggerAttributionWithSubresourceRedirect(Connection& connection, co
         connection.send(WTF::move(redirect), [connection, location] {
             connection.receiveHTTPRequest([connection, location] (Vector<char>&& request2) {
                 auto expectedHttpGetString = makeString("GET "_s, location, " HTTP/1.1\r\n"_s).utf8();
-                EXPECT_TRUE(contains(request2.span(), expectedHttpGetString.span()));
+                EXPECT_TRUE(contains(request2.span(), byteCast<uint8_t>(expectedHttpGetString.span())));
                 constexpr auto response = "HTTP/1.1 200 OK\r\n"
                     "Content-Length: 0\r\n\r\n"_s;
                 connection.send(response);
@@ -359,8 +359,8 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
                                         EXPECT_TRUE(contains(request4.span(), "POST / HTTP/1.1\r\n"_span));
                                         EXPECT_TRUE(contains(request4.span(), "{\"source_engagement_type\":\"click\",\"source_site\":\"127.0.0.1\",\"source_id\":42,\"attributed_on_site\":\"example.com\",\"trigger_data\":12,\"version\":3,"_span));
 
-                                        EXPECT_FALSE(contains(request4.span(), token.utf8().span()));
-                                        EXPECT_FALSE(contains(request4.span(), unlinkableToken.utf8().span()));
+                                        EXPECT_FALSE(contains(request4.span(), byteCast<uint8_t>(token.utf8().span())));
+                                        EXPECT_FALSE(contains(request4.span(), byteCast<uint8_t>(unlinkableToken.utf8().span())));
 
                                         auto request4String = String::fromLatin1(request4.span());
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NetworkProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NetworkProcess.mm
@@ -80,7 +80,7 @@ TEST(WebKit, HTTPReferer)
             connection.receiveHTTPRequest([connection, expectedReferer, &done] (Vector<char>&& request) {
                 if (expectedReferer) {
                     auto expectedHeaderField = makeString("Referer: "_s, unsafeSpan(expectedReferer), "\r\n"_s);
-                    EXPECT_TRUE(contains(request.span(), expectedHeaderField.utf8().span()));
+                    EXPECT_TRUE(contains(request.span(), byteCast<uint8_t>(expectedHeaderField.utf8().span())));
                 } else
                     EXPECT_FALSE(contains(request.span(), "Referer:"_span));
                 done = true;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm
@@ -2492,7 +2492,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByParent)
     auto resonseHtmlCString = generateHTML(newWindowResponseTemplate, emptyString()).utf8();
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
-        [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:resonseHtmlCString.data() length:resonseHtmlCString.length()]).get()];
+        [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:resonseHtmlCString.legacyCStringPointer() length:resonseHtmlCString.length()]).get()];
     }
     Util::run(&allMessagesReceived);
 }
@@ -2530,7 +2530,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByWebKit)
     auto resonseHtmlCString = generateHTML(newWindowResponseTemplate, emptyString()).utf8();
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
-        [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:resonseHtmlCString.data() length:resonseHtmlCString.length()]).get()];
+        [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:resonseHtmlCString.legacyCStringPointer() length:resonseHtmlCString.length()]).get()];
     }
     Util::run(&allMessagesReceived);
 }
@@ -2567,7 +2567,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedWithOtherHttpStatusCode)
     policyForAppSSOPerformed = false;
     RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:400 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto resonseHtmlCString = generateHTML(newWindowResponseTemplate, emptyString()).utf8();
-    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:resonseHtmlCString.data() length:resonseHtmlCString.length()]).get()];
+    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:resonseHtmlCString.legacyCStringPointer() length:resonseHtmlCString.length()]).get()];
     Util::run(&newWindowCreated);
     Util::run(&navigationCompleted);
     EXPECT_WK_STREQ(testURL.get().absoluteString, finalURL);
@@ -2609,7 +2609,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedWithCookie)
     auto resonseHtmlCString = generateHTML(newWindowResponseTemplate, emptyString()).utf8();
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
-        [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:resonseHtmlCString.data() length:resonseHtmlCString.length()]).get()];
+        [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:resonseHtmlCString.legacyCStringPointer() length:resonseHtmlCString.length()]).get()];
     }
     Util::run(&allMessagesReceived);
 }
@@ -2652,7 +2652,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedTwice)
         auto resonseHtmlCString = generateHTML(newWindowResponseTemplate, emptyString()).utf8();
         // The secret WKWebView needs to be destroyed right the way.
         @autoreleasepool {
-            [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:resonseHtmlCString.data() length:resonseHtmlCString.length()]).get()];
+            [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:resonseHtmlCString.legacyCStringPointer() length:resonseHtmlCString.length()]).get()];
         }
         Util::run(&allMessagesReceived);
     }
@@ -2719,7 +2719,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)
     auto resonseHtmlCString = generateHTML(newWindowResponseTemplate, emptyString()).utf8();
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
-        [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:resonseHtmlCString.data() length:resonseHtmlCString.length()]).get()];
+        [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:resonseHtmlCString.legacyCStringPointer() length:resonseHtmlCString.length()]).get()];
     }
     Util::run(&allMessagesReceived);
 }
@@ -2757,7 +2757,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedNewWindowNavigation)
     auto resonseHtmlCString = generateHTML(newWindowResponseTemplate, emptyString()).utf8();
     // The secret WKWebView needs to be destroyed right the way.
     @autoreleasepool {
-        [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:resonseHtmlCString.data() length:resonseHtmlCString.length()]).get()];
+        [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:resonseHtmlCString.legacyCStringPointer() length:resonseHtmlCString.length()]).get()];
     }
     Util::run(&allMessagesReceived);
 }
@@ -3042,7 +3042,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccess)
 
     RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto iframeHtmlCString = generateHTML(iframeTemplate, emptyString()).utf8();
-    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
+    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.legacyCStringPointer() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);
 }
 
@@ -3077,7 +3077,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccessBackForwardList)
 
     RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:exampleURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto iframeHtmlCString = generateHTML(iframeTemplate, emptyString()).utf8();
-    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
+    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.legacyCStringPointer() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);
 
     EXPECT_FALSE([webView canGoBack]);
@@ -3112,7 +3112,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSucceedWithOtherHttpStatusCode)
     // Will fallback to web path.
     RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:400 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto iframeHtmlCString = generateHTML(iframeTemplate, emptyString()).utf8();
-    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
+    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.legacyCStringPointer() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);
     // Make sure we don't load the request of the iframe to the main frame.
     EXPECT_WK_STREQ("", finalURL);
@@ -3245,7 +3245,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccessTwice)
 
         RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
         auto iframeHtmlCString = generateHTML(iframeTemplate, emptyString()).utf8();
-        [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
+        [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.legacyCStringPointer() length:iframeHtmlCString.length()]).get()];
         Util::run(&allMessagesReceived);
     }
 }
@@ -3326,7 +3326,7 @@ TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyAllowAsync)
 
     RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto iframeHtmlCString = generateHTML(iframeTemplate, emptyString()).utf8();
-    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
+    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.legacyCStringPointer() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);
 }
 
@@ -3449,7 +3449,7 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccessMessageOrder)
 
     RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.createNSURL().get() statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil]);
     auto iframeHtmlCString = generateHTML(iframeTemplate, emptyString()).utf8();
-    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
+    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.legacyCStringPointer() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestAutomationSession.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestAutomationSession.cpp
@@ -296,14 +296,14 @@ const SocketConnection::MessageHandlers AutomationTest::s_messageHandlers = {
 
 static void testAutomationSessionRequestSession(AutomationTest* test, gconstpointer)
 {
-    CString sessionID = createVersion4UUIDString().utf8();
+    auto sessionID = createVersion4UUIDString().utf8();
     // WebKitAutomationSession::automation-started is never emitted if automation is not enabled.
     g_assert_false(webkit_web_context_is_automation_allowed(test->m_webContext.get()));
 #if ENABLE(2022_GLIB_API)
     // Network session for automation is nullptr if automation is not enabled.
     g_assert_null(webkit_web_context_get_network_session_for_automation(test->m_webContext.get()));
 #endif
-    auto* session = test->requestSession(sessionID.data());
+    auto* session = test->requestSession(sessionID.legacyCStringPointer());
     g_assert_null(session);
 
     webkit_web_context_set_automation_allowed(test->m_webContext.get(), TRUE);
@@ -323,8 +323,8 @@ static void testAutomationSessionRequestSession(AutomationTest* test, gconstpoin
     Test::addLogFatalFlag(G_LOG_LEVEL_WARNING);
     g_assert_false(webkit_web_context_is_automation_allowed(otherContext.get()));
 
-    session = test->requestSession(sessionID.data());
-    g_assert_cmpstr(webkit_automation_session_get_id(session), ==, sessionID.data());
+    session = test->requestSession(sessionID.legacyCStringPointer());
+    g_assert_cmpstr(webkit_automation_session_get_id(session), ==, sessionID.legacyCStringPointer());
     g_assert_cmpuint(test->m_target.id, >, 0);
     ASSERT_CMP_CSTRING(test->m_target.name, ==, sessionID);
     g_assert_false(test->m_target.isPaired);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestSSL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestSSL.cpp
@@ -242,7 +242,7 @@ public:
 
     GTlsCertificate* certificate() const { return m_certificate.get(); }
     GTlsCertificateFlags tlsErrors() const { return m_tlsErrors; }
-    CString host() const { return m_failingURL.host().toString().utf8(); }
+    UTF8CString host() const { return m_failingURL.host().toString().utf8(); }
 
 private:
     GRefPtr<GTlsCertificate> m_certificate;
@@ -268,9 +268,9 @@ static void testLoadFailedWithTLSErrors(TLSErrorsTest* test, gconstpointer)
 
     // Test allowing an exception for this certificate on this host.
 #if ENABLE(2022_GLIB_API)
-    webkit_network_session_allow_tls_certificate_for_host(test->m_networkSession.get(), test->certificate(), test->host().data());
+    webkit_network_session_allow_tls_certificate_for_host(test->m_networkSession.get(), test->certificate(), test->host().legacyCStringPointer());
 #else
-    webkit_web_context_allow_tls_certificate_for_host(test->m_webContext.get(), test->certificate(), test->host().data());
+    webkit_web_context_allow_tls_certificate_for_host(test->m_webContext.get(), test->certificate(), test->host().legacyCStringPointer());
 #endif
     // The page should now load without errors.
     test->loadURI(kHttpsServer->getURIForPath("/test-tls/").data());

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -786,7 +786,7 @@ WKURLRequestRef InjectedBundlePage::willSendRequestForFrame(WKBundlePageRef page
     if (testRunner) {
         String body = testRunner->willSendRequestHTTPBody();
         if (!body.isEmpty()) {
-            CString cBody = body.utf8();
+            auto cBody = body.utf8();
             auto body = adoptWK(WKDataCreate(reinterpret_cast<const unsigned char*>(cBody.data()), cBody.length()));
             return WKURLRequestCopySettingHTTPBody(request, body.get());
         }

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2143,7 +2143,7 @@ WKURLRef TestController::createTestURL(std::span<const char> pathOrURL)
 
     // Creating from filesytem path.
     auto urlString = makeString("file://"_s, FileSystem::realPath(String::fromUTF8(pathOrURL))).utf8();
-    auto url = adoptWK(WKURLCreateWithUTF8String(urlString.data(), urlString.length()));
+    auto url = adoptWK(WKURLCreateWithUTF8String(urlString.legacyCStringPointer(), urlString.length()));
     auto path = testPath(url.get());
     auto pathString = String::fromUTF8(std::span { path });
     if (!m_usingServerMode && !FileSystem::fileExists(pathString)) {
@@ -2491,7 +2491,7 @@ static WKRetainPtr<WKArrayRef> WKURLArrayFromWKStringArray(const WKTypeRef array
     for (size_t i = 0; i < length; i++) {
         auto str = WKArrayGetItemAtIndex(stringArray, i);
         auto cstr = toWTFString(stringValue(str)).utf8();
-        WKArrayAppendItem(urlArray.get(), adoptWK(WKURLCreateWithUTF8CString(cstr.data())).get());
+        WKArrayAppendItem(urlArray.get(), adoptWK(WKURLCreateWithUTF8CString(cstr.legacyCStringPointer())).get());
     }
 
     return urlArray;
@@ -3071,7 +3071,7 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         for (size_t i = 0; i < length; i++) {
             auto key = WKArrayGetItemAtIndex(keys, i);
             auto keyStr = toWTFString(stringValue(key)).utf8();
-            auto intValue = doubleValue(dictionary, keyStr.data());
+            auto intValue = doubleValue(dictionary, keyStr.legacyCStringPointer());
             bytes.append(static_cast<unsigned char>(intValue));
         }
         WKDataRef data = WKDataCreate(bytes.begin(), bytes.size());

--- a/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp
@@ -88,9 +88,9 @@ void UIScriptControllerGtk::copyText(JSStringRef text)
 {
     auto string = text->string().utf8();
 #if USE(GTK4)
-    gdk_clipboard_set_text(gdk_display_get_clipboard(gdk_display_get_default()), string.data());
+    gdk_clipboard_set_text(gdk_display_get_clipboard(gdk_display_get_default()), string.legacyCStringPointer());
 #else
-    gtk_clipboard_set_text(gtk_clipboard_get(GDK_SELECTION_CLIPBOARD), string.data(), string.length());
+    gtk_clipboard_set_text(gtk_clipboard_get(GDK_SELECTION_CLIPBOARD), string.legacyCStringPointer(), string.length());
 #endif
 }
 


### PR DESCRIPTION
#### 00130dc2f37dea8c621033fada8377063d93993c
<pre>
Make String::utf8(), StringImpl::utf8() and StringView::utf8() return a UTF8CString
<a href="https://bugs.webkit.org/show_bug.cgi?id=323846">https://bugs.webkit.org/show_bug.cgi?id=323846</a>

Reviewed by Darin Adler.

320652@main introduced CStringWithEncoding (UTF8CString / Latin1CString / ASCIICString) and
migrated String::ascii(), String::latin1() and the tryGetUTF8() family, leaving utf8() itself
returning a plain CString behind a FIXME. 320795@main did the mechanical half of what was left:
it added CString::legacyCStringPointer() and moved all 2516 utf8().data() call sites onto it
while the two spellings were still equivalent.

This is the retype. utf8() now returns UTF8CString on String, StringImpl and StringView, so
data() is a const char8_t*, span() is a std::span&lt;const char8_t&gt;, and the encoding survives into
every expression built from the result rather than stopping at the accessor. All three are done
together because they share the one FIXME and because the call sites do not distinguish them:
the same helper is reached from a String, a StringView substring and an Impl in adjacent lines,
and retyping only one of them would leave the type meaningless in practice.

String gains a constructor taking a CStringWithEncoding&lt;T&gt;, which is the same idea as its
existing span constructors one level up: the character type already says how to decode the bytes,
so the caller should not have to.

* Source/JavaScriptCore/jsc.cpp:
(fetchModuleFromLocalFileSystem):
(JSC_DEFINE_HOST_FUNCTION):
(CommandLine::parseArguments):
* Source/JavaScriptCore/runtime/Identifier.h:
(JSC::Identifier::utf8 const):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::createDateIntervalFormatIfNecessary):
(JSC::IntlDateTimeFormat::createTemporalIntervalFormat const):
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::IntlNumberFormat::initializeNumberFormat):
* Source/JavaScriptCore/runtime/IntlPluralRules.cpp:
(JSC::IntlPluralRules::initializePluralRules):
* Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp:
(JSC::IntlRelativeTimeFormat::initializeRelativeTimeFormat):
* Source/JavaScriptCore/runtime/JSDateMath.cpp:
(JSC::DateCache::timeZoneDisplayName):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::printTraceData):
* Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp:
(JSC::Wasm::StreamingCompiler::StreamingCompiler):
* Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp:
(JSC::Wasm::stringToHex):
* Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp:
(JSC::Wasm::WTF_REQUIRES_LOCK):
* Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp:
(JSC::compileAndInstantiate):
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::toStdFileSystemPath):
* Source/WTF/wtf/FormattedLogging.h:
(std::formatter&lt;T&gt;::format const):
* Source/WTF/wtf/cf/URLCF.cpp:
(WTF::URL::createCFURL):
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::openTemporaryFile):
* Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm:
(WTF::LibraryPathDiagnosticsLogger::logJSONPayload):
(WTF::LibraryPathDiagnosticsLogger::logDynamicLibraryInfo):
(WTF::LibraryPathDiagnosticsLogger::logCryptexCanaryInfo):
* Source/WTF/wtf/glib/FilePathWatcher.cpp:
(WTF::FilePathWatcher::FilePathWatcher):
* Source/WTF/wtf/posix/FileSystemPOSIX.cpp:
(WTF::FileSystemImpl::openTemporaryFile):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::unsafeSpan):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::utf8 const):
* Source/WTF/wtf/text/StringImpl.h:
* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::utf8 const):
* Source/WTF/wtf/text/StringView.h:
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::utf8 const):
* Source/WTF/wtf/text/WTFString.h:
(WTF::String::String):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp:
(WebCore::WebGPU::AdapterImpl::requestDevice):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp:
(WebCore::WebGPU::CommandEncoderImpl::beginRenderPass):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::invalidEntryPointName):
(WebCore::WebGPU::hasNullCharacter):
(WebCore::WebGPU::DeviceImpl::createBuffer):
(WebCore::WebGPU::DeviceImpl::createTexture):
(WebCore::WebGPU::DeviceImpl::importExternalTexture):
(WebCore::WebGPU::DeviceImpl::createBindGroupLayout):
(WebCore::WebGPU::DeviceImpl::createPipelineLayout):
(WebCore::WebGPU::DeviceImpl::createBindGroup):
(WebCore::WebGPU::DeviceImpl::createShaderModule):
(WebCore::WebGPU::convertToBacking):
(WebCore::WebGPU::DeviceImpl::createCommandEncoder):
(WebCore::WebGPU::DeviceImpl::createRenderBundleEncoder):
(WebCore::WebGPU::DeviceImpl::createQuerySet):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPURenderBundleEncoderImpl.cpp:
(WebCore::WebGPU::RenderBundleEncoderImpl::finish):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp:
(WebCore::WebGPU::TextureImpl::createView):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::packageFormData):
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::close):
* Source/WebCore/Modules/websockets/WebSocketExtensionDispatcher.cpp:
(WebCore::WebSocketExtensionDispatcher::processHeaderValue):
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::text const):
(WebCore::AccessibilityObjectAtspi::textInserted):
(WebCore::AccessibilityObjectAtspi::textDeleted):
(WebCore::AccessibilityObjectAtspi::textAtOffset const):
(WebCore::AccessibilityObjectAtspi::characterAtOffset const):
(WebCore::AccessibilityObjectAtspi::characterIndex const):
(WebCore::AccessibilityObjectAtspi::textExtents const):
(WebCore::AccessibilityObjectAtspi::selectionBounds const):
(WebCore::AccessibilityObjectAtspi::selectRange):
(WebCore::AccessibilityObjectAtspi::selectionChanged):
(WebCore::AccessibilityObjectAtspi::textAttributesWithUTF8Offset const):
(WebCore::AccessibilityObjectAtspi::scrollToMakeVisible const):
(WebCore::AccessibilityObjectAtspi::scrollToPoint const):
* Source/WebCore/bindings/js/GarbageCollectionController.cpp:
(WebCore::GarbageCollectionController::dumpHeapForVM):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::SelectorCodeGenerator::SelectorCodeGenerator):
* Source/WebCore/html/MediaFragmentURIParser.cpp:
(WebCore::MediaFragmentURIParser::parseFragments):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::getActiveUniformBlockName):
* Source/WebCore/html/canvas/WebGLProgram.cpp:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::ensureNotNull):
(WebCore::WebGLRenderingContextBase::addDebugMessage):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::defaultSubstituteDataForURL):
* Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp:
(WebCore::MHTMLArchive::generateMHTMLData):
* Source/WebCore/page/Performance.cpp:
(WebCore::Performance::measure):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::generateHashesForContent):
* Source/WebCore/platform/audio/HRTFElevation.cpp:
(WebCore::HRTFElevation::calculateKernelsForAzimuthElevation):
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::destroyDecodedFrames):
(WebCore::BitmapImageSource::stopDecoderWorkQueue):
(WebCore::BitmapImageSource::decode):
(WebCore::BitmapImageSource::imageFrameDecodeAtIndexHasFinished):
(WebCore::BitmapImageSource::requestNativeImageAtIndex):
(WebCore::BitmapImageSource::requestNativeImageAtIndexIfNeeded):
(WebCore::BitmapImageSource::nativeImageAtIndexCacheIfNeeded):
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/GraphicsContextGLActiveInfo.h:
* Source/WebCore/platform/graphics/ImageFrameAnimator.cpp:
(WebCore::ImageFrameAnimator::startAnimation):
(WebCore::ImageFrameAnimator::advanceAnimation):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::extensionEnum):
(WebCore::GraphicsContextGLANGLE::initialize):
(WebCore::GraphicsContextGLANGLE::bindAttribLocation):
(WebCore::GraphicsContextGLANGLE::activeAttribs):
(WebCore::GraphicsContextGLANGLE::activeUniforms):
(WebCore::GraphicsContextGLANGLE::getString):
(WebCore::GraphicsContextGLANGLE::shaderSource):
(WebCore::GraphicsContextGLANGLE::getProgramInfoLog):
(WebCore::GraphicsContextGLANGLE::getShaderInfoLog):
(WebCore::GraphicsContextGLANGLE::getUniformBlockIndex):
(WebCore::GraphicsContextGLANGLE::getActiveUniformBlockName):
(WebCore::GraphicsContextGLANGLE::transformFeedbackVaryings):
(WebCore::GraphicsContextGLANGLE::getTransformFeedbackVarying):
(WebCore::GraphicsContextGLANGLE::getFragDataLocation):
(WebCore::GraphicsContextGLANGLE::getTranslatedShaderSourceANGLE):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::elementIdChanged const):
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoEncoder::encode):
* Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp:
(WebCore::TextureMapperShaderProgram::TextureMapperShaderProgram):
* Source/WebCore/platform/libwpe/PlatformPasteboardLibWPE.cpp:
(WebCore::PlatformPasteboard::write):
* Source/WebCore/platform/network/curl/PublicSuffixStoreCurl.cpp:
(WebCore::PublicSuffixStore::platformTopPrivatelyControlledDomain const):
* Source/WebCore/platform/soup/PublicSuffixStoreSoup.cpp:
(WebCore::PublicSuffixStore::platformTopPrivatelyControlledDomain const):
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::prepareStatementSlow):
* Source/WebCore/platform/text/enchant/TextCheckerEnchant.cpp:
(WebCore::TextCheckerEnchant::ignoreWord):
(WebCore::TextCheckerEnchant::learnWord):
(WebCore::TextCheckerEnchant::checkSpellingOfWord):
(WebCore::TextCheckerEnchant::getGuessesForWord):
(WebCore::TextCheckerEnchant::updateSpellCheckingLanguages):
* Source/WebCore/platform/text/hyphen/HyphenationLibHyphen.cpp:
(WebCore::lastHyphenLocation):
* Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp:
(WebCore::markupToCFHTML):
(WebCore::setUTF8Data):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::capitalizeWordWithLocale):
* Source/WebCore/xml/XSLStyleSheetLibxslt.cpp:
(WebCore::XSLStyleSheet::locateStylesheetSubResource):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::appendFragmentSource):
* Source/WebDriver/WebDriverService.cpp:
(WebDriver::WebDriverService::run):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::addDebugMessage):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGL::bindAttribLocation):
(WebKit::RemoteGraphicsContextGL::getString):
(WebKit::RemoteGraphicsContextGL::getProgramInfoLog):
(WebKit::RemoteGraphicsContextGL::getShaderInfoLog):
(WebKit::RemoteGraphicsContextGL::shaderSource):
(WebKit::RemoteGraphicsContextGL::getFragDataLocation):
(WebKit::RemoteGraphicsContextGL::transformFeedbackVaryings):
(WebKit::RemoteGraphicsContextGL::getUniformBlockIndex):
(WebKit::RemoteGraphicsContextGL::getActiveUniformBlockName):
(WebKit::RemoteGraphicsContextGL::getTranslatedShaderSourceANGLE):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::setIBLAssetOwnership):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::completeAuthentication):
(WebKit::NetworkDataTaskSoup::download):
(WebKit::NetworkDataTaskSoup::didFinishDownload):
* Source/WebKit/NetworkProcess/soup/NetworkStorageSessionSoup.cpp:
(WebKit::NetworkStorageSession::saveCredentialToPersistentStorage):
(WebKit::NetworkStorageSession::setCookiesFromDOM const):
(WebKit::NetworkStorageSession::deleteCookie const):
(WebKit::NetworkStorageSession::deleteCookiesForHostnames):
(WebKit::NetworkStorageSession::domCookiesForHost):
* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(decodeObject):
* Source/WebKit/Shared/RTCNetwork.cpp:
(WebKit::RTCNetwork::value const):
(WebKit::WebRTCNetwork::SocketAddress::rtcAddress const):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebGL.serialization.in:
* Source/WebKit/Shared/WebMemorySampler.cpp:
(WebKit::WebMemorySampler::appendCurrentMemoryUsageToFile):
* Source/WebKit/Shared/WebPushMessage.cpp:
(WebKit::WebPushMessage::notificationPayloadToCoreData const):
* Source/WebKit/UIProcess/API/glib/InputMethodFilter.cpp:
(WebKit::InputMethodFilter::notifySurrounding):
* Source/WebKit/UIProcess/API/glib/WebKitContextMenuClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/API/glib/WebKitSecurityOrigin.cpp:
(webkit_security_origin_to_string):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webkit_settings_set_user_agent):
(webkit_settings_set_user_agent_with_application_details):
* Source/WebKit/UIProcess/API/glib/WebKitUserContentFilterStore.cpp:
(webkit_user_content_filter_store_fetch_identifiers):
* Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp:
(WebKit::DragSource::DragSource):
* Source/WebKit/UIProcess/API/gtk/DragSourceGtk4.cpp:
(WebKit::DragSource::begin):
* Source/WebKit/UIProcess/API/gtk/WebKitRemoteInspectorProtocolHandler.cpp:
(WebKit::RemoteInspectorProtocolHandler::updateTargetList):
* Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseSetPlugID):
* Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp:
(WebKit::DownloadProxy::updateQuarantinePropertiesIfPossible):
* Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp:
(WebKit::RemoteInspectorHTTPServer::handleRequest const):
(WebKit::RemoteInspectorHTTPServer::sendMessageToFrontend const):
* Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp:
(WebKit::computeContentHash):
(WebKit::WebInspectorUIProxy::platformSave):
* Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp:
(WebKit::bindV4l):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::WebAuthenticatorCoordinatorProxy::requestsForAssertion):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::platformSetNetworkParameters):
* Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp:
(WebKit::Clipboard::write):
* Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp:
(WebKit::Clipboard::write):
* Source/WebKit/UIProcess/gtk/ValidationBubbleGtk.cpp:
(WebKit::ValidationBubbleGtk::ValidationBubbleGtk):
* Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp:
(WebKit::setClipboardContentFromSpan):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::addDebugMessage):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::bindAttribLocation):
(WebKit::RemoteGraphicsContextGLProxy::getString):
(WebKit::RemoteGraphicsContextGLProxy::getProgramInfoLog):
(WebKit::RemoteGraphicsContextGLProxy::getShaderInfoLog):
(WebKit::RemoteGraphicsContextGLProxy::shaderSource):
(WebKit::RemoteGraphicsContextGLProxy::getFragDataLocation):
(WebKit::RemoteGraphicsContextGLProxy::transformFeedbackVaryings):
(WebKit::RemoteGraphicsContextGLProxy::getUniformBlockIndex):
(WebKit::RemoteGraphicsContextGLProxy::getActiveUniformBlockName):
(WebKit::RemoteGraphicsContextGLProxy::getTranslatedShaderSourceANGLE):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebProcessExtensionManager.cpp:
(WebKit::parseUserData):
* Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm:
(WebKit::InjectedBundle::extendClassesForParameterCoder):
* Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp:
(WebKit::WebPrintOperationGtk::endPrint):
* Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp:
(TestWebKitAPI::TEST_F(FileSystemTest, readEntireFile)):
* Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp:
(TestWebKitAPI::TEST(WTF, StringUTF8ConversionInvalidUTF16LenientMode)):
(TestWebKitAPI::TEST(WTF, StringUTF8ConversionStrictReplacingMode)):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::TEST(URLExtras, URLExtras_Spoof)):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm:
* Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/EventAttribution.mm:
(TestWebKitAPI::triggerAttributionWithSubresourceRedirect):
(TestWebKitAPI::signUnlinkableTokenAndSendSecretToken):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NetworkProcess.mm:
(TEST(WebKit, HTTPReferer)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SOAuthorizationTests.mm:
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByParent)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByWebKit)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedWithOtherHttpStatusCode)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedWithCookie)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedTwice)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)):
(TestWebKitAPI::TEST(SOAuthorizationPopUp, InterceptionSucceedNewWindowNavigation)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSuccess)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSuccessBackForwardList)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSucceedWithOtherHttpStatusCode)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSuccessTwice)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyAllowAsync)):
(TestWebKitAPI::TEST(SOAuthorizationSubFrame, InterceptionSuccessMessageOrder)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestAutomationSession.cpp:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/glib/TestSSL.cpp:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::InjectedBundlePage::willSendRequestForFrame):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::createTestURL):
* Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp:
(WTR::UIScriptControllerGtk::copyText):

Canonical link: <a href="https://commits.webkit.org/320905@main">https://commits.webkit.org/320905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e72ec6acfe52726d890ea2f4beb1201016c1ec89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196518 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150783 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145517 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125854 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47921 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7698 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14563 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158274 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45633 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7590 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47466 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198505 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59780 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165565 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155081 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/41549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60490 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154724 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28275 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49157 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129903 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58917 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20612 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58319 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58537 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58383 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->