### PR TITLE
Make WKWebViewConfiguration._allowedNetworkHosts restrict WebTransport

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2072,6 +2072,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/NavigatorBase.h
     page/NavigatorLoginStatus.h
     page/NavigatorUAData.h
+    page/NetworkLoadPolicy.h
     page/OriginAccessPatterns.h
     page/Page.h
     page/PageColorSampler.h

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
@@ -66,7 +66,8 @@ static WorkletParameters generateWorkletParameters(AudioWorklet& worklet)
         document->advancedPrivacyProtections(),
         document->noiseInjectionHashSalt(),
         document->agentClusterID(),
-        protect(document->contentSecurityPolicy())->responseHeaders()
+        protect(document->contentSecurityPolicy())->responseHeaders(),
+        document->networkLoadPolicy()
     };
 }
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2337,6 +2337,7 @@ page/NavigatorBase.cpp
 page/NavigatorGlobalPrivacyControl.cpp
 page/NavigatorLoginStatus.cpp
 page/NavigatorUAData.cpp
+page/NetworkLoadPolicy.cpp
 page/OpportunisticTaskScheduler.cpp
 page/OriginAccessEntry.cpp
 page/OriginAccessPatterns.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -6299,6 +6299,7 @@
 		D61496E32E428EDB00BAF335 /* UserAgentStringParser.h in Headers */ = {isa = PBXBuildFile; fileRef = D61496E12E428EDB00BAF335 /* UserAgentStringParser.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D619A308144E00BE004BC302 /* ChildListMutationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = D619A306144E00BE004BC302 /* ChildListMutationScope.h */; };
 		D640B2462E30461D00EB6C49 /* NavigatorUAData.h in Headers */ = {isa = PBXBuildFile; fileRef = D640B2422E2F09F900EB6C49 /* NavigatorUAData.h */; };
+		08B786B0CEACA0F21D6A5676 /* NetworkLoadPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 02357438619C3D1E3719E438 /* NetworkLoadPolicy.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D640B24B2E30589300EB6C49 /* UALowEntropyJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = D640B2472E30587100EB6C49 /* UALowEntropyJSON.h */; };
 		D640B24F2E3058D500EB6C49 /* UADataValues.h in Headers */ = {isa = PBXBuildFile; fileRef = D640B24C2E3058C800EB6C49 /* UADataValues.h */; };
 		D6489D26166FFCF1007C031B /* JSHTMLTemplateElement.h in Headers */ = {isa = PBXBuildFile; fileRef = D6489D24166FFCF1007C031B /* JSHTMLTemplateElement.h */; };
@@ -21963,6 +21964,8 @@
 		D6306E5657152075F782FE3A /* SkipForward10.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = SkipForward10.svg; sourceTree = "<group>"; };
 		D640B2412E2F09DE00EB6C49 /* NavigatorUA.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = NavigatorUA.idl; sourceTree = "<group>"; };
 		D640B2422E2F09F900EB6C49 /* NavigatorUAData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NavigatorUAData.h; sourceTree = "<group>"; };
+		02357438619C3D1E3719E438 /* NetworkLoadPolicy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkLoadPolicy.h; sourceTree = "<group>"; };
+		E5E93BDFA28F5D63963BED0F /* NetworkLoadPolicy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkLoadPolicy.cpp; sourceTree = "<group>"; };
 		D640B2442E2F09F900EB6C49 /* NavigatorUAData.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = NavigatorUAData.idl; sourceTree = "<group>"; };
 		D640B2452E3038FD00EB6C49 /* NavigatorUAData.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NavigatorUAData.cpp; sourceTree = "<group>"; };
 		D640B2472E30587100EB6C49 /* UALowEntropyJSON.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UALowEntropyJSON.h; sourceTree = "<group>"; };
@@ -31506,6 +31509,8 @@
 				D640B2452E3038FD00EB6C49 /* NavigatorUAData.cpp */,
 				D640B2422E2F09F900EB6C49 /* NavigatorUAData.h */,
 				D640B2442E2F09F900EB6C49 /* NavigatorUAData.idl */,
+				E5E93BDFA28F5D63963BED0F /* NetworkLoadPolicy.cpp */,
+				02357438619C3D1E3719E438 /* NetworkLoadPolicy.h */,
 				F4E9E2462A23C5D000A5B134 /* OpportunisticTaskScheduler.cpp */,
 				F4E9E2452A23C5D000A5B134 /* OpportunisticTaskScheduler.h */,
 				00146288103CD1DE000B20DB /* OriginAccessEntry.cpp */,
@@ -47953,6 +47958,7 @@
 				628D214C12131ED10055DCFC /* NetworkingContext.h in Headers */,
 				416D75A220C651A500D02D2C /* NetworkLoadInformation.h in Headers */,
 				8A81BF8511DCFD9000DA2B98 /* NetworkLoadMetrics.h in Headers */,
+				08B786B0CEACA0F21D6A5676 /* NetworkLoadPolicy.h in Headers */,
 				59C27F07138D28CF0079B7E2 /* NetworkResourcesData.h in Headers */,
 				41E9DCE92319CA7600F35949 /* NetworkSendQueue.h in Headers */,
 				1A7FA6190DDA3B3A0028F8A5 /* NetworkStateNotifier.h in Headers */,

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -213,6 +213,7 @@
 #include "Navigator.h"
 #include "NavigatorMediaSession.h"
 #include "NestingLevelIncrementer.h"
+#include "NetworkLoadPolicy.h"
 #include "NodeIterator.h"
 #include "NodeRareData.h"
 #include "NodeWithIndex.h"
@@ -12067,6 +12068,14 @@ std::optional<PAL::SessionID> Document::sessionID() const
         return page->sessionID();
 
     return std::nullopt;
+}
+
+const NetworkLoadPolicy& Document::networkLoadPolicy() const
+{
+    if (RefPtr page = this->page())
+        return page->networkLoadPolicy();
+
+    return NetworkLoadPolicy::unrestricted();
 }
 
 void Document::addElementWithPendingUserAgentShadowTreeUpdate(Element& element)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -828,6 +828,8 @@ public:
 
     inline const SettingsValues& settingsValues() const final; // Defined in DocumentSettingsValues.h.
 
+    const NetworkLoadPolicy& networkLoadPolicy() const final;
+
     void NODELETE suspendDeviceMotionAndOrientationUpdates();
     void NODELETE resumeDeviceMotionAndOrientationUpdates();
 

--- a/Source/WebCore/dom/EmptyScriptExecutionContext.h
+++ b/Source/WebCore/dom/EmptyScriptExecutionContext.h
@@ -28,6 +28,7 @@
 #include "AdvancedPrivacyProtections.h"
 #include "EventLoop.h"
 #include "Microtasks.h"
+#include "NetworkLoadPolicy.h"
 #include "ReferrerPolicy.h"
 #include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"
@@ -107,6 +108,7 @@ private:
     void logExceptionToConsole(const String&, const String&, int, int, RefPtr<Inspector::ScriptCallStack>&&) final { }
 
     const SettingsValues& settingsValues() const LIFETIME_BOUND final { return m_settingsValues; }
+    const NetworkLoadPolicy& networkLoadPolicy() const final { return NetworkLoadPolicy::unrestricted(); }
 
 #if ENABLE(NOTIFICATIONS)
     NotificationClient* notificationClient() final { return nullptr; }

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -114,6 +114,7 @@ enum class ScriptTrackingPrivacyCategory : uint8_t;
 enum class StorageBlockingPolicy : uint8_t;
 enum class TaskSource : uint8_t;
 struct CryptoKeyData;
+struct NetworkLoadPolicy;
 struct SettingsValues;
 
 #if ENABLE(NOTIFICATIONS)
@@ -160,6 +161,8 @@ public:
     virtual String userAgent(const URL&) const = 0;
 
     virtual const SettingsValues& settingsValues() const = 0;
+
+    virtual const NetworkLoadPolicy& networkLoadPolicy() const = 0;
 
     virtual NotificationClient* notificationClient() { return nullptr; }
     virtual std::optional<PAL::SessionID> sessionID() const;

--- a/Source/WebCore/page/NetworkLoadPolicy.cpp
+++ b/Source/WebCore/page/NetworkLoadPolicy.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "NetworkLoadPolicy.h"
+
+#include <wtf/CrossThreadCopier.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/URL.h>
+#include <wtf/text/StringHash.h>
+
+namespace WebCore {
+
+bool NetworkLoadPolicy::allowsLoadFromURL(const URL& url, MainFrameMainResource mainFrameMainResource) const
+{
+    if (mainFrameMainResource == MainFrameMainResource::No && !loadsSubresources)
+        return false;
+    if (!allowedNetworkHosts)
+        return true;
+    if (!url.protocolIsInHTTPFamily() && !url.protocolIs("ws"_s) && !url.protocolIs("wss"_s))
+        return true;
+    return allowedNetworkHosts->contains<StringViewHashTranslator>(url.host());
+}
+
+NetworkLoadPolicy NetworkLoadPolicy::isolatedCopy() const
+{
+    return { loadsSubresources, crossThreadCopy(allowedNetworkHosts) };
+}
+
+const NetworkLoadPolicy& NetworkLoadPolicy::unrestricted()
+{
+    static NeverDestroyed<NetworkLoadPolicy> policy;
+    return policy;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/page/NetworkLoadPolicy.h
+++ b/Source/WebCore/page/NetworkLoadPolicy.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/PlatformExportMacros.h>
+#include <optional>
+#include <wtf/Forward.h>
+#include <wtf/RobinHoodHashSet.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+enum class MainFrameMainResource : bool { No, Yes };
+
+struct NetworkLoadPolicy {
+    bool loadsSubresources { true };
+    std::optional<MemoryCompactLookupOnlyRobinHoodHashSet<String>> allowedNetworkHosts;
+
+    WEBCORE_EXPORT bool allowsLoadFromURL(const URL&, MainFrameMainResource) const;
+    WEBCORE_EXPORT NetworkLoadPolicy isolatedCopy() const;
+
+    // The policy of a context with no Page, which restricts nothing.
+    WEBCORE_EXPORT static const NetworkLoadPolicy& unrestricted();
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -473,8 +473,7 @@ Page::Page(PageConfiguration&& pageConfiguration)
 #endif
     , m_corsDisablingPatterns(WTF::move(pageConfiguration.corsDisablingPatterns))
     , m_maskedURLSchemes(WTF::move(pageConfiguration.maskedURLSchemes))
-    , m_allowedNetworkHosts(WTF::move(pageConfiguration.allowedNetworkHosts))
-    , m_loadsSubresources(pageConfiguration.loadsSubresources)
+    , m_networkLoadPolicy { pageConfiguration.loadsSubresources, WTF::move(pageConfiguration.allowedNetworkHosts) }
     , m_shouldRelaxThirdPartyCookieBlocking(pageConfiguration.shouldRelaxThirdPartyCookieBlocking)
     , m_fixedContainerEdgesAndElements(std::make_pair(makeUniqueRef<FixedContainerEdges>(), WeakElementEdges { }))
     , m_httpsUpgradeEnabled(pageConfiguration.httpsUpgradeEnabled)
@@ -4826,13 +4825,7 @@ void Page::forEachWindowEventLoop(NOESCAPE const Function<void(WindowEventLoop&)
 
 bool Page::allowsLoadFromURL(const URL& url, MainFrameMainResource mainFrameMainResource) const
 {
-    if (mainFrameMainResource == MainFrameMainResource::No && !m_loadsSubresources)
-        return false;
-    if (!m_allowedNetworkHosts)
-        return true;
-    if (!url.protocolIsInHTTPFamily() && !url.protocolIs("ws"_s) && !url.protocolIs("wss"_s))
-        return true;
-    return m_allowedNetworkHosts->contains<StringViewHashTranslator>(url.host());
+    return m_networkLoadPolicy.allowsLoadFromURL(url, mainFrameMainResource);
 }
 
 bool Page::hasLocalDataForURL(const URL& url)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -34,6 +34,7 @@
 #include <WebCore/IntRectHash.h>
 #include <WebCore/LoadSchedulingMode.h>
 #include <WebCore/MediaSessionGroupIdentifier.h>
+#include <WebCore/NetworkLoadPolicy.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/Pagination.h>
 #include <WebCore/PlaybackTargetClientContextIdentifier.h>
@@ -277,7 +278,6 @@ using MediaProducerMediaStateFlags = OptionSet<MediaProducerMediaState>;
 using MediaProducerMutedStateFlags = OptionSet<MediaProducerMutedState>;
 
 enum class EventThrottlingBehavior : bool { Responsive, Unresponsive };
-enum class MainFrameMainResource : bool { No, Yes };
 
 enum class PageIsEditable : bool { No, Yes };
 
@@ -1137,6 +1137,7 @@ public:
     bool isUtilityPage() const { return m_isUtilityPage; }
 
     WEBCORE_EXPORT bool allowsLoadFromURL(const URL&, MainFrameMainResource) const;
+    const NetworkLoadPolicy& networkLoadPolicy() const { return m_networkLoadPolicy; }
     WEBCORE_EXPORT bool hasLocalDataForURL(const URL&);
 
     ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking() const { return m_shouldRelaxThirdPartyCookieBlocking; }
@@ -1791,9 +1792,8 @@ private:
     Vector<UserContentURLPattern> m_corsDisablingPatterns;
     const HashSet<String> m_maskedURLSchemes;
     Vector<UserStyleSheet> m_userStyleSheetsPendingInjection;
-    const std::optional<MemoryCompactLookupOnlyRobinHoodHashSet<String>> m_allowedNetworkHosts;
+    const NetworkLoadPolicy m_networkLoadPolicy;
     bool m_isTakingSnapshotsForApplicationSuspension { false };
-    bool m_loadsSubresources { true };
     bool m_canUseCredentialStorage { true };
     ShouldRelaxThirdPartyCookieBlocking m_shouldRelaxThirdPartyCookieBlocking;
     LoadSchedulingMode m_loadSchedulingMode { LoadSchedulingMode::Direct };

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -128,6 +128,7 @@ WorkerGlobalScope::WorkerGlobalScope(WorkerThreadType type, const WorkerParamete
     , m_workerType(params.workerType)
     , m_credentials(params.credentials)
     , m_agentClusterID(params.agentClusterID)
+    , m_networkLoadPolicy(params.networkLoadPolicy)
 {
     {
         Locker locker { allWorkerGlobalScopeIdentifiersLock };

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -30,6 +30,7 @@
 #include <WebCore/CacheStorageConnection.h>
 #include <WebCore/ClientOrigin.h>
 #include <WebCore/ImageBitmap.h>
+#include <WebCore/NetworkLoadPolicy.h>
 #include <WebCore/ReportingClient.h>
 #include <WebCore/ScriptExecutionContext.h>
 #include <WebCore/Settings.h>
@@ -161,6 +162,8 @@ public:
 
     const SettingsValues& settingsValues() const LIFETIME_BOUND final { return m_settingsValues; }
 
+    const NetworkLoadPolicy& networkLoadPolicy() const LIFETIME_BOUND final { return m_networkLoadPolicy; }
+
     FetchOptions::Credentials credentials() const { return m_credentials; }
 
     void releaseMemory(Synchronous);
@@ -250,6 +253,7 @@ private:
     WorkerType m_workerType;
     FetchOptions::Credentials m_credentials;
     String m_agentClusterID;
+    const NetworkLoadPolicy m_networkLoadPolicy;
     const RefPtr<WorkerStorageConnection> m_storageConnection;
     RefPtr<WorkerFileSystemStorageConnection> m_fileSystemStorageConnection;
 };

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -170,7 +170,8 @@ void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::Ses
         initializationData.clientIdentifier,
         scriptExecutionContext->advancedPrivacyProtections(),
         scriptExecutionContext->noiseInjectionHashSalt(),
-        WTF::move(agentClusterID)
+        WTF::move(agentClusterID),
+        scriptExecutionContext->networkLoadPolicy()
     };
     auto thread = DedicatedWorkerThread::create(params, sourceCode, *this, *this, *this, *this, startMode, protect(scriptExecutionContext->topOrigin()), proxy.get(), socketProvider.get(), runtimeFlags);
 

--- a/Source/WebCore/workers/WorkerThread.cpp
+++ b/Source/WebCore/workers/WorkerThread.cpp
@@ -77,7 +77,8 @@ WorkerParameters WorkerParameters::isolatedCopy() const
         clientIdentifier,
         advancedPrivacyProtections,
         noiseInjectionHashSalt,
-        agentClusterID.isolatedCopy()
+        agentClusterID.isolatedCopy(),
+        networkLoadPolicy.isolatedCopy()
     };
 }
 

--- a/Source/WebCore/workers/WorkerThread.h
+++ b/Source/WebCore/workers/WorkerThread.h
@@ -29,6 +29,7 @@
 #include <WebCore/ContentSecurityPolicyResponseHeaders.h>
 #include <WebCore/CrossOriginEmbedderPolicy.h>
 #include <WebCore/FetchRequestCredentials.h>
+#include <WebCore/NetworkLoadPolicy.h>
 #include <WebCore/NotificationPermission.h>
 #include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <WebCore/ServiceWorkerRegistrationData.h>
@@ -91,6 +92,7 @@ public:
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections;
     std::optional<uint64_t> noiseInjectionHashSalt;
     String agentClusterID;
+    NetworkLoadPolicy networkLoadPolicy;
 
     WorkerParameters isolatedCopy() const;
 };

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -120,7 +120,8 @@ static WorkerParameters generateWorkerParameters(const ServiceWorkerContextData&
         { },
         advancedPrivacyProtections,
         noiseInjectionHashSalt,
-        makeString(Process::identifier().toUInt64(), "-serviceworker-"_s, contextData.serviceWorkerIdentifier.toUInt64())
+        makeString(Process::identifier().toUInt64(), "-serviceworker-"_s, contextData.serviceWorkerIdentifier.toUInt64()),
+        NetworkLoadPolicy::unrestricted()
     };
 }
 

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -90,7 +90,8 @@ static WorkerParameters generateWorkerParameters(const WorkerFetchResult& worker
         *initializationData.clientIdentifier,
         document.advancedPrivacyProtections(),
         document.noiseInjectionHashSalt(),
-        makeString(Process::identifier().toUInt64(), "-sharedworker-"_s, initializationData.clientIdentifier->toString())
+        makeString(Process::identifier().toUInt64(), "-sharedworker-"_s, initializationData.clientIdentifier->toString()),
+        document.networkLoadPolicy()
     };
 }
 

--- a/Source/WebCore/worklets/WorkletGlobalScope.cpp
+++ b/Source/WebCore/worklets/WorkletGlobalScope.cpp
@@ -59,6 +59,7 @@ WorkletGlobalScope::WorkletGlobalScope(WorkerOrWorkletThread& thread, Ref<JSC::V
     , m_jsRuntimeFlags(parameters.jsRuntimeFlags)
     , m_settingsValues(parameters.settingsValues)
     , m_agentClusterID(parameters.agentClusterID)
+    , m_networkLoadPolicy(parameters.networkLoadPolicy)
 {
     ++gNumberOfWorkletGlobalScopes;
 
@@ -76,6 +77,7 @@ WorkletGlobalScope::WorkletGlobalScope(Document& document, Ref<JSC::VM>&& vm, Sc
     , m_code(WTF::move(code))
     , m_settingsValues(document.settingsValues().isolatedCopy())
     , m_agentClusterID(document.agentClusterID())
+    , m_networkLoadPolicy(document.networkLoadPolicy().isolatedCopy())
 {
     ++gNumberOfWorkletGlobalScopes;
 

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -29,6 +29,7 @@
 #include "Document.h"
 #include "EventTargetInterfaces.h"
 #include "FetchRequestCredentials.h"
+#include "NetworkLoadPolicy.h"
 #include "ScriptExecutionContext.h"
 #include "ScriptSourceCode.h"
 #include "Settings.h"
@@ -114,6 +115,7 @@ private:
     URL parseURL(const String&) const final;
     String userAgent(const URL&) const final;
     const SettingsValues& settingsValues() const LIFETIME_BOUND final { return m_settingsValues; }
+    const NetworkLoadPolicy& networkLoadPolicy() const LIFETIME_BOUND final { return m_networkLoadPolicy; }
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 
@@ -127,6 +129,7 @@ private:
 
     SettingsValues m_settingsValues;
     String m_agentClusterID;
+    const NetworkLoadPolicy m_networkLoadPolicy;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/worklets/WorkletParameters.h
+++ b/Source/WebCore/worklets/WorkletParameters.h
@@ -27,6 +27,7 @@
 
 #include "AdvancedPrivacyProtections.h"
 #include "ContentSecurityPolicyResponseHeaders.h"
+#include "NetworkLoadPolicy.h"
 #include "Settings.h"
 #include <JavaScriptCore/RuntimeFlags.h>
 #include <pal/SessionID.h>
@@ -48,9 +49,10 @@ struct WorkletParameters {
     std::optional<uint64_t> noiseInjectionHashSalt;
     String agentClusterID;
     ContentSecurityPolicyResponseHeaders contentSecurityPolicyResponseHeaders;
+    NetworkLoadPolicy networkLoadPolicy;
 
-    WorkletParameters isolatedCopy() const & { return { windowURL.isolatedCopy(), jsRuntimeFlags, sampleRate, currentFrame, identifier.isolatedCopy(), sessionID, settingsValues.isolatedCopy(), referrerPolicy, isAudioContextRealTime, advancedPrivacyProtections, noiseInjectionHashSalt, agentClusterID.isolatedCopy(), contentSecurityPolicyResponseHeaders.isolatedCopy() }; }
-    WorkletParameters isolatedCopy() && { return { WTF::move(windowURL).isolatedCopy(), jsRuntimeFlags, sampleRate, currentFrame, WTF::move(identifier).isolatedCopy(), sessionID, WTF::move(settingsValues).isolatedCopy(), referrerPolicy, isAudioContextRealTime, advancedPrivacyProtections, WTF::move(noiseInjectionHashSalt), WTF::move(agentClusterID).isolatedCopy(), WTF::move(contentSecurityPolicyResponseHeaders).isolatedCopy() }; }
+    WorkletParameters isolatedCopy() const & { return { windowURL.isolatedCopy(), jsRuntimeFlags, sampleRate, currentFrame, identifier.isolatedCopy(), sessionID, settingsValues.isolatedCopy(), referrerPolicy, isAudioContextRealTime, advancedPrivacyProtections, noiseInjectionHashSalt, agentClusterID.isolatedCopy(), contentSecurityPolicyResponseHeaders.isolatedCopy(), networkLoadPolicy.isolatedCopy() }; }
+    WorkletParameters isolatedCopy() && { return { WTF::move(windowURL).isolatedCopy(), jsRuntimeFlags, sampleRate, currentFrame, WTF::move(identifier).isolatedCopy(), sessionID, WTF::move(settingsValues).isolatedCopy(), referrerPolicy, isAudioContextRealTime, advancedPrivacyProtections, WTF::move(noiseInjectionHashSalt), WTF::move(agentClusterID).isolatedCopy(), WTF::move(contentSecurityPolicyResponseHeaders).isolatedCopy(), networkLoadPolicy.isolatedCopy() }; }
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
@@ -34,6 +34,7 @@
 #include <WebCore/ContentSecurityPolicy.h>
 #include <WebCore/Document.h>
 #include <WebCore/Exception.h>
+#include <WebCore/NetworkLoadPolicy.h>
 #include <WebCore/ScriptExecutionContext.h>
 #include <WebCore/WebTransportConnectionInfo.h>
 #include <WebCore/WebTransportConnectionStats.h>
@@ -139,6 +140,8 @@ Ref<WebCore::WebTransportSessionInitializationPromise> WebTransportSession::init
     if (RefPtr document = dynamicDowncast<WebCore::Document>(context))
         sourcePosition = document->currentParserSourcePosition();
     if (CheckedPtr csp = context.contentSecurityPolicy(); !csp || !csp->allowConnectToSource(url, WTF::move(sourcePosition)))
+        return WebCore::WebTransportSessionInitializationPromise::createAndReject();
+    if (!context.networkLoadPolicy().allowsLoadFromURL(url, WebCore::MainFrameMainResource::No))
         return WebCore::WebTransportSessionInitializationPromise::createAndReject();
     return sendWithPromisedReply(Messages::NetworkConnectionToWebProcess::InitializeWebTransportSession(m_identifier, url, options, additionalHeaders, m_pageID, origin))->whenSettled(RunLoop::mainSingleton(), [] (auto&& result) {
         if (result && *result)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebTransport.mm
@@ -38,6 +38,7 @@
 #import "Helpers/cocoa/WebTransportServer.h"
 #import <CommonCrypto/CommonDigest.h>
 #import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebsiteDataStorePrivate.h>
 #import <WebKit/_WKInternalDebugFeature.h>
 #import <pal/spi/cocoa/NetworkSPI.h>
@@ -764,6 +765,61 @@ TEST(WebTransport, CSP)
     };
     EXPECT_WK_STREQ(runTest("none"), "caught WebTransportError session null true");
     EXPECT_WK_STREQ(runTest([NSString stringWithFormat:@"https://localhost:%d", server.port()].UTF8String), "ready");
+}
+
+TEST(WebTransport, AllowedNetworkHosts)
+{
+    WebTransportServer transportServer([](ConnectionGroup group) -> ConnectionTask {
+        co_return;
+    });
+
+    NSString *transportURL = [NSString stringWithFormat:@"https://127.0.0.1:%d/", transportServer.port()];
+
+    NSString *workerJS = [NSString stringWithFormat:@""
+        "async function test() {"
+        "  try {"
+        "    let t = new WebTransport('%@');"
+        "    await t.ready;"
+        "    self.postMessage('ready');"
+        "  } catch (e) { self.postMessage('caught ' + e.name); }"
+        "}; test();", transportURL];
+
+    NSString *mainHTML = [NSString stringWithFormat:@"<script>"
+        "async function connectFromDocument() {"
+        "  try {"
+        "    let t = new WebTransport('%@');"
+        "    await t.ready;"
+        "    return 'ready';"
+        "  } catch (e) { return 'caught ' + e.name; }"
+        "}"
+        "async function test() {"
+        "  const documentResult = await connectFromDocument();"
+        "  const worker = new Worker('worker.js');"
+        "  worker.onmessage = (event) => {"
+        "    alert('document: ' + documentResult + ', worker: ' + event.data);"
+        "  };"
+        "}; test();"
+        "</script>", transportURL];
+
+    HTTPServer loadingServer({
+        { "/"_s, { mainHTML } },
+        { "/worker.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, workerJS } }
+    });
+
+    auto runTest = [&] (NSSet<NSString *> *allowedNetworkHosts) {
+        RetainPtr configuration = adoptNS([WKWebViewConfiguration new]);
+        enableWebTransport(configuration.get());
+        configuration.get()._allowedNetworkHosts = allowedNetworkHosts;
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+        RetainPtr delegate = adoptNS([TestNavigationDelegate new]);
+        [delegate allowAnyTLSCertificate];
+        [webView setNavigationDelegate:delegate.get()];
+        [webView loadRequest:loadingServer.requestWithLocalhost()];
+        return [webView _test_waitForAlert];
+    };
+
+    EXPECT_WK_STREQ(runTest([NSSet setWithObject:@"localhost"]), "document: caught WebTransportError, worker: caught WebTransportError");
+    EXPECT_WK_STREQ(runTest(([NSSet setWithObjects:@"localhost", @"127.0.0.1", nil])), "document: ready, worker: ready");
 }
 
 TEST(WebTransport, ServerCertificateHashes)


### PR DESCRIPTION
#### 038b254e879cfdd51c5f7443fb4dde51a48081cc
<pre>
Make WKWebViewConfiguration._allowedNetworkHosts restrict WebTransport
<a href="https://bugs.webkit.org/show_bug.cgi?id=323903">https://bugs.webkit.org/show_bug.cgi?id=323903</a>
<a href="https://rdar.apple.com/187142326">rdar://187142326</a>

Reviewed by Ben Nham.

It already restricted loads and WebSocket.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebTransport.mm

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp:
(WebCore::generateWorkletParameters):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::networkLoadPolicy const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/EmptyScriptExecutionContext.h:
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/page/NetworkLoadPolicy.cpp: Added.
(WebCore::NetworkLoadPolicy::allowsLoadFromURL const):
(WebCore::NetworkLoadPolicy::isolatedCopy const):
(WebCore::NetworkLoadPolicy::unrestricted):
* Source/WebCore/page/NetworkLoadPolicy.h: Added.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::allowsLoadFromURL const):
* Source/WebCore/page/Page.h:
(WebCore::Page::networkLoadPolicy const):
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::m_networkLoadPolicy):
(WebCore::m_agentClusterID): Deleted.
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::startWorkerGlobalScope):
* Source/WebCore/workers/WorkerThread.cpp:
(WebCore::WorkerParameters::isolatedCopy const):
* Source/WebCore/workers/WorkerThread.h:
* Source/WebCore/worklets/WorkletGlobalScope.cpp:
(WebCore::WorkletGlobalScope::WorkletGlobalScope):
* Source/WebCore/worklets/WorkletGlobalScope.h:
* Source/WebCore/worklets/WorkletParameters.h:
(WebCore::WorkletParameters::isolatedCopy const):
(WebCore::WorkletParameters::isolatedCopy):
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::initialize):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebTransport.mm:
(TestWebKitAPI::AllowedNetworkHosts)):
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::generateWorkerParameters):
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::generateWorkerParameters):

Canonical link: <a href="https://commits.webkit.org/320940@main">https://commits.webkit.org/320940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a255c194a1d110ef6feb118138951f3c85a4e6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150739 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145472 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100832 "1 flakes 13 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49147 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165998 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125804 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47876 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45855 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158230 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45590 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7538 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52575 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198446 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59729 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155031 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60440 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154675 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28292 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49114 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132704 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129852 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58869 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20569 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58269 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58489 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58330 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->