### PR TITLE
[Swift Testing] Add a style checker rule to ensure tests aren't missed from Xcode and/or CMake

### DIFF
--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -65,6 +65,7 @@ from webkitpy.style.checkers.api_test_allowlist import APITestAllowlistChecker
 from webkitpy.style.checkers.api_test_expectations import APITestExpectationsChecker
 from webkitpy.style.checkers.swift import SwiftChecker
 from webkitpy.style.checkers.swift_association import SwiftAssociationChecker
+from webkitpy.style.checkers.swift_build_registration import SwiftBuildRegistrationChecker
 from webkitpy.style.checkers.test_expectations import TestExpectationsChecker
 from webkitpy.style.checkers.text import TextChecker
 from webkitpy.style.checkers.watchlist import WatchListChecker
@@ -699,6 +700,7 @@ def _all_categories():
     categories = categories.union(XcodeSchemeChecker.categories)
     categories = categories.union(SwiftChecker.categories)
     categories = categories.union(SwiftAssociationChecker.categories)
+    categories = categories.union(SwiftBuildRegistrationChecker.categories)
 
     # FIXME: Consider adding all of the pep8 categories.  Since they
     #        are not too meaningful for documentation purposes, for
@@ -1364,6 +1366,8 @@ class StyleProcessor(ProcessorBase):
         APITestExpectationsChecker.lint_test_expectations(files, self._configuration, cwd, self._increment_error_count, host=host)
 
         SwiftAssociationChecker.check_associations(files, self._configuration, cwd, self._increment_error_count, host=host)
+
+        SwiftBuildRegistrationChecker.check_registrations(files, self._configuration, cwd, self._increment_error_count, host=host)
 
         wpt_dir = os.path.join('LayoutTests', *IMPORTED_WPT_DIR.split('/'))
         wpt_paths = []

--- a/Tools/Scripts/webkitpy/style/checkers/swift_build_registration.py
+++ b/Tools/Scripts/webkitpy/style/checkers/swift_build_registration.py
@@ -1,0 +1,216 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Checks that Swift test sources are registered in both the Xcode and the CMake build.
+"""
+
+import logging
+
+from webkitpy.common.host import Host
+from webkitpy.style.error_handlers import DefaultStyleErrorHandler
+
+
+_log = logging.getLogger(__name__)
+
+_CATEGORY = 'swift/buildsystem'
+
+_TEST_DIRECTORY = 'Tools/TestWebKitAPI'
+_PROJECT_FILE = _TEST_DIRECTORY + '/TestWebKitAPI.xcodeproj/project.pbxproj'
+_CMAKE_FILE = _TEST_DIRECTORY + '/PlatformCocoa.cmake'
+
+_CMAKE_DIRECTORY_VARIABLE = '${TESTWEBKITAPI_DIR}/'
+
+# Importing SwiftUI alongside WebKit pulls in the _WebKit_SwiftUI cross-import overlay,
+# which the CMake build cannot link yet.
+_SWIFTUI_MODULES = ('SwiftUI', '_WebKit_SwiftUI')
+
+# The folders holding Swift tests and their helpers, with the Xcode target a new source
+# there normally belongs to and where it belongs in PlatformCocoa.cmake.
+_DESTINATIONS = (
+    ('Tests/WTF/', 'TestWTF', 'the list(APPEND TestWTF_SOURCES ...) block'),
+    ('Tests/WebKit/', 'TestWebKitAPI', 'the list(APPEND TestWebKit_SOURCES ...) block'),
+    ('Helpers/', 'TestWebKitAPILibrary', 'the add_library(TestWebKitAPILibrary OBJECT ...) source list'),
+    ('TestWebKitAPILibrary/', 'TestWebKitAPILibrary', 'the add_library(TestWebKitAPILibrary OBJECT ...) source list'),
+    ('TestWTFLibrary/', 'TestWTFLibrary', 'the add_library(TestWTFLibrary OBJECT ...) source list'),
+)
+
+
+def build_file_entries(filesystem, path):
+    """Returns the set of paths a build file names, or None.
+
+    None means the file could not be read, or names no Swift source at all, which can
+    only mean its format changed.
+    """
+    try:
+        contents = filesystem.read_text_file(path)
+    except (IOError, OSError, UnicodeDecodeError) as error:
+        _log.debug("%s: cannot read '%s': %s" % (_CATEGORY, path, error))
+        return None
+
+    entries = set()
+    for line in contents.splitlines():
+        # A path is quoted only when it contains a space, and is followed by a comma in
+        # the Xcode project.
+        entry = line.strip().rstrip(',').strip('"')
+        if entry.startswith(_CMAKE_DIRECTORY_VARIABLE):
+            entry = entry[len(_CMAKE_DIRECTORY_VARIABLE):]
+        entries.add(entry)
+
+    if not any(entry.endswith('.swift') for entry in entries):
+        _log.debug("%s: no Swift sources named in '%s', skipping." % (_CATEGORY, path))
+        return None
+
+    return entries
+
+
+def _imports_swiftui(filesystem, absolute_path):
+    """Returns whether a Swift source imports SwiftUI, in any of the forms Swift allows."""
+    try:
+        contents = filesystem.read_text_file(absolute_path)
+    except (IOError, OSError, UnicodeDecodeError):
+        return False
+
+    for line in contents.splitlines():
+        words = line.split()
+        # Covers 'import SwiftUI', 'private import SwiftUI' and 'import struct SwiftUI.X'.
+        if len(words) < 2 or 'import' not in words or words[0].startswith('/'):
+            continue
+        if words[-1].split('.')[0] in _SWIFTUI_MODULES:
+            return True
+    return False
+
+
+def _destination(relative_path):
+    """Returns the Xcode target and the CMake source list for a path, or None."""
+    for prefix, target, source_list in _DESTINATIONS:
+        if relative_path.startswith(prefix):
+            return target, source_list
+    return None
+
+
+def _project_entry(relative_path):
+    """Returns how the Xcode project names a path.
+
+    Xcode names a source relative to the synchronized folder holding it, so
+    Tests/WebKit/WKWebView/CodingTests.swift appears as WebKit/WKWebView/CodingTests.swift.
+    """
+    return relative_path.split('/', 1)[1]
+
+
+def _is_newly_added(line_numbers, absolute_path, filesystem):
+    """Returns whether the patch adds the file, rather than modifying or removing it."""
+    # None means the file was removed, or that a whole file was checked outside of a patch.
+    if not line_numbers:
+        return False
+    if not filesystem.exists(absolute_path):
+        return False
+    # Every line of a newly added file is part of the patch, so the modified line numbers
+    # of such a file are exactly 1 through N.
+    return line_numbers == list(range(1, len(line_numbers) + 1))
+
+
+class SwiftBuildRegistrationChecker(object):
+    """Flags Swift test sources which reach only one of the two builds."""
+
+    categories = set([_CATEGORY])
+
+    @staticmethod
+    def check_registrations(files, configuration, cwd, increment_error_count=lambda: 0, host=None):
+        """Report Swift sources which are in the Xcode build or the CMake build but not both.
+
+        Args:
+            files: A dictionary mapping absolute file paths to the lists of lines
+                modified in each file. Removed files map to None.
+            configuration: A StyleProcessorConfiguration instance.
+            cwd: The root of the SCM checkout, used to relativize the file paths.
+            increment_error_count: Callable invoked once per reported error.
+            host: The current host (for testing).
+        """
+        host = host or Host()
+        filesystem = host.filesystem
+
+        test_directory = filesystem.join(cwd, *_TEST_DIRECTORY.split('/'))
+        project_path = filesystem.join(cwd, *_PROJECT_FILE.split('/'))
+        cmake_path = filesystem.join(cwd, *_CMAKE_FILE.split('/'))
+
+        added = []
+        removed = []
+        for absolute_path, line_numbers in files.items():
+            if not absolute_path.endswith('.swift'):
+                continue
+            if not absolute_path.startswith(test_directory + filesystem.sep):
+                continue
+            relative_path = filesystem.relpath(absolute_path, test_directory).replace(filesystem.sep, '/')
+            if not _destination(relative_path):
+                continue
+            if _is_newly_added(line_numbers, absolute_path, filesystem):
+                added.append((absolute_path, relative_path))
+            elif line_numbers is None and not filesystem.exists(absolute_path):
+                removed.append(relative_path)
+
+        # Both build files are only read when the patch can possibly be at fault.
+        if not added and not removed:
+            return
+
+        project_entries = build_file_entries(filesystem, project_path)
+        cmake_entries = build_file_entries(filesystem, cmake_path)
+        if project_entries is None or cmake_entries is None:
+            return
+
+        def report(absolute_path, message):
+            style_error_handler = DefaultStyleErrorHandler(
+                absolute_path, configuration, increment_error_count, files.get(absolute_path))
+            # Report at line 0 so the error is emitted regardless of which lines of the
+            # file the patch happened to touch.
+            style_error_handler(0, _CATEGORY, 5, message)
+
+        for absolute_path, relative_path in sorted(added, key=lambda entry: entry[1]):
+            target, source_list = _destination(relative_path)
+            in_xcode = _project_entry(relative_path) in project_entries
+            in_cmake = relative_path in cmake_entries or _imports_swiftui(filesystem, absolute_path)
+
+            if not in_xcode and not in_cmake:
+                report(absolute_path, (
+                    '{path} is in neither {project} nor {cmake}, so no build will compile it. '
+                    'Add it to both.').format(
+                        path=relative_path, project=_PROJECT_FILE, cmake=_CMAKE_FILE))
+            elif not in_xcode:
+                report(absolute_path, (
+                    '{path} is not named in {project}, so Xcode will not compile it. Select '
+                    'the file in Xcode and check {target} under Target Membership in the File '
+                    'Inspector.').format(
+                        path=relative_path, project=_PROJECT_FILE, target=target))
+            elif not in_cmake:
+                report(absolute_path, (
+                    '{path} is in the Xcode project but not in {cmake}, so the CMake build '
+                    'will not compile it. Add it to {source_list}.').format(
+                        path=relative_path, cmake=_CMAKE_FILE, source_list=source_list))
+
+        for relative_path in sorted(removed):
+            if _project_entry(relative_path) in project_entries:
+                report(project_path, (
+                    '{path} was removed but is still named in {project}. Remove it there '
+                    'too.').format(path=relative_path, project=_PROJECT_FILE))
+            if relative_path in cmake_entries:
+                report(cmake_path, (
+                    '{path} was removed but is still named in {cmake}. Remove it there '
+                    'too.').format(path=relative_path, cmake=_CMAKE_FILE))

--- a/Tools/Scripts/webkitpy/style/checkers/swift_build_registration_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/swift_build_registration_unittest.py
@@ -1,0 +1,276 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from unittest.mock import MagicMock
+
+from webkitpy.common.system.filesystem import FileSystem
+from webkitpy.common.system.filesystem_mock import MockFileSystem
+from webkitpy.common.webkit_finder import WebKitFinder
+from webkitpy.style.checkers.swift_build_registration import _imports_swiftui, build_file_entries, SwiftBuildRegistrationChecker
+
+
+CWD = '/mock-checkout'
+TEST_DIRECTORY = CWD + '/Tools/TestWebKitAPI'
+PROJECT_PATH = TEST_DIRECTORY + '/TestWebKitAPI.xcodeproj/project.pbxproj'
+CMAKE_PATH = TEST_DIRECTORY + '/PlatformCocoa.cmake'
+
+# Xcode names a source relative to the synchronized folder holding it, and quotes it only
+# when it contains a space.
+PROJECT_CONTENTS = '\n'.join([
+    '\t\t07AA27602F83C3A900FE10FC /* Exceptions for "Tests" folder in "TestWebKitAPI" target */ = {',
+    '\t\t\tisa = PBXFileSystemSynchronizedBuildFileExceptionSet;',
+    '\t\t\tmembershipExceptions = (',
+    '\t\t\t\t"WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift",',
+    '\t\t\t\tWebKit/WebPage/InBoth.swift,',
+    '\t\t\t\tWebKit/WebPage/OnlyInXcode.swift,',
+    '\t\t\t);',
+    '\t\t\ttarget = 8DD76F960486AA7600D96B5E /* TestWebKitAPI */;',
+    '\t\t};',
+    '\t\t07C907B32F820907003A09D8 /* Exceptions for "Helpers" folder in "TestWebKitAPILibrary" target */ = {',
+    '\t\t\tisa = PBXFileSystemSynchronizedBuildFileExceptionSet;',
+    '\t\t\tmembershipExceptions = (',
+    '\t\t\t\tcocoa/HTTPServer.swift,',
+    '\t\t\t);',
+    '\t\t\ttarget = 7CCE7E8B1A41144E00447C4C /* TestWebKitAPILibrary */;',
+    '\t\t};',
+])
+
+CMAKE_CONTENTS = '\n'.join([
+    'add_library(TestWebKitAPILibrary OBJECT',
+    '    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/HTTPServer.swift',
+    '    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/OnlyInCMake.swift',
+    ')',
+    '',
+    'list(APPEND TestWebKit_SOURCES',
+    '    Tests/WebKit/WebPage/InBoth.swift',
+    ')',
+    '',
+    '# FIXME: Support tests which need the _WebKit_SwiftUI cross-import overlay linked.',
+])
+
+
+class SwiftBuildRegistrationCheckerTest(unittest.TestCase):
+
+    def check(self, files, project_contents=PROJECT_CONTENTS, cmake_contents=CMAKE_CONTENTS,
+              existing_files=None, source='import Testing\n'):
+        """Runs the checker and returns the errors it reported as (file path, message)."""
+        contents = {}
+        if project_contents is not None:
+            contents[PROJECT_PATH] = project_contents
+        if cmake_contents is not None:
+            contents[CMAKE_PATH] = cmake_contents
+        # A file with modified lines is on disk; a file which was removed is not.
+        for path, line_numbers in files.items():
+            if line_numbers is not None:
+                contents.setdefault(path, source)
+        for path in existing_files or []:
+            contents.setdefault(path, source)
+
+        host = MagicMock()
+        host.filesystem = MockFileSystem(contents)
+        configuration = MagicMock()
+        configuration.is_reportable.return_value = True
+        increment_error_count = MagicMock()
+
+        SwiftBuildRegistrationChecker.check_registrations(
+            files, configuration, CWD, increment_error_count, host=host)
+
+        self.assertEqual(increment_error_count.call_count, configuration.write_style_error.call_count)
+        errors = []
+        for call in configuration.write_style_error.call_args_list:
+            self.assertEqual(call.kwargs['category'], 'swift/buildsystem')
+            self.assertEqual(call.kwargs['confidence_in_error'], 5)
+            # Reported at line 0 so the error survives whichever lines the patch touched.
+            self.assertEqual(call.kwargs['line_number'], 0)
+            errors.append((call.kwargs['file_path'], call.kwargs['message']))
+        return errors
+
+    @staticmethod
+    def added(path, line_count=3):
+        return {path: list(range(1, line_count + 1))}
+
+    def test_added_to_both_builds(self):
+        self.assertEqual(self.check(self.added(TEST_DIRECTORY + '/Tests/WebKit/WebPage/InBoth.swift')), [])
+
+    def test_helper_added_to_both_builds(self):
+        self.assertEqual(self.check(self.added(TEST_DIRECTORY + '/Helpers/cocoa/HTTPServer.swift')), [])
+
+    def test_added_to_xcode_only(self):
+        path = TEST_DIRECTORY + '/Tests/WebKit/WebPage/OnlyInXcode.swift'
+        errors = self.check(self.added(path))
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0][0], path)
+        self.assertIn('not in Tools/TestWebKitAPI/PlatformCocoa.cmake', errors[0][1])
+        self.assertIn('list(APPEND TestWebKit_SOURCES ...)', errors[0][1])
+
+    def test_added_to_cmake_only(self):
+        path = TEST_DIRECTORY + '/Helpers/cocoa/OnlyInCMake.swift'
+        errors = self.check(self.added(path))
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0][0], path)
+        self.assertIn('is not named in', errors[0][1])
+        self.assertIn('TestWebKitAPILibrary', errors[0][1])
+
+    def test_added_to_neither_build(self):
+        errors = self.check(self.added(TEST_DIRECTORY + '/Tests/WebKit/WebPage/Nowhere.swift'))
+        self.assertEqual(len(errors), 1)
+        self.assertIn('is in neither', errors[0][1])
+
+    def test_path_with_spaces_is_quoted_in_the_xcode_project(self):
+        path = TEST_DIRECTORY + '/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift'
+        errors = self.check(self.added(path))
+        # Named in the project file, so only the CMake half is reported.
+        self.assertEqual(len(errors), 1)
+        self.assertIn('not in Tools/TestWebKitAPI/PlatformCocoa.cmake', errors[0][1])
+
+    def test_swiftui_test_is_not_required_in_cmake(self):
+        # SwiftUI pulls in the _WebKit_SwiftUI overlay, which CMake cannot link yet.
+        path = TEST_DIRECTORY + '/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift'
+        self.assertEqual(self.check(
+            self.added(path), source='import SwiftUI\nimport Testing\n'), [])
+
+    def test_swiftui_test_is_still_required_in_the_xcode_project(self):
+        path = TEST_DIRECTORY + '/Tests/WebKit/WebPage/NotInXcode.swift'
+        errors = self.check(self.added(path), source='private import SwiftUI\n')
+        self.assertEqual(len(errors), 1)
+        self.assertIn('is not named in', errors[0][1])
+
+    def test_swiftui_named_in_a_comment_is_not_an_import(self):
+        path = TEST_DIRECTORY + '/Tests/WebKit/WebPage/OnlyInXcode.swift'
+        errors = self.check(self.added(path), source='// This does not import SwiftUI\n')
+        self.assertEqual(len(errors), 1)
+        self.assertIn('not in Tools/TestWebKitAPI/PlatformCocoa.cmake', errors[0][1])
+
+    def test_similar_file_name_is_not_a_match(self):
+        # OnlyInXcode.swift is registered; MyOnlyInXcode.swift must not match it.
+        errors = self.check(self.added(TEST_DIRECTORY + '/Tests/WebKit/WebPage/MyOnlyInXcode.swift'))
+        self.assertEqual(len(errors), 1)
+        self.assertIn('is in neither', errors[0][1])
+
+    def test_modified_file_is_not_checked(self):
+        self.assertEqual(self.check({TEST_DIRECTORY + '/Tests/WebKit/WebPage/OnlyInXcode.swift': [7, 8]}), [])
+
+    def test_whole_file_check_is_not_an_addition(self):
+        path = TEST_DIRECTORY + '/Tests/WebKit/WebPage/OnlyInXcode.swift'
+        self.assertEqual(self.check({path: None}, existing_files=[path]), [])
+
+    def test_folders_without_a_cmake_counterpart_are_out_of_scope(self):
+        # Xcode synchronizes Runner and App wholesale, so their sources are named in
+        # neither the project file nor a membershipExceptions list.
+        self.assertEqual(self.check({
+            TEST_DIRECTORY + '/Runner/TestRunner.swift': [1, 2, 3],
+            TEST_DIRECTORY + '/App/mac/Scratch.swift': [1, 2, 3],
+        }), [])
+
+    def test_non_swift_and_non_test_files_are_ignored(self):
+        self.assertEqual(self.check({
+            TEST_DIRECTORY + '/Tests/WebKit/WebPage/Something.mm': [1, 2, 3],
+            CWD + '/Source/WebKit/Elsewhere.swift': [1, 2, 3],
+        }), [])
+
+    def test_removed_file_still_in_both_builds(self):
+        errors = self.check({TEST_DIRECTORY + '/Tests/WebKit/WebPage/InBoth.swift': None})
+        self.assertEqual([error[0] for error in errors], [PROJECT_PATH, CMAKE_PATH])
+        self.assertIn('still named in Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj', errors[0][1])
+        self.assertIn('still named in Tools/TestWebKitAPI/PlatformCocoa.cmake', errors[1][1])
+
+    def test_removed_file_absent_from_both_builds(self):
+        self.assertEqual(self.check({TEST_DIRECTORY + '/Tests/WebKit/WebPage/LongGone.swift': None}), [])
+
+    def test_missing_project_file_reports_nothing(self):
+        self.assertEqual(self.check(
+            self.added(TEST_DIRECTORY + '/Tests/WebKit/WebPage/OnlyInXcode.swift'),
+            project_contents=None), [])
+
+    def test_project_file_without_swift_sources_reports_nothing(self):
+        self.assertEqual(self.check(
+            self.added(TEST_DIRECTORY + '/Tests/WebKit/WebPage/OnlyInXcode.swift'),
+            project_contents='this is not a project file'), [])
+
+    def test_missing_cmake_file_reports_nothing(self):
+        self.assertEqual(self.check(
+            self.added(TEST_DIRECTORY + '/Tests/WebKit/WebPage/OnlyInXcode.swift'),
+            cmake_contents=None), [])
+
+    def test_cmake_file_without_swift_sources_reports_nothing(self):
+        self.assertEqual(self.check(
+            self.added(TEST_DIRECTORY + '/Tests/WebKit/WebPage/OnlyInXcode.swift'),
+            cmake_contents='add_library(TestWebKitAPILibrary OBJECT)\n'), [])
+
+    def test_filtered_out_category_reports_nothing(self):
+        files = self.added(TEST_DIRECTORY + '/Tests/WebKit/WebPage/OnlyInXcode.swift')
+        host = MagicMock()
+        host.filesystem = MockFileSystem({
+            PROJECT_PATH: PROJECT_CONTENTS,
+            CMAKE_PATH: CMAKE_CONTENTS,
+            list(files)[0]: 'import Testing\n',
+        })
+        configuration = MagicMock()
+        configuration.is_reportable.return_value = False
+        increment_error_count = MagicMock()
+
+        SwiftBuildRegistrationChecker.check_registrations(
+            files, configuration, CWD, increment_error_count, host=host)
+
+        self.assertEqual(configuration.write_style_error.call_count, 0)
+        self.assertEqual(increment_error_count.call_count, 0)
+
+
+class SwiftBuildRegistrationCheckedInFilesTest(unittest.TestCase):
+    """Checks the real build files, so that reformatting either one cannot go unnoticed.
+
+    Deliberately asserts nothing about individual files, so adding a Swift test never has
+    to touch this test.
+    """
+
+    def setUp(self):
+        self.filesystem = FileSystem()
+        self.test_directory = WebKitFinder(self.filesystem).path_from_webkit_base('Tools', 'TestWebKitAPI')
+
+    def entries(self, *components):
+        entries = build_file_entries(self.filesystem, self.filesystem.join(self.test_directory, *components))
+        self.assertIsNotNone(entries)
+        return entries
+
+    def test_checked_in_swift_files_are_in_both_builds(self):
+        project_entries = self.entries('TestWebKitAPI.xcodeproj', 'project.pbxproj')
+        cmake_entries = self.entries('PlatformCocoa.cmake')
+
+        def is_swift(filesystem, dirname, basename):
+            return basename.endswith('.swift')
+
+        missing_from_xcode = []
+        missing_from_cmake = []
+        for path in self.filesystem.files_under(self.test_directory, file_filter=is_swift):
+            relative_path = self.filesystem.relpath(path, self.test_directory).replace(self.filesystem.sep, '/')
+            # Mirrors the folders the checker looks at.
+            if not relative_path.startswith(('Tests/', 'Helpers/', 'TestWebKitAPILibrary/', 'TestWTFLibrary/')):
+                continue
+            if relative_path.split('/', 1)[1] not in project_entries:
+                missing_from_xcode.append(relative_path)
+            if relative_path not in cmake_entries and not _imports_swiftui(self.filesystem, path):
+                missing_from_cmake.append(relative_path)
+
+        self.assertEqual(missing_from_xcode, [])
+        self.assertEqual(missing_from_cmake, [])

--- a/Tools/TestWebKitAPI/PlatformCocoa.cmake
+++ b/Tools/TestWebKitAPI/PlatformCocoa.cmake
@@ -645,6 +645,7 @@ add_library(TestWebKitAPILibrary OBJECT
     ${TESTWEBKITAPI_DIR}/Helpers/cocoa/SwiftUI+Extras.swift
     ${TESTWEBKITAPI_DIR}/Helpers/cocoa/TestCocoaImageUtilities.swift
     ${TESTWEBKITAPI_DIR}/Helpers/cocoa/TestPDFDocument.swift
+    ${TESTWEBKITAPI_DIR}/Helpers/cocoa/WebExtensionUtilities.swift
     ${TESTWEBKITAPI_DIR}/Helpers/cocoa/WebPage+Extras.swift
     ${TESTWEBKITAPI_DIR}/Helpers/cocoa/WebPage+JavaScriptExpression.swift
     ${TESTWEBKITAPI_DIR}/Helpers/cocoa/WebPageConfiguration+Extras.swift
@@ -660,6 +661,7 @@ webkit_target_add_swift_options(TestWebKitAPILibrary
 
 list(APPEND TestWebKit_SOURCES
     Tests/WebKit/WKWebView/CodingTests.swift
+    Tests/WebKit/WKWebView/TextFragments.swift
     Tests/WebKit/WKWebView/WKWebViewSwiftOverlayTests.swift
 
     Tests/WebKit/WebPage/ControlledByExternalAgent.swift


### PR DESCRIPTION
#### 0f0696c6d38131a1e4e5a9e2452474bf4f6a0ca3
<pre>
[Swift Testing] Add a style checker rule to ensure tests aren&apos;t missed from Xcode and/or CMake
<a href="https://bugs.webkit.org/show_bug.cgi?id=323947">https://bugs.webkit.org/show_bug.cgi?id=323947</a>
<a href="https://rdar.apple.com/187185767">rdar://187185767</a>

Reviewed by Adrian Taylor.

It&apos;s super easy to have these accidentally mismatch, so ensure they don&apos;t with this check.

And add some missing files to CMake that this check caught.

* Tools/Scripts/webkitpy/style/checker.py:
(_all_categories):
(StyleProcessor.do_association_check):
* Tools/Scripts/webkitpy/style/checkers/swift_build_registration.py: Added.
(build_file_entries):
(_imports_swiftui):
(_destination):
(_project_entry):
(_is_newly_added):
(SwiftBuildRegistrationChecker):
(SwiftBuildRegistrationChecker.check_registrations):
(SwiftBuildRegistrationChecker.check_registrations.report):
* Tools/Scripts/webkitpy/style/checkers/swift_build_registration_unittest.py: Added.
(SwiftBuildRegistrationCheckerTest):
(SwiftBuildRegistrationCheckerTest.check):
(SwiftBuildRegistrationCheckerTest.added):
(SwiftBuildRegistrationCheckerTest.test_added_to_both_builds):
(SwiftBuildRegistrationCheckerTest.test_helper_added_to_both_builds):
(SwiftBuildRegistrationCheckerTest.test_added_to_xcode_only):
(SwiftBuildRegistrationCheckerTest.test_added_to_cmake_only):
(SwiftBuildRegistrationCheckerTest.test_added_to_neither_build):
(SwiftBuildRegistrationCheckerTest.test_path_with_spaces_is_quoted_in_the_xcode_project):
(SwiftBuildRegistrationCheckerTest.test_swiftui_test_is_not_required_in_cmake):
(SwiftBuildRegistrationCheckerTest.test_swiftui_test_is_still_required_in_the_xcode_project):
(SwiftBuildRegistrationCheckerTest.test_swiftui_named_in_a_comment_is_not_an_import):
(SwiftBuildRegistrationCheckerTest.test_similar_file_name_is_not_a_match):
(SwiftBuildRegistrationCheckerTest.test_modified_file_is_not_checked):
(SwiftBuildRegistrationCheckerTest.test_whole_file_check_is_not_an_addition):
(SwiftBuildRegistrationCheckerTest.test_folders_without_a_cmake_counterpart_are_out_of_scope):
(SwiftBuildRegistrationCheckerTest.test_non_swift_and_non_test_files_are_ignored):
(SwiftBuildRegistrationCheckerTest.test_removed_file_still_in_both_builds):
(SwiftBuildRegistrationCheckerTest.test_removed_file_absent_from_both_builds):
(SwiftBuildRegistrationCheckerTest.test_missing_project_file_reports_nothing):
(SwiftBuildRegistrationCheckerTest.test_project_file_without_swift_sources_reports_nothing):
(SwiftBuildRegistrationCheckerTest.test_missing_cmake_file_reports_nothing):
(SwiftBuildRegistrationCheckerTest.test_cmake_file_without_swift_sources_reports_nothing):
(SwiftBuildRegistrationCheckerTest.test_filtered_out_category_reports_nothing):
(SwiftBuildRegistrationCheckedInFilesTest):
(SwiftBuildRegistrationCheckedInFilesTest.setUp):
(SwiftBuildRegistrationCheckedInFilesTest.entries):
(SwiftBuildRegistrationCheckedInFilesTest.test_checked_in_swift_files_are_in_both_builds):
(SwiftBuildRegistrationCheckedInFilesTest.test_checked_in_swift_files_are_in_both_builds.is_swift):
* Tools/TestWebKitAPI/PlatformCocoa.cmake:

Canonical link: <a href="https://commits.webkit.org/320910@main">https://commits.webkit.org/320910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfc01a10ec808f2db5ae11ae447331ec4dad6f76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196557 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1f27d5fc-a123-4413-8f1f-77e05a85c492) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188141 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59875 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49222 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/166066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/125886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/93572f24-b895-4c03-ae4c-84041bf55d59) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/185608 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47951 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/45922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158303 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45660 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7631 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198544 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59821 "Built successfully") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/155114 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60531 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154757 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28281 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/49192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129970 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58957 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20639 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58359 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58574 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58424 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->