### PR TITLE
Cherry-pick 320815@main (92641830324a). https://bugs.webkit.org/show_bug.cgi?id=322171

### DIFF
--- a/Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py
@@ -20,10 +20,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import asyncio
 import contextlib
 import errno
 import os
+import selectors
 import shutil
+import signal
 import sys
 import tempfile
 
@@ -107,7 +110,7 @@ class SubtestResultRecorder(object):
             self.record_skip(report)
 
     def _was_timeout(self, report):
-        return hasattr(report.longrepr, 'reprcrash') and report.longrepr.reprcrash.message.startswith('Failed: Timeout >')
+        return hasattr(report.longrepr, 'reprcrash') and report.longrepr.reprcrash.message.startswith('Failed: Timeout')
 
     def record_pass(self, report):
         if hasattr(report, 'wasxfail'):
@@ -169,6 +172,46 @@ class TestExpectationsMarker(object):
                 item.add_marker(pytest.mark.skip)
 
 
+class TimeoutSignalHandler(object):
+    """Keep pytest-timeout's SIGALRM from firing inside asyncio's scheduler.
+
+    pytest-timeout raises from the signal handler wherever the alarm lands. Inside the
+    event loop's own scheduling code (e.g. while Future.set_result() is queueing the
+    wake-up of the awaiting task) that leaves the future done but the task never resumed,
+    and the loop runs forever. Defer the alarm until the loop is idle in the selector, from
+    where the exception propagates cleanly out of run_until_complete().
+    """
+
+    RETRY_INTERVAL = 0.005
+
+    @pytest.hookimpl(wrapper=True)
+    def pytest_timeout_set_timer(self, item, settings):
+        result = yield
+        if settings.method != 'signal':
+            return result
+        handler = signal.getsignal(signal.SIGALRM)
+        if callable(handler):
+            def deferring_handler(signum, frame):
+                __tracebackhide__ = True
+                if self._should_defer_timeout(frame):
+                    signal.setitimer(signal.ITIMER_REAL, self.RETRY_INTERVAL)
+                else:
+                    handler(signum, frame)
+            signal.signal(signal.SIGALRM, deferring_handler)
+        return result
+
+    @staticmethod
+    def _should_defer_timeout(frame):
+        # Raising timeout exceptions while the loop is running outside selector wait might
+        # corrupt internal state updates, leaving tasks hanging.
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return False
+        code = frame.f_code
+        return not (code.co_filename == selectors.__file__ and code.co_name == 'select')
+
+
 def collect(directory, args, ignore_param=None):
     collect_recorder = CollectRecorder(ignore_param)
     with open(os.devnull, 'w') as f:
@@ -200,7 +243,7 @@ def run(path, args, timeout, env, expectations, ignore_param=None):
                    '-p', 'no:cacheprovider']
             cmd.extend(args)
             cmd.append(path)
-            result = pytest.main(cmd, plugins=[harness_recorder, subtests_recorder, expectations_marker])
+            result = pytest.main(cmd, plugins=[harness_recorder, subtests_recorder, expectations_marker, TimeoutSignalHandler()])
 
             if result == ExitCode.INTERNAL_ERROR:
                 harness_recorder.outcome = ('ERROR', None)


### PR DESCRIPTION
#### 9106ada8d005040e244d31c03fa386ba2ba4a2df
<pre>
Cherry-pick 320815@main (92641830324a). <a href="https://bugs.webkit.org/show_bug.cgi?id=322171">https://bugs.webkit.org/show_bug.cgi?id=322171</a>

    [WebDriver] pytest-timeout&apos;s SIGALRM can wedge the asyncio loop and hang the run
    <a href="https://bugs.webkit.org/show_bug.cgi?id=322171">https://bugs.webkit.org/show_bug.cgi?id=322171</a>

    Reviewed by Carlos Alberto Lopez Perez.

    pytest-timeout raises from its SIGALRM handler wherever the alarm lands. When
    that is inside asyncio&apos;s scheduler, for instance while Future.set_result() is
    queueing the wake-up of the task awaiting it, the future is marked done but the
    wake-up is never scheduled. asyncio swallows the exception as &quot;Exception in
    callback&quot;, the test task is parked for good, and the loop keeps servicing the
    websockets keepalive until someone kills the bot. Every run of the BiDi tests
    expected to time out goes through this path.

    Wrap the handler pytest-timeout installs so that, while an event loop is
    running, the alarm is only delivered from the selector the idle loop is blocked
    in, where the exception propagates cleanly out of run_until_complete(). Anywhere
    else inside the loop it is re-armed a few milliseconds later instead.

    Also match the timeout message pytest-timeout 2.4.0 produces, which has been
    making unexpected timeouts show up as failures since the bump.

    * Tools/Scripts/webkitpy/webdriver_tests/pytest_runner.py:
    (SubtestResultRecorder._was_timeout):
    (TimeoutSignalHandler):
    (TimeoutSignalHandler.pytest_timeout_set_timer):
    (TimeoutSignalHandler._should_defer_timeout):
    (run):

    Canonical link: <a href="https://commits.webkit.org/320815@main">https://commits.webkit.org/320815@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.1176@webkitglib/2.52">https://commits.webkit.org/305877.1176@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/faaff9fa55c4592f37154eed9cce61d944ce5061

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186057 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59955 "Build is in progress. Recent messages:") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53744 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196348 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150659 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187919 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/61328 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59675 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145383 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150659 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189012 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/61328 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53744 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125703 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/185386 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/61328 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59675 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53744 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/61328 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53744 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7419 "Built successfully") | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59675 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198326 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59613 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53744 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154946 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/60322 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53744 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154586 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28246 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/60322 "The change is no longer eligible for processing.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129728 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58768 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53744 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/58158 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58390 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/58216 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->