### PR TITLE
Remove dead Supplement<Navigator> machinery from NavigatorWebDriver

### DIFF
--- a/Source/WebCore/Modules/webdriver/NavigatorWebDriver.cpp
+++ b/Source/WebCore/Modules/webdriver/NavigatorWebDriver.cpp
@@ -32,16 +32,8 @@
 #include "NavigatorWebDriverActivePolicy.h"
 #include "Page.h"
 #include "Settings.h"
-#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
-using namespace JSC;
-
-WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigatorWebDriver);
-
-NavigatorWebDriver::NavigatorWebDriver() = default;
-
-NavigatorWebDriver::~NavigatorWebDriver() = default;
 
 bool NavigatorWebDriver::isControlledByAutomation(const Navigator& navigator)
 {
@@ -58,17 +50,6 @@ bool NavigatorWebDriver::isControlledByAutomation(const Navigator& navigator)
         break;
     }
     return frame->page()->isControlledByAutomation();
-}
-
-NavigatorWebDriver* NavigatorWebDriver::from(Navigator* navigator)
-{
-    auto* supplement = downcast<NavigatorWebDriver>(Supplement<Navigator>::from(navigator, supplementName()));
-    if (!supplement) {
-        auto newSupplement = makeUnique<NavigatorWebDriver>();
-        supplement = newSupplement.get();
-        provideTo(navigator, supplementName(), WTF::move(newSupplement));
-    }
-    return supplement;
 }
 
 bool NavigatorWebDriver::webdriver(const Navigator& navigator)

--- a/Source/WebCore/Modules/webdriver/NavigatorWebDriver.h
+++ b/Source/WebCore/Modules/webdriver/NavigatorWebDriver.h
@@ -25,29 +25,18 @@
 
 #pragma once
 
-#include "Supplementable.h"
-#include <wtf/TZoneMalloc.h>
+#include <wtf/Compiler.h>
 
 namespace WebCore {
 
 class Navigator;
 
-class NavigatorWebDriver final : public Supplement<Navigator> {
-    WTF_MAKE_TZONE_ALLOCATED(NavigatorWebDriver);
+class NavigatorWebDriver {
 public:
-    NavigatorWebDriver();
-    virtual ~NavigatorWebDriver();
-
-    static NavigatorWebDriver* from(Navigator*);
     static bool NODELETE webdriver(const Navigator&);
+
 private:
-    static ASCIILiteral supplementName() { return "NavigatorWebDriver"_s; }
-    bool isNavigatorWebDriver() const final { return true; }
     static bool NODELETE isControlledByAutomation(const Navigator&);
 };
 
 } // namespace WebCore
-
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NavigatorWebDriver)
-    static bool isType(const WebCore::SupplementBase& supplement) { return supplement.isNavigatorWebDriver(); }
-SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/platform/Supplementable.h
+++ b/Source/WebCore/platform/Supplementable.h
@@ -108,7 +108,6 @@ public:
     virtual bool isNavigatorPermissions() const { return false; }
     virtual bool isNavigatorScreenWakeLock() const { return false; }
     virtual bool isNavigatorUserActivation() const { return false; }
-    virtual bool isNavigatorWebDriver() const { return false; }
     virtual bool isNotificationController() const { return false; }
     virtual bool isServiceWorkerRegistrationBackgroundFetchAPI() const { return false; }
     virtual bool isServiceWorkerRegistrationPushAPI() const { return false; }


### PR DESCRIPTION
#### a1848da321203d18234a90c743b362a75ae2092a
<pre>
Remove dead Supplement&lt;Navigator&gt; machinery from NavigatorWebDriver
<a href="https://bugs.webkit.org/show_bug.cgi?id=323950">https://bugs.webkit.org/show_bug.cgi?id=323950</a>
<a href="https://rdar.apple.com/187187307">rdar://187187307</a>

Reviewed by Chris Dumez.

navigator.webdriver is exposed via [ImplementedBy=NavigatorWebDriver] and
resolves to the static NavigatorWebDriver::webdriver(const Navigator&amp;),
which forwards to the static isControlledByAutomation(). Neither needs an
instance, and NavigatorWebDriver::from() -- the only code that ever
constructed one -- has no callers anywhere. The class carried no state, so
the entire Supplement&lt;Navigator&gt; apparatus was dead.

Drop the Supplement base, from(), supplementName(), the constructor and
destructor, the TZone allocation, the isNavigatorWebDriver() type trait,
and the corresponding virtual in Supplementable.h. NavigatorWebDriver is
now a plain holder for the two static functions backing the IDL binding.

No change in behavior.

* Source/WebCore/Modules/webdriver/NavigatorWebDriver.cpp:
(WebCore::NavigatorWebDriver::from): Deleted.
* Source/WebCore/Modules/webdriver/NavigatorWebDriver.h:
(): Deleted.
(isType): Deleted.
* Source/WebCore/platform/Supplementable.h:
(WebCore::SupplementBase::isNavigatorUserActivation const):
(WebCore::SupplementBase::isNavigatorWebDriver const): Deleted.

Canonical link: <a href="https://commits.webkit.org/321027@main">https://commits.webkit.org/321027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6616af48806cf9c7097567747281618f790da0aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196564 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150817 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/09bbdba0-e66f-4451-b057-3a8443c66442) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59882 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145559 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100891 "2 flakes 13 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c222693a-2c49-4412-81a5-225faf044e86) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125902 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0cd41fdb-1ba8-40e1-87be-db33fe570143) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47959 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45928 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158311 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45671 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7638 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50398 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198551 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59829 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155121 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41646 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60539 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154763 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49196 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132778 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129979 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58964 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20650 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58366 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58582 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58431 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->