### PR TITLE
[webkitbot] Don't claim a revert PR was created when it was only updated

### DIFF
--- a/Tools/WebKitBot/src/CommandParser.mjs
+++ b/Tools/WebKitBot/src/CommandParser.mjs
@@ -39,6 +39,15 @@ export function parseBugId(string)
     if (match)
         return match[1];
 
+    // A bare decimal is equally a plausible svn revision or an abbreviated hash, so this
+    // is bounded to the width bug numbers actually have. Once they reach seven digits this
+    // stops matching and extractRevision claims the number as a short hash instead, so the
+    // request fails with "Please provide a reason or a bug URL" rather than reverting or
+    // filing the wrong thing.
+    let trimmed = stripTokenDecoration(string.trim());
+    if (/^\d{6}$/.test(trimmed))
+        return trimmed;
+
     return null;
 }
 
@@ -51,6 +60,26 @@ export function parsePRUrl(string)
     return match ? match[0] : null;
 }
 
+export function parsePullRequestAction(string)
+{
+    if (!string)
+        return null;
+
+    let match = string.match(/^(Created|Updated) 'PR \d+ \| .*'!$/m);
+    return match ? match[1].toLowerCase() : null;
+}
+
+// Strip the decoration Slack messages accumulate around an identifier: a commits.webkit.org
+// prefix, trailing sentence punctuation (e.g. "319904@main.") so it isn't captured as part of
+// the identifier or branch name, and a leading "(" or "[" left unbalanced by that strip
+// (e.g. "(319904@main)" or "(319904@main.").
+function stripTokenDecoration(candidate)
+{
+    candidate = candidate.replace(/^https?:\/\/commits\.webkit\.org\//, "");
+    candidate = candidate.replace(/[.;!?)\]]+$/, "");
+    return candidate.replace(/^[(\[]+/, "");
+}
+
 function extractRevision(text)
 {
     let revisions = [];
@@ -59,14 +88,7 @@ function extractRevision(text)
         if (!candidate)
             continue;
 
-        // Accept identifiers pasted as commits.webkit.org links, which is what webkitbot itself posts.
-        candidate = candidate.replace(/^https?:\/\/commits\.webkit\.org\//, "");
-
-        // Strip trailing sentence punctuation (e.g. "319904@main.") so it isn't captured as part
-        // of the identifier or branch name, along with a leading "(" or "[" left unbalanced by
-        // that strip (e.g. "(319904@main)" or "(319904@main.").
-        candidate = candidate.replace(/[.;!?)\]]+$/, "");
-        candidate = candidate.replace(/^[(\[]+/, "");
+        candidate = stripTokenDecoration(candidate);
 
         let match = candidate.match(/^r?(\d{5,6}|\d+@[^:\s]+|[0-9a-f]{6,40}):?$/);
         if (!match)
@@ -75,6 +97,15 @@ function extractRevision(text)
         revisions.push(match[1]);
     }
     return revisions;
+}
+
+function namesRevisionUnambiguously(candidate)
+{
+    candidate = stripTokenDecoration(candidate.trim());
+    if (!candidate || /^\d+:?$/.test(candidate))
+        return false;
+
+    return extractRevision(candidate) !== null;
 }
 
 export function buildGitWebkitRevertCommand(gitWebkitPath, revisions, reason, issueUrl)
@@ -100,10 +131,15 @@ export function extractRevisionsAndReason(args)
 {
     let revisions = [];
     let reason = "";
+    let sawUnambiguousRevision = false;
     for (let i = 0; i < args.length; ++i) {
         let arg = args[i];
         let extracted = extractRevision(arg);
-        if (!extracted) {
+
+        let isTrailingBugNumber = sawUnambiguousRevision && i === args.length - 1
+            && /^\d{6}$/.test(stripTokenDecoration(arg.trim()));
+
+        if (!extracted || isTrailingBugNumber) {
             let reasons = [];
             for (; i < args.length; ++i)
                 reasons.push(args[i]);
@@ -111,6 +147,8 @@ export function extractRevisionsAndReason(args)
             break;
         }
         revisions.push(...extracted);
+        if (arg.split(",").some(namesRevisionUnambiguously))
+            sawUnambiguousRevision = true;
     }
 
     // If reason starts with quote and ends with the same quote, remove them once.

--- a/Tools/WebKitBot/src/Utility.mjs
+++ b/Tools/WebKitBot/src/Utility.mjs
@@ -31,6 +31,22 @@ export function escapeForSlackText(text)
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
 }
 
+export function buildRevertSuccessMessage(user, result)
+{
+    if (!result.prUrl)
+        return `<@${user}> Created a revert patch https://webkit.org/b/${escapeForSlackText(result.bugId)}`;
+
+    if (result.action === "created")
+        return `<@${user}> Created revert PR: ${escapeForSlackText(result.prUrl)}`;
+
+    if (result.action === "updated")
+        return `<@${user}> A revert PR for this already existed, so I updated it instead of creating a new one: ${escapeForSlackText(result.prUrl)}`;
+
+    // git-webkit did not tell us whether it created or updated the pull request, so don't
+    // claim a creation we never observed.
+    return `<@${user}> Posted revert PR: ${escapeForSlackText(result.prUrl)}`;
+}
+
 export function dataLogLn(message)
 {
     if (process.env.DEBUG)

--- a/Tools/WebKitBot/src/WebKitBot.mjs
+++ b/Tools/WebKitBot/src/WebKitBot.mjs
@@ -33,8 +33,8 @@ import LogLevel from "@slack/rtm-api";
 import SlackRTMAPI from "@slack/rtm-api";
 import AsyncTaskQueue from "./AsyncTaskQueue.mjs";
 import {buildGitWebkitRevertCommand, extractCommandAndArgs, extractRevisionsAndReason,
-    extractTextIfMentioned, parseBugId, parsePRUrl} from "./CommandParser.mjs";
-import {dataLogLn, escapeForSlackText, isASCII, rootDirectoryOfWebKit} from "./Utility.mjs";
+    extractTextIfMentioned, parseBugId, parsePRUrl, parsePullRequestAction} from "./CommandParser.mjs";
+import {buildRevertSuccessMessage, dataLogLn, escapeForSlackText, isASCII, rootDirectoryOfWebKit} from "./Utility.mjs";
 
 const defaultTaskLimit = 10;
 const defaultPullPeriod = 60 * 1000 * 60;
@@ -192,15 +192,9 @@ export default class WebKitBot {
                     issueUrl,
                 });
 
-                let successMessage;
-                if (result.startsWith("https://github.com/"))
-                    successMessage = `<@${event.user}> Created revert PR: ${escapeForSlackText(result)}`;
-                else
-                    successMessage = `<@${event.user}> Created a revert patch https://webkit.org/b/${escapeForSlackText(result)}`;
-
                 await this.postMessage({
                     channel: event.channel,
-                    text: successMessage,
+                    text: buildRevertSuccessMessage(event.user, result),
                 });
             } catch (error) {
                 console.error(error);
@@ -496,16 +490,23 @@ Type \`help COMMAND\` for help on my individual commands.`,
         dataLogLn("3. Fetching");
         await this.execInWebKitDirectorySimple("git", ["fetch", "origin"]);
 
-        dataLogLn("4. Checkout out origin/main");
+        dataLogLn("4. Pruning stale 'fork' refs");
+        try {
+            await this.execInWebKitDirectorySimple("git", ["fetch", "--prune", "fork"]);
+        } catch (error) {
+            dataLogLn("Warning: Failed to fetch 'fork':" + String(error));
+        }
+
+        dataLogLn("5. Checkout out origin/main");
         await this.execInWebKitDirectorySimple("git", ["checkout", "origin/main", "-f"]);
 
-        dataLogLn("5. Deleting local 'main' ref");
+        dataLogLn("6. Deleting local 'main' ref");
         await this.execInWebKitDirectorySimple("git", ["branch", "-D", "main"]);
 
-        dataLogLn("6. Creating local 'main' ref");
+        dataLogLn("7. Creating local 'main' ref");
         await this.execInWebKitDirectorySimple("git", ["checkout", "origin/main", "-b", "main"]);
 
-        dataLogLn("7. Cleaning up leftover branches");
+        dataLogLn("8. Cleaning up leftover branches");
         try {
             let {stdout} = await execFileAsync("git", ["for-each-ref", "--format", "%(refname:short)", "refs/heads/"], {
                 cwd: process.env.webkitWorkingDirectory,
@@ -598,8 +599,10 @@ Type \`help COMMAND\` for help on my individual commands.`,
         // captured output for the PR URL (don't re-dump it).
         let {stdout, stderr} = results;
         let prUrl = parsePRUrl(stdout) || parsePRUrl(stderr);
-        if (prUrl)
-            return prUrl;
+        if (prUrl) {
+            let action = parsePullRequestAction(stdout) || parsePullRequestAction(stderr);
+            return {prUrl, action};
+        }
 
         throw new Error("PR URL not found in git-webkit output");
     }
@@ -617,7 +620,7 @@ Type \`help COMMAND\` for help on my individual commands.`,
 
         await this.cleanUpWorkingCopy();
 
-        dataLogLn("7. Creating revert patch ", revisions, reason);
+        dataLogLn("9. Creating revert patch ", revisions, reason);
         let results;
         try {
             const webkitPatchPath = path.resolve("BotWebKit", "Tools", "Scripts", "webkit-patch");
@@ -658,12 +661,12 @@ Type \`help COMMAND\` for help on my individual commands.`,
         {
             let bugId = parseBugId(stdout);
             if (bugId !== null)
-                return bugId;
+                return {bugId};
         }
         {
             let bugId = parseBugId(stderr);
             if (bugId !== null)
-                return bugId;
+                return {bugId};
         }
         throw new Error("bug-id cannot be found");
     }

--- a/Tools/WebKitBot/tests/WebKitBot.test.mjs
+++ b/Tools/WebKitBot/tests/WebKitBot.test.mjs
@@ -23,7 +23,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import {buildGitWebkitRevertCommand, extractRevisionsAndReason, extractTextIfMentioned, extractCommandAndArgs} from "../src/CommandParser.mjs";
+import {buildGitWebkitRevertCommand, extractRevisionsAndReason, extractTextIfMentioned,
+    extractCommandAndArgs, parseBugId, parsePRUrl, parsePullRequestAction} from "../src/CommandParser.mjs";
+import {buildRevertSuccessMessage} from "../src/Utility.mjs";
 const WebKitBotID = 42;
 
 test("buildGitWebkitRevertCommand skips style checks with a reason", () => {
@@ -295,4 +297,157 @@ test("identifier wrapped in parentheses followed by a period", () => {
     let {revisions, reason} = extractRevisionsAndReason(args);
     expect(revisions).toEqual(["319904@main"]);
     expect(reason).toBe("Broke the build.");
+});
+
+const createdTranscript = `Cloning 'origin/main' to 'eng/revert-5-main-reason-for-revert'
+Reverting 5@main...
+Created the local development branch 'eng/revert-5-main-reason-for-revert'
+Using committed changes...
+    Found 1 commit...
+Creating pull-request for 'eng/revert-5-main-reason-for-revert'...
+Created 'PR 1 | Unreviewed, reverting 5@main (d8bce26fa65c)'!
+https://github.com/WebKit/WebKit/pull/1
+`;
+
+const updatedTranscript = `Cloning 'origin/main' to 'eng/revert-5-main-reason-for-revert'
+Reverting 5@main...
+Using committed changes...
+    Found 1 commit...
+Updating pull-request for 'eng/revert-5-main-reason-for-revert'...
+Updated 'PR 1 | Unreviewed, reverting 5@main (d8bce26fa65c)'!
+https://github.com/WebKit/WebKit/pull/1
+`;
+
+// git-webkit printed a URL but no line we recognize as an action. buildRevertSuccessMessage
+// turns this into "Posted revert PR" rather than claiming a creation.
+const noActionTranscript = `Reverting 5@main...
+Using committed changes...
+https://github.com/WebKit/WebKit/pull/1
+`;
+
+test("parsePullRequestAction detects a created pull request", () => {
+    expect(parsePullRequestAction(createdTranscript)).toBe("created");
+    expect(parsePRUrl(createdTranscript)).toBe("https://github.com/WebKit/WebKit/pull/1");
+});
+
+test("parsePullRequestAction detects an updated pull request", () => {
+    expect(parsePullRequestAction(updatedTranscript)).toBe("updated");
+    expect(parsePRUrl(updatedTranscript)).toBe("https://github.com/WebKit/WebKit/pull/1");
+});
+
+test("parsePullRequestAction returns null when there is no action line", () => {
+    expect(parsePullRequestAction(noActionTranscript)).toBe(null);
+    expect(parsePRUrl(noActionTranscript)).toBe("https://github.com/WebKit/WebKit/pull/1");
+});
+
+test("parsePullRequestAction on empty output", () => {
+    expect(parsePullRequestAction("")).toBe(null);
+    expect(parsePullRequestAction(null)).toBe(null);
+    expect(parsePullRequestAction("Created 'PR 1'!\n")).toBe(null);
+    expect(parsePullRequestAction("Updated something that is not a pull request\n")).toBe(null);
+});
+
+test("buildRevertSuccessMessage reports a created pull request", () => {
+    let message = buildRevertSuccessMessage(WebKitBotID, {prUrl: "https://github.com/WebKit/WebKit/pull/1", action: "created"});
+    expect(message).toBe(`<@${WebKitBotID}> Created revert PR: https://github.com/WebKit/WebKit/pull/1`);
+});
+
+test("buildRevertSuccessMessage does not claim a creation when the pull request was updated", () => {
+    let message = buildRevertSuccessMessage(WebKitBotID, {prUrl: "https://github.com/WebKit/WebKit/pull/1", action: "updated"});
+    expect(message).toBe(`<@${WebKitBotID}> A revert PR for this already existed, so I updated it instead of creating a new one: https://github.com/WebKit/WebKit/pull/1`);
+});
+
+test("buildRevertSuccessMessage does not claim a creation when the action is unknown", () => {
+    let message = buildRevertSuccessMessage(WebKitBotID, {prUrl: "https://github.com/WebKit/WebKit/pull/1", action: null});
+    expect(message).toBe(`<@${WebKitBotID}> Posted revert PR: https://github.com/WebKit/WebKit/pull/1`);
+});
+
+test("buildRevertSuccessMessage reports a revert patch", () => {
+    let message = buildRevertSuccessMessage(WebKitBotID, {bugId: "321686"});
+    expect(message).toBe(`<@${WebKitBotID}> Created a revert patch https://webkit.org/b/321686`);
+});
+
+test("parseBugId accepts bug URLs", () => {
+    expect(parseBugId("https://webkit.org/b/321569")).toBe("321569");
+    expect(parseBugId("https://bugs.webkit.org/show_bug.cgi?id=321569")).toBe("321569");
+});
+
+test("parseBugId accepts a bare bug number", () => {
+    expect(parseBugId("321569")).toBe("321569");
+    expect(parseBugId(" 321569 ")).toBe("321569");
+});
+
+test("parseBugId rejects numbers that are not bug numbers", () => {
+    expect(parseBugId("")).toBe(null);
+    expect(parseBugId("32156")).toBe(null);
+    expect(parseBugId("3215690")).toBe(null);
+    expect(parseBugId("321569 causes a crash")).toBe(null);
+    // A bare number on its own line of tool output is not a bug number.
+    expect(parseBugId("Reverting 5@main...\n321569\nDone\n")).toBe(null);
+});
+
+test("a trailing bare bug number is not a revision", () => {
+    let message = `<@${WebKitBotID}> revert 318045@main 321569`;
+
+    let text = extractTextIfMentioned(message, WebKitBotID);
+    let {command, args} = extractCommandAndArgs(text);
+    expect(command).toBe("revert");
+
+    let {revisions, reason} = extractRevisionsAndReason(args);
+    expect(revisions).toEqual(["318045@main"]);
+    expect(reason).toBe("321569");
+    expect(parseBugId(reason)).toBe("321569");
+});
+
+test("a trailing bare bug number after a hash revision is not a revision", () => {
+    let {revisions, reason} = extractRevisionsAndReason(["d8bce26fa65c", "321569"]);
+    expect(revisions).toEqual(["d8bce26fa65c"]);
+    expect(reason).toBe("321569");
+});
+
+test("bare svn revisions are still parsed as revisions", () => {
+    // `263483 263484` is ambiguous, so it keeps its historical meaning: two svn revisions.
+    expect(extractRevisionsAndReason(["263483", "263484"])).toEqual({revisions: ["263483", "263484"], reason: ""});
+    expect(extractRevisionsAndReason(["263483", "263484", "testing", "revert"])).toEqual({revisions: ["263483", "263484"], reason: "testing revert"});
+    expect(extractRevisionsAndReason(["r263483", "263484", "testing"])).toEqual({revisions: ["263483", "263484"], reason: "testing"});
+    expect(extractRevisionsAndReason(["96324"])).toEqual({revisions: ["96324"], reason: ""});
+    expect(extractRevisionsAndReason(["96324", "testing"])).toEqual({revisions: ["96324"], reason: "testing"});
+});
+
+test("a comma separated revision list is never a bug number", () => {
+    expect(extractRevisionsAndReason(["318045@main,321569"])).toEqual({revisions: ["318045@main", "321569"], reason: ""});
+});
+
+test("a bare number followed by a reason is still a revision", () => {
+    // Ambiguous, so leave today's behavior alone rather than guess.
+    let {revisions, reason} = extractRevisionsAndReason(["318045@main", "321569", "causes", "a", "crash"]);
+    expect(revisions).toEqual(["318045@main", "321569"]);
+    expect(reason).toBe("causes a crash");
+});
+
+test("a bug URL in the reason position still becomes the issue", () => {
+    let {revisions, reason} = extractRevisionsAndReason(["318045@main", "https://bugs.webkit.org/show_bug.cgi?id=321569"]);
+    expect(revisions).toEqual(["318045@main"]);
+    expect(parseBugId(reason)).toBe("321569");
+});
+
+test("a punctuated bare revision does not turn the next revision into a bug number", () => {
+    let args = extractCommandAndArgs("revert 263483. 263484").args;
+    let {revisions, reason} = extractRevisionsAndReason(args);
+    expect(revisions).toEqual(["263483", "263484"]);
+    expect(reason).toBe("");
+});
+
+test("a trailing bug number is recognized through sentence punctuation", () => {
+    let args = extractCommandAndArgs("revert 318045@main 321569.").args;
+    let {revisions, reason} = extractRevisionsAndReason(args);
+    expect(revisions).toEqual(["318045@main"]);
+    expect(parseBugId(reason)).toBe("321569");
+});
+
+test("a trailing bug number is recognized when wrapped in parentheses", () => {
+    let args = extractCommandAndArgs("revert 318045@main (321569)").args;
+    let {revisions, reason} = extractRevisionsAndReason(args);
+    expect(revisions).toEqual(["318045@main"]);
+    expect(parseBugId(reason)).toBe("321569");
 });


### PR DESCRIPTION
#### 9e969ab274673e5d16029200529ee71d90f5e940
<pre>
[webkitbot] Don&apos;t claim a revert PR was created when it was only updated
<a href="https://bugs.webkit.org/show_bug.cgi?id=323679">https://bugs.webkit.org/show_bug.cgi?id=323679</a>
<a href="https://rdar.apple.com/problem/186934915">rdar://problem/186934915</a>

Reviewed by NOBODY (OOPS!).

webkitbot has a hardcoded &quot;Created revert PR:&quot; message even though git-webkit distinguishes
between creating a new PR vs. updating an existing one. This meant that when webkitbot reused
an existing pull-request it misleadingly reported it as a creation.

Parse the action alongside the URL and say what actually happened, including a non-committal
wording for the case where git-webkit printed a URL but no recognizable action line, so the
bot never asserts a creation it did not observe.

Also fetch the fork with --prune during working-copy cleanup. cleanUpWorkingCopy deletes local
branches but never remote-tracking refs, and it only ever fetched origin, so git-webkit&apos;s
check for a branch that already exists on the fork was reading refs that were never populated,
and once populated would go stale and warn forever.

Finally, recognize a bare bug number so `revert <a href="https://commits.webkit.org/318045@main">318045@main</a> 321569` uses bug 321569 as the
tracking issue instead of treating the number as a second revision.

* Tools/WebKitBot/src/CommandParser.mjs:
* Tools/WebKitBot/src/Utility.mjs:
* Tools/WebKitBot/src/WebKitBot.mjs:
* Tools/WebKitBot/tests/WebKitBot.test.mjs:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e969ab274673e5d16029200529ee71d90f5e940

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196396 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150691 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8aac4de3-d3c7-4406-914f-69b0b2006964) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145418 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100801 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0faeb2a2-8537-4cfa-bdc9-18d703e3d832) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49094 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165955 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125743 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/93953d7c-36b6-45a2-a443-dd018824eb06) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47827 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45813 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158181 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45542 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7467 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198374 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59657 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154985 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60369 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42126 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154622 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49060 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129783 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58808 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20526 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58201 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58430 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58260 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->