### PR TITLE
Web Inspector: more inspector/debugger tests use the inert page-target

### DIFF
--- a/LayoutTests/inspector/debugger/continueUntilNextRunLoop.html
+++ b/LayoutTests/inspector/debugger/continueUntilNextRunLoop.html
@@ -19,7 +19,7 @@ function pause2() {
 function test()
 {
     function topCallFrameName() {
-        let targetData = WI.debuggerManager.dataForTarget(WI.mainTarget);
+        let targetData = WI.debuggerManager.dataForTarget(InspectorTest.mainFrameTarget);
         return targetData.stackTrace.callFrames[0].functionName;
     }
 
@@ -29,7 +29,7 @@ function test()
         name: "Debugger.Unpaused.continueUntilNextRunLoop",
         description: "Debugger.continueUntilNextRunLoop should only work when paused.",
         test(resolve, reject) {
-            DebuggerAgent.continueUntilNextRunLoop((error) => {
+            InspectorTest.mainFrameTarget.DebuggerAgent.continueUntilNextRunLoop((error) => {
                 InspectorTest.expectThat(error, "Should produce an error if not paused.");
                 InspectorTest.log(error);
                 resolve();
@@ -45,7 +45,7 @@ function test()
             WI.debuggerManager.singleFireEventListener(WI.DebuggerManager.Event.Paused, (event) => {
                 InspectorTest.pass("Received First Pause Event.");
                 InspectorTest.expectEqual(topCallFrameName(), "pause1", "Should be paused in pause1.");
-                WI.debuggerManager.continueUntilNextRunLoop(WI.mainTarget);
+                WI.debuggerManager.continueUntilNextRunLoop(InspectorTest.mainFrameTarget);
                 WI.debuggerManager.singleFireEventListener(WI.DebuggerManager.Event.Paused, (event) => {
                     InspectorTest.pass("Received Second Pause Event.");
                     InspectorTest.expectEqual(topCallFrameName(), "pause2", "Should be paused in pause2.");

--- a/LayoutTests/inspector/debugger/pause-for-internal-scripts.html
+++ b/LayoutTests/inspector/debugger/pause-for-internal-scripts.html
@@ -42,7 +42,7 @@ function test()
         description: "Should not be able to step into statements which use internal injected scripts.",
         expression: "setTimeout(entryInternalObject)",
         // Call out directly to the backend since there is no other way to wait on the command result if changing via the setting.
-        setup: async () => { return DebuggerAgent.setPauseForInternalScripts(false); },
+        setup: async () => { return InspectorTest.mainFrameTarget.DebuggerAgent.setPauseForInternalScripts(false); },
         steps: [
             "over",
                 "in", // internalObject.test(1)
@@ -57,8 +57,8 @@ function test()
         description: "Should be able to step into statements which use internal injected scripts.",
         expression: "setTimeout(entryInternalObject)",
         // Call out directly to the backend since there is no other way to wait on the command result if changing via the setting.
-        setup: async () => { return DebuggerAgent.setPauseForInternalScripts(true); },
-        teardown: async () => { return DebuggerAgent.setPauseForInternalScripts(false); },
+        setup: async () => { return InspectorTest.mainFrameTarget.DebuggerAgent.setPauseForInternalScripts(true); },
+        teardown: async () => { return InspectorTest.mainFrameTarget.DebuggerAgent.setPauseForInternalScripts(false); },
         steps: [
             "over",
                 "in", // internalObject.test(1)

--- a/LayoutTests/inspector/debugger/pause-reason.html
+++ b/LayoutTests/inspector/debugger/pause-reason.html
@@ -12,7 +12,7 @@ function test()
     WI.debuggerManager.allExceptionsBreakpoint.disabled = false;
     WI.debuggerManager.assertionFailuresBreakpoint.disabled = false;
 
-    for (let script of WI.debuggerManager.dataForTarget(WI.mainTarget).scripts) {
+    for (let script of WI.debuggerManager.dataForTarget(InspectorTest.mainFrameTarget).scripts) {
         if (!/pause-reasons\.js$/.test(script.url))
             continue;
         let sourceCodeLocation = script.createSourceCodeLocation(3, 0);

--- a/LayoutTests/inspector/debugger/search-scripts.html
+++ b/LayoutTests/inspector/debugger/search-scripts.html
@@ -19,7 +19,7 @@ function test()
     }
 
     function searchInContent(script, query, options = {}) {
-        return DebuggerAgent.searchInContent(script.id, query, options.caseSensitive, options.isRegex)
+        return script.target.DebuggerAgent.searchInContent(script.id, query, options.caseSensitive, options.isRegex)
         .then(({result}) => {
             InspectorTest.log("");
             InspectorTest.log("QUERY: " + query + " " + JSON.stringify(options));

--- a/LayoutTests/inspector/debugger/setBreakpoint-condition-ignoreCount.html
+++ b/LayoutTests/inspector/debugger/setBreakpoint-condition-ignoreCount.html
@@ -22,7 +22,7 @@ function test() {
                 WI.debuggerManager.resume();
             });
 
-            let debuggerData = WI.debuggerManager.dataForTarget(WI.mainTarget);
+            let debuggerData = WI.debuggerManager.dataForTarget(InspectorTest.mainFrameTarget);
 
             let script = debuggerData.scripts.filter(isHelperScript)[0];
             if (!script) {

--- a/LayoutTests/inspector/debugger/sourceURL-repeated-identical-executions.html
+++ b/LayoutTests/inspector/debugger/sourceURL-repeated-identical-executions.html
@@ -32,7 +32,7 @@ function test()
     let suite = InspectorTest.createAsyncSuite("Debugger.scriptParsed.sourceURLRepeatedIdenticalExecutions");
 
     // Disable breakpoints to ensure we do not avoid the CodeCache.
-    DebuggerAgent.setBreakpointsActive(false);
+    InspectorTest.mainFrameTarget.DebuggerAgent.setBreakpointsActive(false);
 
     suite.addTestCase({
         name: "CheckFunctionConstructorMultipleTimes",


### PR DESCRIPTION
#### d22e7108a8bd2847c5683e4663f4d9373341e90a
<pre>
Web Inspector: more inspector/debugger tests use the inert page-target
<a href="https://bugs.webkit.org/show_bug.cgi?id=323914">https://bugs.webkit.org/show_bug.cgi?id=323914</a>
<a href="https://rdar.apple.com/187150604">rdar://187150604</a>

Reviewed by Qianlang Chen.

Under site isolation PageDebugger::attachDebugger() returns before
Page::setDebugger(), so the page target&apos;s Debugger domain is registered
but owns no scripts and never pauses. Commands sent to it succeed and do
nothing. Test.js defines window.DebuggerAgent as
WI.mainTarget._agents[&quot;Debugger&quot;], and WI.mainTarget is the page target,
so every bare DebuggerAgent call and every dataForTarget(WI.mainTarget)
reaches that inert agent.

Route them to InspectorTest.mainFrameTarget, which resolves to the frame
target that owns the scripts and falls back to WI.mainTarget when site
isolation is off, so each change is unconditional and correct in both
configurations. No baselines change.

* LayoutTests/inspector/debugger/continueUntilNextRunLoop.html:
* LayoutTests/inspector/debugger/pause-for-internal-scripts.html:
* LayoutTests/inspector/debugger/pause-reason.html:
* LayoutTests/inspector/debugger/search-scripts.html:
* LayoutTests/inspector/debugger/setBreakpoint-condition-ignoreCount.html:
* LayoutTests/inspector/debugger/sourceURL-repeated-identical-executions.html:

Canonical link: <a href="https://commits.webkit.org/320903@main">https://commits.webkit.org/320903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/162ebfc0c123c05a1449d71e2bddf80963841d24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196485 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150753 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59801 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145478 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189150 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166014 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125810 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47894 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45870 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158248 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45606 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7555 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198463 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165538 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155047 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41546 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60457 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154690 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49129 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129870 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58885 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20585 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58286 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58505 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58347 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->