### PR TITLE
Annotate EventListenerMap's entries as owner-thread state

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -127,6 +127,40 @@
 
 namespace JSC {
 
+namespace {
+
+// The heap, if any, that the calling thread is currently doing collection work for. Recorded
+// rather than a plain flag so that currentThreadIsCollectingWithWorldStopped() reads
+// worldIsStopped() at the point of the query: a collector thread spans both the stop-the-world
+// phases and concurrent marking, so the answer changes during its lifetime.
+thread_local Heap* t_currentlyCollectingHeap;
+
+class CurrentlyCollectingHeapScope {
+    WTF_MAKE_NONCOPYABLE(CurrentlyCollectingHeapScope);
+public:
+    explicit CurrentlyCollectingHeapScope(Heap& heap)
+        : m_previous(t_currentlyCollectingHeap)
+    {
+        t_currentlyCollectingHeap = &heap;
+    }
+
+    ~CurrentlyCollectingHeapScope()
+    {
+        t_currentlyCollectingHeap = m_previous;
+    }
+
+private:
+    Heap* m_previous;
+};
+
+} // namespace
+
+bool currentThreadIsCollectingWithWorldStopped()
+{
+    auto* heap = t_currentlyCollectingHeap;
+    return heap && heap->worldIsStopped();
+}
+
 namespace HeapInternal {
 static constexpr bool verbose = false;
 static constexpr bool verboseStop = false;
@@ -317,6 +351,7 @@ private:
     
     WorkResult work() final
     {
+        CurrentlyCollectingHeapScope scope(m_heap);
         m_heap.collectInCollectorThread();
         return WorkResult::Continue;
     }
@@ -1600,6 +1635,7 @@ NEVER_INLINE bool Heap::runBeginPhase(GCConductor conn)
             Thread::registerGCThread(GCThreadType::Helper);
 
             {
+                CurrentlyCollectingHeapScope scope(*this);
                 ParallelModeEnabler parallelModeEnabler(*visitor);
                 visitor->drainFromShared(SlotVisitor::HelperDrain);
             }

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -1324,6 +1324,12 @@ private:
 
 } // namespace GCClient
 
+// True when the calling thread is performing garbage collection work for a heap that currently
+// has the world stopped. State that the mutator may read without locking only because it is
+// paused can assert this, rather than settling for "some GC thread", which does not distinguish
+// the stop-the-world phases from concurrent marking.
+JS_EXPORT_PRIVATE bool currentThreadIsCollectingWithWorldStopped();
+
 } // namespace JSC
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WebCore/dom/EventListenerMap.cpp
+++ b/Source/WebCore/dom/EventListenerMap.cpp
@@ -37,6 +37,7 @@
 #include "Event.h"
 #include "EventTarget.h"
 #include "JSEventListener.h"
+#include <JavaScriptCore/Heap.h>
 #include <wtf/MainThread.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
@@ -46,8 +47,20 @@ namespace WebCore {
 
 EventListenerMap::EventListenerMap() = default;
 
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+void EventListenerMap::assertIsOwnerThreadOrGCThreadWithWorldStopped() const
+{
+#if PLATFORM(IOS_FAMILY)
+    if (WebThreadIsEnabled())
+        return;
+#endif
+    ASSERT_WITH_SECURITY_IMPLICATION(!m_threadUID || m_threadUID == currentThreadID() || JSC::currentThreadIsCollectingWithWorldStopped());
+}
+#endif
+
 bool EventListenerMap::containsCapturing(const AtomString& eventType) const
 {
+    assertIsOwnerThreadOrGCThreadWithWorldStopped();
     auto* listeners = find(eventType);
     if (!listeners)
         return false;
@@ -61,6 +74,7 @@ bool EventListenerMap::containsCapturing(const AtomString& eventType) const
 
 bool EventListenerMap::containsActive(const AtomString& eventType) const
 {
+    assertIsOwnerThreadOrGCThreadWithWorldStopped();
     auto* listeners = find(eventType);
     if (!listeners)
         return false;
@@ -77,17 +91,18 @@ void EventListenerMap::clear()
     releaseAssertOrSetThreadUID();
     Locker locker { m_lock };
 
-    for (auto& entry : m_entries) {
+    for (auto& entry : entriesForMutation()) {
         for (auto& listener : entry.second)
             listener->markAsRemoved();
     }
 
-    m_entries.clear();
+    entriesForMutation().clear();
 }
 
 Vector<AtomString> EventListenerMap::eventTypes() const
 {
-    return m_entries.map([](auto& entry) {
+    assertIsOwnerThread();
+    return entries().map([](auto& entry) {
         return entry.first;
     });
 }
@@ -107,7 +122,7 @@ void EventListenerMap::replacePreservingOptions(const AtomString& eventType, Eve
     releaseAssertOrSetThreadUID();
     Locker locker { m_lock };
 
-    auto* listeners = find(eventType);
+    auto* listeners = findForMutation(eventType);
     ASSERT(listeners);
     size_t index = findListener(*listeners, oldListener, useCapture);
     ASSERT(index != notFound);
@@ -122,14 +137,14 @@ bool EventListenerMap::add(const AtomString& eventType, Ref<EventListener>&& lis
     releaseAssertOrSetThreadUID();
     Locker locker { m_lock };
 
-    if (auto* listeners = find(eventType)) {
+    if (auto* listeners = findForMutation(eventType)) {
         if (findListener(*listeners, listener, options.capture) != notFound)
             return false; // Duplicate listener.
         listeners->append(RegisteredEventListener::create(WTF::move(listener), options));
         return true;
     }
 
-    m_entries.append({ eventType, EventListenerVector { RegisteredEventListener::create(WTF::move(listener), options) } });
+    entriesForMutation().append({ eventType, EventListenerVector { RegisteredEventListener::create(WTF::move(listener), options) } });
     return true;
 }
 
@@ -149,11 +164,12 @@ bool EventListenerMap::remove(const AtomString& eventType, EventListener& listen
     releaseAssertOrSetThreadUID();
     Locker locker { m_lock };
 
-    for (unsigned i = 0; i < m_entries.size(); ++i) {
-        if (m_entries[i].first == eventType) {
-            bool wasRemoved = removeListenerFromVector(m_entries[i].second, listener, useCapture);
-            if (m_entries[i].second.isEmpty())
-                m_entries.removeAt(i);
+    auto& entries = entriesForMutation();
+    for (unsigned i = 0; i < entries.size(); ++i) {
+        if (entries[i].first == eventType) {
+            bool wasRemoved = removeListenerFromVector(entries[i].second, listener, useCapture);
+            if (entries[i].second.isEmpty())
+                entries.removeAt(i);
             return wasRemoved;
         }
     }
@@ -161,14 +177,20 @@ bool EventListenerMap::remove(const AtomString& eventType, EventListener& listen
     return false;
 }
 
-EventListenerVector* EventListenerMap::find(const AtomString& eventType)
+const EventListenerVector* EventListenerMap::find(const AtomString& eventType) const
 {
-    for (auto& entry : m_entries) {
+    for (auto& entry : entries()) {
         if (entry.first == eventType)
             return &entry.second;
     }
 
     return nullptr;
+}
+
+EventListenerVector* EventListenerMap::findForMutation(const AtomString& eventType)
+{
+    // Safe to drop the const: this requires m_lock exclusively, so no other thread can be reading.
+    return const_cast<EventListenerVector*>(find(eventType));
 }
 
 static void removeFirstListenerCreatedFromMarkup(EventListenerVector& listenerVector)
@@ -188,17 +210,18 @@ void EventListenerMap::removeFirstEventListenerCreatedFromMarkup(const AtomStrin
     releaseAssertOrSetThreadUID();
     Locker locker { m_lock };
 
-    for (unsigned i = 0; i < m_entries.size(); ++i) {
-        if (m_entries[i].first == eventType) {
-            removeFirstListenerCreatedFromMarkup(m_entries[i].second);
-            if (m_entries[i].second.isEmpty())
-                m_entries.removeAt(i);
+    auto& entries = entriesForMutation();
+    for (unsigned i = 0; i < entries.size(); ++i) {
+        if (entries[i].first == eventType) {
+            removeFirstListenerCreatedFromMarkup(entries[i].second);
+            if (entries[i].second.isEmpty())
+                entries.removeAt(i);
             return;
         }
     }
 }
 
-static void copyListenersNotCreatedFromMarkupToTarget(const AtomString& eventType, EventListenerVector& listenerVector, EventTarget* target)
+static void copyListenersNotCreatedFromMarkupToTarget(const AtomString& eventType, const EventListenerVector& listenerVector, EventTarget* target)
 {
     for (auto& registeredListener : listenerVector) {
         // Event listeners created from markup have already been transfered to the shadow tree during cloning.
@@ -210,7 +233,8 @@ static void copyListenersNotCreatedFromMarkupToTarget(const AtomString& eventTyp
 
 void EventListenerMap::copyEventListenersNotCreatedFromMarkupToTarget(EventTarget* target)
 {
-    for (auto& entry : m_entries)
+    assertIsOwnerThread();
+    for (auto& entry : entries())
         copyListenersNotCreatedFromMarkupToTarget(entry.first, entry.second, target);
 }
 

--- a/Source/WebCore/dom/EventListenerMap.h
+++ b/Source/WebCore/dom/EventListenerMap.h
@@ -62,8 +62,8 @@ class EventListenerMap {
 public:
     WEBCORE_EXPORT EventListenerMap();
 
-    bool isEmpty() const { return m_entries.isEmpty(); }
-    bool contains(const AtomString& eventType) const { return find(eventType); }
+    bool isEmpty() const { assertIsOwnerThreadOrGCThreadWithWorldStopped(); return entries().isEmpty(); }
+    bool contains(const AtomString& eventType) const { assertIsOwnerThreadOrGCThreadWithWorldStopped(); return find(eventType); }
     bool NODELETE containsCapturing(const AtomString& eventType) const;
     bool NODELETE containsActive(const AtomString& eventType) const;
 
@@ -71,20 +71,23 @@ public:
     void clearEntriesForTearDown()
     {
         releaseAssertOrSetThreadUID();
-        m_entries.clear();
+        Locker locker { m_lock };
+        entriesForMutation().clear();
     }
 
     void replacePreservingOptions(const AtomString& eventType, EventListener& oldListener, Ref<EventListener>&& newListener, bool useCapture = false);
     bool add(const AtomString& eventType, Ref<EventListener>&&, const RegisteredEventListener::Options&);
     bool remove(const AtomString& eventType, EventListener&, bool useCapture);
-    WEBCORE_EXPORT EventListenerVector* NODELETE find(const AtomString& eventType);
-    const EventListenerVector* find(const AtomString& eventType) const { return const_cast<EventListenerMap*>(this)->find(eventType); }
+    // Returns const so that m_entries cannot be mutated through it while only shared access is
+    // held. Mutating callers use findForMutation(), which requires the lock exclusively.
+    WEBCORE_EXPORT const EventListenerVector* NODELETE find(const AtomString& eventType) const WTF_REQUIRES_SHARED_LOCK(m_lock);
     Vector<AtomString> eventTypes() const;
 
     template<typename CallbackType>
     void enumerateEventListenerTypes(NOESCAPE const CallbackType& callback) const
     {
-        for (auto& entry : m_entries) {
+        assertIsOwnerThread();
+        for (auto& entry : entries()) {
             uint32_t capturingCount = 0;
             uint32_t bubblingCount = 0;
             for (auto& listener : entry.second) {
@@ -100,8 +103,9 @@ public:
     template<typename CallbackType>
     bool containsMatchingEventListener(NOESCAPE const CallbackType& callback) const
     {
-        for (auto& entry : m_entries) {
-            if (callback(entry.first, m_entries))
+        assertIsOwnerThread();
+        for (auto& entry : entries()) {
+            if (callback(entry.first, entries()))
                 return true;
         }
         return false;
@@ -113,7 +117,43 @@ public:
     template<typename Visitor> void visitJSEventListenersInGCThread(Visitor&);
     Lock& lock() LIFETIME_BOUND { return m_lock; }
 
+    // Grants read-only access to m_entries on the thread that owns this map, without locking.
+    // Public because EventTarget and Style::Adjuster reach m_entries through find(). Unlike
+    // releaseAssertOrSetThreadUID() this never claims the map and costs nothing in release
+    // builds, so it is usable on the event dispatch path.
+    void assertIsOwnerThread() const WTF_ASSERTS_ACQUIRED_SHARED_LOCK(m_lock)
+    {
+#if PLATFORM(IOS_FAMILY)
+        if (WebThreadIsEnabled())
+            return;
+#endif
+        ASSERT_WITH_SECURITY_IMPLICATION(!m_threadUID || m_threadUID == currentThreadID());
+    }
+
 private:
+    using Entries = Vector<std::pair<AtomString, EventListenerVector>, 0, CrashOnOverflow, 4>;
+
+    // The only ways to reach the entries. Thread safety analysis counts a non-const call on a
+    // guarded container as a read, so a mutating call would be accepted under merely shared
+    // access; routing every mutation through an accessor that requires the lock exclusively is
+    // what makes the write half of the invariant enforceable.
+    const Entries& entries() const LIFETIME_BOUND WTF_REQUIRES_SHARED_LOCK(m_lock) { return m_entries; }
+    Entries& entriesForMutation() LIFETIME_BOUND WTF_REQUIRES_LOCK(m_lock) { return m_entries; }
+
+    EventListenerVector* NODELETE findForMutation(const AtomString& eventType) WTF_REQUIRES_LOCK(m_lock);
+
+    // As above, but also permits a collector thread, and only while it has the world stopped:
+    // that is what makes an unlocked read from a thread that does not own the map safe, since
+    // the owning thread cannot be mutating. The hasPendingActivity() and
+    // isReachableFromOpaqueRoots() implementations query the map from the GC in exactly that
+    // state. Concurrent marking is not accepted, so an unlocked read from a GC thread while the
+    // owning thread is running is still caught. Out of line to keep JSC's Heap out of this header.
+#if ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
+    void assertIsOwnerThreadOrGCThreadWithWorldStopped() const WTF_ASSERTS_ACQUIRED_SHARED_LOCK(m_lock) { }
+#else
+    WEBCORE_EXPORT void assertIsOwnerThreadOrGCThreadWithWorldStopped() const WTF_ASSERTS_ACQUIRED_SHARED_LOCK(m_lock);
+#endif
+
     void releaseAssertOrSetThreadUID()
     {
 #if PLATFORM(IOS_FAMILY)
@@ -130,7 +170,12 @@ private:
         RELEASE_ASSERT(currentThreadMayBeGCThread());
     }
 
-    Vector<std::pair<AtomString, EventListenerVector>, 0, CrashOnOverflow, 4> m_entries;
+    // Mutated on the owning thread while holding m_lock and read on the GC threads by
+    // visitJSEventListenersInGCThread(), which locks; the owning thread's own reads use
+    // assertIsOwnerThread() instead of locking. Note that thread safety analysis treats a
+    // non-const call on a guarded container as a read, so keeping every mutable path behind
+    // exclusive access is what actually enforces the write half of this.
+    Entries m_entries WTF_GUARDED_BY_LOCK(m_lock);
     Lock m_lock;
     uint32_t m_threadUID { 0 };
 };
@@ -139,7 +184,7 @@ template<typename Visitor>
 void EventListenerMap::visitJSEventListenersInGCThread(Visitor& visitor)
 {
     Locker locker { m_lock };
-    for (auto& entry : m_entries) {
+    for (auto& entry : entries()) {
         for (auto& eventListener : entry.second)
             eventListener->callback().visitJSFunctionInGCThread(visitor);
     }

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -324,6 +324,7 @@ void EventTarget::fireEventListeners(Event& event, EventInvokePhase phase)
     if (!data)
         return;
 
+    data->eventListenerMap.assertIsOwnerThread();
     if (auto* listenersVector = data->eventListenerMap.find(event.type())) {
         innerInvokeEventListeners(event, *listenersVector, phase);
         return;
@@ -419,9 +420,14 @@ Vector<AtomString> EventTarget::eventTypes() const
 
 const EventListenerVector& EventTarget::eventListeners(const AtomString& eventType)
 {
-    auto* data = eventTargetData();
-    auto* listenerVector = data ? data->eventListenerMap.find(eventType) : nullptr;
     static NeverDestroyed<EventListenerVector> emptyVector;
+
+    auto* data = eventTargetData();
+    if (!data)
+        return emptyVector.get();
+
+    data->eventListenerMap.assertIsOwnerThread();
+    auto* listenerVector = data->eventListenerMap.find(eventType);
     return listenerVector ? *listenerVector : emptyVector.get();
 }
 

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -241,7 +241,9 @@ OptionSet<EventListenerRegionType> Adjuster::computeEventListenerRegionTypes(con
 
 #if ENABLE(WHEEL_EVENT_REGIONS) || ENABLE(TOUCH_EVENT_REGIONS)
     auto findListeners = [&](auto& eventName, auto type, auto nonPassiveType) {
-        auto* eventListenerVector = eventTarget.eventTargetData()->eventListenerMap.find(eventName);
+        auto& eventListenerMap = eventTarget.eventTargetData()->eventListenerMap;
+        eventListenerMap.assertIsOwnerThread();
+        auto* eventListenerVector = eventListenerMap.find(eventName);
         if (!eventListenerVector)
             return;
 


### PR DESCRIPTION
#### 4beafc6a6cf072cea111be41d84fc6460a99fcf7
<pre>
Annotate EventListenerMap&apos;s entries as owner-thread state
<a href="https://bugs.webkit.org/show_bug.cgi?id=323853">https://bugs.webkit.org/show_bug.cgi?id=323853</a>

Reviewed by NOBODY (OOPS!).

m_entries is mutated on the thread that owns the map while holding m_lock, and read on the
garbage collector&apos;s threads by visitJSEventListenersInGCThread(), which locks. That reader is
reached through visitAdditionalChildrenInGCThread() on JSEventTarget, JSDOMWindow and
JSWorkerGlobalScope, so it runs concurrently with the owning thread rather than with the world
paused, and the lock it takes is load-bearing. Every mutator already took it; nothing enforced
that they did, nor that a reader on any other thread would.

Guard m_entries with WTF_GUARDED_BY_LOCK() and give the owning thread&apos;s unlocked reads an
assertion, following <a href="https://commits.webkit.org/320637@main">320637@main</a>. Three things make this map differ from the classes annotated
there.

The owner is not necessarily the main thread. An EventTarget may belong to a worker, and the map
already tracks whichever thread claimed it in m_threadUID, so mainThreadLike does not apply and
there is no ThreadLikeAssertion to name. Rather than introduce a second notion of the owning
thread, assertIsOwnerThread() reuses m_threadUID and repeats the WebThreadIsEnabled() bypass that
releaseAssertOrSetThreadUID() already has. It differs from that function in never claiming the
map and in compiling out in release builds, which is what makes it usable from
fireEventListeners() without adding work to event dispatch. It is public because EventTarget and
Style::Adjuster reach m_entries through find().

The map is also read from the collector, and legitimately so: the hasPendingActivity() and
isReachableFromOpaqueRoots() implementations query it through hasEventListeners() with the owning
thread paused, so they neither own the map nor lock it. Tolerating any GC thread would be too
weak, since it would equally excuse an unlocked read during concurrent marking, when the owning
thread is running and the lock is what makes the read safe. JSC therefore grows
currentThreadIsCollectingWithWorldStopped(): a thread doing collection work records the heap it
is collecting for, and the predicate reads worldIsStopped() from it at the point of the query,
because a collector thread spans both the stop-the-world phases and concurrent marking, so the
answer changes during its lifetime. Recording the heap rather than a flag also keeps the answer
per-VM, so a worker heap stopping its own world cannot vouch for a main-thread-owned map.
assertIsOwnerThreadOrGCThreadWithWorldStopped() is used only by the four read-only predicates
that the collector reaches, and is private so that nothing which can reach the entries mutably
can claim it.

Guarding the member is not by itself enough to enforce the write half of the invariant. Thread
safety analysis counts a non-const call on a guarded container as a read, so m_entries.clear()
would be accepted while holding only shared access, which is exactly the mistake the annotation
is meant to prevent. What is checked is the call itself, so the entries are now reachable only
through entries(), which requires the lock shared, and entriesForMutation(), which requires it
exclusively; m_entries appears nowhere else. For the same reason find() now returns a const
pointer, so the vector that escapes to EventTarget and Style::Adjuster cannot be mutated through,
and the two mutating callers use findForMutation(), which requires the lock exclusively.

Annotating this turned up a caller that reading the code had not: Style::Adjuster&apos;s
computeEventListenerRegionTypes() reaches into eventTargetData()-&gt;eventListenerMap and calls
find() during style resolution. EventTarget::eventListeners() is restructured to return early
when there is no EventTargetData, since an assertion inside a branch does not carry to the
statement after it, and copyListenersNotCreatedFromMarkupToTarget() takes its vector by const
reference, which is what it always wanted.

No behaviour change is intended: both assertions compile out in release builds and only move
thread safety analysis state, and the heap recorded for a collector thread is set once per
collection per thread rather than in any inner loop.

No new tests: the annotations are verified by the compiler.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::CurrentlyCollectingHeapScope::CurrentlyCollectingHeapScope):
(JSC::CurrentlyCollectingHeapScope::~CurrentlyCollectingHeapScope):
(JSC::currentThreadIsCollectingWithWorldStopped):
(JSC::Heap::runBeginPhase):
* Source/JavaScriptCore/heap/Heap.h:
* Source/WebCore/dom/EventListenerMap.cpp:
(WebCore::EventListenerMap::assertIsOwnerThreadOrGCThreadWithWorldStopped const):
(WebCore::EventListenerMap::containsCapturing const):
(WebCore::EventListenerMap::containsActive const):
(WebCore::EventListenerMap::clear):
(WebCore::EventListenerMap::eventTypes const):
(WebCore::EventListenerMap::replacePreservingOptions):
(WebCore::EventListenerMap::add):
(WebCore::EventListenerMap::remove):
(WebCore::EventListenerMap::find const):
(WebCore::EventListenerMap::findForMutation):
(WebCore::EventListenerMap::removeFirstEventListenerCreatedFromMarkup):
(WebCore::copyListenersNotCreatedFromMarkupToTarget):
(WebCore::EventListenerMap::copyEventListenersNotCreatedFromMarkupToTarget):
* Source/WebCore/dom/EventListenerMap.h:
(WebCore::EventListenerMap::isEmpty const):
(WebCore::EventListenerMap::contains const):
(WebCore::EventListenerMap::enumerateEventListenerTypes const):
(WebCore::EventListenerMap::containsMatchingEventListener const):
(WebCore::EventListenerMap::assertIsOwnerThread const):
(WebCore::EventListenerMap::entries const):
(WebCore::EventListenerMap::entriesForMutation):
(WebCore::EventListenerMap::visitJSEventListenersInGCThread):
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::fireEventListeners):
(WebCore::EventTarget::eventListeners):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::computeEventListenerRegionTypes):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4beafc6a6cf072cea111be41d84fc6460a99fcf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186016 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196310 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150634 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ab7b3c11-ed7f-4ed9-bef9-6966c4801fc3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59634 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145361 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100763 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c708573d-6915-4a91-ad8b-e80997b55efe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165903 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125677 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1972370c-b640-47cf-a632-38043da4987e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47772 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45768 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7539 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14420 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45490 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7381 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47257 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52479 "Found 1 new failure in dom/EventTarget.cpp") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198287 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59572 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154917 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60281 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154558 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49004 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132604 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129671 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58727 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20485 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58117 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58349 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58175 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->