### PR TITLE
[JSC] Wasm debugger should resume breakpoints by dispatching the displaced opcode

### DIFF
--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -1550,6 +1550,35 @@ class WasmUnreachableFaultTestCase:
         )
 
 
+class BreakpointOnUnreachableTestCase:
+    test_file = "resources/wasm/unreachable.js"
+
+    def execute(self):
+        # A breakpoint on unreachable reports the breakpoint first, then the trap.
+        self.session.cmd("b 0x4000000000000024", patterns=["Breakpoint 1"])
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 1", "->  0x4000000000000024: unreachable"],
+        )
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "Unreachable code should not be executed"],
+        )
+
+
+class StepOffUnreachableTestCase:
+    test_file = "resources/wasm/unreachable.js"
+
+    def execute(self):
+        # Unreachable has no successor instruction, so a step off it lands on the trap.
+        self.session.cmd("b 0x4000000000000024", patterns=["Breakpoint 1"])
+        self.session.cmd(
+            "c",
+            patterns=["Process 1 stopped", "stop reason = breakpoint 1", "->  0x4000000000000024: unreachable"],
+        )
+        self.session.cmd("si", patterns=["Unreachable code should not be executed"])
+
+
 class WasmDivByZeroTrapTestCase:
     test_file = "resources/wasm/trap-div-by-zero.js"
 
@@ -1756,6 +1785,8 @@ ALL_TESTS = [
     WasmJsWasmJsWasmCallStackTestCase,
     SwiftWasmCrashTestCase,
     WasmUnreachableFaultTestCase,
+    BreakpointOnUnreachableTestCase,
+    StepOffUnreachableTestCase,
     WasmDivByZeroTrapTestCase,
     WasmOutOfBoundsCallIndirectTrapTestCase,
     WasmStackOverflowTrapTestCase,

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -1162,14 +1162,11 @@ end
 
 op(wasm_ipint_check_debugger_hook_and_throw_trap, macro ()
     handleDebuggerTrapIfNeeded()
-    # r0 == 0 i.e. DebuggerTrapStatus::ResolvedByDebugger i.e. this was purely a debugger trap / breakpoint,
-    #              and has been handled.  We should continue executing because it's not a Wasm trap.
-    # r0 == 1 i.e. DebuggerTrapStatus::NotResolvedByDebugger i.e. this was a fatal Wasm trap.  We should
-    #              throw it to terminate Wasm execution.
-    btpz r0, .continue
+    # r0 is the displaced opcode to resume with, or Unreachable (0) to throw.
+    btpz r0, .throwTrap
+    dispatchIPIntOpcode(r0)
+.throwTrap:
     jmp _wasm_throw_from_slow_path_trampoline
-.continue:
-    nextIPIntInstruction()
 end)
 
 op(wasm_throw_from_slow_path_trampoline, macro ()

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -64,21 +64,24 @@ end
 
 # Tail-call bytecode dispatch
 
-macro nextIPIntInstruction()
-    loadb [PC], t0
+macro dispatchIPIntOpcode(opcode)
 if ARM64 or ARM64E
-    # x0 = opcode
     pcrtoaddr ipint_dispatch_base, t7
-    addlshiftp t7, t0, (constexpr (WTF::fastLog2(JSC::IPInt::alignIPInt))), t0
+    addlshiftp t7, opcode, (constexpr (WTF::fastLog2(JSC::IPInt::alignIPInt))), t0
     jmp t0
 elsif X86_64
     pcrtoaddr ipint_dispatch_base, t1
-    lshiftq (constexpr (WTF::fastLog2(JSC::IPInt::alignIPInt))), t0
-    addq t1, t0
-    jmp t0
+    lshiftq (constexpr (WTF::fastLog2(JSC::IPInt::alignIPInt))), opcode
+    addq t1, opcode
+    jmp opcode
 else
     error
 end
+end
+
+macro nextIPIntInstruction()
+    loadb [PC], t0
+    dispatchIPIntOpcode(t0)
 end
 
 # Stack operations

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -1506,10 +1506,8 @@ static UNUSED_FUNCTION void displayWasmDebugState(JSWebAssemblyInstance* instanc
 
 WASM_IPINT_EXTERN_CPP_DECL(handle_debugger_trap_if_needed, CallFrame* callFrame, Register* sp)
 {
-    // By default, the trap is a fatal Wasm trap and must propagate (shouldThrow = true).
-    // If the debugger is connected and determines this was solely a debugger trap (e.g. a
-    // breakpoint on unreachable), it sets shouldThrow = false and execution resumes.
-    bool shouldThrow = true;
+    // Unreachable propagates the trap; otherwise resumes with the displaced opcode.
+    Wasm::OpType resumeOpcode = Wasm::OpType::Unreachable;
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
     if (Options::enableWasmDebugger()) [[unlikely]] {
         Wasm::DebugServer& debugServer = Wasm::DebugServer::singleton();
@@ -1521,8 +1519,7 @@ WASM_IPINT_EXTERN_CPP_DECL(handle_debugger_trap_if_needed, CallFrame* callFrame,
             auto exceptionType = static_cast<Wasm::ExceptionType>(callFrame->argumentCountIncludingThis());
             if (Options::verboseWasmDebugger() && exceptionType == Wasm::ExceptionType::Unreachable)
                 displayWasmDebugState(instance, callee, callFrame, stack);
-            auto trapStatus = debugServer.execution().handleDebuggerTrapIfNeeded(callFrame, instance, callee, pc, mc, stack, exceptionType);
-            shouldThrow = trapStatus == Wasm::DebuggerTrapStatus::NotResolvedByDebugger;
+            resumeOpcode = debugServer.execution().handleDebuggerTrapIfNeeded(callFrame, instance, callee, pc, mc, stack, exceptionType);
         }
     }
 #else
@@ -1530,7 +1527,7 @@ WASM_IPINT_EXTERN_CPP_DECL(handle_debugger_trap_if_needed, CallFrame* callFrame,
     UNUSED_PARAM(callFrame);
     UNUSED_PARAM(sp);
 #endif
-    IPINT_RETURN(static_cast<EncodedJSValue>(static_cast<int32_t>(shouldThrow)));
+    IPINT_RETURN(static_cast<EncodedJSValue>(static_cast<uint32_t>(resumeOpcode)));
 }
 
 } } // namespace JSC::IPInt

--- a/Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.cpp
@@ -44,58 +44,90 @@ BreakpointManager::~BreakpointManager()
     clearAllBreakpoints();
 }
 
-bool BreakpointManager::hasBreakpoints()
-{
-    Locker locker { m_lock };
-    return !m_breakpoints.isEmpty();
-}
-
 bool BreakpointManager::hasOneTimeBreakpoints()
 {
     Locker locker { m_lock };
     return !m_oneTimeBreakpoints.isEmpty();
 }
 
-void BreakpointManager::setBreakpoint(VirtualAddress address, Ref<Breakpoint>&& breakpoint)
+Breakpoint& BreakpointManager::ensurePatched(const ModuleInformation& owner, uint8_t* pc)
 {
-    Locker locker { m_lock };
+    RELEASE_ASSERT(pc);
+    if (auto it = m_breakpoints.find(pc); it != m_breakpoints.end()) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[BreakpointManager] Reusing the patch at ", RawPointer(pc));
+        return it->value;
+    }
+
+    Ref<Breakpoint> breakpoint = Breakpoint::create(owner, pc);
     breakpoint->patchBreakpoint();
-    dataLogLnIf(Options::verboseWasmDebugger(), "[BreakpointManager] setBreakpoint ", breakpoint, " at moduleAddress:", address);
-    if (breakpoint->isOneTimeBreakpoint())
-        m_oneTimeBreakpoints.add(address);
-    m_breakpoints.set(address, WTF::move(breakpoint));
+    dataLogLnIf(Options::verboseWasmDebugger(), "[BreakpointManager] Patched ", breakpoint);
+    return m_breakpoints.set(pc, WTF::move(breakpoint)).iterator->value;
 }
 
-RefPtr<Breakpoint> BreakpointManager::findBreakpoint(VirtualAddress address)
+void BreakpointManager::releasePatchIfUnused(uint8_t* pc)
 {
-    Locker locker { m_lock };
-    return m_breakpoints.get(address);
-}
-
-bool BreakpointManager::removeBreakpointImpl(VirtualAddress address)
-{
-    auto it = m_breakpoints.find(address);
+    auto it = m_breakpoints.find(pc);
     RELEASE_ASSERT(it != m_breakpoints.end());
-    dataLogLnIf(Options::verboseWasmDebugger(), "[BreakpointManager] Removing breakpoint ", it->value, " at ", address);
+    if (it->value->hasSite || m_oneTimeBreakpoints.contains(pc))
+        return;
+
+    dataLogLnIf(Options::verboseWasmDebugger(), "[BreakpointManager] Restoring ", it->value);
     it->value->restorePatch();
     m_breakpoints.remove(it);
+}
+
+void BreakpointManager::setStepBreakpoint(const ModuleInformation& owner, uint8_t* pc)
+{
+    Locker locker { m_lock };
+    ensurePatched(owner, pc);
+    m_oneTimeBreakpoints.add(pc);
+}
+
+void BreakpointManager::setBreakpointAt(VirtualAddress address, const ModuleInformation& owner, uint8_t* pc)
+{
+    Locker locker { m_lock };
+    // Re-arming an existing site is a no-op.
+    auto result = m_addressToPC.add(address, pc);
+    if (!result.isNewEntry) {
+        RELEASE_ASSERT(result.iterator->value == pc);
+        return;
+    }
+    ensurePatched(owner, pc).hasSite = true;
+}
+
+bool BreakpointManager::removeBreakpointAt(VirtualAddress address)
+{
+    Locker locker { m_lock };
+    uint8_t* pc = m_addressToPC.take(address);
+    if (!pc)
+        return false;
+
+    auto it = m_breakpoints.find(pc);
+    RELEASE_ASSERT(it != m_breakpoints.end());
+    it->value->hasSite = false;
+    releasePatchIfUnused(pc);
     return true;
 }
 
-bool BreakpointManager::removeBreakpoint(VirtualAddress address)
+std::optional<BreakpointManager::TrapAction> BreakpointManager::trapActionFor(uint8_t* pc)
 {
     Locker locker { m_lock };
-    bool removed = removeBreakpointImpl(address);
-    RELEASE_ASSERT(removed);
-    return true;
+    auto it = m_breakpoints.find(pc);
+    if (it == m_breakpoints.end())
+        return std::nullopt;
+
+    // A breakpoint site takes precedence over a step.
+    Breakpoint::Type stopType = it->value->hasSite ? Breakpoint::Type::Regular : Breakpoint::Type::Step;
+    return TrapAction { static_cast<OpType>(it->value->originalBytecode), stopType };
 }
 
 void BreakpointManager::clearAllOneTimeBreakpoints()
 {
     Locker locker { m_lock };
-    for (VirtualAddress address : m_oneTimeBreakpoints)
-        removeBreakpointImpl(address);
-    m_oneTimeBreakpoints.clear();
+    // Cleared first so releasePatchIfUnused can free unreferenced patches.
+    auto steppedPCs = std::exchange(m_oneTimeBreakpoints, { });
+    for (uint8_t* pc : steppedPCs)
+        releasePatchIfUnused(pc);
     dataLogLnIf(Options::verboseWasmDebugger(), "[BreakpointManager] Cleared all one-time breakpoints");
 }
 
@@ -105,7 +137,8 @@ void BreakpointManager::clearAllBreakpoints()
     for (auto& [_, breakpoint] : m_breakpoints)
         breakpoint->restorePatch();
     m_breakpoints.clear();
-    RELEASE_ASSERT(m_oneTimeBreakpoints.isEmpty());
+    m_oneTimeBreakpoints.clear();
+    m_addressToPC.clear();
 }
 
 } // namespace Wasm

--- a/Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.h
@@ -29,6 +29,7 @@
 
 #include "WasmDebugServerUtilities.h"
 #include "WasmVirtualAddress.h"
+#include <optional>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
@@ -39,6 +40,7 @@
 namespace JSC {
 namespace Wasm {
 
+// A bytecode patch persists while either a breakpoint site or single-step references it.
 class JS_EXPORT_PRIVATE BreakpointManager {
     WTF_MAKE_TZONE_ALLOCATED(BreakpointManager);
 
@@ -46,21 +48,31 @@ public:
     BreakpointManager() = default;
     ~BreakpointManager();
 
-    bool hasBreakpoints();
+    struct TrapAction {
+        OpType displacedOpcode { OpType::Unreachable };
+        Breakpoint::Type stopType { Breakpoint::Type::Regular };
+    };
+
     bool hasOneTimeBreakpoints();
 
-    RefPtr<Breakpoint> findBreakpoint(VirtualAddress);
-    void setBreakpoint(VirtualAddress, Ref<Breakpoint>&&);
-    bool removeBreakpoint(VirtualAddress);
+    std::optional<TrapAction> trapActionFor(uint8_t* pc);
+
+    void setStepBreakpoint(const ModuleInformation& owner, uint8_t* pc);
     void clearAllOneTimeBreakpoints();
+
+    void setBreakpointAt(VirtualAddress, const ModuleInformation& owner, uint8_t* pc);
+    bool removeBreakpointAt(VirtualAddress);
+
     void clearAllBreakpoints();
 
 private:
-    bool removeBreakpointImpl(VirtualAddress) WTF_REQUIRES_LOCK(m_lock);
+    Breakpoint& ensurePatched(const ModuleInformation& owner, uint8_t* pc) WTF_REQUIRES_LOCK(m_lock);
+    void releasePatchIfUnused(uint8_t* pc) WTF_REQUIRES_LOCK(m_lock);
 
     mutable Lock m_lock;
-    UncheckedKeyHashMap<VirtualAddress, Ref<Breakpoint>> m_breakpoints WTF_GUARDED_BY_LOCK(m_lock);
-    UncheckedKeyHashSet<VirtualAddress> m_oneTimeBreakpoints WTF_GUARDED_BY_LOCK(m_lock);
+    UncheckedKeyHashMap<uint8_t*, Ref<Breakpoint>> m_breakpoints WTF_GUARDED_BY_LOCK(m_lock);
+    UncheckedKeyHashSet<uint8_t*> m_oneTimeBreakpoints WTF_GUARDED_BY_LOCK(m_lock);
+    UncheckedKeyHashMap<VirtualAddress, uint8_t*> m_addressToPC WTF_GUARDED_BY_LOCK(m_lock);
 };
 
 } // namespace Wasm

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp
@@ -154,7 +154,7 @@ static const uint8_t* savedWasmToJSPC(CallFrame* wasmToJSFrame)
     return WTF::unalignedLoad<const uint8_t*>(reinterpret_cast<const uint8_t*>(wasmToJSFrame) + Wasm::WasmToJSIPIntReturnPCSlot);
 }
 
-bool getWasmReturnPC(CallFrame* currentFrame, uint8_t*& returnPC, VirtualAddress& virtualReturnPC)
+WasmReturnSite getWasmReturnPC(CallFrame* currentFrame)
 {
     // Safe to use the non-EntryFrame overload: IPInt WASM frames are always entered via a
     // JSToWasm trampoline (a normal CallFrame), never directly from C++, so no EntryFrame
@@ -162,20 +162,17 @@ bool getWasmReturnPC(CallFrame* currentFrame, uint8_t*& returnPC, VirtualAddress
     CallFrame* callerFrame = currentFrame->callerFrame();
 
     if (!callerFrame->callee().isNativeCallee())
-        return false;
+        return { };
 
     RefPtr caller = callerFrame->callee().asNativeCallee();
     if (caller->category() != NativeCallee::Category::Wasm)
-        return false;
+        return { };
 
     RefPtr wasmCaller = uncheckedDowncast<const Wasm::Callee>(caller.get());
     if (wasmCaller->compilationMode() != Wasm::CompilationMode::IPIntMode)
-        return false;
+        return { };
 
-    RefPtr ipintCaller = uncheckedDowncast<const Wasm::IPIntCallee>(wasmCaller.get());
-    returnPC = const_cast<uint8_t*>(savedWasmToWasmPC(currentFrame));
-    virtualReturnPC = VirtualAddress::toVirtual(callerFrame->wasmInstance(), ipintCaller->functionIndex(), returnPC);
-    return true;
+    return { const_cast<uint8_t*>(savedWasmToWasmPC(currentFrame)), callerFrame->wasmInstance() };
 }
 
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
@@ -101,56 +101,35 @@ class Breakpoint final : public ThreadSafeRefCounted<Breakpoint> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(Breakpoint, JS_EXPORT_PRIVATE);
 public:
     enum class Type : uint8_t {
-        // User-set breakpoint (persistent, tracked by virtual address)
         Regular = 0,
-
-        // One-time breakpoint (auto-removed after each stop)
         Step = 1,
     };
 
-    static Ref<Breakpoint> create()
+    static Ref<Breakpoint> create(const ModuleInformation& owner, uint8_t* pc)
     {
-        return adoptRef(*new Breakpoint);
-    }
-
-    static Ref<Breakpoint> create(uint8_t* pc, Type type)
-    {
-        return adoptRef(*new Breakpoint(pc, type));
-    }
-
-    static Ref<Breakpoint> create(const Breakpoint& copy)
-    {
-        return adoptRef(*new Breakpoint(copy));
+        return adoptRef(*new Breakpoint(owner, pc));
     }
 
     void patchBreakpoint() { *pc = 0x00; }
     void restorePatch() { *pc = originalBytecode; }
 
-    bool isOneTimeBreakpoint() { return type != Type::Regular; }
-
     void dump(PrintStream& out) const
     {
-        out.print("Breakpoint(type:", type);
-        out.print(", pc:", RawPointer(pc));
+        out.print("Breakpoint(pc:", RawPointer(pc));
         out.print(", *pc:", (int)*pc);
-        out.print(", originalBytecode:", originalBytecode, ")");
+        out.print(", originalBytecode:", originalBytecode);
+        out.print(", hasSite:", hasSite, ")");
     }
 
-    Type type { Type::Regular };
+    // Keeps the bytecode buffer alive.
+    RefPtr<const ModuleInformation> owner;
     uint8_t* pc { nullptr };
     uint8_t originalBytecode { 0 };
+    bool hasSite { false };
 
 private:
-    Breakpoint() = default;
-    Breakpoint(const Breakpoint& other)
-        : type(other.type)
-        , pc(other.pc)
-        , originalBytecode(other.originalBytecode)
-    {
-    }
-
-    Breakpoint(uint8_t* pc, Type type)
-        : type(type)
+    Breakpoint(const ModuleInformation& owner, uint8_t* pc)
+        : owner(&owner)
         , pc(pc)
         , originalBytecode(*pc)
     {
@@ -328,7 +307,15 @@ uint32_t parseDecimal(StringView, uint32_t defaultValue = 0);
 
 Vector<StringView> splitWithDelimiters(StringView packet, StringView delimiters);
 
-bool getWasmReturnPC(CallFrame* currentFrame, uint8_t*& returnPC, VirtualAddress& virtualReturnPC);
+// Caller resume location and enclosing instance.
+struct WasmReturnSite {
+    uint8_t* pc { nullptr };
+    JSWebAssemblyInstance* instance { nullptr };
+
+    explicit operator bool() const { return pc && instance; }
+};
+
+WasmReturnSite getWasmReturnPC(CallFrame* currentFrame);
 
 struct FrameInfo {
     VirtualAddress address;
@@ -358,11 +345,6 @@ inline StringView getErrorReply(ProtocolError error)
         return "E00"_s;
     }
 }
-
-enum class DebuggerTrapStatus : uint8_t {
-    ResolvedByDebugger,
-    NotResolvedByDebugger,
-};
 
 } // namespace Wasm
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp
@@ -133,21 +133,23 @@ void ExecutionHandler::stopTheWorld(VM& debuggee, StopTheWorldEvent event)
     VMManager::singleton().notifyVMStop(debuggee, event);
 }
 
-DebuggerTrapStatus ExecutionHandler::handleDebuggerTrapIfNeeded(CallFrame* callFrame, JSWebAssemblyInstance* instance, IPIntCallee* callee, uint8_t* pc, uint8_t* mc, IPInt::IPIntStackEntry* stack, Wasm::ExceptionType exceptionType)
+OpType ExecutionHandler::handleDebuggerTrapIfNeeded(CallFrame* callFrame, JSWebAssemblyInstance* instance, IPIntCallee* callee, uint8_t* pc, uint8_t* mc, IPInt::IPIntStackEntry* stack, Wasm::ExceptionType exceptionType)
 {
     VM& debuggee = instance->vm();
-    if (exceptionType == Wasm::ExceptionType::Unreachable && hasBreakpoints()) {
-        VirtualAddress address = VirtualAddress::toVirtual(instance, callee->functionIndex(), pc);
-        if (RefPtr breakpoint = m_breakpointManager->findBreakpoint(address)) {
-            debuggee.debugState()->setBreakpointStopData(breakpoint->type, address, breakpoint->originalBytecode, pc, mc, stack, callee, instance, callFrame);
-            dataLogLnIf(Options::verboseWasmDebugger(), "[Code][handleDebuggerTrapIfNeeded] Breakpoint at ", *breakpoint, " with ", *debuggee.debugState()->stopData);
+    if (exceptionType == Wasm::ExceptionType::Unreachable) {
+        if (auto action = m_breakpointManager->trapActionFor(pc)) {
+            VirtualAddress address = VirtualAddress::toVirtual(instance, callee->functionIndex(), pc);
+            debuggee.debugState()->setBreakpointStopData(action->stopType, address, action->displacedOpcode, pc, mc, stack, callee, instance, callFrame);
+            dataLogLnIf(Options::verboseWasmDebugger(), "[Code][handleDebuggerTrapIfNeeded] Breakpoint with ", *debuggee.debugState()->stopData);
             stopTheWorld(debuggee, StopTheWorldEvent::WasmProgramStop);
-            return DebuggerTrapStatus::ResolvedByDebugger; // Don't throw; resume execution at this breakpoint
+            // If the breakpoint was on an unreachable instruction, fall through to report the trap.
+            if (action->displacedOpcode != OpType::Unreachable)
+                return action->displacedOpcode;
         }
     }
 
     if (!m_debugServer.isDebuggerReady())
-        return DebuggerTrapStatus::NotResolvedByDebugger; // Throw; no debugger connected
+        return OpType::Unreachable; // Throw; no debugger connected
 
     if (exceptionType == Wasm::ExceptionType::StackOverflow || exceptionType == Wasm::ExceptionType::Termination) {
         // Prologue trap: pc/mc/stack are caller's, not the overflowing function's.
@@ -162,7 +164,7 @@ DebuggerTrapStatus ExecutionHandler::handleDebuggerTrapIfNeeded(CallFrame* callF
         debuggee.debugState()->setTrapStopData(callee, instance, callFrame, pc, mc, stack, exceptionType);
     dataLogLnIf(Options::verboseWasmDebugger(), "[Code][handleDebuggerTrapIfNeeded] Wasm trap at ", *debuggee.debugState()->stopData);
     stopTheWorld(debuggee, StopTheWorldEvent::WasmProgramStop);
-    return DebuggerTrapStatus::NotResolvedByDebugger; // Throw; trap was reported, now propagate it
+    return OpType::Unreachable; // Throw; trap was reported, now propagate it
 }
 
 ExecutionHandler::ResumeMode ExecutionHandler::stopCode(Locker<Lock>& locker, StopTheWorldEvent event)
@@ -423,7 +425,7 @@ void ExecutionHandler::step()
         resumeAll = stepAtBytecode(locker, state);
     else {
         RELEASE_ASSERT(state->isStoppedAtPrologue());
-        setBreakpointAtEntry(state->stopData->instance, state->stopData->callee.get(), Breakpoint::Type::Step);
+        setStepBreakpointAtEntry(state->stopData->callee.get(), state->stopData->instance->moduleInformation());
     }
 
     if (resumeAll) {
@@ -450,18 +452,13 @@ bool ExecutionHandler::stepAtBytecode(Locker<Lock>& locker, DebugState* state)
     uint8_t* currentPC = stopData.pc;
 
     auto setStepBreakpoint = [&](const uint8_t* nextPC) WTF_REQUIRES_LOCK(m_lock) {
-        VirtualAddress nextAddress = VirtualAddress(stopData.address.value() + (nextPC - currentPC));
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Step][SetOneTimeBreakpoint] current PC=", RawPointer(currentPC), "(", stopData.address, "), next PC=", RawPointer(nextPC), "(", nextAddress, ")");
-        if (m_breakpointManager->findBreakpoint(nextAddress))
-            return;
-        m_breakpointManager->setBreakpoint(nextAddress, Breakpoint::create(const_cast<uint8_t*>(nextPC), Breakpoint::Type::Step));
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][Step][SetOneTimeBreakpoint] current PC=", RawPointer(currentPC), "(", stopData.address, "), next PC=", RawPointer(nextPC));
+        m_breakpointManager->setStepBreakpoint(stopData.instance->moduleInformation(), const_cast<uint8_t*>(nextPC));
     };
 
     auto setStepBreakpointAtCaller = [&]() WTF_REQUIRES_LOCK(m_lock) {
-        uint8_t* returnPC = nullptr;
-        VirtualAddress virtualReturnPC;
-        if (getWasmReturnPC(stopData.callFrame, returnPC, virtualReturnPC))
-            m_breakpointManager->setBreakpoint(virtualReturnPC, Breakpoint::create(const_cast<uint8_t*>(returnPC), Breakpoint::Type::Step));
+        if (WasmReturnSite returnSite = getWasmReturnPC(stopData.callFrame))
+            m_breakpointManager->setStepBreakpoint(returnSite.instance->moduleInformation(), returnSite.pc);
     };
 
     auto setStepBreakpointsFromDebugInfo = [&]() WTF_REQUIRES_LOCK(m_lock) {
@@ -476,6 +473,9 @@ bool ExecutionHandler::stepAtBytecode(Locker<Lock>& locker, DebugState* state)
     };
 
     switch (stopData.originalBytecode) {
+    case Unreachable:
+        // Unreachable has no successor.
+        break;
     case Nop:
     case Drop:
     case Select:
@@ -550,10 +550,8 @@ void ExecutionHandler::setStepIntoBreakpointForCall(VM& callerVM, CalleeBits box
         if (wasmCallee->compilationMode() != Wasm::CompilationMode::IPIntMode)
             return;
 
-        // Set breakpoint at the callee's entry point.
-        // Use calleeInstance (not caller's instance) because callee may be in a different Wasm module instance.
         RELEASE_ASSERT(&calleeInstance->vm() == &callerVM);
-        setBreakpointAtEntry(calleeInstance, downcast<IPIntCallee>(wasmCallee.get()), Breakpoint::Type::Step);
+        setStepBreakpointAtEntry(downcast<IPIntCallee>(wasmCallee.get()), calleeInstance->moduleInformation());
     }();
 
     stopTheWorld(callerVM, StopTheWorldEvent::WasmStepIntoSiteReached);
@@ -591,28 +589,27 @@ void ExecutionHandler::setStepIntoBreakpointForThrow(VM& throwVM)
             handlerPC = handlerPC + blockMetadata->deltaPC;
         }
 
-        // Set breakpoint at the exception handler.
-        // Use catchInstance (not thrower's instance) because exception may be caught in a different Wasm module instance.
         JSWebAssemblyInstance* catchInstance = throwVM.callFrameForCatch->wasmInstance();
         RELEASE_ASSERT(&catchInstance->vm() == &throwVM);
-        setBreakpointAtPC(catchInstance, catchCallee->functionIndex(), Breakpoint::Type::Step, handlerPC);
+        m_breakpointManager->setStepBreakpoint(catchInstance->moduleInformation(), const_cast<uint8_t*>(handlerPC));
     }();
 
     stopTheWorld(throwVM, StopTheWorldEvent::WasmStepIntoSiteReached);
 }
 
-void ExecutionHandler::setBreakpointAtEntry(JSWebAssemblyInstance* instance, IPIntCallee* callee, Breakpoint::Type type)
+void ExecutionHandler::setStepBreakpointAtEntry(IPIntCallee* callee, const ModuleInformation& owner)
 {
-    setBreakpointAtPC(instance, callee->functionIndex(), type, callee->bytecode());
+    m_breakpointManager->setStepBreakpoint(owner, const_cast<uint8_t*>(callee->bytecode()));
 }
 
-void ExecutionHandler::setBreakpointAtPC(JSWebAssemblyInstance* instance, FunctionCodeIndex functionIndex, Breakpoint::Type type, const uint8_t* pc)
+bool ExecutionHandler::requireModuleAddress(VirtualAddress address)
 {
-    RELEASE_ASSERT(pc);
-    VirtualAddress address = VirtualAddress::toVirtual(instance, functionIndex, pc);
-    if (m_breakpointManager->findBreakpoint(address))
-        return;
-    m_breakpointManager->setBreakpoint(address, Breakpoint::create(const_cast<uint8_t*>(pc), type));
+    VirtualAddress::Type addressType = address.type();
+    if (addressType == VirtualAddress::Type::Module)
+        return true;
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Breakpoint must be in module code region, got type: ", static_cast<int>(addressType));
+    sendErrorReply(ProtocolError::InvalidAddress);
+    return false;
 }
 
 void ExecutionHandler::setBreakpoint(StringView packet)
@@ -646,28 +643,19 @@ void ExecutionHandler::setBreakpoint(StringView packet)
         return;
     }
 
-    VirtualAddress::Type addressType = address.type();
-    if (addressType != VirtualAddress::Type::Module) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[ExecutionHandler] Breakpoint must be in module code region, got type: ", (int)addressType);
-        sendErrorReply(ProtocolError::InvalidAddress);
+    if (!requireModuleAddress(address))
         return;
-    }
-
-    if (m_breakpointManager->findBreakpoint(address)) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[ExecutionHandler] Breakpoint already exists at address: ", address);
-        sendErrorReply(ProtocolError::InvalidAddress);
-        return;
-    }
 
     uint8_t* pc = address.toPhysicalPC(m_moduleManager);
-    if (!pc) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[ExecutionHandler] Failed to convert virtual address to physical: ", address);
+    RefPtr module = m_moduleManager.module(address.id());
+    if (!pc || !module) {
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] No module bytecode at ", address);
         sendErrorReply(ProtocolError::InvalidAddress);
         return;
     }
 
-    m_breakpointManager->setBreakpoint(address, Breakpoint::create(pc, Breakpoint::Type::Regular));
-    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][SetBreakpoint] Successfully set breakpoint at ", address, " (physical: ", RawPointer(pc), ", original: 0x", hex(*pc, 2, Lowercase), ")");
+    m_breakpointManager->setBreakpointAt(address, module->moduleInformation(), pc);
+    dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger][SetBreakpoint] Successfully set breakpoint at ", address, " (physical: ", RawPointer(pc), ")");
     sendReplyOK();
 }
 
@@ -701,14 +689,12 @@ void ExecutionHandler::removeBreakpoint(StringView packet)
         return;
     }
 
-    // Delegate to breakpoint manager
-    if (m_breakpointManager->removeBreakpoint(address)) {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Breakpoint removed successfully from ", address);
-        sendReplyOK();
-    } else {
-        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] Breakpoint not found at address: ", address);
-        sendErrorReply(ProtocolError::InvalidAddress);
-    }
+    if (!requireModuleAddress(address))
+        return;
+
+    if (!m_breakpointManager->removeBreakpointAt(address))
+        dataLogLnIf(Options::verboseWasmDebugger(), "[Debugger] No breakpoint to remove at ", address);
+    sendReplyOK();
 }
 
 void ExecutionHandler::handleThreadStopInfo(StringView packet)
@@ -926,11 +912,6 @@ DebugState* ExecutionHandler::debuggeeStateForTest() const
     Locker locker { m_lock };
     RELEASE_ASSERT(m_debuggee);
     return m_debuggee->debugState();
-}
-
-bool ExecutionHandler::hasBreakpoints() const
-{
-    return m_breakpointManager && m_breakpointManager->hasBreakpoints();
 }
 
 String ExecutionHandler::callStackStringFor(uint64_t vmId)

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
@@ -78,7 +78,8 @@ public:
 
     ResumeMode stopCode(Locker<Lock>&, StopTheWorldEvent) WTF_REQUIRES_LOCK(m_lock);
 
-    DebuggerTrapStatus handleDebuggerTrapIfNeeded(CallFrame*, JSWebAssemblyInstance*, IPIntCallee*, uint8_t* pc, uint8_t* mc, IPInt::IPIntStackEntry*, Wasm::ExceptionType);
+    // Returns the opcode to resume with, or Unreachable to propagate the trap.
+    OpType handleDebuggerTrapIfNeeded(CallFrame*, JSWebAssemblyInstance*, IPIntCallee*, uint8_t* pc, uint8_t* mc, IPInt::IPIntStackEntry*, Wasm::ExceptionType);
 
     JS_EXPORT_PRIVATE void resume();
     JS_EXPORT_PRIVATE void step();
@@ -88,16 +89,13 @@ public:
     String callStackStringFor(uint64_t threadId);
     JS_EXPORT_PRIVATE void reset();
 
-    JS_EXPORT_PRIVATE void setBreakpointAtEntry(JSWebAssemblyInstance*, IPIntCallee*, Breakpoint::Type);
-    void setBreakpointAtPC(JSWebAssemblyInstance*, FunctionCodeIndex, Breakpoint::Type, const uint8_t* pc);
+    JS_EXPORT_PRIVATE void setStepBreakpointAtEntry(IPIntCallee*, const ModuleInformation&);
     void setBreakpoint(StringView packet);
     void removeBreakpoint(StringView packet);
     JS_EXPORT_PRIVATE BreakpointManager* breakpointManager() { return m_breakpointManager.get(); };
 
     void setStepIntoBreakpointForCall(VM&, CalleeBits, JSWebAssemblyInstance*);
     void setStepIntoBreakpointForThrow(VM&);
-
-    bool hasBreakpoints() const;
 
     uint64_t debugServerThreadId() const
     {
@@ -147,6 +145,8 @@ private:
     void sendErrorReply(ProtocolError);
 
     void selectDebuggeeIfNeeded(VM& fallbackVM) WTF_REQUIRES_LOCK(m_lock);
+
+    bool requireModuleAddress(VirtualAddress);
 
     bool requiresStopConfirmation() const WTF_REQUIRES_LOCK(m_lock)
     {

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp
@@ -60,7 +60,6 @@ using ExecutionHandlerTestSupport::workerThreadTask;
 using JSC::JSWebAssemblyInstance;
 using JSC::VM;
 using JSC::VMManager;
-using JSC::Wasm::Breakpoint;
 using JSC::Wasm::DebugServer;
 using JSC::Wasm::DebugState;
 using JSC::Wasm::ExecutionHandler;
@@ -141,13 +140,19 @@ static void switchTarget(VM* newDebuggee)
     CHECK(executionHandler->debuggeeVM() == newDebuggee, "Switch to new debuggee failed");
 }
 
-static void setBreakpointsAtAllFunctionEntries(Breakpoint::Type type)
+static JSC::Wasm::VirtualAddress entryAddress(JSWebAssemblyInstance* instance, JSC::Wasm::IPIntCallee* callee)
+{
+    return JSC::Wasm::VirtualAddress::toVirtual(instance, callee->functionIndex(), callee->bytecode());
+}
+
+static void setBreakpointsAtAllFunctionEntries()
 {
     VLOG("Setting breakpoints at all function entries...");
     unsigned count = 0;
 
     ModuleManager& moduleManager = debugServer->moduleManager();
     uint32_t maxInstanceId = moduleManager.nextInstanceId();
+    auto* breakpointManager = executionHandler->breakpointManager();
 
     // Breakpoints patch module bytecode, which all instances of a module share, so visit each once.
     UncheckedKeyHashSet<uint32_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> patchedModuleIds;
@@ -169,7 +174,7 @@ static void setBreakpointsAtAllFunctionEntries(Breakpoint::Type type)
         for (uint32_t funcIndex = 0; funcIndex < internalCount; ++funcIndex) {
             FunctionSpaceIndex spaceIndex = moduleInfo.toSpaceIndex(JSC::Wasm::FunctionCodeIndex(funcIndex));
             auto callee = instance->calleeGroup()->ipintCalleeFromFunctionIndexSpace(spaceIndex);
-            executionHandler->setBreakpointAtEntry(instance, callee.ptr(), type);
+            breakpointManager->setBreakpointAt(entryAddress(instance, callee.ptr()), moduleInfo, const_cast<uint8_t*>(callee->bytecode()));
             count++;
         }
     }
@@ -226,7 +231,7 @@ static void testBreakpointContinueCycles()
 
     interrupt();
 
-    setBreakpointsAtAllFunctionEntries(Breakpoint::Type::Regular);
+    setBreakpointsAtAllFunctionEntries();
     for (unsigned i = 0; i < STRESS_TEST_ITERATIONS; ++i) {
         VLOG("Continue cycle ", i);
 
@@ -257,7 +262,7 @@ static void testBreakpointSingleStepping()
     interrupt();
 
     // 2. Set breakpoints at ALL function entries
-    setBreakpointsAtAllFunctionEntries(Breakpoint::Type::Regular);
+    setBreakpointsAtAllFunctionEntries();
 
     // 3. Continue - should hit a breakpoint immediately
     VLOG("Continuing execution (expecting breakpoint hit)...");
@@ -283,17 +288,13 @@ static void testBreakpointSingleStepping()
     for (unsigned step = 0; step < STRESS_TEST_ITERATIONS; ++step) {
         VLOG("Step ", step + 1, "/", STRESS_TEST_ITERATIONS);
 
-        // Simulate lldb behavior:
-        // 1. If at Regular breakpoint: remove it, step, then re-insert it
-        // 2. If at one-time breakpoint: just step directly
-        RefPtr<Breakpoint> breakpoint = executionHandler->breakpointManager()->findBreakpoint(beforeStepAddress);
-        RefPtr<Breakpoint> breakpointCopy;
-
-        if (breakpoint) {
-            breakpointCopy = Breakpoint::create(*breakpoint);
-            CHECK(breakpoint->type == Breakpoint::Type::Regular, "One-time breakpoints are cleared before stop. So, this must be a regular breakpoint");
-            executionHandler->breakpointManager()->removeBreakpoint(beforeStepAddress);
-        }
+        // Step over an existing breakpoint site by removing and re-arming it.
+        uint8_t* stoppedPC = state->stopData->pc;
+        JSC::Wasm::VirtualAddress stoppedAddress = state->stopData->address;
+        // Stepping clears stopData.
+        RefPtr<const JSC::Wasm::ModuleInformation> owner = &state->stopData->instance->moduleInformation();
+        bool hadSite = executionHandler->breakpointManager()->removeBreakpointAt(stoppedAddress);
+        CHECK(hadSite == (state->stopReason == DebugState::Reason::Breakpoint), "A breakpoint stop must be reported at an address that holds a site");
 
         unsigned expectedReplyCount = getReplyCount() + 1;
         executionHandler->step();
@@ -302,8 +303,8 @@ static void testBreakpointSingleStepping()
             return getReplyCount() == expectedReplyCount;
         });
 
-        if (breakpoint)
-            executionHandler->breakpointManager()->setBreakpoint(beforeStepAddress, breakpointCopy.releaseNonNull());
+        if (hadSite)
+            executionHandler->breakpointManager()->setBreakpointAt(stoppedAddress, *owner, stoppedPC);
 
         state = executionHandler->debuggeeStateForTest();
         CHECK(state->isStoppedAtBytecode(), "Should be at breakpoint after step");
@@ -367,6 +368,59 @@ static void testSoleInstanceOfModule()
     resume();
 
     TEST_LOG("PASS (", soleModules, " module(s) with one live instance, ", ambiguousModules, " with several)");
+}
+
+static void testPatchLifetime()
+{
+    TEST_LOG("\n=== Breakpoint Patch Lifetime ===");
+
+    interrupt();
+
+    ModuleManager& moduleManager = debugServer->moduleManager();
+    auto* breakpointManager = executionHandler->breakpointManager();
+
+    uint32_t maxInstanceId = moduleManager.nextInstanceId();
+    JSWebAssemblyInstance* instance = nullptr;
+    for (uint32_t instanceId = 0; instanceId < maxInstanceId && !instance; ++instanceId)
+        instance = moduleManager.jsInstance(instanceId);
+    CHECK(instance, "Expected at least one live instance while stopped");
+
+    auto& moduleInfo = instance->module().moduleInformation();
+    FunctionSpaceIndex spaceIndex = moduleInfo.toSpaceIndex(JSC::Wasm::FunctionCodeIndex(0));
+    auto callee = instance->calleeGroup()->ipintCalleeFromFunctionIndexSpace(spaceIndex);
+    auto address = entryAddress(instance, callee.ptr());
+    uint8_t* pc = const_cast<uint8_t*>(callee->bytecode());
+    const uint8_t originalBytecode = *pc;
+
+    CHECK(!breakpointManager->removeBreakpointAt(address), "Removing an address that holds no site should report there was nothing to remove");
+
+    breakpointManager->setBreakpointAt(address, moduleInfo, pc);
+    CHECK(*pc != originalBytecode, "Setting a breakpoint should patch the bytecode");
+
+    // Re-arming an existing site must not displace the patch byte over the real opcode.
+    breakpointManager->setBreakpointAt(address, moduleInfo, pc);
+
+    // A step target on a byte a site already patched: clearing it must leave the site armed.
+    breakpointManager->setStepBreakpoint(moduleInfo, pc);
+    CHECK(breakpointManager->hasOneTimeBreakpoints(), "The step target should be pending");
+    breakpointManager->clearAllOneTimeBreakpoints();
+    CHECK(!breakpointManager->hasOneTimeBreakpoints(), "Clearing should drop the step target");
+    CHECK(*pc != originalBytecode, "The bytecode must stay patched while the site refers to it");
+
+    CHECK(breakpointManager->removeBreakpointAt(address), "The site should be removable");
+    CHECK(*pc == originalBytecode, "Removing the last reference should restore the displaced opcode");
+
+    // The other order: the site goes away first, the step target holds the patch.
+    breakpointManager->setBreakpointAt(address, moduleInfo, pc);
+    breakpointManager->setStepBreakpoint(moduleInfo, pc);
+    CHECK(breakpointManager->removeBreakpointAt(address), "The site should be removable");
+    CHECK(*pc != originalBytecode, "The bytecode must stay patched while the step target refers to it");
+    breakpointManager->clearAllOneTimeBreakpoints();
+    CHECK(*pc == originalBytecode, "Clearing the last reference should restore the displaced opcode");
+
+    resume();
+
+    TEST_LOG("PASS");
 }
 
 // ========== TEST ORCHESTRATION HELPERS ==========
@@ -473,6 +527,7 @@ UNUSED_FUNCTION static int runTests()
         testBreakpointContinueCycles();
         testBreakpointSingleStepping();
         testSoleInstanceOfModule();
+        testPatchLifetime();
 
         cleanupAfterScript(script, workerThread);
 


### PR DESCRIPTION
#### e00002d2d87af12a8d1ab1fcc5c40802dd37c90f
<pre>
[JSC] Wasm debugger should resume breakpoints by dispatching the displaced opcode
<a href="https://bugs.webkit.org/show_bug.cgi?id=323845">https://bugs.webkit.org/show_bug.cgi?id=323845</a>
<a href="https://rdar.apple.com/187149541">rdar://187149541</a>

Reviewed by Yijia Huang.

A breakpoint patches the first byte of an instruction with `unreachable`
so IPInt traps into the debugger. Resuming re-read the byte at PC and
dispatched whatever it found, which is only correct while the patch
happens to be gone. That holds when LLDB clears a site to step over it,
and nowhere else: any resume with the patch still in place dispatches
the patch itself and traps again at the same PC forever.

Capture the displaced opcode when the trap is handled and return it to
the interpreter, which dispatches that opcode instead of re-reading PC.
The saved byte is what the program was going to run, so the resume is
correct whether or not the patch is still there.

A site on a real `unreachable` has no displaced opcode to replay: the
instruction and the patch are the same byte. Report the breakpoint, then
fall through to the trap path, so the program&apos;s own trap is still
reported and propagates instead of being swallowed by the resume.
Stepping off such a site has no successor to break on either, so the
step resumes and lands on the trap.

Key breakpoints on the physical PC rather than the virtual address. The
patch is a property of a byte in module bytecode, which every instance
of a module shares, and the PC is what the trap path has in hand. A user
site and an internal step target can now name the same byte with the
displaced opcode saved once between them; the patch is reference counted
and restored when the last of the two goes away. Breakpoint holds a
RefPtr to the ModuleInformation owning the bytecode it patched.

Also stop crashing on a z0 for an address that holds no site. LLDB
clears a site to step over it and can send z0 for a byte the server no
longer breaks on, which used to hit a RELEASE_ASSERT. Reply OK, which is
what a client that already dropped its own site expects.

Test: BreakpointOnUnreachableTestCase and StepOffUnreachableTestCase
cover the two ways a site on a real `unreachable` resumes,
testPatchLifetime covers the reference counting and the byte-level
restore.

* JSTests/wasm/debugger/tests/tests.py:
(BreakpointOnUnreachableTestCase):
(BreakpointOnUnreachableTestCase.execute):
(StepOffUnreachableTestCase):
(StepOffUnreachableTestCase.execute):
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.cpp:
(JSC::Wasm::BreakpointManager::hasOneTimeBreakpoints):
(JSC::Wasm::BreakpointManager::ensurePatched):
(JSC::Wasm::BreakpointManager::releasePatchIfUnused):
(JSC::Wasm::BreakpointManager::setStepBreakpoint):
(JSC::Wasm::BreakpointManager::setBreakpointAt):
(JSC::Wasm::BreakpointManager::removeBreakpointAt):
(JSC::Wasm::BreakpointManager::trapActionFor):
(JSC::Wasm::BreakpointManager::clearAllOneTimeBreakpoints):
(JSC::Wasm::BreakpointManager::clearAllBreakpoints):
(JSC::Wasm::BreakpointManager::hasBreakpoints): Deleted.
(JSC::Wasm::BreakpointManager::setBreakpoint): Deleted.
(JSC::Wasm::BreakpointManager::findBreakpoint): Deleted.
(JSC::Wasm::BreakpointManager::removeBreakpointImpl): Deleted.
(JSC::Wasm::BreakpointManager::removeBreakpoint): Deleted.
* Source/JavaScriptCore/wasm/debugger/WasmBreakpointManager.h:
* Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.cpp:
(JSC::Wasm::getWasmReturnPC):
* Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h:
(JSC::Wasm::Breakpoint::create):
(JSC::Wasm::Breakpoint::Breakpoint):
(JSC::Wasm::Breakpoint::dump const):
(JSC::Wasm::WasmReturnSite::operator bool const):
* Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.cpp:
(JSC::Wasm::ExecutionHandler::handleDebuggerTrapIfNeeded):
(JSC::Wasm::ExecutionHandler::step):
(JSC::Wasm::ExecutionHandler::stepAtBytecode):
(JSC::Wasm::ExecutionHandler::setStepIntoBreakpointForCall):
(JSC::Wasm::ExecutionHandler::setStepIntoBreakpointForThrow):
(JSC::Wasm::ExecutionHandler::setStepBreakpointAtEntry):
(JSC::Wasm::ExecutionHandler::requireModuleAddress):
(JSC::Wasm::ExecutionHandler::setBreakpoint):
(JSC::Wasm::ExecutionHandler::removeBreakpoint):
(JSC::Wasm::ExecutionHandler::setBreakpointAtEntry): Deleted.
(JSC::Wasm::ExecutionHandler::setBreakpointAtPC): Deleted.
(JSC::Wasm::ExecutionHandler::hasBreakpoints const): Deleted.
* Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h:
* Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTest.cpp:
(ExecutionHandlerTest::entryAddress):
(ExecutionHandlerTest::setBreakpointsAtAllFunctionEntries):
(ExecutionHandlerTest::testBreakpointContinueCycles):
(ExecutionHandlerTest::testBreakpointSingleStepping):
(ExecutionHandlerTest::testPatchLifetime):
(ExecutionHandlerTest::runTests):

Canonical link: <a href="https://commits.webkit.org/320918@main">https://commits.webkit.org/320918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3860d72234040088c7a5f1ba7445067ed6b21020

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196514 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150779 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59830 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145506 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166037 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125841 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47918 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45894 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7687 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14559 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45629 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7586 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47462 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52615 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50359 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198501 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59776 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155076 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41559 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60486 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154719 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49150 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132742 "Built successfully") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129899 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58913 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20608 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58315 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58533 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->