### PR TITLE
Cherry-pick 320824@main (361bf1bd5adf). https://bugs.webkit.org/show_bug.cgi?id=323720

### DIFF
--- a/LayoutTests/compositing/filters/repeated-filter-transitions-expected.txt
+++ b/LayoutTests/compositing/filters/repeated-filter-transitions-expected.txt
@@ -1,0 +1,1 @@
+PASS: Repeated filter transitions did not crash.

--- a/LayoutTests/compositing/filters/repeated-filter-transitions.html
+++ b/LayoutTests/compositing/filters/repeated-filter-transitions.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.target { transition: filter 0.1s; }
+.dim { filter: brightness(0.95); }
+</style>
+</head>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+async function runTest()
+{
+    const targets = Array.from({ length: 10 }, () => {
+        const target = document.createElement("div");
+        target.className = "target";
+        target.textContent = "hello";
+        document.body.appendChild(target);
+        return target;
+    });
+    document.body.offsetHeight;
+
+    for (let iteration = 0; iteration < 10; ++iteration) {
+        for (const dimmed of [true, false]) {
+            const finished = Promise.all(targets.map(target => new Promise(resolve => {
+                target.addEventListener("transitionend", resolve, { once: true });
+            })));
+            targets.forEach(target => target.classList.toggle("dim", dimmed));
+            await finished;
+        }
+    }
+
+    targets.forEach(target => target.remove());
+    document.body.append("PASS: Repeated filter transitions did not crash.");
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+runTest();
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
@@ -222,7 +222,7 @@ void ManetteGamepad::effectDelayTimerFired()
 
 void ManetteGamepad::startRumble(const GamepadEffectParameters& parameters)
 {
-#if LIBMANETTE_CHECK_VERSION(0, 2, 13)
+#if MANETTE_CHECK_VERSION(1, 0, 0)
     manette_device_rumble(m_device.get(), parameters.strongMagnitude, parameters.weakMagnitude, static_cast<guint>(parameters.duration));
 #else
     manette_device_rumble(m_device.get(), parameters.strongMagnitude * G_MAXUINT16, parameters.weakMagnitude * G_MAXUINT16, static_cast<guint>(parameters.duration));

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -1259,7 +1259,7 @@ void SkiaCompositingLayer::paintWithMaskAndBackdrop(SkCanvas& canvas, PaintConte
 void SkiaCompositingLayer::paintWithFilterAndMask(SkCanvas& canvas, PaintContext& context)
 {
     auto filter = this->filter();
-    if (!filter) {
+    if (!filter || !filter->filter) {
         paintSelfAndChildren(canvas, context);
         return;
     }

--- a/Source/WebKit/WPEPlatform/wpe/WPEGamepadManette.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGamepadManette.cpp
@@ -173,7 +173,7 @@ static gboolean wpeGamepadManetteHasRumble(WPEGamepad* gamepad)
 static gboolean wpeGamepadManetteRumble(WPEGamepad* gamepad, gdouble strongMagnitude, gdouble weakMagnitude, guint durationMs)
 {
     auto* priv = WPE_GAMEPAD_MANETTE(gamepad)->priv;
-#if LIBMANETTE_CHECK_VERSION(0, 2, 13)
+#if MANETTE_CHECK_VERSION(1, 0, 0)
     return manette_device_rumble(priv->device.get(), strongMagnitude, weakMagnitude, durationMs);
 #else
     return manette_device_rumble(priv->device.get(), strongMagnitude * G_MAXUINT16, weakMagnitude * G_MAXUINT16, durationMs);

--- a/Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py
@@ -20,10 +20,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import asyncio
 import contextlib
 import errno
 import os
+import selectors
 import shutil
+import signal
 import sys
 import tempfile
 
@@ -107,7 +110,7 @@ class SubtestResultRecorder(object):
             self.record_skip(report)
 
     def _was_timeout(self, report):
-        return hasattr(report.longrepr, 'reprcrash') and report.longrepr.reprcrash.message.startswith('Failed: Timeout >')
+        return hasattr(report.longrepr, 'reprcrash') and report.longrepr.reprcrash.message.startswith('Failed: Timeout')
 
     def record_pass(self, report):
         expected = dict(report.user_properties).get("expectations", [])
@@ -179,6 +182,46 @@ class TestExpectationsMarker(object):
             item.user_properties.append(("expectations", expected))
 
 
+class TimeoutSignalHandler(object):
+    """Keep pytest-timeout's SIGALRM from firing inside asyncio's scheduler.
+
+    pytest-timeout raises from the signal handler wherever the alarm lands. Inside the
+    event loop's own scheduling code (e.g. while Future.set_result() is queueing the
+    wake-up of the awaiting task) that leaves the future done but the task never resumed,
+    and the loop runs forever. Defer the alarm until the loop is idle in the selector, from
+    where the exception propagates cleanly out of run_until_complete().
+    """
+
+    RETRY_INTERVAL = 0.005
+
+    @pytest.hookimpl(wrapper=True)
+    def pytest_timeout_set_timer(self, item, settings):
+        result = yield
+        if settings.method != 'signal':
+            return result
+        handler = signal.getsignal(signal.SIGALRM)
+        if callable(handler):
+            def deferring_handler(signum, frame):
+                __tracebackhide__ = True
+                if self._should_defer_timeout(frame):
+                    signal.setitimer(signal.ITIMER_REAL, self.RETRY_INTERVAL)
+                else:
+                    handler(signum, frame)
+            signal.signal(signal.SIGALRM, deferring_handler)
+        return result
+
+    @staticmethod
+    def _should_defer_timeout(frame):
+        # Raising timeout exceptions while the loop is running outside selector wait might
+        # corrupt internal state updates, leaving tasks hanging.
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return False
+        code = frame.f_code
+        return not (code.co_filename == selectors.__file__ and code.co_name == 'select')
+
+
 def collect(directory, args, ignore_param=None):
     collect_recorder = CollectRecorder(ignore_param)
     with open(os.devnull, 'w') as f:
@@ -210,7 +253,7 @@ def run(path, args, timeout, env, expectations, ignore_param=None):
                    '-p', 'no:cacheprovider']
             cmd.extend(args)
             cmd.append(path)
-            result = pytest.main(cmd, plugins=[harness_recorder, subtests_recorder, expectations_marker])
+            result = pytest.main(cmd, plugins=[harness_recorder, subtests_recorder, expectations_marker, TimeoutSignalHandler()])
 
             if result == ExitCode.INTERNAL_ERROR:
                 harness_recorder.outcome = ('ERROR', None)


### PR DESCRIPTION
#### 70bcd8b658c3a6bd99fbb411e9ec4ab4e0a73dd2
<pre>
Cherry-pick 320824@main (361bf1bd5adf). <a href="https://bugs.webkit.org/show_bug.cgi?id=323720">https://bugs.webkit.org/show_bug.cgi?id=323720</a>

    [WPE] SkiaCompositingLayer: SIGSEGV in isColorFilterNode
    <a href="https://bugs.webkit.org/show_bug.cgi?id=323720">https://bugs.webkit.org/show_bug.cgi?id=323720</a>

    Reviewed by Carlos Garcia Campos.

    Add a check for the underlying `sk_sp&lt;SkImageFilter&gt;` before using it.

    * Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
    (WebCore::SkiaCompositingLayer::paintWithFilterAndMask):

    * LayoutTests/compositing/filters/repeated-filter-transitions.html: Added.
    * LayoutTests/compositing/filters/repeated-filter-transitions-expected.txt: Added.

    Canonical link: <a href="https://commits.webkit.org/320824@main">https://commits.webkit.org/320824@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.260@webkitglib/2.54">https://commits.webkit.org/317695.260@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 1dcc8a1448b96429478363ad0dc6929d6dc76511
<pre>
Cherry-pick 320815@main (92641830324a). <a href="https://bugs.webkit.org/show_bug.cgi?id=322171">https://bugs.webkit.org/show_bug.cgi?id=322171</a>

    [WebDriver] pytest-timeout&apos;s SIGALRM can wedge the asyncio loop and hang the run
    <a href="https://bugs.webkit.org/show_bug.cgi?id=322171">https://bugs.webkit.org/show_bug.cgi?id=322171</a>

    Reviewed by Carlos Alberto Lopez Perez.

    pytest-timeout raises from its SIGALRM handler wherever the alarm lands. When
    that is inside asyncio&apos;s scheduler, for instance while Future.set_result() is
    queueing the wake-up of the task awaiting it, the future is marked done but the
    wake-up is never scheduled. asyncio swallows the exception as &quot;Exception in
    callback&quot;, the test task is parked for good, and the loop keeps servicing the
    websockets keepalive until someone kills the bot. Every run of the BiDi tests
    expected to time out goes through this path.

    Wrap the handler pytest-timeout installs so that, while an event loop is
    running, the alarm is only delivered from the selector the idle loop is blocked
    in, where the exception propagates cleanly out of run_until_complete(). Anywhere
    else inside the loop it is re-armed a few milliseconds later instead.

    Also match the timeout message pytest-timeout 2.4.0 produces, which has been
    making unexpected timeouts show up as failures since the bump.

    * Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py:
    (SubtestResultRecorder._was_timeout):
    (TimeoutSignalHandler):
    (TimeoutSignalHandler.pytest_timeout_set_timer):
    (TimeoutSignalHandler._should_defer_timeout):
    (run):

    Canonical link: <a href="https://commits.webkit.org/320815@main">https://commits.webkit.org/320815@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.259@webkitglib/2.54">https://commits.webkit.org/317695.259@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 6d153629a66a4852cca65326a148c7a0303ea6f4
<pre>
Cherry-pick 320820@main (9f1b3cc75649). <a href="https://bugs.webkit.org/show_bug.cgi?id=323663">https://bugs.webkit.org/show_bug.cgi?id=323663</a>

    [WPE][GTK] rumble does not work in case of libmanette 0.2.13
    <a href="https://bugs.webkit.org/show_bug.cgi?id=323663">https://bugs.webkit.org/show_bug.cgi?id=323663</a>

    Reviewed by Carlos Garcia Campos.

    Macros from libmanette: LIBMANETTE_CHECK_VERSION(deprecated) and
    MANETTE_CHECK_VERSION evaluate to TRUE in case of greater than or
    equal to. This caused that in case of version 0.2.13 wrong values
    were passed to manette_device_rumble (normalized floating-point
    rumble magnitudes) and it was rounded to 0 (guint16).

    The normalized floating-point rumble magnitudes are demanded in
    case of libmanette version &gt;= 1.0.0.

    Also deprecated macro is replaced with the new one.

    No new tests.
    * Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp:
    (WebCore::ManetteGamepad::startRumble):
    * Source/WebKit/WPEPlatform/wpe/WPEGamepadManette.cpp:
    (wpeGamepadManetteRumble):

    Canonical link: <a href="https://commits.webkit.org/320820@main">https://commits.webkit.org/320820@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.258@webkitglib/2.54">https://commits.webkit.org/317695.258@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54bba24350c2d02dc89e517a7eba90f2d1d483ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186053 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59951 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53740 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196344 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150657 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187915 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/61324 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59671 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145380 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150657 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189008 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/61324 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53740 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125699 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/185382 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/61324 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59671 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53740 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/61324 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53740 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7415 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52496 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59671 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198322 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59609 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53740 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154941 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/60318 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53740 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154581 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28247 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/60318 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132621 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129724 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58764 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53740 "The change is no longer eligible for processing.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58154 "Build is in progress. Recent messages:") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58386 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/58212 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->