### PR TITLE
Null-pointer crash in `FileSystemWritableFileStreamSink::write()` when the document is detached from its frame

### DIFF
--- a/LayoutTests/storage/filesystemaccess/writable-file-stream-detached-frame-expected.txt
+++ b/LayoutTests/storage/filesystemaccess/writable-file-stream-detached-frame-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Writing to a FileSystemWritableFileStream whose realm was detached from its frame does not crash
+

--- a/LayoutTests/storage/filesystemaccess/writable-file-stream-detached-frame.html
+++ b/LayoutTests/storage/filesystemaccess/writable-file-stream-detached-frame.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+async_test(t => {
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+
+    // Create the stream in the subframe's realm so that its context resolves to the subframe's document.
+    const createStream = iframe.contentWindow.eval(`(async function() {
+        const root = await navigator.storage.getDirectory();
+        await root.removeEntry("writable-file-stream-detached-frame.txt").then(() => { }, () => { });
+        const handle = await root.getFileHandle("writable-file-stream-detached-frame.txt", { create: true });
+        return await handle.createWritable();
+    })`);
+
+    createStream().then(t.step_func(stream => {
+        iframe.remove();
+
+        // The returned promise never settles, because promises of a stopped document are inert.
+        stream.write("chunk");
+
+        t.step_timeout(() => t.done(), 0);
+    }), t.unreached_func("Could not create stream in subframe"));
+}, "Writing to a FileSystemWritableFileStream whose realm was detached from its frame does not crash");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.cpp
+++ b/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,6 +36,7 @@
 #include "JSDOMConvertDictionary.h"
 #include "JSDOMConvertInterface.h"
 #include "JSDOMConvertUnion.h"
+#include "JSDOMGlobalObject.h"
 #include "JSDOMPromiseDeferred.h"
 #include <JavaScriptCore/ArrayBufferView.h>
 #include <JavaScriptCore/JSArrayBuffer.h>
@@ -136,8 +137,13 @@ FileSystemWritableFileStreamSink::~FileSystemWritableFileStreamSink()
 
 static ExceptionOr<FileSystemWritableFileStream::ChunkType> convertFileSystemWritableChunk(ScriptExecutionContext& context, JSC::JSValue value)
 {
-    auto scope = DECLARE_THROW_SCOPE(context.vm());
-    auto chunkResult = convert<IDLUnion<IDLArrayBufferView, IDLArrayBuffer, IDLInterface<Blob>, IDLUSVString, IDLDictionary<FileSystemWritableFileStream::WriteParams>>>(*context.globalObject(), value);
+    // ScriptExecutionContext::globalObject() is null once a document has been detached from its frame.
+    auto* globalObject = downcast<JSDOMGlobalObject>(context.globalObject());
+    if (!globalObject) [[unlikely]]
+        return Exception { ExceptionCode::InvalidStateError, "Global object is invalid"_s };
+
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    auto chunkResult = convert<IDLUnion<IDLArrayBufferView, IDLArrayBuffer, IDLInterface<Blob>, IDLUSVString, IDLDictionary<FileSystemWritableFileStream::WriteParams>>>(*globalObject, value);
     if (chunkResult.hasException(scope)) [[unlikely]]
         return Exception { ExceptionCode::ExistingExceptionError };
 


### PR DESCRIPTION
#### 1e0fe8b882354c3c876de0e3f92028c8e82ed984
<pre>
Null-pointer crash in `FileSystemWritableFileStreamSink::write()` when the document is detached from its frame
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=323938">https://bugs.webkit.org/show_bug.cgi?id=323938</a>&gt;
&lt;<a href="https://rdar.apple.com/164580967">rdar://164580967</a>&gt;

Reviewed by Youenn Fablet.

`WritableStreamSink::write()` is called with the `ScriptExecutionContext`
of the current realm, and `FileSystemWritableFileStreamSink::write()`
re-derived a global object from it with
`ScriptExecutionContext::globalObject()`. For a `Document` that getter
goes through `Document::frame()`, so it returns null as soon as the
document has been detached from its frame, and
`convertFileSystemWritableChunk()` then dereferenced null when reading
`JSGlobalObject::m_vm` (offset 0x38) at the top of the generated union
converter for `FileSystemWriteChunkType`.

Script of a detached realm can still run - e.g. a microtask that was
queued before the frame went away, or a function of that realm still
referenced from another frame - so a `write()` can reach the sink after
detach. Null-check the global object and error the stream out with
`InvalidStateError` instead, which is what the other
`WritableStreamSink::write()` implementations already do
(`WebTransportSendStreamSink::write()`, `DatagramSink::write()` and
`RTCEncodedStreamProducer::writeFrame()`).

Test: storage/filesystemaccess/writable-file-stream-detached-frame.html

* LayoutTests/storage/filesystemaccess/writable-file-stream-detached-frame-expected.txt: Added.
* LayoutTests/storage/filesystemaccess/writable-file-stream-detached-frame.html: Added.
* Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.cpp:
(WebCore::convertFileSystemWritableChunk): Derive the `JSDOMGlobalObject`
from the context here and return an `InvalidStateError` exception when it
is null, so a detached realm is handled through the existing exception path.
(WebCore::FileSystemWritableFileStreamSink::write): Pass the context to
`convertFileSystemWritableChunk()` and reject and abort the writable via
its returned exception, dropping the separate null global object check.

Canonical link: <a href="https://commits.webkit.org/320949@main">https://commits.webkit.org/320949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15d5dde7ef85c3f7271d365ec457c11984086667

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196652 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145605 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166125 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125954 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48019 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45722 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7726 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198639 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59915 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165654 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155192 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60626 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154829 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28299 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49250 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130092 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59050 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20701 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58453 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58669 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58519 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->