### PR TITLE
REGRESSION(319603@main): Broke http/tests/webgpu/webgpu/api/validation/render_pipeline/vertex_state.html

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pipeline/vertex_state-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pipeline/vertex_state-expected.txt
@@ -48,6 +48,7 @@ PASS :vertex_shader_type_matches_attribute_format:format="sint32x3"
 PASS :vertex_shader_type_matches_attribute_format:format="sint32x4"
 PASS :vertex_shader_type_matches_attribute_format:format="unorm10-10-10-2"
 PASS :vertex_shader_type_matches_attribute_format:format="unorm8x4-bgra"
+PASS :vertex_shader_type_matches_attribute_format:format="snorm10-10-10-2"
 PASS :vertex_attribute_offset_alignment:format="uint8";arrayStrideVariant={"mult":0,"add":256};offsetVariant={"mult":0,"add":0}
 PASS :vertex_attribute_offset_alignment:format="uint8";arrayStrideVariant={"mult":0,"add":256};offsetVariant={"mult":0,"add":1}
 PASS :vertex_attribute_offset_alignment:format="uint8";arrayStrideVariant={"mult":0,"add":256};offsetVariant={"mult":0,"add":2}
@@ -636,6 +637,18 @@ PASS :vertex_attribute_offset_alignment:format="unorm8x4-bgra";arrayStrideVarian
 PASS :vertex_attribute_offset_alignment:format="unorm8x4-bgra";arrayStrideVariant={"mult":1,"add":0};offsetVariant={"mult":1,"add":-4}
 PASS :vertex_attribute_offset_alignment:format="unorm8x4-bgra";arrayStrideVariant={"mult":1,"add":0};offsetVariant={"mult":1,"add":-6}
 PASS :vertex_attribute_offset_alignment:format="unorm8x4-bgra";arrayStrideVariant={"mult":1,"add":0};offsetVariant={"mult":1,"add":-8}
+PASS :vertex_attribute_offset_alignment:format="snorm10-10-10-2";arrayStrideVariant={"mult":0,"add":256};offsetVariant={"mult":0,"add":0}
+PASS :vertex_attribute_offset_alignment:format="snorm10-10-10-2";arrayStrideVariant={"mult":0,"add":256};offsetVariant={"mult":0,"add":2}
+PASS :vertex_attribute_offset_alignment:format="snorm10-10-10-2";arrayStrideVariant={"mult":0,"add":256};offsetVariant={"mult":0,"add":4}
+PASS :vertex_attribute_offset_alignment:format="snorm10-10-10-2";arrayStrideVariant={"mult":0,"add":256};offsetVariant={"mult":1,"add":-4}
+PASS :vertex_attribute_offset_alignment:format="snorm10-10-10-2";arrayStrideVariant={"mult":0,"add":256};offsetVariant={"mult":1,"add":-6}
+PASS :vertex_attribute_offset_alignment:format="snorm10-10-10-2";arrayStrideVariant={"mult":0,"add":256};offsetVariant={"mult":1,"add":-8}
+PASS :vertex_attribute_offset_alignment:format="snorm10-10-10-2";arrayStrideVariant={"mult":1,"add":0};offsetVariant={"mult":0,"add":0}
+PASS :vertex_attribute_offset_alignment:format="snorm10-10-10-2";arrayStrideVariant={"mult":1,"add":0};offsetVariant={"mult":0,"add":2}
+PASS :vertex_attribute_offset_alignment:format="snorm10-10-10-2";arrayStrideVariant={"mult":1,"add":0};offsetVariant={"mult":0,"add":4}
+PASS :vertex_attribute_offset_alignment:format="snorm10-10-10-2";arrayStrideVariant={"mult":1,"add":0};offsetVariant={"mult":1,"add":-4}
+PASS :vertex_attribute_offset_alignment:format="snorm10-10-10-2";arrayStrideVariant={"mult":1,"add":0};offsetVariant={"mult":1,"add":-6}
+PASS :vertex_attribute_offset_alignment:format="snorm10-10-10-2";arrayStrideVariant={"mult":1,"add":0};offsetVariant={"mult":1,"add":-8}
 PASS :vertex_attribute_contained_in_stride:format="uint8"
 PASS :vertex_attribute_contained_in_stride:format="uint8x2"
 PASS :vertex_attribute_contained_in_stride:format="uint8x4"
@@ -677,5 +690,6 @@ PASS :vertex_attribute_contained_in_stride:format="sint32x3"
 PASS :vertex_attribute_contained_in_stride:format="sint32x4"
 PASS :vertex_attribute_contained_in_stride:format="unorm10-10-10-2"
 PASS :vertex_attribute_contained_in_stride:format="unorm8x4-bgra"
+PASS :vertex_attribute_contained_in_stride:format="snorm10-10-10-2"
 PASS :many_attributes_overlapping:
 


### PR DESCRIPTION
#### 5dfb4dcabb5893ef9bb6dd35003371d90582fcb9
<pre>
REGRESSION(319603@main): Broke http/tests/webgpu/webgpu/api/validation/render_pipeline/vertex_state.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=323890">https://bugs.webkit.org/show_bug.cgi?id=323890</a>
<a href="https://rdar.apple.com/187132653">rdar://187132653</a>

Unreviewed rebaseline.

* LayoutTests/http/tests/webgpu/webgpu/api/validation/render_pipeline/vertex_state-expected.txt:

Canonical link: <a href="https://commits.webkit.org/320858@main">https://commits.webkit.org/320858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c684dc93e7a07401d229406c47993f69daa697b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196406 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f0c6934-d8f6-477c-9916-c96df0163c60) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59730 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145426 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/cc8cb704-0e35-4db7-87e3-0cc2d28fab74) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49103 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125752 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8ee4fc70-533c-43e2-95a3-cb6ec2fe4491) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47836 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45552 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7477 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198384 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59667 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/154993 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60379 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154630 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28261 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49067 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129793 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58818 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58211 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58440 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58270 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->