### PR TITLE
[Table] Orthogonal caption

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/caption-orthogonal-block-start-margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/caption-orthogonal-block-start-margin-expected.txt
@@ -1,0 +1,6 @@
+c
+c
+
+PASS A caption in the table's writing mode is offset by its block-start margin
+PASS A caption in an orthogonal writing mode is offset by its block-start margin
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/caption-orthogonal-block-start-margin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/caption-orthogonal-block-start-margin.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Tables: a caption is offset from the table's block-start edge by its margin on that edge</title>
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-flows">
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/#table-wrapper-box">
+<meta name="assert" content="The caption sits inside its own margin box at the table's block-start edge, whether or not the caption's writing mode matches the table's.">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+table { writing-mode: vertical-rl; border-spacing: 0; font: 10px/1 Ahem; }
+caption { margin: 7px 40px 3px 0; }
+td { width: 50px; height: 30px; padding: 0; }
+.same-writing-mode caption { writing-mode: vertical-rl; }
+.orthogonal caption { writing-mode: horizontal-tb; }
+</style>
+<table class="same-writing-mode" id="same"><caption>c</caption><tr><td></td></tr></table>
+<table class="orthogonal" id="orthogonal"><caption>c</caption><tr><td></td></tr></table>
+<script>
+// The table is vertical-rl, so its block-start edge is its right edge and the caption's margin
+// there is its 40px right margin, in either writing mode.
+function gapFromTableBlockStartEdge(id) {
+  const table = document.getElementById(id);
+  const caption = table.querySelector("caption");
+  return table.getBoundingClientRect().right - caption.getBoundingClientRect().right;
+}
+
+test(() => {
+  assert_equals(gapFromTableBlockStartEdge("same"), 40);
+}, "A caption in the table's writing mode is offset by its block-start margin");
+
+test(() => {
+  assert_equals(gapFromTableBlockStartEdge("orthogonal"), 40);
+}, "A caption in an orthogonal writing mode is offset by its block-start margin");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/caption-orthogonal-margin-in-table-block-axis-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/caption-orthogonal-margin-in-table-block-axis-expected.txt
@@ -1,0 +1,8 @@
+c
+c
+c
+c
+
+PASS A caption in the table's writing mode adds its horizontal margins to the table's block size
+PASS A caption in an orthogonal writing mode adds its horizontal margins to the table's block size
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/caption-orthogonal-margin-in-table-block-axis.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/caption-orthogonal-margin-in-table-block-axis.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Tables: a caption's margins add to the table's block size along the table's block axis</title>
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-flows">
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/#table-wrapper-box">
+<meta name="assert" content="The caption's physical margins contribute to the table wrapper's block size along the wrapper's block axis, whether or not the caption's writing mode matches the table's.">
+<link rel="stylesheet" href="/fonts/ahem.css">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+table { writing-mode: vertical-rl; border-spacing: 0; font: 10px/1 Ahem; }
+td { width: 50px; height: 30px; padding: 0; }
+caption { margin: 10px 40px; }
+.same-writing-mode caption { writing-mode: vertical-rl; }
+.orthogonal caption { writing-mode: horizontal-tb; }
+.no-margin caption { margin: 0; }
+</style>
+<table class="same-writing-mode" id="same-margin"><caption>c</caption><tr><td></td></tr></table>
+<table class="same-writing-mode no-margin" id="same-no-margin"><caption>c</caption><tr><td></td></tr></table>
+<table class="orthogonal" id="orthogonal-margin"><caption>c</caption><tr><td></td></tr></table>
+<table class="orthogonal no-margin" id="orthogonal-no-margin"><caption>c</caption><tr><td></td></tr></table>
+<script>
+// The table is vertical-rl, so its block axis is horizontal and the caption contributes its
+// horizontal margins, 40px on each side, no matter which writing mode the caption itself uses.
+function blockSizeGrowth(withMargin, withoutMargin) {
+  const width = id => document.getElementById(id).getBoundingClientRect().width;
+  return width(withMargin) - width(withoutMargin);
+}
+
+test(() => {
+  assert_equals(blockSizeGrowth("same-margin", "same-no-margin"), 80);
+}, "A caption in the table's writing mode adds its horizontal margins to the table's block size");
+
+test(() => {
+  assert_equals(blockSizeGrowth("orthogonal-margin", "orthogonal-no-margin"), 80);
+}, "A caption in an orthogonal writing mode adds its horizontal margins to the table's block size");
+</script>

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -414,15 +414,20 @@ void RenderTable::layoutCaption(RenderTableCaption& caption)
 {
     LayoutRect captionRect(caption.borderBoxRectInContainer());
 
+    auto setCaptionLocation = [&] {
+        auto logicalLocation = LayoutPoint { caption.marginStart(writingMode()), caption.marginBefore(writingMode()) + logicalHeight() };
+        caption.setLocation(writingMode().isHorizontal() ? logicalLocation : logicalLocation.transposedPoint());
+    };
+
     if (caption.needsLayout()) {
         // The margins may not be available but ensure the caption is at least located beneath any previous sibling caption
         // so that it does not mistakenly think any floats in the previous caption intrude into it.
-        caption.setLogicalLocation(LayoutPoint(caption.marginStart(), caption.marginBefore() + logicalHeight()));
+        setCaptionLocation();
         // If RenderTableCaption ever gets a layout() function, use it here.
         caption.layoutIfNeeded();
     }
     // Apply the margins to the location now that they are definitely available from layout
-    caption.setLogicalLocation(LayoutPoint(caption.marginStart(), caption.marginBefore() + logicalHeight()));
+    setCaptionLocation();
 
     if (!selfNeedsLayout() && caption.checkForRepaintDuringLayout())
         caption.repaintDuringLayoutIfMoved(captionRect);

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -404,6 +404,12 @@ template<typename SizeType> LayoutUnit RenderTable::convertStyleLogicalHeightToC
     );
 }
 
+static LayoutUnit captionLogicalHeight(const RenderTableCaption& caption, WritingMode tableWritingMode)
+{
+    auto captionLogicalHeight = caption.writingMode().isOrthogonal(tableWritingMode) ? caption.logicalWidth() : caption.logicalHeight();
+    return captionLogicalHeight + caption.marginBefore(tableWritingMode) + caption.marginAfter(tableWritingMode);
+}
+
 void RenderTable::layoutCaption(RenderTableCaption& caption)
 {
     LayoutRect captionRect(caption.borderBoxRectInContainer());
@@ -421,14 +427,7 @@ void RenderTable::layoutCaption(RenderTableCaption& caption)
     if (!selfNeedsLayout() && caption.checkForRepaintDuringLayout())
         caption.repaintDuringLayoutIfMoved(captionRect);
 
-    // When caption has a different writing mode, we need to use the caption's size in the table's writing mode.
-    LayoutUnit captionLogicalHeightInTableWritingMode;
-    if (caption.writingMode().isOrthogonal(writingMode()))
-        captionLogicalHeightInTableWritingMode = caption.logicalWidth();
-    else
-        captionLogicalHeightInTableWritingMode = caption.logicalHeight();
-
-    setLogicalHeight(logicalHeight() + captionLogicalHeightInTableWritingMode + caption.marginBefore() + caption.marginAfter());
+    setLogicalHeight(logicalHeight() + captionLogicalHeight(caption, writingMode()));
 }
 
 void RenderTable::layoutCaptions(BottomCaptionLayoutPhase bottomCaptionLayoutPhase)
@@ -508,7 +507,7 @@ LayoutUnit RenderTable::sumCaptionsLogicalHeight() const
 {
     LayoutUnit height;
     for (auto& caption : m_captions)
-        height += caption->logicalHeight() + caption->marginBefore() + caption->marginAfter();
+        height += captionLogicalHeight(*caption, writingMode());
     return height;
 }
 
@@ -561,7 +560,7 @@ void RenderTable::layout()
         for (auto& caption : m_captions) {
             if (caption->style().captionSide() == CaptionSide::Bottom)
                 continue;
-            oldTableLogicalTop += caption->logicalHeight() + caption->marginBefore() + caption->marginAfter();
+            oldTableLogicalTop += captionLogicalHeight(*caption, writingMode());
         }
 
         bool collapsing = collapseBorders();
@@ -931,16 +930,16 @@ void RenderTable::paintCollapsedBordersForRow(PaintInfo& paintInfo, RenderTableR
 void RenderTable::adjustBorderBoxRectForPainting(LayoutRect& rect)
 {
     for (auto& caption : m_captions) {
-        LayoutUnit captionLogicalHeight = caption->logicalHeight() + caption->marginBefore() + caption->marginAfter();
+        auto captionLogicalHeightInTableWritingMode = captionLogicalHeight(*caption, writingMode());
         bool captionIsBefore = (caption->style().captionSide() != CaptionSide::Bottom) ^ writingMode().isBlockFlipped();
         if (writingMode().isHorizontal()) {
-            rect.setHeight(rect.height() - captionLogicalHeight);
+            rect.setHeight(rect.height() - captionLogicalHeightInTableWritingMode);
             if (captionIsBefore)
-                rect.move(0_lu, captionLogicalHeight);
+                rect.move(0_lu, captionLogicalHeightInTableWritingMode);
         } else {
-            rect.setWidth(rect.width() - captionLogicalHeight);
+            rect.setWidth(rect.width() - captionLogicalHeightInTableWritingMode);
             if (captionIsBefore)
-                rect.move(captionLogicalHeight, 0_lu);
+                rect.move(captionLogicalHeightInTableWritingMode, 0_lu);
         }
     }
     


### PR DESCRIPTION
#### e5a1f99659bd60aec6ddbbc041706e393475f764
<pre>
[Table] Orthogonal caption ignores its margin against the table edge
<a href="https://bugs.webkit.org/show_bug.cgi?id=323900">https://bugs.webkit.org/show_bug.cgi?id=323900</a>
&lt;<a href="https://rdar.apple.com/problem/187139068">rdar://problem/187139068</a>&gt;

Reviewed by NOBODY (OOPS!).

A caption sits inside its own margin box at the table&apos;s block-start edge, so the margins that
position it and the axes they apply to both belong to the table&apos;s writing mode. layoutCaption()
asked the caption for marginStart() and marginBefore() in the caption&apos;s own mode and then handed the
point to setLogicalLocation(), which transposes through the caption&apos;s mode as well, so a vertical-rl
table with a horizontal-tb caption placed the caption flush against the table&apos;s right edge and left
its 40px right margin as a gap on the other side. Build the location from the table&apos;s writing mode
and transpose it through the table&apos;s too.

Test: imported/w3c/web-platform-tests/css/css-tables/caption-orthogonal-block-start-margin.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/caption-orthogonal-block-start-margin-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/caption-orthogonal-block-start-margin.html: Added.
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::layoutCaption):
</pre>
----------------------------------------------------------------------
#### 1d076fa7ad6fe2f8aca013dc83d557573a3e6cf3
<pre>
[Table] Orthogonal caption&apos;s margins are missing from the table
<a href="https://bugs.webkit.org/show_bug.cgi?id=323897">https://bugs.webkit.org/show_bug.cgi?id=323897</a>
&lt;<a href="https://rdar.apple.com/problem/187137359">rdar://problem/187137359</a>&gt;

Reviewed by NOBODY (OOPS!).

A caption takes up its own size plus its margins along the table&apos;s block axis, and the caption may
be written in a different mode than the table, so both have to be measured in the table&apos;s writing
mode. layoutCaption() converted the size but asked the caption for marginBefore() and marginAfter()
in the caption&apos;s own mode, and sumCaptionsLogicalHeight(), layoutBlock() and
adjustBorderBoxRectForPainting() converted neither, so a vertical-rl table with a horizontal-tb
caption reserved the caption&apos;s 10px top and bottom margins instead of its 40px left and right ones
and came out 60px short. Measure both through one captionLogicalHeight() helper that takes the
table&apos;s writing mode.

Test: imported/w3c/web-platform-tests/css/css-tables/caption-orthogonal-margin-in-table-block-axis.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/caption-orthogonal-margin-in-table-block-axis-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/caption-orthogonal-margin-in-table-block-axis.html: Added.
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::captionLogicalHeight):
(WebCore::RenderTable::layoutCaption):
(WebCore::RenderTable::sumCaptionsLogicalHeight):
(WebCore::RenderTable::layoutBlock):
(WebCore::RenderTable::adjustBorderBoxRectForPainting):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5a1f99659bd60aec6ddbbc041706e393475f764

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196431 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150718 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59755 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145441 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100816 "2 flakes 13 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125768 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47853 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45836 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158207 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45567 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7502 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52556 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198409 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59692 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165499 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155010 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60404 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154648 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49090 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132685 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129818 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58843 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20547 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58236 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58465 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58295 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->