### PR TITLE
Cherry-pick 320724@main (249ede976fcc). https://bugs.webkit.org/show_bug.cgi?id=321012

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1,6 +1,7 @@
 /*
  *  Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  *  Copyright (C) 2007 Eric Seidel <eric@webkit.org>
+ *  Copyright (C) 2026 Igalia S.L.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -109,6 +110,7 @@
 #include <wtf/Scope.h>
 #include <wtf/SetForScope.h>
 #include <wtf/SimpleStats.h>
+#include <wtf/SpinBackoff.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Threading.h>
@@ -1967,6 +1969,7 @@ NEVER_INLINE void Heap::resumeThePeriphery()
             visitorsToUpdate.append(&visitor);
         });
     
+    SpinBackoff backoff;
     for (unsigned countdown = 40; !visitorsToUpdate.isEmpty() && countdown--;) {
         for (unsigned index = 0; index < visitorsToUpdate.size(); ++index) {
             SlotVisitor& visitor = *visitorsToUpdate[index];
@@ -1983,7 +1986,7 @@ NEVER_INLINE void Heap::resumeThePeriphery()
                 visitorsToUpdate.takeLast();
             }
         }
-        Thread::yield();
+        backoff.spinOnce();
     }
     
     for (SlotVisitor* visitor : visitorsToUpdate)

--- a/Source/JavaScriptCore/runtime/JSLock.cpp
+++ b/Source/JavaScriptCore/runtime/JSLock.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2005-2026 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -26,6 +27,7 @@
 #include "MachineStackMarker.h"
 #include "SamplingProfiler.h"
 #include "VMTrapsInlines.h"
+#include <wtf/SpinBackoff.h>
 #include <wtf/StackPointer.h>
 #include <wtf/Threading.h>
 #include <wtf/threads/Signals.h>
@@ -368,9 +370,10 @@ void JSLock::grabAllLocks(DropAllLocks* dropper, unsigned droppedLockCount)
     ASSERT(!currentThreadIsHoldingLock());
     lock(droppedLockCount);
 
+    SpinBackoff backoff;
     while (dropper->dropDepth() != m_lockDropDepth) {
         unlock(droppedLockCount);
-        Thread::yield();
+        backoff.spinOnce();
         lock(droppedLockCount);
     }
 

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -331,6 +331,7 @@
 		DD3DC87527A4BF8E007E5B61 /* Scope.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A3524AA1D63A2FF0031729B /* Scope.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC87627A4BF8E007E5B61 /* TriState.h in Headers */ = {isa = PBXBuildFile; fileRef = 149EF16216BBFE0D000A4331 /* TriState.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC87727A4BF8E007E5B61 /* Spectrum.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4730D151A825B004123FF /* Spectrum.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9FA6E9C851704768955938F6 /* SpinBackoff.h in Headers */ = {isa = PBXBuildFile; fileRef = 94A250FE7BAD45FC95BF810C /* SpinBackoff.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC87827A4BF8E007E5B61 /* Liveness.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF4B4C41E88939C00DBBE86 /* Liveness.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0FA1B2C30000000000000002 /* SSACalculator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FA1B2C30000000000000001 /* SSACalculator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC87927A4BF8E007E5B61 /* RefCounted.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472FF151A825B004123FF /* RefCounted.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1697,6 +1698,7 @@
 		A8A4730B151A825B004123FF /* SinglyLinkedList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SinglyLinkedList.h; sourceTree = "<group>"; };
 		A8A4730C151A825B004123FF /* SizeLimits.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SizeLimits.cpp; sourceTree = "<group>"; };
 		A8A4730D151A825B004123FF /* Spectrum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Spectrum.h; sourceTree = "<group>"; };
+		94A250FE7BAD45FC95BF810C /* SpinBackoff.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpinBackoff.h; sourceTree = "<group>"; };
 		A8A4730E151A825B004123FF /* StackBounds.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StackBounds.cpp; sourceTree = "<group>"; };
 		A8A4730F151A825B004123CF /* StackAllocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StackAllocation.h; sourceTree = "<group>"; };
 		A8A4730F151A825B004123FF /* StackBounds.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StackBounds.h; sourceTree = "<group>"; };
@@ -2798,6 +2800,7 @@
 				79038E05224B05A7004C0738 /* SpanningTree.h */,
 				02F0B57890A842688F808D7C /* SparseBitVector.h */,
 				A8A4730D151A825B004123FF /* Spectrum.h */,
+				94A250FE7BAD45FC95BF810C /* SpinBackoff.h */,
 				0FA1B2C30000000000000001 /* SSACalculator.h */,
 				A8A4730F151A825B004123CF /* StackAllocation.h */,
 				A8A4730E151A825B004123FF /* StackBounds.cpp */,
@@ -3972,6 +3975,7 @@
 				DD3DC8CD27A4BF8E007E5B61 /* SpanningTree.h in Headers */,
 				08982C1A106045F4A68DF4F1 /* SparseBitVector.h in Headers */,
 				DD3DC87727A4BF8E007E5B61 /* Spectrum.h in Headers */,
+				9FA6E9C851704768955938F6 /* SpinBackoff.h in Headers */,
 				0FA1B2C30000000000000002 /* SSACalculator.h in Headers */,
 				DD3DC97F27A4BF8E007E5BC1 /* StackAllocation.h in Headers */,
 				DD3DC97F27A4BF8E007E5B61 /* StackBounds.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -332,6 +332,7 @@ set(WTF_PUBLIC_HEADERS
     SpanningTree.h
     SparseBitVector.h
     Spectrum.h
+    SpinBackoff.h
     StackAllocation.h
     StackBounds.h
     StackCheck.h

--- a/Source/WTF/wtf/LockAlgorithmInlines.h
+++ b/Source/WTF/wtf/LockAlgorithmInlines.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,8 +30,8 @@
 #include <wtf/LockAlgorithm.h>
 #include <wtf/ParkingLot.h>
 #include <wtf/Platform.h>
+#include <wtf/SpinBackoff.h>
 #include <wtf/Threading.h>
-#include <wtf/simde/simde.h>
 
 // It's a good idea to avoid including this header in too many places, so that it's possible to change
 // the lock algorithm slow path without recompiling the world. Right now this should be included in two
@@ -41,78 +42,7 @@ namespace WTF {
 template<typename LockType, LockType isHeldBit, LockType hasParkedBit, typename Hooks>
 void LockAlgorithm<LockType, isHeldBit, hasParkedBit, Hooks>::lockSlow(Atomic<LockType>& lock)
 {
-    // These values were selected empirically.
-    // The balancing act here lies in speeding up the "semi-contended" case
-    // without too strongly disadvantaging the "heavily-contended" case
-    // (the uncontended case of course never hits the spinloop).
-    // There are a few variables to consider:
-    //
-    //   * Time-to-park: the total CPU time of a full spinloop
-    //     ~= spinLimit * (nopCount + 1/yieldInterval)
-    //     Increases with spinLimit, nopCount; decreases with yieldInterval.
-    //     Higher is better (to a point) for semi-contended,
-    //     but significantly worse for heavily-contended, as we pay
-    //     the full cost of the spinloop on ~every attempt to acquire.
-    //
-    //   * Niceness: (vaguely) how often we yield vs. run on core
-    //     ~= 1 / (yieldInterval * nopCount)
-    //     Higher is better for heavily-contended, as it means that high-
-    //     priority threads will 'make room' for other threads as they
-    //     spin, rather than taking up high-priority CPU time on a spinloop.
-    //     However, it's worse for the semi-contended case, as when we
-    //     do acquire the spinlock the priority depression can last
-    //     for some time, meaning it could take a few quanta to get
-    //     back to 'full speed'.
-    //
-    //   * Poll-rate: the rate at which we read the atomic lock bit
-    //     ~= 1 / (nopCount + 1/yieldInterval)
-    //     This affects performance in two different ways.
-    //     The first is that, if the lock does become available, we
-    //     may be in the middle of a nop-spin, and therefore have to
-    //     execute the remaining nops before we check again.
-    //     Therefore, in the semi-contended case we want a higher frequency.
-    //     However, the higher the frequency, the more often we hammer the
-    //     lock's cache line. In sparse contention regimes this is relatively
-    //     OK: e.g. if there's only a single waiter, then the cache-line
-    //     stays local. With multiple waiters, however, then the line
-    //     can ping between cores, hurting performance.
-    //     Therefore, in the heavily-contended case it's better for this
-    //     to be lower.
-    //
-    // In general, the gains for the semi-contended case are modest, but
-    // show up across the board. On the flipside, hits to the heavily-
-    // contended case tend to be localized to a few scenarios, but have
-    // a very large effect-size; heavy contention is very rare
-    // (by design, from how WebKit uses locks), but very sensitive
-    // because spinlocks are poorly-adapted for that regime. E.g.
-    // omitting sched-yield entirely can more than double the runtime
-    // of certain benchmarks!
-    //
-    // N.b.: there are of course more considerations than just the above three.
-    // Fairness suffers as time-to-park increases, while all three can have
-    // deleterious effects on the rest of the system (e.g. scheduler churn,
-    // wasting memory bandwidth, etc.) depending on the details. But since
-    // those factors are harder to frame neatly I'm leaving them to this
-    // appendix.
-#if CPU(ARM64) && OS(MACOS)
-    static constexpr unsigned spinLimit = 80;
-    static constexpr unsigned nopCount = 8;
-    static constexpr unsigned yieldInterval = 16;
-#elif CPU(ARM64) && OS(IOS_FAMILY)
-    static constexpr unsigned spinLimit = 40;
-    static constexpr unsigned nopCount = 16;
-    static constexpr unsigned yieldInterval = 4;
-#else
-    static constexpr unsigned spinLimit = 40;
-    // The tuning necessary to determine the optimal values
-    // for other platforms has not yet been done, so we
-    // retain the old sched-yield loop to avoid
-    // possible regressions.
-    static constexpr unsigned nopCount = 0;
-    static constexpr unsigned yieldInterval = 1;
-#endif
-    
-    unsigned spinCount = 0;
+    SpinBackoff backoff;
     
     for (;;) {
         LockType currentValue = lock.load();
@@ -125,18 +55,8 @@ void LockAlgorithm<LockType, isHeldBit, hasParkedBit, Hooks>::lockSlow(Atomic<Lo
         }
 
         // If there is nobody parked and we haven't spun too much, we can just try to spin around.
-        if (!(currentValue & hasParkedBit) && spinCount < spinLimit) {
-            spinCount++;
-            // It's important that we check this after incrementing,
-            // as we want to avoid yielding for the first few spins.
-            // This makes it more likely that we can acquire the lock
-            // without having depressed our own priority beforehand.
-            if (!(spinCount % yieldInterval))
-                Thread::yield();
-            for (unsigned i = 0; i < nopCount; i++)
-                simde_mm_pause();
+        if (!(currentValue & hasParkedBit) && !backoff.shouldParkAfterSpinOnce())
             continue;
-        }
 
         // Need to park. We do this by setting the parked bit first, and then parking. We spin around
         // if the parked bit wasn't set and we failed at setting it.

--- a/Source/WTF/wtf/SpinBackoff.h
+++ b/Source/WTF/wtf/SpinBackoff.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2015-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Threading.h>
+#include <wtf/simde/simde.h>
+
+namespace WTF {
+
+// A caller that can park uses shouldParkAfterSpinOnce() and parks when it returns true:
+//     SpinBackoff backoff;
+//     for (;;) {
+//         if (tryLock())
+//             return;
+//         if (backoff.shouldParkAfterSpinOnce())
+//             park();
+//     }
+//
+// A caller with nothing to park on uses spinOnce(), which yields for as long as it is called:
+//     SpinBackoff backoff;
+//     while (!tryLock())
+//         backoff.spinOnce();
+
+// The balancing act here lies in speeding up the "semi-contended" case
+// without too strongly disadvantaging the "heavily-contended" case
+// (the uncontended case of course never hits the spinloop).
+// There are a few variables to consider:
+//
+//   * Time-to-park: the total CPU time of a full spinloop
+//     Higher is better (to a point) for semi-contended,
+//     but significantly worse for heavily-contended, as we pay
+//     the full cost of the spinloop on ~every attempt to acquire.
+//
+//   * Niceness: (vaguely) how often we yield vs. run on core
+//     Higher is better for heavily-contended, as it means that high-
+//     priority threads will 'make room' for other threads as they
+//     spin, rather than taking up high-priority CPU time on a spinloop.
+//     However, it's worse for the semi-contended case, as when we
+//     do acquire the spinlock the priority depression can last
+//     for some time, meaning it could take a few quanta to get
+//     back to 'full speed'.
+//
+//   * Poll-rate: the rate at which we read the atomic lock bit
+//     This affects performance in two different ways.
+//     The first is that, if the lock does become available, we
+//     may be in the middle of a nop-spin, and therefore have to
+//     execute the remaining nops before we check again.
+//     Therefore, in the semi-contended case we want a higher frequency.
+//     However, the higher the frequency, the more often we hammer the
+//     lock's cache line. In sparse contention regimes this is relatively
+//     OK: e.g. if there's only a single waiter, then the cache-line
+//     stays local. With multiple waiters, however, then the line
+//     can ping between cores, hurting performance.
+//     Therefore, in the heavily-contended case it's better for this
+//     to be lower.
+//
+// In general, the gains for the semi-contended case are modest, but
+// show up across the board. On the flipside, hits to the heavily-
+// contended case tend to be localized to a few scenarios, but have
+// a very large effect-size; heavy contention is very rare
+// (by design, from how WebKit uses locks), but very sensitive
+// because spinlocks are poorly-adapted for that regime. E.g. on
+// Darwin, omitting thread_switch entirely can more than
+// double the runtime of certain benchmarks!
+//
+// N.b.: there are of course more considerations than just the above three.
+// Fairness suffers as time-to-park increases, while all three can have
+// deleterious effects on the rest of the system (e.g. scheduler churn,
+// wasting memory bandwidth, etc.) depending on the details. But since
+// those factors are harder to frame neatly I'm leaving them to this
+// appendix.
+
+// Keep this up to date with bmalloc/SpinBackoff.h.
+class SpinBackoff {
+public:
+    // Takes one step, in which case it returns true
+    // to say that the caller should park now.
+    bool shouldParkAfterSpinOnce()
+    {
+        if (m_spinCount >= s_spinLimit)
+            return true;
+        spinOnce();
+        return false;
+    }
+
+    // Takes one spin step, and keeps yielding once the budget is spent.
+    void spinOnce()
+    {
+        unsigned step = m_spinCount;
+        if (step < s_pauseSteps) {
+            m_spinCount = step + 1;
+            for (unsigned remaining = 1U << step; remaining--;)
+                simde_mm_pause();
+            return;
+        }
+        if (step < s_spinLimit)
+            m_spinCount = step + 1;
+        Thread::yield();
+    }
+
+private:
+    // These are tuned empirically.
+#if CPU(X86_64)
+    static constexpr unsigned s_extraPauseSteps = 0;
+#else
+    static constexpr unsigned s_extraPauseSteps = 2;
+#endif
+
+// Tuned empirically.
+#if CPU(ARM64) && OS(MACOS)
+    static constexpr unsigned s_pauseSteps = 9;
+    static constexpr unsigned s_yieldSteps = 5;
+#elif CPU(ARM64) && OS(IOS_FAMILY)
+    static constexpr unsigned s_pauseSteps = 9;
+    static constexpr unsigned s_yieldSteps = 10;
+#elif OS(DARWIN) || OS(WINDOWS)
+    static constexpr unsigned s_pauseSteps = 0;
+    static constexpr unsigned s_yieldSteps = 40;
+#else
+    static constexpr unsigned s_pauseSteps = 6 + s_extraPauseSteps;
+    static constexpr unsigned s_yieldSteps = 0;
+#endif
+    static constexpr unsigned s_spinLimit = s_pauseSteps + s_yieldSteps;
+
+    unsigned m_spinCount { 0 };
+};
+
+} // namespace WTF
+
+using WTF::SpinBackoff;

--- a/Source/WTF/wtf/WordLock.cpp
+++ b/Source/WTF/wtf/WordLock.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +29,7 @@
 
 #include <condition_variable>
 #include <mutex>
+#include <wtf/SpinBackoff.h>
 #include <wtf/Threading.h>
 
 namespace WTF {
@@ -61,11 +63,8 @@ struct ThreadData {
 
 NEVER_INLINE void WordLock::lockSlow()
 {
-    unsigned spinCount = 0;
+    SpinBackoff backoff;
 
-    // This magic number turns out to be optimal based on past JikesRVM experiments.
-    const unsigned spinLimit = 40;
-    
     for (;;) {
         uintptr_t currentWordValue = m_word.load();
         
@@ -81,11 +80,8 @@ NEVER_INLINE void WordLock::lockSlow()
         }
 
         // If there is no queue and we haven't spun too much, we can just try to spin around again.
-        if (!(currentWordValue & ~queueHeadMask) && spinCount < spinLimit) {
-            spinCount++;
-            Thread::yield();
+        if (!(currentWordValue & ~queueHeadMask) && !backoff.shouldParkAfterSpinOnce())
             continue;
-        }
 
         // Need to put ourselves on the queue. Create the queue if one does not exist. This requries
         // owning the queue for a little bit. The lock that controls the queue is itself a spinlock.
@@ -100,7 +96,7 @@ NEVER_INLINE void WordLock::lockSlow()
         if ((currentWordValue & isQueueLockedBit)
             || !(currentWordValue & isLockedBit)
             || !m_word.compareExchangeWeak(currentWordValue, currentWordValue | isQueueLockedBit)) {
-            Thread::yield();
+            backoff.spinOnce();
             continue;
         }
         
@@ -165,6 +161,7 @@ NEVER_INLINE void WordLock::unlockSlow()
     // Acquire the queue lock, or release the lock. This loop handles both lock release in case the
     // fast path's weak CAS spuriously failed and it handles queue lock acquisition if there is
     // actually something interesting on the queue.
+    SpinBackoff backoff;
     for (;;) {
         uintptr_t currentWordValue = m_word.load();
 
@@ -176,13 +173,12 @@ NEVER_INLINE void WordLock::unlockSlow()
                 // unlocked and we're done!
                 return;
             }
-            // Loop around and try again.
-            Thread::yield();
+            backoff.spinOnce();
             continue;
         }
         
         if (currentWordValue & isQueueLockedBit) {
-            Thread::yield();
+            backoff.spinOnce();
             continue;
         }
 

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -3,6 +3,7 @@
  * Copyright (C) 2007 Justin Haygood <jhaygood@reaktix.com>
  * Copyright (C) 2011 Research In Motion Limited. All rights reserved.
  * Copyright (C) 2017 Yusuke Suzuki <utatane.tea@gmail.com>
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,6 +36,8 @@
 #if USE(PTHREADS)
 
 #include <errno.h>
+#include <time.h>
+#include <wtf/Logging.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SafeStrerror.h>
@@ -725,7 +728,9 @@ void Thread::yield()
     constexpr mach_msg_timeout_t timeoutInMS = 1;
     thread_switch(MACH_PORT_NULL, SWITCH_OPTION_DEPRESS, timeoutInMS);
 #else
-    sched_yield();
+    // A one nanosecond sleep costs a whole timer slack period, 50us by default on Linux (see PR_SET_TIMERSLACK)
+    struct timespec minimalSleep { 0, 1 };
+    nanosleep(&minimalSleep, nullptr);
 #endif
 }
 

--- a/Source/bmalloc/CMakeLists.txt
+++ b/Source/bmalloc/CMakeLists.txt
@@ -578,6 +578,7 @@ set(bmalloc_PUBLIC_HEADERS
 set(bmalloc_PRIVATE_HEADERS
     bmalloc/ProcessCheck.h
     bmalloc/ScopeExit.h
+    bmalloc/SpinBackoff.h
 
     libpas/src/libpas/hotbit_heap_inlines.h
     libpas/src/libpas/iso_heap_inlines.h

--- a/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/bmalloc.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		14895D911A3A319C0006235D /* Environment.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14895D8F1A3A319C0006235D /* Environment.cpp */; };
 		14895D921A3A319C0006235D /* Environment.h in Headers */ = {isa = PBXBuildFile; fileRef = 14895D901A3A319C0006235D /* Environment.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		148EFAE81D6B953B008E721E /* ScopeExit.h in Headers */ = {isa = PBXBuildFile; fileRef = 148EFAE61D6B953B008E721E /* ScopeExit.h */; };
+		1C2D4B9492754104B4052BDD /* SpinBackoff.h in Headers */ = {isa = PBXBuildFile; fileRef = 05075FEE15D7410B97D990F4 /* SpinBackoff.h */; };
 		14C8992B1CC485E70027A057 /* Map.h in Headers */ = {isa = PBXBuildFile; fileRef = 14C8992A1CC485E70027A057 /* Map.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		14C919C918FCC59F0028DB43 /* BPlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = 14C919C818FCC59F0028DB43 /* BPlatform.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		14CC394C18EA8858004AFE34 /* libbmalloc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 14F271BE18EA3963008C152F /* libbmalloc.a */; };
@@ -1164,6 +1165,7 @@
 		14895D8F1A3A319C0006235D /* Environment.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Environment.cpp; path = bmalloc/Environment.cpp; sourceTree = "<group>"; };
 		14895D901A3A319C0006235D /* Environment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Environment.h; path = bmalloc/Environment.h; sourceTree = "<group>"; };
 		148EFAE61D6B953B008E721E /* ScopeExit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ScopeExit.h; path = bmalloc/ScopeExit.h; sourceTree = "<group>"; };
+		05075FEE15D7410B97D990F4 /* SpinBackoff.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SpinBackoff.h; path = bmalloc/SpinBackoff.h; sourceTree = "<group>"; };
 		14B650C518F39F4800751968 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		14B650C618F39F4800751968 /* bmalloc.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = bmalloc.xcconfig; sourceTree = "<group>"; };
 		14B650C718F39F4800751968 /* DebugRelease.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DebugRelease.xcconfig; sourceTree = "<group>"; };
@@ -1946,6 +1948,7 @@
 				143CB81A19022BC900B16A45 /* Mutex.cpp */,
 				143CB81B19022BC900B16A45 /* Mutex.h */,
 				148EFAE61D6B953B008E721E /* ScopeExit.h */,
+				05075FEE15D7410B97D990F4 /* SpinBackoff.h */,
 				E31E747F2238CA5B005D084A /* StaticPerProcess.h */,
 				1417F64F18B7280C0076FA99 /* valgrind.h */,
 				1479E21217A1A255006D4E9D /* Vector.h */,
@@ -2372,6 +2375,7 @@
 				AD14AD29202529C400890E3B /* ProcessCheck.h in Headers */,
 				148EFAE81D6B953B008E721E /* ScopeExit.h in Headers */,
 				14DD789018F48CEB00950702 /* Sizes.h in Headers */,
+				1C2D4B9492754104B4052BDD /* SpinBackoff.h in Headers */,
 				E31E74802238CA5C005D084A /* StaticPerProcess.h in Headers */,
 				142B44371E2839E7001DA6E9 /* SystemHeap.h in Headers */,
 				ED4BEC4929CBA49700398E35 /* tagged_bmalloc_heap.h in Headers */,

--- a/Source/bmalloc/bmalloc/Mutex.cpp
+++ b/Source/bmalloc/bmalloc/Mutex.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014 Apple Inc. All rights reserved.
  * Copyright (C) 2018 Yusuke Suzuki <utatane.tea@gmail.com>.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,32 +28,11 @@
 #include "Mutex.h"
 
 #include "ScopeExit.h"
-#if BOS(DARWIN)
-#include <mach/mach_traps.h>
-#include <mach/thread_switch.h>
-#endif
-#if BOS(WINDOWS)
-#include <windows.h>
-#endif
+#include "SpinBackoff.h"
 
 #include <thread>
 
 namespace bmalloc {
-
-static inline void yield()
-{
-#if BOS(DARWIN)
-    constexpr mach_msg_timeout_t timeoutInMS = 1;
-    thread_switch(MACH_PORT_NULL, SWITCH_OPTION_DEPRESS, timeoutInMS);
-#elif BOS(WINDOWS)
-    // SwitchToThread only yields to threads on the same processor
-    // If that fails we'll Sleep, which will also yield for threads ready to run on other processors
-    if (!SwitchToThread())
-        Sleep(0);
-#else
-    sched_yield();
-#endif
-}
 
 void Mutex::lockSlowCase()
 {
@@ -60,7 +40,7 @@ void Mutex::lockSlowCase()
     // time it takes to make a system call to yield to the OS scheduler.
     // So, we try again a lot before we yield.
     static constexpr size_t aLot = 256;
-    
+
     if (!m_isSpinning.exchange(true)) {
         auto clear = makeScopeExit([&] { m_isSpinning.store(false); });
 
@@ -72,7 +52,7 @@ void Mutex::lockSlowCase()
 
     // Avoid spinning pathologically.
     while (!try_lock())
-        yield();
+        SpinBackoff::yield();
 }
 
 } // namespace bmalloc

--- a/Source/bmalloc/bmalloc/SpinBackoff.h
+++ b/Source/bmalloc/bmalloc/SpinBackoff.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2018 Yusuke Suzuki <utatane.tea@gmail.com>.
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+
+#include "BPlatform.h"
+
+#if BOS(DARWIN)
+#include <mach/mach_traps.h>
+#include <mach/thread_switch.h>
+#endif
+#if BOS(WINDOWS)
+#include <windows.h>
+#endif
+#if BOS(UNIX)
+#include <time.h>
+#endif
+
+namespace bmalloc {
+
+// Keep up to date with WTF::SpinBackoff
+class SpinBackoff {
+public:
+    bool shouldParkAfterSpinOnce()
+    {
+        if (m_spinCount >= s_spinLimit)
+            return true;
+        spinOnce();
+        return false;
+    }
+
+    void spinOnce()
+    {
+        unsigned step = m_spinCount;
+        if (step < s_pauseSteps) {
+            m_spinCount = step + 1;
+            for (unsigned remaining = 1U << step; remaining--;)
+                cpuPause();
+            return;
+        }
+        if (step < s_spinLimit)
+            m_spinCount = step + 1;
+        yield();
+    }
+
+    static void yield()
+    {
+#if BOS(DARWIN)
+        constexpr mach_msg_timeout_t timeoutInMS = 1;
+        thread_switch(MACH_PORT_NULL, SWITCH_OPTION_DEPRESS, timeoutInMS);
+#elif BOS(WINDOWS)
+        // SwitchToThread only yields to threads on the same processor
+        if (!SwitchToThread())
+            Sleep(0);
+#else
+        struct timespec minimalSleep { 0, 1 };
+        nanosleep(&minimalSleep, nullptr);
+#endif
+    }
+
+private:
+    static void cpuPause()
+    {
+#if BCPU(X86_64)
+        __asm__ volatile("pause");
+#elif BCPU(ARM64)
+        __asm__ volatile("isb");
+#endif
+    }
+
+#if BCPU(X86_64)
+    static constexpr unsigned s_extraPauseSteps = 0;
+#else
+    static constexpr unsigned s_extraPauseSteps = 2;
+#endif
+
+#if BCPU(ARM64) && BPLATFORM(MAC)
+    static constexpr unsigned s_pauseSteps = 9;
+    static constexpr unsigned s_yieldSteps = 5;
+#elif BCPU(ARM64) && BPLATFORM(IOS_FAMILY)
+    static constexpr unsigned s_pauseSteps = 9;
+    static constexpr unsigned s_yieldSteps = 10;
+#elif BOS(DARWIN) || BOS(WINDOWS)
+    static constexpr unsigned s_pauseSteps = 0;
+    static constexpr unsigned s_yieldSteps = 40;
+#else
+    static constexpr unsigned s_pauseSteps = 6 + s_extraPauseSteps;
+    static constexpr unsigned s_yieldSteps = 0;
+#endif
+    static constexpr unsigned s_spinLimit = s_pauseSteps + s_yieldSteps;
+
+    unsigned m_spinCount { 0 };
+};
+
+} // namespace bmalloc
+
+#endif // __cplusplus


### PR DESCRIPTION
#### 30084183ed393374d7184bb2d55fd2c3be2100c1
<pre>
Cherry-pick 320724@main (249ede976fcc). <a href="https://bugs.webkit.org/show_bug.cgi?id=321012">https://bugs.webkit.org/show_bug.cgi?id=321012</a>

    Replace sched_yield with nanosleep and abstract away spin lock logic on all platforms
    <a href="https://bugs.webkit.org/show_bug.cgi?id=321012">https://bugs.webkit.org/show_bug.cgi?id=321012</a>

    Reviewed by Yusuke Suzuki.

    sched_yield is not so helpful, since it isn&apos;t guaranteed
    to actually yield (unlike the macOS thread_switch) and can
    cause deadlocks.

    Darwin&apos;s tier setup remains mostly unchanged:

    Tier 1: spinloop
    Tier 2: thread_switch
    Tier 3: Parking lot if available (i.e, nothing for bmalloc)

    or

    Tier 1: spinloop
    Tier 2A: pause (avoid hammering the cache)
    Tier 2B: thread_switch

    (depending on the location)

    Linux now has:
    Tier 1: spinloop
    Tier 2: waiting with backoff to avoid hammering the cache
    Tier 3: parking lot OR thread_yield

    Thread::yield now definitely always yields, but it is slower.

    We acomplish this by making SpinBackoff, which abstracts this logic
    away.

    We then extend it to a few other places for consistency.

    This is measured to be perf-neutral on MBA M4, Neoverse N1 (linux) and RPI4/5 64-bit.

    * Source/JavaScriptCore/heap/Heap.cpp:
    (JSC::Heap::clearConcurrentRetainedDataIfPossible):
    * Source/JavaScriptCore/runtime/JSLock.cpp:
    (JSC::JSLock::grabAllLocks):
    * Source/WTF/WTF.xcodeproj/project.pbxproj:
    * Source/WTF/wtf/CMakeLists.txt:
    * Source/WTF/wtf/LockAlgorithmInlines.h:
    (WTF::Hooks&gt;::lockSlow):
    * Source/WTF/wtf/SpinBackoff.h: Added.
    (WTF::SpinBackoff::shouldParkAfterSpinOnce):
    (WTF::SpinBackoff::spinOnce):
    * Source/WTF/wtf/WordLock.cpp:
    (WTF::WordLock::lockSlow):
    (WTF::WordLock::unlockSlow):
    * Source/WTF/wtf/posix/ThreadingPOSIX.cpp:
    (WTF::Thread::yield):
    * Source/bmalloc/CMakeLists.txt:
    * Source/bmalloc/bmalloc.xcodeproj/project.pbxproj:
    * Source/bmalloc/bmalloc/Mutex.cpp:
    (bmalloc::Mutex::lockSlowCase):
    (bmalloc::yield): Deleted.
    * Source/bmalloc/bmalloc/SpinBackoff.h: Added.
    (bmalloc::SpinBackoff::shouldParkAfterSpinOnce):
    (bmalloc::SpinBackoff::spinOnce):
    (bmalloc::SpinBackoff::cpuPause):
    (bmalloc::SpinBackoff::platformYield):
    (bmalloc::SpinBackoff::yield):

    Canonical link: <a href="https://commits.webkit.org/320724@main">https://commits.webkit.org/320724@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.254@webkitglib/2.54">https://commits.webkit.org/317695.254@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53403548843356e6413f620724788245af46b75e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186005 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59903 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53690 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196299 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150624 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/61275 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59623 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145340 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150624 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188960 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/61275 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53690 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125657 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/61275 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59623 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7523 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53690 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/61275 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53690 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7370 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/47244 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52471 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59623 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198276 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59559 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53690 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154899 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/60268 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53690 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154544 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28240 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/60268 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132595 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129649 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58715 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53690 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/58106 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58336 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/58164 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->