### PR TITLE
GraphicsContextGL::Client::addDebugMessage() should take a std::span<const char8_t> rather than a UTF8CString

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5693,7 +5693,7 @@ static ASCIILiteral debugMessageSeverityToString(GCGLenum severity)
     }
 }
 
-void WebGLRenderingContextBase::addDebugMessage(GCGLenum type, GCGLenum id, GCGLenum severity, const UTF8CString& message)
+void WebGLRenderingContextBase::addDebugMessage(GCGLenum type, GCGLenum id, GCGLenum severity, std::span<const char8_t> message)
 {
     if (!shouldPrintToConsole())
         return;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -467,7 +467,7 @@ public:
 
     // GraphicsContextGL::Client
     void forceContextLost() final;
-    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const UTF8CString&) final;
+    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, std::span<const char8_t>) final;
     void didChangeMemoryCost() final;
 
     void recycleContext();

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1223,7 +1223,7 @@ public:
         WEBCORE_EXPORT Client();
         WEBCORE_EXPORT virtual ~Client();
         virtual void forceContextLost() = 0;
-        virtual void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const UTF8CString&) = 0;
+        virtual void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, std::span<const char8_t> message) = 0;
         virtual void didChangeMemoryCost() = 0;
     };
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -291,7 +291,7 @@ bool GraphicsContextGLANGLE::initialize()
     auto debugMessageCallback = [](GCGLenum, GCGLenum type, GCGLenum id, GCGLenum severity, GCGLsizei length, const GCGLchar* message, const void* context) {
         auto* gl = reinterpret_cast<const GraphicsContextGLANGLE*>(context);
         if (gl->m_client)
-            gl->m_client->addDebugMessage(type, id, severity, UTF8CString { byteCast<char8_t>(unsafeMakeSpan(message, length)) });
+            gl->m_client->addDebugMessage(type, id, severity, byteCast<char8_t>(unsafeMakeSpan(message, length)));
     };
     GL_DebugMessageCallbackKHR(debugMessageCallback, this);
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -195,7 +195,7 @@ void RemoteGraphicsContextGL::forceContextLost()
     send(Messages::RemoteGraphicsContextGLProxy::WasLost());
 }
 
-void RemoteGraphicsContextGL::addDebugMessage(GCGLenum type, GCGLenum id, GCGLenum severity, const UTF8CString& message)
+void RemoteGraphicsContextGL::addDebugMessage(GCGLenum type, GCGLenum id, GCGLenum severity, std::span<const char8_t> message)
 {
     assertIsCurrent(workQueue());
     send(Messages::RemoteGraphicsContextGLProxy::addDebugMessage(type, id, severity, message));

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -114,7 +114,7 @@ protected:
 
     // GraphicsContextGL::Client overrides.
     void forceContextLost() final;
-    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const UTF8CString&) final;
+    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, std::span<const char8_t>) final;
     void didChangeMemoryCost() final;
 
     // Messages to be received.

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -584,12 +584,12 @@ void RemoteGraphicsContextGLProxy::wasLost()
     markContextLost();
 }
 
-void RemoteGraphicsContextGLProxy::addDebugMessage(GCGLenum type, GCGLenum id, GCGLenum severity, UTF8CString&& message)
+void RemoteGraphicsContextGLProxy::addDebugMessage(GCGLenum type, GCGLenum id, GCGLenum severity, std::span<const char8_t> message)
 {
     if (isContextLost())
         return;
     if (m_client)
-        m_client->addDebugMessage(type, id, severity, WTF::move(message));
+        m_client->addDebugMessage(type, id, severity, message);
 }
 
 void RemoteGraphicsContextGLProxy::memoryCostChanged(std::optional<uint64_t> memoryCost)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -416,7 +416,7 @@ private:
     // Messages to be received.
     void wasCreated(std::optional<RemoteGraphicsContextGLInitializationState>&&);
     void wasLost();
-    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, UTF8CString&&);
+    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, std::span<const char8_t>);
     void memoryCostChanged(std::optional<uint64_t>);
 
     void NODELETE initialize(const RemoteGraphicsContextGLInitializationState&);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.messages.in
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.messages.in
@@ -29,7 +29,7 @@
 messages -> RemoteGraphicsContextGLProxy {
     void WasCreated(struct std::optional<WebKit::RemoteGraphicsContextGLInitializationState> initializationState) CanDispatchOutOfOrder
     void WasLost()
-    void addDebugMessage(unsigned type, unsigned id, unsigned severity, UTF8CString message) CanDispatchOutOfOrder
+    void addDebugMessage(unsigned type, unsigned id, unsigned severity, std::span<const char8_t> message) CanDispatchOutOfOrder
     void MemoryCostChanged(std::optional<uint64_t> memoryCost)
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
@@ -52,7 +52,7 @@ namespace {
 class MockGraphicsContextGLClient final : public GraphicsContextGL::Client {
 public:
     void forceContextLost() final { ++m_contextLostCalls; }
-    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const UTF8CString&) final { }
+    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, std::span<const char8_t>) final { }
     void didChangeMemoryCost() final { }
     int contextLostCalls() { return m_contextLostCalls; }
 private:

--- a/Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp
@@ -56,7 +56,7 @@ static RefPtr<TestedGraphicsContextGLTextureMapper> createTestedGraphicsContextG
 class MockGraphicsContextGLClient final : public GraphicsContextGL::Client {
 public:
     void forceContextLost() final { ++m_contextLostCalls; }
-    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, const UTF8CString&) final { }
+    void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, std::span<const char8_t>) final { }
     void didChangeMemoryCost() final { }
     int contextLostCalls() { return m_contextLostCalls; }
 private:


### PR DESCRIPTION
#### 981f2c532e67b14de772b9afd25cfe79a68f9a07
<pre>
GraphicsContextGL::Client::addDebugMessage() should take a std::span&lt;const char8_t&gt; rather than a UTF8CString
<a href="https://bugs.webkit.org/show_bug.cgi?id=323951">https://bugs.webkit.org/show_bug.cgi?id=323951</a>

Reviewed by Darin Adler.

Taking a UTF8CString forces every producer of a debug message to build a ref-counted,
heap-allocated buffer just to hand over some characters. The only real producer already
has the characters as a pointer and a length: ANGLE&apos;s KHR_debug callback. It allocates
a CStringBuffer solely to satisfy the signature.

Take a std::span&lt;const char8_t&gt; instead. The span is the natural shape at both ends: the
ANGLE callback passes its (message, length) pair straight through, and
WebGLRenderingContextBase::addDebugMessage() feeds it to makeString(), which already has
a StringTypeAdapter for std::span&lt;const char8_t&gt; that decodes UTF-8 the same way the
UTF8CString adapter did. The formatted message is built in one pass with no intermediate
allocation.

Nothing changes on the wire. WTFArgumentCoders.serialization.in already serializes
UTF8CString as exactly its std::span&lt;const char8_t&gt;, so declaring the IPC argument as the
span encodes the same bytes and merely skips materializing a CStringBuffer on each side.
On the receiving side the span points into the Decoder&apos;s buffer and stays valid for the
synchronous duration of the message dispatch;
RemoteGraphicsContextGLProxy::addDebugMessage() forwards it to the client, which formats
a String immediately, so it never escapes. This is the GPU-to-WebContent direction on a
regular Connection, whose Decoder owns a private copy of the message, not a shared-memory
stream read.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::addDebugMessage):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::initialize):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::addDebugMessage):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::addDebugMessage):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm:
* Tools/TestWebKitAPI/Tests/WebCore/glib/GraphicsContextGLTextureMapper.cpp:

Canonical link: <a href="https://commits.webkit.org/320979@main">https://commits.webkit.org/320979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/634e0f856a00d777559a9de528c298bb6e8ce05b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196566 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150819 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188151 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145551 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125893 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47958 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45930 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158310 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45669 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7640 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50400 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198553 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59831 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155122 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/41567 "The change is no longer eligible for processing.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60541 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154764 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28312 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49194 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132780 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129982 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58966 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20648 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58368 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58584 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58433 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->