### PR TITLE
[Win][CMake] Use the configured Swift runtime when archiving

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,43 @@ if (SWIFT_REQUIRED)
         WEBKIT_XCRUN(CMAKE_Swift_COMPILER --find swiftc)
     endif ()
     set(ORIGINAL_Swift_COMPILER "${CMAKE_Swift_COMPILER}")
+    WEBKIT_QUERY_SWIFT_TARGET_INFO(WEBKIT_SWIFT_TARGET_INFO "${ORIGINAL_Swift_COMPILER}")
 
     if (WIN32)
+        string(JSON _swift_runtime_library_path_count ERROR_VARIABLE _swift_runtime_library_paths_error
+            LENGTH "${WEBKIT_SWIFT_TARGET_INFO}" "paths" "runtimeLibraryPaths")
+        if (NOT _swift_runtime_library_paths_error STREQUAL "NOTFOUND")
+            message(FATAL_ERROR "Could not read Swift runtime library paths: ${_swift_runtime_library_paths_error}")
+        endif ()
+        set(_swift_runtime_bin_directory "")
+        if (_swift_runtime_library_path_count)
+            math(EXPR _swift_runtime_library_path_last "${_swift_runtime_library_path_count} - 1")
+            # Prefer the installed runtime over the toolchain-adjacent testing fallback.
+            foreach (_index RANGE ${_swift_runtime_library_path_last} 0 -1)
+                string(JSON _swift_runtime_library_path GET "${WEBKIT_SWIFT_TARGET_INFO}" "paths" "runtimeLibraryPaths" ${_index})
+                if (EXISTS "${_swift_runtime_library_path}/swiftCore.dll")
+                    set(_swift_runtime_bin_directory "${_swift_runtime_library_path}")
+                    break ()
+                endif ()
+            endforeach ()
+        endif ()
+        if (NOT _swift_runtime_bin_directory)
+            message(FATAL_ERROR "Could not find the Swift runtime bin directory")
+        endif ()
+        file(WRITE "${CMAKE_BINARY_DIR}/swift-runtime-bin-directory.txt.tmp" "${_swift_runtime_bin_directory}\n")
+        execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${CMAKE_BINARY_DIR}/swift-runtime-bin-directory.txt.tmp"
+            "${CMAKE_BINARY_DIR}/swift-runtime-bin-directory.txt"
+            COMMAND_ERROR_IS_FATAL ANY
+        )
+        file(REMOVE "${CMAKE_BINARY_DIR}/swift-runtime-bin-directory.txt.tmp")
+        unset(_swift_runtime_library_path_count)
+        unset(_swift_runtime_library_path_last)
+        unset(_swift_runtime_library_paths_error)
+        unset(_swift_runtime_library_path)
+        unset(_swift_runtime_bin_directory)
+        unset(_index)
+
         # Avoid cmd.exe due to command-line length limits.
         set(CMAKE_Swift_COMPILER "${Python_EXECUTABLE}")
         set(CMAKE_Swift_COMPILER_ARG1 "${CMAKE_SOURCE_DIR}/Tools/Scripts/swift/swiftc-wrapper.py")
@@ -63,6 +98,8 @@ if (SWIFT_REQUIRED)
     string(REPLACE "<CMAKE_Swift_COMPILER>"
         "<CMAKE_Swift_COMPILER> --original-swift-compiler=${ORIGINAL_Swift_COMPILER}"
         CMAKE_Swift_CREATE_STATIC_LIBRARY "${CMAKE_Swift_CREATE_STATIC_LIBRARY}")
+elseif (WIN32)
+    file(REMOVE "${CMAKE_BINARY_DIR}/swift-runtime-bin-directory.txt")
 endif ()
 
 # -----------------------------------------------------------------------------

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -1348,24 +1348,29 @@ function(_webkit_setup_swift_header_deps _target _stamp _header _resp)
     add_dependencies(${_target}_SwiftInterop ${_target}_SwiftCxxHeader)
 endfunction()
 
+function(WEBKIT_QUERY_SWIFT_TARGET_INFO _result _swift_compiler)
+    set(_swift_target_info_args "")
+    if (CMAKE_Swift_COMPILER_TARGET)
+        list(APPEND _swift_target_info_args "-target" "${CMAKE_Swift_COMPILER_TARGET}")
+    endif ()
+    execute_process(
+        COMMAND "${_swift_compiler}" -print-target-info ${_swift_target_info_args}
+        RESULT_VARIABLE _swift_target_info_result
+        OUTPUT_VARIABLE _swift_target_info
+        ERROR_VARIABLE _swift_target_info_error
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if (NOT _swift_target_info_result EQUAL 0)
+        message(FATAL_ERROR "Failed to query Swift target information: ${_swift_target_info_error}")
+    endif ()
+    set(${_result} "${_swift_target_info}" PARENT_SCOPE)
+endfunction()
+
 macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_name _interop_module_path _output_header)
     if (SWIFT_REQUIRED)
         set_target_properties(${_target} PROPERTIES Swift_MODULE_NAME ${_module_name})
-        # Ask swiftc where to find the header files which support C/C++ builds
-        # Right now this macro is used only once; if it's used more often then
-        # we should abstract this so it's executed only once.
-        # The target has to be named: without it swiftc answers for the platform
-        # it runs on, whose runtime library directory is macosx.
-        set(_swift_target_info_args "")
-        if (CMAKE_Swift_COMPILER_TARGET)
-            list(APPEND _swift_target_info_args -target ${CMAKE_Swift_COMPILER_TARGET})
-        endif ()
-        execute_process(
-            COMMAND ${ORIGINAL_Swift_COMPILER} -print-target-info ${_swift_target_info_args}
-            OUTPUT_VARIABLE _swift_target_info
-        )
-        unset(_swift_target_info_args)
-        string(JSON _swift_target_paths GET ${_swift_target_info} "paths")
+        # Ask swiftc where to find the header files which support C/C++ builds.
+        string(JSON _swift_target_paths GET "${WEBKIT_SWIFT_TARGET_INFO}" "paths")
         string(JSON _swift_runtime_resource_path GET ${_swift_target_paths} "runtimeResourcePath")
         target_include_directories(${_target} SYSTEM AFTER PRIVATE "${_swift_runtime_resource_path}")
         # Swift C++-interop objects auto-link swiftCxx/swiftCxxStdlib; consumers

--- a/Tools/CISupport/built-product-archive
+++ b/Tools/CISupport/built-product-archive
@@ -28,7 +28,6 @@ from __future__ import print_function
 import errno
 import filecmp
 import fnmatch
-import json
 import optparse
 import os
 import shutil
@@ -142,27 +141,20 @@ def copyBuildFiles(source, destination, patterns):
     shutil.copytree(source, destination, ignore=shutil.ignore_patterns(*patterns))
 
 
-def swiftRuntimeIsRequired(buildDirectory):
-    with open(os.path.join(buildDirectory, 'cmakeconfig.h')) as configuration:
-        enabledDefinitions = set(line.strip() for line in configuration)
-    return any(
-        '#define {} 1'.format(feature) in enabledDefinitions
-        for feature in ('ENABLE_BACK_FORWARD_LIST_SWIFT', 'ENABLE_SWIFT_DEMO_URI_SCHEME')
-    )
-
-
-def copySwiftRuntimeLibraries(destination):
-    swiftCompiler = shutil.which('swiftc')
-    if not swiftCompiler:
-        raise RuntimeError('Could not find swiftc while archiving the Windows build')
-
-    targetInfo = json.loads(subprocess.check_output([swiftCompiler, '-print-target-info'], text=True))
-    runtimeBinDirectory = next((
-        path for path in targetInfo['paths']['runtimeLibraryPaths']
-        if os.path.isfile(os.path.join(path, 'swiftCore.dll'))
-    ), None)
+def swiftRuntimeBinDirectory(buildDirectory):
+    path = os.path.join(buildDirectory, 'swift-runtime-bin-directory.txt')
+    if not os.path.isfile(path):
+        return None
+    with open(path, encoding='utf-8') as file:
+        runtimeBinDirectory = file.read().strip()
     if not runtimeBinDirectory:
-        raise RuntimeError('Could not find the Swift runtime bin directory')
+        raise RuntimeError('Swift runtime bin directory file is empty: {}'.format(path))
+    return runtimeBinDirectory
+
+
+def copySwiftRuntimeLibraries(runtimeBinDirectory, destination):
+    if not os.path.isfile(os.path.join(runtimeBinDirectory, 'swiftCore.dll')):
+        raise RuntimeError('Could not find the Swift runtime in {}'.format(runtimeBinDirectory))
     runtimeLibraries = [
         os.path.join(runtimeBinDirectory, filename)
         for filename in sorted(os.listdir(runtimeBinDirectory))
@@ -323,8 +315,9 @@ def archiveBuiltProduct(configuration, platform, fullPlatform, minify=False):
 
         removeDirectoryIfExists(thinDirectory, platform)
         copyBuildFiles(binDirectory, thinBinDirectory, ['*.ilk'])
-        if swiftRuntimeIsRequired(_configurationBuildDirectory):
-            copySwiftRuntimeLibraries(thinBinDirectory)
+        swiftRuntimeDirectory = swiftRuntimeBinDirectory(_configurationBuildDirectory)
+        if swiftRuntimeDirectory:
+            copySwiftRuntimeLibraries(swiftRuntimeDirectory, thinBinDirectory)
 
         if createZip(thinDirectory, configuration):
             return 1

--- a/Tools/CISupport/built_product_archive_unittest.py
+++ b/Tools/CISupport/built_product_archive_unittest.py
@@ -23,7 +23,6 @@
 
 import importlib.machinery
 import importlib.util
-import json
 import os
 import tempfile
 import unittest
@@ -40,43 +39,41 @@ built_product_archive = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(built_product_archive)
 
 
-class SwiftRuntimeIsRequiredTest(unittest.TestCase):
-    def test_detects_enabled_swift_features(self):
-        configurations = (
-            ('#define ENABLE_BACK_FORWARD_LIST_SWIFT 1\n#define ENABLE_SWIFT_DEMO_URI_SCHEME 0\n', True),
-            ('#define ENABLE_BACK_FORWARD_LIST_SWIFT 0\n#define ENABLE_SWIFT_DEMO_URI_SCHEME 1\n', True),
-            ('#define ENABLE_BACK_FORWARD_LIST_SWIFT 0\n#define ENABLE_SWIFT_DEMO_URI_SCHEME 0\n', False),
-        )
-        for contents, expected in configurations:
-            with self.subTest(contents=contents), tempfile.TemporaryDirectory() as directory:
-                with open(os.path.join(directory, 'cmakeconfig.h'), 'w') as file:
-                    file.write(contents)
-                self.assertEqual(built_product_archive.swiftRuntimeIsRequired(directory), expected)
+class SwiftRuntimeBinDirectoryTest(unittest.TestCase):
+    def test_reads_cmake_generated_path(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with open(os.path.join(directory, 'swift-runtime-bin-directory.txt'), 'w', encoding='utf-8') as file:
+                file.write('C:\\swift-runtime-p\N{LATIN SMALL LETTER A WITH DIAERESIS}th-goes-here\n')
+            self.assertEqual(
+                built_product_archive.swiftRuntimeBinDirectory(directory),
+                'C:\\swift-runtime-p\N{LATIN SMALL LETTER A WITH DIAERESIS}th-goes-here',
+            )
+
+    def test_returns_none_without_cmake_generated_path(self):
+        with tempfile.TemporaryDirectory() as directory:
+            self.assertIsNone(built_product_archive.swiftRuntimeBinDirectory(directory))
+
+    def test_rejects_empty_cmake_generated_path(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with open(os.path.join(directory, 'swift-runtime-bin-directory.txt'), 'w', encoding='utf-8'):
+                pass
+            with self.assertRaisesRegex(RuntimeError, 'file is empty'):
+                built_product_archive.swiftRuntimeBinDirectory(directory)
 
 
 class CopySwiftRuntimeLibrariesTest(unittest.TestCase):
     def test_copies_only_dlls_from_runtime_bin_directory(self):
         with tempfile.TemporaryDirectory() as directory:
-            compilerBinDirectory = os.path.join(directory, 'toolchain', 'usr', 'bin')
             runtimeBinDirectory = os.path.join(directory, 'usr', 'bin')
             destination = os.path.join(directory, 'archive')
-            os.makedirs(compilerBinDirectory)
             os.makedirs(runtimeBinDirectory)
             os.makedirs(destination)
 
-            with open(os.path.join(compilerBinDirectory, 'sourcekitdInProc.dll'), 'w') as file:
-                file.write('sourcekitdInProc.dll')
             for filename in ('swiftCore.dll', 'FoundationEssentials.DLL', 'README.txt'):
                 with open(os.path.join(runtimeBinDirectory, filename), 'w') as file:
                     file.write(filename)
 
-            targetInfo = json.dumps({
-                'paths': {'runtimeLibraryPaths': [compilerBinDirectory, runtimeBinDirectory]},
-            })
-            with patch.object(built_product_archive.shutil, 'which', return_value='swiftc'), patch.object(
-                built_product_archive.subprocess, 'check_output', return_value=targetInfo
-            ):
-                built_product_archive.copySwiftRuntimeLibraries(destination)
+            built_product_archive.copySwiftRuntimeLibraries(runtimeBinDirectory, destination)
 
             self.assertEqual(sorted(os.listdir(destination)), ['FoundationEssentials.DLL', 'swiftCore.dll'])
 
@@ -90,11 +87,7 @@ class CopySwiftRuntimeLibrariesTest(unittest.TestCase):
                 with open(os.path.join(parent, 'swiftCore.dll'), 'w') as file:
                     file.write('swiftCore.dll')
 
-            targetInfo = json.dumps({'paths': {'runtimeLibraryPaths': [runtimeBinDirectory]}})
-            with patch.object(built_product_archive.shutil, 'which', return_value='swiftc'), patch.object(
-                built_product_archive.subprocess, 'check_output', return_value=targetInfo
-            ):
-                built_product_archive.copySwiftRuntimeLibraries(destination)
+            built_product_archive.copySwiftRuntimeLibraries(runtimeBinDirectory, destination)
 
             self.assertEqual(os.listdir(destination), ['swiftCore.dll'])
 
@@ -109,33 +102,18 @@ class CopySwiftRuntimeLibrariesTest(unittest.TestCase):
             with open(os.path.join(destination, 'swiftCore.dll'), 'w') as file:
                 file.write('existing')
 
-            targetInfo = json.dumps({'paths': {'runtimeLibraryPaths': [runtimeBinDirectory]}})
-            with patch.object(built_product_archive.shutil, 'which', return_value='swiftc'), patch.object(
-                built_product_archive.subprocess, 'check_output', return_value=targetInfo
-            ):
-                with self.assertRaisesRegex(RuntimeError, 'conflicts with existing file'):
-                    built_product_archive.copySwiftRuntimeLibraries(destination)
+            with self.assertRaisesRegex(RuntimeError, 'conflicts with existing file'):
+                built_product_archive.copySwiftRuntimeLibraries(runtimeBinDirectory, destination)
 
-    def test_fails_when_swiftc_is_unavailable(self):
-        with tempfile.TemporaryDirectory() as destination, patch.object(
-            built_product_archive.shutil, 'which', return_value=None
-        ):
-            with self.assertRaisesRegex(RuntimeError, 'Could not find swiftc'):
-                built_product_archive.copySwiftRuntimeLibraries(destination)
-
-    def test_fails_when_runtime_bin_directory_is_unavailable(self):
+    def test_fails_when_swift_runtime_is_unavailable(self):
         with tempfile.TemporaryDirectory() as directory:
             runtimeBinDirectory = os.path.join(directory, 'usr', 'bin')
             destination = os.path.join(directory, 'archive')
             os.makedirs(runtimeBinDirectory)
             os.makedirs(destination)
 
-            targetInfo = json.dumps({'paths': {'runtimeLibraryPaths': [runtimeBinDirectory]}})
-            with patch.object(built_product_archive.shutil, 'which', return_value='swiftc'), patch.object(
-                built_product_archive.subprocess, 'check_output', return_value=targetInfo
-            ):
-                with self.assertRaisesRegex(RuntimeError, 'Could not find the Swift runtime bin directory'):
-                    built_product_archive.copySwiftRuntimeLibraries(destination)
+            with self.assertRaisesRegex(RuntimeError, 'Could not find the Swift runtime'):
+                built_product_archive.copySwiftRuntimeLibraries(runtimeBinDirectory, destination)
 
 
 class ArchiveBuiltProductTest(unittest.TestCase):
@@ -145,7 +123,9 @@ class ArchiveBuiltProductTest(unittest.TestCase):
         try:
             with patch.object(built_product_archive, 'removeDirectoryIfExists'), patch.object(
                 built_product_archive, 'copyBuildFiles'
-            ), patch.object(built_product_archive, 'swiftRuntimeIsRequired', return_value=True), patch.object(
+            ), patch.object(
+                built_product_archive, 'swiftRuntimeBinDirectory', return_value=os.path.join('Swift', 'Runtime')
+            ), patch.object(
                 built_product_archive, 'copySwiftRuntimeLibraries'
             ) as copyRuntime, patch.object(
                 built_product_archive, 'createZip', return_value=0
@@ -155,7 +135,10 @@ class ArchiveBuiltProductTest(unittest.TestCase):
             built_product_archive._configurationBuildDirectory = oldConfigurationBuildDirectory
 
         self.assertIsNone(result)
-        copyRuntime.assert_called_once_with(os.path.join('WebKitBuild', 'Release', 'thin', 'bin'))
+        copyRuntime.assert_called_once_with(
+            os.path.join('Swift', 'Runtime'),
+            os.path.join('WebKitBuild', 'Release', 'thin', 'bin'),
+        )
 
     def test_windows_archive_without_swift_does_not_copy_runtime_libraries(self):
         oldConfigurationBuildDirectory = built_product_archive._configurationBuildDirectory
@@ -163,7 +146,7 @@ class ArchiveBuiltProductTest(unittest.TestCase):
         try:
             with patch.object(built_product_archive, 'removeDirectoryIfExists'), patch.object(
                 built_product_archive, 'copyBuildFiles'
-            ), patch.object(built_product_archive, 'swiftRuntimeIsRequired', return_value=False), patch.object(
+            ), patch.object(built_product_archive, 'swiftRuntimeBinDirectory', return_value=None), patch.object(
                 built_product_archive, 'copySwiftRuntimeLibraries'
             ) as copyRuntime, patch.object(
                 built_product_archive, 'createZip', return_value=0


### PR DESCRIPTION
#### a761c97f806edc2211635d9f812a1454b269445d
<pre>
[Win][CMake] Use the configured Swift runtime when archiving

<a href="https://bugs.webkit.org/show_bug.cgi?id=323228">https://bugs.webkit.org/show_bug.cgi?id=323228</a>

Reviewed by Adrian Taylor.

CMake already knows whether Swift is required and which compiler and target the build uses. Query Swift target information once, select the installed runtime bin directory, and write it into the build directory for built-product-archive to consume.

This avoids duplicating the set of Swift features in the packaging script, prevents it from finding an unrelated swiftc through PATH, and provides targeted failures for malformed target information or marker-copy errors. Packaging tests cover missing, empty, and UTF-8 marker paths, DLL selection and conflicts, and Swift-disabled archives.

Canonical link: <a href="https://commits.webkit.org/320956@main">https://commits.webkit.org/320956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f365a31ab43e6f5e19454bbbe86c40ca1cd261db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196679 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145625 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49316 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/166150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125981 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48045 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7807 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14677 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158393 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45747 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7754 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47631 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198667 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59937 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155216 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41591 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60649 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154854 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49273 "Passed tests") | | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/130114 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59071 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20726 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58475 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58542 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->