### PR TITLE
[Swift Testing] Make Swift-friendly Web Extension utility functions and types

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.swift
@@ -237,6 +237,23 @@ extension HTTPServer {
         /// The port of the server.
         public let port: Int
 
+        // swift-format-ignore: NeverForceUnwrap
+        /// The URL of the server, addressed by IP.
+        public var address: Foundation.URL {
+            // Well formed for every port number, so this cannot fail.
+            Foundation.URL(string: "http://127.0.0.1:\(port)/")!
+        }
+
+        // swift-format-ignore: NeverForceUnwrap
+        /// The URL of the server, addressed by the `localhost` host name.
+        ///
+        /// Some code paths treat `localhost` and `127.0.0.1` as distinct origins, so a test that
+        /// needs two same-server origins can use one of each.
+        public var localhostAddress: Foundation.URL {
+            // Well formed for every port number, so this cannot fail.
+            Foundation.URL(string: "http://localhost:\(port)/")!
+        }
+
         /// The URL representing the HTTPS proxy for the server.
         public var httpsProxy: Foundation.URL? {
             Foundation.URL(string: "https://127.0.0.1:\(port)/")

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageUtilities.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageUtilities.swift
@@ -29,6 +29,7 @@ private import TestWebKitAPILibrary.Helpers.cocoa.TestCocoaImageUtilities
 public import UIKit
 #else
 public import AppKit
+private import TestWebKitAPILibrary.Helpers.mac.AppKitSPI
 #endif
 
 /// A system appearance to draw with.
@@ -92,6 +93,17 @@ public func pixelColor(of image: CocoaImage, at point: CGPoint = .zero) -> Cocoa
 @MainActor
 public func compareColors(_ color: CocoaColor?, _ otherColor: CocoaColor?, tolerance: CGFloat = 0.01) -> Bool {
     TestCocoaImageUtilities.compareColors(color, otherColor, tolerance: tolerance)
+}
+
+extension CocoaImage {
+    /// Whether this image was created from a system symbol.
+    public var isSymbol: Bool {
+        #if WTF_PLATFORM_IOS_FAMILY
+        isSymbolImage
+        #else
+        _isSymbolImage
+        #endif
+    }
 }
 
 @MainActor

--- a/Tools/TestWebKitAPI/Helpers/cocoa/TestWebExtensionsDelegate.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/TestWebExtensionsDelegate.h
@@ -42,44 +42,49 @@
 #import <WebKit/WKWebExtensionWindowConfiguration.h>
 #import <WebKit/WebKit.h>
 
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
+
+NS_SWIFT_UI_ACTOR
 @interface TestWebExtensionsDelegate : NSObject <WKWebExtensionControllerDelegate, WKWebExtensionControllerDelegatePrivate>
 
-@property (nonatomic, copy) NSArray<id <WKWebExtensionWindow>> *(^openWindows)(WKWebExtensionContext *);
-@property (nonatomic, copy) id <WKWebExtensionWindow> (^focusedWindow)(WKWebExtensionContext *);
+@property (nonatomic, copy, nullable) NSArray<id <WKWebExtensionWindow>> *(^openWindows)(WKWebExtensionContext *);
+@property (nonatomic, copy, nullable) id <WKWebExtensionWindow> _Nullable (^focusedWindow)(WKWebExtensionContext *);
 
 #if PLATFORM(MAC)
-@property (nonatomic, copy) void (^openNewWindow)(WKWebExtensionWindowConfiguration *, WKWebExtensionContext *, void (^)(id<WKWebExtensionWindow>, NSError *));
+@property (nonatomic, copy, nullable) void (^openNewWindow)(WKWebExtensionWindowConfiguration *, WKWebExtensionContext *, void (^)(id<WKWebExtensionWindow> _Nullable, NSError * _Nullable));
 #endif
 
-@property (nonatomic, copy) void (^openNewTab)(WKWebExtensionTabConfiguration *, WKWebExtensionContext *, void (^)(id<WKWebExtensionTab>, NSError *));
-@property (nonatomic, copy) void (^moveTabs)(NSArray<id <WKWebExtensionTab>> *, NSUInteger index, id <WKWebExtensionWindow> window, WKWebExtensionContext *, void (^)(NSError *));
-@property (nonatomic, copy) void (^openOptionsPage)(WKWebExtensionContext *, void (^)(NSError *));
+@property (nonatomic, copy, nullable) void (^openNewTab)(WKWebExtensionTabConfiguration *, WKWebExtensionContext *, void (^)(id<WKWebExtensionTab> _Nullable, NSError * _Nullable));
+@property (nonatomic, copy, nullable) void (^moveTabs)(NSArray<id <WKWebExtensionTab>> *, NSUInteger index, id <WKWebExtensionWindow> window, WKWebExtensionContext *, void (^)(NSError * _Nullable));
+@property (nonatomic, copy, nullable) void (^openOptionsPage)(WKWebExtensionContext *, void (^)(NSError * _Nullable));
 
-@property (nonatomic, copy) void (^promptForPermissions)(id <WKWebExtensionTab>, NSSet<NSString *> *, void (^)(NSSet<WKWebExtensionPermission> *, NSDate *));
-@property (nonatomic, copy) void (^promptForPermissionMatchPatterns)(id <WKWebExtensionTab>, NSSet<WKWebExtensionMatchPattern *> *, void (^)(NSSet<WKWebExtensionMatchPattern *> *, NSDate *));
-@property (nonatomic, copy) void (^promptForPermissionToAccessURLs)(id <WKWebExtensionTab>, NSSet<NSURL *> *, void (^)(NSSet<NSURL *> *, NSDate *));
+@property (nonatomic, copy, nullable) void (^promptForPermissions)(id <WKWebExtensionTab> _Nullable, NSSet<NSString *> *, void (^)(NSSet<WKWebExtensionPermission> *, NSDate * _Nullable));
+@property (nonatomic, copy, nullable) void (^promptForPermissionMatchPatterns)(id <WKWebExtensionTab> _Nullable, NSSet<WKWebExtensionMatchPattern *> *, void (^)(NSSet<WKWebExtensionMatchPattern *> *, NSDate * _Nullable));
+@property (nonatomic, copy, nullable) void (^promptForPermissionToAccessURLs)(id <WKWebExtensionTab> _Nullable, NSSet<NSURL *> *, void (^)(NSSet<NSURL *> *, NSDate * _Nullable));
 
-@property (nonatomic, copy) void (^sendMessage)(id message, NSString *applicationIdentifier, void (^)(id replyMessage, NSError *));
-@property (nonatomic, copy) void (^connectUsingMessagePort)(WKWebExtensionMessagePort *);
+@property (nonatomic, copy, nullable) void (^sendMessage)(id message, NSString * _Nullable applicationIdentifier, void (^)(id _Nullable replyMessage, NSError * _Nullable));
+@property (nonatomic, copy, nullable) void (^connectUsingMessagePort)(WKWebExtensionMessagePort *);
 
-@property (nonatomic, copy) void (^didUpdateAction)(WKWebExtensionAction *);
-@property (nonatomic, copy) void (^presentPopupForAction)(WKWebExtensionAction *);
+@property (nonatomic, copy, nullable) void (^didUpdateAction)(WKWebExtensionAction *);
+@property (nonatomic, copy, nullable) void (^presentPopupForAction)(WKWebExtensionAction *);
 
-@property (nonatomic, copy) void (^presentSidebar)(_WKWebExtensionSidebar *);
+@property (nonatomic, copy, nullable) void (^presentSidebar)(_WKWebExtensionSidebar *);
 
-@property (nonatomic, copy) void (^closeSidebar)(_WKWebExtensionSidebar *);
+@property (nonatomic, copy, nullable) void (^closeSidebar)(_WKWebExtensionSidebar *);
 
-@property (nonatomic, copy) void (^didUpdateSidebar)(_WKWebExtensionSidebar *);
+@property (nonatomic, copy, nullable) void (^didUpdateSidebar)(_WKWebExtensionSidebar *);
 
-@property (nonatomic, copy) void (^didInvalidateSidebar)(_WKWebExtensionSidebar *);
-@property (nonatomic, copy) _WKWebExtensionSidebarSide (^sidebarSide)(void);
+@property (nonatomic, copy, nullable) void (^didInvalidateSidebar)(_WKWebExtensionSidebar *);
+@property (nonatomic, copy, nullable) _WKWebExtensionSidebarSide (^sidebarSide)(void);
 
-@property (nonatomic, copy) void (^createBookmarkWithParentIdentifier)(NSString *parentId, NSNumber *index, NSString *url, NSString *title, void (^)(NSObject<_WKWebExtensionBookmark> *, NSError *));
-@property (nonatomic, copy) void (^bookmarksForExtensionContext)(void (^)(NSArray<NSObject<_WKWebExtensionBookmark> *> *, NSError *));
-@property (nonatomic, copy) void (^removeBookmarkWithIdentifier)(NSString *bookmarkId, BOOL removeFolderWithChildren, void (^completionHandler)(NSError *));
-@property (nonatomic, copy) void (^updateBookmarkWithIdentifier)(NSString *bookmarkId, NSString *title, NSString *url, void (^)(NSObject<_WKWebExtensionBookmark> *, NSError *));
-@property (nonatomic, copy) void (^moveBookmarkWithIdentifier)(NSString *bookmarkId, NSString *parentId, NSNumber *index, void (^)(NSObject<_WKWebExtensionBookmark> *, NSError *));
+@property (nonatomic, copy, nullable) void (^createBookmarkWithParentIdentifier)(NSString * _Nullable parentId, NSNumber * _Nullable index, NSString * _Nullable url, NSString *title, void (^)(NSObject<_WKWebExtensionBookmark> * _Nullable, NSError * _Nullable));
+@property (nonatomic, copy, nullable) void (^bookmarksForExtensionContext)(void (^)(NSArray<NSObject<_WKWebExtensionBookmark> *> * _Nullable, NSError * _Nullable));
+@property (nonatomic, copy, nullable) void (^removeBookmarkWithIdentifier)(NSString *bookmarkId, BOOL removeFolderWithChildren, void (^completionHandler)(NSError * _Nullable));
+@property (nonatomic, copy, nullable) void (^updateBookmarkWithIdentifier)(NSString *bookmarkId, NSString * _Nullable title, NSString * _Nullable url, void (^)(NSObject<_WKWebExtensionBookmark> * _Nullable, NSError * _Nullable));
+@property (nonatomic, copy, nullable) void (^moveBookmarkWithIdentifier)(NSString *bookmarkId, NSString * _Nullable parentId, NSNumber * _Nullable index, void (^)(NSObject<_WKWebExtensionBookmark> * _Nullable, NSError * _Nullable));
 @end
+
+NS_HEADER_AUDIT_END(nullability, sendability)
 
 #endif // __OBJC__
 

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#ifdef __cplusplus
-
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "Helpers/cocoa/TestCocoa.h"
@@ -36,66 +34,91 @@
 
 #ifdef __OBJC__
 
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
+
 @class TestWebExtensionTab;
 @class TestWebExtensionWindow;
 @class TestWebExtensionsDelegate;
 
+NS_SWIFT_UI_ACTOR
 @interface TestWebExtensionManager : NSObject
 
 - (instancetype)initForExtension:(WKWebExtension *)extension;
-- (instancetype)initForExtension:(WKWebExtension *)extension extensionControllerConfiguration:(WKWebExtensionControllerConfiguration *)configuration;
-- (instancetype)initForExtension:(WKWebExtension *)extension extensionControllerConfiguration:(WKWebExtensionControllerConfiguration *)configuration usesEnhancedSecurity:(BOOL)usesEnhancedSecurity;
+- (instancetype)initForExtension:(WKWebExtension *)extension extensionControllerConfiguration:(nullable WKWebExtensionControllerConfiguration *)configuration;
+- (instancetype)initForExtension:(WKWebExtension *)extension extensionControllerConfiguration:(nullable WKWebExtensionControllerConfiguration *)configuration usesEnhancedSecurity:(BOOL)usesEnhancedSecurity;
+
+// The equivalent of Util::parseExtension() for callers that cannot spell RetainPtr, such as Swift.
+- (instancetype)initWithManifest:(NSDictionary<NSString *, id> *)manifest resources:(nullable NSDictionary<NSString *, id> *)resources;
 
 @property (nonatomic, strong) WKWebExtension *extension;
-@property (nonatomic, strong) WKWebExtensionContext *context;
+// Cleared by tests that check what the controller does once the context is released.
+@property (nonatomic, strong, nullable) WKWebExtensionContext *context;
 @property (nonatomic, strong) WKWebExtensionController *controller;
-@property (nonatomic, weak) id <WKWebExtensionControllerDelegate> controllerDelegate;
+@property (nonatomic, weak, nullable) id <WKWebExtensionControllerDelegate> controllerDelegate;
 
 @property (nonatomic, readonly, strong) TestWebExtensionsDelegate *internalDelegate;
-@property (nonatomic, readonly, strong) TestWebExtensionWindow *defaultWindow;
-@property (nonatomic, readonly, strong) TestWebExtensionTab *defaultTab;
+
+// Nil once the last window has been closed; every window and tab the manager creates itself outlives that.
+@property (nonatomic, readonly, strong, nullable) TestWebExtensionWindow *defaultWindow;
+@property (nonatomic, readonly, strong, nullable) TestWebExtensionTab *defaultTab;
+
 @property (nonatomic, readonly, copy) NSArray<TestWebExtensionWindow *> *windows;
 @property (nonatomic, readonly, copy) NSArray<NSString *> *testsAdded;
 @property (nonatomic, readonly, copy) NSArray<NSString *> *testsStarted;
 @property (nonatomic, readonly, copy) NSDictionary<NSString *, id> *testResults;
 
+// Collects failures from the extension's `browser.test` harness and from -load / -unload rather
+// than recording them with GoogleTest, so a Swift test can surface them from whichever call awaited.
+@property (nonatomic) BOOL collectsFailures;
+
+// Fails with anything the harness collected since the last check, and clears it.
+- (BOOL)checkCollectedFailuresWithError:(NSError **)error;
+
 - (TestWebExtensionWindow *)openNewWindow;
 - (TestWebExtensionWindow *)openNewWindowUsingPrivateBrowsing:(BOOL)usesPrivateBrowsing;
-- (void)focusWindow:(TestWebExtensionWindow *)window;
+- (void)focusWindow:(nullable TestWebExtensionWindow *)window;
 - (void)closeWindow:(TestWebExtensionWindow *)window;
 
 - (void)sendTestMessage:(NSString *)message;
-- (void)sendTestMessage:(NSString *)message withArgument:(id)argument;
-- (void)sendTestStartedWithArgument:(id)argument;
-- (void)sendTestFinishedWithArgument:(id)argument;
+- (void)sendTestMessage:(NSString *)message withArgument:(nullable id)argument;
+- (void)sendTestStartedWithArgument:(nullable id)argument;
+- (void)sendTestFinishedWithArgument:(nullable id)argument;
 
-- (void)loadAndRun;
+- (void)loadAndRun NS_SWIFT_UNAVAILABLE("Spins the run loop; use loadAndRun() async instead.");
 
 - (void)load;
 - (void)unload;
 
-- (void)run;
-- (void)runForTimeInterval:(NSTimeInterval)interval;
-- (id)runUntilTestMessage:(NSString *)message;
-- (void)runUntilContextError;
+- (void)run NS_SWIFT_UNAVAILABLE("Spins the run loop; use run() async instead.");
+- (void)runForTimeInterval:(NSTimeInterval)interval NS_SWIFT_UNAVAILABLE("Spins the run loop; add an async variant instead.");
+- (id)runUntilTestMessage:(NSString *)message NS_SWIFT_UNAVAILABLE("Spins the run loop; use waitForTestMessage(_:) async instead.");
+- (void)runUntilContextError NS_SWIFT_UNAVAILABLE("Spins the run loop; add an async variant instead.");
+
+- (void)runWithCompletionHandler:(void (^)(NSError * _Nullable error))completionHandler;
+- (void)waitForTestMessage:(NSString *)message completionHandler:(void (^)(NSError * _Nullable error))completionHandler NS_SWIFT_NAME(waitForTestMessage(_:completionHandler:));
+- (void)loadAndRunWithCompletionHandler:(void (^)(NSError * _Nullable error))completionHandler;
 
 - (void)done;
 
 @end
 
+NS_SWIFT_UI_ACTOR
 @interface TestWebExtensionTab : NSObject <WKWebExtensionTab>
 
-- (instancetype)initWithWindow:(TestWebExtensionWindow *)window extensionController:(WKWebExtensionController *)extensionController NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithWindow:(nullable TestWebExtensionWindow *)window extensionController:(nullable WKWebExtensionController *)extensionController NS_DESIGNATED_INITIALIZER;
 
-- (void)assignWindow:(TestWebExtensionWindow *)window;
+- (void)assignWindow:(nullable TestWebExtensionWindow *)window;
 
-@property (nonatomic, weak) TestWebExtensionWindow *window;
-@property (nonatomic, strong) WKWebView *webView;
-@property (nonatomic, copy) NSURL *overrideURL;
+@property (nonatomic, weak, nullable) TestWebExtensionWindow *window;
+
+// Nil for a tab created without an extension controller, which has nothing to host a web view for.
+@property (nonatomic, strong, nullable) WKWebView *webView;
+
+@property (nonatomic, copy, nullable) NSURL *overrideURL;
 
 - (void)changeWebViewIfNeededForURL:(NSURL *)url forExtensionContext:(WKWebExtensionContext *)context;
 
-@property (nonatomic, weak) TestWebExtensionTab *parentTab;
+@property (nonatomic, weak, nullable) TestWebExtensionTab *parentTab;
 
 @property (nonatomic) bool shouldBypassPermissions;
 @property (nonatomic, getter=isPinned) bool pinned;
@@ -103,23 +126,26 @@
 @property (nonatomic, getter=isSelected) bool selected;
 @property (nonatomic, getter=isShowingReaderMode) bool showingReaderMode;
 
-@property (nonatomic, copy) void (^setReaderModeShowing)(BOOL);
-@property (nonatomic, copy) NSLocale *(^webpageLocale)(void);
+@property (nonatomic, copy, nullable) void (^setReaderModeShowing)(BOOL);
+@property (nonatomic, copy, nullable) NSLocale * _Nullable (^webpageLocale)(void);
 
-@property (nonatomic, copy) void (^reload)(BOOL);
-@property (nonatomic, copy) void (^goBack)(void);
-@property (nonatomic, copy) void (^goForward)(void);
-@property (nonatomic, copy) void (^duplicate)(WKWebExtensionTabConfiguration *, void (^completionHandler)(TestWebExtensionTab *, NSError *));
+@property (nonatomic, copy, nullable) void (^reload)(BOOL);
+@property (nonatomic, copy, nullable) void (^goBack)(void);
+@property (nonatomic, copy, nullable) void (^goForward)(void);
+@property (nonatomic, copy, nullable) void (^duplicate)(WKWebExtensionTabConfiguration *, void (^completionHandler)(TestWebExtensionTab * _Nullable, NSError * _Nullable));
 
 @end
 
+NS_SWIFT_UI_ACTOR
 @interface TestWebExtensionWindow : NSObject <WKWebExtensionWindow>
 
-- (instancetype)initWithExtensionController:(WKWebExtensionController *)extensionController usesPrivateBrowsing:(BOOL)usesPrivateBrowsing;
-- (instancetype)initWithExtensionController:(WKWebExtensionController *)extensionController usesPrivateBrowsing:(BOOL)usesPrivateBrowsing usesEnhancedSecurity:(BOOL)usesEnhancedSecurity NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithExtensionController:(nullable WKWebExtensionController *)extensionController usesPrivateBrowsing:(BOOL)usesPrivateBrowsing;
+- (instancetype)initWithExtensionController:(nullable WKWebExtensionController *)extensionController usesPrivateBrowsing:(BOOL)usesPrivateBrowsing usesEnhancedSecurity:(BOOL)usesEnhancedSecurity NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, copy) NSArray<TestWebExtensionTab *> *tabs;
-@property (nonatomic, strong) TestWebExtensionTab *activeTab;
+
+// Nil while the window has no tabs, which happens between closing the last one and opening another.
+@property (nonatomic, strong, nullable) TestWebExtensionTab *activeTab;
 
 - (TestWebExtensionTab *)openNewTab;
 - (TestWebExtensionTab *)openNewTabAtIndex:(NSUInteger)index;
@@ -141,10 +167,12 @@
 @property (nonatomic, readonly, getter=isUsingPrivateBrowsing) BOOL usingPrivateBrowsing;
 @property (nonatomic, readonly, getter=isUsingEnhancedSecurity) BOOL usingEnhancedSecurity;
 
-@property (nonatomic, copy) void (^didFocus)(void);
-@property (nonatomic, copy) void (^didClose)(void);
+@property (nonatomic, copy, nullable) void (^didFocus)(void);
+@property (nonatomic, copy, nullable) void (^didClose)(void);
 
 @end
+
+NS_HEADER_AUDIT_END(nullability, sendability)
 
 #else // not __OBJC__
 
@@ -155,29 +183,31 @@ OBJC_CLASS TestWebExtensionsDelegate;
 
 #endif // __OBJC__
 
+#ifdef __cplusplus
+
 namespace TestWebKitAPI::Util {
 
 #ifdef __OBJC__
 
-inline NSString *constructScript(NSArray *lines) { return [lines componentsJoinedByString:@"\n"]; }
-inline NSString *constructJSArrayOfStrings(NSArray *elements) { return [NSString stringWithFormat:@"['%@']", [elements componentsJoinedByString:@"', '"]]; }
+inline NSString * _Nonnull constructScript(NSArray * _Nonnull lines) { return [lines componentsJoinedByString:@"\n"]; }
+inline NSString * _Nonnull constructJSArrayOfStrings(NSArray * _Nonnull elements) { return [NSString stringWithFormat:@"['%@']", [elements componentsJoinedByString:@"', '"]]; }
 
-NSData *makePNGData(CGSize, SEL colorSelector);
+NSData * _Nonnull makePNGData(CGSize, SEL _Nonnull colorSelector);
 
 enum class Appearance { Light, Dark };
 
-void performWithAppearance(Appearance, void (^block)(void));
+void performWithAppearance(Appearance, void (^ _Nonnull block)(void));
 
 #endif
 
 extern bool shouldEnableSiteIsolationForWebExtensionsTest;
 
-RetainPtr<TestWebExtensionManager> parseExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil, BOOL usesEnhancedSecurity = NO);
-RetainPtr<TestWebExtensionManager> loadExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil, BOOL usesEnhancedSecurity = NO);
-void loadAndRunExtension(NSDictionary *manifest, NSDictionary *resources, WKWebExtensionControllerConfiguration * = nil);
+RetainPtr<TestWebExtensionManager> parseExtension(NSDictionary * _Nonnull manifest, NSDictionary * _Nonnull resources, WKWebExtensionControllerConfiguration * _Nullable = nil, BOOL usesEnhancedSecurity = NO);
+RetainPtr<TestWebExtensionManager> loadExtension(NSDictionary * _Nonnull manifest, NSDictionary * _Nonnull resources, WKWebExtensionControllerConfiguration * _Nullable = nil, BOOL usesEnhancedSecurity = NO);
+void loadAndRunExtension(NSDictionary * _Nonnull manifest, NSDictionary * _Nonnull resources, WKWebExtensionControllerConfiguration * _Nullable = nil);
 
 } // namespace TestWebKitAPI::Util
 
-#endif // ENABLE(WK_WEB_EXTENSIONS)
-
 #endif // __cplusplus
+
+#endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm
@@ -45,19 +45,37 @@
 #import <wtf/darwin/DispatchExtras.h>
 
 @interface TestWebExtensionManager () <WKWebExtensionControllerDelegatePrivate>
+- (id)_takeTestMessage:(NSString *)message;
+- (void)_recordFailureWithMessage:(NSString *)message sourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber;
+- (nullable NSError *)_collectedFailuresError;
 @end
+
+static NSError *managerError(NSString *description)
+{
+    return [NSError errorWithDomain:@"TestWebExtensionManager" code:1 userInfo:@{ NSLocalizedDescriptionKey: description }];
+}
 
 @implementation TestWebExtensionManager {
     bool _done;
     bool _receivedMessage;
     bool _runningTestFromQueue;
     NSMutableDictionary *_messages;
-    NSMutableArray *_windows;
+    NSMutableArray<TestWebExtensionWindow *> *_windows;
+    void (^_doneHandler)(NSError *);
+    NSMutableArray<NSString *> *_collectedFailures;
+    NSString *_pendingTestMessage;
+    void (^_pendingTestMessageHandler)(NSError *);
 }
 
 - (instancetype)initForExtension:(WKWebExtension *)extension
 {
     return [self initForExtension:extension extensionControllerConfiguration:nil];
+}
+
+- (instancetype)initWithManifest:(NSDictionary<NSString *, id> *)manifest resources:(NSDictionary<NSString *, id> *)resources
+{
+    RetainPtr extension = adoptNS([[WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
+    return [self initForExtension:extension.get()];
 }
 
 - (instancetype)initForExtension:(WKWebExtension *)extension extensionControllerConfiguration:(WKWebExtensionControllerConfiguration *)configuration
@@ -260,18 +278,28 @@
     [_context _sendTestFinishedWithArgument:argument];
 }
 
+- (NSArray<TestWebExtensionWindow *> *)windows
+{
+    // Copied so that a caller enumerating the result can open or close windows while it does.
+    return [_windows copy];
+}
+
 - (void)load
 {
     NSError *error;
-    EXPECT_TRUE([_controller loadExtensionContext:_context error:&error]);
-    EXPECT_NULL(error);
+    if ([_controller loadExtensionContext:_context error:&error] && !error)
+        return;
+
+    [self _recordFailureWithMessage:error.description ?: @"Failed to load the extension context." sourceURL:@(__FILE__) lineNumber:__LINE__];
 }
 
 - (void)unload
 {
     NSError *error;
-    EXPECT_TRUE([_controller unloadExtensionContext:_context error:&error]);
-    EXPECT_NULL(error);
+    if ([_controller unloadExtensionContext:_context error:&error] && !error)
+        return;
+
+    [self _recordFailureWithMessage:error.description ?: @"Failed to unload the extension context." sourceURL:@(__FILE__) lineNumber:__LINE__];
 }
 
 - (void)run
@@ -308,18 +336,7 @@
 
 - (id)runUntilTestMessage:(NSString *)message
 {
-    id (^processMessage)(void) = ^id {
-        NSMutableArray *messagesArray = self->_messages[message];
-        if (!messagesArray.count)
-            return nil;
-
-        id argument = messagesArray.firstObject;
-        [messagesArray removeObjectAtIndex:0];
-
-        return argument;
-    };
-
-    if (id result = processMessage())
+    if (id result = [self _takeTestMessage:message])
         return result;
 
     while (true) {
@@ -327,9 +344,55 @@
 
         TestWebKitAPI::Util::run(&_receivedMessage);
 
-        if (id result = processMessage())
+        if (id result = [self _takeTestMessage:message])
             return result;
     }
+}
+
+- (void)runWithCompletionHandler:(void (^)(NSError *))completionHandler
+{
+    if (_done) {
+        _done = false;
+        completionHandler([self _collectedFailuresError]);
+        return;
+    }
+
+    _doneHandler = [completionHandler copy];
+}
+
+- (void)waitForTestMessage:(NSString *)message completionHandler:(void (^)(NSError *))completionHandler
+{
+    if ([self _takeTestMessage:message]) {
+        completionHandler([self _collectedFailuresError]);
+        return;
+    }
+
+    _pendingTestMessage = [message copy];
+    _pendingTestMessageHandler = [completionHandler copy];
+}
+
+- (void)loadAndRunWithCompletionHandler:(void (^)(NSError *))completionHandler
+{
+    [self load];
+
+    if (NSError *error = [self _collectedFailuresError]) {
+        completionHandler(error);
+        return;
+    }
+
+    [self runWithCompletionHandler:completionHandler];
+}
+
+- (id)_takeTestMessage:(NSString *)message
+{
+    NSMutableArray *messagesArray = _messages[message];
+    if (!messagesArray.count)
+        return nil;
+
+    id argument = messagesArray.firstObject;
+    [messagesArray removeObjectAtIndex:0];
+
+    return argument;
 }
 
 - (void)loadAndRun
@@ -340,7 +403,60 @@
 
 - (void)done
 {
+    // Hand the completion to whoever is waiting for it. With nobody waiting, latch it instead, so
+    // that a -runWithCompletionHandler: that arrives afterwards does not wait for a second one.
+    if (auto handler = _doneHandler) {
+        _doneHandler = nil;
+        handler([self _collectedFailuresError]);
+        return;
+    }
+
+    if (auto handler = _pendingTestMessageHandler) {
+        auto *message = _pendingTestMessage;
+        _pendingTestMessageHandler = nil;
+        _pendingTestMessage = nil;
+
+        handler([self _collectedFailuresError] ?: managerError([NSString stringWithFormat:@"The extension finished without sending the test message \"%@\".", message]));
+        return;
+    }
+
     _done = true;
+}
+
+- (void)_recordFailureWithMessage:(NSString *)message sourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber
+{
+    if (_collectsFailures) {
+        if (!_collectedFailures)
+            _collectedFailures = [NSMutableArray array];
+
+        [_collectedFailures addObject:[NSString stringWithFormat:@"%@\n  at %@:%u", message, sourceURL, lineNumber]];
+        return;
+    }
+
+    ::testing::internal::AssertHelper(::testing::TestPartResult::kNonFatalFailure, sourceURL.UTF8String, lineNumber, message.UTF8String) = ::testing::Message();
+}
+
+- (NSError *)_collectedFailuresError
+{
+    if (!_collectedFailures.count)
+        return nil;
+
+    auto *description = [_collectedFailures componentsJoinedByString:@"\n"];
+    [_collectedFailures removeAllObjects];
+
+    return managerError(description);
+}
+
+- (BOOL)checkCollectedFailuresWithError:(NSError **)error
+{
+    NSError *failure = [self _collectedFailuresError];
+    if (!failure)
+        return YES;
+
+    if (error)
+        *error = failure;
+
+    return NO;
 }
 
 - (void)_webExtensionController:(WKWebExtensionController *)controller recordTestAssertionResult:(BOOL)result withMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber
@@ -351,7 +467,7 @@
     if (!message.length)
         message = @"Assertion failed with no message.";
 
-    ::testing::internal::AssertHelper(::testing::TestPartResult::kNonFatalFailure, sourceURL.UTF8String, lineNumber, message.UTF8String) = ::testing::Message();
+    [self _recordFailureWithMessage:message sourceURL:sourceURL lineNumber:lineNumber];
 }
 
 - (void)_webExtensionController:(WKWebExtensionController *)controller recordTestEqualityResult:(BOOL)result expectedValue:(NSString *)expectedValue actualValue:(NSString *)actualValue withMessage:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber
@@ -361,6 +477,11 @@
 
     if (!message.length)
         message = @"Expected equality of these values";
+
+    if (_collectsFailures) {
+        [self _recordFailureWithMessage:[NSString stringWithFormat:@"%@:\n  Actual: %@\nExpected: %@", message, actualValue, expectedValue] sourceURL:sourceURL lineNumber:lineNumber];
+        return;
+    }
 
     ::testing::internal::AssertHelper(::testing::TestPartResult::kNonFatalFailure, sourceURL.UTF8String, lineNumber, "") = ::testing::Message()
         << message.UTF8String << ":\n"
@@ -387,6 +508,17 @@
     }
 
     [messagesArray addObject:argument ?: NSNull.null];
+
+    if (!_pendingTestMessageHandler)
+        return;
+
+    if (![self _takeTestMessage:_pendingTestMessage])
+        return;
+
+    auto handler = _pendingTestMessageHandler;
+    _pendingTestMessageHandler = nil;
+    _pendingTestMessage = nil;
+    handler([self _collectedFailuresError]);
 }
 
 - (void)_webExtensionController:(WKWebExtensionController *)controller recordTestAddedWithName:(NSString *)testName andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber
@@ -412,15 +544,16 @@
         return;
     }
 
-    _done = true;
+    // Record the failure before signalling, so that an async waiter cannot resume and finish the
+    // test before the failure has been attributed to it.
+    if (!result) {
+        if (!message.length)
+            message = @"Test failed with no message.";
 
-    if (result)
-        return;
+        [self _recordFailureWithMessage:message sourceURL:sourceURL lineNumber:lineNumber];
+    }
 
-    if (!message.length)
-        message = @"Test failed with no message.";
-
-    ::testing::internal::AssertHelper(::testing::TestPartResult::kNonFatalFailure, sourceURL.UTF8String, lineNumber, message.UTF8String) = ::testing::Message();
+    [self done];
 }
 
 @end

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.swift
@@ -1,0 +1,185 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE_WK_WEB_EXTENSIONS
+
+import CoreGraphics
+import Foundation
+private import TestWebKitAPILibrary.Helpers.cocoa.WebExtensionUtilities
+public import WebKit
+
+public import struct Swift.String
+
+#if WTF_PLATFORM_MAC
+import AppKit
+#else
+import UIKit
+#endif
+
+/// Creates a manager for an extension parsed from a manifest, without loading it.
+///
+/// - Parameters:
+///   - manifest: The extension's manifest, as it would appear in `manifest.json`.
+///   - resources: The extension's resources, keyed by path.
+/// - Returns: A manager for the parsed extension.
+@MainActor
+public func parseWebExtension(manifest: [String: Any], resources: [String: Any] = [:]) -> TestWebExtensionManager {
+    let manager = TestWebExtensionManager(manifest: manifest, resources: resources)
+    manager.collectsFailures = true
+    return manager
+}
+
+/// Creates a manager for an extension parsed from a manifest, and loads it.
+///
+/// - Parameters:
+///   - manifest: The extension's manifest, as it would appear in `manifest.json`.
+///   - resources: The extension's resources, keyed by path.
+/// - Returns: A manager for the loaded extension.
+/// - Throws: the failure the extension reported if it could not be loaded.
+@MainActor
+public func loadWebExtension(manifest: [String: Any], resources: [String: Any] = [:]) throws -> TestWebExtensionManager {
+    let manager = parseWebExtension(manifest: manifest, resources: resources)
+
+    manager.load()
+
+    try manager.checkCollectedFailures()
+
+    return manager
+}
+
+extension TestWebExtensionManager {
+    /// Waits for the extension to present the popup for one of its actions.
+    ///
+    /// - Parameter body: Work that causes the popup to be presented, such as performing the action
+    ///   for a tab. Omit it when the extension opens its own popup.
+    /// - Returns: The action whose popup was presented.
+    /// - Throws: if the extension's test harness reported a failure
+    ///   while this call was waiting.
+    @MainActor
+    public func nextPresentedAction(triggeredBy body: () -> Void = {}) async throws -> WKWebExtension.Action {
+        try await nextAction(reportedBy: \.presentPopupForAction, triggeredBy: body)
+    }
+
+    /// Waits for the extension to change the appearance or behavior of one of its actions.
+    ///
+    /// - Parameter body: Work that causes the action to be updated. Omit it when the extension's
+    ///   background script updates the action on its own.
+    /// - Returns: The action that was updated.
+    /// - Throws: if the extension's test harness reported a failure
+    ///   while this call was waiting.
+    @MainActor
+    public func nextUpdatedAction(triggeredBy body: () -> Void = {}) async throws -> WKWebExtension.Action {
+        try await nextAction(reportedBy: \.didUpdateAction, triggeredBy: body)
+    }
+
+    @MainActor
+    private func nextAction(
+        reportedBy callback: ReferenceWritableKeyPath<TestWebExtensionsDelegate, ((WKWebExtension.Action) -> Void)?>,
+        triggeredBy body: () -> Void
+    ) async throws -> WKWebExtension.Action {
+        let previousCallback = internalDelegate[keyPath: callback]
+        defer { internalDelegate[keyPath: callback] = previousCallback }
+
+        let action = await withCheckedContinuation { continuation in
+            internalDelegate[keyPath: callback] = { action in
+                continuation.resume(returning: action)
+            }
+
+            body()
+        }
+
+        try checkCollectedFailures()
+
+        return action
+    }
+
+    /// Waits for the extension to ask for a new tab, and opens it.
+    ///
+    /// - Parameter body: Work that causes the tab to be requested.
+    /// - Returns: The configuration the extension asked for.
+    /// - Throws: if the extension's test harness reported a failure
+    ///   while this call was waiting.
+    @MainActor
+    public func nextRequestedTab(triggeredBy body: () -> Void = {}) async throws -> WKWebExtension.TabConfiguration {
+        let openNewTab = internalDelegate.openNewTab
+        defer { internalDelegate.openNewTab = openNewTab }
+
+        let configuration = await withCheckedContinuation { continuation in
+            internalDelegate.openNewTab = { configuration, context, completionHandler in
+                openNewTab?(configuration, context, completionHandler)
+                continuation.resume(returning: configuration)
+            }
+
+            body()
+        }
+
+        try checkCollectedFailures()
+
+        return configuration
+    }
+
+    #if WTF_PLATFORM_MAC
+    /// Waits for the extension to ask for a new window, and opens it.
+    ///
+    /// - Parameter body: Work that causes the window to be requested.
+    /// - Returns: The configuration the extension asked for.
+    /// - Throws: if the extension's test harness reported a failure
+    ///   while this call was waiting.
+    @MainActor
+    public func nextRequestedWindow(triggeredBy body: () -> Void = {}) async throws -> WKWebExtension.WindowConfiguration {
+        let openNewWindow = internalDelegate.openNewWindow
+        defer { internalDelegate.openNewWindow = openNewWindow }
+
+        let configuration = await withCheckedContinuation { continuation in
+            internalDelegate.openNewWindow = { configuration, context, completionHandler in
+                openNewWindow?(configuration, context, completionHandler)
+                continuation.resume(returning: configuration)
+            }
+
+            body()
+        }
+
+        try checkCollectedFailures()
+
+        return configuration
+    }
+    #endif
+
+    /// Grants every permission the extension asks for.
+    @MainActor
+    public func grantRequestedPermissions() {
+        internalDelegate.promptForPermissions = { _, permissions, callback in
+            callback(Set(permissions.map { WKWebExtension.Permission($0) }), nil)
+        }
+
+        internalDelegate.promptForPermissionMatchPatterns = { _, matchPatterns, callback in
+            callback(matchPatterns, nil)
+        }
+
+        internalDelegate.promptForPermissionToAccessURLs = { _, urls, callback in
+            callback(urls, nil)
+        }
+    }
+}
+
+#endif // ENABLE_WK_WEB_EXTENSIONS

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -630,6 +630,7 @@
 				cocoa/TestPDFDocument.swift,
 				cocoa/UtilitiesCocoa.mm,
 				cocoa/WebExtensionUtilities.mm,
+				cocoa/WebExtensionUtilities.swift,
 				"cocoa/WebPage+Extras.swift",
 				"cocoa/WebPage+JavaScriptExpression.swift",
 				"cocoa/WebPageConfiguration+Extras.swift",


### PR DESCRIPTION
#### 56b81e93382042575c4e6f1fee71f2379b9b8e9a
<pre>
[Swift Testing] Make Swift-friendly Web Extension utility functions and types
<a href="https://bugs.webkit.org/show_bug.cgi?id=323906">https://bugs.webkit.org/show_bug.cgi?id=323906</a>
<a href="https://rdar.apple.com/187142895">rdar://187142895</a>

Reviewed by Timothy Hatcher.

- Add nullability &amp; sendability annotations
- Convert some sync functions to async and throwing functions
- Add a few small helpful utility functions

* Tools/TestWebKitAPI/Helpers/cocoa/HTTPServer.swift:
(Configuration.address):
(Configuration.localhostAddress):
* Tools/TestWebKitAPI/Helpers/cocoa/TestCocoaImageUtilities.swift:
(CocoaImage.isSymbol):
* Tools/TestWebKitAPI/Helpers/cocoa/TestWebExtensionsDelegate.h:
* Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.h:
(TestWebKitAPI::Util::constructScript):
(TestWebKitAPI::Util::constructJSArrayOfStrings):
* Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager initWithManifest:resources:]):
(-[TestWebExtensionManager windows]):
(-[TestWebExtensionManager load]):
(-[TestWebExtensionManager unload]):
(-[TestWebExtensionManager runUntilTestMessage:]):
(-[TestWebExtensionManager runWithCompletionHandler:]):
(-[TestWebExtensionManager waitForTestMessage:completionHandler:]):
(-[TestWebExtensionManager loadAndRunWithCompletionHandler:]):
(-[TestWebExtensionManager _takeTestMessage:]):
(-[TestWebExtensionManager done]):
(-[TestWebExtensionManager _recordFailureWithMessage:sourceURL:lineNumber:]):
(-[TestWebExtensionManager _collectedFailuresError]):
(-[TestWebExtensionManager checkCollectedFailuresWithError:]):
(-[TestWebExtensionManager _webExtensionController:recordTestAssertionResult:withMessage:andSourceURL:lineNumber:]):
(-[TestWebExtensionManager _webExtensionController:recordTestEqualityResult:expectedValue:actualValue:withMessage:andSourceURL:lineNumber:]):
(-[TestWebExtensionManager _webExtensionController:receivedTestMessage:withArgument:andSourceURL:lineNumber:]):
(-[TestWebExtensionManager _webExtensionController:recordTestFinishedWithName:result:message:andSourceURL:lineNumber:]):
* Tools/TestWebKitAPI/Helpers/cocoa/WebExtensionUtilities.swift: Added.
(Swift.parseWebExtension(_:resources:)):
(Swift.loadWebExtension(_:resources:)):
(TestWebExtensionManager.nextPresentedAction(triggeredBy:)):
(nextUpdatedAction(triggeredBy:)):
(nextRequestedTab(triggeredBy:)):
(nextRequestedWindow(triggeredBy:)):
(grantRequestedPermissions):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/320896@main">https://commits.webkit.org/320896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74f5e8a11a555cfe4908b394a8f0030b8983e17c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196473 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150742 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145468 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166002 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125800 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47875 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45861 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158229 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45594 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7543 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198451 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59734 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155034 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41544 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60445 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154678 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49115 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129857 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58873 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20573 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58274 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58493 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58335 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->