### PR TITLE
[scroll-animations] Style resolution with scroll-timeline name blocks main thread for multiple seconds

### DIFF
--- a/PerformanceTests/Animation/scroll-timeline-shared-name.html
+++ b/PerformanceTests/Animation/scroll-timeline-shared-name.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.scroller { overflow-x: scroll; width: 60px; height: 12px; }
+.content { width: 400px; height: 1px; }
+.dot { display: inline-block; width: 4px; height: 4px; background: green; animation: fade 1s linear; }
+@keyframes fade { from { opacity: 0; } to { opacity: 1; } }
+</style>
+<script src="../resources/runner.js"></script>
+</head>
+<body>
+<div id="container"></div>
+<script>
+
+// Create a DOM tree with a number of elements contained in a scrolling container. The
+// last element sets animation-timeline to reference its previous sibling and the parent
+// sets a timeline-scope for this name. All scroll timelines use the same name.
+// https://bugs.webkit.org/show_bug.cgi?id=322283
+
+const tiles = 300;
+const container = document.getElementById("container");
+
+let markup = "";
+for (let i = 0; i < tiles; ++i) {
+    markup += '<div style="timeline-scope:--timeline">'
+           +      '<div class="scroller" style="scroll-timeline:--timeline inline"><div class="content"></div></div>'
+           +      '<span class="dot" style="animation-timeline:--timeline"></span>'
+           +  '</div>';
+}
+
+
+PerfTestRunner.measureTime({
+    description: "Resolving style for " + tiles + " tiles that all name the same scroll timeline.",
+    setup: function () {
+        container.innerHTML = "";
+        container.offsetHeight;
+    },
+    run: function () {
+        container.innerHTML = markup;
+        container.offsetHeight;
+    }
+});
+
+</script>
+</body>
+</html>

--- a/PerformanceTests/Animation/scroll-timeline-unique-names.html
+++ b/PerformanceTests/Animation/scroll-timeline-unique-names.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.scroller { overflow-x: scroll; width: 60px; height: 12px; }
+.content { width: 400px; height: 1px; }
+.dot { display: inline-block; width: 4px; height: 4px; background: green; animation: fade 1s linear; }
+@keyframes fade { from { opacity: 0; } to { opacity: 1; } }
+</style>
+<script src="../resources/runner.js"></script>
+</head>
+<body>
+<div id="container"></div>
+<script>
+
+// Create a DOM tree with a number of elements contained in a scrolling container. The
+// last element sets animation-timeline to reference its previous sibling and the parent
+// sets a timeline-scope for this name. All scroll timelines use a unique name.
+// https://bugs.webkit.org/show_bug.cgi?id=322283
+
+const tiles = 300;
+const container = document.getElementById("container");
+
+let markup = "";
+for (let i = 0; i < tiles; ++i) {
+    const name = "--timeline-" + i;
+    markup += '<div style="timeline-scope:' + name + '">'
+           +      '<div class="scroller" style="scroll-timeline:' + name + ' inline"><div class="content"></div></div>'
+           +      '<span class="dot" style="animation-timeline:' + name + '"></span>'
+           +  '</div>';
+}
+
+PerfTestRunner.measureTime({
+    description: "Resolving style for " + tiles + " tiles that each name their own scroll timeline.",
+    setup: function () {
+        container.innerHTML = "";
+        container.offsetHeight;
+    },
+    run: function () {
+        container.innerHTML = markup;
+        container.offsetHeight;
+    }
+});
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -152,19 +152,6 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTreeOrder(const Vec
     return sortedTimelines.first().unsafePtr();
 }
 
-static bool timelineIsInScopeForTarget(const Ref<ScrollTimeline>& timeline, Element& targetElement, Style::ScopeOrdinal animationTimelineNameScopeOrdinal)
-{
-    if (!targetElement.isConnected())
-        return false;
-    RefPtr timelineOriginatingElement { originatingElement(timeline).element() };
-    ASSERT(timelineOriginatingElement);
-    CheckedPtr scrollTimelineNameStyleScope = Style::Scope::forOrdinal(*timelineOriginatingElement, timeline->name().scopeOrdinal);
-    ASSERT(scrollTimelineNameStyleScope);
-    return Style::resolveTreeScopedReference(targetElement, { timeline->name().name, animationTimelineNameScopeOrdinal }, [&](const Style::Scope& scope, const Style::ScopedName&) {
-        return scrollTimelineNameStyleScope == &scope;
-    });
-}
-
 ScrollTimeline* StyleOriginatedTimelinesController::determineTimelineForElement(const Vector<Ref<ScrollTimeline>>& timelines, const Styleable& styleable, Style::ScopeOrdinal targetTimelineScopeOrdinal, const Element* timelineScopeElement)
 {
     // https://drafts.csswg.org/scroll-animations-1/#timeline-scoping
@@ -174,19 +161,47 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTimelineForElement(
     // If multiple elements have declared the same timeline name, the matching timeline is the one declared on the nearest element in tree order.
     // In case of a name conflict on the same element, names declared later in the naming property (scroll-timeline-name, view-timeline-name) take
     // precedence, and scroll progress timelines take precedence over view progress timelines.
-    Vector<Ref<ScrollTimeline>> matchedTimelines;
+    Ref targetElement { styleable.element };
+    if (!targetElement->isConnected())
+        return nullptr;
+
+    // While timeline names match globally, matching a timeline declared within the target's own
+    // hierarchy is the most common case. We split candidate timelines in two buckets such that calling
+    // determineTreeOrder() only considers the handful of timelines that can actually qualify, this way
+    // we only perform tree scope checks of the remaining timelines in the rare case where the
+    // target's hierarchy yields no match at all.
+    Vector<Ref<ScrollTimeline>> timelinesInTargetHierarchy;
+    Vector<Ref<ScrollTimeline>> timelinesOutsideTargetHierarchy;
     for (auto& timeline : timelines) {
         auto styleableForTimeline = originatingStyleableIncludingTimelineScope(timeline).styleable();
         if (!styleableForTimeline)
             continue;
-        Ref targetElement { styleable.element };
-        if (!timelineIsInScopeForTarget(timeline, targetElement.get(), targetTimelineScopeOrdinal))
-            continue;
-        matchedTimelines.append(timeline);
+        Ref elementForTimeline { styleableForTimeline->element };
+        if (elementForTimeline == targetElement || targetElement->isComposedTreeDescendantOf(elementForTimeline))
+            timelinesInTargetHierarchy.append(timeline);
+        else
+            timelinesOutsideTargetHierarchy.append(timeline);
     }
-    if (matchedTimelines.isEmpty())
-        return nullptr;
-    return determineTreeOrder(matchedTimelines, styleable, timelineScopeElement);
+
+    auto timelineIsNotInScopeForTarget = [&](auto& timeline) {
+        RefPtr timelineOriginatingElement { originatingElement(timeline).element() };
+        ASSERT(timelineOriginatingElement);
+        CheckedPtr scrollTimelineNameStyleScope = Style::Scope::forOrdinal(*timelineOriginatingElement, timeline->name().scopeOrdinal);
+        ASSERT(scrollTimelineNameStyleScope);
+        return !Style::resolveTreeScopedReference(targetElement, { timeline->name().name, targetTimelineScopeOrdinal }, [&](const Style::Scope& scope, const Style::ScopedName&) {
+            return scrollTimelineNameStyleScope == &scope;
+        });
+    };
+
+    timelinesInTargetHierarchy.removeAllMatching(timelineIsNotInScopeForTarget);
+    if (!timelinesInTargetHierarchy.isEmpty())
+        return determineTreeOrder(timelinesInTargetHierarchy, styleable, timelineScopeElement);
+
+    timelinesOutsideTargetHierarchy.removeAllMatching(timelineIsNotInScopeForTarget);
+    if (!timelinesOutsideTargetHierarchy.isEmpty())
+        return determineTreeOrder(timelinesOutsideTargetHierarchy, styleable, timelineScopeElement);
+
+    return nullptr;
 }
 
 Vector<Ref<ScrollTimeline>>& StyleOriginatedTimelinesController::timelinesForName(const AtomString& name)
@@ -242,7 +257,7 @@ void StyleOriginatedTimelinesController::registerNamedScrollTimeline(const Style
         newScrollTimeline->setSource(source);
         updateTimelineForTimelineScope(newScrollTimeline, scopedName.name);
         timelines.append(WTF::move(newScrollTimeline));
-        updateCSSAnimationsAssociatedWithNamedTimeline(scopedName.name);
+        m_timelineNamesPendingAnimationUpdate.add(scopedName.name);
     }
 }
 
@@ -278,6 +293,10 @@ void StyleOriginatedTimelinesController::removePendingOperationsForCSSAnimation(
 
 void StyleOriginatedTimelinesController::documentDidResolveStyle()
 {
+    auto timelineNamesPendingAnimationUpdate = std::exchange(m_timelineNamesPendingAnimationUpdate, { });
+    for (auto& name : timelineNamesPendingAnimationUpdate)
+        updateCSSAnimationsAssociatedWithNamedTimeline(name);
+
     auto cssAnimationsPendingAttachment = std::exchange(m_cssAnimationsPendingAttachment, { });
     for (auto& cssAnimationPendingAttachment : cssAnimationsPendingAttachment) {
         if (cssAnimationPendingAttachment->owningElement())
@@ -322,7 +341,7 @@ void StyleOriginatedTimelinesController::registerNamedViewTimeline(const Style::
     }
 
     if (!hasExistingTimeline)
-        updateCSSAnimationsAssociatedWithNamedTimeline(scopedName.name);
+        m_timelineNamesPendingAnimationUpdate.add(scopedName.name);
 }
 
 void StyleOriginatedTimelinesController::unregisterNamedTimeline(const AtomString& name, const Styleable& styleable)
@@ -361,7 +380,7 @@ void StyleOriginatedTimelinesController::unregisterNamedTimeline(const AtomStrin
     if (timelines.isEmpty())
         m_nameToTimelineMap.remove(it);
     else
-        updateCSSAnimationsAssociatedWithNamedTimeline(name);
+        m_timelineNamesPendingAnimationUpdate.add(name);
 }
 
 void StyleOriginatedTimelinesController::attachAnimation(CSSAnimation& animation)
@@ -456,6 +475,12 @@ void StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope(
 {
     LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope: " << scope << " styleable: " << styleable);
 
+    auto addTimelineScopeEntryIfNew = [&] {
+        TimelineScopeEntry timelineScopeEntry { scope, styleable };
+        if (!m_timelineScopeEntries.contains(timelineScopeEntry))
+            m_timelineScopeEntries.append(timelineScopeEntry);
+    };
+
     // https://drafts.csswg.org/scroll-animations-1/#timeline-scope
     // This property declares the scope of the specified timeline names to extend across this element’s subtree. This allows a named timeline
     // (such as a named scroll progress timeline or named view progress timeline) to be referenced by elements outside the timeline-defining element’s
@@ -472,7 +497,7 @@ void StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope(
                 namedTimelinesToUpdate.add(timeline.get());
             }
         }
-        m_timelineScopeEntries.removeAllMatching([&](const std::pair<Style::NameScope, WeakStyleable> entry) {
+        m_timelineScopeEntries.removeAllMatching([&](auto& entry) {
             return entry.second == styleable;
         });
         for (auto& timeline : namedTimelinesToUpdate) {
@@ -488,7 +513,7 @@ void StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope(
     case Style::NameScope::Type::All:
         for (auto& entry : m_nameToTimelineMap)
             updateTimelinesForTimelineScope(entry.value, styleable);
-        m_timelineScopeEntries.append(std::make_pair(scope, styleable));
+        addTimelineScopeEntryIfNew();
         break;
     case Style::NameScope::Type::Ident:
         for (auto& name : scope.names) {
@@ -496,7 +521,7 @@ void StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope(
             if (it != m_nameToTimelineMap.end())
                 updateTimelinesForTimelineScope(it->value, styleable);
         }
-        m_timelineScopeEntries.append(std::make_pair(scope, styleable));
+        addTimelineScopeEntryIfNew();
         break;
     }
 }
@@ -530,6 +555,10 @@ void StyleOriginatedTimelinesController::unregisterNamedTimelinesAssociatedWithE
 
 void StyleOriginatedTimelinesController::styleableWasRemoved(const Styleable& styleable)
 {
+    m_timelineScopeEntries.removeAllMatching([&](auto& entry) {
+        return entry.second == styleable;
+    });
+
     for (Ref timeline : m_removedTimelines) {
         if (originatingElement(timeline) != styleable)
             continue;

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.h
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.h
@@ -89,10 +89,12 @@ private:
     ScrollTimeline* determineTreeOrder(const Vector<Ref<ScrollTimeline>>&, const Styleable&, const Element*);
     ScrollTimeline& inactiveNamedTimeline(const AtomString&);
 
+    using TimelineScopeEntry = std::pair<Style::NameScope, WeakStyleable>;
     Vector<Ref<CSSAnimation>> m_cssAnimationsPendingAttachment;
-    Vector<std::pair<Style::NameScope, WeakStyleable>> m_timelineScopeEntries;
+    Vector<TimelineScopeEntry> m_timelineScopeEntries;
     HashMap<AtomString, Vector<Ref<ScrollTimeline>>> m_nameToTimelineMap;
     HashSet<Ref<ScrollTimeline>> m_removedTimelines;
+    HashSet<AtomString> m_timelineNamesPendingAnimationUpdate;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 3ef0f816b871dce775eb312f998f2de34fb4e4af
<pre>
[scroll-animations] Style resolution with scroll-timeline name blocks main thread for multiple seconds
<a href="https://bugs.webkit.org/show_bug.cgi?id=322283">https://bugs.webkit.org/show_bug.cgi?id=322283</a>
<a href="https://rdar.apple.com/186090970">rdar://186090970</a>

Reviewed by Anne van Kesteren.

When N elements have the same `scroll-timeline-name` and N animation targets use it as their
`animation-timeline`, the time taken to resolve style would grow cubically because we run three
nested linear passes under `StyleOriginatedTimelinesController::determineTimelineForElement()`:

1. each element declaring the name registers a timeline,
2. each registration re-syncs every animation already using that name, and
3. each of those re-syncs scans every timeline registered under that name.

To ensure that the time taken to resolve style in such cases is linear we:

1. no longer re-sync animations when registering or unregistering a named timeline, instead adding
them to a list of timelines to update in one pass under style resolution (in `documentDidResolveStyle()`)
the same way we already batch animation attachment requests.

2. partition timelines into those declared within the animation target&apos;s hierarchy and those outside,
processing timelines inside the target&apos;s hierarchy, the more common case, first and only timelines
matching globally as a backup.

As a result, the new performance test `Animation/scroll-timeline-shared-name.html` that used to run
on a MacBook Pro (M4 Max) for ~360ms now takes ~12ms.

This patch was created using LLM code assistance.

* PerformanceTests/Animation/scroll-timeline-shared-name.html: Added.
* PerformanceTests/Animation/scroll-timeline-unique-names.html: Added.
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::determineTimelineForElement):
(WebCore::StyleOriginatedTimelinesController::registerNamedScrollTimeline):
(WebCore::StyleOriginatedTimelinesController::documentDidResolveStyle):
(WebCore::StyleOriginatedTimelinesController::registerNamedViewTimeline):
(WebCore::StyleOriginatedTimelinesController::unregisterNamedTimeline):
(WebCore::StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope):
(WebCore::StyleOriginatedTimelinesController::styleableWasRemoved):
(WebCore::timelineIsInScopeForTarget): Deleted.
* Source/WebCore/animation/StyleOriginatedTimelinesController.h:

Canonical link: <a href="https://commits.webkit.org/320902@main">https://commits.webkit.org/320902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2c56dc009d9f1f2c0256be5bf2fc2ceca037aac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196353 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150664 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187924 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145387 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100783 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165929 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125707 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47800 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45791 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158154 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45516 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7424 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52503 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198331 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59618 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154948 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60327 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154588 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28274 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49032 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132628 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129733 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58773 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20503 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58163 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58395 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58221 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->