### PR TITLE
Cherry-pick 320725@main (0864bb24e02a). https://bugs.webkit.org/show_bug.cgi?id=323660

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_optional_offsetRay.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_optional_offsetRay.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Ensures an omitted offsetRay hit tests along the default ray - webgl
+PASS Ensures an omitted offsetRay hit tests along the default ray - webgl2
+PASS Ensures an omitted offsetRay hit tests along the default ray for transient input - webgl
+PASS Ensures an omitted offsetRay hit tests along the default ray for transient input - webgl2
+PASS Ensures a null offsetRay is rejected - webgl
+PASS Ensures a null offsetRay is rejected - webgl2
+PASS Ensures a null offsetRay is rejected for transient input - webgl
+PASS Ensures a null offsetRay is rejected for transient input - webgl2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_optional_offsetRay.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_optional_offsetRay.https.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/webxr_util.js"></script>
+<script src="../resources/webxr_math_utils.js"></script>
+<script src="../resources/webxr_test_asserts.js"></script>
+<script src="../resources/webxr_test_constants.js"></script>
+<script src="../resources/webxr_test_constants_fake_world.js"></script>
+
+<script>
+
+// 1m above world origin.
+const VIEWER_ORIGIN_TRANSFORM = {
+  position: [0, 1, 0],
+  orientation: [0, 0, 0, 1],
+};
+
+const SCREEN_POINTER_TRANSFORM = VIEWER_ORIGIN_TRANSFORM;
+
+const screen_controller_init = {
+    handedness: "none",
+    targetRayMode: "screen",
+    pointerOrigin: SCREEN_POINTER_TRANSFORM,
+    profiles: ["generic-touchscreen",]
+};
+
+const fakeDeviceInitParams = {
+  supportedModes: ["immersive-ar"],
+  views: VALID_VIEWS,
+  viewerOrigin: VIEWER_ORIGIN_TRANSFORM,
+  supportedFeatures: ALL_FEATURES,
+  world: createFakeWorld(5.0, 2.0, 5.0),  // see webxr_test_constants_fake_world.js for details
+};
+
+const sessionInit = { 'requiredFeatures': ['hit-test'] };
+
+const nextAnimationFrame = function(session) {
+  return new Promise((resolve) => session.requestAnimationFrame((time, frame) => resolve(frame)));
+};
+
+// FakeXRDevice methods called outside of an animation frame only take effect on a subsequent one.
+const skipAnimationFrame = function(session) {
+  return new Promise((resolve) => requestSkipAnimationFrame(session, (time, frame) => resolve(frame)));
+};
+
+// offsetRay is optional and defaults to an identity XRRay, so subscribing without one has to produce the very same results as subscribing with an explicitly constructed default XRRay.
+const assertResultsMatch = function(defaultedResults, explicitResults, localRefSpace) {
+  assert_greater_than(explicitResults.length, 0, "An explicit default XRRay should hit the fake world");
+  assert_equals(defaultedResults.length, explicitResults.length, "An omitted offsetRay should produce as many results as an explicit default XRRay");
+  for (const [index, explicitResult] of explicitResults.entries()) {
+    const defaultedPose = defaultedResults[index].getPose(localRefSpace);
+    const explicitPose = explicitResult.getPose(localRefSpace);
+    assert_true(defaultedPose != null && explicitPose != null, "Each hit test result should have a pose in local space");
+    assert_transform_approx_equals(defaultedPose.transform, explicitPose.transform, FLOAT_EPSILON, "Result " + index + ": ");
+  }
+};
+
+xr_session_promise_test("Ensures an omitted offsetRay hit tests along the default ray",
+  async (session, fakeDeviceController, t) => {
+    const localRefSpace = await session.requestReferenceSpace('local');
+    const viewerRefSpace = await session.requestReferenceSpace('viewer');
+
+    const defaultedSource = await session.requestHitTestSource({ space: viewerRefSpace });
+    const explicitSource = await session.requestHitTestSource({ space: viewerRefSpace, offsetRay: new XRRay() });
+
+    const frame = await nextAnimationFrame(session);
+    t.step(() => {
+      assertResultsMatch(frame.getHitTestResults(defaultedSource), frame.getHitTestResults(explicitSource), localRefSpace);
+    });
+  }, fakeDeviceInitParams, 'immersive-ar', sessionInit);
+
+xr_session_promise_test("Ensures an omitted offsetRay hit tests along the default ray for transient input",
+  async (session, fakeDeviceController, t) => {
+    const localRefSpace = await session.requestReferenceSpace('local');
+
+    fakeDeviceController.simulateInputSourceConnection(screen_controller_init);
+    await skipAnimationFrame(session);
+    t.step(() => {
+      assert_equals(session.inputSources.length, 1, "The simulated screen input source should be connected");
+    });
+
+    const defaultedSource = await session.requestHitTestSourceForTransientInput({ profile: "generic-touchscreen" });
+    const explicitSource = await session.requestHitTestSourceForTransientInput({ profile: "generic-touchscreen", offsetRay: new XRRay() });
+
+    const frame = await nextAnimationFrame(session);
+    const defaultedResults = frame.getHitTestResultsForTransientInput(defaultedSource);
+    const explicitResults = frame.getHitTestResultsForTransientInput(explicitSource);
+    t.step(() => {
+      assert_equals(explicitResults.length, 1, "There should be exactly one group of transient hit test results");
+      assert_equals(defaultedResults.length, explicitResults.length, "An omitted offsetRay should produce as many result groups as an explicit default XRRay");
+      assertResultsMatch(defaultedResults[0].results, explicitResults[0].results, localRefSpace);
+    });
+  }, fakeDeviceInitParams, 'immersive-ar', sessionInit);
+
+xr_session_promise_test("Ensures a null offsetRay is rejected",
+  async (session, fakeDeviceController, t) => {
+    const viewerRefSpace = await session.requestReferenceSpace('viewer');
+    await promise_rejects_js(t, TypeError, session.requestHitTestSource({ space: viewerRefSpace, offsetRay: null }));
+  }, fakeDeviceInitParams, 'immersive-ar', sessionInit);
+
+xr_session_promise_test("Ensures a null offsetRay is rejected for transient input",
+  async (session, fakeDeviceController, t) => {
+    await promise_rejects_js(t, TypeError, session.requestHitTestSourceForTransientInput({ profile: "generic-touchscreen", offsetRay: null }));
+  }, fakeDeviceInitParams, 'immersive-ar', sessionInit);
+
+</script>

--- a/Source/WebCore/Modules/webxr/XRHitTestOptionsInit.idl
+++ b/Source/WebCore/Modules/webxr/XRHitTestOptionsInit.idl
@@ -30,5 +30,5 @@
 ] dictionary XRHitTestOptionsInit {
     required WebXRSpace space;
     [ImplementationDefaultValue=[]] sequence<XRHitTestTrackableType> entityTypes;
-    [ImplementationDefaultValue=null] WebXRRay offsetRay;
+    WebXRRay offsetRay;
 };

--- a/Source/WebCore/Modules/webxr/XRTransientInputHitTestOptionsInit.idl
+++ b/Source/WebCore/Modules/webxr/XRTransientInputHitTestOptionsInit.idl
@@ -30,5 +30,5 @@
 ] dictionary XRTransientInputHitTestOptionsInit {
     required DOMString profile;
     [ImplementationDefaultValue=[]] sequence<XRHitTestTrackableType> entityTypes;
-    [ImplementationDefaultValue=null] WebXRRay offsetRay;
+    WebXRRay offsetRay;
 };

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
@@ -60,7 +60,8 @@ using namespace WebCore;
  * load the images found into a memory cache if possible. That cache
  * is frozen to an on-disk database for persistence.
  *
- * If #WebKitSettings:enable-private-browsing is %TRUE, new icons
+ * If [property@WebView:is-ephemeral] or
+ * [property@WebsiteDataManager:is-ephemeral] is %TRUE, new icons
  * won't be added to the on-disk database and no existing icons will
  * be deleted from it. Nevertheless, WebKit will still store them in
  * the in-memory cache during the current execution.


### PR DESCRIPTION
#### ee1e8b20c36c73e5954a43bea30351ec6e167cce
<pre>
Cherry-pick 320725@main (0864bb24e02a). <a href="https://bugs.webkit.org/show_bug.cgi?id=323660">https://bugs.webkit.org/show_bug.cgi?id=323660</a>

    Fix WebKitFaviconDatabase docstring.
    <a href="https://bugs.webkit.org/show_bug.cgi?id=323660">https://bugs.webkit.org/show_bug.cgi?id=323660</a>

    Reviewed by Adrian Perez de Castro.

    * Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp: Fix
    WebKitFaviconDatabase docstring.

    Canonical link: <a href="https://commits.webkit.org/320725@main">https://commits.webkit.org/320725@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.253@webkitglib/2.54">https://commits.webkit.org/317695.253@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### e8257744727cfe15140a8eba2aa251f74db60aa1
<pre>
Cherry-pick 320717@main (4671d8f9fbe2). <a href="https://bugs.webkit.org/show_bug.cgi?id=323656">https://bugs.webkit.org/show_bug.cgi?id=323656</a>

    REGRESSION(r311167): It made hit testing fail whenever offsetRay was not specified
    <a href="https://bugs.webkit.org/show_bug.cgi?id=323656">https://bugs.webkit.org/show_bug.cgi?id=323656</a>

    Reviewed by Anne van Kesteren and Dan Glastonbury.

    311167@main broke hit testing because it added
    [ImplementationDefaultValue=null] to offsetRay which is not a nullable
    dictionary member (it&apos;s simply optional). When offsetRay was not
    specified (and considering that a default null value was declared) then
    JSToWrappedOverloader&lt;WebXRRay&gt;::toWrapped() converted the undefined
    from the dictionary into a nullptr which causes JSDOMCovertInterface to
    throw a TypeError (because a missing wrapper is considered as an error).

    We are adding a new WPT test that properly detects whether the absence
    of optional parameters passed to request(Transient)HitTestSource do not
    trigger exceptions.

    Tests: imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_optional_offsetRay.https.html

    * Source/WebCore/Modules/webxr/XRHitTestOptionsInit.idl:
    * Source/WebCore/Modules/webxr/XRTransientInputHitTestOptionsInit.idl:
    * LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_optional_offsetRay.https-expected.txt: Added.
    * LayoutTests/imported/w3c/web-platform-tests/webxr/hit-test/ar_hittest_subscription_optional_offsetRay.https.html: Added.

    Canonical link: <a href="https://commits.webkit.org/320717@main">https://commits.webkit.org/320717@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.252@webkitglib/2.54">https://commits.webkit.org/317695.252@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c35e288336a46088a8baa53c42fab7b66982e5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186002 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59900 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53687 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196296 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150622 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187864 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/61272 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59620 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145338 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150622 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188957 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/61272 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53687 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125655 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/61272 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59620 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53687 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/61272 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53687 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7367 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52469 "Build is in progress. Recent messages:") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59620 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198273 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59556 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53687 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154898 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/60265 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53687 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154543 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28238 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/60265 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132593 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129646 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58712 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53687 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/58103 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58333 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/58161 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->