### PR TITLE
[selectors] Support for class prefix selector (.prefix-*)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-has-invalidation.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-has-invalidation.tentative-expected.txt
@@ -1,0 +1,10 @@
+
+PASS :has(> .foo-*) invalidates the :has() subject when a direct child gains/loses a matching class
+PASS :has(.foo-*) invalidates the :has() subject when a descendant at any depth gains/loses a matching class
+PASS :has(+ .foo-*) invalidates the :has() subject when its immediately following sibling gains/loses a matching class
+PASS :has(~ .foo-*) invalidates the :has() subject when a later (non-adjacent) sibling gains/loses a matching class
+PASS :has(~ .bar > .foo-*) invalidates the :has() subject when a direct child of a later ".bar" sibling gains/loses a matching class
+PASS :has(~ .bar .foo-*) invalidates the :has() subject when a descendant, at any depth, of a later ".bar" sibling gains/loses a matching class
+PASS :has(.foo-*) in non-subject (ancestor) position invalidates a separate descendant of the :has() bearer
+PASS :has(> .foo-*) in non-subject (parent) position invalidates a sibling child of the :has() bearer
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-has-invalidation.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-has-invalidation.tentative.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Selectors: class prefix selector inside :has() invalidates style correctly</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/selectors-5/#class-prefix">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #child-subject:has(> .foo-*) { color: rgb(1, 2, 3); }
+  #descendant-subject:has(.foo-*) { color: rgb(4, 5, 6); }
+  #direct-sibling-subject:has(+ .foo-*) { color: rgb(7, 8, 9); }
+  #indirect-sibling-subject:has(~ .foo-*) { color: rgb(10, 11, 12); }
+  #sibling-child-subject:has(~ .bar > .foo-*) { color: rgb(13, 14, 15); }
+  #sibling-descendant-subject:has(~ .bar .foo-*) { color: rgb(16, 17, 18); }
+  #ancestor-has:has(.foo-*) #ancestor-subject { color: rgb(19, 20, 21); }
+  #parent-has:has(> .foo-*) > #parent-subject { color: rgb(22, 23, 24); }
+</style>
+
+<div id="child-container">
+  <div id="child-subject"><div id="child-trigger"></div></div>
+</div>
+
+<div id="descendant-container">
+  <div id="descendant-subject"><div><div id="descendant-trigger"></div></div></div>
+</div>
+
+<div id="direct-sibling-container">
+  <div id="direct-sibling-subject"></div>
+  <div id="direct-sibling-trigger"></div>
+</div>
+
+<div id="indirect-sibling-container">
+  <div id="indirect-sibling-subject"></div>
+  <div id="indirect-sibling-buffer"></div>
+  <div id="indirect-sibling-trigger"></div>
+</div>
+
+<div id="sibling-child-container">
+  <div id="sibling-child-subject"></div>
+  <div class="bar"><div id="sibling-child-trigger"></div></div>
+</div>
+
+<div id="sibling-descendant-container">
+  <div id="sibling-descendant-subject"></div>
+  <div class="bar"><div><div id="sibling-descendant-trigger"></div></div></div>
+</div>
+
+<div id="ancestor-container">
+  <div id="ancestor-has">
+    <div id="ancestor-trigger"></div>
+    <div><div id="ancestor-subject"></div></div>
+  </div>
+</div>
+
+<div id="parent-container">
+  <div id="parent-has">
+    <div id="parent-trigger"></div>
+    <div id="parent-subject"></div>
+  </div>
+</div>
+
+<script>
+function color(id) {
+  return getComputedStyle(document.getElementById(id)).color;
+}
+
+test(() => {
+  assert_equals(color('child-subject'), 'rgb(0, 0, 0)');
+  document.getElementById('child-trigger').classList.add('foo-x');
+  assert_equals(color('child-subject'), 'rgb(1, 2, 3)');
+  document.getElementById('child-trigger').classList.remove('foo-x');
+  assert_equals(color('child-subject'), 'rgb(0, 0, 0)');
+}, ':has(> .foo-*) invalidates the :has() subject when a direct child gains/loses a matching class');
+
+test(() => {
+  assert_equals(color('descendant-subject'), 'rgb(0, 0, 0)');
+  document.getElementById('descendant-trigger').classList.add('foo-x');
+  assert_equals(color('descendant-subject'), 'rgb(4, 5, 6)');
+  document.getElementById('descendant-trigger').classList.remove('foo-x');
+  assert_equals(color('descendant-subject'), 'rgb(0, 0, 0)');
+}, ':has(.foo-*) invalidates the :has() subject when a descendant at any depth gains/loses a matching class');
+
+test(() => {
+  assert_equals(color('direct-sibling-subject'), 'rgb(0, 0, 0)');
+  document.getElementById('direct-sibling-trigger').classList.add('foo-x');
+  assert_equals(color('direct-sibling-subject'), 'rgb(7, 8, 9)');
+  document.getElementById('direct-sibling-trigger').classList.remove('foo-x');
+  assert_equals(color('direct-sibling-subject'), 'rgb(0, 0, 0)');
+}, ':has(+ .foo-*) invalidates the :has() subject when its immediately following sibling gains/loses a matching class');
+
+test(() => {
+  assert_equals(color('indirect-sibling-subject'), 'rgb(0, 0, 0)');
+  document.getElementById('indirect-sibling-trigger').classList.add('foo-x');
+  assert_equals(color('indirect-sibling-subject'), 'rgb(10, 11, 12)');
+  document.getElementById('indirect-sibling-trigger').classList.remove('foo-x');
+  assert_equals(color('indirect-sibling-subject'), 'rgb(0, 0, 0)');
+}, ':has(~ .foo-*) invalidates the :has() subject when a later (non-adjacent) sibling gains/loses a matching class');
+
+test(() => {
+  assert_equals(color('sibling-child-subject'), 'rgb(0, 0, 0)');
+  document.getElementById('sibling-child-trigger').classList.add('foo-x');
+  assert_equals(color('sibling-child-subject'), 'rgb(13, 14, 15)');
+  document.getElementById('sibling-child-trigger').classList.remove('foo-x');
+  assert_equals(color('sibling-child-subject'), 'rgb(0, 0, 0)');
+}, ':has(~ .bar > .foo-*) invalidates the :has() subject when a direct child of a later ".bar" sibling gains/loses a matching class');
+
+test(() => {
+  assert_equals(color('sibling-descendant-subject'), 'rgb(0, 0, 0)');
+  document.getElementById('sibling-descendant-trigger').classList.add('foo-x');
+  assert_equals(color('sibling-descendant-subject'), 'rgb(16, 17, 18)');
+  document.getElementById('sibling-descendant-trigger').classList.remove('foo-x');
+  assert_equals(color('sibling-descendant-subject'), 'rgb(0, 0, 0)');
+}, ':has(~ .bar .foo-*) invalidates the :has() subject when a descendant, at any depth, of a later ".bar" sibling gains/loses a matching class');
+
+test(() => {
+  assert_equals(color('ancestor-subject'), 'rgb(0, 0, 0)');
+  document.getElementById('ancestor-trigger').classList.add('foo-x');
+  assert_equals(color('ancestor-subject'), 'rgb(19, 20, 21)');
+  document.getElementById('ancestor-trigger').classList.remove('foo-x');
+  assert_equals(color('ancestor-subject'), 'rgb(0, 0, 0)');
+}, ':has(.foo-*) in non-subject (ancestor) position invalidates a separate descendant of the :has() bearer');
+
+test(() => {
+  assert_equals(color('parent-subject'), 'rgb(0, 0, 0)');
+  document.getElementById('parent-trigger').classList.add('foo-x');
+  assert_equals(color('parent-subject'), 'rgb(22, 23, 24)');
+  document.getElementById('parent-trigger').classList.remove('foo-x');
+  assert_equals(color('parent-subject'), 'rgb(0, 0, 0)');
+}, ':has(> .foo-*) in non-subject (parent) position invalidates a sibling child of the :has() bearer');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-has-matching.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-has-matching.tentative-expected.txt
@@ -1,0 +1,10 @@
+
+PASS :has(.foo-*) matches an element with a descendant, at any depth, whose class matches the prefix
+PASS :has(> .foo-*) only matches a direct child, unlike the plain descendant form
+PASS :has(+ .foo-*) matches when the immediately following sibling matches the prefix
+PASS :has(~ .foo-*) matches a later sibling that is not the immediately following one
+PASS :has(~ .bar > .foo-*) matches when a later sibling has a matching direct child
+PASS :has(~ .bar .foo-*) matches at any depth under a later sibling, unlike the direct-child form
+PASS class prefix selector works inside :has() used as a :not() argument
+PASS a class prefix selector on the same compound as :has() still matches normally
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-has-matching.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-has-matching.tentative.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Selectors: class prefix selector matching inside :has()</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/selectors-5/#class-prefix">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="descendant-match"><div class="foo-x"></div></div>
+<div id="descendant-match-deep"><div><div class="foo-x"></div></div></div>
+<div id="descendant-no-match"><div class="foobar"></div></div>
+
+<div id="child-match"><div class="foo-x"></div></div>
+<div id="child-no-match-but-descendant"><div><div class="foo-x"></div></div></div>
+
+<div id="sibling-container-1">
+  <div id="sc1-a"></div>
+  <div id="sc1-b" class="foo-x"></div>
+</div>
+
+<div id="sibling-container-2">
+  <div id="sc2-a"></div>
+  <div id="sc2-b"></div>
+  <div id="sc2-c" class="foo-x"></div>
+</div>
+
+<div id="sibling-child-container">
+  <div id="scc-a"></div>
+  <div class="bar"><div class="foo-x"></div></div>
+</div>
+
+<div id="sibling-descendant-container">
+  <div id="sdc-a"></div>
+  <div class="bar"><div><div class="foo-x"></div></div></div>
+</div>
+
+<div id="not-container"><div class="foo-x"></div></div>
+<div id="not-container-empty"></div>
+
+<div id="compound-container" class="foo-x"><div class="bar"></div></div>
+
+<script>
+test(() => {
+  assert_true(document.getElementById('descendant-match').matches(':has(.foo-*)'));
+  assert_true(document.getElementById('descendant-match-deep').matches(':has(.foo-*)'));
+  assert_false(document.getElementById('descendant-no-match').matches(':has(.foo-*)'));
+}, ':has(.foo-*) matches an element with a descendant, at any depth, whose class matches the prefix');
+
+test(() => {
+  assert_true(document.getElementById('child-match').matches(':has(> .foo-*)'));
+  assert_false(document.getElementById('child-no-match-but-descendant').matches(':has(> .foo-*)'));
+  assert_true(document.getElementById('child-no-match-but-descendant').matches(':has(.foo-*)'));
+}, ':has(> .foo-*) only matches a direct child, unlike the plain descendant form');
+
+test(() => {
+  const a = document.getElementById('sc1-a');
+  const b = document.getElementById('sc1-b');
+  assert_true(a.matches(':has(+ .foo-*)'));
+  assert_true(a.matches(':has(~ .foo-*)'));
+  assert_false(b.matches(':has(+ .foo-*)'));
+  assert_false(b.matches(':has(~ .foo-*)'));
+}, ':has(+ .foo-*) matches when the immediately following sibling matches the prefix');
+
+test(() => {
+  const a = document.getElementById('sc2-a');
+  const b = document.getElementById('sc2-b');
+  assert_false(a.matches(':has(+ .foo-*)'), 'the immediately following sibling does not match');
+  assert_true(a.matches(':has(~ .foo-*)'), 'a later sibling matches');
+  assert_true(b.matches(':has(+ .foo-*)'), 'sc2-b\'s immediately following sibling (sc2-c) does match');
+  assert_true(b.matches(':has(~ .foo-*)'));
+}, ':has(~ .foo-*) matches a later sibling that is not the immediately following one');
+
+test(() => {
+  assert_true(document.getElementById('scc-a').matches(':has(~ .bar > .foo-*)'));
+}, ':has(~ .bar > .foo-*) matches when a later sibling has a matching direct child');
+
+test(() => {
+  const a = document.getElementById('sdc-a');
+  assert_false(a.matches(':has(~ .bar > .foo-*)'), 'the match is a grandchild, not a direct child, of the "bar" sibling');
+  assert_true(a.matches(':has(~ .bar .foo-*)'), 'the descendant form still matches at any depth');
+}, ':has(~ .bar .foo-*) matches at any depth under a later sibling, unlike the direct-child form');
+
+test(() => {
+  assert_false(document.getElementById('not-container').matches(':not(:has(.foo-*))'));
+  assert_true(document.getElementById('not-container-empty').matches(':not(:has(.foo-*))'));
+}, 'class prefix selector works inside :has() used as a :not() argument');
+
+test(() => {
+  assert_true(document.getElementById('compound-container').matches('.foo-*:has(.bar)'));
+  assert_false(document.getElementById('compound-container').matches('.baz-*:has(.bar)'));
+}, 'a class prefix selector on the same compound as :has() still matches normally');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-invalidation.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-invalidation.tentative-expected.txt
@@ -1,0 +1,5 @@
+
+PASS adding/removing a class that starts matching the prefix invalidates the element itself (subject position)
+PASS a class change on an ancestor invalidates descendants selected through the class prefix selector
+PASS a class change on a preceding sibling invalidates a following sibling selected through the class prefix selector
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-invalidation.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-invalidation.tentative.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Selectors: class prefix selector matching updates when the class attribute changes</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/selectors-5/#class-prefix">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #subject.foo-* { color: rgb(1, 2, 3); }
+  #ancestor.foo-* #descendant { color: rgb(4, 5, 6); }
+  #sibling-ref.foo-* ~ #sibling { color: rgb(7, 8, 9); }
+</style>
+<div id="subject"></div>
+<div id="ancestor"><div id="descendant"></div></div>
+<div id="sibling-ref"></div>
+<div id="sibling"></div>
+<script>
+function color(element) {
+  return getComputedStyle(element).color;
+}
+
+test(() => {
+  const subject = document.getElementById('subject');
+  assert_equals(color(subject), 'rgb(0, 0, 0)');
+
+  subject.classList.add('foo-x');
+  assert_equals(color(subject), 'rgb(1, 2, 3)');
+
+  subject.classList.add('foo-y');
+  assert_equals(color(subject), 'rgb(1, 2, 3)');
+
+  subject.classList.remove('foo-x');
+  assert_equals(color(subject), 'rgb(1, 2, 3)', 'still matches via "foo-y"');
+
+  subject.classList.remove('foo-y');
+  assert_equals(color(subject), 'rgb(0, 0, 0)');
+}, 'adding/removing a class that starts matching the prefix invalidates the element itself (subject position)');
+
+test(() => {
+  const ancestor = document.getElementById('ancestor');
+  const descendant = document.getElementById('descendant');
+  assert_equals(color(descendant), 'rgb(0, 0, 0)');
+
+  ancestor.classList.add('foo-x');
+  assert_equals(color(descendant), 'rgb(4, 5, 6)');
+
+  ancestor.classList.remove('foo-x');
+  assert_equals(color(descendant), 'rgb(0, 0, 0)');
+}, 'a class change on an ancestor invalidates descendants selected through the class prefix selector');
+
+test(() => {
+  const siblingRef = document.getElementById('sibling-ref');
+  const sibling = document.getElementById('sibling');
+  assert_equals(color(sibling), 'rgb(0, 0, 0)');
+
+  siblingRef.classList.add('foo-x');
+  assert_equals(color(sibling), 'rgb(7, 8, 9)');
+
+  siblingRef.classList.remove('foo-x');
+  assert_equals(color(sibling), 'rgb(0, 0, 0)');
+}, 'a class change on a preceding sibling invalidates a following sibling selected through the class prefix selector');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-matching.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-matching.tentative-expected.txt
@@ -1,0 +1,20 @@
+
+PASS class="foo-bar-baz" matches .foo-*
+PASS class="foo-bar-baz" matches .foo-bar-*
+PASS class="foo--bar" matches .foo--*
+PASS class="foo--bar" does not match .foo-* (the separator is "--", not "-")
+PASS class="foo-bar-" (ends in a dash) matches .foo-*
+PASS class="foo-bar-" does not match .foo-bar-* (nothing left after the prefix)
+PASS class="foobar" does not match .foo-* (no "-" separator)
+PASS class="foo-" does not match .foo-* (no character beyond the prefix)
+PASS class="foo-a" matches .foo-* (exactly one character beyond the prefix)
+PASS a class matching the prefix among several space-separated classes still matches
+PASS an element with no class attribute does not match .foo-*
+PASS class prefix selector combines with a type selector in a compound
+PASS class prefix selector combines with another class selector in a compound
+PASS class prefix selector works as a :not() argument
+PASS class prefix selector works inside :is()
+PASS class="foo---baz" matches .foo---* (a three-hyphen prefix works the same way as one or two hyphens)
+PASS class="foo---baz" does not match .foo--* (the separator is "---", not "--")
+PASS class="foo----qux" does not match .foo---* but does match .foo----* (an extra hyphen right after the prefix disqualifies a shorter prefix match)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-matching.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-matching.tentative.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Selectors: class prefix selector matching</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/selectors-5/#class-prefix">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<div id="target1" class="foo-bar-baz"></div>
+<div id="target2" class="foo--bar"></div>
+<div id="target3" class="foo-bar-"></div>
+<div id="target4" class="foobar"></div>
+<div id="target5" class="foo-"></div>
+<div id="target6" class="foo-a"></div>
+<div id="target7" class="bar foo-baz"></div>
+<div id="target8"></div>
+<div id="target9" class="foo-bar active"></div>
+<span id="target10" class="foo-bar"></span>
+<div id="target11" class="baz"></div>
+<div id="target12" class="quux"></div>
+<div id="target13" class="foo---baz"></div>
+<div id="target14" class="foo----qux"></div>
+<script>
+const target1 = document.getElementById('target1');
+const target2 = document.getElementById('target2');
+const target3 = document.getElementById('target3');
+const target4 = document.getElementById('target4');
+const target5 = document.getElementById('target5');
+const target6 = document.getElementById('target6');
+const target7 = document.getElementById('target7');
+const target8 = document.getElementById('target8');
+const target9 = document.getElementById('target9');
+const target10 = document.getElementById('target10');
+const target11 = document.getElementById('target11');
+const target12 = document.getElementById('target12');
+const target13 = document.getElementById('target13');
+const target14 = document.getElementById('target14');
+
+test(() => {
+  assert_true(target1.matches('.foo-*'));
+}, 'class="foo-bar-baz" matches .foo-*');
+
+test(() => {
+  assert_true(target1.matches('.foo-bar-*'));
+}, 'class="foo-bar-baz" matches .foo-bar-*');
+
+test(() => {
+  assert_true(target2.matches('.foo--*'));
+}, 'class="foo--bar" matches .foo--*');
+
+test(() => {
+  assert_false(target2.matches('.foo-*'));
+}, 'class="foo--bar" does not match .foo-* (the separator is "--", not "-")');
+
+test(() => {
+  assert_true(target3.matches('.foo-*'));
+}, 'class="foo-bar-" (ends in a dash) matches .foo-*');
+
+test(() => {
+  assert_false(target3.matches('.foo-bar-*'));
+}, 'class="foo-bar-" does not match .foo-bar-* (nothing left after the prefix)');
+
+test(() => {
+  assert_false(target4.matches('.foo-*'));
+}, 'class="foobar" does not match .foo-* (no "-" separator)');
+
+test(() => {
+  assert_false(target5.matches('.foo-*'));
+}, 'class="foo-" does not match .foo-* (no character beyond the prefix)');
+
+test(() => {
+  assert_true(target6.matches('.foo-*'));
+}, 'class="foo-a" matches .foo-* (exactly one character beyond the prefix)');
+
+test(() => {
+  assert_true(target7.matches('.foo-*'));
+}, 'a class matching the prefix among several space-separated classes still matches');
+
+test(() => {
+  assert_false(target8.matches('.foo-*'));
+}, 'an element with no class attribute does not match .foo-*');
+
+test(() => {
+  assert_true(target10.matches('span.foo-*'));
+  assert_false(target10.matches('div.foo-*'));
+}, 'class prefix selector combines with a type selector in a compound');
+
+test(() => {
+  assert_true(target9.matches('.active.foo-*'));
+}, 'class prefix selector combines with another class selector in a compound');
+
+test(() => {
+  assert_false(target1.matches(':not(.foo-*)'));
+  assert_true(target11.matches(':not(.foo-*)'));
+}, 'class prefix selector works as a :not() argument');
+
+test(() => {
+  assert_true(target1.matches(':is(.foo-*, .qux)'));
+  assert_false(target12.matches(':is(.foo-*, .qux)'));
+}, 'class prefix selector works inside :is()');
+
+test(() => {
+  assert_true(target13.matches('.foo---*'));
+}, 'class="foo---baz" matches .foo---* (a three-hyphen prefix works the same way as one or two hyphens)');
+
+test(() => {
+  assert_false(target13.matches('.foo--*'));
+}, 'class="foo---baz" does not match .foo--* (the separator is "---", not "--")');
+
+test(() => {
+  assert_false(target14.matches('.foo---*'));
+  assert_true(target14.matches('.foo----*'));
+}, 'class="foo----qux" does not match .foo---* but does match .foo----* (an extra hyphen right after the prefix disqualifies a shorter prefix match)');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-queryselector.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-queryselector.tentative-expected.txt
@@ -1,0 +1,8 @@
+
+PASS querySelectorAll(".foo-*") returns matching elements in document order and excludes non-matches (foobar, foo-)
+PASS querySelector(".foo-*") returns the first matching element in document order
+PASS querySelectorAll with a selector list containing a class prefix selector does not duplicate an element that matches more than one branch
+PASS Element.closest() finds an ancestor via the class prefix selector
+PASS Element.closest() matches the element itself first
+PASS Element.closest() returns null when no ancestor matches the class prefix selector
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-queryselector.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-queryselector.tentative.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Selectors: class prefix selector in querySelector(All) and closest()</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/selectors-5/#class-prefix">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="container">
+  <div id="a" class="foo-alpha"></div>
+  <div id="b" class="bar-beta"></div>
+  <div id="c" class="foo-gamma">
+    <div id="d" class="unrelated"></div>
+  </div>
+  <div id="e" class="foobar"></div>
+  <div id="f" class="foo-"></div>
+  <div id="g" class="foo-delta bar-epsilon"></div>
+</div>
+<script>
+test(() => {
+  assert_array_equals(Array.from(document.querySelectorAll('.foo-*'), e => e.id), ['a', 'c', 'g']);
+}, 'querySelectorAll(".foo-*") returns matching elements in document order and excludes non-matches (foobar, foo-)');
+
+test(() => {
+  assert_equals(document.querySelector('.foo-*').id, 'a');
+}, 'querySelector(".foo-*") returns the first matching element in document order');
+
+test(() => {
+  assert_array_equals(Array.from(document.querySelectorAll('.foo-*, .bar-*'), e => e.id), ['a', 'b', 'c', 'g']);
+}, 'querySelectorAll with a selector list containing a class prefix selector does not duplicate an element that matches more than one branch');
+
+test(() => {
+  assert_equals(document.getElementById('d').closest('.foo-*').id, 'c');
+}, 'Element.closest() finds an ancestor via the class prefix selector');
+
+test(() => {
+  assert_equals(document.getElementById('a').closest('.foo-*').id, 'a');
+}, 'Element.closest() matches the element itself first');
+
+test(() => {
+  assert_equals(document.getElementById('d').closest('.bar-*'), null);
+}, 'Element.closest() returns null when no ancestor matches the class prefix selector');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-class-prefix.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-class-prefix.tentative-expected.txt
@@ -1,0 +1,18 @@
+
+PASS ".foo-*" should be a valid selector
+PASS ".foo--*" should be a valid selector
+PASS ".foo---*" should be a valid selector
+PASS ".foo-bar-*" should be a valid selector
+PASS "*.foo-*" should be a valid selector
+PASS "h1.foo-*" should be a valid selector
+PASS "p.foo-*.bar-*" should be a valid selector
+PASS ".foo-*:hover" should be a valid selector
+PASS ":not(.foo-*)" should be a valid selector
+PASS ":is(.foo-*)" should be a valid selector
+PASS ".foo-* .bar" should be a valid selector
+PASS ".foo- *" should be a valid selector
+PASS ".foo*" should be an invalid selector
+PASS ".foo-**" should be an invalid selector
+PASS ".-*" should be an invalid selector
+PASS ".*" should be an invalid selector
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-class-prefix.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-class-prefix.tentative.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Selectors: class prefix selector parsing</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/selectors-5/#class-prefix">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script>
+  // Valid: dash-terminated identifier immediately followed by an asterisk.
+  test_valid_selector('.foo-*');
+  test_valid_selector('.foo--*');
+  test_valid_selector('.foo---*');
+  test_valid_selector('.foo-bar-*');
+
+  // The universal selector may or may not be dropped when serializing a compound
+  // that also has a class prefix selector, just like for a plain class selector.
+  test_valid_selector('*.foo-*', ['*.foo-*', '.foo-*']);
+
+  // Combines with a type selector and with other simple selectors in a compound.
+  test_valid_selector('h1.foo-*');
+  test_valid_selector('p.foo-*.bar-*');
+
+  // Combines with pseudo-classes, logical combinators, and combinators.
+  test_valid_selector('.foo-*:hover');
+  test_valid_selector(':not(.foo-*)');
+  test_valid_selector(':is(.foo-*)');
+  test_valid_selector('.foo-* .bar');
+
+  // Whitespace between the dash-terminated identifier and the asterisk means the
+  // asterisk is not "immediately following" the identifier, so this is instead a
+  // valid descendant combinator selector (".foo-" then a universal selector),
+  // not a class prefix selector.
+  test_valid_selector('.foo- *');
+
+  // Invalid: a class selector immediately followed by an asterisk is only a class
+  // prefix selector when the identifier ends in a hyphen. Otherwise it is a class
+  // selector followed by a bare universal selector, which is invalid.
+  test_invalid_selector('.foo*');
+
+  // Invalid: nothing may follow the asterisk of a class prefix selector.
+  test_invalid_selector('.foo-**');
+
+  // Invalid: "-" alone is not a valid identifier, so this never reaches the class
+  // prefix selector codepath in the first place.
+  test_invalid_selector('.-*');
+
+  // Invalid: a class selector requires an identifier after the dot.
+  test_invalid_selector('.*');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-class-prefix.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-class-prefix.tentative-expected.txt
@@ -1,0 +1,17 @@
+
+PASS ":has(.foo-*)" should be a valid selector
+PASS ":has(> .foo-*)" should be a valid selector
+PASS ":has(+ .foo-*)" should be a valid selector
+PASS ":has(~ .foo-*)" should be a valid selector
+PASS ":has(~ .bar > .foo-*)" should be a valid selector
+PASS ":has(~ .bar .foo-*)" should be a valid selector
+PASS ".a:has(.foo-*)" should be a valid selector
+PASS ".foo-*:has(.a)" should be a valid selector
+PASS ":has(.foo-*) .a" should be a valid selector
+PASS ":has(> .foo-*) > .a" should be a valid selector
+PASS ":not(:has(.foo-*))" should be a valid selector
+PASS ":has(.foo-*, .bar-*)" should be a valid selector
+PASS ":has(.foo-*):has(.bar-*)" should be a valid selector
+PASS ":has(.foo*)" should be an invalid selector
+PASS ":has(.foo-*, .bar*)" should be an invalid selector
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-class-prefix.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-class-prefix.tentative.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Selectors: class prefix selector inside :has()</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/selectors-5/#class-prefix">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script>
+  // The various :has() relative-selector combinator forms.
+  test_valid_selector(':has(.foo-*)');
+  test_valid_selector(':has(> .foo-*)');
+  test_valid_selector(':has(+ .foo-*)');
+  test_valid_selector(':has(~ .foo-*)');
+  test_valid_selector(':has(~ .bar > .foo-*)');
+  test_valid_selector(':has(~ .bar .foo-*)');
+
+  // A class prefix selector may also be on the outer compound, on either side of :has(),
+  // and in non-subject (ancestor/parent) position relative to the :has() bearer.
+  test_valid_selector('.a:has(.foo-*)');
+  test_valid_selector('.foo-*:has(.a)');
+  test_valid_selector(':has(.foo-*) .a');
+  test_valid_selector(':has(> .foo-*) > .a');
+
+  // Combines with logical combinators and multiple :has() arguments/pseudo-classes.
+  test_valid_selector(':not(:has(.foo-*))');
+  test_valid_selector(':has(.foo-*, .bar-*)');
+  test_valid_selector(':has(.foo-*):has(.bar-*)');
+
+  // :has() is unforgiving: an invalid class prefix selector anywhere in its
+  // argument list invalidates the whole selector.
+  test_invalid_selector(':has(.foo*)');
+  test_invalid_selector(':has(.foo-*, .bar*)');
+</script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -832,6 +832,14 @@ CSSCalcSizeFunctionEnabled:
   humanReadableDescription: "Enable support for CSS calc-size()"
   defaultValue: false
 
+CSSClassPrefixSelectorEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS class prefix selector"
+  humanReadableDescription: "Enable the CSS class prefix selector (.foo-*)"
+  defaultValue: false
+
 CSSColorLayersEnabled:
   type: bool
   category: css

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -196,6 +196,7 @@ SelectorSpecificity simpleSelectorSpecificity(const CSSSelector& simpleSelector,
         }
     case CSSSelector::Match::Exact:
     case CSSSelector::Match::Class:
+    case CSSSelector::Match::ClassPrefix:
     case CSSSelector::Match::Set:
     case CSSSelector::Match::List:
     case CSSSelector::Match::Hyphen:
@@ -505,6 +506,10 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
         } else if (selector->match() == Match::Class) {
             builder.append('.');
             serializeIdentifier(builder, selector->serializingValue());
+        } else if (selector->match() == Match::ClassPrefix) {
+            builder.append('.');
+            serializeIdentifier(builder, selector->serializingValue());
+            builder.append('*');
         } else if (selector->match() == Match::ForgivingUnknown || selector->match() == Match::ForgivingUnknownNestContaining) {
             builder.append(selector->value());
         } else if (selector->match() == Match::HasScope) {

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -89,6 +89,7 @@ public:
         Tag,
         Id,
         Class,
+        ClassPrefix, // .foo-*
         Exact,
         Set,
         List,

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -747,6 +747,7 @@ static bool NODELETE canMatchHoverOrActiveInQuirksMode(const SelectorChecker::Lo
         }
         case CSSSelector::Match::Id:
         case CSSSelector::Match::Class:
+        case CSSSelector::Match::ClassPrefix:
         case CSSSelector::Match::Exact:
         case CSSSelector::Match::Set:
         case CSSSelector::Match::List:
@@ -818,6 +819,8 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
         ASSERT(m_strictParsing);
         return element->hasClassName(selector.value());
     }
+    if (selector.match() == CSSSelector::Match::ClassPrefix)
+        return element->hasClassNamePrefix(selector.value());
 
     if (selector.match() == CSSSelector::Match::Id) {
         ASSERT(!selector.value().isNull());

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -100,6 +100,7 @@ CSSParserContext::CSSParserContext(const Settings& settings)
 #endif
     , gridLanesEnabled { settings.gridLanesEnabled() }
     , cssAppearanceBaseEnabled { settings.cssAppearanceBaseEnabled() }
+    , cssClassPrefixSelectorEnabled { settings.cssClassPrefixSelectorEnabled() }
     , cssPaintingAPIEnabled { settings.cssPaintingAPIEnabled() }
     , cssTextDecorationLineErrorValues { settings.cssTextDecorationLineErrorValues() }
     , cssFlexWrapBalanceEnabled { settings.cssFlexWrapBalanceEnabled() }
@@ -154,6 +155,7 @@ void add(Hasher& hasher, const CSSParserContext& context)
 #endif
         context.gridLanesEnabled,
         context.cssAppearanceBaseEnabled,
+        context.cssClassPrefixSelectorEnabled,
         context.cssPaintingAPIEnabled,
         context.cssWordBreakAutoPhraseEnabled,
         context.popoverAttributeEnabled,

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -63,6 +63,7 @@ struct CSSParserContext {
 #endif
     bool gridLanesEnabled : 1 { false };
     bool cssAppearanceBaseEnabled : 1 { false };
+    bool cssClassPrefixSelectorEnabled : 1 { false };
     bool cssPaintingAPIEnabled : 1 { false };
     bool cssTextDecorationLineErrorValues : 1 { false };
     bool cssFlexWrapBalanceEnabled : 1 { false };

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -749,11 +749,21 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumeClass(CSSParserTok
     if (range.peek().type() != IdentToken)
         return nullptr;
 
-    auto selector = makeUnique<MutableCSSSelector>();
-    selector->setMatch(CSSSelector::Match::Class);
-
     auto token = range.consume();
-    selector->setValue(token.value().toAtomString(), m_context.mode == HTMLQuirksMode);
+    auto identifier = token.value();
+
+    auto selector = makeUnique<MutableCSSSelector>();
+
+    // The class prefix selector (.foo-*) is a dash-terminated identifier immediately followed by
+    // an asterisk, with no intervening whitespace. https://drafts.csswg.org/selectors/#class-prefix
+    if (m_context.cssClassPrefixSelectorEnabled && !identifier.isEmpty() && identifier[identifier.length() - 1] == '-'
+        && range.peek().type() == DelimiterToken && range.peek().delimiter() == '*') {
+        range.consume();
+        selector->setMatch(CSSSelector::Match::ClassPrefix);
+    } else
+        selector->setMatch(CSSSelector::Match::Class);
+
+    selector->setValue(identifier.toAtomString(), m_context.mode == HTMLQuirksMode);
 
     return selector;
 }

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -39,6 +39,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
     , imageControlsEnabled(context.imageControlsEnabled)
 #endif
     , popoverAttributeEnabled(context.popoverAttributeEnabled)
+    , cssClassPrefixSelectorEnabled(context.cssClassPrefixSelectorEnabled)
     , cssPickerPseudoElementEnabled(context.cssPickerPseudoElementEnabled)
     , htmlEnhancedSelectEnabled(context.htmlEnhancedSelectEnabled)
     , targetTextPseudoElementEnabled(context.targetTextPseudoElementEnabled)
@@ -54,6 +55,7 @@ CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
     , imageControlsEnabled(document.settings().imageControlsEnabled())
 #endif
     , popoverAttributeEnabled(document.settings().popoverAttributeEnabled())
+    , cssClassPrefixSelectorEnabled(document.settings().cssClassPrefixSelectorEnabled())
     , cssPickerPseudoElementEnabled(document.settings().cssPickerPseudoElementEnabled())
     , htmlEnhancedSelectEnabled(document.settings().htmlEnhancedSelectEnabled())
     , targetTextPseudoElementEnabled(document.settings().targetTextPseudoElementEnabled())
@@ -70,6 +72,7 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
         context.imageControlsEnabled,
 #endif
         context.popoverAttributeEnabled,
+        context.cssClassPrefixSelectorEnabled,
         context.cssPickerPseudoElementEnabled,
         context.htmlEnhancedSelectEnabled,
         context.targetTextPseudoElementEnabled,

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -40,6 +40,7 @@ struct CSSSelectorParserContext {
     bool imageControlsEnabled : 1 { false };
 #endif
     bool popoverAttributeEnabled : 1 { false };
+    bool cssClassPrefixSelectorEnabled : 1 { false };
     bool cssPickerPseudoElementEnabled : 1 { false };
     bool htmlEnhancedSelectEnabled : 1 { false };
     bool targetTextPseudoElementEnabled : 1 { false };

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1560,6 +1560,9 @@ static FunctionType constructFragmentsInternal(const CSSSelector& rootSelector, 
             fragment->classNames.append(selector->value().impl());
             fragment->onlyMatchesLinksInQuirksMode = false;
             break;
+        case CSSSelector::Match::ClassPrefix:
+            // Class prefix selectors can't be matched via pointer-identity comparison against a fixed AtomStringImpl*; fall back to the non-JIT selector checker.
+            return FunctionType::CannotCompile;
         case CSSSelector::Match::PseudoClass: {
             FragmentPositionInRootFragments subPosition = positionInRootFragments;
             if (relationToPreviousFragment != FragmentRelation::Rightmost)

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -770,6 +770,7 @@ public:
     inline bool hasName() const;
     inline const SpaceSplitString& classNames() const;
     inline bool hasClassName(const AtomString& className) const;
+    inline bool hasClassNamePrefix(const AtomString& prefix) const;
 
     ScrollPosition NODELETE savedLayerScrollPosition() const;
     void setSavedLayerScrollPosition(const ScrollPosition&);

--- a/Source/WebCore/dom/ElementInlines.h
+++ b/Source/WebCore/dom/ElementInlines.h
@@ -160,6 +160,13 @@ inline bool Element::hasClassName(const AtomString& className) const
     return elementData()->classNames().contains(className);
 }
 
+inline bool Element::hasClassNamePrefix(const AtomString& prefix) const
+{
+    if (!elementData())
+        return false;
+    return elementData()->classNames().containsClassPrefix(prefix);
+}
+
 inline unsigned Element::attributeCount() const
 {
     ASSERT(elementData());

--- a/Source/WebCore/dom/SpaceSplitString.cpp
+++ b/Source/WebCore/dom/SpaceSplitString.cpp
@@ -63,6 +63,17 @@ static inline void tokenizeSpaceSplitString(TokenProcessor& tokenProcessor, Stri
         tokenizeSpaceSplitString(tokenProcessor, string.span16());
 }
 
+bool SpaceSplitString::containsClassPrefix(const AtomString& prefix) const
+{
+    if (!m_data)
+        return false;
+    for (auto& className : *m_data) {
+        if (classNameMatchesPrefix(className, prefix))
+            return true;
+    }
+    return false;
+}
+
 bool SpaceSplitStringData::containsAll(const SpaceSplitStringData& other) const
 {
     if (this == &other)

--- a/Source/WebCore/dom/SpaceSplitString.h
+++ b/Source/WebCore/dom/SpaceSplitString.h
@@ -119,6 +119,18 @@ public:
     bool contains(const AtomString& string) const { return m_data && m_data->contains(string); }
     bool containsAll(const SpaceSplitString& names) const { return !names.m_data || (m_data && m_data->containsAll(*names.m_data)); }
 
+    // A class token matches a prefix (e.g. ".foo-*") if it starts with the prefix, has at least
+    // one character beyond it, and that character isn't also a hyphen. https://drafts.csswg.org/selectors/#class-prefix
+    static bool classNameMatchesPrefix(StringView className, StringView prefix)
+    {
+        if (className.length() <= prefix.length())
+            return false;
+        if (!className.startsWith(prefix))
+            return false;
+        return className[prefix.length()] != '-';
+    }
+    bool containsClassPrefix(const AtomString& prefix) const;
+
     unsigned size() const { return m_data ? m_data->size() : 0; }
     bool isEmpty() const { return !m_data; }
     const AtomString& operator[](unsigned i) const LIFETIME_BOUND

--- a/Source/WebCore/style/ClassChangeInvalidation.cpp
+++ b/Source/WebCore/style/ClassChangeInvalidation.cpp
@@ -101,7 +101,15 @@ void ClassChangeInvalidation::computeInvalidation(const SpaceSplitString& oldCla
                 mayAffectStyleInShadowTree = true;
             if (features.classesAffectingHost.contains(classChange.className))
                 shouldInvalidateCurrent = true;
+            for (auto& prefix : features.classPrefixesAffectingHost) {
+                if (SpaceSplitString::classNameMatchesPrefix(AtomString { classChange.className }, prefix))
+                    shouldInvalidateCurrent = true;
+            }
         }
+        // Class prefix rules can't be looked up by the exact changed class name, so conservatively
+        // treat any class change as possibly affecting the shadow tree when such rules exist.
+        if (mayAffectShadowTree && !classChanges.isEmpty() && !features.classPrefixRules.isEmpty())
+            mayAffectStyleInShadowTree = true;
     });
 
     if (mayAffectStyleInShadowTree) {
@@ -165,6 +173,42 @@ void ClassChangeInvalidation::computeInvalidation(const SpaceSplitString& oldCla
 
     if (RefPtr shadowRoot = m_element->shadowRoot())
         collect(shadowRoot->styleScope().resolver().ruleSets(), MatchElement::Relation::Host);
+
+    // Class prefix (`.foo-*`) rules aren't indexed by exact class name, so they're matched here by
+    // comparing whole before/after class lists against each rule's prefix, mirroring how attribute
+    // selector invalidation re-evaluates the selector rather than relying on a value-keyed lookup.
+    auto collectClassPrefixRules = [&](auto& ruleSets, std::optional<MatchElement::Relation> onlyRelation = { }) {
+        for (auto& invalidationRuleSet : ruleSets.classPrefixInvalidationRuleSets()) {
+            if (onlyRelation && invalidationRuleSet.matchElement.relation != onlyRelation)
+                continue;
+
+            if (invalidateBeforeAndAfterChange(invalidationRuleSet)) {
+                Invalidator::addToMatchElementRuleSets(m_beforeChangeRuleSets, invalidationRuleSet);
+                Invalidator::addToMatchElementRuleSets(m_afterChangeRuleSets, invalidationRuleSet);
+                continue;
+            }
+
+            for (auto& selector : invalidationRuleSet.invalidationSelectors) {
+                ASSERT(selector.match() == CSSSelector::Match::ClassPrefix);
+                bool oldMatches = oldClasses.containsClassPrefix(selector.value());
+                bool newMatches = newClasses.containsClassPrefix(selector.value());
+                if (oldMatches == newMatches)
+                    continue;
+
+                bool shouldInvalidateBeforeChange = invalidationRuleSet.isNegation == IsNegation::Yes ? newMatches : oldMatches;
+                if (shouldInvalidateBeforeChange)
+                    Invalidator::addToMatchElementRuleSets(m_beforeChangeRuleSets, invalidationRuleSet);
+                else
+                    Invalidator::addToMatchElementRuleSets(m_afterChangeRuleSets, invalidationRuleSet);
+                break;
+            }
+        }
+    };
+
+    collectClassPrefixRules(m_element->styleResolver().ruleSets());
+
+    if (RefPtr shadowRoot = m_element->shadowRoot())
+        collectClassPrefixRules(shadowRoot->styleScope().resolver().ruleSets(), MatchElement::Relation::Host);
 }
 
 void ClassChangeInvalidation::invalidateBeforeChange()

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -349,6 +349,8 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
                 selectorFeatures.ids.append({ selector, matchElement, context.isNegation, scopeSourcesForFeature() });
         } else if (selector->match() == CSSSelector::Match::Class || selector->isEquivalentToClassSelector())
             selectorFeatures.classes.append({ selector, matchElement, context.isNegation, scopeSourcesForFeature() });
+        else if (selector->match() == CSSSelector::Match::ClassPrefix)
+            selectorFeatures.classPrefixes.append({ selector, matchElement, context.isNegation, scopeSourcesForFeature() });
         else if (selector->isAttributeSelector()) {
             attributeLowercaseLocalNamesInRules.add(selector->attribute().localNameLowercase());
             attributeLocalNamesInRules.add(selector->attribute().localName());
@@ -533,6 +535,23 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
     addToMap(idRules, selectorFeatures.ids, nullptr);
     addToMap(classRules, selectorFeatures.classes, &classesAffectingHost);
 
+    for (auto& entry : selectorFeatures.classPrefixes) {
+        auto& [selector, matchElement, isNegation, scopeSources] = entry;
+
+        addToVector(classPrefixRules, RuleFeature {
+            ruleData,
+            matchElement,
+            isNegation,
+            CSSSelectorList::makeCopyingSimpleSelector(*selector),
+            scopeSelectorFromSources(scopeSources)
+        });
+
+        setUsesRelation(matchElement.relation);
+
+        if (matchElement.relation == MatchElement::Relation::Host)
+            classPrefixesAffectingHost.add(selector->value());
+    }
+
     for (auto& entry : selectorFeatures.attributes) {
         auto& [selector, matchElement, isNegation, scopeSources] = entry;
         auto& featureVector = *attributeRules.ensure(selector->attribute().localNameLowercase(), [] {
@@ -636,6 +655,9 @@ void RuleFeatureSet::add(const RuleFeatureSet& other)
     addMap(classRules, other.classRules);
     classesAffectingHost.addAll(other.classesAffectingHost);
 
+    classPrefixRules.appendVector(other.classPrefixRules);
+    classPrefixesAffectingHost.addAll(other.classPrefixesAffectingHost);
+
     addMap(attributeRules, other.attributeRules);
     attributesAffectingHost.addAll(other.attributesAffectingHost);
 
@@ -666,6 +688,8 @@ void RuleFeatureSet::clear()
     classRules.clear();
     hasPseudoClassRules.clear();
     classesAffectingHost.clear();
+    classPrefixRules.clear();
+    classPrefixesAffectingHost.clear();
     attributeRules.clear();
     attributesAffectingHost.clear();
     pseudoClassRules.clear();
@@ -682,6 +706,7 @@ void RuleFeatureSet::shrinkToFit()
         rules->shrinkToFit();
     for (auto& rules : classRules.values())
         rules->shrinkToFit();
+    classPrefixRules.shrinkToFit();
     for (auto& rules : attributeRules.values())
         rules->shrinkToFit();
     for (auto& rules : pseudoClassRules.values())

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -147,7 +147,11 @@ struct RuleFeatureSet {
     HashMap<PseudoClassInvalidationKey, std::unique_ptr<RuleFeatureVector>> pseudoClassRules;
     HashMap<PseudoClassInvalidationKey, std::unique_ptr<RuleFeatureVector>> hasPseudoClassRules;
 
+    // Class prefix (`.foo-*`) rules can't be indexed by an exact class name, so they're kept in a flat list that's always consulted.
+    RuleFeatureVector classPrefixRules;
+
     HashSet<AtomString> classesAffectingHost;
+    HashSet<AtomString> classPrefixesAffectingHost;
     HashSet<AtomString> attributesAffectingHost;
     HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>> pseudoClassesAffectingHost;
     HashSet<CSSSelector::PseudoClass, IntHash<CSSSelector::PseudoClass>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClass>> pseudoClasses;
@@ -165,6 +169,7 @@ private:
 
         Vector<InvalidationFeature> ids;
         Vector<InvalidationFeature> classes;
+        Vector<InvalidationFeature> classPrefixes;
         Vector<InvalidationFeature> attributes;
         Vector<InvalidationFeature> pseudoClasses;
         Vector<InvalidationFeature> hasPseudoClasses;

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -338,6 +338,8 @@ void RuleSet::addRuleToBucket(RuleData& ruleData)
             case CSSSelector::Match::HasScope:
             case CSSSelector::Match::NestingParent:
             case CSSSelector::Match::PagePseudoClass:
+            case CSSSelector::Match::ClassPrefix:
+                // Class prefix selectors can't be indexed by an exact class name, so they fall into the universal bucket.
                 break;
             }
         }

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -284,6 +284,7 @@ void ScopeRuleSets::collectFeatures() const
 
     m_idInvalidationRuleSets.clear();
     m_classInvalidationRuleSets.clear();
+    m_classPrefixInvalidationRuleSets = std::nullopt;
     m_attributeInvalidationRuleSets.clear();
     m_pseudoClassInvalidationRuleSets.clear();
     m_hasPseudoClassInvalidationRuleSets.clear();
@@ -339,6 +340,70 @@ static OptionSet<HasArgumentProperty> hasArgumentProperties(const CSSSelectorLis
     return info.properties();
 }
 
+static Vector<InvalidationRuleSet> buildInvalidationRuleSets(const RuleFeatureVector& features)
+{
+    struct RuleSetKey {
+        MatchElement matchElement;
+        IsNegation isNegation;
+        const CSSSelectorList* invalidationSelector { nullptr };
+        const CSSSelectorList* scopeSelector { nullptr };
+
+        unsigned hash() const
+        {
+            Hasher hasher;
+            add(hasher, matchElement.relation, matchElement.hasRelation, isNegation);
+            if (invalidationSelector)
+                add(hasher, *invalidationSelector);
+            if (scopeSelector)
+                add(hasher, *scopeSelector);
+            return hasher.hash();
+        }
+        bool operator==(const RuleSetKey& other) const
+        {
+            return matchElement == other.matchElement
+                && isNegation == other.isNegation
+                && arePointingToEqualData(invalidationSelector, other.invalidationSelector)
+                && arePointingToEqualData(scopeSelector, other.scopeSelector);
+        }
+    };
+
+    HashMap<GenericHashKey<RuleSetKey>, RefPtr<RuleSet>> ruleSetMap;
+
+    for (auto& feature : features) {
+        auto key = GenericHashKey<RuleSetKey> { { feature.matchElement, feature.isNegation, &feature.invalidationSelector, &feature.scopeSelector } };
+
+        auto& ruleSet = ruleSetMap.ensure(key, [] {
+            return RuleSet::create();
+        }).iterator->value;
+
+        ruleSet->addRule(protect(*feature.styleRule), feature.selectorIndex, feature.selectorListIndex);
+    }
+
+    return WTF::map(ruleSetMap, [](auto& entry) {
+        auto& key = entry.key.key();
+        entry.value->shrinkToFit();
+        auto invalidationSelector = [&] {
+            if (!key.invalidationSelector->isEmpty() && !key.scopeSelector->isEmpty())
+                return CSSSelectorParser::makeHasArgumentWithScope(key.invalidationSelector->first(), key.scopeSelector->first());
+            if (!key.invalidationSelector->isEmpty())
+                return CSSSelectorList { *key.invalidationSelector };
+            return CSSSelectorList { };
+        }();
+        // Null scopeSelector means scope-breaking; otherwise wrap a copy so it outlives this cache.
+        RefPtr<const RefCountedCSSSelectorList> scopeSelector;
+        if (!key.scopeSelector->isEmpty())
+            scopeSelector = RefCountedCSSSelectorList::create(CSSSelectorList { *key.scopeSelector });
+        return InvalidationRuleSet {
+            WTF::move(entry.value),
+            WTF::move(invalidationSelector),
+            key.matchElement,
+            key.isNegation,
+            hasArgumentProperties(*key.invalidationSelector),
+            WTF::move(scopeSelector)
+        };
+    });
+}
+
 template<typename KeyType, typename Hash, typename HashTraits>
 static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& key, HashMap<KeyType, std::unique_ptr<Vector<InvalidationRuleSet>>, Hash, HashTraits>& ruleSetMap, const HashMap<KeyType, std::unique_ptr<RuleFeatureVector>, Hash, HashTraits>& ruleFeatures)
 {
@@ -347,66 +412,7 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
         if (!features)
             return nullptr;
 
-        struct RuleSetKey {
-            MatchElement matchElement;
-            IsNegation isNegation;
-            const CSSSelectorList* invalidationSelector { nullptr };
-            const CSSSelectorList* scopeSelector { nullptr };
-
-            unsigned hash() const
-            {
-                Hasher hasher;
-                add(hasher, matchElement.relation, matchElement.hasRelation, isNegation);
-                if (invalidationSelector)
-                    add(hasher, *invalidationSelector);
-                if (scopeSelector)
-                    add(hasher, *scopeSelector);
-                return hasher.hash();
-            }
-            bool operator==(const RuleSetKey& other) const
-            {
-                return matchElement == other.matchElement
-                    && isNegation == other.isNegation
-                    && arePointingToEqualData(invalidationSelector, other.invalidationSelector)
-                    && arePointingToEqualData(scopeSelector, other.scopeSelector);
-            }
-        };
-
-        HashMap<GenericHashKey<RuleSetKey>, RefPtr<RuleSet>> ruleSetMap;
-
-        for (auto& feature : *features) {
-            auto key = GenericHashKey<RuleSetKey> { { feature.matchElement, feature.isNegation, &feature.invalidationSelector, &feature.scopeSelector } };
-
-            auto& ruleSet = ruleSetMap.ensure(key, [] {
-                return RuleSet::create();
-            }).iterator->value;
-
-            ruleSet->addRule(protect(*feature.styleRule), feature.selectorIndex, feature.selectorListIndex);
-        }
-
-        return makeUnique<Vector<InvalidationRuleSet>>(WTF::map(ruleSetMap, [](auto& entry) {
-            auto& key = entry.key.key();
-            entry.value->shrinkToFit();
-            auto invalidationSelector = [&] {
-                if (!key.invalidationSelector->isEmpty() && !key.scopeSelector->isEmpty())
-                    return CSSSelectorParser::makeHasArgumentWithScope(key.invalidationSelector->first(), key.scopeSelector->first());
-                if (!key.invalidationSelector->isEmpty())
-                    return CSSSelectorList { *key.invalidationSelector };
-                return CSSSelectorList { };
-            }();
-            // Null scopeSelector means scope-breaking; otherwise wrap a copy so it outlives this cache.
-            RefPtr<const RefCountedCSSSelectorList> scopeSelector;
-            if (!key.scopeSelector->isEmpty())
-                scopeSelector = RefCountedCSSSelectorList::create(CSSSelectorList { *key.scopeSelector });
-            return InvalidationRuleSet {
-                WTF::move(entry.value),
-                WTF::move(invalidationSelector),
-                key.matchElement,
-                key.isNegation,
-                hasArgumentProperties(*key.invalidationSelector),
-                WTF::move(scopeSelector)
-            };
-        }));
+        return makeUnique<Vector<InvalidationRuleSet>>(buildInvalidationRuleSets(*features));
     }).iterator->value.get();
 }
 
@@ -418,6 +424,13 @@ const Vector<InvalidationRuleSet>* ScopeRuleSets::idInvalidationRuleSets(const A
 const Vector<InvalidationRuleSet>* ScopeRuleSets::classInvalidationRuleSets(const AtomString& className) const
 {
     return ensureInvalidationRuleSets(className, m_classInvalidationRuleSets, m_features.classRules);
+}
+
+const Vector<InvalidationRuleSet>& ScopeRuleSets::classPrefixInvalidationRuleSets() const
+{
+    if (!m_classPrefixInvalidationRuleSets)
+        m_classPrefixInvalidationRuleSets = buildInvalidationRuleSets(m_features.classPrefixRules);
+    return *m_classPrefixInvalidationRuleSets;
 }
 
 const Vector<InvalidationRuleSet>* ScopeRuleSets::attributeInvalidationRuleSets(const AtomString& attributeName) const

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -97,6 +97,7 @@ public:
 
     const Vector<InvalidationRuleSet>* idInvalidationRuleSets(const AtomString&) const LIFETIME_BOUND;
     const Vector<InvalidationRuleSet>* classInvalidationRuleSets(const AtomString&) const LIFETIME_BOUND;
+    const Vector<InvalidationRuleSet>& classPrefixInvalidationRuleSets() const LIFETIME_BOUND;
     const Vector<InvalidationRuleSet>* attributeInvalidationRuleSets(const AtomString&) const LIFETIME_BOUND;
     const Vector<InvalidationRuleSet>* pseudoClassInvalidationRuleSets(const PseudoClassInvalidationKey&) const LIFETIME_BOUND;
     const Vector<InvalidationRuleSet>* hasPseudoClassInvalidationRuleSets(const PseudoClassInvalidationKey&) const LIFETIME_BOUND;
@@ -144,6 +145,7 @@ private:
     mutable RuleFeatureSet m_features;
     mutable HashMap<AtomString, std::unique_ptr<Vector<InvalidationRuleSet>>> m_idInvalidationRuleSets;
     mutable HashMap<AtomString, std::unique_ptr<Vector<InvalidationRuleSet>>> m_classInvalidationRuleSets;
+    mutable std::optional<Vector<InvalidationRuleSet>> m_classPrefixInvalidationRuleSets;
     mutable HashMap<AtomString, std::unique_ptr<Vector<InvalidationRuleSet>>> m_attributeInvalidationRuleSets;
     mutable HashMap<PseudoClassInvalidationKey, std::unique_ptr<Vector<InvalidationRuleSet>>> m_pseudoClassInvalidationRuleSets;
     mutable HashMap<PseudoClassInvalidationKey, std::unique_ptr<Vector<InvalidationRuleSet>>> m_hasPseudoClassInvalidationRuleSets;


### PR DESCRIPTION
#### ae3016b37a0142c1aac5e94eda82487d20777d01
<pre>
[selectors] Support for class prefix selector (.prefix-*)
<a href="https://bugs.webkit.org/show_bug.cgi?id=323916">https://bugs.webkit.org/show_bug.cgi?id=323916</a>
<a href="https://rdar.apple.com/187150976">rdar://187150976</a>

Reviewed by NOBODY (OOPS!).

Implement the class prefix selector (e.g. .foo-*), which matches an element whose class
attribute contains a token that starts with the given dash- terminated prefix, has at least one
character beyond it, and where that next character isn&apos;t itself a hyphen.

The feature is guarded by a new, off-by-default CSSClassPrefixSelectorEnabled setting while
it&apos;s experimental, threaded through CSSParserContext and CSSSelectorParserContext the same way
as other selector-gating flags.

Parsing (CSSSelectorParser::consumeClass) recognizes the syntax when a class identifier ending
in one or more hyphens is immediately followed, with no intervening whitespace, by an asterisk,
producing a new CSSSelector::Match::ClassPrefix simple selector whose value is the identifier
including its trailing hyphen(s); otherwise it falls back to parsing a plain class selector, so
&quot;.foo*&quot; (no hyphen) is simply invalid rather than being treated as a class selector followed by
a universal selector.

Matching reuses the same machinery as the plain class selector:
SpaceSplitString::classNameMatchesPrefix()/containsClassPrefix() implement the prefix
predicate, wired into Element::hasClassNamePrefix() and SelectorChecker::checkOne().

Two matching optimizations are deliberately skipped for now, since a class prefix selector has
no single exact string value to use as a lookup key:

- RuleSet doesn&apos;t bucket these rules by class name; they fall into the existing &quot;universal&quot;
bucket, which is unconditionally matched against every element, keeping matching correct at
some extra cost. - cssjit/SelectorCompiler bails out with CannotCompile for compounds using
this selector and falls back to the interpreter, since the JIT&apos;s class matching is a
pointer-identity comparison against a fixed AtomStringImpl* baked in at compile time, which
doesn&apos;t generalize to prefix comparisons.

Style invalidation (RuleFeatureSet, StyleScopeRuleSets, ClassChangeInvalidation) needed a
parallel, unkeyed path: class-prefix rule features are collected into a flat
RuleFeatureSet::classPrefixRules list (plus a classPrefixesAffectingHost set for :host() cases)
instead of the exact-class-name-keyed classRules map, since a class attribute change only
carries the concrete class name being added/removed, not any rule&apos;s prefix.
ClassChangeInvalidation now also walks this flat list and compares the before/after class lists
against each rule&apos;s prefix directly, mirroring how non-exact attribute selectors (e.g.
[attr^=]) are invalidated. This includes full support for the selector appearing inside :has()
arguments across all relative-combinator forms (:has(&gt; ...), :has(+ ...), :has(~ ...), :has(~
.a &gt; ...), :has(~ .a ...)), both with :has() in subject position and in ancestor/parent
position relative to the :has() bearer.

Tests: imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-has-invalidation.tentative.html
       imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-has-matching.tentative.html
       imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-invalidation.tentative.html
       imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-matching.tentative.html
       imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-queryselector.tentative.html
       imported/w3c/web-platform-tests/css/selectors/parsing/parse-class-prefix.tentative.html
       imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-class-prefix.tentative.html

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-has-invalidation.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-has-invalidation.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-has-matching.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-has-matching.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-invalidation.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-invalidation.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-matching.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-matching.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-queryselector.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/class-prefix-selector-queryselector.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-class-prefix.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-class-prefix.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-class-prefix.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-class-prefix.tentative.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::simpleSelectorSpecificity):
(WebCore::CSSSelector::selectorText const):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::canMatchHoverOrActiveInQuirksMode):
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeClass):
* Source/WebCore/css/parser/CSSSelectorParserContext.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSSelectorParserContext.h:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::constructFragmentsInternal):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementInlines.h:
(WebCore::Element::hasClassNamePrefix const):
* Source/WebCore/dom/SpaceSplitString.cpp:
(WebCore::SpaceSplitString::containsClassPrefix const):
* Source/WebCore/dom/SpaceSplitString.h:
(WebCore::SpaceSplitString::classNameMatchesPrefix):
* Source/WebCore/style/ClassChangeInvalidation.cpp:
(WebCore::Style::ClassChangeInvalidation::computeInvalidation):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
(WebCore::Style::RuleFeatureSet::collectFeatures):
(WebCore::Style::RuleFeatureSet::add):
(WebCore::Style::RuleFeatureSet::clear):
(WebCore::Style::RuleFeatureSet::shrinkToFit):
* Source/WebCore/style/RuleFeature.h:
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRuleToBucket):
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::collectFeatures const):
(WebCore::Style::buildInvalidationRuleSets):
(WebCore::Style::ensureInvalidationRuleSets):
(WebCore::Style::ScopeRuleSets::classPrefixInvalidationRuleSets const):
* Source/WebCore/style/StyleScopeRuleSets.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae3016b37a0142c1aac5e94eda82487d20777d01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150789 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145519 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100871 "3 flakes 14 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189200 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125856 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47925 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45902 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7700 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14570 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158278 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45640 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7597 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47473 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198512 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59787 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155086 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60497 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154729 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49162 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132751 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129915 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58924 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20619 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58326 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58544 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58390 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->