### PR TITLE
Make WTF::UUID's empty value unnameable outside HashTraits and MarkableTraits

### DIFF
--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -49,9 +49,6 @@ class StringView;
 class UUID {
 WTF_DEPRECATED_MAKE_FAST_ALLOCATED(UUID);
 public:
-    static constexpr UInt128 emptyValue = 0;
-    static constexpr UInt128 deletedValue = 1;
-
     static UUID createVersion4()
     {
         return UUID { };
@@ -87,12 +84,13 @@ public:
     explicit constexpr UUID(UInt128 data)
         : m_data(data)
     {
+        RELEASE_ASSERT(data != emptyValue && data != deletedValue);
     }
 
     explicit UUID(uint64_t high, uint64_t low)
         : m_data((static_cast<UInt128>(high) << 64) | low)
     {
-        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!isHashTableDeletedValue());
+        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(isValid());
     }
 
     std::span<const uint8_t, 16> span() const LIFETIME_BOUND
@@ -102,20 +100,17 @@ public:
 
     friend bool operator==(const UUID&, const UUID&) = default;
 
-    explicit constexpr UUID(HashTableDeletedValueType)
-        : m_data(deletedValue)
-    {
-    }
-
-    explicit constexpr UUID(HashTableEmptyValueType)
-        : m_data(emptyValue)
-    {
-    }
-
     static bool isValid(uint64_t high, uint64_t low)
     {
         auto data = (static_cast<UInt128>(high) << 64) | low;
         return data != deletedValue && data != emptyValue;
+    }
+
+    // Public so that composite types can build their own hash traits. Unlike the empty value, the deleted
+    // value is not a usable "no UUID" sentinel, since Markable and HashTraits both treat it as engaged.
+    explicit constexpr UUID(HashTableDeletedValueType)
+        : m_data(deletedValue)
+    {
     }
 
     constexpr bool isHashTableDeletedValue() const { return m_data == deletedValue; }
@@ -132,8 +127,21 @@ public:
     uint64_t high() const { return static_cast<uint64_t>(m_data >> 64);  }
 
 private:
-    WTF_EXPORT_PRIVATE UUID();
+    friend struct HashTraits<UUID>;
+    friend struct MarkableTraits<UUID>;
     friend void add(Hasher&, UUID);
+
+    // The empty and deleted values are reserved for HashTraits and MarkableTraits. Code that needs to express
+    // "no UUID" should use Markable<WTF::UUID> or std::optional<WTF::UUID> rather than naming these.
+    static constexpr UInt128 emptyValue = 0;
+    static constexpr UInt128 deletedValue = 1;
+
+    explicit constexpr UUID(HashTableEmptyValueType)
+        : m_data(emptyValue)
+    {
+    }
+
+    WTF_EXPORT_PRIVATE UUID();
 
     WTF_EXPORT_PRIVATE static UInt128 generateWeakRandomUUIDVersion4();
 
@@ -143,7 +151,7 @@ private:
 template<>
 struct MarkableTraits<UUID> {
     static bool isEmptyValue(const UUID& uuid) { return !uuid; }
-    static UUID emptyValue() { return UUID { UInt128 { 0 } }; }
+    static UUID emptyValue() { return UUID { HashTableEmptyValue }; }
 };
 
 inline void add(Hasher& hasher, UUID uuid)

--- a/Source/WebCore/dom/DocumentMarker.h
+++ b/Source/WebCore/dom/DocumentMarker.h
@@ -23,6 +23,7 @@
 #include <WebCore/DictationContext.h>
 #include <WebCore/SimpleRange.h>
 #include <wtf/Forward.h>
+#include <wtf/Markable.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Platform.h>
 #include <wtf/UUID.h>
@@ -142,7 +143,7 @@ public:
 
     struct TransparentContentData {
         RefPtr<Node> node;
-        WTF::UUID uuid;
+        Markable<WTF::UUID> uuid;
     };
 
     struct DictationStreamingOpacityData {

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4572,7 +4572,7 @@ void Editor::selectionStartSetMarkerForTesting(DocumentMarkerType markerType, in
 
     switch (markerType) {
     case DocumentMarkerType::TransparentContent:
-        markers->addMarker(*text, unsignedFrom, unsignedLength, markerType, DocumentMarker::TransparentContentData { node, WTF::UUID { 0 } });
+        markers->addMarker(*text, unsignedFrom, unsignedLength, markerType, DocumentMarker::TransparentContentData { node, std::nullopt });
         return;
 
     case DocumentMarkerType::DraggedContent:

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -47,10 +47,12 @@
 #include <wtf/Assertions.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
+#include <wtf/Markable.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Platform.h>
 #include <wtf/Seconds.h>
 #include <wtf/URL.h>
+#include <wtf/UUID.h>
 #include <wtf/Vector.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -779,7 +781,7 @@ public:
 
     virtual void addSourceTextAnimationForActiveWritingToolsSession(const WTF::UUID& /*sourceAnimationUUID*/, const WTF::UUID& /*destinationAnimationUUID*/, bool, const CharacterRange&, const String&, CompletionHandler<void(TextAnimationRunMode)>&&) { }
 
-    virtual void addDestinationTextAnimationForActiveWritingToolsSession(const WTF::UUID& /*sourceAnimationUUID*/, const WTF::UUID& /*destinationAnimationUUID*/, const std::optional<CharacterRange>&, const String&) { }
+    virtual void addDestinationTextAnimationForActiveWritingToolsSession(Markable<WTF::UUID> /*sourceAnimationUUID*/, Markable<WTF::UUID> /*destinationAnimationUUID*/, const std::optional<CharacterRange>&, const String&) { }
 
     virtual void saveSnapshotOfTextPlaceholderForAnimation(const SimpleRange&) { };
 

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -31,6 +31,7 @@
 #import "WritingToolsCompositionCommand.h"
 #import "WritingToolsTypes.h"
 #import <wtf/CheckedPtr.h>
+#import <wtf/Markable.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/WeakHashSet.h>
 #import <wtf/WeakPtr.h>
@@ -198,11 +199,11 @@ private:
     void replaceContentsOfRangeInSession(CompositionState&, const SimpleRange&, const AttributedString&, WritingToolsCompositionCommand::State);
 
     void compositionSessionDidFinishReplacement();
-    void compositionSessionDidFinishReplacement(const WTF::UUID& sourceAnimationUUID, const WTF::UUID& destinationAnimationUUID, const CharacterRange&, const String&);
+    void compositionSessionDidFinishReplacement(Markable<WTF::UUID> sourceAnimationUUID, Markable<WTF::UUID> destinationAnimationUUID, const CharacterRange&, const String&);
 
     void smartReplySessionDidReceiveTextWithReplacementRange(const WritingTools::Session&, const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished);
 
-    void compositionSessionDidReceiveTextWithReplacementRangeAsync(const WTF::UUID&, const WTF::UUID&, const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished, TextAnimationRunMode);
+    void compositionSessionDidReceiveTextWithReplacementRangeAsync(Markable<WTF::UUID>, Markable<WTF::UUID>, const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished, TextAnimationRunMode);
 
     void showOriginalCompositionForSession();
     void showRewrittenCompositionForSession();

--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -284,7 +284,7 @@ void WritingToolsController::willBeginWritingToolsSession(const std::optional<Wr
         // If there is no session, this implies that the Writing Tools delegate is used for the "non-inline editing" case;
         // as such, no mutating delegate methods will be invoked, and so there need not be any state tracked.
 
-        completionHandler({ { WTF::UUID { 0 }, attributedStringFromRange, selectedTextCharacterRange } });
+        completionHandler({ { std::nullopt, attributedStringFromRange, selectedTextCharacterRange } });
         return;
     }
 
@@ -320,7 +320,7 @@ void WritingToolsController::willBeginWritingToolsSession(const std::optional<Wr
 
     document->editor().setSuppressEditingForWritingTools(true);
 
-    completionHandler({ { WTF::UUID { 0 }, attributedStringFromRange, selectedTextCharacterRange } });
+    completionHandler({ { std::nullopt, attributedStringFromRange, selectedTextCharacterRange } });
 }
 
 void WritingToolsController::didBeginWritingToolsSession(const WritingTools::Session& session, const Vector<WritingTools::Context>& contexts)
@@ -377,7 +377,8 @@ void WritingToolsController::proofreadingSessionDidReceiveSuggestions(const Writ
 
     document->markers().forEach(adjustedProcessedRangeBeforeReplacement, { DocumentMarkerType::TransparentContent }, [&](auto&, auto marker) {
         auto& data = std::get<DocumentMarker::TransparentContentData>(marker.data());
-        transparentContentMarkerIdentifiers.add(data.uuid);
+        if (data.uuid)
+            transparentContentMarkerIdentifiers.add(*data.uuid);
 
         return false;
     });
@@ -634,12 +635,11 @@ void WritingToolsController::intelligenceTextAnimationsDidComplete()
 
 void WritingToolsController::compositionSessionDidFinishReplacement()
 {
-    // An empty optional range implies that an animation should be considered to have already been finished.
-    WTF::UUID emptyUUID { WTF::UUID::emptyValue };
-    m_page->chrome().client().addDestinationTextAnimationForActiveWritingToolsSession(emptyUUID, emptyUUID, std::nullopt, ""_s);
+    // No animation UUIDs and an empty optional range imply that an animation should be considered to have already been finished.
+    m_page->chrome().client().addDestinationTextAnimationForActiveWritingToolsSession({ }, { }, std::nullopt, ""_s);
 }
 
-void WritingToolsController::compositionSessionDidFinishReplacement(const WTF::UUID& sourceAnimationUUID, const WTF::UUID& destinationAnimationUUID, const CharacterRange& updatedRange, const String& replacementText)
+void WritingToolsController::compositionSessionDidFinishReplacement(Markable<WTF::UUID> sourceAnimationUUID, Markable<WTF::UUID> destinationAnimationUUID, const CharacterRange& updatedRange, const String& replacementText)
 {
     m_page->chrome().client().addDestinationTextAnimationForActiveWritingToolsSession(sourceAnimationUUID, destinationAnimationUUID, updatedRange, replacementText);
 }
@@ -689,7 +689,8 @@ void WritingToolsController::smartReplySessionDidReceiveTextWithReplacementRange
 
     document->markers().forEach(resolvedRange, { DocumentMarkerType::TransparentContent }, [&](auto&, auto& marker) {
         auto& data = std::get<DocumentMarker::TransparentContentData>(marker.data());
-        transparentContentMarkerIdentifiers.add(data.uuid);
+        if (data.uuid)
+            transparentContentMarkerIdentifiers.add(*data.uuid);
 
         return false;
     });
@@ -711,7 +712,7 @@ void WritingToolsController::smartReplySessionDidReceiveTextWithReplacementRange
     document->selection().clear();
 }
 
-void WritingToolsController::compositionSessionDidReceiveTextWithReplacementRangeAsync(const WTF::UUID& sourceAnimationUUID, const WTF::UUID& destinationAnimationUUID, const AttributedString& attributedText, const CharacterRange& range, const WritingTools::Context& context, bool finished, TextAnimationRunMode runMode)
+void WritingToolsController::compositionSessionDidReceiveTextWithReplacementRangeAsync(Markable<WTF::UUID> sourceAnimationUUID, Markable<WTF::UUID> destinationAnimationUUID, const AttributedString& attributedText, const CharacterRange& range, const WritingTools::Context& context, bool finished, TextAnimationRunMode runMode)
 {
     RefPtr document = this->document();
     if (!document) {
@@ -856,8 +857,7 @@ void WritingToolsController::compositionSessionDidReceiveTextWithReplacementRang
     state->pendingReplacedRange = range;
 
     if (session.compositionType == WritingTools::Session::CompositionType::Other) {
-        WTF::UUID emptyUUID { WTF::UUID::emptyValue };
-        compositionSessionDidReceiveTextWithReplacementRangeAsync(emptyUUID, emptyUUID, attributedText, range, context, finished, WebCore::TextAnimationRunMode::OnlyReplaceText);
+        compositionSessionDidReceiveTextWithReplacementRangeAsync({ }, { }, attributedText, range, context, finished, WebCore::TextAnimationRunMode::OnlyReplaceText);
         return;
     }
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -14421,8 +14421,8 @@ static inline WKTextAnimationType toWKTextAnimationType(WebCore::TextAnimationTy
     if (!protect(_page->preferences())->textAnimationsEnabled())
         return;
 
-    if (data.style == WebCore::TextAnimationType::Final)
-        [_sourceAnimationIDtoDestinationAnimationID setObject:uuid forKey:data.sourceAnimationUUID.value_or(WTF::UUID(WTF::UUID::emptyValue)).createNSUUID().get()];
+    if (data.style == WebCore::TextAnimationType::Final && data.sourceAnimationUUID)
+        [_sourceAnimationIDtoDestinationAnimationID setObject:uuid forKey:data.sourceAnimationUUID->createNSUUID().get()];
 
     if (!_textAnimationManager)
         _textAnimationManager = adoptNS([WebKit::allocWKTextAnimationManagerInstance() initWithDelegate:self]);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -2502,7 +2502,7 @@ void WebChromeClient::addSourceTextAnimationForActiveWritingToolsSession(const W
         page->addSourceTextAnimationForActiveWritingToolsSession(sourceAnimationUUID, destinationAnimationUUID, finished, range, string, WTF::move(completionHandler));
 }
 
-void WebChromeClient::addDestinationTextAnimationForActiveWritingToolsSession(const WTF::UUID& sourceAnimationUUID, const WTF::UUID& destinationAnimationUUID, const std::optional<CharacterRange>& range, const String& string)
+void WebChromeClient::addDestinationTextAnimationForActiveWritingToolsSession(Markable<WTF::UUID> sourceAnimationUUID, Markable<WTF::UUID> destinationAnimationUUID, const std::optional<CharacterRange>& range, const String& string)
 {
     if (RefPtr page = m_page.get())
         page->addDestinationTextAnimationForActiveWritingToolsSession(sourceAnimationUUID, destinationAnimationUUID, range, string);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -28,6 +28,7 @@
 
 #include <WebCore/ChromeClient.h>
 #include <WebCore/Site.h>
+#include <wtf/Markable.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRef.h>
 
@@ -561,7 +562,7 @@ private:
 
     void addSourceTextAnimationForActiveWritingToolsSession(const WTF::UUID& sourceAnimationUUID, const WTF::UUID& destinationAnimationUUID, bool finished, const WebCore::CharacterRange&, const String&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&&) final;
 
-    void addDestinationTextAnimationForActiveWritingToolsSession(const WTF::UUID& sourceAnimationUUID, const WTF::UUID& destinationAnimationUUID, const std::optional<WebCore::CharacterRange>&, const String&) final;
+    void addDestinationTextAnimationForActiveWritingToolsSession(Markable<WTF::UUID> sourceAnimationUUID, Markable<WTF::UUID> destinationAnimationUUID, const std::optional<WebCore::CharacterRange>&, const String&) final;
 
     void saveSnapshotOfTextPlaceholderForAnimation(const WebCore::SimpleRange&);
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
@@ -31,6 +31,7 @@
 #include <WebCore/SimpleRange.h>
 #include <WebCore/TextIndicator.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/Markable.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UUID.h>
@@ -74,7 +75,7 @@ public:
     void removeInitialTextAnimationForActiveWritingToolsSession();
     void addInitialTextAnimationForActiveWritingToolsSession();
     void addSourceTextAnimationForActiveWritingToolsSession(const WTF::UUID& sourceAnimationUUID, const WTF::UUID& destinationAnimationUUID, bool finished, const WebCore::CharacterRange&, const String&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&&);
-    void addDestinationTextAnimationForActiveWritingToolsSession(const WTF::UUID& sourceAnimationUUID, const WTF::UUID& destinationAnimationUUID, const std::optional<WebCore::CharacterRange>&, const String&);
+    void addDestinationTextAnimationForActiveWritingToolsSession(Markable<WTF::UUID> sourceAnimationUUID, Markable<WTF::UUID> destinationAnimationUUID, const std::optional<WebCore::CharacterRange>&, const String&);
 
     void saveSnapshotOfTextPlaceholderForAnimation(const WebCore::SimpleRange&);
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
@@ -244,18 +244,21 @@ void TextAnimationController::addSourceTextAnimationForActiveWritingToolsSession
     }
 
     // On iOS this will search for the completion handler to pass the text indicator to so that the animation can continue.
-    protect(m_webPage.get())->addTextAnimationForAnimationID(sourceAnimationUUID, { WebCore::TextAnimationType::Source, runMode, WTF::UUID(WTF::UUID::emptyValue), sourceAnimationUUID, destinationAnimationUUID }, textIndicator, WTF::move(completionHandler));
+    protect(m_webPage.get())->addTextAnimationForAnimationID(sourceAnimationUUID, { WebCore::TextAnimationType::Source, runMode, { }, sourceAnimationUUID, destinationAnimationUUID }, textIndicator, WTF::move(completionHandler));
     m_activeAnimation = sourceAnimationUUID;
     m_textAnimationRanges.append({ sourceAnimationUUID, replaceCharacterRange });
 }
 
-void TextAnimationController::addDestinationTextAnimationForActiveWritingToolsSession(const WTF::UUID& sourceAnimationUUID, const WTF::UUID& destinationAnimationUUID, const std::optional<WebCore::CharacterRange>& characterRangeAfterReplace, const String& string)
+void TextAnimationController::addDestinationTextAnimationForActiveWritingToolsSession(Markable<WTF::UUID> sourceAnimationUUIDValue, Markable<WTF::UUID> destinationAnimationUUIDValue, const std::optional<WebCore::CharacterRange>& characterRangeAfterReplace, const String& string)
 {
     RefPtr webPage = m_webPage.get();
-    if (!characterRangeAfterReplace) {
+    if (!characterRangeAfterReplace || !sourceAnimationUUIDValue || !destinationAnimationUUIDValue) {
         webPage->didEndPartialIntelligenceTextAnimation();
         return;
     }
+
+    auto sourceAnimationUUID = *sourceAnimationUUIDValue;
+    auto destinationAnimationUUID = *destinationAnimationUUIDValue;
 
     auto sessionRange = contextRangeForActiveWritingToolsSession();
     if (!sessionRange) {
@@ -281,13 +284,14 @@ void TextAnimationController::addDestinationTextAnimationForActiveWritingToolsSe
     auto endPosition = makeContainerOffsetPosition(sessionRange->start);
     auto endBoundaryPoint = makeBoundaryPoint(endOfEditableContent(endPosition));
 
-    WTF::UUID unanimatedRangeUUID { WTF::UUID::emptyValue };
+    Markable<WTF::UUID> unanimatedRangeUUID;
     if (endBoundaryPoint) {
         auto unanimatedRange = makeSimpleRangeHelper(replacedRangeAfterReplace.end, *endBoundaryPoint);
 
         if (unanimatedRange) {
-            unanimatedRangeUUID = WTF::UUID::createVersion4();
-            m_unanimatedRangeData = { unanimatedRangeUUID, *unanimatedRange };
+            auto animationUUID = WTF::UUID::createVersion4();
+            unanimatedRangeUUID = animationUUID;
+            m_unanimatedRangeData = { animationUUID, *unanimatedRange };
         }
     }
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -1418,7 +1418,7 @@ void WebPage::addSourceTextAnimationForActiveWritingToolsSession(const WTF::UUID
     m_textAnimationController->addSourceTextAnimationForActiveWritingToolsSession(sourceAnimationUUID, destinationAnimationUUID, finished, range, string, WTF::move(completionHandler));
 }
 
-void WebPage::addDestinationTextAnimationForActiveWritingToolsSession(const WTF::UUID& sourceAnimationUUID, const WTF::UUID& destinationAnimationUUID, const std::optional<CharacterRange>& range, const String& string)
+void WebPage::addDestinationTextAnimationForActiveWritingToolsSession(Markable<WTF::UUID> sourceAnimationUUID, Markable<WTF::UUID> destinationAnimationUUID, const std::optional<CharacterRange>& range, const String& string)
 {
     m_textAnimationController->addDestinationTextAnimationForActiveWritingToolsSession(sourceAnimationUUID, destinationAnimationUUID, range, string);
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -75,11 +75,13 @@
 #include <wtf/CallbackAggregator.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
+#include <wtf/Markable.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RunLoop.h>
 #include <wtf/Seconds.h>
+#include <wtf/UUID.h>
 #include <wtf/WallTime.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
@@ -2153,7 +2155,7 @@ public:
     void removeInitialTextAnimationForActiveWritingToolsSession();
     void addInitialTextAnimationForActiveWritingToolsSession();
     void addSourceTextAnimationForActiveWritingToolsSession(const WTF::UUID& sourceAnimationUUID, const WTF::UUID& destinationAnimationUUID, bool finished, const WebCore::CharacterRange&, const String&, CompletionHandler<void(WebCore::TextAnimationRunMode)>&&);
-    void addDestinationTextAnimationForActiveWritingToolsSession(const WTF::UUID& sourceAnimationUUID, const WTF::UUID& destinationAnimationUUID, const std::optional<WebCore::CharacterRange>&, const String&);
+    void addDestinationTextAnimationForActiveWritingToolsSession(Markable<WTF::UUID> sourceAnimationUUID, Markable<WTF::UUID> destinationAnimationUUID, const std::optional<WebCore::CharacterRange>&, const String&);
     void saveSnapshotOfTextPlaceholderForAnimation(const WebCore::SimpleRange&);
     void clearAnimationsForActiveWritingToolsSession();
     void showWritingToolsAffordance();

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/UUIDCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/UUIDCocoa.mm
@@ -24,24 +24,21 @@
  */
 
 #import "config.h"
+#import <wtf/RetainPtr.h>
 #import <wtf/UUID.h>
 
 #import "Helpers/PlatformUtilities.h"
 
 TEST(WTF, NSUUIDConversionForDeletedValue)
 {
-    WTF::UUID deletedUUID { WTF::UUID::deletedValue };
-    RetainPtr deletedNSUUID = deletedUUID.createNSUUID();
-    EXPECT_STREQ("00000000-0000-0000-0000-000000000001", [[deletedNSUUID UUIDString] UTF8String]);
+    RetainPtr deletedNSUUID = adoptNS([[NSUUID alloc] initWithUUIDString:@"00000000-0000-0000-0000-000000000001"]);
     auto uuid = WTF::UUID::fromNSUUID(deletedNSUUID.get());
     EXPECT_FALSE(uuid);
 }
 
 TEST(WTF, NSUUIDConversionForEmptyValue)
 {
-    WTF::UUID emptyUUID { WTF::UUID::emptyValue };
-    RetainPtr emptyNSUUID = emptyUUID.createNSUUID();
-    EXPECT_STREQ("00000000-0000-0000-0000-000000000000", [[emptyNSUUID UUIDString] UTF8String]);
+    RetainPtr emptyNSUUID = adoptNS([[NSUUID alloc] initWithUUIDString:@"00000000-0000-0000-0000-000000000000"]);
     auto uuid = WTF::UUID::fromNSUUID(emptyNSUUID.get());
     EXPECT_FALSE(uuid);
 }


### PR DESCRIPTION
#### 2aedf51ba631caa8a95ba38f188f1ccf8a750b41
<pre>
Make WTF::UUID&apos;s empty value unnameable outside HashTraits and MarkableTraits
<a href="https://bugs.webkit.org/show_bug.cgi?id=323944">https://bugs.webkit.org/show_bug.cgi?id=323944</a>

Reviewed by Darin Adler.

TextAnimationData&apos;s UUID fields and WritingTools::Context::identifier are
Markable&lt;WTF::UUID&gt;, but several Writing Tools callers were constructing
WTF::UUID { WTF::UUID::emptyValue } (or WTF::UUID { 0 }) to mean &quot;no UUID&quot;.
MarkableTraits&lt;UUID&gt;::isEmptyValue is !uuid, so such a value does not survive
as an engaged Markable holding zero — it silently becomes a disengaged one.
The call sites read as though they are passing a UUID when they are in fact
passing &quot;absent&quot;, and nothing at the call site says so.

This expresses the absence in the type instead. Where the sentinel only ever
filled a slot that the callee ignores, it becomes Markable&apos;s empty state; the
two ChromeClient-boundary methods that had to carry it take Markable&lt;WTF::UUID&gt;
parameters, and the null check is folded into the early return that
TextAnimationController already performs for the equivalent empty-range case.
DocumentMarker&apos;s TransparentContentData::uuid becomes Markable for the same
reason, which also means an empty query UUID can no longer match a marker:
operator==(const Markable&lt;T&gt;&amp;, const T&amp;) is bool(x) &amp;&amp; x.value() == v.

With the last producer gone, UUID adopts what ObjectIdentifier already does,
so the sentinel cannot be reintroduced. emptyValue and deletedValue become
private, which makes WTF::UUID(WTF::UUID::emptyValue) a compile error, and
the UInt128 constructor gains the validity assertion ObjectIdentifier&apos;s
uint64_t constructor has, which catches the WTF::UUID { 0 } spelling that
privatizing the constants does not. UUID(uint64_t, uint64_t) is tightened to
reject the empty value as well; it previously rejected only the deleted one.
Code that needs to express &quot;no UUID&quot; must now use Markable or std::optional.

Two deliberate exceptions. The std::span constructors keep taking arbitrary
bytes without assertion, because an all-zero UUID is real data there — FIDO
authenticators commonly report an all-zero AAGUID. And UUID(HashTableDeletedValueType)
stays public so composite types can build their own hash traits, as
PushSubscriptionSetIdentifier does; unlike the empty value it is not usable as
a &quot;no UUID&quot; sentinel, since Markable and HashTraits both treat it as engaged.

This is a step toward the property ObjectIdentifier already has: an invalid
value that cannot be constructed cannot be sent over IPC. UUID does not have it
yet — the std::span constructors above still accept arbitrary bytes — and
neither type validates on encode today; both rely on the decoder&apos;s validator at
their single ArgumentCoder bottleneck. Finishing this means either reworking the
three remaining span callers so UUID cannot hold an invalid value at all, or
teaching the serializer generator to assert on encode for types that declare a
Validator.

The generated IPC decoder for WTF::UUID runs its isValid validator before
constructing, so the tightened constructor is not reachable from a malformed
message. The silent Markable conversion this removes is what let an empty
unanimatedRangeUUID reach the UI process in
<a href="https://bugs.webkit.org/show_bug.cgi?id=323917.">https://bugs.webkit.org/show_bug.cgi?id=323917.</a> This change does not fix that
crash — the receiver-side check there is still required, since a compromised
or fuzzed web process can set the Markable&apos;s empty bit directly on the wire
regardless of what the sender&apos;s type permits.

* Source/WTF/wtf/UUID.h:
(WTF::UUID::UUID):
(WTF::UUID::isValid):
(WTF::MarkableTraits&lt;UUID&gt;::emptyValue):
* Source/WebCore/dom/DocumentMarker.h:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::selectionStartSetMarkerForTesting):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::addDestinationTextAnimationForActiveWritingToolsSession):
* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::willBeginWritingToolsSession):
(WebCore::WritingToolsController::proofreadingSessionDidReceiveSuggestions):
(WebCore::WritingToolsController::smartReplySessionDidReceiveTextWithReplacementRange):
(WebCore::WritingToolsController::compositionSessionDidFinishReplacement):
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRangeAsync):
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRange):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView addTextAnimationForAnimationID:withData:]):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::addDestinationTextAnimationForActiveWritingToolsSession):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm:
(WebKit::TextAnimationController::addSourceTextAnimationForActiveWritingToolsSession):
(WebKit::TextAnimationController::addDestinationTextAnimationForActiveWritingToolsSession):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::addDestinationTextAnimationForActiveWritingToolsSession):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/TestWebKitAPI/Tests/WTF/cocoa/UUIDCocoa.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/320928@main">https://commits.webkit.org/320928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf7d25929749b4c3dddb16feecded5e214afb8cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196565 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150818 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59883 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145557 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e216490a-204a-45e2-86fe-fd6961bea508) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166076 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125900 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2a60dbf6-4d42-46ad-8bac-b4c4cba8d819) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47961 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45929 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7735 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14602 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158313 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45672 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7639 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47516 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198552 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59830 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155120 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41566 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60540 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154762 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49193 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132779 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129980 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58965 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20651 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58367 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58583 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58432 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->