### PR TITLE
Web Inspector: Network: REGRESSION(?): network emulation tab bar icon is inverted in dark mode

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/NetworkTabContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkTabContentView.css
@@ -23,6 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+.tab-bar > .tabs > .item.network.emulated > .icon {
+    --tab-bar-icon-filter-override: none;
+}
+
 .content-view.network > .content-browser {
     position: absolute;
     top: 0;

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkTabContentView.js
@@ -41,18 +41,16 @@ WI.NetworkTabContentView = class NetworkTabContentView extends WI.TabContentView
         this.addSubview(this._contentBrowser);
 
         WI.networkManager.addEventListener(WI.NetworkManager.Event.EmulatedConditionChanged, this._handleEmulatedConditionChanged, this);
+        this._handleEmulatedConditionChanged();
     }
 
     // Static
 
     static tabInfo()
     {
-        let hasEmulatedCondition = WI.networkManager.emulatedCondition !== WI.NetworkManager.EmulatedCondition.None;
-
         return {
             identifier: NetworkTabContentView.Type,
-            image: hasEmulatedCondition ? "Images/Warning.svg" : "Images/Network.svg",
-            title: hasEmulatedCondition ? WI.UIString("Network throttling is enabled") : "",
+            image: "Images/Network.svg",
             displayName: WI.UIString("Network", "Network Tab Name", "Name of Network Tab"),
         };
     }
@@ -142,6 +140,7 @@ WI.NetworkTabContentView = class NetworkTabContentView extends WI.TabContentView
 
         this.tabBarItem.image = hasEmulatedCondition ? "Images/Warning.svg" : "Images/Network.svg";
         this.tabBarItem.title = hasEmulatedCondition ? WI.UIString("Network throttling is enabled") : "";
+        this.tabBarItem.element.classList.toggle("emulated", hasEmulatedCondition);
     }
 };
 

--- a/Source/WebInspectorUI/UserInterface/Views/TabBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TabBar.css
@@ -240,6 +240,8 @@ body.window-inactive .tab-bar > .tabs > .item:not(.disabled).selected {
     opacity: 0.55; /* Assumes black glyphs. */
 
     -webkit-user-drag: none;
+
+    filter: var(--tab-bar-icon-filter-override, var(--tab-bar-icon-filter-default));
 }
 
 .tab-bar > .tabs > .item.pinned > .icon {
@@ -381,7 +383,7 @@ body.window-inactive .tab-bar > .tabs.animating.closing-tab > .item:not(.disable
     }
 
     .tab-bar > .tabs > .item > .icon {
-        filter: var(--filter-invert);
+        --tab-bar-icon-filter-default: var(--filter-invert);
     }
 
     .tab-bar > .tabs:not(.animating) > .item:not(.selected, .disabled):hover > .icon {

--- a/Source/WebInspectorUI/UserInterface/Views/TabBarItem.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TabBarItem.js
@@ -28,6 +28,11 @@ WI.TabBarItem = class TabBarItem
 {
     constructor(representedObject, image, displayName, title)
     {
+        // This class should not be instantiated directly. Create a concrete subclass instead.
+        console.assert(this.constructor !== WI.TabBarItem && this instanceof WI.TabBarItem, this);
+
+        console.assert(representedObject instanceof WI.TabContentView, representedObject);
+
         this._representedObject = representedObject || null;
         this._parentTabBar = null;
 
@@ -36,6 +41,9 @@ WI.TabBarItem = class TabBarItem
         this._element.setAttribute("role", "tab");
         this._element.tabIndex = 0;
         this._element[WI.TabBarItem.ElementReferenceSymbol] = this;
+
+        if (this._representedObject)
+            this._element.classList.add(this._representedObject.identifier);
 
         this._element.createChild("div", "flex-space");
 


### PR DESCRIPTION
#### 7bc684074c22e4cdb3bbdac8b885db39203b7150
<pre>
Web Inspector: Network: REGRESSION(?): network emulation tab bar icon is inverted in dark mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=323940">https://bugs.webkit.org/show_bug.cgi?id=323940</a>

Reviewed by NOBODY (OOPS!).

* Source/WebInspectorUI/UserInterface/Views/TabBarItem.js:
(WI.TabBarItem):
Add the `WI.TabContentView.prototype.get identifier` as a CSS class for instances to target.

* Source/WebInspectorUI/UserInterface/Views/TabBar.css:
(.tab-bar &gt; .tabs &gt; .item &gt; .icon):
(@media (prefers-color-scheme: dark) .tab-bar &gt; .tabs &gt; .item &gt; .icon):
Allow instances to override the `filter` of the `&lt;img&gt;` as needed.

* Source/WebInspectorUI/UserInterface/Views/NetworkTabContentView.js:
(WI.NetworkTabContentView):
(WI.NetworkTabContentView.tabInfo):
(WI.NetworkTabContentView.prototype._handleEmulatedConditionChanged):
* Source/WebInspectorUI/UserInterface/Views/NetworkTabContentView.css:
(.tab-bar &gt; .tabs &gt; .item.network.emulated &gt; .icon): Added.
Use the above to prevent the dark mode `--filter-invert` from being used when network emulation is active.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bc684074c22e4cdb3bbdac8b885db39203b7150

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196546 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150804 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145538 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100882 "2 flakes 14 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125879 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47942 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45917 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158294 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45655 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7620 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52640 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50385 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198533 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59810 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155102 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60520 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154745 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49180 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132766 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129956 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58947 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20634 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58349 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58564 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->