### PR TITLE
[macOS] inspector/heap/getRemoteObject.html is a flaky crash

### DIFF
--- a/LayoutTests/inspector/heap/getRemoteObject.html
+++ b/LayoutTests/inspector/heap/getRemoteObject.html
@@ -80,9 +80,9 @@ function test()
         name: "GetRemoteObjectCollectedObject",
         description: "Calling Heap.getRemoteObject for an object that has been collected should result in an error.",
         test(resolve, reject) {
-            function findNodeByPropertyName(objectId, maps, propertyName, callback) {
+            function findNodeByPropertyName(maps, propertyName, callback) {
                 for (let node of maps) {
-                    WI.HeapSnapshotWorkerProxy.singleton().callMethod(objectId, "retainers", node.id, ({edges}) => {
+                    node.retainers((retainerNodes, edges) => {
                         if (edges.some((edge) => (edge.type === "Property" || edge.type === "Variable") && edge.data === propertyName))
                             callback(node);
                     });
@@ -101,7 +101,7 @@ function test()
                             InspectorTest.evaluateInPage("triggerDeleteMapObject()");
                             HeapAgent.gc();
 
-                            findNodeByPropertyName(objectId, maps, "myMap", (heapSnapshotNode) => {
+                            findNodeByPropertyName(maps, "myMap", (heapSnapshotNode) => {
                                 HeapAgent.getRemoteObject(heapSnapshotNode.id, "test", (error, remoteObjectPayload) => {
                                     InspectorTest.expectThat(error, "Should get an error when object has been collected.");
                                     InspectorTest.pass(error);

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -819,8 +819,6 @@ webkit.org/b/206708 fast/animation/request-animation-frame-iframe.html [ Pass Fa
 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform.https.html [ Pass Failure ]
 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-write-twice-transform.https.html [ Pass Failure ]
 
-webkit.org/b/206903 inspector/heap/getRemoteObject.html [ Pass Crash ]
-
 webkit.org/b/207141 [ Debug ] inspector/canvas/create-context-bitmaprenderer.html [ Pass Failure ]
 
 webkit.org/b/207166 http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavailable-gpuprocess.html [ Pass Failure ]

--- a/Source/JavaScriptCore/heap/HeapSnapshot.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshot.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "HeapSnapshot.h"
+#include "HeapSnapshotInlines.h"
 
 #include <numeric>
 #include <wtf/DataLog.h>
@@ -64,8 +65,8 @@ void HeapSnapshot::sweepCell(JSCell* cell)
             if (cell == node.cell) {
                 // Cells should always have 0 as low bits.
                 // Mark this cell for removal by setting the low bit.
-                ASSERT(!(reinterpret_cast<intptr_t>(node.cell) & CellToSweepTag));
-                node.cell = reinterpret_cast<JSCell*>(reinterpret_cast<intptr_t>(node.cell) | CellToSweepTag);
+                ASSERT(!hasCellToSweepTag(node));
+                setCellToSweepTag(node);
                 m_hasCellsToSweep = true;
                 return;
             }
@@ -86,7 +87,7 @@ void HeapSnapshot::shrinkToFit()
         m_filter.reset();
         m_nodes.removeAllMatching(
             [&] (const HeapSnapshotNode& node) -> bool {
-                bool willRemoveCell = std::bit_cast<intptr_t>(node.cell) & CellToSweepTag;
+                bool willRemoveCell = hasCellToSweepTag(node);
                 if (!willRemoveCell)
                     m_filter.add(std::bit_cast<uintptr_t>(node.cell));
                 return willRemoveCell;
@@ -120,7 +121,7 @@ void HeapSnapshot::finalize()
     JSCell* previousCell = nullptr;
     for (auto& node : m_nodes) {
         ASSERT(node.cell);
-        ASSERT(!(reinterpret_cast<intptr_t>(node.cell) & CellToSweepTag));
+        ASSERT(!hasCellToSweepTag(node));
         if (node.cell == previousCell) {
             dataLog("Seeing same cell twice: ", RawPointer(previousCell), "\n");
             ASSERT(node.cell != previousCell);
@@ -174,7 +175,7 @@ std::optional<HeapSnapshotNode> HeapSnapshot::nodeForObjectIdentifier(unsigned o
     }
 
     for (auto& node : m_nodes) {
-        if (node.identifier == objectIdentifier)
+        if (node.identifier == objectIdentifier && !hasCellToSweepTag(node))
             return std::optional<HeapSnapshotNode>(node);
     }
 

--- a/Source/JavaScriptCore/heap/HeapSnapshot.h
+++ b/Source/JavaScriptCore/heap/HeapSnapshot.h
@@ -50,7 +50,6 @@ public:
 
 private:
     friend class HeapSnapshotBuilder;
-    static constexpr intptr_t CellToSweepTag = 1;
 
     Vector<HeapSnapshotNode> m_nodes;
     TinyBloomFilter<uintptr_t> m_filter;

--- a/Source/JavaScriptCore/heap/HeapSnapshotInlines.h
+++ b/Source/JavaScriptCore/heap/HeapSnapshotInlines.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "HeapSnapshot.h"
+
+namespace JSC {
+
+constexpr intptr_t CellToSweepTag = 1;
+
+inline bool hasCellToSweepTag(const HeapSnapshotNode& node)
+{
+    return reinterpret_cast<intptr_t>(node.cell) & CellToSweepTag;
+}
+
+inline void setCellToSweepTag(HeapSnapshotNode& node)
+{
+    node.cell = reinterpret_cast<JSCell*>(reinterpret_cast<intptr_t>(node.cell) | CellToSweepTag);
+}
+
+} // namespace JSC


### PR DESCRIPTION
#### 94e7154f5eaaad26284db3bef80bde6e76a8a563
<pre>
[macOS] inspector/heap/getRemoteObject.html is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=206903">https://bugs.webkit.org/show_bug.cgi?id=206903</a>

Reviewed by NOBODY (OOPS!).

&apos;Heap::removeDeadHeapSnapshotNodes()&apos; tags a HeapSnapshotNode&apos;s cell
pointer with &apos;CellToSweepTag&apos; as soon as the GC determines the cell is
dead, but only removes the node from the snapshot afterwards, in a
single &apos;shrinkToFit()&apos; call. Between those two steps, the node is
still present in &apos;HeapSnapshot::m_nodes&apos; with a poisoned,
non-dereferenceable cell pointer.

&apos;HeapSnapshot::nodeForObjectIdentifier()&apos; ignored this tag and matched
nodes by identifier alone, so it could hand back one of these
dead nodes to &apos;InspectorHeapAgent::getRemoteObject()&apos;, which then
dereferenced the poisoned pointer and eventually crashed a few frames
later inside &apos;InjectedScriptModule::ensureInjected()&apos;.

Skip nodes that already have &apos;CellToSweepTag&apos; set in
&apos;nodeForObjectIdentifier()&apos;, so a collected-but-not-yet-purged object is
treated the same as an already-removed one.

Also simplify the layout test to resolve heap snapshot nodes via
&apos;HeapSnapshotNode.retainers()&apos; instead of going through
&apos;WI.HeapSnapshotWorkerProxy&apos; directly.

Co-Authored-By: Claude Sonnet 5 &lt;noreply@anthropic.com&gt;

* LayoutTests/inspector/heap/getRemoteObject.html:
* Source/JavaScriptCore/heap/HeapSnapshot.cpp:
(JSC::HeapSnapshot::sweepCell):
(JSC::HeapSnapshot::shrinkToFit):
(JSC::HeapSnapshot::finalize):
(JSC::HeapSnapshot::nodeForObjectIdentifier):
* Source/JavaScriptCore/heap/HeapSnapshot.h:
* Source/JavaScriptCore/heap/HeapSnapshotInlines.h: Added.
(JSC::hasCellToSweepTag):
(JSC::setCellToSweepTag):
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94e7154f5eaaad26284db3bef80bde6e76a8a563

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196570 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150820 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145550 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100893 "2 flakes 15 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125892 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/185622 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47960 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45931 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7728 "Passed tests") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14600 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158312 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45670 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7644 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47521 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198557 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59834 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155124 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60545 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42238 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154766 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49197 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132781 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/129986 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58969 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20649 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58372 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58588 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58437 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->