### PR TITLE
[WPE] Remove duplicate headings in the new API documentation

### DIFF
--- a/Source/WebKit/WPEPlatform/docs/compiling.md
+++ b/Source/WebKit/WPEPlatform/docs/compiling.md
@@ -1,8 +1,6 @@
 Title: Compiling against WPEPlatform
 Slug: compiling
 
-# Compiling against WPEPlatform
-
 This page lists the `pkg-config` modules and headers an application or
 browser needs to build against WPEPlatform, plus minimal
 [CMake](https://cmake.org) and [Meson](https://mesonbuild.com/)

--- a/Source/WebKit/WPEPlatform/docs/overview.md
+++ b/Source/WebKit/WPEPlatform/docs/overview.md
@@ -1,8 +1,6 @@
 Title: Overview
 Slug: overview
 
-# Overview
-
 WPEPlatform is a GObject library that abstracts the platform layer for
 WPE WebKit. It is the successor to [libwpe](https://github.com/WebKit/libwpe)
 and the various out-of-tree backends written against it (notably

--- a/Source/WebKit/WPEPlatform/docs/tutorial-browser.md
+++ b/Source/WebKit/WPEPlatform/docs/tutorial-browser.md
@@ -1,8 +1,6 @@
 Title: How to Use WPE Platform to Create a WPE WebKit Browser
 Slug: tutorial-browser
 
-# How to Use WPE Platform to Create a WPE WebKit Browser
-
 This tutorial walks through writing the smallest useful WPE WebKit
 browser: a single window that loads a URL and runs a GLib main loop.
 It is aimed at application developers who are starting a new project

--- a/Source/WebKit/WPEPlatform/docs/tutorial-platform.md
+++ b/Source/WebKit/WPEPlatform/docs/tutorial-platform.md
@@ -1,8 +1,6 @@
 Title: Writing a WPE platform implementation
 Slug: tutorial-platform
 
-# Writing a WPE platform implementation
-
 WPE WebKit renders web content, but it does not talk to the underlying
 platform on its own. That job belongs to a *platform implementation*: a
 small set of GObject subclasses that connect WebKit to a display


### PR DESCRIPTION
#### c815e1d4f3748ae213a7f5bd4b9190015d2c5d35
<pre>
[WPE] Remove duplicate headings in the new API documentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=323875">https://bugs.webkit.org/show_bug.cgi?id=323875</a>

Reviewed by Adrian Perez de Castro.

These headings are redundant with the page names and render as a double
title. Remove.

* Source/WebKit/WPEPlatform/docs/compiling.md:
* Source/WebKit/WPEPlatform/docs/overview.md:
* Source/WebKit/WPEPlatform/docs/tutorial-browser.md:
* Source/WebKit/WPEPlatform/docs/tutorial-platform.md:

Canonical link: <a href="https://commits.webkit.org/320827@main">https://commits.webkit.org/320827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b30e2973ebd8123f6a65fe3f3290d5be51fc3de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196346 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59673 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145381 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49061 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125700 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47794 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158148 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45510 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7417 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198324 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59611 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154942 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60320 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154582 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28245 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/49031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129726 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58766 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58156 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58388 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->