### PR TITLE
[Site Isolation] Make FrameTreeSyncClient and DocumentSyncClient methods take movable types

### DIFF
--- a/Source/WebCore/Scripts/generate-process-sync-data.py
+++ b/Source/WebCore/Scripts/generate-process-sync-data.py
@@ -138,7 +138,7 @@ public:
 
 _process_sync_client_header_suffix = """
 protected:
-    virtual void broadcast{prefix}SyncDataToOtherProcesses(const {prefix}SyncSerializationData&) {{ }}
+    virtual void broadcast{prefix}SyncDataToOtherProcesses({prefix}SyncSerializationData&&) {{ }}
 }};
 
 }} // namespace WebCore
@@ -161,6 +161,7 @@ def generate_process_sync_client_header(prefix, synched_datas):
         if data.conditional is not None:
             result.append('#if %s' % data.conditional)
         result.append('    WEBCORE_EXPORT void broadcast%sToOtherProcesses(const %s&);' % (data.name, data.fully_qualified_type))
+        result.append('    WEBCORE_EXPORT void broadcast%sToOtherProcesses(%s&&);' % (data.name, data.fully_qualified_type))
         if data.conditional is not None:
             result.append('#endif')
 
@@ -174,6 +175,7 @@ _process_sync_client_impl_prefix = """
 
 #include "{prefix}SyncData.h"
 #include <wtf/EnumTraits.h>
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {{
 """
@@ -192,8 +194,14 @@ def generate_process_sync_client_impl(prefix, synched_datas):
         result.append('    broadcast%sSyncDataToOtherProcesses({ %sSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(%sSyncDataType::%s)>, data } });' % (prefix, prefix, prefix, data.name))
 
         result.append('}')
+        result.append('')
+        result.append('void %sSyncClient::broadcast%sToOtherProcesses(%s&& data)' % (prefix, data.name, data.fully_qualified_type))
+        result.append('{')
+        result.append('    broadcast%sSyncDataToOtherProcesses({ %sSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(%sSyncDataType::%s)>, WTF::move(data) } });' % (prefix, prefix, prefix, data.name))
+        result.append('}')
         if data.conditional is not None:
             result.append('#endif')
+        result.append('')
 
     result.append('\n} // namespace WebCore\n')
     return '\n'.join(result)

--- a/Source/WebCore/Scripts/tests/TestSyncClient.cpp
+++ b/Source/WebCore/Scripts/tests/TestSyncClient.cpp
@@ -28,6 +28,7 @@
 
 #include "TestSyncData.h"
 #include <wtf/EnumTraits.h>
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
@@ -36,26 +37,62 @@ void TestSyncClient::broadcastAudioSessionTypeToOtherProcesses(const WebCore::DO
 {
     broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::AudioSessionType)>, data } });
 }
+
+void TestSyncClient::broadcastAudioSessionTypeToOtherProcesses(WebCore::DOMAudioSessionType&& data)
+{
+    broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::AudioSessionType)>, WTF::move(data) } });
+}
 #endif
+
 void TestSyncClient::broadcastMainFrameURLChangeToOtherProcesses(const URL& data)
 {
     broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::MainFrameURLChange)>, data } });
 }
+
+void TestSyncClient::broadcastMainFrameURLChangeToOtherProcesses(URL&& data)
+{
+    broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::MainFrameURLChange)>, WTF::move(data) } });
+}
+
 void TestSyncClient::broadcastIsAutofocusProcessedToOtherProcesses(const bool& data)
 {
     broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::IsAutofocusProcessed)>, data } });
 }
+
+void TestSyncClient::broadcastIsAutofocusProcessedToOtherProcesses(bool&& data)
+{
+    broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::IsAutofocusProcessed)>, WTF::move(data) } });
+}
+
 void TestSyncClient::broadcastUserDidInteractWithPageToOtherProcesses(const bool& data)
 {
     broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::UserDidInteractWithPage)>, data } });
 }
+
+void TestSyncClient::broadcastUserDidInteractWithPageToOtherProcesses(bool&& data)
+{
+    broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::UserDidInteractWithPage)>, WTF::move(data) } });
+}
+
 void TestSyncClient::broadcastAnotherOneToOtherProcesses(const StringifyThis& data)
 {
     broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::AnotherOne)>, data } });
 }
+
+void TestSyncClient::broadcastAnotherOneToOtherProcesses(StringifyThis&& data)
+{
+    broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::AnotherOne)>, WTF::move(data) } });
+}
+
 void TestSyncClient::broadcastMultipleHeadersToOtherProcesses(const HashSet<URL>& data)
 {
     broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::MultipleHeaders)>, data } });
 }
+
+void TestSyncClient::broadcastMultipleHeadersToOtherProcesses(HashSet<URL>&& data)
+{
+    broadcastTestSyncDataToOtherProcesses({ TestSyncDataVariant { WTF::InPlaceIndex<std::to_underlying(TestSyncDataType::MultipleHeaders)>, WTF::move(data) } });
+}
+
 
 } // namespace WebCore

--- a/Source/WebCore/Scripts/tests/TestSyncClient.h
+++ b/Source/WebCore/Scripts/tests/TestSyncClient.h
@@ -47,15 +47,21 @@ public:
 
 #if ENABLE(DOM_AUDIO_SESSION)
     WEBCORE_EXPORT void broadcastAudioSessionTypeToOtherProcesses(const WebCore::DOMAudioSessionType&);
+    WEBCORE_EXPORT void broadcastAudioSessionTypeToOtherProcesses(WebCore::DOMAudioSessionType&&);
 #endif
     WEBCORE_EXPORT void broadcastMainFrameURLChangeToOtherProcesses(const URL&);
+    WEBCORE_EXPORT void broadcastMainFrameURLChangeToOtherProcesses(URL&&);
     WEBCORE_EXPORT void broadcastIsAutofocusProcessedToOtherProcesses(const bool&);
+    WEBCORE_EXPORT void broadcastIsAutofocusProcessedToOtherProcesses(bool&&);
     WEBCORE_EXPORT void broadcastUserDidInteractWithPageToOtherProcesses(const bool&);
+    WEBCORE_EXPORT void broadcastUserDidInteractWithPageToOtherProcesses(bool&&);
     WEBCORE_EXPORT void broadcastAnotherOneToOtherProcesses(const StringifyThis&);
+    WEBCORE_EXPORT void broadcastAnotherOneToOtherProcesses(StringifyThis&&);
     WEBCORE_EXPORT void broadcastMultipleHeadersToOtherProcesses(const HashSet<URL>&);
+    WEBCORE_EXPORT void broadcastMultipleHeadersToOtherProcesses(HashSet<URL>&&);
 
 protected:
-    virtual void broadcastTestSyncDataToOtherProcesses(const TestSyncSerializationData&) { }
+    virtual void broadcastTestSyncDataToOtherProcesses(TestSyncSerializationData&&) { }
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -209,6 +209,8 @@ def types_that_must_be_moved():
         'HashMap<WebKit::ImageBufferSetIdentifier, std::unique_ptr<WebKit::BufferSetBackendHandle>>',
         'WebCore::DMABufBufferAttributes',
         'std::optional<WebCore::DMABufBufferAttributes>',
+        'WebCore::DocumentSyncSerializationData',
+        'WebCore::FrameTreeSyncSerializationData',
     ]
 
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9157,7 +9157,7 @@ void WebPageProxy::broadcastDocumentSyncData(IPC::Connection& connection, const 
     forEachWebContentProcess([&](auto& webProcess, auto pageID) {
         if (webProcess == process)
             return;
-        webProcess.send(Messages::WebPage::TopDocumentSyncDataChangedInAnotherProcess(data), pageID);
+        webProcess.send(Messages::WebPage::TopDocumentSyncDataChangedInAnotherProcess(WebCore::DocumentSyncSerializationData { data }), pageID);
     });
 }
 
@@ -9224,7 +9224,7 @@ void WebPageProxy::broadcastFrameTreeSyncData(IPC::Connection& connection, Frame
     forEachWebContentProcess([&](auto& webProcess, auto pageID) {
         if (webProcess == process)
             return;
-        webProcess.send(Messages::WebPage::FrameTreeSyncDataChangedInAnotherProcess(frameID, data), pageID);
+        webProcess.send(Messages::WebPage::FrameTreeSyncDataChangedInAnotherProcess(frameID, WebCore::FrameTreeSyncSerializationData { data }), pageID);
     });
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDocumentSyncClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDocumentSyncClient.cpp
@@ -50,10 +50,10 @@ bool WebDocumentSyncClient::siteIsolationEnabled()
     return corePage && corePage->settings().siteIsolationEnabled();
 }
 
-void WebDocumentSyncClient::broadcastDocumentSyncDataToOtherProcesses(const WebCore::DocumentSyncSerializationData& data)
+void WebDocumentSyncClient::broadcastDocumentSyncDataToOtherProcesses(WebCore::DocumentSyncSerializationData&& data)
 {
     ASSERT(siteIsolationEnabled());
-    protect(m_page)->send(Messages::WebPageProxy::BroadcastDocumentSyncData(data));
+    protect(m_page)->send(Messages::WebPageProxy::BroadcastDocumentSyncData(WTF::move(data)));
 }
 
 void WebDocumentSyncClient::broadcastAllDocumentSyncDataToOtherProcesses(WebCore::DocumentSyncData& data)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDocumentSyncClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDocumentSyncClient.h
@@ -42,7 +42,7 @@ public:
 private:
     bool siteIsolationEnabled();
 
-    void broadcastDocumentSyncDataToOtherProcesses(const WebCore::DocumentSyncSerializationData&) final;
+    void broadcastDocumentSyncDataToOtherProcesses(WebCore::DocumentSyncSerializationData&&) final;
     void broadcastAllDocumentSyncDataToOtherProcesses(WebCore::DocumentSyncData&) final;
 
     const WeakRef<WebPage> m_page;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -287,10 +287,10 @@ void WebFrameLoaderClient::broadcastAllFrameTreeSyncDataToOtherProcesses(FrameTr
         webPage->send(Messages::WebPageProxy::BroadcastAllFrameTreeSyncData(m_frame->frameID(), data));
 }
 
-void WebFrameLoaderClient::broadcastFrameTreeSyncDataToOtherProcesses(const FrameTreeSyncSerializationData& data)
+void WebFrameLoaderClient::broadcastFrameTreeSyncDataToOtherProcesses(FrameTreeSyncSerializationData&& data)
 {
     if (RefPtr webPage = m_frame->page())
-        webPage->send(Messages::WebPageProxy::BroadcastFrameTreeSyncData(m_frame->frameID(), data));
+        webPage->send(Messages::WebPageProxy::BroadcastFrameTreeSyncData(m_frame->frameID(), WTF::move(data)));
 }
 
 void WebFrameLoaderClient::didNotifyUserActivation(MonotonicTime activationTime)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
@@ -82,7 +82,7 @@ protected:
     void setPrinting(bool printing, WebCore::FloatSize pageSize, WebCore::FloatSize originalPageSize, float maximumShrinkRatio, WebCore::AdjustViewSize);
 
     void broadcastAllFrameTreeSyncDataToOtherProcesses(WebCore::FrameTreeSyncData&);
-    void broadcastFrameTreeSyncDataToOtherProcesses(const WebCore::FrameTreeSyncSerializationData&);
+    void broadcastFrameTreeSyncDataToOtherProcesses(WebCore::FrameTreeSyncSerializationData&&);
 
     void didNotifyUserActivation(MonotonicTime);
     void didConsumeUserActivation();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1125,9 +1125,9 @@ void WebLocalFrameLoaderClient::broadcastAllFrameTreeSyncDataToOtherProcesses(Fr
     WebFrameLoaderClient::broadcastAllFrameTreeSyncDataToOtherProcesses(data);
 }
 
-void WebLocalFrameLoaderClient::broadcastFrameTreeSyncDataToOtherProcesses(const FrameTreeSyncSerializationData& data)
+void WebLocalFrameLoaderClient::broadcastFrameTreeSyncDataToOtherProcesses(FrameTreeSyncSerializationData&& data)
 {
-    WebFrameLoaderClient::broadcastFrameTreeSyncDataToOtherProcesses(data);
+    WebFrameLoaderClient::broadcastFrameTreeSyncDataToOtherProcesses(WTF::move(data));
 }
 
 void WebLocalFrameLoaderClient::didNotifyUserActivation(MonotonicTime activationTime)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -292,7 +292,7 @@ private:
     bool NODELETE siteIsolationEnabled() const;
 
     void broadcastAllFrameTreeSyncDataToOtherProcesses(WebCore::FrameTreeSyncData&) final;
-    void broadcastFrameTreeSyncDataToOtherProcesses(const WebCore::FrameTreeSyncSerializationData&) final;
+    void broadcastFrameTreeSyncDataToOtherProcesses(WebCore::FrameTreeSyncSerializationData&&) final;
 
     void didNotifyUserActivation(MonotonicTime) final;
     void didConsumeUserActivation() final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -235,9 +235,9 @@ void WebRemoteFrameClient::broadcastAllFrameTreeSyncDataToOtherProcesses(FrameTr
     WebFrameLoaderClient::broadcastAllFrameTreeSyncDataToOtherProcesses(data);
 }
 
-void WebRemoteFrameClient::broadcastFrameTreeSyncDataToOtherProcesses(const FrameTreeSyncSerializationData& data)
+void WebRemoteFrameClient::broadcastFrameTreeSyncDataToOtherProcesses(FrameTreeSyncSerializationData&& data)
 {
-    WebFrameLoaderClient::broadcastFrameTreeSyncDataToOtherProcesses(data);
+    WebFrameLoaderClient::broadcastFrameTreeSyncDataToOtherProcesses(WTF::move(data));
 }
 
 void WebRemoteFrameClient::didNotifyUserActivation(MonotonicTime activationTime)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -72,7 +72,7 @@ private:
     void dispatchCrossOriginBeforeUnloadCheck(const WebCore::SecurityOriginData& navigatingFrameOrigin) final;
 
     void broadcastAllFrameTreeSyncDataToOtherProcesses(WebCore::FrameTreeSyncData&) final;
-    void broadcastFrameTreeSyncDataToOtherProcesses(const WebCore::FrameTreeSyncSerializationData&) final;
+    void broadcastFrameTreeSyncDataToOtherProcesses(WebCore::FrameTreeSyncSerializationData&&) final;
 
     void didNotifyUserActivation(MonotonicTime) final;
     void didConsumeUserActivation() final;


### PR DESCRIPTION
#### 693bc951a7a451aec2de43678b20145b376b7e5b
<pre>
[Site Isolation] Make FrameTreeSyncClient and DocumentSyncClient methods take movable types
<a href="https://bugs.webkit.org/show_bug.cgi?id=323878">https://bugs.webkit.org/show_bug.cgi?id=323878</a>
<a href="https://rdar.apple.com/187122873">rdar://187122873</a>

Reviewed by Alex Christensen.

This changes the sync clients to emit methods that take movable types. Some of the data we send via
the sync clients (like FrameGeometrySyncData) are relatively large and are sent at frame rate, so we
should avoid the extra copy.

* Source/WebCore/Scripts/generate-process-sync-data.py:
(generate_process_sync_client_header):
(generate_process_sync_client_impl):
* Source/WebCore/Scripts/tests/TestSyncClient.cpp:
(WebCore::TestSyncClient::broadcastAudioSessionTypeToOtherProcesses):
(WebCore::TestSyncClient::broadcastMainFrameURLChangeToOtherProcesses):
(WebCore::TestSyncClient::broadcastIsAutofocusProcessedToOtherProcesses):
(WebCore::TestSyncClient::broadcastUserDidInteractWithPageToOtherProcesses):
(WebCore::TestSyncClient::broadcastAnotherOneToOtherProcesses):
(WebCore::TestSyncClient::broadcastMultipleHeadersToOtherProcesses):
* Source/WebCore/Scripts/tests/TestSyncClient.h:
(WebCore::TestSyncClient::broadcastTestSyncDataToOtherProcesses):
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_must_be_moved):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::broadcastDocumentSyncData):
(WebKit::WebPageProxy::broadcastFrameTreeSyncData):
* Source/WebKit/WebProcess/WebCoreSupport/WebDocumentSyncClient.cpp:
(WebKit::WebDocumentSyncClient::broadcastDocumentSyncDataToOtherProcesses):
* Source/WebKit/WebProcess/WebCoreSupport/WebDocumentSyncClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::broadcastFrameTreeSyncDataToOtherProcesses):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::broadcastFrameTreeSyncDataToOtherProcesses):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::broadcastFrameTreeSyncDataToOtherProcesses):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h:

Canonical link: <a href="https://commits.webkit.org/320879@main">https://commits.webkit.org/320879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4078db418fea9ead375b20c6f9c00b115c93afc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59972 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196365 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150673 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187936 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145397 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100788 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125720 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/185403 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47809 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45799 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158163 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45524 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7436 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52511 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198343 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59630 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154961 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41530 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60339 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154599 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49041 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132636 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129748 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58785 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20511 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58174 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58407 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58233 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->