### PR TITLE
i18n.getMessage() drops non-string substitution arguments instead of coercing them to strings

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm
@@ -51,7 +51,7 @@ namespace WebKit {
 
 class JSWebExtensionWrappable;
 
-NSString *WebExtensionAPILocalization::getMessage(NSString* messageName, id substitutions)
+NSString *WebExtensionAPILocalization::getMessage(NSString* messageName, JSValue *substitutions)
 {
     // Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/i18n/getMessage
 
@@ -59,18 +59,19 @@ NSString *WebExtensionAPILocalization::getMessage(NSString* messageName, id subs
     if (!localization)
         return @"";
 
-    NSArray<NSString *> *substitutionsArray;
-    if ([substitutions isKindOfClass:NSString.class])
-        substitutionsArray = @[ substitutions ];
-    else if ([substitutions isKindOfClass:NSArray.class]) {
-        substitutionsArray = filterObjects((NSArray *)substitutions, ^bool(id, id value) {
-            return [value isKindOfClass:NSString.class];
-        });
+    Vector<String> substitutionsVector;
+
+    if (substitutions && !substitutions.isUndefined && !substitutions.isNull) {
+        if (substitutions.isArray) {
+            auto count = [[substitutions valueForProperty:@"length"] toUInt32];
+            substitutionsVector.reserveInitialCapacity(count);
+            for (unsigned i = 0; i < count; ++i)
+                substitutionsVector.append(String { [[substitutions valueAtIndex:i] toString] });
+        } else
+            substitutionsVector.append(String { [substitutions toString] });
     }
 
-    auto substitutionsVector = makeVector<String>(substitutionsArray);
-
-    return localization->localizedStringForKey(messageName, substitutionsVector).createNSString().autorelease();
+    return localization->localizedStringForKey(messageName, WTF::move(substitutionsVector)).createNSString().autorelease();
 }
 
 NSString *WebExtensionAPILocalization::getUILanguage()

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h
@@ -37,7 +37,7 @@ class WebExtensionAPILocalization : public WebExtensionAPIObject, public JSWebEx
 
 public:
 #if PLATFORM(COCOA)
-    NSString *getMessage(NSString* messageName, id substitutions);
+    NSString *getMessage(NSString* messageName, JSValue *substitutions);
     NSString *getUILanguage();
 #endif
     void getAcceptLanguages(Ref<WebExtensionCallbackHandler>&&);

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl
@@ -34,7 +34,7 @@ dictionary WebExtensionLanguageDetectionResult {
 ] interface WebExtensionAPILocalization {
 
     // Get the localized string for the given message in the current locale, optionally providing up 9 substitutions.
-    DOMString getMessage([CannotBeEmpty] DOMString name, [Optional, NSObject] any substitutions);
+    DOMString getMessage([CannotBeEmpty] DOMString name, [Optional, ValuesAllowed] any substitutions);
 
     // Get the UI language of the browser.
     DOMString getUILanguage();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPILocalization.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPILocalization.mm
@@ -484,6 +484,14 @@ TEST(WKWebExtensionAPILocalization, Placeholders)
                 },
             },
         },
+        @"key13": @{
+            messageKey: @"$count$ apples",
+            placeholdersKey: @{
+                @"count": @{
+                    placeholderDictionaryContentKey: @"$1",
+                },
+            },
+        },
     };
 
     auto *backgroundScript = Util::constructScript(@[
@@ -509,6 +517,13 @@ TEST(WKWebExtensionAPILocalization, Placeholders)
 
         [NSString stringWithFormat:@"placeholders = %@", Util::constructJSArrayOfStrings(@[ @"value1", @"value2" ])],
         @"browser.test.assertEq(browser.i18n.getMessage('key6', placeholders), 'value1 and value2 but not  or ')",
+
+        @"browser.test.assertEq(browser.i18n.getMessage('key13', [5]), '5 apples')",
+        @"browser.test.assertEq(browser.i18n.getMessage('key13', [0]), '0 apples')",
+        @"browser.test.assertEq(browser.i18n.getMessage('key11', [5, 6]), '5 6')",
+        @"browser.test.assertEq(browser.i18n.getMessage('key11', [5, 'trackers']), '5 trackers')",
+        @"browser.test.assertEq(browser.i18n.getMessage('key11', [true, null]), 'true null')",
+        @"browser.test.assertEq(browser.i18n.getMessage('key11', [{}, [1, 2, 3]]), '[object Object] 1,2,3')",
 
         // Finish
         @"browser.test.notifyPass()",


### PR DESCRIPTION
#### 431c31819b794afe09f7584e0530cf8cd0dd6983
<pre>
i18n.getMessage() drops non-string substitution arguments instead of coercing them to strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=291956">https://bugs.webkit.org/show_bug.cgi?id=291956</a>
<a href="https://rdar.apple.com/149855718">rdar://149855718</a>

Reviewed by Kiara Rose and Timothy Hatcher.

This patch makes browser.i18n.getMessage() coerce every substitution argument to a
string with JavaScript String() semantics, matching Chrome and Firefox. The argument
was previously bridged to an Objective-C object and filtered down to NSString values,
so a number like getMessage(key, [5]) was dropped; because the filter compacted the
array, it also shifted the remaining positional arguments, turning
getMessage(key, [5, &quot;x&quot;]) into $1 = &quot;x&quot; with $2 empty.

The substitutions are now received as a JSValue and each element is converted with the
engine&apos;s own toString, which reproduces String() for numbers, booleans, null, undefined,
bigints, objects, and arrays without dropping elements or shifting positions. The
conversion has to happen at the JavaScript boundary because the bridged object cannot
reproduce those results (a boolean and a number both bridge to NSNumber, and so on).

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPILocalization.mm

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPILocalizationCocoa.mm:
(WebKit::WebExtensionAPILocalization::getMessage):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPILocalization.idl:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPILocalization.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPILocalization, Placeholders)):

Canonical link: <a href="https://commits.webkit.org/320931@main">https://commits.webkit.org/320931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1559b17a5d3e92ca08d97d46da78e510c508376

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196488 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150756 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6bc53b67-137e-4ba0-adc2-faae1a6b8e50) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145482 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100844 "1 flakes 15 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3623681a-f0f0-4ba1-a0f6-c2a3fca3c32d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49160 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166015 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125815 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae3bfc41-e225-4531-a9ca-aaa2a1c16cb0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47889 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45872 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45607 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7558 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52592 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198466 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59749 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155052 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60460 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154695 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28289 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49132 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132720 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129873 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58888 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20586 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58289 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58508 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58350 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->