### PR TITLE
[GFC] Repaint fix WIP.

### DIFF
--- a/LayoutTests/fast/repaint/align-items-overflow-change-gfc-expected.txt
+++ b/LayoutTests/fast/repaint/align-items-overflow-change-gfc-expected.txt
@@ -1,0 +1,7 @@
+Tests invalidation on align-items style change (just overflow). Passes if there is no red.
+
+(repaint rects
+  (rect 0 2 200 350)
+  (rect 0 2 800 14)
+)
+

--- a/LayoutTests/fast/repaint/align-items-overflow-change-gfc.html
+++ b/LayoutTests/fast/repaint/align-items-overflow-change-gfc.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML>
+<script src="resources/text-based-repaint.js"></script>
+<script>
+function repaintTest() {
+  document.getElementById('container').style.alignItems = 'safe end';
+}
+onload = runRepaintTest;
+</script>
+<style>
+body {
+  margin: 0;
+}
+#container {
+  display: grid;
+  grid: 150px 150px / 200px;
+  align-items: unsafe end;
+  width: 200px;
+  height: 300px;
+  background-color: red;
+}
+.item1 {
+  grid-row: 1;
+  grid-column: 1 / 2;
+  background-color: green;
+}
+.item2 {
+  grid-row: 2;
+  grid-column: 1 / 2;
+  background-color: green;
+}
+</style>
+<p style="height: 20px">Tests invalidation on align-items style change (just overflow). Passes if there is no red.</p>
+<div id="container">
+    <div class="item1">
+        <div style="height: 200px"></div>
+    </div>
+    <div class="item2">
+        <div style="height: 100px"></div>
+    </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/implicit-grids/grid-item-placed-in-trailing-implicit-column-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/implicit-grids/grid-item-placed-in-trailing-implicit-column-001-expected.txt
@@ -1,0 +1,6 @@
+
+PASS .grid 1
+PASS .grid 2
+PASS .grid 3
+PASS .grid 4
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/implicit-grids/grid-item-placed-in-trailing-implicit-column-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/implicit-grids/grid-item-placed-in-trailing-implicit-column-001.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Grid items placed into trailing implicit columns</title>
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#auto-tracks">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#line-placement">
+<meta name="assert" content="A grid item whose definite column placement lands past the last explicit column line creates a trailing implicit column that is sized by grid-auto-columns.">
+<style>
+.grid {
+    display: grid;
+    position: relative;
+}
+.grid > div { background: green; }
+
+/* Single trailing implicit column via an explicit start / explicit end. */
+#explicit-end {
+    grid-template-columns: 50px;
+    grid-template-rows: 30px 30px;
+    grid-auto-columns: 100px;
+}
+
+/* Single-value grid-column (explicit start, auto end) resolving to a single-cell span. */
+#auto-end {
+    grid-template-columns: 60px;
+    grid-template-rows: 30px;
+    grid-auto-columns: 80px;
+}
+
+/* Multiple trailing implicit columns cycle through the grid-auto-columns track list. */
+#cycling {
+    grid-template-columns: 40px;
+    grid-template-rows: 30px 30px 30px;
+    grid-auto-columns: 20px 30px;
+}
+
+/* column-gap is applied at the boundary between the explicit and implicit columns. */
+#with-gap {
+    grid-template-columns: 50px;
+    grid-template-rows: 30px;
+    grid-auto-columns: 100px;
+    column-gap: 10px;
+}
+</style>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+
+<body onload="checkLayout('.grid')">
+<div id="log"></div>
+
+<div class="grid" id="explicit-end">
+    <div style="grid-column: 1 / 2; grid-row: 1 / 2;"
+        data-offset-x="0" data-offset-y="0" data-expected-width="50" data-expected-height="30"></div>
+    <div style="grid-column: 2 / 3; grid-row: 2 / 3;"
+        data-offset-x="50" data-offset-y="30" data-expected-width="100" data-expected-height="30"></div>
+</div>
+
+<div class="grid" id="auto-end">
+    <div style="grid-column: 2; grid-row: 1 / 2;"
+        data-offset-x="60" data-offset-y="0" data-expected-width="80" data-expected-height="30"></div>
+</div>
+
+<div class="grid" id="cycling">
+    <div style="grid-column: 2 / 3; grid-row: 1 / 2;"
+        data-offset-x="40" data-offset-y="0" data-expected-width="20" data-expected-height="30"></div>
+    <div style="grid-column: 3 / 4; grid-row: 2 / 3;"
+        data-offset-x="60" data-offset-y="30" data-expected-width="30" data-expected-height="30"></div>
+    <div style="grid-column: 4 / 5; grid-row: 3 / 4;"
+        data-offset-x="90" data-offset-y="60" data-expected-width="20" data-expected-height="30"></div>
+</div>
+
+<div class="grid" id="with-gap">
+    <div style="grid-column: 2 / 3; grid-row: 1 / 2;"
+        data-offset-x="60" data-offset-y="0" data-expected-width="100" data-expected-height="30"></div>
+</div>
+
+</body>

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -86,7 +86,6 @@ enum class GridAvoidanceReason : uint8_t {
     GridItemColumnStartHasLineName,
     GridItemColumnStartHasNegativeLineNumber,
     GridItemColumnStartHasSpan,
-    GridItemHasColumnStartOutsideExplicitGrid,
     GridItemHasUnsupportedColumnEnd,
 
     GridNeedsImplicitColumnsForItemsLockedToRow,
@@ -113,7 +112,6 @@ static bool avoidanceReasonIsColumnPlacementRelated(GridAvoidanceReason gridAvoi
     case GridAvoidanceReason::GridItemColumnStartHasLineName:
     case GridAvoidanceReason::GridItemColumnStartHasNegativeLineNumber:
     case GridAvoidanceReason::GridItemColumnStartHasSpan:
-    case GridAvoidanceReason::GridItemHasColumnStartOutsideExplicitGrid:
     case GridAvoidanceReason::GridItemHasUnsupportedColumnEnd:
         return true;
     default:
@@ -152,14 +150,16 @@ static bool avoidanceReasonIsRowPlacementRelated(GridAvoidanceReason gridAvoidan
     }
 #endif
 
-static bool hasValidColumnEnd(const Style::GridPositionExplicit& explicitColumnStart, const Style::GridPosition columnEnd, size_t linesFromGridTemplateColumnsCount)
+static bool hasValidColumnEnd(const Style::GridPositionExplicit& explicitColumnStart, const Style::GridPosition columnEnd)
 {
     return WTF::switchOn(columnEnd,
         [](const CSS::Keyword::Auto&) {
-            return false;
+            // An auto end with an explicit start resolves to a single-column span at the start line
+            // (grid shorthand behavior), so trailing implicit columns are supported here.
+            return true;
         },
         [&](const Style::GridPositionExplicit&) {
-            if (!columnEnd.namedGridLine().value.isEmpty() || columnEnd.explicitPosition() < 0 || columnEnd.explicitPosition() > static_cast<int>(linesFromGridTemplateColumnsCount))
+            if (!columnEnd.namedGridLine().value.isEmpty() || columnEnd.explicitPosition() < 0)
                 return false;
 
             // FIXME: Multi-span items are not yet supported in intrinsic sizing
@@ -548,9 +548,7 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
                     return GridAvoidanceReason::GridItemColumnStartHasLineName;
                 if (columnStartLineNumber < 0)
                     return GridAvoidanceReason::GridItemColumnStartHasNegativeLineNumber;
-                if (columnStartLineNumber > static_cast<int>(linesFromGridTemplateColumnsCount))
-                    return GridAvoidanceReason::GridItemHasColumnStartOutsideExplicitGrid;
-                if (!hasValidColumnEnd(explicitPosition, gridItemStyle->gridItemColumnEnd(), linesFromGridTemplateColumnsCount))
+                if (!hasValidColumnEnd(explicitPosition, gridItemStyle->gridItemColumnEnd()))
                     return GridAvoidanceReason::GridItemHasUnsupportedColumnEnd;
                 return { };
             },
@@ -587,6 +585,7 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
                 if (!hasValidRowEnd(explicitPosition, rowEnd, linesFromGridTemplateRowsCount))
                     return GridAvoidanceReason::GridItemHasUnsupportedRowEnd;
 
+                ASSERT(rowEnd.isExplicit() || rowEnd.isAuto());
                 size_t rowIndex = rowStartLineNumber + 1;
                 auto rowsCount = explicitlyPlacedItemsInRowCount.size();
                 if (rowIndex > rowsCount)
@@ -822,9 +821,6 @@ static void printReason(GridAvoidanceReason reason, TextStream& stream)
         break;
     case GridAvoidanceReason::GridItemColumnStartHasSpan:
         stream << "grid item column start has span";
-        break;
-    case GridAvoidanceReason::GridItemHasColumnStartOutsideExplicitGrid:
-        stream << "grid item has column start outside explicit grid";
         break;
     case GridAvoidanceReason::GridItemHasUnsupportedColumnEnd:
         stream << "grid item has unsupported column end";

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -152,6 +152,7 @@ static inline Layout::GridLayoutConstraints constraintsForGridContent(const Layo
 
 void GridLayout::updateGridItemRenderers()
 {
+    CheckedRef renderGrid = gridBoxRenderer();
     CheckedRef layoutState = this->layoutState();
     auto& gridBoxGeometry = layoutState->geometryForBox(gridBox());
     auto contentBoxOffset = LayoutPoint(gridBoxGeometry.contentBoxLeft(), gridBoxGeometry.contentBoxTop());
@@ -161,6 +162,8 @@ void GridLayout::updateGridItemRenderers()
         auto& gridItemGeometry = layoutState->geometryForBox(layoutBox);
         auto borderBoxRect = Layout::BoxGeometry::borderBoxRect(gridItemGeometry);
 
+        auto oldGridItemRect = renderer->borderBoxRectInContainer();
+
         renderer->setLocation(contentBoxOffset + borderBoxRect.topLeft());
         renderer->setBorderBoxWidth(borderBoxRect.width());
         renderer->setBorderBoxHeight(borderBoxRect.height());
@@ -169,6 +172,9 @@ void GridLayout::updateGridItemRenderers()
         renderer->setMarginAfter(gridItemGeometry.marginAfter());
         renderer->setMarginStart(gridItemGeometry.marginStart());
         renderer->setMarginEnd(gridItemGeometry.marginEnd());
+
+        if (!renderGrid->selfNeedsLayout() && renderer->checkForRepaintDuringLayout())
+            renderer->repaintDuringLayoutIfMoved(oldGridItemRect);
     }
 }
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -404,6 +404,8 @@ void RenderGrid::layoutBlock(RelayoutChildren relayoutChildren, LayoutUnit)
     if (relayoutChildren == RelayoutChildren::No && simplifiedLayout())
         return;
 
+    LayoutRepainter repainter(*this);
+
     // The layoutBlock was handling the layout of both the grid and grid lanes implementations.
     // This caused a huge amount of branching code to handle grid lanes specific cases. Splitting up the code
     // to layout will simplify both implementations.
@@ -411,6 +413,10 @@ void RenderGrid::layoutBlock(RelayoutChildren relayoutChildren, LayoutUnit)
         layoutGrid(relayoutChildren);
     else
         layoutGridLanes(relayoutChildren);
+
+    updateLayerTransform();
+
+    repainter.repaintAfterLayout();
 }
 
 static void clearGridItemOverridingSizesBeforeLayout(RenderGrid& renderGrid)
@@ -444,8 +450,6 @@ const std::optional<LayoutUnit> RenderGrid::availableLogicalHeightForContentBox(
 
 void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
 {
-
-    LayoutRepainter repainter(*this);
     {
         LayoutStateMaintainer statePusher(*this, locationOffset(), isTransformed() || hasReflection() || writingMode().isBlockFlipped());
 
@@ -565,10 +569,6 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
         m_trackSizingAlgorithm.reset();
     }
 
-    updateLayerTransform();
-
-    repainter.repaintAfterLayout();
-
     m_trackSizingAlgorithm.clearBaselineItemsCache();
 }
 
@@ -631,7 +631,6 @@ void RenderGrid::layoutGridLanes(RelayoutChildren relayoutChildren)
 {
     ASSERT(isGridLanes());
 
-    LayoutRepainter repainter(*this);
     {
         LayoutStateMaintainer statePusher(*this, locationOffset(), isTransformed() || hasReflection() || writingMode().isBlockFlipped());
         RenderGridLayoutState gridLayoutState;
@@ -754,10 +753,6 @@ void RenderGrid::layoutGridLanes(RelayoutChildren relayoutChildren)
 
         m_trackSizingAlgorithm.reset();
     }
-
-    updateLayerTransform();
-
-    repainter.repaintAfterLayout();
 
     m_trackSizingAlgorithm.clearBaselineItemsCache();
 }


### PR DESCRIPTION
#### f2b820a80a944c975859e57743849434a284680a
<pre>
[GFC] Repaint fix WIP.
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

Tests: fast/repaint/align-items-overflow-change-gfc.html
       imported/w3c/web-platform-tests/css/css-grid/implicit-grids/grid-item-placed-in-trailing-implicit-column-001.html

* LayoutTests/fast/repaint/align-items-overflow-change-gfc-expected.txt: Added.
* LayoutTests/fast/repaint/align-items-overflow-change-gfc.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/implicit-grids/grid-item-placed-in-trailing-implicit-column-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/implicit-grids/grid-item-placed-in-trailing-implicit-column-001.html: Added.
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
(WebCore::LayoutIntegration::avoidanceReasonIsColumnPlacementRelated):
(WebCore::LayoutIntegration::hasValidColumnEnd):
(WebCore::LayoutIntegration::gridLayoutAvoidanceReason):
(WebCore::LayoutIntegration::printReason):
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp:
(WebCore::LayoutIntegration::GridLayout::updateGridItemRenderers):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::layoutBlock):
(WebCore::RenderGrid::layoutGrid):
(WebCore::RenderGrid::layoutGridLanes):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2b820a80a944c975859e57743849434a284680a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196401 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150696 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8adf9012-0beb-41f1-8685-279289ccbf00) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59725 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145422 "Found 7 new test failures: fast/repaint/align-items-overflow-change-gfc.html fast/repaint/align-items-overflow-change.html fast/repaint/align-self-change.html fast/repaint/align-self-overflow-change.html fast/repaint/justify-items-overflow-change.html fast/repaint/justify-self-change.html fast/repaint/justify-self-overflow-change.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100802 "Exiting early after 60 failures. 60 tests run. 61 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ee278d3c-2d0d-4800-bbac-ca24f940fbc7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125748 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2f740ae9-37cb-4a26-ae31-36c81e4a855a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47831 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45817 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158185 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45544 "Found 8 new test failures: fast/repaint/align-items-overflow-change-gfc.html fast/repaint/align-items-overflow-change.html fast/repaint/align-self-change.html fast/repaint/align-self-overflow-change.html fast/repaint/justify-items-legacy-change.html fast/repaint/justify-items-overflow-change.html fast/repaint/justify-self-change.html fast/repaint/justify-self-overflow-change.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7472 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52534 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50273 "Found 7 new test failures: fast/repaint/align-items-overflow-change-gfc.html fast/repaint/align-items-overflow-change.html fast/repaint/align-self-change.html fast/repaint/align-self-overflow-change.html fast/repaint/justify-items-overflow-change.html fast/repaint/justify-self-change.html fast/repaint/justify-self-overflow-change.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198379 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59662 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165476 "Exiting early after 10 failures. 41 tests run. 1 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/154989 "Found 7 new test failures: fast/repaint/align-items-overflow-change-gfc.html fast/repaint/align-items-overflow-change.html fast/repaint/align-self-change.html fast/repaint/align-self-overflow-change.html fast/repaint/justify-items-overflow-change.html fast/repaint/justify-self-change.html fast/repaint/justify-self-overflow-change.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60374 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42128 "Found 7 new test failures: fast/repaint/align-items-overflow-change-gfc.html fast/repaint/align-items-overflow-change.html fast/repaint/align-self-change.html fast/repaint/align-self-overflow-change.html fast/repaint/justify-items-overflow-change.html fast/repaint/justify-self-change.html fast/repaint/justify-self-overflow-change.html (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154626 "Found 1 new API test failure: TestWebKitWebXR:/webkit/WebKitWebXR/leave-immersive-mode (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49063 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132662 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129788 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58813 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20528 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58206 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58435 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58265 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->