### PR TITLE
DataTransferItemList.clear() ignores the drag data store mode

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-clear-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-clear-expected.txt
@@ -1,0 +1,4 @@
+
+PASS clear() removes string items from a read/write drag data store
+PASS clear() removes file items from a read/write drag data store
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-clear-read-only-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-clear-read-only-expected.txt
@@ -1,0 +1,5 @@
+Drag me
+Drop here
+
+PASS DataTransferItemList.clear() is a no-op in the protected and read-only modes
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-clear-read-only.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-clear-read-only.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>DataTransferItemList.clear() does nothing outside the read/write mode</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransferitemlist-clear">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-store">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+  #source { width: 80px; height: 80px; background: cornflowerblue; }
+  #target { width: 120px; height: 120px; background: lightgreen; }
+</style>
+
+<div id="source" draggable="true">Drag me</div>
+<div id="target">Drop here</div>
+
+<script>
+const PAYLOAD = 'drag-payload';
+
+function centerOf(elem) {
+    const r = elem.getBoundingClientRect();
+    return { x: Math.round(r.left + r.width / 2),
+             y: Math.round(r.top + r.height / 2) };
+}
+
+promise_test(async t => {
+    const source = document.getElementById('source');
+    const target = document.getElementById('target');
+
+    const protectedMode = { calls: 0 };
+    const readOnlyMode = { calls: 0 };
+
+    source.addEventListener('dragstart', e => {
+        e.dataTransfer.setData('text/plain', PAYLOAD);
+    });
+
+    target.addEventListener('dragenter', e => e.preventDefault());
+
+    target.addEventListener('dragover', e => {
+        e.preventDefault();
+        if (protectedMode.calls++)
+            return;
+        const items = e.dataTransfer.items;
+        protectedMode.lengthBefore = items.length;
+        try {
+            items.clear();
+        } catch (exception) {
+            protectedMode.exception = exception;
+        }
+        protectedMode.lengthAfter = items.length;
+    });
+
+    target.addEventListener('drop', e => {
+        e.preventDefault();
+        readOnlyMode.calls++;
+        const items = e.dataTransfer.items;
+        readOnlyMode.dataBefore = e.dataTransfer.getData('text/plain');
+        readOnlyMode.lengthBefore = items.length;
+        try {
+            items.clear();
+        } catch (exception) {
+            readOnlyMode.exception = exception;
+        }
+        readOnlyMode.lengthAfter = items.length;
+        readOnlyMode.dataAfter = e.dataTransfer.getData('text/plain');
+        readOnlyMode.typesAfter = Array.from(e.dataTransfer.types);
+    });
+
+    const from = centerOf(source);
+    const to = centerOf(target);
+
+    await new test_driver.Actions()
+        .addPointer('mouse', 'mouse')
+        .pointerMove(from.x, from.y)
+        .pointerDown()
+        .pause(200)
+        .pointerMove(to.x, to.y)
+        .pause(50)
+        .pointerMove(to.x, to.y + 1)
+        .pause(50)
+        .pointerUp()
+        .send();
+
+    assert_greater_than(protectedMode.calls, 0, 'dragover fired on the drop target');
+    assert_equals(readOnlyMode.calls, 1, 'drop fired on the drop target');
+
+    assert_equals(protectedMode.exception, undefined,
+        'clear() during dragover should not throw');
+    assert_equals(protectedMode.lengthAfter, protectedMode.lengthBefore,
+        'clear() during dragover (protected mode) should not remove any item');
+
+    assert_equals(readOnlyMode.dataBefore, PAYLOAD,
+        'clear() during dragover (protected mode) should not discard the drag data');
+
+    assert_equals(readOnlyMode.exception, undefined,
+        'clear() during drop should not throw');
+    assert_greater_than(readOnlyMode.lengthBefore, 0,
+        'the drop event exposes the dragged item');
+    assert_equals(readOnlyMode.lengthAfter, readOnlyMode.lengthBefore,
+        'clear() during drop (read-only mode) should not remove any item');
+    assert_equals(readOnlyMode.dataAfter, PAYLOAD,
+        'clear() during drop (read-only mode) should not discard the drag data');
+    assert_true(readOnlyMode.typesAfter.includes('text/plain'),
+        'clear() during drop (read-only mode) should not discard the types');
+}, 'DataTransferItemList.clear() is a no-op in the protected and read-only modes');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-clear.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-clear.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>DataTransferItemList.clear() in the read/write mode removes all items</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransferitemlist-clear">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+test(t => {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add('hello', 'text/plain');
+    dataTransfer.items.add('<b>hello</b>', 'text/html');
+    assert_equals(dataTransfer.items.length, 2, 'two string items were added');
+
+    dataTransfer.items.clear();
+
+    assert_equals(dataTransfer.items.length, 0, 'clear() removed every item');
+    assert_equals(dataTransfer.types.length, 0, 'clear() removed every type');
+    assert_equals(dataTransfer.getData('text/plain'), '', 'the text/plain data is gone');
+}, 'clear() removes string items from a read/write drag data store');
+
+test(t => {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add('hello', 'text/plain');
+    dataTransfer.items.add(new File(['contents'], 'file.txt', { type: 'text/plain' }));
+    assert_equals(dataTransfer.items.length, 2, 'one string item and one file item were added');
+    assert_equals(dataTransfer.files.length, 1, 'the file item is exposed through files');
+
+    dataTransfer.items.clear();
+
+    assert_equals(dataTransfer.items.length, 0, 'clear() removed every item');
+    assert_equals(dataTransfer.files.length, 0, 'clear() emptied the file list');
+}, 'clear() removes file items from a read/write drag data store');
+</script>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -482,6 +482,7 @@ imported/w3c/web-platform-tests/html/editing/editing-0/spelling-and-grammar-chec
 # Drag-and-drop testdriver automation is not supported on GTK/WPE.
 webkit.org/b/66547 imported/w3c/web-platform-tests/html/editing/dnd/events/dragenter-dragleave-related-target.html [ Skip ]
 webkit.org/b/66547 fast/events/drag-relatedTarget.html [ Skip ]
+imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-clear-read-only.html [ Skip ]
 
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-pre-N-between-Rs.html [ Pass ]
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-N-between-Rs.html [ Pass ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -6927,6 +6927,7 @@ imported/w3c/web-platform-tests/html/editing/focus/sequential-focus-navigation-a
 
 # Drag-and-drop testdriver automation is not supported on iOS.
 webkit.org/b/66547 imported/w3c/web-platform-tests/html/editing/dnd/events/dragenter-dragleave-related-target.html [ Skip ]
+imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-clear-read-only.html [ Skip ]
 
 ######################################################
 # Test failures from turning GPU Process on by default

--- a/Source/WebCore/dom/DataTransferItemList.cpp
+++ b/Source/WebCore/dom/DataTransferItemList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -129,9 +129,13 @@ ExceptionOr<void> DataTransferItemList::remove(unsigned index)
     return { };
 }
 
+// https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransferitemlist-clear
 void DataTransferItemList::clear()
 {
-    Ref dataTransfer = m_dataTransfer.get();
+    Ref dataTransfer = m_dataTransfer;
+    if (!dataTransfer->canWriteData())
+        return;
+
     dataTransfer->pasteboard().clear();
     bool removedItemContainingFile = false;
     if (m_items) {


### PR DESCRIPTION
#### 94a1cd4ef3a758acbc871df5501a1ed1563bef18
<pre>
DataTransferItemList.clear() ignores the drag data store mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=323928">https://bugs.webkit.org/show_bug.cgi?id=323928</a>
<a href="https://rdar.apple.com/187160061">rdar://187160061</a>

Reviewed by Chris Dumez.

<a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransferitemlist-clear">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransferitemlist-clear</a> says:

    The clear() method, if the DataTransferItemList object is in the read/write
    mode, must remove all the items from the drag data store. Otherwise, it must
    do nothing.

WebKit performed the removal unconditionally. add() and remove() in the same class
already implement their own mode checks to the letter -- add() returns null and
remove() throws an InvalidStateError -- so clear() was the one mutating method
missing its guard.

The store is in the protected mode during dragenter/dragover/dragleave/dragend and
in the read-only mode during drop, and in each of those cases the DataTransfer is
backed by the real drag pasteboard rather than a StaticPasteboard. Calling
items.clear() from such a handler therefore reached Pasteboard::clear(), which on
macOS is setTypes({}) on the live NSPasteboardNameDrag, letting a page destroy the
drag payload mid-drag; dropped items.length to zero on a store it was only allowed
to read; and, for a file-backed item, tripped ASSERT(canWriteData()) in
DataTransfer::updateFileList().

Add the missing canWriteData() guard, matching Blink and Gecko, which both already
early-return here. Uses that are genuinely read/write -- a DataTransfer from the
constructor, or the one exposed during dragstart -- are unaffected, which the first
test below pins down.

As drive-by, also drop get().

Tests: imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-clear-read-only.html
       imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-clear.html

* LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-clear-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-clear-read-only-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-clear-read-only.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/editing/dnd/datastore/datatransferitemlist-clear.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/dom/DataTransferItemList.cpp:
(WebCore::DataTransferItemList::clear):

Canonical link: <a href="https://commits.webkit.org/320919@main">https://commits.webkit.org/320919@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fc25d8024ec239d06d24ce555a424d9f1ba2954

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196587 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7c0e86eb-1c43-4a3c-a185-d7647f294ebc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59905 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145562 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/71442525-8c1e-40ad-9ef2-e29be455e1ce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49242 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/166084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125905 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d7bc73f-080d-426c-b300-c80013fc3ac7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47971 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158322 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45680 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7661 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50412 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198574 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59851 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165612 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155136 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41557 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60562 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154779 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49207 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130010 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58986 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20659 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58389 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58605 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58454 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->