### PR TITLE
[CMake] Support Swift Testing

### DIFF
--- a/Tools/TestWebKitAPI/PlatformCocoa.cmake
+++ b/Tools/TestWebKitAPI/PlatformCocoa.cmake
@@ -43,16 +43,34 @@ add_custom_target(TestWebKitAPISwiftArgs DEPENDS "${_test_swift_resp}")
 
 # Swift flags for all Test* targets.
 _WEBKIT_COMPUTE_SWIFT_SHARED_CLANG_FLAGS(_test_swift_cc_flags)
-set(_testwebkitapi_swiftmodule_dir "${CMAKE_BINARY_DIR}/TestWebKitAPI/SwiftModules")
+
+set(_testwebkitapi_swiftmodule_dir "${CMAKE_CURRENT_BINARY_DIR}/SwiftModules")
 set(_testwebkitapi_swift_options
     ${WEBKIT_SWIFT_CXX_INTEROP_FLAGS}
+    "-D ENABLE_CXX_INTEROP"
     -no-verify-emitted-module-interface
     "@${_test_swift_resp}"
     -F${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
     "-Xcc -I${CMAKE_BINARY_DIR}"
+    "-Xcc -I${TESTWEBKITAPI_DIR}"
+    "-I${_testwebkitapi_swiftmodule_dir}"
 )
 if (CMAKE_Swift_COMPILER_TARGET)
     list(APPEND _testwebkitapi_swift_options "-clang-target ${CMAKE_Swift_COMPILER_TARGET}")
+endif ()
+
+# @Test and @Suite expand through libTestingMacros, in a `testing` subdirectory
+# swiftc does not search on its own. It must come from the default toolchain to
+# match the Testing.framework staged above.
+WEBKIT_XCRUN(_swift_plugin_server --toolchain XcodeDefault --find swift-plugin-server)
+get_filename_component(_swift_toolchain_bin "${_swift_plugin_server}" DIRECTORY)
+get_filename_component(_swift_toolchain_usr "${_swift_toolchain_bin}" DIRECTORY)
+set(_swift_testing_plugins "${_swift_toolchain_usr}/lib/swift/host/plugins/testing")
+if (IS_DIRECTORY "${_swift_testing_plugins}")
+    # Out of process, as Xcode runs macros: the plugin is not from this compiler's toolchain.
+    list(APPEND _testwebkitapi_swift_options
+        "-external-plugin-path ${_swift_testing_plugins}#${_swift_plugin_server}"
+    )
 endif ()
 foreach (_f IN LISTS _test_swift_cc_flags)
     list(APPEND _testwebkitapi_swift_options "-Xcc ${_f}")
@@ -67,7 +85,12 @@ macro(WEBKIT_TEST_ENABLE_SWIFT _target)
         ${TESTWEBKITAPI_DIR}/Runner/SwiftTestingABI.swift
         ${TESTWEBKITAPI_DIR}/Runner/TestWebKitAPISupport.mm
     )
-    set_target_properties(${_target} PROPERTIES Swift_MODULE_NAME ${_target})
+
+    get_target_property(_swift_module_name ${_target} OUTPUT_NAME)
+    if (NOT _swift_module_name)
+        set(_swift_module_name ${_target})
+    endif ()
+    set_target_properties(${_target} PROPERTIES Swift_MODULE_NAME ${_swift_module_name})
     webkit_target_add_swift_options(${_target}
         ${_testwebkitapi_swift_options}
         "-import-objc-header ${TESTWEBKITAPI_DIR}/Runner/TestWebKitAPI-Bridging-Header.h"
@@ -255,12 +278,9 @@ list(APPEND TestWebKit_SOURCES
     Helpers/TestNotificationProvider.cpp
     Helpers/WebCoreTestUtilities.cpp
 
-    Helpers/cocoa/CocoaTypes.swift
     Helpers/cocoa/HTTPServer.mm
-    Helpers/cocoa/PDFTestHelpers.swift
     Helpers/cocoa/MiniTURNServer.mm
     Helpers/cocoa/TestCocoaImageAndCocoaColor.mm
-    Helpers/cocoa/TestCocoaImageUtilities.swift
     Helpers/cocoa/TestElementFullscreenDelegate.mm
     Helpers/cocoa/TestNSBundleExtras.m
     Helpers/cocoa/UtilitiesCocoa.mm
@@ -575,6 +595,87 @@ endif ()
 foreach (_dir IN LISTS _testapi_framework_headers)
     list(APPEND _testwebkitapi_swift_options "-Xcc -I${_dir}")
 endforeach ()
+
+macro(WEBKIT_TEST_SWIFT_HELPER_LIBRARY _library _test_target)
+    set_target_properties(${_library} PROPERTIES
+        Swift_MODULE_NAME ${_library}
+        Swift_MODULE_DIRECTORY ${_testwebkitapi_swiftmodule_dir}
+    )
+    webkit_target_add_swift_options(${_library} ${_testwebkitapi_swift_options})
+    target_include_directories(${_library} PRIVATE
+        ${CMAKE_BINARY_DIR}
+        ${TESTWEBKITAPI_DIR}
+        ${_testapi_framework_headers}
+    )
+    # config.h includes <gtest/gtest.h>.
+    target_link_libraries(${_library} PRIVATE WebKit::gtest)
+    add_dependencies(${_library} TestWebKitAPIStageTesting TestWebKitAPISwiftArgs)
+    target_link_libraries(${_test_target} PRIVATE ${_library})
+endmacro()
+
+add_library(TestWTFLibrary OBJECT
+    ${TESTWEBKITAPI_DIR}/TestWTFLibrary/SwiftCxxInteropTestbed.cpp
+    ${TESTWEBKITAPI_DIR}/TestWTFLibrary/TestWTFLibrary.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/WTFCompletionHandler+Extras.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/WTFExpected+Extras.swift
+)
+WEBKIT_TEST_SWIFT_HELPER_LIBRARY(TestWTFLibrary TestWTF)
+
+list(APPEND TestWTF_SOURCES
+    Tests/WTF/cocoa/SwiftCxxInteropTests.swift
+)
+
+add_library(TestWebKitAPILibrary OBJECT
+    ${TESTWEBKITAPI_DIR}/TestWebKitAPILibrary/TestWebKitAPILibrary.swift
+
+    ${TESTWEBKITAPI_DIR}/Helpers/WTFCompletionHandler+Extras.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/WTFExpected+Extras.swift
+
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/AppKit+Extras.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/Bundle+Extras.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/CocoaTypes.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/Foundation+Extras.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/HTTPServer.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/ImageAnalysisTestingUtilities.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/JavaScriptMessages.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/JavaScriptTypes.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/PDFTestHelpers.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/SafeBrowsingTestUtilities.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/StdLibExtras.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/SwiftUI+Extras.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/TestCocoaImageUtilities.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/TestPDFDocument.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/WebPage+Extras.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/WebPage+JavaScriptExpression.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/WebPageConfiguration+Extras.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/WKWebView+Extras.swift
+)
+WEBKIT_TEST_SWIFT_HELPER_LIBRARY(TestWebKitAPILibrary TestWebKit)
+target_include_directories(TestWebKitAPILibrary PRIVATE
+    ${TestWebKit_PRIVATE_INCLUDE_DIRECTORIES}
+)
+webkit_target_add_swift_options(TestWebKitAPILibrary
+    "-import-objc-header ${TESTWEBKITAPI_DIR}/Runner/TestWebKitAPI-Bridging-Header.h"
+)
+
+list(APPEND TestWebKit_SOURCES
+    Tests/WebKit/WKWebView/CodingTests.swift
+    Tests/WebKit/WKWebView/WKWebViewSwiftOverlayTests.swift
+
+    Tests/WebKit/WebPage/ControlledByExternalAgent.swift
+    Tests/WebKit/WebPage/EditingFontSizeTests.swift
+    Tests/WebKit/WebPage/JSHandleTests.swift
+    Tests/WebKit/WebPage/JavaScriptEvaluationTests.swift
+    Tests/WebKit/WebPage/JavaScriptExpressionTests.swift
+    Tests/WebKit/WebPage/NavigatorWebDriverOverride.swift
+    Tests/WebKit/WebPage/SendInspectorMessage.swift
+    Tests/WebKit/WebPage/SimulateClickOverTextTests.swift
+    Tests/WebKit/WebPage/URLSchemeHandlerTests.swift
+    Tests/WebKit/WebPage/UserContentControllerTests.swift
+    Tests/WebKit/WebPage/WebPageNavigationTests.swift
+)
+
+# FIXME: Support WebKitAdditions and tests which need the _WebKit_SwiftUI cross-import overlay linked.
 
 # TestWebKitAPIBase needs framework headers for config.h includes.
 target_include_directories(TestWebKitAPIBase PRIVATE ${_testapi_framework_headers})


### PR DESCRIPTION
#### a85255614c4bb3b3462df62177fa8eb700c923e9
<pre>
[CMake] Support Swift Testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=323922">https://bugs.webkit.org/show_bug.cgi?id=323922</a>
<a href="https://rdar.apple.com/187156324">rdar://187156324</a>

Reviewed by Elliott Williams.

Support most of the existing Swift Testing tests in CMake.

- Set the `ENABLE_CXX_INTEROP` active compilation condition
- Add the clang and swift modules to the search paths
- Create two object libraries for Swift helpers to live in
- Make the module names follow the product names
- Get the Testing macros to compile by adding libTestingMacros.

* Tools/TestWebKitAPI/PlatformCocoa.cmake:

Canonical link: <a href="https://commits.webkit.org/320899@main">https://commits.webkit.org/320899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0338144ccfbc41faee3696a2ee2843e2ebc1aa5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60143 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196536 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c0fefb38-e5d1-4d5c-af96-ca2971cc4395) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59853 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145528 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b6eda6f2-74f5-48db-97b2-8dce05b20d23) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49207 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125866 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f8880081-0067-4bc5-9ed3-008b5c48ab88) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47936 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/158288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7610 "Built successfully") | | 
| | | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/50377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198523 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59799 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/155097 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60509 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154740 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28272 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/49175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129944 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58936 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58338 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58555 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58402 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->