### PR TITLE
Straighten out SVGSMILElement::{begin,end}ListChanged

### DIFF
--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -573,12 +573,22 @@ void SVGSMILElement::svgAttributeChanged(const QualifiedName& attrName)
         break;
     }
     case AttributeNames::beginAttr:
-        if (isConnected())
-            beginListChanged(elapsed());
+        if (isConnected()) {
+            SMILTime elapsed = this->elapsed();
+            beginListChanged(elapsed);
+            m_nextProgressTime = elapsed;
+            if (RefPtr timeContainer = m_timeContainer)
+                timeContainer->notifyIntervalsChanged();
+        }
         break;
     case AttributeNames::endAttr:
-        if (isConnected())
-            endListChanged(elapsed());
+        if (isConnected()) {
+            SMILTime elapsed = this->elapsed();
+            endListChanged(elapsed);
+            m_nextProgressTime = elapsed;
+            if (RefPtr timeContainer = m_timeContainer)
+                timeContainer->notifyIntervalsChanged();
+        }
         break;
     default:
         break;
@@ -800,6 +810,9 @@ void SVGSMILElement::addInstanceTime(BeginOrEnd beginOrEnd, SMILTime time, SMILT
         beginListChanged(elapsed);
     else
         endListChanged(elapsed);
+    m_nextProgressTime = elapsed;
+    if (RefPtr timeContainer = m_timeContainer)
+        timeContainer->notifyIntervalsChanged();
 }
 
 SMILTime SVGSMILElement::findInstanceTime(BeginOrEnd beginOrEnd, SMILTime minimumTime, bool equalsMinimumOK) const
@@ -945,54 +958,54 @@ SMILTime SVGSMILElement::nextProgressTime() const
     
 void SVGSMILElement::beginListChanged(SMILTime eventTime)
 {
-    if (m_isWaitingForFirstInterval)
+    if (m_isWaitingForFirstInterval) {
         resolveFirstInterval();
-    else {
-        if (restart() == RestartNever)
-            return;
-
-        SMILTime newBegin = findInstanceTime(Begin, eventTime, true);
-        if (newBegin.isFinite() && (m_intervalEnd <= eventTime || newBegin < m_intervalBegin)) {
-            // Begin time changed, re-resolve the interval.
-            SMILTime oldBegin = m_intervalBegin;
-            m_intervalEnd = eventTime;
-            resolveInterval(false, m_intervalBegin, m_intervalEnd);  
-            ASSERT(!m_intervalBegin.isUnresolved());
-            if (m_intervalBegin != oldBegin) {
-                if (m_activeState == Active && m_intervalBegin > eventTime) {
-                    m_activeState = determineActiveState(eventTime);
-                    if (m_activeState != Active)
-                        endedActiveInterval();
-                }
-                notifyDependentsIntervalChanged();
-            }
-        }
+        return;
     }
-    m_nextProgressTime = elapsed();
-
-    if (RefPtr timeContainer = m_timeContainer)
-        timeContainer->notifyIntervalsChanged();
+    // Never resolve more than one interval when restart is 'never'.
+    if (restart() == RestartNever)
+        return;
+    SMILTime newBegin = findInstanceTime(Begin, eventTime, true);
+    if (!newBegin.isFinite())
+        return;
+    // If the current interval is still active and already contains the new begin
+    // time, a potentially new interval will be picked up during the regular
+    // interval update.
+    if (newBegin >= m_intervalBegin && eventTime < m_intervalEnd)
+        return;
+    // Begin time changed, re-resolve the interval.
+    SMILTime oldBegin = m_intervalBegin;
+    m_intervalEnd = eventTime;
+    resolveInterval(false, m_intervalBegin, m_intervalEnd);
+    ASSERT(!m_intervalBegin.isUnresolved());
+    if (m_intervalBegin == oldBegin)
+        return;
+    if (m_activeState == Active && m_intervalBegin > eventTime) {
+        m_activeState = determineActiveState(eventTime);
+        if (m_activeState != Active)
+            endedActiveInterval();
+    }
+    notifyDependentsIntervalChanged();
 }
 
-void SVGSMILElement::endListChanged(SMILTime)
+void SVGSMILElement::endListChanged(SMILTime eventTime)
 {
-    SMILTime elapsed = this->elapsed();
-    if (m_isWaitingForFirstInterval)
+    if (m_isWaitingForFirstInterval) {
         resolveFirstInterval();
-    else if (elapsed < m_intervalEnd && m_intervalBegin.isFinite()) {
-        SMILTime newEnd = findInstanceTime(End, m_intervalBegin, false);
-        if (newEnd < m_intervalEnd) {
-            newEnd = resolveActiveEnd(m_intervalBegin, newEnd);
-            if (newEnd != m_intervalEnd) {
-                m_intervalEnd = newEnd;
-                notifyDependentsIntervalChanged();
-            }
-        }
+        return;
     }
-    m_nextProgressTime = elapsed;
-
-    if (RefPtr timeContainer = m_timeContainer)
-        timeContainer->notifyIntervalsChanged();
+    // If we have no resolved interval, or the current interval already ends at or
+    // before the indicated time, then a new 'end' instance time will have no effect.
+    if (!m_intervalBegin.isFinite() || m_intervalEnd <= eventTime)
+        return;
+    SMILTime newEnd = findInstanceTime(End, m_intervalBegin, false);
+    if (newEnd >= m_intervalEnd)
+        return;
+    newEnd = resolveActiveEnd(m_intervalBegin, newEnd);
+    if (newEnd == m_intervalEnd)
+        return;
+    m_intervalEnd = newEnd;
+    notifyDependentsIntervalChanged();
 }
 
 void SVGSMILElement::checkRestart(SMILTime elapsed)


### PR DESCRIPTION
#### d844d25c25f03a3a83bc0a5bab40e6cd7adc4be4
<pre>
Straighten out SVGSMILElement::{begin,end}ListChanged
<a href="https://bugs.webkit.org/show_bug.cgi?id=323905">https://bugs.webkit.org/show_bug.cgi?id=323905</a>
<a href="https://rdar.apple.com/187142869">rdar://187142869</a>

Reviewed by NOBODY (OOPS!).

This refactors said methods to have straighter code flow, replacing the
nested conditionals with early-return guard clauses and documenting the
relevant preconditions in each.

The updates to m_nextProgressTime and the calls to
SMILTimeContainer::notifyIntervalsChanged() are sunk out to the
respective callers (svgAttributeChanged() and addInstanceTime()).

A minor change is that endListChanged() now considers the eventTime
argument it is passed rather than always recomputing elapsed(). This is
not observable today since both callers already pass elapsed(), but it
removes a trap for future callers.

The boundary comparisons are preserved exactly (WebKit&apos;s strict &apos;&lt;&apos; on
the begin side and &apos;&lt;=&apos; on the end side), so behavior is otherwise
unchanged.

* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::svgAttributeChanged):
(WebCore::SVGSMILElement::addInstanceTime):
(WebCore::SVGSMILElement::beginListChanged):
(WebCore::SVGSMILElement::endListChanged):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d844d25c25f03a3a83bc0a5bab40e6cd7adc4be4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196445 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150728 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145455 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100825 "1 flakes 15 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d9575645-80f9-4ad9-b9a4-e97aa5fc2a0f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/165985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125784 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47863 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45847 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158217 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45576 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7516 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198423 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59706 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155022 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60418 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42154 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154660 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49101 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132693 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129832 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58855 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20556 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58249 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58476 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58308 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->