### PR TITLE
U+0000 NULL should be replaced with U+FFFD when fragment parsing in foreign content

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/cdata-in-integration-point-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/cdata-in-integration-point-fragment-expected.txt
@@ -9,4 +9,9 @@ PASS CDATA allowed when fragment-parsing with <desc> context (SVG HTML integrati
 PASS CDATA allowed when fragment-parsing with <title> context (SVG HTML integration point)
 PASS CDATA allowed when fragment-parsing with <path> context (non-integration-point SVG element)
 PASS CDATA not allowed when fragment-parsing with <div> context (HTML element)
+PASS CDATA allowed at the start of a fragment with <ms> context (MathML text integration point)
+PASS CDATA allowed at the start of a fragment with <title> context (SVG HTML integration point)
+PASS CDATA allowed at the start of a fragment with <path> context (non-integration-point SVG element)
+PASS CDATA allowed at the start of a fragment with <annotation-xml> context (non-integration-point MathML element)
+PASS CDATA not allowed at the start of a fragment with <div> context (HTML element)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/cdata-in-integration-point-fragment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/cdata-in-integration-point-fragment.html
@@ -19,12 +19,13 @@
 // DocumentFragment). So for a context element in a non-HTML namespace, CDATA
 // sections are allowed even if that element is an integration point.
 //
-// The input "x<![CDATA[y]]>" is used because:
-// 1. "x" is emitted as a character token first
-// 2. After processing "x", the tree builder sets tokenizer flags
-// 3. "<![CDATA[y]]>" is then tokenized with those flags
+// The input "x<![CDATA[y]]>" exercises the flag as the tree builder leaves it after
+// processing a token: "x" is emitted as a character token first, and "<![CDATA[y]]>"
+// is tokenized afterwards. The tests at the end of this file use "<![CDATA[y]]>" on
+// its own, where no token precedes the CDATA section, so the flag has to be set when
+// the fragment parser is created.
 //
-// If CDATA is allowed, "y" becomes text content (textContent === "xy").
+// If CDATA is allowed, "y" becomes text content.
 // If CDATA is disallowed, "<![CDATA[y]]>" becomes a bogus comment.
 
 // MathML text integration points: still in the MathML namespace, so CDATA is allowed.
@@ -71,4 +72,32 @@ test(function() {
         "CDATA should be parsed as a bogus comment for an HTML context element");
     assert_equals(el.lastChild.data, "[CDATA[y]]", "bogus comment data");
 }, "CDATA not allowed when fragment-parsing with <div> context (HTML element)");
+
+// A CDATA section at the very start of the fragment is tokenized before any token has
+// reached the tree builder, so the flag cannot be set by processing a preceding token.
+for (const [namespace, tagName, description] of [
+    ["http://www.w3.org/1998/Math/MathML", "ms", "MathML text integration point"],
+    ["http://www.w3.org/2000/svg", "title", "SVG HTML integration point"],
+    ["http://www.w3.org/2000/svg", "path", "non-integration-point SVG element"],
+    ["http://www.w3.org/1998/Math/MathML", "annotation-xml", "non-integration-point MathML element"],
+]) {
+    test(function() {
+        const el = document.createElementNS(namespace, tagName);
+        el.innerHTML = "<![CDATA[y]]>";
+        assert_equals(el.textContent, "y",
+            "CDATA should be parsed as character data because the adjusted current node is not in the HTML namespace");
+        assert_equals(el.childNodes.length, 1, "should have a single text node");
+        assert_equals(el.firstChild.nodeType, Node.TEXT_NODE, "child should be a text node");
+    }, "CDATA allowed at the start of a fragment with <" + tagName + "> context (" + description + ")");
+}
+
+// Control: the same input with an HTML context element is still a bogus comment.
+test(function() {
+    const el = document.createElement("div");
+    el.innerHTML = "<![CDATA[y]]>";
+    assert_equals(el.childNodes.length, 1, "should have a single comment node");
+    assert_equals(el.firstChild.nodeType, Node.COMMENT_NODE,
+        "CDATA should be parsed as a bogus comment for an HTML context element");
+    assert_equals(el.firstChild.data, "[CDATA[y]]", "bogus comment data");
+}, "CDATA not allowed at the start of a fragment with <div> context (HTML element)");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/html5lib_url_file=plain-text-unsafe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/html5lib_url_file=plain-text-unsafe-expected.txt
@@ -38,14 +38,8 @@ PASS <math>\x00filler\x00text
 PASS <math><![CDATA[\x00filler\x00text\x00]]>
 PASS <math><annotation-xml>\x00x
 PASS <math><annotation-xml encoding="text/html">\x00x
-FAIL \x00filler\x00text (innerHTML in svg path) assert_equals: expected "#document\n| \"\ufffdfiller\ufffdtext\"" but got "#document\n| \"fillertext\""
+PASS \x00filler\x00text (innerHTML in svg path)
 PASS \x00filler\x00text (innerHTML in svg title)
 PASS \x00filler\x00text (innerHTML in math ms)
-FAIL \x00x (innerHTML in math annotation-xml) assert_equals: expected "#document\n| \"\ufffdx\"" but got "#document\n| \"x\""
-\x00filler\x00text (innerHTML in svg path)
-
-innerHTML Container
-
-svg path
-Input
+PASS \x00x (innerHTML in math annotation-xml)
 

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -293,6 +293,10 @@ HTMLTreeBuilder::HTMLTreeBuilder(HTMLDocumentParser& parser, DocumentFragment& f
     auto* formElement = dynamicDowncast<HTMLFormElement>(contextElement);
     m_tree.setForm(protect(formElement ? formElement : HTMLFormElement::findClosestFormAncestor(contextElement)));
 
+    // Characters are tokenized before any token reaches the tree builder, so the tokenizer flags
+    // implied by the context element have to be set up front rather than after the first token.
+    updateTokenizerForAdjustedCurrentNode();
+
 #if ASSERT_ENABLED
     m_destructionProhibited = false;
 #endif
@@ -351,6 +355,18 @@ void HTMLTreeBuilder::constructTree(AtomHTMLToken&& token)
     else
         processToken(WTF::move(token));
 
+    updateTokenizerForAdjustedCurrentNode();
+
+#if ASSERT_ENABLED
+    m_destructionProhibited = false;
+#endif
+
+    m_tree.executeQueuedTasks();
+    // The tree builder might have been destroyed as an indirect result of executing the queued tasks.
+}
+
+void HTMLTreeBuilder::updateTokenizerForAdjustedCurrentNode()
+{
     // Both flags are computed from the adjusted current node, matching the tree construction
     // dispatcher. When fragment-parsing with only one element on the stack, the adjusted current
     // node is the context element, not the DocumentFragment.
@@ -372,13 +388,6 @@ void HTMLTreeBuilder::constructTree(AtomHTMLToken&& token)
 
     m_parser->tokenizer().setForceNullCharacterReplacement(m_insertionMode == InsertionMode::Text || inForeignContent);
     m_parser->tokenizer().setShouldAllowCDATA(adjustedCurrentNodeIsForeign);
-
-#if ASSERT_ENABLED
-    m_destructionProhibited = false;
-#endif
-
-    m_tree.executeQueuedTasks();
-    // The tree builder might have been destroyed as an indirect result of executing the queued tasks.
 }
 
 void HTMLTreeBuilder::processToken(AtomHTMLToken&& token)

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.h
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.h
@@ -174,6 +174,8 @@ private:
 
     HTMLStackItem& NODELETE adjustedCurrentStackItem() LIFETIME_BOUND;
 
+    ALWAYS_INLINE void updateTokenizerForAdjustedCurrentNode();
+
     void callTheAdoptionAgency(AtomHTMLToken&);
 
     void closeTheCell();


### PR DESCRIPTION
#### 294b5b56d930d94057b56f016baf33826b9bd250
<pre>
U+0000 NULL should be replaced with U+FFFD when fragment parsing in foreign content
<a href="https://bugs.webkit.org/show_bug.cgi?id=323867">https://bugs.webkit.org/show_bug.cgi?id=323867</a>

Reviewed by Chris Dumez.

The tokenizer&apos;s forceNullCharacterReplacement flag is computed from the adjusted current
node after each token is processed. When fragment parsing the adjusted current node is the
context element from the start, but the first characters are tokenized before any token
reaches the tree builder, so NULL in the first character run was dropped instead of being
replaced with U+FFFD.

Compute the flags when the fragment tree builder is constructed as well. This also fixes
shouldAllowCDATA, so a CDATA section at the start of the fragment is no longer parsed as a
bogus comment.

The extracted helper is ALWAYS_INLINE because constructTree() calls it for every token.

Tests upstream: <a href="https://github.com/web-platform-tests/wpt/pull/62593">https://github.com/web-platform-tests/wpt/pull/62593</a>

Canonical link: <a href="https://commits.webkit.org/320909@main">https://commits.webkit.org/320909@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8d6c677b47189153aabdcecd10c39818da37d3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196328 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150647 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/313c1904-e93f-4741-94f3-eefd5b79c413) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187898 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145372 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100770 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c2f80bd3-6c36-4e83-9008-752556b64244) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/188991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125690 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/039e4846-f038-4196-b53a-24d0064fb7b8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47783 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45778 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158137 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45501 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7399 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198306 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165433 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154929 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41551 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60301 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42089 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154570 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49016 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132613 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129702 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58747 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20492 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58137 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58369 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58195 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->