### PR TITLE
Replace references to FontDescription "specifiedLocale" with "computedLocale"

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1430,7 +1430,6 @@
                 "auto"
             ],
             "codegen-properties": {
-                "font-description-name-for-methods": "SpecifiedLocale",
                 "font-property": true,
                 "high-priority": true,
                 "computed-style-storage-container": "opaque",

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -11683,7 +11683,7 @@ const Style::ComputedStyle& Document::initialStyle() const
         auto allowUserInstalledFonts = settings().shouldAllowUserInstalledFonts() ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No;
 
         FontCascadeDescription fontDescription;
-        fontDescription.setSpecifiedLocale(contentLanguage());
+        fontDescription.setComputedLocale(contentLanguage());
         fontDescription.setOneFamily(WTF::move(initialFontFamily));
         fontDescription.setKeywordSizeFromIdentifier(CSSValueMedium);
         fontDescription.setComputedSize(initialComputedFontSize);

--- a/Source/WebCore/platform/graphics/FontDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontDescription.cpp
@@ -103,12 +103,12 @@ static const AtomString& specializedChineseLocale()
     return locale;
 }
 
-void FontDescription::setSpecifiedLocale(const AtomString& locale)
+void FontDescription::setComputedLocale(const AtomString& computedLocale)
 {
     ASSERT(isMainThread());
-    m_specifiedLocale = locale;
-    m_script = localeToScriptCode(m_specifiedLocale);
-    m_usedLocale = m_script == USCRIPT_HAN ? specializedChineseLocale() : m_specifiedLocale;
+    m_computedLocale = computedLocale;
+    m_script = localeToScriptCode(m_computedLocale);
+    m_usedLocale = m_script == USCRIPT_HAN ? specializedChineseLocale() : m_computedLocale;
 }
 
 #if !PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/FontDescription.h
+++ b/Source/WebCore/platform/graphics/FontDescription.h
@@ -60,7 +60,7 @@ public:
     TextAutospace textAutospace() const { return m_textAutospace; }
     UScriptCode script() const { return static_cast<UScriptCode>(m_script); }
     const AtomString& usedLocale() const { return m_usedLocale; } // This is what you should be using for things like text shaping and font fallback
-    const AtomString& specifiedLocale() const { return m_specifiedLocale; } // This is what you should be using for web-exposed things like -webkit-locale
+    const AtomString& computedLocale() const { return m_computedLocale; } // This is what you should be using for web-exposed things like -webkit-locale
 
     FontOrientation orientation() const { return static_cast<FontOrientation>(m_orientation); }
     NonCJKGlyphOrientation nonCJKGlyphOrientation() const { return static_cast<NonCJKGlyphOrientation>(m_nonCJKGlyphOrientation); }
@@ -119,7 +119,7 @@ public:
     void setOrientation(FontOrientation orientation) { m_orientation = std::to_underlying(orientation); }
     void setNonCJKGlyphOrientation(NonCJKGlyphOrientation orientation) { m_nonCJKGlyphOrientation = std::to_underlying(orientation); }
     void setWidthVariant(FontWidthVariant widthVariant) { m_widthVariant = std::to_underlying(widthVariant); } // Make sure new callers of this sync with FontPlatformData::isForTextCombine()!
-    void setSpecifiedLocale(const AtomString&);
+    void setComputedLocale(const AtomString&);
     void setFeatureSettings(FontFeatureSettings&& settings) { m_featureSettings = WTF::move(settings); }
     void setVariationSettings(FontVariationSettings&& settings) { m_variationSettings = WTF::move(settings); }
     void setFontSynthesisWeight(FontSynthesisLonghandValue value) { m_fontSynthesisWeight =  std::to_underlying(value); }
@@ -166,7 +166,7 @@ private:
     FontPalette m_fontPalette;
     FontSizeAdjust m_sizeAdjust;
     AtomString m_usedLocale;
-    AtomString m_specifiedLocale;
+    AtomString m_computedLocale;
 
     FontSelectionRequest m_fontSelectionRequest;
     TextSpacingTrim m_textSpacingTrim;

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -267,7 +267,7 @@ auto TextAutoSizingValue::adjustTextNodeSizes() -> StillHasNodes
         );
         parentEvaluatedLineHeight *= scaleChange;
 
-        // This calculation matches the line-height computed size calculation in StyleBuilderCustom::applyValueLineHeight().
+        // This calculation matches the line-height computed size calculation in Style::BuilderCustom::applyValueLineHeight().
         if (auto fixedLineHeight = parentLineHeight.tryLength(); fixedLineHeight && fixedLineHeight->resolveZoom(Style::ZoomFactor::none()) == parentEvaluatedLineHeight)
             continue;
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -158,7 +158,7 @@ static bool isDutchIJDigraph(StringView text, unsigned offset)
     return (first == 'i' && second == 'j') || (first == 'I' && second == 'J');
 }
 
-static unsigned firstLetterLength(StringView text, const AtomString& specifiedLocale)
+static unsigned firstLetterLength(StringView text, const AtomString& locale)
 {
     if (text.isEmpty())
         return 0;
@@ -173,7 +173,7 @@ static unsigned firstLetterLength(StringView text, const AtomString& specifiedLo
     length += numCodeUnitsInGraphemeClusters(text.substring(length), 1);
 
     // In Dutch, "ij" is a digraph treated as a single letter for ::first-letter.
-    if (length < text.length() && isDutchLocale(specifiedLocale) && isDutchIJDigraph(text, length - 1))
+    if (length < text.length() && isDutchLocale(locale) && isDutchIJDigraph(text, length - 1))
         length += numCodeUnitsInGraphemeClusters(text.substring(length), 1);
 
     // Keep looking for following punctuation and intervening typographic space,
@@ -251,7 +251,8 @@ void RenderTreeBuilder::FirstLetter::updateAfterDescendants(RenderBlock& block)
             if (is<Text>(textNode->previousSibling()))
                 return true;
             // Length can change due to a locale change.
-            return firstLetterLength(textNode->data(), remainingText->style().fontDescription().specifiedLocale()) != remainingText->start();
+            // FIXME: This should probably be using `fontDescription().usedLocale()`, as that is what is used for shaping.
+            return firstLetterLength(textNode->data(), remainingText->style().fontDescription().computedLocale()) != remainingText->start();
         };
         if (isFirstLetterStale()) {
             ASSERT(remainingText.get());
@@ -362,7 +363,8 @@ void RenderTreeBuilder::FirstLetter::createRenderers(RenderText& currentTextChil
     ASSERT(!oldText.isNull());
 
     if (!oldText.isEmpty()) {
-        unsigned length = firstLetterLength(oldText, currentTextChild.style().fontDescription().specifiedLocale());
+        // FIXME: This should probably be using `fontDescription().usedLocale()`, as that is what is used for shaping.
+        unsigned length = firstLetterLength(oldText, currentTextChild.style().fontDescription().computedLocale());
 
         RefPtr textNode = currentTextChild.textNode();
         WeakPtr beforeChild = currentTextChild.nextSibling();

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -111,12 +111,10 @@ public:
     static void applyHighlightValueColor(BuilderState&, CSSValue&);
 
     // Custom handling of value setting only.
-    static void applyValueWebkitLocale(BuilderState&, CSSValue&);
     static void applyValueTextOrientation(BuilderState&, CSSValue&);
     static void applyValueWebkitTextSizeAdjust(BuilderState&, CSSValue&);
     static void applyValueWebkitTextZoom(BuilderState&, CSSValue&);
     static void applyValueWritingMode(BuilderState&, CSSValue&);
-    static void applyValueFontSizeAdjust(BuilderState&, CSSValue&);
 
 private:
     static void resetUsedZoom(BuilderState&);
@@ -242,10 +240,10 @@ void maybeUpdateFontForLetterSpacingOrWordSpacing(BuilderState& builderState, CS
 {
     // This is unfortunate. It's related to https://github.com/w3c/csswg-drafts/issues/5498.
     //
-    // From StyleBuilder's point of view, there's a dependency cycle:
+    // From Style::Builder's point of view, there's a dependency cycle:
     // letter-spacing accepts an arbitrary <length>, which must be resolved against a font, which must
     // be selected after all the properties that affect font selection are processed, but letter-spacing
-    // itself affects font selection because it can disable font features. StyleBuilder has some (valid)
+    // itself affects font selection because it can disable font features. Style::Builder has some (valid)
     // ASSERT()s which would fire because of this cycle.
     //
     // There isn't *actually* a dependency cycle, though, as none of the font-relative units are
@@ -379,11 +377,6 @@ inline void BuilderCustom::applyValueLineHeight(BuilderState& builderState, CSSV
 
     builderState.style().setTextAutosizingAdjustedLineHeight(WTF::move(textAutosizingAdjustedLineHeight));
     builderState.style().setLineHeight(WTF::move(lineHeight));
-}
-
-inline void BuilderCustom::applyValueWebkitLocale(BuilderState& builderState, CSSValue& value)
-{
-    builderState.setFontDescriptionSpecifiedLocale(toStyleFromCSSValue<WebkitLocale>(builderState, value));
 }
 
 inline void BuilderCustom::applyValueWritingMode(BuilderState& builderState, CSSValue& value)

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -227,7 +227,7 @@ public:
     void setFontDescriptionFontSynthesisWeight(FontSynthesisLonghandValue);
     void setFontDescriptionKerning(Kerning);
     void setFontDescriptionOpticalSizing(FontOpticalSizing);
-    void setFontDescriptionSpecifiedLocale(WebkitLocale&&);
+    void setFontDescriptionLocale(WebkitLocale&&);
     void setFontDescriptionTextAutospace(TextAutospace);
     void setFontDescriptionTextRenderingMode(TextRenderingMode);
     void setFontDescriptionTextSpacingTrim(TextSpacingTrim);

--- a/Source/WebCore/style/StyleBuilderStateInlines.h
+++ b/Source/WebCore/style/StyleBuilderStateInlines.h
@@ -42,15 +42,40 @@ inline bool BuilderState::isBuildingHighlightStyle() const
     return pseudoElementType && isHighlightPseudoElement(*pseudoElementType);
 }
 
-inline void BuilderState::setTextOrientation(TextOrientation orientation) { m_fontDirty |= m_style.setTextOrientation(orientation); }
-inline void BuilderState::setWritingMode(StyleWritingMode mode) { m_fontDirty |= m_style.setWritingMode(mode); }
+inline void BuilderState::setTextOrientation(TextOrientation orientation)
+{
+    m_fontDirty |= m_style.setTextOrientation(orientation);
+}
 
-inline void BuilderState::setZoom(Zoom zoom) { m_fontDirty |= m_style.setZoom(zoom); }
-inline void BuilderState::setUsedZoom(float zoom) { m_fontDirty |= m_style.setUsedZoom(zoom); }
+inline void BuilderState::setWritingMode(StyleWritingMode mode)
+{
+    m_fontDirty |= m_style.setWritingMode(mode);
+}
 
-inline const FontCascadeDescription& BuilderState::parentFontDescription() { return parentStyle().fontDescription(); }
-inline const FontCascadeDescription& BuilderState::fontDescription() { return m_style.fontDescription(); }
-inline void BuilderState::setFontDescription(FontCascadeDescription&& description) { m_fontDirty |= m_style.setFontDescriptionWithoutUpdate(WTF::move(description)); }
+inline void BuilderState::setZoom(Zoom zoom)
+{
+    m_fontDirty |= m_style.setZoom(zoom);
+}
+
+inline void BuilderState::setUsedZoom(float zoom)
+{
+    m_fontDirty |= m_style.setUsedZoom(zoom);
+}
+
+inline const FontCascadeDescription& BuilderState::parentFontDescription()
+{
+    return parentStyle().fontDescription();
+}
+
+inline const FontCascadeDescription& BuilderState::fontDescription()
+{
+    return m_style.fontDescription();
+}
+
+inline void BuilderState::setFontDescription(FontCascadeDescription&& description)
+{
+    m_fontDirty |= m_style.setFontDescriptionWithoutUpdate(WTF::move(description));
+}
 
 inline void BuilderState::setFontDescriptionKeywordSizeFromIdentifier(CSSValueID identifier)
 {
@@ -195,13 +220,13 @@ inline void BuilderState::setFontDescriptionOpticalSizing(FontOpticalSizing opti
     m_style.mutableFontDescriptionWithoutUpdate().setOpticalSizing(opticalSizing);
 }
 
-inline void BuilderState::setFontDescriptionSpecifiedLocale(WebkitLocale&& specifiedLocale)
+inline void BuilderState::setFontDescriptionLocale(WebkitLocale&& locale)
 {
-    if (m_style.fontDescription().specifiedLocale() == specifiedLocale.platform())
+    if (m_style.fontDescription().computedLocale() == locale.platform())
         return;
 
     m_fontDirty = true;
-    m_style.mutableFontDescriptionWithoutUpdate().setSpecifiedLocale(specifiedLocale.takePlatform());
+    m_style.mutableFontDescriptionWithoutUpdate().setComputedLocale(locale.takePlatform());
 }
 
 inline void BuilderState::setFontDescriptionTextAutospace(TextAutospace textAutospace)

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -87,7 +87,7 @@ Style::ComputedStyle resolveForDocument(const Document& document)
         auto& settings = renderView->frame().settings();
 
         FontCascadeDescription fontDescription;
-        fontDescription.setSpecifiedLocale(document.contentLanguage());
+        fontDescription.setComputedLocale(document.contentLanguage());
         fontDescription.setOneFamily(WebCore::FontFamily { standardFamily, FontFamilyKind::Generic });
         fontDescription.setShouldAllowUserInstalledFonts(settings.shouldAllowUserInstalledFonts() ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No);
 

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h
@@ -266,7 +266,7 @@ inline TextSpacingTrim ComputedStyleProperties::textSpacingTrim() const
 
 inline WebkitLocale ComputedStyleProperties::locale() const
 {
-    return fontDescription().specifiedLocale();
+    return fontDescription().computedLocale();
 }
 
 // MARK: - Custom ColorPropertyTrait function definitions

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
@@ -302,7 +302,7 @@ inline void ComputedStyleProperties::setFontVariantPosition(FontVariantPosition 
 inline void ComputedStyleProperties::setLocale(WebkitLocale value)
 {
     auto description = fontDescription();
-    description.setSpecifiedLocale(value.takePlatform());
+    description.setComputedLocale(value.takePlatform());
     setFontDescription(WTF::move(description));
 }
 


### PR DESCRIPTION
#### 727f7d2e4e1ba52ca2def49e9fc7b45ab3562c49
<pre>
Replace references to FontDescription &quot;specifiedLocale&quot; with &quot;computedLocale&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=323770">https://bugs.webkit.org/show_bug.cgi?id=323770</a>

Reviewed by Alan Baradlay.

Part 2 of <a href="https://bugs.webkit.org/show_bug.cgi?id=323768">https://bugs.webkit.org/show_bug.cgi?id=323768</a>

In this step we make the following renames:

  - FontDescription::specifiedLocale() -&gt; FontDescription::computedLocale()

Also does some light cleanup, removing unused functions in StyleBuilderCustom.h
and formatting a few functions in StyleBuilderStateInlines.h.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/platform/graphics/FontDescription.cpp:
* Source/WebCore/platform/graphics/FontDescription.h:
* Source/WebCore/rendering/TextAutoSizing.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
* Source/WebCore/style/StyleBuilderCustom.h:
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleBuilderStateInlines.h:
* Source/WebCore/style/StyleResolveForDocument.cpp:
* Source/WebCore/style/computed/StyleComputedStyleProperties+GettersCustomInlines.h:
* Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h:

Canonical link: <a href="https://commits.webkit.org/320888@main">https://commits.webkit.org/320888@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75b3ee17c898e9128b05ffd87482a550f5971675

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/59970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196363 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150672 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59690 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145399 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100789 "Exiting early after 60 failures. 60 tests run. 61 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49075 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125722 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47808 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45798 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158162 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45522 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7434 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198341 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59628 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154978 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41538 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60337 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42109 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154600 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49042 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132635 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129746 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58783 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20509 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58173 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58405 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58231 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->