### PR TITLE
[Writing Tools] A final text animation with no unanimated range crashes the UI process

### DIFF
--- a/LayoutTests/ipc/add-text-animation-missing-uuid-crash-expected.txt
+++ b/LayoutTests/ipc/add-text-animation-missing-uuid-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/add-text-animation-missing-uuid-crash.html
+++ b/LayoutTests/ipc/add-text-animation-missing-uuid-crash.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=true ] -->
+<title>Text animation messages with an empty unanimated range UUID must not crash the UI process</title>
+<p>This test passes if WebKit does not crash.</p>
+<script>
+testRunner?.dumpAsText();
+testRunner?.waitUntilDone();
+</script>
+<script type="module">
+if (!window.IPC) {
+    testRunner?.notifyDone();
+} else {
+
+const { CoreIPC } = await import('./coreipc.js');
+const page = CoreIPC.UI.WebPageProxy;
+const pageProxyID = IPC.webPageProxyID;
+
+// Writing tools, and with it the text animation messages, are not enabled on every port.
+if (!page.AddTextAnimationForAnimationIDWithCompletionHandler) {
+    testRunner?.notifyDone();
+} else {
+
+let nextAnimationID = 0;
+const animationID = () => ({ high: 660, low: ++nextAnimationID });
+const someUUID = { optionalValue: { high: 916, low: 765 } };
+// An empty Markable<WTF::UUID>. The all-zero UUID does not survive decoding, so this is the only way one arrives.
+const noUUID = { };
+const noTextIndicator = { };
+
+const Initial = 0, Source = 1, Final = 2;
+const RunAnimation = 2;
+
+const styleData = (style, overrides) => ({
+    style,
+    runMode: RunAnimation,
+    unanimatedRangeUUID: someUUID,
+    sourceAnimationUUID: someUUID,
+    destinationAnimationUUID: someUUID,
+    ...overrides,
+});
+
+const send = data => page.AddTextAnimationForAnimationID(pageProxyID, {
+    uuid: animationID(),
+    styleData: data,
+    textIndicator: noTextIndicator,
+});
+
+// Only rejected messages reply promptly: an accepted animation replies when it finishes running.
+const sendAndAwaitRejection = data => new Promise(resolve => {
+    page.AddTextAnimationForAnimationIDWithCompletionHandler(pageProxyID, {
+        uuid: animationID(),
+        styleData: data,
+        textIndicator: noTextIndicator,
+    }, resolve);
+});
+
+// A final animation can be sent with no unanimated range at all: TextAnimationController leaves the UUID empty when
+// the session range has no editable root left to bound it. It has to be accepted, not rejected.
+send(styleData(Final, { unanimatedRangeUUID: noUUID }));
+
+// An initial animation references no other animation at all.
+send(styleData(Initial, { unanimatedRangeUUID: noUUID, sourceAnimationUUID: noUUID, destinationAnimationUUID: noUUID }));
+
+// A source animation, on the other hand, dereferences destinationAnimationUUID to pair itself with the final
+// animation, so a message without one has to be rejected.
+await sendAndAwaitRejection(styleData(Source, { destinationAnimationUUID: noUUID }));
+
+// The message without a reply takes the other message check path.
+send(styleData(Source, { destinationAnimationUUID: noUUID }));
+
+// Messages are dispatched in order, so this reply means the UI process is done with all of the messages above.
+await sendAndAwaitRejection(styleData(Source, { destinationAnimationUUID: noUUID }));
+
+testRunner?.notifyDone();
+
+}
+}
+</script>

--- a/LayoutTests/ipc/did-end-partial-intelligence-text-animation-crash-expected.txt
+++ b/LayoutTests/ipc/did-end-partial-intelligence-text-animation-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/did-end-partial-intelligence-text-animation-crash.html
+++ b/LayoutTests/ipc/did-end-partial-intelligence-text-animation-crash.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true IgnoreInvalidMessageWhenIPCTestingAPIEnabled=true ] -->
+<title>Ending a partial intelligence text animation that was never started must not crash the UI process</title>
+<p>This test passes if WebKit does not crash.</p>
+<script>
+testRunner?.dumpAsText();
+testRunner?.waitUntilDone();
+</script>
+<script type="module">
+if (!window.IPC) {
+    testRunner?.notifyDone();
+} else {
+
+const { CoreIPC } = await import('./coreipc.js');
+const page = CoreIPC.UI.WebPageProxy;
+const pageProxyID = IPC.webPageProxyID;
+
+// Writing tools are not enabled on every port.
+if (!page.DidEndPartialIntelligenceTextAnimation) {
+    testRunner?.notifyDone();
+} else {
+
+// The count of in-flight partial animations is only ever raised by a writing tools session driving the WKWebView SPI,
+// so every one of these arrives without a matching start.
+page.DidEndPartialIntelligenceTextAnimation(pageProxyID, { });
+page.DidEndPartialIntelligenceTextAnimation(pageProxyID, { });
+
+// A final text animation reaches the same code through the effect's completion block.
+page.AddTextAnimationForAnimationID(pageProxyID, {
+    uuid: { high: 660, low: 1 },
+    styleData: {
+        style: 2,
+        runMode: 2,
+        unanimatedRangeUUID: { optionalValue: { high: 916, low: 765 } },
+        sourceAnimationUUID: { optionalValue: { high: 916, low: 766 } },
+        destinationAnimationUUID: { },
+    },
+    textIndicator: { },
+});
+
+// Messages are dispatched in order, and a source animation with no destination animation to pair with is rejected
+// with a prompt reply, so this tells us the UI process has finished with the messages above.
+await new Promise(resolve => {
+    page.AddTextAnimationForAnimationIDWithCompletionHandler(pageProxyID, {
+        uuid: { high: 660, low: 2 },
+        styleData: {
+            style: 1,
+            runMode: 2,
+            unanimatedRangeUUID: { },
+            sourceAnimationUUID: { },
+            destinationAnimationUUID: { },
+        },
+        textIndicator: { },
+    }, resolve);
+});
+
+testRunner?.notifyDone();
+
+}
+}
+</script>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3182,10 +3182,8 @@ std::optional<WebCore::JSHandleIdentifier> WebKit::jsHandleIdentifierInFrame(con
 
 - (void)_didEndPartialIntelligenceTextAnimation
 {
-    if (!_partialIntelligenceTextAnimationCount) {
-        ASSERT_NOT_REACHED();
+    if (!_partialIntelligenceTextAnimationCount)
         return;
-    }
 
     _partialIntelligenceTextAnimationCount -= 1;
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1584,6 +1584,14 @@ void WebPageProxy::removeTextEffectForID(IPC::Connection& connection, const WTF:
 }
 #endif // ENABLE(WRITING_TOOLS_TEXT_EFFECTS)
 
+static bool isValidTextAnimationData(const WebCore::TextAnimationData& styleData)
+{
+    if (styleData.style != WebCore::TextAnimationType::Source)
+        return true;
+
+    return styleData.destinationAnimationUUID && styleData.destinationAnimationUUID->isValid();
+}
+
 void WebPageProxy::addTextAnimationForAnimationID(IPC::Connection& connection, const WTF::UUID& uuid, const WebCore::TextAnimationData& styleData, const RefPtr<WebCore::TextIndicator> textIndicator)
 {
     addTextAnimationForAnimationIDWithCompletionHandler(connection, uuid, styleData, textIndicator, { });
@@ -1591,10 +1599,13 @@ void WebPageProxy::addTextAnimationForAnimationID(IPC::Connection& connection, c
 
 void WebPageProxy::addTextAnimationForAnimationIDWithCompletionHandler(IPC::Connection& connection, const WTF::UUID& uuid, const WebCore::TextAnimationData& styleData, const RefPtr<WebCore::TextIndicator> textIndicator, CompletionHandler<void(WebCore::TextAnimationRunMode)>&& completionHandler)
 {
-    if (completionHandler)
+    if (completionHandler) {
         MESSAGE_CHECK_COMPLETION(uuid.isValid(), connection, completionHandler({ }));
-    else
+        MESSAGE_CHECK_COMPLETION(isValidTextAnimationData(styleData), connection, completionHandler({ }));
+    } else {
         MESSAGE_CHECK(uuid.isValid(), connection);
+        MESSAGE_CHECK(isValidTextAnimationData(styleData), connection);
+    }
 
     internals().textIndicatorForAnimationID.add(uuid, textIndicator);
 

--- a/Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm
@@ -132,12 +132,15 @@
     case WebCore::TextAnimationType::Final:
         effect = adoptNS([PAL::alloc_WTReplaceDestinationTextEffectInstance() initWithChunk:chunk.get() effectView:_effectView.get()]);
 
-        effect.get().preCompletion = makeBlockPtr([weakWebView = WeakPtr<WebKit::WebViewImpl>(_webView), remainingID = *data.unanimatedRangeUUID] {
+        effect.get().preCompletion = makeBlockPtr([weakWebView = WeakPtr<WebKit::WebViewImpl>(_webView), remainingID = data.unanimatedRangeUUID] {
+            if (!remainingID)
+                return;
+
             if (CheckedPtr webView = weakWebView.get())
-                webView->page().updateUnderlyingTextVisibilityForTextAnimationID(remainingID, false);
+                webView->page().updateUnderlyingTextVisibilityForTextAnimationID(*remainingID, false);
         }).get();
 
-        effect.get().completion = makeBlockPtr([weakSelf = WeakObjCPtr<WKTextAnimationManager>(self), weakWebView = WeakPtr<WebKit::WebViewImpl>(_webView), remainingID = *data.unanimatedRangeUUID, uuid = RetainPtr(uuid), runMode = data.runMode, effect = WeakObjCPtr<id<_WTTextEffect>>(effect.get())] {
+        effect.get().completion = makeBlockPtr([weakSelf = WeakObjCPtr<WKTextAnimationManager>(self), weakWebView = WeakPtr<WebKit::WebViewImpl>(_webView), remainingID = data.unanimatedRangeUUID, uuid = RetainPtr(uuid), runMode = data.runMode, effect = WeakObjCPtr<id<_WTTextEffect>>(effect.get())] {
             if (auto strongEffect = effect.get())
                 [strongEffect setCompletion:nil];
 
@@ -158,7 +161,8 @@
 
             webView->page().didEndPartialIntelligenceTextAnimationImpl();
 
-            webView->page().updateUnderlyingTextVisibilityForTextAnimationID(remainingID, true);
+            if (remainingID)
+                webView->page().updateUnderlyingTextVisibilityForTextAnimationID(*remainingID, true);
             webView->page().callCompletionHandlerForAnimationID(*animationID, runMode);
         }).get();
 


### PR DESCRIPTION
#### 436386a065b7f98c6935d6e48068bcb8cef2560e
<pre>
[Writing Tools] A final text animation with no unanimated range crashes the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=323917">https://bugs.webkit.org/show_bug.cgi?id=323917</a>
<a href="https://rdar.apple.com/185195580">rdar://185195580</a>

Reviewed by Chris Dumez.

Markable&lt;T&gt; uses one value of T as its empty marker rather than a separate bool,
and MarkableTraits&lt;UUID&gt;::isEmptyValue is !uuid. An engaged Markable&lt;WTF::UUID&gt;
holding UUID::emptyValue is therefore indistinguishable from a disengaged one.
TextAnimationController sends exactly that value for a Final animation whenever
it cannot resolve an end-of-editable-content boundary for the session range:
endOfEditableContent() yields a null VisiblePosition once highestEditableRoot()
is null, which leaves unanimatedRangeUUID at its UUID::emptyValue initializer. A
page that drops contenteditable while the asynchronous replacement is in flight
gets there. The two blocks the Mac text animation manager builds then captured
that value with *data.unanimatedRangeUUID and hit the RELEASE_ASSERT in
Markable::operator*() — at block construction, before any effect ran. The
receiver was converted to Markable in 293636@main; the sender was not.

This commit handles the empty range instead of asserting on it:

- WKTextAnimationManagerMac — capture the Markable and skip
  updateUnderlyingTextVisibilityForTextAnimationID when it is empty. Sending it
  would not have worked in any case: the message takes a bare WTF::UUID, whose
  decoder has rejected emptyValue since 293636@main, so it would have been an
  invalid message rather than the no-op the web process side would have made
  of it, in either direction.
- WKWebView — _didEndPartialIntelligenceTextAnimation no longer asserts when the
  count is zero. A Restart action resets it while animations are in flight, so
  their ends need not pair up with an increment. The web process reaches this
  directly too, with no animation running at all, on every early return in
  addDestinationTextAnimationForActiveWritingToolsSession. The early return was
  already correct, so Release was fine.
- WebPageProxy — a Source animation&apos;s destination UUID is dereferenced as a hash
  map key on iOS and is always generated by WritingToolsController, so an empty
  one only comes from a malformed message and is rejected with MESSAGE_CHECK.
  The check is not conditioned on the platform or the run mode, since a Source
  animation without a destination is malformed everywhere.

Tests: ipc/add-text-animation-missing-uuid-crash.html
       ipc/did-end-partial-intelligence-text-animation-crash.html

* LayoutTests/ipc/add-text-animation-missing-uuid-crash-expected.txt: Added.
* LayoutTests/ipc/add-text-animation-missing-uuid-crash.html: Added.
* LayoutTests/ipc/did-end-partial-intelligence-text-animation-crash-expected.txt: Added.
* LayoutTests/ipc/did-end-partial-intelligence-text-animation-crash.html: Added.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _didEndPartialIntelligenceTextAnimation]):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::isValidTextAnimationData):
(WebKit::WebPageProxy::addTextAnimationForAnimationIDWithCompletionHandler):
* Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm:
(-[WKTextAnimationManager addTextAnimationForAnimationID:withData:]):

Canonical link: <a href="https://commits.webkit.org/320997@main">https://commits.webkit.org/320997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/605d6e4e34ff6e2e9167d215ba6771254262e9ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196766 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150953 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/207907d5-e608-430d-ab6d-ba99a3d34f58) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145687 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3c0271ab-fbb8-43d5-a619-e1f1dc91fbc6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126049 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/323812f1-137d-4acf-8412-d2bdfe8d4428) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48106 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46049 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158454 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45796 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7842 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198757 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60016 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165728 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155280 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41619 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60727 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42351 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154919 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49335 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132915 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130189 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59143 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20775 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58555 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58778 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58663 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->