### PR TITLE
makeStringByJoining() drops separators preceding the first non-empty string

### DIFF
--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -78,14 +78,7 @@ char32_t String::codePointAt(unsigned i) const
 
 String makeStringByJoining(std::span<const String> strings, const String& separator)
 {
-    StringBuilder builder;
-    for (const auto& string : strings) {
-        if (builder.isEmpty())
-            builder.append(string);
-        else
-            builder.append(separator, string);
-    }
-    return builder.toString();
+    return makeString(interleave(strings, separator));
 }
 
 String makeStringByRemoving(const String& string, unsigned position, unsigned lengthToRemove)

--- a/Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp
@@ -510,6 +510,25 @@ TEST(WTF, StringMakeStringByJoining)
     std::vector<String> test3 = { "foo"_s, "bar"_s };
     auto test3_result = makeStringByJoining(test3, ", "_s);
     ASSERT_EQ(test3_result, "foo, bar"_s);
+
+    Vector<String> test4 = { emptyString(), "a"_s };
+    ASSERT_EQ(makeStringByJoining(test4, "\n"_s), "\na"_s);
+
+    Vector<String> test5 = { emptyString(), emptyString(), "a"_s, "b"_s };
+    ASSERT_EQ(makeStringByJoining(test5, "\n"_s), "\n\na\nb"_s);
+
+    Vector<String> test6 = { emptyString(), emptyString() };
+    ASSERT_EQ(makeStringByJoining(test6, "\n"_s), "\n"_s);
+
+    Vector<String> test7 = { String { }, "a"_s };
+    ASSERT_EQ(makeStringByJoining(test7, "\n"_s), "\na"_s);
+
+    Vector<String> test8 = { "a"_s, emptyString(), "b"_s };
+    ASSERT_EQ(makeStringByJoining(test8, "\n"_s), "a\n\nb"_s);
+
+    auto test9_result = makeStringByJoining(Vector<String> { }, ", "_s);
+    ASSERT_TRUE(test9_result.isEmpty());
+    ASSERT_FALSE(test9_result.isNull());
 }
 
 TEST(WTF, StringUTF8ConversionInvalidUTF16LenientMode)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -1610,6 +1610,42 @@ TEST(TextExtractionTests, FilterOptions)
     }
 }
 
+TEST(TextExtractionTests, WordLimitDoesNotReportFilteringLeadingBlankLines)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+
+    auto extractWithWordLimit = [webView](NSUInteger wordLimit) {
+        return [webView synchronouslyExtractDebugTextResult:^{
+            RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+            [configuration setMaxWordsPerParagraph:wordLimit];
+            [configuration setMaxWordsPerParagraphPolicy:_WKTextExtractionWordLimitPolicyAlways];
+            return configuration.autorelease();
+        }()];
+    };
+
+    [webView synchronouslyLoadHTMLString:@"<div style='white-space: pre'>\n\nhello world</div>"];
+    {
+        RetainPtr result = extractWithWordLimit(100);
+        EXPECT_TRUE([[result textContent] containsString:@"hello world"]);
+        EXPECT_FALSE([result filteredOutAnyText]);
+    }
+    {
+        RetainPtr result = extractWithWordLimit(1);
+        EXPECT_TRUE([result filteredOutAnyText]);
+    }
+
+    [webView synchronouslyLoadHTMLString:@"<div style='white-space: pre'>hello world</div>"];
+    {
+        RetainPtr result = extractWithWordLimit(100);
+        EXPECT_TRUE([[result textContent] containsString:@"hello world"]);
+        EXPECT_FALSE([result filteredOutAnyText]);
+    }
+}
+
 TEST(TextExtractionTests, FilterRedundantTextInLinks)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{


### PR DESCRIPTION
#### 6103d1b95adad0e21a5b3cbd21059bd8488b8e76
<pre>
makeStringByJoining() drops separators preceding the first non-empty string
<a href="https://bugs.webkit.org/show_bug.cgi?id=323919">https://bugs.webkit.org/show_bug.cgi?id=323919</a>
<a href="https://rdar.apple.com/187152412">rdar://187152412</a>

Reviewed by Chris Dumez.

StringBuilder::isEmpty() was used as a stand-in for &quot;is this the first element&quot;,
but it stays true until the first non-empty string is appended, so every separator
before that point was dropped:

    { &quot;&quot;_s, &quot;a&quot;_s }               with &quot;\n&quot; gave &quot;a&quot;     not &quot;\na&quot;
    { &quot;&quot;_s, &quot;&quot;_s, &quot;a&quot;_s, &quot;b&quot;_s }  with &quot;\n&quot; gave &quot;a\nb&quot;  not &quot;\n\na\nb&quot;

Null strings behaved like empty ones; once a non-empty element was appended the
function was correct, so only an empty prefix was affected.

Interleave::writeUsing() in StringConcatenate.h is already the correct form of this
loop, and interleave(container, between) is a ready-made overload, so express
makeStringByJoining() in terms of it instead of repairing the duplicate. Behavior
is otherwise unchanged: the result still comes from StringBuilder::toString(), so
an empty span still returns a non-null empty string.

Of the 41 callers, only truncateByWordCount() in
TextExtractionToStringConversion.cpp can pass an empty prefix - it splits with
splitAllowingEmptyEntries(&apos;\n&apos;) and never prunes. The others guard each append
with !isEmpty(), prune empty elements first (the m_lines join, which is why the
main text extraction output is unaffected), filter empties one layer down
(DataTransfer), or join values that cannot be empty.

textContent does not change, because every output format strips leading
whitespace. The visible symptom is filteredOutAnyText: its caller sets the flag
whenever truncated != text, and truncateByWordCount() has no early return for text
already under the limit, so a paragraph opening with a blank line reported
filtered text when nothing had been filtered.

Tests: Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm

* Source/WTF/wtf/text/WTFString.cpp:
(WTF::makeStringByJoining):
* Tools/TestWebKitAPI/Tests/WTF/WTFString.cpp:
(TestWebKitAPI::TEST(WTF, StringMakeStringByJoining)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::(TextExtractionTests, WordLimitDoesNotReportFilteringLeadingBlankLines)):

Canonical link: <a href="https://commits.webkit.org/320911@main">https://commits.webkit.org/320911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53a42b513137e4fe7661f51a9f9649a42219dedf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196490 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150758 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188063 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145483 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166019 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125816 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47893 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45874 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7664 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14541 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158247 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45611 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7560 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47438 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198469 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59751 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155054 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41552 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60462 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42185 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154697 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49134 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132721 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129875 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58890 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20590 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58291 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58510 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58352 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->