### PR TITLE
Avoid mixing GraphicsContext state setting and CG draws in FontCascade::drawGlyphs

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -170,6 +170,10 @@ public:
     // to the platform context's state.
     virtual void didUpdateState(GraphicsContextState&) = 0;
 
+    void didInvalidatePlatformState(GraphicsContextState::ChangeFlags properties) { m_state.markChanged(properties); }
+
+    void updatePlatformContextState() { didUpdateState(m_state); }
+
     WEBCORE_EXPORT virtual void save(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore);
     WEBCORE_EXPORT virtual void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore);
 

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -87,6 +87,8 @@ public:
     ChangeFlags changes() const { return m_changeFlags; }
     void didApplyChanges() { m_changeFlags = { }; }
 
+    void markChanged(ChangeFlags properties) { m_changeFlags.add(properties); }
+
     // The mask travels with save() and restore(), matching what the other context does to its own
     // state: a property established inside a save block is unknown again after the restore.
     ChangeFlags indeterminateProperties() const { return m_indeterminateProperties; }

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -23,6 +23,7 @@
 #include "config.h"
 #include "FontCascade.h"
 
+#include "Color.h"
 #include "ComplexTextController.h"
 #include "DashArray.h"
 #include "Font.h"
@@ -308,20 +309,6 @@ private:
 };
 }
 
-static void setCGFontRenderingMode(GraphicsContext& context)
-{
-    RetainPtr<CGContextRef> cgContext = context.platformContext();
-    CGContextSetShouldAntialiasFonts(cgContext.get(), true);
-
-    CGAffineTransform contextTransform = CGContextGetCTM(cgContext.get());
-    bool isTranslationOrIntegralScale = WTF::isIntegral(contextTransform.a) && WTF::isIntegral(contextTransform.d) && contextTransform.b == 0.f && contextTransform.c == 0.f;
-    bool isRotated = ((contextTransform.b || contextTransform.c) && (contextTransform.a || contextTransform.d));
-    bool doSubpixelQuantization = isTranslationOrIntegralScale || (!isRotated && context.shouldSubpixelQuantizeFonts());
-
-    CGContextSetShouldSubpixelPositionFonts(cgContext.get(), true);
-    CGContextSetShouldSubpixelQuantizeFonts(cgContext.get(), doSubpixelQuantization);
-}
-
 void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, std::span<const GlyphBufferGlyph> glyphs, std::span<const GlyphBufferAdvance> advances, const FloatPoint& anchorPoint, FontSmoothingMode smoothingMode)
 {
     const auto& platformData = font.platformData();
@@ -333,49 +320,15 @@ void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, std::sp
         return;
     }
 
-    RetainPtr<CGContextRef> cgContext = context.platformContext();
-
     if (!font.allowsAntialiasing())
         smoothingMode = FontSmoothingMode::None;
 
-    bool shouldAntialias = true;
-    bool shouldSmoothFonts = true;
-
-    switch (smoothingMode) {
-    case FontSmoothingMode::Antialiased:
-        shouldSmoothFonts = false;
-        break;
-    case FontSmoothingMode::Auto:
-    case FontSmoothingMode::SubpixelAntialiased:
-        break;
-    case FontSmoothingMode::None:
-        shouldAntialias = false;
-        shouldSmoothFonts = false;
-        break;
-    }
-
-#if PLATFORM(IOS_FAMILY)
-    UNUSED_VARIABLE(shouldSmoothFonts);
-#else
-    bool originalShouldUseFontSmoothing = CGContextGetShouldSmoothFonts(cgContext.get());
-    if (shouldSmoothFonts != originalShouldUseFontSmoothing)
-        CGContextSetShouldSmoothFonts(cgContext.get(), shouldSmoothFonts);
-#endif
-
-    bool originalShouldAntialias = CGContextGetShouldAntialias(cgContext.get());
-    if (shouldAntialias != originalShouldAntialias)
-        CGContextSetShouldAntialias(cgContext.get(), shouldAntialias);
-
-    FloatPoint point = anchorPoint;
-
     auto textMatrix = computeTextMatrix(font);
-    CGContextSetTextMatrix(cgContext.get(), textMatrix);
-    setCGFontRenderingMode(context);
-    CGContextSetFontSize(cgContext.get(), platformData.size());
-
     auto shadow = context.dropShadow();
-
+    bool shouldSubpixelQuantizeFonts = context.shouldSubpixelQuantizeFonts();
+    bool shadowsIgnoreTransforms = context.shadowsIgnoreTransforms();
     AffineTransform contextCTM = context.getCTM();
+
     float syntheticBoldOffset = font.syntheticBoldOffset();
     if (syntheticBoldOffset && !contextCTM.isIdentityOrTranslationOrFlipped()) {
         FloatSize horizontalUnitSizeInDevicePixels = contextCTM.mapSize(FloatSize(1, 0));
@@ -386,40 +339,56 @@ void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, std::sp
         }
     }
 
-    bool hasSimpleShadow = context.textDrawingMode() == TextDrawingMode::Fill && shadow && shadow->color.isValid() && !shadow->radius && !platformData.isColorBitmapFont() && (!context.shadowsIgnoreTransforms() || contextCTM.isIdentityOrTranslationOrFlipped()) && !context.isInTransparencyLayer();
+    bool hasSimpleShadow = context.textDrawingMode() == TextDrawingMode::Fill && shadow && shadow->color.isValid() && !shadow->radius && !platformData.isColorBitmapFont() && (!shadowsIgnoreTransforms || contextCTM.isIdentityOrTranslationOrFlipped()) && !context.isInTransparencyLayer();
+
+    RetainPtr<CGContextRef> cgContext = context.platformContext();
+
+#if !PLATFORM(IOS_FAMILY)
+    bool shouldSmoothFonts = smoothingMode != FontSmoothingMode::Antialiased && smoothingMode != FontSmoothingMode::None;
+    if (shouldSmoothFonts != context.shouldSmoothFonts()) {
+        context.didInvalidatePlatformState(GraphicsContextState::Change::ShouldSmoothFonts);
+        CGContextSetShouldSmoothFonts(cgContext.get(), shouldSmoothFonts);
+    }
+#endif
+
+    bool shouldAntialias = smoothingMode != FontSmoothingMode::None;
+    if (shouldAntialias != context.shouldAntialias()) {
+        context.didInvalidatePlatformState(GraphicsContextState::Change::ShouldAntialias);
+        CGContextSetShouldAntialias(cgContext.get(), shouldAntialias);
+    }
+
+    CGContextSetTextMatrix(cgContext.get(), textMatrix);
+    CGContextSetFontSize(cgContext.get(), platformData.size());
+    CGContextSetShouldAntialiasFonts(cgContext.get(), true);
+    CGContextSetShouldSubpixelPositionFonts(cgContext.get(), true);
+
+    CGAffineTransform contextTransform = CGContextGetCTM(cgContext.get());
+    bool isTranslationOrIntegralScale = WTF::isIntegral(contextTransform.a) && WTF::isIntegral(contextTransform.d) && contextTransform.b == 0.f && contextTransform.c == 0.f;
+    bool isRotated = ((contextTransform.b || contextTransform.c) && (contextTransform.a || contextTransform.d));
+    CGContextSetShouldSubpixelQuantizeFonts(cgContext.get(), isTranslationOrIntegralScale || (!isRotated && shouldSubpixelQuantizeFonts));
 
     RepeatedDrawGlyphs repeatedDrawGlyphs { font, glyphs, advances, textMatrix };
 
     if (hasSimpleShadow) {
         // Paint simple shadows ourselves instead of relying on CG shadows, to avoid losing subpixel antialiasing.
-        context.clearDropShadow();
-        Color fillColor = context.fillColor();
-        Color shadowFillColor = shadow->color.colorWithAlphaMultipliedBy(fillColor.alphaAsFloat());
-        context.setFillColor(shadowFillColor);
-        auto shadowTextOffset = point + context.platformShadowOffset(shadow->offset);
+        context.didInvalidatePlatformState(GraphicsContextState::Change::DropShadow);
+        auto shadowTextOffset = anchorPoint + context.platformShadowOffset(shadow->offset);
+        RetainPtr shadowFillCGColor = cachedCGColorInDestinationStandardRange(shadow->color.colorWithAlphaMultipliedBy(context.fillColor().alphaAsFloat()), context.colorSpace());
+        RetainPtr originalFillColor = CGContextGetFillColorAsColor(cgContext.get());
+        CGContextSetStyle(cgContext.get(), nullptr);
+        CGContextSetFillColorWithColor(cgContext.get(), shadowFillCGColor.get());
         repeatedDrawGlyphs.showGlyphsWithAdvances(shadowTextOffset, cgContext.get());
-        if (syntheticBoldOffset) {
-            shadowTextOffset.move(syntheticBoldOffset, 0);
-            repeatedDrawGlyphs.showGlyphsWithAdvances(shadowTextOffset, cgContext.get());
-        }
-        context.setFillColor(fillColor);
+        if (syntheticBoldOffset)
+            repeatedDrawGlyphs.showGlyphsWithAdvances(shadowTextOffset + FloatSize(syntheticBoldOffset, 0), cgContext.get());
+        CGContextSetFillColorWithColor(cgContext.get(), originalFillColor.get());
     }
 
-    repeatedDrawGlyphs.showGlyphsWithAdvances(point, cgContext.get());
+    repeatedDrawGlyphs.showGlyphsWithAdvances(anchorPoint, cgContext.get());
 
     if (syntheticBoldOffset)
-        repeatedDrawGlyphs.showGlyphsWithAdvances(FloatPoint(point.x() + syntheticBoldOffset, point.y()), cgContext.get());
+        repeatedDrawGlyphs.showGlyphsWithAdvances(anchorPoint + FloatSize(syntheticBoldOffset, 0), cgContext.get());
 
-    if (hasSimpleShadow)
-        context.setDropShadow(*shadow);
-
-#if !PLATFORM(IOS_FAMILY)
-    if (shouldSmoothFonts != originalShouldUseFontSmoothing)
-        CGContextSetShouldSmoothFonts(cgContext.get(), originalShouldUseFontSmoothing);
-#endif
-
-    if (shouldAntialias != originalShouldAntialias)
-        CGContextSetShouldAntialias(cgContext.get(), originalShouldAntialias);
+    context.updatePlatformContextState();
 }
 
 bool FontCascade::primaryFontIsSystemFont() const


### PR DESCRIPTION
#### fce07f2707722d00809fa59386ad889268f8fbca
<pre>
Avoid mixing GraphicsContext state setting and CG draws in FontCascade::drawGlyphs
<a href="https://bugs.webkit.org/show_bug.cgi?id=323872">https://bugs.webkit.org/show_bug.cgi?id=323872</a>
<a href="https://rdar.apple.com/187112779">rdar://187112779</a>

Reviewed by NOBODY (OOPS!).

Code would do:
  RetainPtr cgcontext = context.platformContext();
  context.setSomething();
  CT*Draw(cgcontext, ..);

This is not good, as it forces the assumption that setSomething()
directly modifies the same platform context obtained previously.
Reorganize the function to obtain the platform context and then change
the state only through consistent CG functions.

Add GraphicsContext::didInvalidatePlatformState() to inform that
the platform context needs to refresh the dirty properties.

* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::didInvalidatePlatformState):
(WebCore::GraphicsContext::updatePlatformContextState):
* Source/WebCore/platform/graphics/GraphicsContextState.h:
(WebCore::GraphicsContextState::markChanged):
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::FontCascade::drawGlyphs):
(WebCore::setCGFontRenderingMode): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fce07f2707722d00809fa59386ad889268f8fbca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196351 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150662 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/365bc119-a2c6-4163-8db0-fef01afc0ba3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145389 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100780 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7e9cf778-1721-432d-9af9-4d35f712b468) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49068 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165930 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125709 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ea3cb24d-418e-4292-abd1-c0bc4c106cbe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47801 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45789 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45517 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7422 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198329 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59616 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154955 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60325 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154585 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49029 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132626 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129731 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58771 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20504 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58161 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58393 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58219 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->