### PR TITLE
Cherry-pick 320809@main (3e4b76f62c88). https://bugs.webkit.org/show_bug.cgi?id=320649

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
@@ -46,6 +46,7 @@
 
 #if USE(LIBDRM)
 #include <drm_fourcc.h>
+#include <xf86drm.h>
 #endif
 
 namespace WebCore {
@@ -122,6 +123,13 @@ static CPUMappingStrategy runCapabilityProbe()
         return CPUMappingStrategy::Unsupported;
     }
 
+    // CPUMappingStrategy::DmaBufFDMmap doesn't work for the combination of i915 driver and Intel Arc.
+    bool preferGBMBoMap = false;
+    if (drmVersion* version = drmGetVersion(gbm_device_get_fd(gbmDevice->device()))) {
+        preferGBMBoMap = equalSpans(unsafeSpan(version->name), "i915"_span);
+        drmFreeVersion(version);
+    }
+
     // mmap capability depends on the kernel dma-buf subsystem and the GBM backend, not on
     // buffer size, format, or modifier -- so the single-plane linear probe generalizes.
     static constexpr int probeSize = 16;
@@ -134,11 +142,13 @@ static CPUMappingStrategy runCapabilityProbe()
 
     auto strategy = CPUMappingStrategy::Unsupported;
 
-    if (auto* bo = createProbeBO()) {
-        UnixFileDescriptor fd { gbm_bo_get_fd_for_plane(bo, 0), UnixFileDescriptor::Adopt };
-        if (fd && probeReadWriteMappability(fd.value(), gbm_bo_get_stride_for_plane(bo, 0) * probeSize))
-            strategy = CPUMappingStrategy::DmaBufFDMmap;
-        gbm_bo_destroy(bo);
+    if (!preferGBMBoMap) {
+        if (auto* bo = createProbeBO()) {
+            UnixFileDescriptor fd { gbm_bo_get_fd_for_plane(bo, 0), UnixFileDescriptor::Adopt };
+            if (fd && probeReadWriteMappability(fd.value(), gbm_bo_get_stride_for_plane(bo, 0) * probeSize))
+                strategy = CPUMappingStrategy::DmaBufFDMmap;
+            gbm_bo_destroy(bo);
+        }
     }
 
     if (strategy == CPUMappingStrategy::Unsupported) {
@@ -484,6 +494,9 @@ MemoryMappedGPUBuffer::AccessScope::AccessScope(MemoryMappedGPUBuffer& buffer, A
 MemoryMappedGPUBuffer::AccessScope::~AccessScope()
 {
     m_buffer.performDMABufSyncSystemCall({ DMABufSyncFlag::End, m_mode == AccessScope::Mode::Read ? DMABufSyncFlag::Read : DMABufSyncFlag::Write });
+
+    if (m_mode == Mode::Write && cachedCPUMappingStrategy() == CPUMappingStrategy::GBMBoMap)
+        m_buffer.unmapIfNeeded();
 }
 
 std::unique_ptr<MemoryMappedGPUBuffer::AccessScope> MemoryMappedGPUBuffer::AccessScope::create(MemoryMappedGPUBuffer& buffer, AccessScope::Mode mode)

--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
@@ -109,12 +109,14 @@ void SkiaGPUAtlas::uploadImages()
 #if USE(GBM)
     if (auto* gpuBuffer = m_atlasTexture->memoryMappedGPUBuffer()) {
         RELEASE_ASSERT(gpuBuffer->isLinear() || gpuBuffer->isVivanteSuperTiled());
-        auto writeScope = makeGPUBufferWriteScope(*gpuBuffer);
-        RELEASE_ASSERT_WITH_MESSAGE(writeScope, "Failed to map GPU buffer for atlas upload");
+        {
+            auto writeScope = makeGPUBufferWriteScope(*gpuBuffer);
+            RELEASE_ASSERT_WITH_MESSAGE(writeScope, "Failed to map GPU buffer for atlas upload");
 
-        for (const auto& entry : m_layout->entries()) {
-            if (auto pixels = pixelDataInSRGB(entry.rasterImage))
-                gpuBuffer->updateContents(*writeScope, pixels->first, entry.atlasRect, pixels->second);
+            for (const auto& entry : m_layout->entries()) {
+                if (auto pixels = pixelDataInSRGB(entry.rasterImage))
+                    gpuBuffer->updateContents(*writeScope, pixels->first, entry.atlasRect, pixels->second);
+            }
         }
 
         m_uploadCondition->signal();

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -1150,10 +1150,12 @@ static void webkitMediaStreamSrcDispose(GObject* object)
     auto priv = self->priv;
 
     GST_DEBUG_OBJECT(self, "Disposing");
-    for (auto& source : priv->sources.values())
-        webkitMediaStreamSrcCleanup(self, source);
-
-    priv->sources.clear();
+    while (!priv->sources.isEmpty()) {
+        auto source = priv->sources.takeFirst();
+        callOnMainThreadAndWait([self, source = WTF::move(source)] {
+            webkitMediaStreamSrcCleanup(self, source);
+        });
+    }
 
     if (priv->stream) {
         priv->stream->removeObserver(*priv->mediaStreamObserver);


### PR DESCRIPTION
#### 4d7525e156e11b9653180210652630fd44e9b258
<pre>
Cherry-pick 320809@main (3e4b76f62c88). <a href="https://bugs.webkit.org/show_bug.cgi?id=320649">https://bugs.webkit.org/show_bug.cgi?id=320649</a>

    [GStreamer] webrtc/disable-encryption.html crashes
    <a href="https://bugs.webkit.org/show_bug.cgi?id=320649">https://bugs.webkit.org/show_bug.cgi?id=320649</a>

    Reviewed by Xabier Rodriguez-Calvar.

    The webkitMediaStreamSrcCleanup function has to run from the main thread and it was the case
    everywhere excepted when the element is replaced (thus disposed) from a non-main thread by playbin3,
    when we send a new collection event from the element pad probe.

    * LayoutTests/platform/wpe/TestExpectations:
    * Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
    (webkitMediaStreamSrcDispose):

    Canonical link: <a href="https://commits.webkit.org/320809@main">https://commits.webkit.org/320809@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.257@webkitglib/2.54">https://commits.webkit.org/317695.257@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 2110d86c43de4ba5654590d1fe5a0926ca90127e
<pre>
Cherry-pick 320811@main (3303c6f5ddfd). <a href="https://bugs.webkit.org/show_bug.cgi?id=311103">https://bugs.webkit.org/show_bug.cgi?id=311103</a>

    [GTK][WPE] white noise images for dma_buf atlas on i915 + Intel Arc
    <a href="https://bugs.webkit.org/show_bug.cgi?id=311103">https://bugs.webkit.org/show_bug.cgi?id=311103</a>

    Reviewed by Nikolas Zimmermann.

    The combination of i915 driver and Intel Arc caused white noise for atlas image
    uploading. Using xe driver work fine for the video card.

    Using CPUMappingStrategy::GBMBoMap and unmapping in ~AccessScope() can work
    around the issue for i915.

    * Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp:
    (WebCore::runCapabilityProbe):
    (WebCore::MemoryMappedGPUBuffer::AccessScope::~AccessScope):

    Canonical link: <a href="https://commits.webkit.org/320811@main">https://commits.webkit.org/320811@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.256@webkitglib/2.54">https://commits.webkit.org/317695.256@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 25aedbe2520a5f4f8523d2b8ea93b2c97ef9e2ef
<pre>
Cherry-pick 320810@main (bfe5ce514044). <a href="https://bugs.webkit.org/show_bug.cgi?id=323643">https://bugs.webkit.org/show_bug.cgi?id=323643</a>

    [GTK][WPE] SkiaGPUAtlas::uploadImages() should destory `writeScope` before signaling `m_uploadCondition`
    <a href="https://bugs.webkit.org/show_bug.cgi?id=323643">https://bugs.webkit.org/show_bug.cgi?id=323643</a>

    Reviewed by Nikolas Zimmermann.

    The type of `writeScope` is MemoryMappedGPUBuffer::AccessScope. The dtor
    ~AccessScope() actually syncs the buffer. We should do that before signaling
    the condition variable.

    * Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp:
    (WebCore::SkiaGPUAtlas::uploadImages):

    Canonical link: <a href="https://commits.webkit.org/320810@main">https://commits.webkit.org/320810@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.255@webkitglib/2.54">https://commits.webkit.org/317695.255@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8a5b75b893a2f3c8fe72bdc7114e8c5f039c07c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186014 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59912 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53699 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196308 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150632 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187876 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/61284 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59632 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145357 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150632 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188969 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/61284 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53699 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125672 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/61284 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59632 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53699 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/61284 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53699 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7379 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52477 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59632 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198285 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59568 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53699 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154916 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/60277 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53699 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154555 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28244 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/60277 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132602 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129667 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58724 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53699 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/58115 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58345 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/58173 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->