### PR TITLE
Cannot run 'git-webkit' or 'check-webkit-style' with python 3.15

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -79,7 +79,7 @@ AutoInstall.register(Package('urllib3', Version(1, 26, 17)))
 AutoInstall.register(Package('wheel', Version(0, 35, 1)))
 AutoInstall.register(Package('cffi', Version(1, 17, 1), aliases=['_cffi_backend']))
 AutoInstall.register(Package('OpenSSL', Version(24, 3, 0), pypi_name='pyOpenSSL'))
-AutoInstall.register(Package('pyyaml', Version(6, 0, 3), pypi_name='PyYAML', wheel=True))
+AutoInstall.register(Package('pyyaml', Version(6, 0, 3), pypi_name='PyYAML', wheel=(sys.version_info < (3, 15))))
 AutoInstall.register(Package('jsone', Version(4, 8, 1), pypi_name='json-e'))
 
 # There are no prebuilt binaries for arm-32 of 'cryptography' and building it requires cargo/rust

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -60,7 +60,7 @@ AutoInstall.register(Package('xmltodict', Version(0, 11, 0)))
 AutoInstall.register(Package('webkitbugspy', Version(0, 15, 3)), local=True)
 
 if sys.version_info >= (3, 10):
-    AutoInstall.register(Package('rapidfuzz', Version(3, 14, 3), wheel=True))
+    AutoInstall.register(Package('rapidfuzz', Version(3, 14, 6), wheel=True))
 else:
     AutoInstall.register(Package('rapidfuzz', Version(3, 4, 0)))
 

--- a/Tools/Scripts/webkitpy/__init__.py
+++ b/Tools/Scripts/webkitpy/__init__.py
@@ -155,7 +155,7 @@ else:
 AutoInstall.register(Package('webkitscmpy', Version(4, 0, 0)), local=True)
 AutoInstall.register(Package('webkitbugspy', Version(0, 3, 1)), local=True)
 AutoInstall.register(Package('webkitexpectationspy', Version(1, 0, 0)), local=True)
-AutoInstall.register(Package('yaml', Version(6, 0, 3), pypi_name='PyYAML', wheel=True))
+AutoInstall.register(Package('yaml', Version(6, 0, 3), pypi_name='PyYAML', wheel=(sys.version_info < (3, 15))))
 
 import webkitscmpy
 

--- a/Tools/Scripts/webkitpy/style/checkers/common.py
+++ b/Tools/Scripts/webkitpy/style/checkers/common.py
@@ -23,7 +23,6 @@
 """Supports style checking not specific to any one file type."""
 
 import re
-import sre_compile
 
 # FIXME: Test this list in the same way that the list of CppChecker
 #        categories is tested, for example by checking that all of its
@@ -45,13 +44,13 @@ _regexp_compile_cache_ignorecase = {}
 
 def match(pattern, s):
     if not pattern in _regexp_compile_cache:
-        _regexp_compile_cache[pattern] = sre_compile.compile(pattern)
+        _regexp_compile_cache[pattern] = re.compile(pattern)
     return _regexp_compile_cache[pattern].match(s)
 
 
 def search(pattern, string):
     if not pattern in _regexp_compile_cache:
-        _regexp_compile_cache[pattern] = sre_compile.compile(pattern)
+        _regexp_compile_cache[pattern] = re.compile(pattern)
     return _regexp_compile_cache[pattern].search(string)
 
 
@@ -63,13 +62,13 @@ def searchIgnorecase(pattern, string):
 
 def sub(pattern, replacement, s):
     if not pattern in _regexp_compile_cache:
-        _regexp_compile_cache[pattern] = sre_compile.compile(pattern)
+        _regexp_compile_cache[pattern] = re.compile(pattern)
     return _regexp_compile_cache[pattern].sub(replacement, s)
 
 
 def subn(pattern, replacement, s):
     if not pattern in _regexp_compile_cache:
-        _regexp_compile_cache[pattern] = sre_compile.compile(pattern)
+        _regexp_compile_cache[pattern] = re.compile(pattern)
     return _regexp_compile_cache[pattern].subn(replacement, s)
 
 


### PR DESCRIPTION
#### 7056b0b5d3f90566190aba68c0d25265f0436ae2
<pre>
Cannot run &apos;git-webkit&apos; or &apos;check-webkit-style&apos; with python 3.15
<a href="https://bugs.webkit.org/show_bug.cgi?id=322418">https://bugs.webkit.org/show_bug.cgi?id=322418</a>

Unreviewed stable branch commit.

Some of these python libraries don&apos;t have wheels available for Python
3.15 yet.

Also, compile_sre has been removed, so we need to switch to regular re
package. Fortunately, that seems to be a drop-in replacement.

Note: although this is enough to make &apos;git-webkit&apos; and
&apos;check-webkit-style&apos; work, it&apos;s not enough to fix test-webkitpy. See bug
322435 for the first problem there.

Canonical link: <a href="https://commits.webkit.org/317695.261@webkitglib/2.54">https://commits.webkit.org/317695.261@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b588a733b15e99f29ea55a5e63fef1aeb3668a51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186099 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/59995 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53779 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196390 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150685 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187961 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/61370 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59714 "The change is no longer eligible for processing.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150685 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189054 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/61370 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53779 "The change is no longer eligible for processing.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/125735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/185428 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/61370 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59714 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53779 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/61370 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53779 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7461 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/47339 "The change is no longer eligible for processing.") | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59714 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198368 "Built successfully") | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/185502 "The change is no longer eligible for processing.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59651 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53779 "The change is no longer eligible for processing.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/60363 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53779 "The change is no longer eligible for processing.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/154615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28251 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/60363 "The change is no longer eligible for processing.") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129777 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58802 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53779 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/58195 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58424 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/58254 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->