### PR TITLE
[Swift] Idiomatic MESSAGE_CHECK for Swift IPC receivers

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -1449,6 +1449,12 @@ if (ENABLE_BACK_FORWARD_LIST_SWIFT)
     )
 endif ()
 
+if (ENABLE_BACK_FORWARD_LIST_SWIFT OR ENABLE_IPC_TESTING_SWIFT)
+    list(APPEND WebKit_SOURCES
+        ${WEBKIT_DIR}/Platform/IPC/MessageCheck.swift
+    )
+endif ()
+
 if (ENABLE_IPC_TESTING_SWIFT)
     list(APPEND WebKit_SOURCES
         ${WEBKIT_DIR}/Shared/IPCTesterReceiver.swift

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -1421,9 +1421,10 @@ void GPUConnectionToWebProcess::setPresentingApplicationAuditToken(WebCore::Page
 #if ENABLE(IPC_TESTING_API)
 void GPUConnectionToWebProcess::takeInvalidMessageStringForTesting(CompletionHandler<void(String&&)>&& callback)
 {
-    ASCIILiteral error = connection().takeErrorString();
-    String errorString = !error.isNull() ? String::fromUTF8(error) : emptyString();
-    callback(WTF::move(errorString));
+    String error = connection().takeErrorString();
+    if (error.isNull())
+        error = emptyString();
+    callback(WTF::move(error));
 }
 #endif
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -2059,9 +2059,10 @@ void NetworkConnectionToWebProcess::shouldOffloadIFrameForHost(const String& hos
 #if ENABLE(IPC_TESTING_API)
 void NetworkConnectionToWebProcess::takeInvalidMessageStringForTesting(CompletionHandler<void(String&&)>&& callback)
 {
-    ASCIILiteral error = connection().takeErrorString();
-    String errorString = !error.isNull() ? String::fromUTF8(error) : emptyString();
-    callback(WTF::move(errorString));
+    String error = connection().takeErrorString();
+    if (error.isNull())
+        error = emptyString();
+    callback(WTF::move(error));
 }
 #endif
 

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -1762,4 +1762,10 @@ void Connection::setShouldCrashOnMessageCheckFailure(bool shouldCrash)
     s_shouldCrashOnMessageCheckFailure = shouldCrash;
 }
 
+void Connection::logFailedMessageCheck(const String& reason, const String& function, const String& file, unsigned line)
+{
+    RELEASE_LOG_FAULT_WITH_PAYLOAD(IPC, "%s %u: Invalid message dispatched %s: %s", file.utf8(), line, function.utf8(), reason.utf8());
+    CRASH_IF_TESTING
+}
+
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -568,6 +568,9 @@ public:
     template<typename T, typename C> static void cancelReply(C&&);
 
     void markCurrentlyDispatchedMessageAsInvalid(ASCIILiteral error);
+    void markCurrentlyDispatchedMessageAsInvalid(const String& error);
+
+    static void logFailedMessageCheck(const String& reason, const String& function, const String& file, unsigned line);
 
 #if ENABLE(CORE_IPC_SIGNPOSTS)
     static bool signpostsEnabled();
@@ -583,12 +586,12 @@ public:
 
 #if ENABLE(IPC_TESTING_API)
     bool hasErrorString() const { return !m_errorString.isNull(); }
-    void setErrorString(ASCIILiteral error)
+    void setErrorString(const String& error)
     {
         if (!hasErrorString())
             m_errorString = error;
     }
-    ASCIILiteral takeErrorString() { return std::exchange(m_errorString, { }); }
+    String takeErrorString() { return std::exchange(m_errorString, { }); }
 #endif
 
 private:
@@ -857,7 +860,7 @@ private:
 #endif
 
 #if ENABLE(IPC_TESTING_API)
-    ASCIILiteral m_errorString;
+    String m_errorString;
 #endif
 
     friend class StreamClientConnection;
@@ -1130,6 +1133,22 @@ inline void Connection::markCurrentlyDispatchedMessageAsInvalid(ASCIILiteral err
 #if ENABLE(IPC_TESTING_API)
     if (!error.isNull())
         setErrorString(error);
+#else
+    UNUSED_PARAM(error);
+#endif
+}
+
+inline void Connection::markCurrentlyDispatchedMessageAsInvalid(const String& error)
+{
+    // This should only be called while processing a message.
+    ASSERT(m_inDispatchMessageCount > 0);
+    m_didReceiveInvalidMessage = true;
+
+#if ENABLE(IPC_TESTING_API)
+    if (!error.isNull())
+        setErrorString(error);
+#else
+    UNUSED_PARAM(error);
 #endif
 }
 

--- a/Source/WebKit/Platform/IPC/MessageCheck.swift
+++ b/Source/WebKit/Platform/IPC/MessageCheck.swift
@@ -1,0 +1,103 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if compiler(>=6.2.3)
+
+#if ENABLE_BACK_FORWARD_LIST_SWIFT || (ENABLE_IPC_TESTING_API && ENABLE_IPC_TESTING_SWIFT)
+
+import WebKit_Internal
+import wtf
+
+/// The Swift spelling of the C++ MESSAGE_CHECK_* family (Connection.h).
+///
+/// A failed message check means the message being dispatched is malformed or malicious, so
+/// dispatch of that message must be abandoned. In C++ that is a hidden `return` inside a macro;
+/// in Swift it is a thrown error, which makes the early exit visible at the call site as `try`
+/// and makes propagating it the compiler's job rather than the author's.
+///
+/// A receiver can name this to declare `throws(InvalidMessage)`, and catch it, but cannot construct
+/// one: the stored properties are fileprivate, so the memberwise initializer is too and only
+/// `messageCheck(_:)` can originate the failure. A receiver must never swallow it with `try?` or
+/// `try!`.
+struct InvalidMessage: Error {
+    fileprivate let reason: StaticString
+    fileprivate let function: StaticString
+    fileprivate let file: StaticString
+    fileprivate let line: UInt
+}
+
+/// Equivalent of MESSAGE_CHECK_BASE / MESSAGE_CHECK_WITH_MESSAGE_BASE.
+///
+/// Logs and crashes here rather than where the error is caught, so that the failing check is still
+/// on the stack as it is for the C++ macros. Marking the in-flight message invalid needs the
+/// connection, so that is left to `dispatchMessage(on:onInvalidMessage:body:)`.
+///
+@inline(__always)
+func messageCheck(
+    _ reason: StaticString = "",
+    function: StaticString = #function,
+    file: StaticString = #fileID,
+    line: UInt = #line,
+    body: () -> Bool
+) throws(InvalidMessage) {
+    guard body() else {
+        logFailedMessageCheck(reason, function: function, file: file, line: line)
+        throw InvalidMessage(reason: reason, function: function, file: file, line: line)
+    }
+}
+
+// onInvalidMessage is defaulted rather than optional so that it stays non-escaping.
+func dispatchMessage(
+    on connection: IPC.Connection,
+    onInvalidMessage: () -> Void = {},
+    body: () throws(InvalidMessage) -> Void
+) {
+    do {
+        try body()
+    } catch {
+        markMessageInvalid(error, on: connection)
+        onInvalidMessage()
+    }
+}
+
+func markMessageInvalid(_ error: InvalidMessage, on connection: IPC.Connection) {
+    connection.markCurrentlyDispatchedMessageAsInvalid(WTF.String(error.reason.description))
+}
+
+private func logFailedMessageCheck(
+    _ reason: StaticString,
+    function: StaticString,
+    file: StaticString,
+    line: UInt
+) {
+    IPC.Connection.logFailedMessageCheck(
+        WTF.String(reason.description),
+        WTF.String(function.description),
+        WTF.String(file.description),
+        UInt32(truncatingIfNeeded: line)
+    )
+}
+
+#endif // ENABLE_BACK_FORWARD_LIST_SWIFT || (ENABLE_IPC_TESTING_API && ENABLE_IPC_TESTING_SWIFT)
+
+#endif // compiler(>=6.2.3)

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -1121,10 +1121,10 @@ void doLoadingReleaseLog(const WTF::String& msg)
 {
     RELEASE_LOG(Loading, "%s", msg.utf8().legacyCStringPointer());
 }
-// rdar://168139740 is the task of doing a productionized Swift MESSAGE_CHECK
-void messageCheckFailed(Ref<WebKit::WebProcessProxy> process)
+
+IPC::Connection& connectionForProcess(WebKit::WebProcessProxy& process)
 {
-    MESSAGE_CHECK_BASE(false, process->connection());
+    return process.connection();
 }
 
 // Workarounds for rdar://171011011

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -85,25 +85,6 @@ private func loadingReleaseLog(_ msgCreator: @autoclosure () -> String) {
     doLoadingReleaseLog(WTF.String(msgCreator()))
 }
 
-// Temporary partial MESSAGE_CHECK_BASE support from Swift
-// Idiomatic equivalent represented by rdar://168139740
-private func messageCheck(process: WebKit.RefWebProcessProxy, _ assertion: @autoclosure () -> Bool) -> Bool {
-    messageCheckCompletion(process: process, completionHandler: {}, assertion())
-}
-
-private func messageCheckCompletion(
-    process: WebKit.RefWebProcessProxy,
-    completionHandler: () -> Void,
-    _ assertion: @autoclosure () -> Bool
-) -> Bool {
-    if !assertion() {
-        messageCheckFailed(process)
-        completionHandler()
-        return true
-    }
-    return false
-}
-
 // FIXME(rdar://130765784): We should be able use the built-in ===, but AnyObject currently excludes foreign reference types
 @_expose(!Cxx) // rdar://169474185
 func === (_ lhs: WebKit.WebBackForwardListItem, _ rhs: WebKit.WebBackForwardListItem) -> Bool {
@@ -1035,8 +1016,7 @@ final class WebBackForwardList {
         return frameState
     }
 
-    // Returns true if a message check failed, in which case the caller should bail out.
-    private func messageCheckItemURLs(frameState: WebKit.RefFrameState, process: WebKit.RefWebProcessProxy) -> Bool {
+    private func messageCheckItemURLs(frameState: WebKit.RefFrameState, process: WebKit.RefWebProcessProxy) throws(InvalidMessage) {
         // 'nil' works around rdar://162310543
         // Safety: it's OK to pass a null pointer to these two functions; in fact it's the default
         let itemURL = unsafe WTF.URL(frameState.ptr().urlString, nil)
@@ -1052,21 +1032,14 @@ final class WebBackForwardList {
             WTF.linkedOnOrAfterSDKWithBehavior(WTF.SDKAlignedBehavior.PushStateFilePathRestriction)
         #endif
         if doMessageChecks { // corresponds to the first 'if' condition in C++ messageCheckItemURLs
-            if messageCheck(
-                process: process,
+            try messageCheck {
                 !itemURL.protocolIsFile() || process.ptr().wasPreviouslyApprovedFileURL(itemURL)
-            ) {
-                return true
             }
-            if messageCheck(
-                process: process,
+            try messageCheck {
                 !itemOriginalURL.protocolIsFile() || process.ptr().wasPreviouslyApprovedFileURL(itemOriginalURL)
-            ) {
-                return true
             }
         }
         #endif
-        return false
     }
 
     @used
@@ -1075,6 +1048,22 @@ final class WebBackForwardList {
         navigatedFrameState: WebKit.RefFrameState,
         loadedWebArchive: WebKit.LoadedWebArchive
     ) {
+        // Also reached from C++ (WebPageProxy::backForwardAddItemShared), so this rather than
+        // the caller is the catch site.
+        dispatchMessage(on: connection) { () throws(InvalidMessage) in
+            try addItemInternal(
+                connection: connection,
+                navigatedFrameState: navigatedFrameState,
+                loadedWebArchive: loadedWebArchive
+            )
+        }
+    }
+
+    private func addItemInternal(
+        connection: IPC.Connection,
+        navigatedFrameState: WebKit.RefFrameState,
+        loadedWebArchive: WebKit.LoadedWebArchive
+    ) throws(InvalidMessage) {
         let process = WebKit.WebProcessProxy.fromConnection(connection)
 
         #if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
@@ -1085,24 +1074,19 @@ final class WebBackForwardList {
         let hasFrameItemID = navigatedFrameState.ptr().frameItemID.__convertToBool()
         #endif
 
-        if messageCheck(
-            process: process,
-            !hasItemID || contentsMatch(navigatedFrameState.ptr().itemID.pointee.processIdentifier(), process.ptr().coreProcessIdentifier())
-        ) {
-            return
+        try messageCheck {
+            !hasItemID
+                || contentsMatch(navigatedFrameState.ptr().itemID.pointee.processIdentifier(), process.ptr().coreProcessIdentifier())
         }
-
-        if messageCheck(
-            process: process,
+        try messageCheck {
             !hasFrameItemID
-                || contentsMatch(navigatedFrameState.ptr().frameItemID.pointee.processIdentifier(), process.ptr().coreProcessIdentifier())
-        ) {
-            return
+                || contentsMatch(
+                    navigatedFrameState.ptr().frameItemID.pointee.processIdentifier(),
+                    process.ptr().coreProcessIdentifier()
+                )
         }
 
-        if messageCheckItemURLs(frameState: navigatedFrameState, process: process) {
-            return
-        }
+        try messageCheckItemURLs(frameState: navigatedFrameState, process: process)
 
         let navigatedFrameID = navigatedFrameState.ptr().frameID
         let targetFrame = WebKit.WebFrameProxy.webFrame(navigatedFrameID)
@@ -1121,9 +1105,7 @@ final class WebBackForwardList {
             pagesMatch = framePage == nil && listPage == nil
         }
 
-        if messageCheck(process: process, pagesMatch) {
-            return
-        }
+        try messageCheck { pagesMatch }
 
         if targetFrame.isPendingInitialHistoryItem() {
             targetFrame.setIsPendingInitialHistoryItem(false)
@@ -1180,10 +1162,18 @@ final class WebBackForwardList {
         frameItemID: WebCore.BackForwardFrameItemIdentifier,
         frameState: WebKit.RefFrameState
     ) {
-        let process = WebKit.WebProcessProxy.fromConnection(connection)
-        if messageCheckItemURLs(frameState: frameState, process: process) {
-            return
+        dispatchMessage(on: connection) { () throws(InvalidMessage) in
+            try setChildItem(connection: connection, frameItemID: frameItemID, frameState: frameState)
         }
+    }
+
+    private func setChildItem(
+        connection: IPC.Connection,
+        frameItemID: WebCore.BackForwardFrameItemIdentifier,
+        frameState: WebKit.RefFrameState
+    ) throws(InvalidMessage) {
+        let process = WebKit.WebProcessProxy.fromConnection(connection)
+        try messageCheckItemURLs(frameState: frameState, process: process)
 
         guard let item = currentItem() else {
             return
@@ -1203,15 +1193,19 @@ final class WebBackForwardList {
 
     @used
     func backForwardUpdateItem(connection: IPC.Connection, frameState: WebKit.RefFrameState) {
+        dispatchMessage(on: connection) { () throws(InvalidMessage) in
+            try updateItem(connection: connection, frameState: frameState)
+        }
+    }
+
+    private func updateItem(connection: IPC.Connection, frameState: WebKit.RefFrameState) throws(InvalidMessage) {
         let process = WebKit.WebProcessProxy.fromConnection(connection)
 
         // In the case of a process swap, the `backForwardUpdateItem` message can be received from the old process,
         // and therefore present an unexpected file: URL.
         // We can safely skip the message check in these cases.
         if !handlingProvisionalMessage {
-            if messageCheckItemURLs(frameState: frameState, process: process) {
-                return
-            }
+            try messageCheckItemURLs(frameState: frameState, process: process)
         }
 
         #if compiler(>=6.4) && !SWIFT_WEBKIT_TOOLCHAIN
@@ -1239,11 +1233,8 @@ final class WebBackForwardList {
         }
 
         // We can't use == here due to rdar://162357139
-        if messageCheck(
-            process: process,
+        try messageCheck {
             contentsMatch(webPageProxy.identifier(), item.pageID()) && contentsMatch(itemID, item.identifier())
-        ) {
-            return
         }
         let oldFrameID = frameItem.frameID()
         frameItem.updateFrameStatePayload(consuming: frameState)
@@ -1300,14 +1291,23 @@ final class WebBackForwardList {
     }
 
     @used
+    // Entry point for C++ (WebPageProxy::backForwardGoToItemShared), which is outside message
+    // dispatch and so has no connection to hand. A failed check is marked against the page's main
+    // frame process, as in C++, and only once it has failed: asking that process for a connection it
+    // no longer has is fatal.
     func backForwardGoToItemShared(itemID: WebCore.BackForwardItemIdentifier) {
-        if let webPageProxy = page.get() {
-            if messageCheck(
-                process: WebKit.RefWebProcessProxy(webPageProxy.legacyMainFrameProcess()),
-                !WebKit.isInspectorPage(webPageProxy)
-            ) {
-                return
+        do {
+            try goToItemInternal(itemID: itemID)
+        } catch {
+            if let webPageProxy = page.get() {
+                markMessageInvalid(error, on: connectionForProcess(webPageProxy.legacyMainFrameProcess()))
             }
+        }
+    }
+
+    private func goToItemInternal(itemID: WebCore.BackForwardItemIdentifier) throws(InvalidMessage) {
+        if let webPageProxy = page.get() {
+            try messageCheck { !WebKit.isInspectorPage(webPageProxy) }
         }
 
         if let item = itemForID(identifier: itemID) {
@@ -1346,26 +1346,28 @@ final class WebBackForwardList {
         frameID: WebCore.FrameIdentifier,
         completionHandler: CompletionHandlers.WebBackForwardList.BackForwardItemAtIndexForWebContentCompletionHandler
     ) {
-        let process = WebKit.WebProcessProxy.fromConnection(connection)
-        if messageCheckCompletion(
-            process: process,
-            completionHandler: { completionHandler.pointee(consuming: WebKit.RefPtrFrameState()) },
-            delta != Int32.min
-        ) {
-            return
+        var reply = WebKit.RefPtrFrameState()
+        dispatchMessage(on: connection) { () throws(InvalidMessage) in
+            reply = try itemAtIndexForWebContent(delta: delta, frameID: frameID)
         }
+        completionHandler.pointee(consuming: reply)
+    }
+
+    private func itemAtIndexForWebContent(
+        delta: Int32,
+        frameID: WebCore.FrameIdentifier
+    ) throws(InvalidMessage) -> WebKit.RefPtrFrameState {
+        try messageCheck { delta != Int32.min }
 
         // FIXME: This should verify that the web process requesting the item hosts the specified frame.
         let delta = Int(delta)
         guard let item = itemAtDeltaFromCurrentIndex(delta: delta, allowSkipping: false) else {
-            completionHandler.pointee(consuming: WebKit.RefPtrFrameState())
-            return
+            return WebKit.RefPtrFrameState()
         }
         guard let frameItem = item.mainFrameItem().childItemForFrameID(frameID) else {
-            completionHandler.pointee(consuming: WebKit.RefPtrFrameState(item.copyMainFrameStateWithChildren().ptr()))
-            return
+            return WebKit.RefPtrFrameState(item.copyMainFrameStateWithChildren().ptr())
         }
-        completionHandler.pointee(consuming: WebKit.RefPtrFrameState(frameItem.copyFrameStateWithChildren().ptr()))
+        return WebKit.RefPtrFrameState(frameItem.copyFrameStateWithChildren().ptr())
     }
 
     @used

--- a/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
+++ b/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
@@ -47,7 +47,10 @@ using SpanConstChar = std::span<const char>;
 // These can't be inline due to rdar://162531519
 void doLog(const WTF::String& msg); // rdar://168139823
 void doLoadingReleaseLog(const WTF::String& msg); // rdar://168139823
-void messageCheckFailed(Ref<WebKit::WebProcessProxy>); // rdar://168139740
+
+// Swift does not import AuxiliaryProcessProxy::connection() through WebProcessProxy in every
+// configuration, so reach it from C++ instead.
+IPC::Connection& connectionForProcess(WebKit::WebProcessProxy&);
 
 // Workaround for rdar://162357139
 template<typename T>

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -3782,9 +3782,10 @@ void WebProcessProxy::updateWasmDebuggerTarget()
 #if ENABLE(IPC_TESTING_API)
 void WebProcessProxy::takeInvalidMessageStringForTesting(CompletionHandler<void(String&&)>&& callback)
 {
-    ASCIILiteral error = protect(connection())->takeErrorString();
-    String errorString = !error.isNull() ? String::fromUTF8(error) : emptyString();
-    callback(WTF::move(errorString));
+    String error = protect(connection())->takeErrorString();
+    if (error.isNull())
+        error = emptyString();
+    callback(WTF::move(error));
 }
 #endif
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1636,6 +1636,7 @@
 		5CD286571E7235C90094FDC8 /* WKContentRuleListStoreInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CD2864F1E722F440094FDC8 /* WKContentRuleListStoreInternal.h */; };
 		5CD286581E7235D10094FDC8 /* WKContentRuleListStorePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CD286501E722F440094FDC8 /* WKContentRuleListStorePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5CDEE4932DACEF3400D2400E /* WebBackForwardList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDEE4922DACEF3400D2400E /* WebBackForwardList.swift */; };
+		AD00CE0C2E1A000000000004 /* MessageCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD00CE0C2E1A000000000003 /* MessageCheck.swift */; };
 		5CE3491228E2396900196304 /* WKFrameMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CE3491028E238E400196304 /* WKFrameMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5CE4B60029CE548D0038F565 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* WebKit.framework */; };
 		5CE4B60D29CF87680038F565 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* WebKit.framework */; };
@@ -3942,6 +3943,7 @@
 		1A3E735F11CC2659007BD539 /* WebPlatformStrategies.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebPlatformStrategies.h; sourceTree = "<group>"; };
 		1A3E736011CC2659007BD539 /* WebPlatformStrategies.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebPlatformStrategies.cpp; sourceTree = "<group>"; };
 		1A3EED0C161A535300AEB4F5 /* MessageReceiverMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MessageReceiverMap.cpp; sourceTree = "<group>"; };
+		AD00CE0C2E1A000000000003 /* MessageCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCheck.swift; sourceTree = "<group>"; };
 		1A3EED0D161A535300AEB4F5 /* MessageReceiverMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageReceiverMap.h; sourceTree = "<group>"; };
 		1A3EED11161A53D600AEB4F5 /* MessageReceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageReceiver.h; sourceTree = "<group>"; };
 		1A422F8A18B29B5400D8CD96 /* WKHistoryDelegatePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKHistoryDelegatePrivate.h; sourceTree = "<group>"; };
@@ -11143,6 +11145,7 @@
 				9BF5EC6325410E9900984E77 /* JSIPCBinding.cpp */,
 				9B47908E253151CC00EC11AB /* JSIPCBinding.h */,
 				9B47908C25314D8300EC11AB /* MessageArgumentDescriptions.h */,
+				AD00CE0C2E1A000000000003 /* MessageCheck.swift */,
 				1AC4C82816B876A90069DCCD /* MessageFlags.h */,
 				2DAF90242B553FD20081E921 /* MessageFlags.serialization.in */,
 				FC1BA3BB2EF45E4C00EC7312 /* MessageLog.h */,
@@ -22372,6 +22375,7 @@
 				0715310D2F3036F400B56C0E /* Logger+Extras.swift in Sources */,
 				E326F4DC2CA6C44F00182187 /* LogStream.mm in Sources */,
 				9B4790912531563200EC11AB /* MessageArgumentDescriptions.cpp in Sources */,
+				AD00CE0C2E1A000000000004 /* MessageCheck.swift in Sources */,
 				EBA8D3B627A5E33F00CB7900 /* MockPushServiceConnection.mm in Sources */,
 				57B826452304F14000B72EB0 /* NearFieldSoftLink.mm in Sources */,
 				C1C1B30F2540F50D00D9100B /* NetworkConnectionToWebProcessMac.mm in Sources */,


### PR DESCRIPTION
#### e7b60aea9920bae50b3ff730eb1d3a229fa1dbdd
<pre>
[Swift] Idiomatic MESSAGE_CHECK for Swift IPC receivers
<a href="https://bugs.webkit.org/show_bug.cgi?id=323854">https://bugs.webkit.org/show_bug.cgi?id=323854</a>
<a href="https://rdar.apple.com/168139740">rdar://168139740</a>

Reviewed by Richard Robinson.

This is part one of two (possibly three) commits to define an idiomatic Swift
version of WebKit&apos;s MESSAGE_CHECK macro family.

That macro family in C++ is used to reject a potentially malicious message
traveling across the IPC boundary from a less privileged to a more privileged
process. That macro does four things: it zaps the potentially-malicious
process; it logs the fault in some configurations; it triggers a debugger or
aborts in some configurations, and above all, it does an early return such that
there is no further handling of the message.

The Swift stand-in for MESSAGE_CHECK in WebBackForwardList.swift was a faithful
port of the macro&apos;s mechanism, but required the caller to do an early return
since we do not have Swift macros.

In this PR we switch the Swift equivalent to throwing a Swift error, thrown
with `try messageCheck { condition }`. The `try` makes the early exit visible at
the call site and enforced by the compiler.

Adds Platform/IPC/MessageCheck.swift with:

  - InvalidMessage.
  - messageCheck(_:), the equivalent of MESSAGE_CHECK_BASE and
    MESSAGE_CHECK_WITH_MESSAGE_BASE.
  - dispatchMessage(on:onInvalidMessage:body:), the normal catch site.
    onInvalidMessage supplies the reply so that a message with a completion
    handler cannot hang the sender.
  - markMessageInvalid(_:on:), for a receiver that has to catch InvalidMessage
    somewhere other than dispatchMessage.

In this commit, a message handler needs to manually call &apos;dispatchMessage&apos; to
catch and handle errors. Subsequent commits will move this to autogenerated
shims.

See WebBackForwardList.swift for the net effect on &apos;typical&apos; message handler
code. It&apos;s slightly simplified by this change, but the big simplification
comes when the autogenerated shims arrive.

Of the things done by a MESSAGE_CHECK:

  - Most are done at the point of &apos;throw&apos; - the fault log and the crash - since
    those are the ones which matter for debuggability.
  - The last, marking the connection as invalid to terminate the sender, is
    done at the point of &apos;catch&apos; because it has access to the required
    IPC::Connection.

This work requires that Connection&apos;s m_errorString accepts a Swift string,
so it&apos;s converted to WTF::String. This is used only when the IPC testing
API is enabled. We retain an ASCIILiteral overload so that 810 existing
C++ call sites do not get bloated.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::takeInvalidMessageStringForTesting):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::takeInvalidMessageStringForTesting):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::setErrorString):
(IPC::Connection::takeErrorString):
(IPC::Connection::markCurrentlyDispatchedMessageAsInvalid):
(IPC::markCurrentlyDispatchedMessageAsInvalid):
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::logFailedMessageCheck):
* Source/WebKit/Platform/IPC/MessageCheck.swift: Added.
(InvalidMessage.markMessageInvalid(_:on:)):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(messageCheckFailed): Deleted.
(connectionForProcess):
* Source/WebKit/UIProcess/WebBackForwardList.swift:
(Direction.messageCheckItemURLs(_:process:)):
(Direction.backForwardUpdateItem(_:frameState:)):
(Direction.updateItem(_:frameState:)):
(Direction.backForwardGoToItemShared(_:)):
(Direction.goToItemInternal(_:)):
(messageCheck(_:_:)): Deleted.
* Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::takeInvalidMessageStringForTesting):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/320937@main">https://commits.webkit.org/320937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cd2fc9f925272603f7aa4849faedd6aa555210d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196541 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150800 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145532 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125871 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47938 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45912 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158290 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45650 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7615 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198528 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59805 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155100 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41573 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60515 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154743 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49174 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132762 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129950 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58942 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20629 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58344 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58559 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58408 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->