### PR TITLE
[CMake] Add missing TestWebKitAPI files to the Cocoa/Mac source lists

### DIFF
--- a/Tools/TestWebKitAPI/PlatformCocoa.cmake
+++ b/Tools/TestWebKitAPI/PlatformCocoa.cmake
@@ -88,6 +88,8 @@ set(TESTWEBKITAPI_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 list(APPEND TestWTF_SOURCES
     Helpers/cocoa/UtilitiesCocoa.mm
 
+    Tests/WTF/bmalloc/MAR.cpp
+
     Tests/WTF/cf/RetainPtr.cpp
     Tests/WTF/cf/RetainPtrHashing.cpp
     Tests/WTF/cf/RetainRef.cpp
@@ -156,18 +158,21 @@ list(APPEND TestWebCore_SOURCES
     Tests/WebCore/HysteresisActivityTests.cpp
     Tests/WebCore/ISOBox.cpp
     Tests/WebCore/Logging.cpp
+    Tests/WebCore/MarkedText.cpp
     Tests/WebCore/PlatformCAAnimationKeyPath.cpp
     Tests/WebCore/StringUtilities.mm
     Tests/WebCore/TextBoundaries.cpp
     Tests/WebCore/UserAgentStringParser.cpp
     Tests/WebCore/YouTubePluginReplacement.cpp
 
+    Tests/WebCore/cocoa/AVFoundationSoftLinkTest.mm
     Tests/WebCore/cocoa/AttributedStringFontCache.mm
     Tests/WebCore/cocoa/AudioStreamDescriptionCocoa.mm
     Tests/WebCore/cocoa/AudioVideoRendererAVFObjCTests.mm
     Tests/WebCore/cocoa/BifurcatedGraphicsContextTestsCG.cpp
     Tests/WebCore/cocoa/CaptionPreferencesTests.mm
     Tests/WebCore/cocoa/CoreMediaUtilities.mm
+    Tests/WebCore/cocoa/DatabaseTrackerTest.mm
     Tests/WebCore/cocoa/GraphicsContextCGTests.mm
     Tests/WebCore/cocoa/H264UtilitiesCocoaTests.mm
     Tests/WebCore/cocoa/IOSurfacePoolTests.cpp
@@ -198,6 +203,7 @@ list(APPEND TestWebCore_LIBRARIES
 list(APPEND TestWebKitLegacy_SOURCES
     Helpers/cocoa/TestNSBundleExtras.m
 
+    Tests/WebKitLegacy/cocoa/SubstituteDataLocalResourceAccess.mm
     Tests/WebKitLegacy/cocoa/WebPreferencesTest.mm
 
     Tests/WebKitLegacy/mac/AccessingPastedImage.mm
@@ -329,6 +335,7 @@ list(APPEND TestWebKit_SOURCES
     Tests/WebKit/WKPage/cocoa/GetBackingScaleFactor.mm
     Tests/WebKit/WKPage/cocoa/GetPIDAfterAbortedProcessLaunch.cpp
     Tests/WebKit/WKPage/cocoa/InjectedBundleAppleEvent.cpp
+    Tests/WebKit/WKPage/cocoa/LocalizedDeviceModel.mm
     Tests/WebKit/WKPage/cocoa/LogForwarding.mm
     Tests/WebKit/WKPage/cocoa/MediaSessionCoordinatorTest.mm
     Tests/WebKit/WKPage/cocoa/MobileAssetSandboxCheck.mm
@@ -344,6 +351,7 @@ list(APPEND TestWebKit_SOURCES
     Tests/WebKit/WKPage/cocoa/SyscallUnixSandboxCheck.mm
     Tests/WebKit/WKPage/cocoa/SystemBeep.mm
     Tests/WebKit/WKPage/cocoa/WeakObjCPtr.mm
+    Tests/WebKit/WKPage/cocoa/WebFilter.mm
     Tests/WebKit/WKPage/cocoa/XPCEndpoint.mm
 
     Tests/WebKit/WKPage/mac/CustomProtocolsSyncXHRTest.mm
@@ -581,6 +589,7 @@ target_sources(TestWebKitAPIInjectedBundle PRIVATE
     # CustomBundleObject.mm is also in TestWebKit; both targets compile it.
     ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKPage/cocoa/CustomBundleObject.mm
     ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKPage/cocoa/CustomBundleParameter_Bundle.mm
+    ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKPage/cocoa/EnableAccessibilityInWebProcess_Bundle.mm
     ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKPage/cocoa/ForceLightAppearanceInBundle_Bundle.mm
     ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKPage/cocoa/GetBackingScaleFactor_Bundle.mm
     ${TESTWEBKITAPI_DIR}/Tests/InjectInternals_Bundle.cpp

--- a/Tools/TestWebKitAPI/Scripts/generate-unified-sources.sh
+++ b/Tools/TestWebKitAPI/Scripts/generate-unified-sources.sh
@@ -17,7 +17,7 @@ fi
 UnifiedSourceCppFileCount=5
 UnifiedSourceCFileCount=0
 UnifiedSourceMmFileCount=0
-UnifiedSourceNonARCMmFileCount=53
+UnifiedSourceNonARCMmFileCount=54
 
 if [ $# -eq 0 ]; then
     echo "Using unified source list files: Sources.txt, SourcesCocoa.txt"

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -75,6 +75,8 @@ Tests/WebKit/WKWebView/AccessibilityAnnouncementTranslation.mm @nonARC
 Tests/WebKit/WKWebView/AdaptiveImageGlyph.mm @nonARC
 Tests/WebKit/WKWebView/AdditionalReadAccessAllowedURLs.mm @nonARC
 Tests/WebKit/WKWebView/AdditionalSupportedImageTypes.mm @nonARC
+Tests/WebKit/WKWebView/AdvancedPrivacyProtections.mm @nonARC
+Tests/WebKit/WKWebView/AllowInlinePlaybackInDesktopClassBrowsing.mm @nonARC
 Tests/WebKit/WKWebView/AlwaysRevalidatedURLSchemes.mm @nonARC
 Tests/WebKit/WKWebView/AnimatedResize.mm @nonARC
 Tests/WebKit/WKWebView/AppPrivacyReport.mm @nonARC
@@ -123,6 +125,7 @@ Tests/WebKit/WKWebView/WritingTools.mm @nonARC
 Tests/WebKit/WKWebView/DecidePolicyForNavigationAction.mm @nonARC
 Tests/WebKit/WKWebView/DeviceManagementRestrictions.mm @nonARC
 Tests/WebKit/WKWebView/DeviceOrientation.mm @nonARC
+Tests/WebKit/WKWebView/DictationStreamingOpacity.mm @nonARC
 Tests/WebKit/WKWebView/DisableSpellcheck.mm @nonARC
 Tests/WebKit/WKWebView/DisplayName.mm @nonARC
 Tests/WebKit/WKWebView/DoAfterNextPresentationUpdateAfterCrash.mm @nonARC
@@ -134,6 +137,7 @@ Tests/WebKit/WKWebView/DragAndDropTests.mm @nonARC
 Tests/WebKit/WKWebView/DrawingToPDF.mm @nonARC
 Tests/WebKit/WKWebView/DuplicateCompletionHandlerCalls.mm @nonARC
 Tests/WebKit/WKWebView/EditorStateTests.mm @nonARC
+Tests/WebKit/WKWebView/ElementFullscreenIntersectionObserver.mm @nonARC
 Tests/WebKit/WKWebView/ElementTargetingTests.mm @nonARC
 Tests/WebKit/WKWebView/ElementTextPreview.mm @nonARC
 Tests/WebKit/WKWebView/EnhancedSecurity.mm @nonARC
@@ -163,6 +167,7 @@ Tests/WebKit/WKWebView/GetDisplayMedia.mm @nonARC
 Tests/WebKit/WKWebView/GetDisplayMediaWindowAndScreen.mm @nonARC
 Tests/WebKit/WKWebView/GetResourceData.mm @nonARC
 Tests/WebKit/WKWebView/GetUserMedia.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/GetUserMediaReprompt.mm @nonARC
 Tests/WebKit/WKWebView/HistoryDelegate.mm @nonARC
 Tests/WebKit/WKWebView/HSTS.mm @nonARC
 Tests/WebKit/WKWebView/HTTP2Server.mm @nonARC
@@ -231,6 +236,7 @@ Tests/WebKit/WKWebView/NoResumeSoundPlayedToTheEndAfterThePageBecomesVisible.mm 
 Tests/WebKit/WKWebView/NotificationAPI.mm @nonARC
 Tests/WebKit/WKWebView/NowPlaying.mm @nonARC
 Tests/WebKit/WKWebView/NowPlayingControlsTests.mm @nonARC
+Tests/WebKit/WKWebView/NowPlayingSession.mm @nonARC
 Tests/WebKit/WKWebView/ObscuredContentInsets.mm @nonARC
 Tests/WebKit/WKWebView/ObservedRenderingProgressEventsAfterCrash.mm @nonARC
 Tests/WebKit/WKWebView/OpenAndCloseWindow.mm @nonARC
@@ -438,4 +444,5 @@ Tests/WebKit/WKWebView/iOSMouseSupport.mm @nonARC
 Tests/WebKit/WKWebView/iOSStylusSupport.mm @nonARC
 
 Tests/WebKit/WKWebView/UI/ElementFullscreen.mm @nonARC
+Tests/WebKit/WKWebView/UI/VideoInShadowDOMElementFullscreen.mm @nonARC
 Tests/WebKit/WKWebView/UI/VideoPresentationMode.mm @nonARC

--- a/Tools/TestWebKitAPI/SourcesMac.txt
+++ b/Tools/TestWebKitAPI/SourcesMac.txt
@@ -83,6 +83,7 @@ Tests/WebKit/WKWebView/mac/MouseEventTests.mm @nonARC @no-unify
 Tests/WebKit/WKWebView/mac/NoPolicyDelegateResponse.mm @nonARC @no-unify
 Tests/WebKit/WKWebView/mac/NSResponderTests.mm @nonARC
 Tests/WebKit/WKWebView/mac/PageVisibilityStateWithWindowChanges.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/PopupMenuTests.mm @nonARC
 Tests/WebKit/WKWebView/mac/RenderedImageFromDOMNode.mm @nonARC @no-unify
 Tests/WebKit/WKWebView/mac/RenderedImageFromDOMRange.mm @nonARC @no-unify
 Tests/WebKit/WKWebView/mac/ScrollbarTests.mm @nonARC @no-unify

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		07275CBC2D01398C002315A5 /* _WebKit_SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07275CBB2D01398C002315A5 /* _WebKit_SwiftUI.framework */; };
 		07275CBD2D01398C002315A5 /* _WebKit_SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07275CBB2D01398C002315A5 /* _WebKit_SwiftUI.framework */; };
 		07792FA62F9D9AE9009EF126 /* WebProcessPlugInWithInternals.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1798B8422433647000764BD /* WebProcessPlugInWithInternals.mm */; };
+		07AA54552F8200000000A055 /* UnifiedSource54-nonARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07AA54542F8200000000A054 /* UnifiedSource54-nonARC.mm */; };
 		143DDE9820C9018B007F76FA /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 574F55D0204D471C002948C6 /* Security.framework */; };
 		1AEDE22613E5E7E700E62FE8 /* InjectedBundleControllerMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1AEDE22413E5E7A000E62FE8 /* InjectedBundleControllerMac.mm */; };
 		2B7E14D63A5F60718293C1A3 /* SyntheticNSEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2B7E14D63A5F60718293C1A2 /* SyntheticNSEvent.mm */; };
@@ -419,6 +420,7 @@
 /* Begin PBXFileReference section */
 		07275CBB2D01398C002315A5 /* _WebKit_SwiftUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = _WebKit_SwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		07597D7E2F81DD59000C96D0 /* config.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
+		07AA54542F8200000000A054 /* UnifiedSource54-nonARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UnifiedSource54-nonARC.mm"; sourceTree = "<group>"; };
 		0DBC072EC3DC8EA98F7B7BEE /* UnifiedSource53-nonARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UnifiedSource53-nonARC.mm"; sourceTree = "<group>"; };
 		0F4FFAA01ED3D0DE00F7111F /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
 		1AEDE22413E5E7A000E62FE8 /* InjectedBundleControllerMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = InjectedBundleControllerMac.mm; path = mac/InjectedBundleControllerMac.mm; sourceTree = "<group>"; };
@@ -985,14 +987,10 @@
 				WebKit/WKPage/WKSecurityOrigin.cpp,
 				WebKit/WKPage/WKString.cpp,
 				WebKit/WKPage/WKStringJSString.cpp,
-				WebKit/WKWebView/AdvancedPrivacyProtections.mm,
-				WebKit/WKWebView/AllowInlinePlaybackInDesktopClassBrowsing.mm,
 				WebKit/WKWebView/AnimationControl.mm,
-				WebKit/WKWebView/DictationStreamingOpacity.mm,
 				WebKit/WKWebView/FullscreenLifecycle.mm,
 				WebKit/WKWebView/GetUserMedia.mm,
 				WebKit/WKWebView/GetUserMediaNavigation.mm,
-				WebKit/WKWebView/GetUserMediaReprompt.mm,
 				WebKit/WKWebView/InjectedBundleHitTest.mm,
 				WebKit/WKWebView/InstanceMethodSwizzler.mm,
 				WebKit/WKWebView/ios/AccessibilityTestsIOS.mm,
@@ -1145,7 +1143,6 @@
 				WebKit/WKWebView/MSEIsTypeSupportedCaching.mm,
 				WebKit/WKWebView/NoHistoryItemScrollToFragment.mm,
 				WebKit/WKWebView/NowPlayingMetadataObserver.mm,
-				WebKit/WKWebView/NowPlayingSession.mm,
 				WebKit/WKWebView/OrthogonalFlowAvailableSize.mm,
 				WebKit/WKWebView/ParentalControlsContentFilteringTests.mm,
 				WebKit/WKWebView/SmartLists.mm,
@@ -1388,13 +1385,6 @@
 				IPC/WebFoundTextRangeTests.cpp,
 			);
 			target = 7B9FC39428A26137007570E7 /* TestIPC */;
-		};
-		07C913DD2F820CCA003A09D8 /* Exceptions for "Tests" folder in "TestWebKitAPIApp" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				WebKit/WKWebView/ElementFullscreenIntersectionObserver.mm,
-			);
-			target = A17C58012C9AA12F009DD0B5 /* TestWebKitAPIApp */;
 		};
 		07C913DE2F820CCA003A09D8 /* Exceptions for "Tests" folder in "TestWebKitAPIBundle" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
@@ -1687,7 +1677,6 @@
 				07C913DB2F820CCA003A09D8 /* Exceptions for "Tests" folder in "TestWTFLibrary" target */,
 				07C913DC2F820CCA003A09D8 /* Exceptions for "Tests" folder in "TestIPC" target */,
 				07AA27602F83C3A900FE10FC /* Exceptions for "Tests" folder in "TestWebKitAPI" target */,
-				07C913DD2F820CCA003A09D8 /* Exceptions for "Tests" folder in "TestWebKitAPIApp" target */,
 				07C913DE2F820CCA003A09D8 /* Exceptions for "Tests" folder in "TestWebKitAPIBundle" target */,
 				07C913DF2F820CCA003A09D8 /* Exceptions for "Tests" folder in "TestWGSL" target */,
 				07C913E02F820CCA003A09D8 /* Exceptions for "Tests" folder in "Copy Files" phase from "TestWGSL" target */,
@@ -1943,6 +1932,7 @@
 				5CABDB952735C9BB00B88BC0 /* UnifiedSource51-nonARC.mm */,
 				51A97F062FD0B59400FBDD0C /* UnifiedSource52-nonARC.mm */,
 				0DBC072EC3DC8EA98F7B7BEE /* UnifiedSource53-nonARC.mm */,
+				07AA54542F8200000000A054 /* UnifiedSource54-nonARC.mm */,
 			);
 			path = "unified-sources";
 			sourceTree = "<group>";
@@ -2572,6 +2562,7 @@
 				5CABDBC22735C9BE00B88BC0 /* UnifiedSource51-nonARC.mm in Sources */,
 				51A97F1B2FD0B5A400FBDD0C /* UnifiedSource52-nonARC.mm in Sources */,
 				F5971BD071D50EA78EF87EE5 /* UnifiedSource53-nonARC.mm in Sources */,
+				07AA54552F8200000000A055 /* UnifiedSource54-nonARC.mm in Sources */,
 				07792FA62F9D9AE9009EF126 /* WebProcessPlugInWithInternals.mm in Sources */,
 			);
 		};

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UI/VideoInShadowDOMElementFullscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UI/VideoInShadowDOMElementFullscreen.mm
@@ -30,6 +30,7 @@
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/cocoa/TestElementFullscreenDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
+#import "Helpers/cocoa/WKWebViewConfigurationExtras.h"
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WebKit.h>

--- a/Tools/TestWebKitAPI/UnifiedSources-output.xcfilelist
+++ b/Tools/TestWebKitAPI/UnifiedSources-output.xcfilelist
@@ -53,6 +53,7 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource51-nonARC.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource52-nonARC.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource53-nonARC.mm
+$(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource54-nonARC.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource6-nonARC.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource7-nonARC.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource8-nonARC.mm


### PR DESCRIPTION
#### 4969aa98f5b628209285e5e31bda048f30a8c0b4
<pre>
[CMake] Add missing TestWebKitAPI files to the Cocoa/Mac source lists
<a href="https://bugs.webkit.org/show_bug.cgi?id=323901">https://bugs.webkit.org/show_bug.cgi?id=323901</a>
<a href="https://rdar.apple.com/187139244">rdar://187139244</a>

Reviewed by Abrar Rahman Protyasha and Elliott Williams.

* Tools/TestWebKitAPI/PlatformCocoa.cmake:
* Tools/TestWebKitAPI/Scripts/generate-unified-sources.sh:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/SourcesMac.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/UnifiedSources-output.xcfilelist:

Canonical link: <a href="https://commits.webkit.org/320869@main">https://commits.webkit.org/320869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c7c2c34ac9119a6d3661c6d4021511f8b7fe00f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60053 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53835 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196448 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/da6d5cdc-aeb9-46a9-a7ed-8072213ff866) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59770 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2b8fa72a-e49d-478d-9492-6ad62ffeb24c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189113 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/49134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/165990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125786 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6b74c92a-9cc4-4874-8c70-17ecd5d2098e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/47866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/158220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/45582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7519 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/50307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198426 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59709 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/165514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/155023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60421 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/154662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28265 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49099 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129835 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58858 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58252 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58479 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58311 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->