### PR TITLE
SVGImage::isAnimating() returns true for SVG images that have no animations

### DIFF
--- a/LayoutTests/svg/animations/css-animated-svg-image-animating-expected.txt
+++ b/LayoutTests/svg/animations/css-animated-svg-image-animating-expected.txt
@@ -1,0 +1,10 @@
+Tests that an SVG image animated with CSS animations reports that it is animating.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.isImageAnimating(animatedImage) became true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/animations/css-animated-svg-image-animating.html
+++ b/LayoutTests/svg/animations/css-animated-svg-image-animating.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<img id="animated" src="resources/cssAnimation.svg">
+<script>
+description("Tests that an SVG image animated with CSS animations reports that it is animating.");
+jsTestIsAsync = true;
+
+onload = function() {
+    animatedImage = document.getElementById("animated");
+
+    shouldBecomeEqual("internals.isImageAnimating(animatedImage)", "true", finishJSTest);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/svg/animations/resources/cssAnimation.svg
+++ b/LayoutTests/svg/animations/resources/cssAnimation.svg
@@ -1,0 +1,12 @@
+<svg width="200" height="100" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        @keyframes move {
+            0% { transform: translateX(0); }
+            100% { transform: translateX(100px); }
+        }
+        rect {
+            animation: move 1s linear infinite;
+        }
+    </style>
+    <rect width="100" height="100" fill="green"/>
+</svg>

--- a/LayoutTests/svg/animations/resources/noAnimation.svg
+++ b/LayoutTests/svg/animations/resources/noAnimation.svg
@@ -1,0 +1,3 @@
+<svg width="200" height="100" xmlns="http://www.w3.org/2000/svg">
+    <rect width="100" height="100" fill="green"/>
+</svg>

--- a/LayoutTests/svg/animations/static-svg-image-not-animating-expected.txt
+++ b/LayoutTests/svg/animations/static-svg-image-not-animating-expected.txt
@@ -1,0 +1,11 @@
+Tests that an SVG image with no animations does not report that it is animating.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.isImageAnimating(animatedImage) became true
+PASS internals.isImageAnimating(staticImage) is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/animations/static-svg-image-not-animating.html
+++ b/LayoutTests/svg/animations/static-svg-image-not-animating.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<img id="static" src="resources/noAnimation.svg">
+<img id="animated" src="resources/smilAnimation.svg">
+<script>
+description("Tests that an SVG image with no animations does not report that it is animating.");
+jsTestIsAsync = true;
+
+onload = function() {
+    staticImage = document.getElementById("static");
+    animatedImage = document.getElementById("animated");
+
+    shouldBecomeEqual("internals.isImageAnimating(animatedImage)", "true", function() {
+        shouldBeFalse("internals.isImageAnimating(staticImage)");
+        finishJSTest();
+    });
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/svg/SVGDocumentExtensions.cpp
+++ b/Source/WebCore/svg/SVGDocumentExtensions.cpp
@@ -109,6 +109,16 @@ void SVGDocumentExtensions::unpauseAnimations()
     m_areAnimationsPaused = false;
 }
 
+bool SVGDocumentExtensions::hasActiveSMILAnimations() const
+{
+    for (Ref container : m_timeContainers) {
+        auto& timeContainer = container->timeContainer();
+        if (timeContainer.isActive() && timeContainer.hasAnimations())
+            return true;
+    }
+    return false;
+}
+
 void SVGDocumentExtensions::dispatchLoadEventToOutermostSVGElements()
 {
     auto timeContainers = copyToVectorOf<Ref<SVGSVGElement>>(m_timeContainers);

--- a/Source/WebCore/svg/SVGDocumentExtensions.h
+++ b/Source/WebCore/svg/SVGDocumentExtensions.h
@@ -60,6 +60,7 @@ public:
     void unpauseAnimations();
     void dispatchLoadEventToOutermostSVGElements();
     bool areAnimationsPaused() const { return m_areAnimationsPaused; }
+    bool hasActiveSMILAnimations() const;
 
     void reportWarning(const String&);
     void reportError(const String&);

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -584,11 +584,6 @@ bool SVGSVGElement::animationsPaused() const
     return timeContainer().isPaused();
 }
 
-bool SVGSVGElement::hasActiveAnimation() const
-{
-    return timeContainer().isActive();
-}
-
 float SVGSVGElement::getCurrentTime() const
 {
     return narrowPrecisionToFloat(protect(timeContainer())->elapsed().value());

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -75,7 +75,6 @@ public: // DOM
     void unpauseAnimations();
     bool resumePausedAnimationsIfNeeded(const IntRect&);
     bool NODELETE animationsPaused() const;
-    bool NODELETE hasActiveAnimation() const;
     float getCurrentTime() const;
     void setCurrentTime(float);
     

--- a/Source/WebCore/svg/animation/SMILTimeContainer.cpp
+++ b/Source/WebCore/svg/animation/SMILTimeContainer.cpp
@@ -110,6 +110,15 @@ bool SMILTimeContainer::isPaused() const
     return !!m_pauseTime;
 }
 
+bool SMILTimeContainer::hasAnimations() const
+{
+    for (auto& animations : m_scheduledAnimations.values()) {
+        if (!animations.isEmpty())
+            return true;
+    }
+    return false;
+}
+
 bool SMILTimeContainer::isStarted() const
 {
     return !!m_beginTime;

--- a/Source/WebCore/svg/animation/SMILTimeContainer.h
+++ b/Source/WebCore/svg/animation/SMILTimeContainer.h
@@ -57,6 +57,7 @@ public:
 
     bool NODELETE isActive() const;
     bool NODELETE isPaused() const;
+    bool NODELETE hasAnimations() const;
 
     void begin();
     void pause();

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -36,6 +36,7 @@
 #include "DocumentLoader.h"
 #include "DocumentPage.h"
 #include "DocumentSVG.h"
+#include "DocumentTimeline.h"
 #include "DocumentView.h"
 #include "EditorClient.h"
 #include "FrameLoader.h"
@@ -52,6 +53,7 @@
 #include "PageConfiguration.h"
 #include "RenderSVGRoot.h"
 #include "RenderView.h"
+#include "SVGDocumentExtensions.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGFEImageElement.h"
 #include "SVGForeignObjectElement.h"
@@ -521,7 +523,15 @@ bool SVGImage::isAnimating() const
     RefPtr rootElement = this->rootElement();
     if (!rootElement)
         return false;
-    return rootElement->hasActiveAnimation();
+
+    Ref document = rootElement->document();
+    if (CheckedPtr svgExtensions = document->svgExtensionsIfExists()) {
+        if (svgExtensions->hasActiveSMILAnimations())
+            return true;
+    }
+
+    RefPtr timeline = document->existingTimeline();
+    return timeline && !timeline->animationsAreSuspended() && !timeline->relevantAnimations().isEmpty();
 }
 
 void SVGImage::reportApproximateMemoryCost() const


### PR DESCRIPTION
#### 3b9b086f63576bf9d807ab74bbad3a9e29d614d7
<pre>
SVGImage::isAnimating() returns true for SVG images that have no animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=323866">https://bugs.webkit.org/show_bug.cgi?id=323866</a>
<a href="https://rdar.apple.com/187106396">rdar://187106396</a>

Reviewed by Simon Fraser.

isAnimating() only checked whether the SMIL timeline had begun and was not
paused, which is true for every SVG document once it finishes loading.
SVG in &lt;img&gt; or a CSS url() reported that it was animating. Additionally,
an SVG image ignored CSS animations.

This PR checks that the SVG image document actually has SMIL animations
and that they are running. It also accounts for CSS animations in the image document.

Test: svg/animations/static-svg-image-not-animating.html

* LayoutTests/svg/animations/resources/noAnimation.svg: Added.
* LayoutTests/svg/animations/static-svg-image-not-animating-expected.txt: Added.
* LayoutTests/svg/animations/static-svg-image-not-animating.html: Added.

* Source/WebCore/svg/SVGDocumentExtensions.cpp:
(WebCore::SVGDocumentExtensions::hasActiveSMILAnimations const):
* Source/WebCore/svg/SVGDocumentExtensions.h:

We query SVGDocumentExtensions rather than root element, since SVGSMILElement binds to
the nearest ancestor &lt;svg&gt;, so SMIL inside a nested &lt;svg&gt; is not reachable from
the outermost element&apos;s container

* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::hasActiveAnimation const): Deleted.

Has no remaining callers so it&apos;s safe to remove

* Source/WebCore/svg/SVGSVGElement.h:
* Source/WebCore/svg/animation/SMILTimeContainer.cpp:
(WebCore::SMILTimeContainer::hasAnimations const):
* Source/WebCore/svg/animation/SMILTimeContainer.h:
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::isAnimating const):
* LayoutTests/svg/animations/css-animated-svg-image-animating-expected.txt: Added.
* LayoutTests/svg/animations/css-animated-svg-image-animating.html: Added.
* LayoutTests/svg/animations/resources/cssAnimation.svg: Added.

Canonical link: <a href="https://commits.webkit.org/320839@main">https://commits.webkit.org/320839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2733d1a25fa765fb1702be4179a712b5d8edd7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196352 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150663 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145385 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100781 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165926 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125705 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47802 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158156 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45513 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7423 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198330 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59617 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154944 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41502 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60326 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154584 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49033 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129732 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58772 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58162 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58394 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58220 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->