### PR TITLE
Cherry-pick 320827@main (c815e1d4f374). https://bugs.webkit.org/show_bug.cgi?id=323875

### DIFF
--- a/Source/WebKit/WPEPlatform/docs/compiling.md
+++ b/Source/WebKit/WPEPlatform/docs/compiling.md
@@ -1,8 +1,6 @@
 Title: Compiling against WPEPlatform
 Slug: compiling
 
-# Compiling against WPEPlatform
-
 This page lists the `pkg-config` modules and headers an application or
 browser needs to build against WPEPlatform, plus minimal
 [CMake](https://cmake.org) and [Meson](https://mesonbuild.com/)

--- a/Source/WebKit/WPEPlatform/docs/overview.md
+++ b/Source/WebKit/WPEPlatform/docs/overview.md
@@ -1,8 +1,6 @@
 Title: Overview
 Slug: overview
 
-# Overview
-
 WPEPlatform is a GObject library that abstracts the platform layer for
 WPE WebKit. It is the successor to [libwpe](https://github.com/WebKit/libwpe)
 and the various out-of-tree backends written against it (notably

--- a/Source/WebKit/WPEPlatform/docs/tutorial-browser.md
+++ b/Source/WebKit/WPEPlatform/docs/tutorial-browser.md
@@ -1,8 +1,6 @@
 Title: How to Use WPE Platform to Create a WPE WebKit Browser
 Slug: tutorial-browser
 
-# How to Use WPE Platform to Create a WPE WebKit Browser
-
 This tutorial walks through writing the smallest useful WPE WebKit
 browser: a single window that loads a URL and runs a GLib main loop.
 It is aimed at application developers who are starting a new project

--- a/Source/WebKit/WPEPlatform/docs/tutorial-platform.md
+++ b/Source/WebKit/WPEPlatform/docs/tutorial-platform.md
@@ -1,8 +1,6 @@
 Title: Writing a WPE platform implementation
 Slug: tutorial-platform
 
-# Writing a WPE platform implementation
-
 WPE WebKit renders web content, but it does not talk to the underlying
 platform on its own. That job belongs to a *platform implementation*: a
 small set of GObject subclasses that connect WebKit to a display


### PR DESCRIPTION
#### 9786d52aded11781d9da7f44670f7bf4fa8a59f4
<pre>
Cherry-pick 320827@main (c815e1d4f374). <a href="https://bugs.webkit.org/show_bug.cgi?id=323875">https://bugs.webkit.org/show_bug.cgi?id=323875</a>

    [WPE] Remove duplicate headings in the new API documentation
    <a href="https://bugs.webkit.org/show_bug.cgi?id=323875">https://bugs.webkit.org/show_bug.cgi?id=323875</a>

    Reviewed by Adrian Perez de Castro.

    These headings are redundant with the page names and render as a double
    title. Remove.

    * Source/WebKit/WPEPlatform/docs/compiling.md:
    * Source/WebKit/WPEPlatform/docs/overview.md:
    * Source/WebKit/WPEPlatform/docs/tutorial-browser.md:
    * Source/WebKit/WPEPlatform/docs/tutorial-platform.md:

    Canonical link: <a href="https://commits.webkit.org/320827@main">https://commits.webkit.org/320827@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.262@webkitglib/2.54">https://commits.webkit.org/317695.262@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c6ca836bff37478beeb6d3602bc2fe9c12960a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186226 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/60113 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53887 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196507 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150772 "The change is no longer eligible for processing.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/61493 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59823 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145498 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150772 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189181 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/61493 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53887 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125833 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/61493 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59823 "The change is no longer eligible for processing.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53887 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/61493 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53887 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7579 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52608 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59823 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198493 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59769 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53887 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155067 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/60479 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53887 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154710 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28270 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/60479 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132735 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129892 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58906 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53887 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/58308 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58526 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/58372 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->