### PR TITLE
[CMake] Add missing includes exposed by a non-unified build - WebExtensionAPITestCocoa, etc.

### DIFF
--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -40,6 +40,7 @@
 #include "EventLoop.h"
 #include "ExceptionData.h"
 #include "ExceptionOr.h"
+#include "FrameDestructionObserverInlines.h"
 #include "JSDOMConvertAny.h"
 #include "JSDOMConvertInterface.h"
 #include "JSDOMConvertJSON.h"

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -83,6 +83,7 @@
 #include "RenderInline.h"
 #include "RenderLayer.h"
 #include "RenderLayerScrollableArea.h"
+#include "RenderObjectStyle.h"
 #include "RenderText.h"
 #include "RenderTextControl.h"
 #include "RenderTheme.h"

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfoInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfoInternal.h
@@ -23,12 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <WebKit/_WKActivatedElementInfo.h>
+
 #if PLATFORM(IOS_FAMILY)
 
 #import "InteractionInformationAtPosition.h"
 #import <WebCore/ElementAnimationContext.h>
 #import <WebCore/IntPoint.h>
-#import <WebKit/_WKActivatedElementInfo.h>
 
 namespace WebCore {
 class ShareableBitmap;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIOffscreenCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIOffscreenCocoa.mm
@@ -37,6 +37,7 @@
 #import "WKWebViewInternal.h"
 #import "WebExtensionContextProxyMessages.h"
 #import "WebExtensionOffscreenDocumentParameters.h"
+#import "WebExtensionPermission.h"
 #import "WebPageProxy.h"
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
@@ -47,6 +47,8 @@ using CocoaMenuItem = UIMenuElement;
 #endif
 
 #if defined(__OBJC__) && USE(APPKIT)
+#import <AppKit/NSMenuItem.h>
+
 using WebExtensionMenuItemHandlerBlock = void (^)(id);
 
 @interface _WKWebExtensionMenuItem : NSMenuItem

--- a/Source/WebKit/UIProcess/PageLoadState.cpp
+++ b/Source/WebKit/UIProcess/PageLoadState.cpp
@@ -501,7 +501,7 @@ void PageLoadState::receivedQualifiedServerTrust(const Transaction::Token& token
 #if PLATFORM(COCOA)
     // QualifiedServerTrustFetch and IPC can take enough time that the page has navigated away.
     // Make sure we are still exposing the server trust for which the qualifiedServerTrust is valid.
-    if (!certificatesMatch(serverTrust.trust(), this->certificateInfo().trust()))
+    if (!WebCore::certificatesMatch(serverTrust.trust(), this->certificateInfo().trust()))
         return;
 #endif
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm
@@ -32,8 +32,11 @@
 #import "WebExtensionAPITest.h"
 
 #import "CocoaHelpers.h"
+#import "MessageSenderInlines.h"
 #import "WebExtensionControllerMessages.h"
 #import "WebExtensionControllerProxy.h"
+#import "WebPage.h"
+#import "WebProcess.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.cpp
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.cpp
@@ -30,6 +30,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#include "MessageSenderInlines.h"
 #include "WebExtensionAPIKeys.h"
 #include "WebExtensionAPINamespace.h"
 #include "WebExtensionAPIPort.h"

--- a/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
@@ -50,6 +50,7 @@
 #import <WebCore/GeometryUtilities.h>
 #import <WebCore/ImmediateActionStage.h>
 #import <WebCore/LocalFrame.h>
+#import <WebCore/LocalFrameInlines.h>
 #import <WebCore/LocalFrameView.h>
 #import <WebCore/NodeDocument.h>
 #import <WebCore/NodeRenderStyle.h>

--- a/Source/WebKitLegacy/mac/WebView/WebPDFRepresentation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFRepresentation.mm
@@ -40,6 +40,7 @@
 #import "WebView.h"
 #import <wtf/Assertions.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 @implementation WebPDFRepresentation
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdaptiveImageGlyph.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdaptiveImageGlyph.mm
@@ -30,6 +30,7 @@
 #import "Helpers/mac/AppKitSPI.h"
 #import "Helpers/cocoa/DragAndDropSimulator.h"
 #import "Helpers/PlatformUtilities.h"
+#import "Helpers/Test.h"
 #import "TestInputDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import "UIKitSPIForTesting.h"

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP2Server.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP2Server.mm
@@ -27,6 +27,7 @@
 
 #if HAVE(NETWORK_FRAMEWORK_HTTP_MESSAGING)
 
+#import "Helpers/PlatformUtilities.h"
 #import "Helpers/Utilities.h"
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP3Server.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP3Server.mm
@@ -27,6 +27,7 @@
 
 #if HAVE(NETWORK_FRAMEWORK_HTTP_MESSAGING)
 
+#import "Helpers/PlatformUtilities.h"
 #import "Helpers/Utilities.h"
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestWKWebView.h"


### PR DESCRIPTION
#### fe013f5aec0c1cf5afb5ee5e075660550e5ca190
<pre>
[CMake] Add missing includes exposed by a non-unified build - WebExtensionAPITestCocoa, etc.
<a href="https://bugs.webkit.org/show_bug.cgi?id=323894">https://bugs.webkit.org/show_bug.cgi?id=323894</a>
<a href="https://rdar.apple.com/187136566">rdar://187136566</a>

Reviewed by Abrar Rahman Protyasha.

Added missing includes found by running a non-unified build.
Fix them now so they aren&apos;t exposed later.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdaptiveImageGlyph.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP2Server.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP3Server.mm

* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
* Source/WebCore/editing/FrameSelection.cpp:
* Source/WebKit/UIProcess/API/Cocoa/_WKActivatedElementInfoInternal.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIOffscreenCocoa.mm:
* Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h:
* Source/WebKit/UIProcess/PageLoadState.cpp:
(WebKit::PageLoadState::receivedQualifiedServerTrust):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.cpp:
* Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm:
* Source/WebKitLegacy/mac/WebView/WebPDFRepresentation.mm:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/AdaptiveImageGlyph.mm:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP2Server.mm:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/HTTP3Server.mm:

Canonical link: <a href="https://commits.webkit.org/320883@main">https://commits.webkit.org/320883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ae8461bc38b213547481ae1557aba755ef577a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196418 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150709 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5f91dd2d-9e31-4de0-a16c-f2bcfa3e9724) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/187989 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145436 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100811 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bb193582-03d5-49a2-a99a-5ca3e729fa89) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189082 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125763 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2c349607-e9d1-4b51-8941-bfc21eb0a64f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47846 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45559 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7489 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50286 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Skipped layout-tests; Ignored 4 pre-existing and 1 flaky failure(s); Uploaded test results") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198396 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59679 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155003 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41533 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60391 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154640 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49079 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129805 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58830 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58223 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58452 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58282 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->