### PR TITLE
[CMake] Support test-lldb-webkit

### DIFF
--- a/Tools/PlatformCocoa.cmake
+++ b/Tools/PlatformCocoa.cmake
@@ -37,4 +37,11 @@ if (ENABLE_WEBKIT_TEST_RUNNER AND ENABLE_WEBKIT)
     )
 endif ()
 
+# Exercises the lldb summary providers and dump_class_layout (Tools/Scripts/test-lldb-webkit).
+# Only needs WTF, so it is not gated on ENABLE_WEBKIT.
+option(ENABLE_LLDB_WEBKIT_TESTER "Build lldbWebKitTester for the Tools/lldb tests" ON)
+if (ENABLE_LLDB_WEBKIT_TESTER)
+    add_subdirectory(lldb/lldbWebKitTester)
+endif ()
+
 endif ()

--- a/Tools/Scripts/build-lldbwebkittester
+++ b/Tools/Scripts/build-lldbwebkittester
@@ -65,6 +65,14 @@ checkRequiredSystemConfig();
 setConfiguration();
 chdirWebKit();
 
+if (isCMakeBuild()) {
+    if ($clean) {
+        print STDERR "--clean is not supported for the CMake build; it would clean the whole build directory.\n";
+        exit 1;
+    }
+    exit(buildCMakeProjectOrExit(0, "", "lldbWebKitTester"));
+}
+
 my @xcodeOptions = XcodeOptions();
 
 $result = exitStatus(buildXcodeScheme("lldbWebKitTester", $clean, @xcodeOptions, @ARGV));

--- a/Tools/Scripts/test-lldb-webkit
+++ b/Tools/Scripts/test-lldb-webkit
@@ -79,6 +79,12 @@ class LldbTester(Tester):
         parser.add_argument('--configuration',
                             dest='configuration', action='store',
                             default=None, help='Set configuration (Debug/Release/ASan/ect.) to build and test the lldb test runner with.')
+        parser.add_argument('--cmake',
+                            dest='use_cmake', action='store_true',
+                            default=False, help='Use the CMake build tree (e.g. WebKitBuild/cmake-mac/<configuration>) instead of the default Xcode tree')
+        parser.add_argument('--xcode',
+                            dest='use_xcode', action='store_true',
+                            default=False, help='Use the Xcode build tree (e.g. WebKitBuild/<configuration>); overrides last-built auto-detection')
         parser.add_argument('names', nargs='*',
                             default=None, help='Name (or names) of test, or test suite, to be run. lldb_webkit_unittest.TestSummaryProviders and dump_class_layout_unittest.TestDumpClassLayout are two examples')
         return parser.parse_args()
@@ -95,16 +101,22 @@ class LldbTester(Tester):
             _log.error('No tests to run')
             return False
 
-        config = Config(host.executive, self.finder.filesystem)
+        config = Config(host.executive, self.finder.filesystem,
+                        use_cmake=self._options.use_cmake, use_xcode=self._options.use_xcode)
         configuration_to_use = self._options.configuration or config.default_configuration()
         self.upload_style = configuration_to_use.lower()
 
         if (not self._options.root and self._options.build is None) or self._options.build:
             self.printer.write_update('Building lldbWebKitTester ...')
             build_lldbwebkittester = self.finder.filesystem.join(webkit_root, 'Tools', 'Scripts', 'build-lldbwebkittester')
+            build_command = [build_lldbwebkittester, config.flag_for_configuration(configuration_to_use)]
+            if self._options.use_cmake:
+                build_command.append('--cmake')
+            if self._options.use_xcode:
+                build_command.append('--xcode')
             try:
                 host.executive.run_and_throw_if_fail(
-                    [build_lldbwebkittester, config.flag_for_configuration(configuration_to_use)],
+                    build_command,
                     quiet=(not bool(self._options.verbose)),
                 )
             except ScriptError as e:

--- a/Tools/lldb/lldbWebKitTester/CMakeLists.txt
+++ b/Tools/lldb/lldbWebKitTester/CMakeLists.txt
@@ -1,0 +1,36 @@
+set(lldbWebKitTester_SOURCES
+    DumpClassLayoutTesting.cpp
+    main.cpp
+)
+
+set(lldbWebKitTester_PRIVATE_INCLUDE_DIRECTORIES
+    ${CMAKE_BINARY_DIR}  # cmakeconfig.h
+)
+
+# The lldb summary providers and dump_class_layout need WTF's debug info in
+# this executable's own image, not in a separate framework, so link WTF and
+# bmalloc directly instead of through JavaScriptCore.
+set(lldbWebKitTester_FRAMEWORKS
+    WTF
+    bmalloc
+)
+
+set(lldbWebKitTester_PRIVATE_LIBRARIES
+    "-framework Cocoa"
+    "-framework Security"
+)
+
+WEBKIT_EXECUTABLE_DECLARE(lldbWebKitTester)
+WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
+WEBKIT_EXECUTABLE(lldbWebKitTester)
+
+# This test works by putting unnused class layouts into the binary, so it
+# always needs -O0, full debug info, and unused warnings silenced.
+target_compile_options(lldbWebKitTester PRIVATE
+    -O0
+    -g
+    -Wno-unused-private-field
+    -Wno-unused-variable
+)
+target_compile_definitions(lldbWebKitTester PRIVATE
+    $<$<NOT:$<CONFIG:Debug>>:RELEASE_WITHOUT_OPTIMIZATIONS>)


### PR DESCRIPTION
#### e47f34d384fec314997e7a119aae5ff5af8a4b1c
<pre>
[CMake] Support test-lldb-webkit
<a href="https://bugs.webkit.org/show_bug.cgi?id=323943">https://bugs.webkit.org/show_bug.cgi?id=323943</a>
<a href="https://rdar.apple.com/187182595">rdar://187182595</a>

Reviewed by Richard Robinson.

Add a CMakeLists.txt to the lldbWebKitTester directory and teach the
relevant scripts how to build it. It&apos;s a tiny target, so build it by
default.

* Tools/PlatformCocoa.cmake:
* Tools/Scripts/build-lldbwebkittester:
* Tools/Scripts/test-lldb-webkit:
(LldbTester.parse_args):
(LldbTester.run):
* Tools/lldb/lldbWebKitTester/CMakeLists.txt: Added.

Canonical link: <a href="https://commits.webkit.org/320945@main">https://commits.webkit.org/320945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2bcb0814251f1fa3c7dec9645f828bbd93bcb7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196552 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150808 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145540 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189229 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125881 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47948 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45919 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158300 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45662 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7626 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50389 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198539 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59816 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155109 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/41577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60526 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42232 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154752 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28296 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49181 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129963 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58952 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20641 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58354 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58569 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58419 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->