### PR TITLE
[QUIRK] google.com: clicking a provider link in the "Where to watch" panel closes the panel instead of navigating

### DIFF
--- a/LayoutTests/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/fast/quirks/active-quirks-by-domain-expected.txt
@@ -89,6 +89,14 @@ https://play.geforcenow.com/
     NeedsGeforcenowWarningDisplayNoneQuirk
 https://www.google.com/
     MaybeBypassBackForwardCache
+https://www.google.com/search
+    MaybeBypassBackForwardCache
+    NeedsAnchorToBeMouseFocusableQuirk
+https://www.google.com/search/howsearchworks
+    MaybeBypassBackForwardCache
+https://www.google.co.jp/search
+    MaybeBypassBackForwardCache
+    NeedsAnchorToBeMouseFocusableQuirk
 https://www.google.com/maps/
     MayNeedToIgnoreContentObservation
     MaybeBypassBackForwardCache

--- a/LayoutTests/fast/quirks/active-quirks-by-domain.html
+++ b/LayoutTests/fast/quirks/active-quirks-by-domain.html
@@ -58,6 +58,12 @@ const urls = [
     "https://gizmodo.com/",
     "https://play.geforcenow.com/",
     "https://www.google.com/",
+    // pathIs("/search") is exact, so the results page picks up the panel-anchor quirk and a
+    // deeper path under /search does not. webkit.org/b/323851
+    "https://www.google.com/search",
+    "https://www.google.com/search/howsearchworks",
+    // anyTopLevelDomain, so the ccTLD results pages match too.
+    "https://www.google.co.jp/search",
     "https://www.google.com/maps/",
     "https://maps.google.com/maps/",
     "https://docs.google.com/",

--- a/LayoutTests/platform/glib/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/glib/fast/quirks/active-quirks-by-domain-expected.txt
@@ -93,6 +93,12 @@ https://play.geforcenow.com/
     NeedsGeforcenowWarningDisplayNoneQuirk
 https://www.google.com/
     MaybeBypassBackForwardCache
+https://www.google.com/search
+    MaybeBypassBackForwardCache
+https://www.google.com/search/howsearchworks
+    MaybeBypassBackForwardCache
+https://www.google.co.jp/search
+    MaybeBypassBackForwardCache
 https://www.google.com/maps/
     MaybeBypassBackForwardCache
     ShouldAvoidResizingWhenInputViewBoundsChangeQuirk

--- a/LayoutTests/platform/ios/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/ios/fast/quirks/active-quirks-by-domain-expected.txt
@@ -100,6 +100,14 @@ https://play.geforcenow.com/
     NeedsGeforcenowWarningDisplayNoneQuirk
 https://www.google.com/
     MaybeBypassBackForwardCache
+https://www.google.com/search
+    MaybeBypassBackForwardCache
+    NeedsAnchorToBeMouseFocusableQuirk
+https://www.google.com/search/howsearchworks
+    MaybeBypassBackForwardCache
+https://www.google.co.jp/search
+    MaybeBypassBackForwardCache
+    NeedsAnchorToBeMouseFocusableQuirk
 https://www.google.com/maps/
     MayNeedToIgnoreContentObservation
     MaybeBypassBackForwardCache

--- a/LayoutTests/platform/ipad/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/ipad/fast/quirks/active-quirks-by-domain-expected.txt
@@ -100,6 +100,14 @@ https://play.geforcenow.com/
     NeedsGeforcenowWarningDisplayNoneQuirk
 https://www.google.com/
     MaybeBypassBackForwardCache
+https://www.google.com/search
+    MaybeBypassBackForwardCache
+    NeedsAnchorToBeMouseFocusableQuirk
+https://www.google.com/search/howsearchworks
+    MaybeBypassBackForwardCache
+https://www.google.co.jp/search
+    MaybeBypassBackForwardCache
+    NeedsAnchorToBeMouseFocusableQuirk
 https://www.google.com/maps/
     MayNeedToIgnoreContentObservation
     MaybeBypassBackForwardCache

--- a/LayoutTests/platform/mac-sequoia/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/mac-sequoia/fast/quirks/active-quirks-by-domain-expected.txt
@@ -89,6 +89,14 @@ https://play.geforcenow.com/
     NeedsGeforcenowWarningDisplayNoneQuirk
 https://www.google.com/
     MaybeBypassBackForwardCache
+https://www.google.com/search
+    MaybeBypassBackForwardCache
+    NeedsAnchorToBeMouseFocusableQuirk
+https://www.google.com/search/howsearchworks
+    MaybeBypassBackForwardCache
+https://www.google.co.jp/search
+    MaybeBypassBackForwardCache
+    NeedsAnchorToBeMouseFocusableQuirk
 https://www.google.com/maps/
     MaybeBypassBackForwardCache
     ShouldAvoidResizingWhenInputViewBoundsChangeQuirk

--- a/LayoutTests/platform/mac-tahoe/fast/quirks/active-quirks-by-domain-expected.txt
+++ b/LayoutTests/platform/mac-tahoe/fast/quirks/active-quirks-by-domain-expected.txt
@@ -89,6 +89,14 @@ https://play.geforcenow.com/
     NeedsGeforcenowWarningDisplayNoneQuirk
 https://www.google.com/
     MaybeBypassBackForwardCache
+https://www.google.com/search
+    MaybeBypassBackForwardCache
+    NeedsAnchorToBeMouseFocusableQuirk
+https://www.google.com/search/howsearchworks
+    MaybeBypassBackForwardCache
+https://www.google.co.jp/search
+    MaybeBypassBackForwardCache
+    NeedsAnchorToBeMouseFocusableQuirk
 https://www.google.com/maps/
     MaybeBypassBackForwardCache
     ShouldAvoidResizingWhenInputViewBoundsChangeQuirk

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -112,7 +112,7 @@ bool HTMLAnchorElement::isMouseFocusable() const
 {
 #if !(PLATFORM(GTK) || PLATFORM(WPE))
     // Only allow links with tabIndex or contentEditable to be mouse focusable.
-    if (isLink() && !protect(document())->quirks().needsAnchorToBeMouseFocusable())
+    if (isLink() && !protect(document())->quirks().needsAnchorToBeMouseFocusable(*this))
         return HTMLElement::supportsFocus();
 #endif
 

--- a/Source/WebCore/page/QuirkBehaviors.h
+++ b/Source/WebCore/page/QuirkBehaviors.h
@@ -42,6 +42,7 @@ enum class QuirkSite : uint8_t {
     GoogleDocs,
     GoogleProperty,
     GoogleMaps,
+    GoogleSearch,
     IHeart,
     InVideo,
     LinkedIn,

--- a/Source/WebCore/page/QuirkTable.cpp
+++ b/Source/WebCore/page/QuirkTable.cpp
@@ -295,6 +295,11 @@ static constexpr Quirk fullTable[] = {
         },
         .site = QuirkSite::GoogleProperty },
 
+    // google.com https://bugs.webkit.org/show_bug.cgi?id=323851 rdar://181740296
+    { .match = URLMatch::anyTopLevelDomain("google"_s).when(pathIs("/search"_s)),
+        .behaviors = { needsAnchorToBeMouseFocusableQuirk },
+        .site = QuirkSite::GoogleSearch },
+
     { .match = URLMatch::anyTopLevelDomain("google"_s).when(pathStartsWith("/maps/"_s)),
         .behaviors = {
             // maps.google.com rdar://152194074

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -235,11 +235,33 @@ bool Quirks::shouldDisableBlobFileAccessEnforcement()
 }
 
 // thesaurus.com, dictionary.com https://bugs.webkit.org/show_bug.cgi?id=312692 rdar://174959285
-bool Quirks::needsAnchorToBeMouseFocusable() const
+// google.com https://bugs.webkit.org/show_bug.cgi?id=323851 rdar://181740296
+bool Quirks::needsAnchorToBeMouseFocusable(const Element& anchor) const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirkBehaviors::needsAnchorToBeMouseFocusableQuirk);
+    if (!m_quirksData.quirkIsEnabled(QuirkBehaviors::needsAnchorToBeMouseFocusableQuirk))
+        return false;
+
+    // On a Google search page only the links inside the "Where to watch" panel need
+    // this. That panel closes on blur, so a link that does not take focus on press
+    // loses its click: the panel collapses before mouseup and the click retargets to
+    // an ancestor. Every other site opted into this quirk needs it for every anchor.
+    if (m_quirksData.isSite(QuirkSite::GoogleSearch)) {
+        // The panel carries data-expc. Bounded walk: this runs on every press on a link.
+        static MainThreadNeverDestroyed<const AtomString> expandablePanelAttribute("data-expc"_s);
+        static constexpr unsigned maxDepth = 12;
+        unsigned depth = 0;
+        for (Ref ancestor : lineageOfType<Element>(anchor)) {
+            if (ancestor->hasAttribute(expandablePanelAttribute.get()))
+                return true;
+            if (++depth > maxDepth)
+                break;
+        }
+        return false;
+    }
+
+    return true;
 }
 
 // ceac.state.gov https://bugs.webkit.org/show_bug.cgi?id=193478

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -75,7 +75,7 @@ public:
     bool shouldDeferIntersectionObserversDuringResize() const;
     bool shouldSilenceMediaQueryListChangeEvents() const;
     bool shouldIgnoreInvalidSignal() const;
-    bool needsAnchorToBeMouseFocusable() const;
+    bool needsAnchorToBeMouseFocusable(const Element&) const;
     bool needsFormControlToBeMouseFocusable() const;
     bool needsAutoplayPlayPauseEvents() const;
     bool needsSeekingSupportDisabled() const;


### PR DESCRIPTION
#### e27850ecf3675c59ef7c7c691a84f3b6c1bca4c4
<pre>
[QUIRK] google.com: clicking a provider link in the &quot;Where to watch&quot; panel closes the panel instead of navigating
<a href="https://bugs.webkit.org/show_bug.cgi?id=323851">https://bugs.webkit.org/show_bug.cgi?id=323851</a>
<a href="https://rdar.apple.com/181740296">rdar://181740296</a>

Reviewed by Cole Carley.

WebKit does not focus a plain link when it is pressed, and Google&apos;s
&quot;Where to watch&quot; panel closes itself when focus leaves it. Pressing a
provider link moves focus to the body, so the panel collapses before
mouseup. Press and release then land on different elements and the
click is dispatched to their common ancestor, so the link is never
activated and nothing navigates.

Opt google.com into the existing needsAnchorToBeMouseFocusableQuirk,
scoped two ways. The table entry matches search result pages rather
than the whole domain, and needsAnchorToBeMouseFocusable() now takes
the anchor so it can require it to be inside the expandable panel,
which carries data-expc. Every other link on a search page, and every
other Google page, keeps the current behaviour. The other sites opted
into this quirk still get it for every anchor.

* LayoutTests/fast/quirks/active-quirks-by-domain-expected.txt:
* LayoutTests/fast/quirks/active-quirks-by-domain.html:
* LayoutTests/platform/glib/fast/quirks/active-quirks-by-domain-expected.txt:
* LayoutTests/platform/ios/fast/quirks/active-quirks-by-domain-expected.txt:
* LayoutTests/platform/ipad/fast/quirks/active-quirks-by-domain-expected.txt:
* LayoutTests/platform/mac-sequoia/fast/quirks/active-quirks-by-domain-expected.txt:
* LayoutTests/platform/mac-tahoe/fast/quirks/active-quirks-by-domain-expected.txt:
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::isMouseFocusable const):
* Source/WebCore/page/QuirkBehaviors.h:
* Source/WebCore/page/QuirkTable.cpp:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsAnchorToBeMouseFocusable const):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/320889@main">https://commits.webkit.org/320889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70772107bbb0215ffc7ce253fbcd2f13d2f98829

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196325 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150646 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1260e451-453c-4f8e-8c33-3010f557da69) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59651 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145369 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100771 "Exiting early after 60 failures. 60 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/17c9b715-372e-4f8f-88e8-f44a5d617950) 
| [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188988 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Failed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165913 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125686 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a557b2a8-7b3a-40db-9f9b-c9ed7e4841bd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47782 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45777 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158136 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45500 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7396 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52487 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50227 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198303 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154928 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41539 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60298 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154569 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49013 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132612 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129698 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58744 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20491 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58134 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58366 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58192 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->