### PR TITLE
`scroll-margin` is not applied in the scroll container's coordinate space

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-scrollMargin-transformed-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-scrollMargin-transformed-container-expected.txt
@@ -1,0 +1,4 @@
+
+PASS scroll-margin is not scaled by the scroll container transform (start)
+PASS scroll-margin is not scaled by the scroll container transform (end)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-scrollMargin-transformed-container.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-scrollMargin-transformed-container.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<title>CSSOM View - scrollIntoView applies scroll-margin in the scroll container's coordinate space</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview">
+<link rel="help" href="https://drafts.csswg.org/css-scroll-snap-1/#scroll-margin">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+#scroller {
+  width: 200px;
+  height: 200px;
+  overflow: scroll;
+  transform: scale(2);
+  transform-origin: 0 0;
+}
+#content {
+  width: 500px;
+  height: 500px;
+}
+#target {
+  position: relative;
+  left: 200px;
+  top: 200px;
+  width: 100px;
+  height: 100px;
+  scroll-margin-top: 4px;
+  scroll-margin-right: 8px;
+  scroll-margin-bottom: 12px;
+  scroll-margin-left: 16px;
+  background-color: lightgreen;
+}
+</style>
+
+<div style="height: 400px">
+  <div id="scroller">
+    <div id="content">
+      <div id="target"></div>
+    </div>
+  </div>
+</div>
+<div id="log"></div>
+
+<script>
+var target = document.getElementById("target");
+var scroller = document.getElementById("scroller");
+
+var expectedXLeft = 200 - 16;
+var expectedXRight = 200 - scroller.clientWidth + target.clientWidth + 8;
+var expectedYTop = 200 - 4;
+var expectedYBottom = 200 - scroller.clientHeight + target.clientHeight + 12;
+
+[
+  ["start", {block: "start", inline: "start"}, expectedXLeft, expectedYTop],
+  ["end", {block: "end", inline: "end"}, expectedXRight, expectedYBottom],
+].forEach(([name, input, expectedX, expectedY]) => {
+  test(() => {
+    scroller.scrollTo(0, 0);
+    target.scrollIntoView(input);
+    assert_approx_equals(scroller.scrollLeft, expectedX, 0.5, "scrollX");
+    assert_approx_equals(scroller.scrollTop, expectedY, 0.5, "scrollY");
+  }, `scroll-margin is not scaled by the scroll container transform (${name})`);
+})
+</script>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1250,6 +1250,7 @@ void Element::scrollIntoView(Variant<bool, ScrollIntoViewOptions>&& arg)
     SingleThreadWeakPtr<RenderElement> renderer;
     bool insideFixed = false;
     LayoutRect absoluteBounds;
+    LayoutBoxExtent scrollMargin;
 
     if (auto listBoxScrollResult = listBoxElementScrollIntoView(*this)) {
         renderer = WTF::move(listBoxScrollResult->first);
@@ -1262,7 +1263,9 @@ void Element::scrollIntoView(Variant<bool, ScrollIntoViewOptions>&& arg)
         if (!renderer)
             return;
 
-        absoluteBounds = renderer->absoluteAnchorRectWithScrollMargin(&insideFixed).marginRect;
+        auto bounds = renderer->absoluteAnchorRectWithScrollMargin(&insideFixed);
+        absoluteBounds = bounds.anchorRect;
+        scrollMargin = bounds.scrollMargin;
     }
 
     auto options = WTF::switchOn(arg,
@@ -1300,7 +1303,8 @@ void Element::scrollIntoView(Variant<bool, ScrollIntoViewOptions>&& arg)
         .alignX = physicalAlignX,
         .alignY = physicalAlignY,
         .behavior = options.behavior,
-        .skipScrollingTargetElement = SkipScrollingTargetElement::Yes
+        .skipScrollingTargetElement = SkipScrollingTargetElement::Yes,
+        .scrollMargin = scrollMargin
     };
     LocalFrameView::scrollRectToVisible(absoluteBounds, *renderer, insideFixed, visibleOptions);
 }
@@ -1314,7 +1318,7 @@ void Element::scrollIntoView(bool alignToTop)
         return;
 
     bool insideFixed;
-    LayoutRect absoluteBounds = renderer->absoluteAnchorRectWithScrollMargin(&insideFixed).marginRect;
+    auto bounds = renderer->absoluteAnchorRectWithScrollMargin(&insideFixed);
 
     // Align to the top / bottom and to the closest edge.
     auto alignX = ScrollAlignment::alignToEdgeIfNeeded;
@@ -1324,10 +1328,11 @@ void Element::scrollIntoView(bool alignToTop)
         .revealMode = SelectionRevealMode::Reveal,
         .alignX = alignX,
         .alignY = alignToTop ? ScrollAlignment::alignTopAlways : ScrollAlignment::alignBottomAlways,
-        .skipScrollingTargetElement = SkipScrollingTargetElement::Yes
+        .skipScrollingTargetElement = SkipScrollingTargetElement::Yes,
+        .scrollMargin = bounds.scrollMargin
     };
 
-    LocalFrameView::scrollRectToVisible(absoluteBounds, *renderer, insideFixed, options);
+    LocalFrameView::scrollRectToVisible(bounds.anchorRect, *renderer, insideFixed, options);
 }
 
 void Element::scrollIntoViewIfNeeded(bool centerIfNeeded)
@@ -1342,7 +1347,7 @@ void Element::scrollIntoViewIfNeeded(bool centerIfNeeded)
         return;
 
     bool insideFixed;
-    LayoutRect absoluteBounds = renderer->absoluteAnchorRectWithScrollMargin(&insideFixed).marginRect;
+    auto bounds = renderer->absoluteAnchorRectWithScrollMargin(&insideFixed);
 
     auto alignX = centerIfNeeded ? ScrollAlignment::alignCenterIfNeeded : ScrollAlignment::alignToEdgeIfNeeded;
     alignX.disableLegacyHorizontalVisibilityThreshold();
@@ -1351,9 +1356,10 @@ void Element::scrollIntoViewIfNeeded(bool centerIfNeeded)
         .revealMode = SelectionRevealMode::Reveal,
         .alignX = alignX,
         .alignY = centerIfNeeded ? ScrollAlignment::alignCenterIfNeeded : ScrollAlignment::alignToEdgeIfNeeded,
-        .skipScrollingTargetElement = SkipScrollingTargetElement::Yes
+        .skipScrollingTargetElement = SkipScrollingTargetElement::Yes,
+        .scrollMargin = bounds.scrollMargin
     };
-    LocalFrameView::scrollRectToVisible(absoluteBounds, *renderer, insideFixed, options);
+    LocalFrameView::scrollRectToVisible(bounds.anchorRect, *renderer, insideFixed, options);
 }
 
 void Element::scrollIntoViewIfNotVisible(bool centerIfNotVisible, AllowScrollingOverflowHidden allowScrollingOverflowHidden)
@@ -1365,17 +1371,18 @@ void Element::scrollIntoViewIfNotVisible(bool centerIfNotVisible, AllowScrolling
         return;
 
     bool insideFixed;
-    LayoutRect absoluteBounds = renderer->absoluteAnchorRectWithScrollMargin(&insideFixed).marginRect;
+    auto bounds = renderer->absoluteAnchorRectWithScrollMargin(&insideFixed);
     auto align = centerIfNotVisible ? ScrollAlignment::alignCenterIfNotVisible : ScrollAlignment::alignToEdgeIfNotVisible;
     auto options = ScrollRectToVisibleOptions {
         .revealMode = SelectionRevealMode::Reveal,
         .alignX = align,
         .alignY = align,
         .allowScrollingOverflowHidden = allowScrollingOverflowHidden,
-        .skipScrollingTargetElement = SkipScrollingTargetElement::Yes
+        .skipScrollingTargetElement = SkipScrollingTargetElement::Yes,
+        .scrollMargin = bounds.scrollMargin
     };
 
-    LocalFrameView::scrollRectToVisible(absoluteBounds, *renderer, insideFixed, options);
+    LocalFrameView::scrollRectToVisible(bounds.anchorRect, *renderer, insideFixed, options);
 }
 
 void Element::scrollBy(const ScrollToOptions& options)

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3500,9 +3500,18 @@ void LocalFrameView::scrollToFocusedElementInternal()
 
     bool insideFixed;
     auto absoluteBounds = renderer->absoluteAnchorRectWithScrollMargin(&insideFixed);
-    auto anchorRectWithScrollMargin = absoluteBounds.marginRect;
     auto anchorRect = absoluteBounds.anchorRect;
-    LocalFrameView::scrollRectToVisible(anchorRectWithScrollMargin, *renderer, insideFixed, { m_selectionRevealModeForFocusedElement, ScrollAlignment::alignCenterIfNeeded, ScrollAlignment::alignCenterIfNeeded, ShouldAllowCrossOriginScrolling::No, ScrollBehavior::Auto, OnlyAllowForwardScrolling::No, AllowScrollingOverflowHidden::Yes, anchorRect });
+    LocalFrameView::scrollRectToVisible(anchorRect, *renderer, insideFixed, {
+        .revealMode = m_selectionRevealModeForFocusedElement,
+        .alignX = ScrollAlignment::alignCenterIfNeeded,
+        .alignY = ScrollAlignment::alignCenterIfNeeded,
+        .shouldAllowCrossOriginScrolling = ShouldAllowCrossOriginScrolling::No,
+        .behavior = ScrollBehavior::Auto,
+        .onlyAllowForwardScrolling = OnlyAllowForwardScrolling::No,
+        .allowScrollingOverflowHidden = AllowScrollingOverflowHidden::Yes,
+        .visibilityCheckRect = anchorRect,
+        .scrollMargin = absoluteBounds.scrollMargin
+    });
 }
 
 void LocalFrameView::textFragmentIndicatorTimerFired()
@@ -4684,9 +4693,13 @@ void LocalFrameView::scrollToAnchor()
     cancelScheduledScrolls();
 
     LayoutRect rect;
+    LayoutBoxExtent scrollMargin;
     bool insideFixed = false;
-    if (anchorNode != m_frame->document() && anchorNode->renderer())
-        rect = anchorNode->renderer()->absoluteAnchorRectWithScrollMargin(&insideFixed).marginRect;
+    if (anchorNode != m_frame->document() && anchorNode->renderer()) {
+        auto bounds = anchorNode->renderer()->absoluteAnchorRectWithScrollMargin(&insideFixed);
+        rect = bounds.anchorRect;
+        scrollMargin = bounds.scrollMargin;
+    }
 
     LOG_WITH_STREAM(Scrolling, stream << " anchor node rect " << rect);
 
@@ -4709,7 +4722,13 @@ void LocalFrameView::scrollToAnchor()
 
     adjustScrollAlignmentForScrollSnapAlign(renderer, &alignX, &alignY);
 
-    scrollRectToVisible(rect, renderer, insideFixed, { SelectionRevealMode::Reveal, alignX, alignY, ShouldAllowCrossOriginScrolling::No });
+    scrollRectToVisible(rect, renderer, insideFixed, {
+        .revealMode = SelectionRevealMode::Reveal,
+        .alignX = alignX,
+        .alignY = alignY,
+        .shouldAllowCrossOriginScrolling = ShouldAllowCrossOriginScrolling::No,
+        .scrollMargin = scrollMargin
+    });
 
     if (AXObjectCache* cache = protect(m_frame->document())->existingAXObjectCache())
         cache->handleScrolledToAnchor(*anchorNode);

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2243,15 +2243,16 @@ MarginRect RenderElement::absoluteAnchorRectWithScrollMargin(bool* insideFixed) 
 
     auto& scrollMarginBox = style().scrollMarginBox();
     if (Style::isZero(scrollMarginBox))
-        return { anchorRect, anchorRect };
+        return { anchorRect, anchorRect, { } };
 
     // The scroll snap specification says that the scroll-margin should be applied in the
     // coordinate system of the scroll container and applied to the rectangular bounding
     // box of the transformed border box of the target element.
-    // See https://www.w3.org/TR/css-scroll-snap-1/#scroll-margin.
+    // See https://drafts.csswg.org/css-scroll-snap-1/#scroll-margin.
+    auto scrollMargin = Style::extentForRect(scrollMarginBox, anchorRect, style().usedZoomForLength());
     auto marginRect = anchorRect;
-    marginRect.expand(Style::extentForRect(scrollMarginBox, anchorRect, style().usedZoomForLength()));
-    return { marginRect, anchorRect };
+    marginRect.expand(scrollMargin);
+    return { marginRect, anchorRect, scrollMargin };
 }
 
 void RenderElement::paintOutline(PaintInfo& paintInfo, const LayoutRect& paintRect)

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -46,6 +46,7 @@ struct ImageOrientation;
 struct MarginRect {
     LayoutRect marginRect;
     LayoutRect anchorRect;
+    LayoutBoxExtent scrollMargin;
 };
 
 namespace Layout {

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -45,6 +45,7 @@
 #pragma once
 
 #include <WebCore/AffineTransform.h>
+#include <WebCore/BoxExtents.h>
 #include <WebCore/ClipRect.h>
 #include <WebCore/GraphicsLayerEnums.h>
 #include <WebCore/LayerFragment.h>
@@ -163,6 +164,7 @@ struct ScrollRectToVisibleOptions {
     AllowScrollingOverflowHidden allowScrollingOverflowHidden { AllowScrollingOverflowHidden::Yes };
     std::optional<LayoutRect> visibilityCheckRect { std::nullopt };
     SkipScrollingTargetElement skipScrollingTargetElement { SkipScrollingTargetElement::No };
+    LayoutBoxExtent scrollMargin { };
 };
 
 enum class UpdateBackingSharingFlags {

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1919,11 +1919,18 @@ LayoutRect RenderLayerScrollableArea::scrollRectToVisible(const LayoutRect& abso
     scrollingViewportWithPadding.contract(scrollPadding);
 
     auto localExposeRect = computeLocalExposeRect(absoluteRect, box);
+
+    // Add the scroll-margin outsets in this container's coordinate space, and thread the
+    // unmargined rect back to ancestor scrollers so each applies the margin in its own space.
+    // https://drafts.csswg.org/css-scroll-snap-1/#scroll-margin
+    auto localExposeRectWithMargin = localExposeRect;
+    localExposeRectWithMargin.expand(options.scrollMargin);
+
     std::optional<LayoutRect> localVisiblityRect;
     if (options.visibilityCheckRect)
         localVisiblityRect = computeLocalExposeRect(*options.visibilityCheckRect, box);
 
-    auto revealRect = getRectToExposeForScrollIntoView(scrollingViewportWithPadding, localExposeRect, options.alignX, options.alignY, localVisiblityRect);
+    auto revealRect = getRectToExposeForScrollIntoView(scrollingViewportWithPadding, localExposeRectWithMargin, options.alignX, options.alignY, localVisiblityRect);
     revealRect.move(-scrollingViewportWithPadding.x(), -scrollingViewportWithPadding.y());
 
     auto scrollPositionOptions = ScrollPositionChangeOptions::createProgrammatic();


### PR DESCRIPTION
#### 255c14542871895c9a9da7a4836e544d0fb62872
<pre>
`scroll-margin` is not applied in the scroll container&apos;s coordinate space
<a href="https://bugs.webkit.org/show_bug.cgi?id=323808">https://bugs.webkit.org/show_bug.cgi?id=323808</a>
<a href="https://rdar.apple.com/187133554">rdar://187133554</a>

Reviewed by NOBODY (OOPS!).

scroll-margin outsets were added to the target&apos;s bounding box in absolute
(document) coordinate space by absoluteAnchorRectWithScrollMargin(), and only
afterwards was the whole rect mapped into the scroll container&apos;s local space by
RenderLayerScrollableArea::scrollRectToVisible() via absoluteToLocalQuad(). When
the scroll container is transformed, that inverse-transform divides the already
-added margin by the container&apos;s scale, so e.g. a 6px scroll-margin under
scale(2) contributed only 3px of scroll offset. scroll-padding was unaffected
because it is derived from the container&apos;s own paddingBoxRect() and applied in
local space.

The scroll snap area is the rectangular bounding box of the transformed border
box, axis-aligned in the scroll container&apos;s coordinate space, with the outsets
added there [1]. Chrome and Firefox match this.

Apply scroll-margin symmetrically with scroll-padding: carry the outsets
separately instead of baking them into the absolute rect, thread the unmargined
anchor rect through the scroller chain, and expand the rect by the outsets in
each scroll container&apos;s local coordinate space. This is behavior-identical to
the previous code for untransformed (including nested) scrollers and correct
under a transformed scroll container.

[1] <a href="https://drafts.csswg.org/css-scroll-snap-1/#scroll-margin">https://drafts.csswg.org/css-scroll-snap-1/#scroll-margin</a>

Test: imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-scrollMargin-transformed-container.html

* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-scrollMargin-transformed-container.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/scrollIntoView-scrollMargin-transformed-container-expected.txt: Added.

* Source/WebCore/rendering/RenderElement.h:
(WebCore::MarginRect): Carry the scroll-margin outsets alongside the rects.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::absoluteAnchorRectWithScrollMargin const): Return the
outsets separately so callers can add them in the container&apos;s coordinate space.

* Source/WebCore/rendering/RenderLayer.h:
(WebCore::ScrollRectToVisibleOptions): Add scrollMargin, appl

* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::scrollRectToVisible): Expand the mapped
local rect by the scroll-margin outsets, and thread the unmar
ancestor scrollers so each applies the margin in its own coordinate space.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::scrollIntoView):
(WebCore::Element::scrollIntoViewIfNeeded):
(WebCore::Element::scrollIntoViewIfNotVisible): Pass the unma
and the outsets via ScrollRectToVisibleOptions.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToFocusedElementInternal):
(WebCore::LocalFrameView::scrollToAnchor): Ditto.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/255c14542871895c9a9da7a4836e544d0fb62872

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150699 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187975 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59728 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145437 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-align-001.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100807 "Exiting early after 60 failures. 60 tests run. 61 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125764 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47844 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-align-001.html imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-snap-001.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45825 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158198 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45558 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-align-001.html imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-snap-001.html (failure)") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7475 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52537 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50282 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-align-001.html imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-snap-001.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198382 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59665 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155001 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60377 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42140 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-align-001.html imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-snap-001.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154638 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49075 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132665 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129791 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58816 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20540 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58209 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58438 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58268 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->