### PR TITLE
[JSC][Wasm] Initialize ref arrays with gcSafeMemfill

### DIFF
--- a/JSTests/wasm/gc/bulk-array-element-types.js
+++ b/JSTests/wasm/gc/bulk-array-element-types.js
@@ -312,6 +312,23 @@ for (const [offset, size] of [[1, -1], [-1, 1], [-1, -1], [0, 9], [8, 1], [9, 0]
 }
 
 {
+    for (const length of [0, 1, 9, 32]) {
+        const m = instantiate(`
+            (module
+               (type $arr (array (mut anyref)))
+               (global $a (ref $arr) (array.new_default $arr (i32.const ${length})))
+               (func (export "len") (result i32)
+                 (array.len (global.get $a)))
+               (func (export "isNull") (param i32) (result i32)
+                 (ref.is_null (array.get $arr (global.get $a) (local.get 0)))))
+        `).exports;
+        assert.eq(m.len(), length);
+        for (let i = 0; i < length; ++i)
+            assert.eq(m.isNull(i), 1);
+    }
+}
+
+{
     for (const length of [1, 9, 32]) {
         const m = instantiate(`
             (module

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1799,10 +1799,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFill16B, void, (void* payloa
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFillRefs, void, (uint64_t* payload, uint64_t value, size_t elementCount))
 {
-    // A reference is stored whole so the concurrent collector cannot observe a torn JSValue.
-    volatile uint64_t* cursor = payload;
-    for (size_t i = 0; i < elementCount; ++i)
-        cursor[i] = value;
+    gcSafeMemfill(payload, value, elementCount * sizeof(uint64_t));
 }
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayCopyRefs, void, (uint64_t* dst, const uint64_t* src, size_t byteCount))


### PR DESCRIPTION
#### 0a09c0224058e61ef812b47712ea651aa30fdbd3
<pre>
[JSC][Wasm] Initialize ref arrays with gcSafeMemfill
<a href="https://bugs.webkit.org/show_bug.cgi?id=323865">https://bugs.webkit.org/show_bug.cgi?id=323865</a>

Reviewed by Yusuke Suzuki.

operationWasmArrayFillRefs filled already-visible ref arrays with a
volatile store loop so the concurrent marker would not see a torn
JSValue. Use gcSafeMemfill, the same helper JSWebAssemblyArray::fill
already uses.

The constructor still uses std::ranges::fill. The cell is not visible
to concurrent markers until finishCreation.

* Source/JavaScriptCore/wasm/WasmOperations.cpp:
* JSTests/wasm/gc/bulk-array-element-types.js:

Canonical link: <a href="https://commits.webkit.org/320951@main">https://commits.webkit.org/320951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7ce23712bbf1e5c2949504b8f651d78a4e7ff65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196414 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150706 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59738 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145433 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100809 "13 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49108 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165965 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125759 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47841 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45827 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7612 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14483 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158195 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45553 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7485 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47363 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52544 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198392 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59675 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154999 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60387 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154636 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28300 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49074 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132673 "Failed to build and analyze WebKit") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129801 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58826 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20536 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58219 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58448 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58278 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->