### PR TITLE
Cherry-pick 320892@main (f6b9f5b24d8f). https://bugs.webkit.org/show_bug.cgi?id=323913

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2597,6 +2597,14 @@ webkit.org/b/132995 transitions/cancel-transition.html [ Failure Pass ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # WebAnimations-related bugs
+
+# Apple ports dont's support `steps()` and `linear()` accelerated animations
+webkit.org/b/323852 webanimations/combining-transform-animations-with-different-acceleration-capabilities-2.html [ Skip ]
+webkit.org/b/323852 webanimations/combining-transform-animations-with-different-acceleration-capabilities-3.html [ Skip ]
+webkit.org/b/323852 webanimations/combining-transform-animations-with-different-acceleration-capabilities-6.html [ Skip ]
+webkit.org/b/323852 webanimations/combining-transform-animations-with-different-acceleration-capabilities-7.html [ Skip ]
+webkit.org/b/323852 webanimations/transform-animation-with-steps-timing-function-not-accelerated.html [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 
 webkit.org/b/263870 imported/w3c/web-platform-tests/scroll-animations/css/animation-range-ignored.html [ Skip ]

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -4096,7 +4096,7 @@ void JSObject::convertToUncacheableDictionary(VM& vm)
 }
 
 
-void JSObject::shiftButterflyAfterFlattening(const GCSafeConcurrentJSLocker&, VM& vm, Structure* structure, size_t outOfLineCapacityAfter)
+void JSObject::shiftButterflyAfterFlattening(const ConcurrentJSLocker&, VM& vm, Structure* structure, size_t outOfLineCapacityAfter)
 {
     // This could interleave visitChildren because some old structure could have been a non
     // dictionary structure. We have to be crazy careful. But, we are guaranteed to be holding

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -562,7 +562,7 @@ public:
     {
         structure()->flattenDictionaryStructure(vm, this);
     }
-    void shiftButterflyAfterFlattening(const GCSafeConcurrentJSLocker&, VM&, Structure* structure, size_t outOfLineCapacityAfter);
+    void shiftButterflyAfterFlattening(const ConcurrentJSLocker&, VM&, Structure*, size_t outOfLineCapacityAfter);
 
     JSGlobalObject* realmMayBeNull() const
     {

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -1029,6 +1029,11 @@ Structure* Structure::flattenDictionaryStructure(VM& vm, JSObject* object)
     ASSERT(isDictionary());
     ASSERT(object->structure() == this);
 
+    // Must outlive cellLocker. The collection this defers until scope exit would otherwise run
+    // while the cell lock is held, and the collector takes that same cell lock to scan an array
+    // storage butterfly, so it would deadlock against us.
+    DeferGC deferGC(vm);
+
     Locker<JSCellLock> cellLocker(NoLockingNecessary);
 
     PropertyTable* table = nullptr;
@@ -1047,7 +1052,7 @@ Structure* Structure::flattenDictionaryStructure(VM& vm, JSObject* object)
     if (beforeOutOfLineCapacity != afterOutOfLineCapacity)
         cellLocker = Locker { object->cellLock() };
 
-    GCSafeConcurrentJSLocker locker(m_lock, vm);
+    ConcurrentJSLocker locker(m_lock);
 
     object->setStructureIDDirectly(id().nuke());
     WTF::storeStoreFence();

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2010,11 +2010,13 @@ bool KeyframeEffect::canBeAccelerated(AccountForTimelineAccelerationAbility acco
     if (m_isAssociatedWithProgressBasedTimeline)
         return false;
 
+#if USE(CA)
     if (m_someKeyframesUseStepsTimingFunction || is<StepsTimingFunction>(timingFunction()))
         return false;
 
     if (m_someKeyframesUseLinearTimingFunctionWithPoints || isLinearTimingFunctionWithPoints(timingFunction()))
         return false;
+#endif
 
     if (m_compositeOperation != CompositeOperation::Replace)
         return false;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.cpp
@@ -144,19 +144,11 @@ static TransformationMatrix applyTransformAnimation(const TransformOperations& f
     return matrix;
 }
 
-static const TimingFunction& timingFunctionForAnimationValue(const GraphicsLayerAnimationValue& animationValue, const TextureMapperAnimation& animation)
-{
-    if (auto* function = animationValue.timingFunction())
-        return *function;
-    if (auto* function = animation.timingFunction())
-        return *function;
-    return CubicBezierTimingFunction::defaultTimingFunction();
-}
-
 TextureMapperAnimation::TextureMapperAnimation(const String& name, const GraphicsLayerKeyframeValueList& keyframes, const GraphicsLayerAnimation& animation, MonotonicTime startTime, Seconds pauseTime, State state)
     : m_name(name.isSafeToSendToAnotherThread() ? name : name.isolatedCopy())
     , m_keyframes(keyframes)
-    , m_timingFunction(animation.defaultTimingFunctionForKeyframes() ? animation.defaultTimingFunctionForKeyframes()->clone() : animation.timingFunction()->clone())
+    , m_timingFunction(animation.timingFunction()->clone())
+    , m_defaultTimingFunctionForKeyframes(animation.defaultTimingFunctionForKeyframes() ? animation.defaultTimingFunctionForKeyframes()->clone() : RefPtr<TimingFunction> { })
     , m_iterationCount(animation.iterationCount())
     , m_duration(animation.duration().value_or(0))
     , m_direction(animation.direction())
@@ -173,6 +165,7 @@ TextureMapperAnimation::TextureMapperAnimation(const TextureMapperAnimation& oth
     : m_name(other.m_name.isSafeToSendToAnotherThread() ? other.m_name : other.m_name.isolatedCopy())
     , m_keyframes(other.m_keyframes)
     , m_timingFunction(other.m_timingFunction->clone())
+    , m_defaultTimingFunctionForKeyframes(other.m_defaultTimingFunctionForKeyframes ? other.m_defaultTimingFunctionForKeyframes->clone() : RefPtr<TimingFunction> { })
     , m_iterationCount(other.m_iterationCount)
     , m_duration(other.m_duration)
     , m_direction(other.m_direction)
@@ -190,6 +183,7 @@ TextureMapperAnimation& TextureMapperAnimation::operator=(const TextureMapperAni
     m_name = other.m_name.isSafeToSendToAnotherThread() ? other.m_name : other.m_name.isolatedCopy();
     m_keyframes = other.m_keyframes;
     m_timingFunction = other.m_timingFunction->clone();
+    m_defaultTimingFunctionForKeyframes = other.m_defaultTimingFunctionForKeyframes ? other.m_defaultTimingFunctionForKeyframes->clone() : RefPtr<TimingFunction> { };
     m_iterationCount = other.m_iterationCount;
     m_duration = other.m_duration;
     m_direction = other.m_direction;
@@ -238,12 +232,18 @@ void TextureMapperAnimation::apply(ApplicationResult& applicationResults, Monoto
         applyInternal(applicationResults, m_keyframes.at(m_keyframes.size() - 2), m_keyframes.at(m_keyframes.size() - 1), 1);
         return;
     }
+
     if (m_keyframes.size() == 2) {
-        auto& timingFunction = timingFunctionForAnimationValue(m_keyframes.at(0), *this);
-        normalizedValue = timingFunction.transformProgress(normalizedValue, m_duration);
+        if (!m_defaultTimingFunctionForKeyframes)
+            normalizedValue = timingFunction()->transformProgress(normalizedValue, m_duration);
+
+        normalizedValue = timingFunctionForKeyframe(m_keyframes.at(0)).transformProgress(normalizedValue, m_duration);
         applyInternal(applicationResults, m_keyframes.at(0), m_keyframes.at(1), normalizedValue);
         return;
     }
+
+    if (!m_defaultTimingFunctionForKeyframes)
+        normalizedValue = timingFunction()->transformProgress(normalizedValue, m_duration);
 
     for (size_t i = 0; i < m_keyframes.size() - 1; ++i) {
         const auto& from = m_keyframes.at(i);
@@ -252,8 +252,7 @@ void TextureMapperAnimation::apply(ApplicationResult& applicationResults, Monoto
             continue;
 
         normalizedValue = (normalizedValue - from.keyTime()) / (to.keyTime() - from.keyTime());
-        auto& timingFunction = timingFunctionForAnimationValue(from, *this);
-        normalizedValue = timingFunction.transformProgress(normalizedValue, m_duration);
+        normalizedValue = timingFunctionForKeyframe(from).transformProgress(normalizedValue, m_duration);
         applyInternal(applicationResults, from, to, normalizedValue);
         break;
     }
@@ -284,6 +283,17 @@ Seconds TextureMapperAnimation::computeTotalRunningTime(MonotonicTime time)
     m_lastRefreshedTime = time;
     m_totalRunningTime += m_lastRefreshedTime - oldLastRefreshedTime;
     return m_totalRunningTime;
+}
+
+const TimingFunction& TextureMapperAnimation::timingFunctionForKeyframe(const GraphicsLayerAnimationValue& from) const
+{
+    if (auto* keyframeTimingFunction = from.timingFunction())
+        return *keyframeTimingFunction;
+
+    if (m_defaultTimingFunctionForKeyframes)
+        return *m_defaultTimingFunctionForKeyframes;
+
+    return LinearTimingFunction::identity();
 }
 
 void TextureMapperAnimation::applyInternal(ApplicationResult& applicationResults, const GraphicsLayerAnimationValue& from, const GraphicsLayerAnimationValue& to, float progress)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.h
@@ -62,10 +62,12 @@ public:
 private:
     void applyInternal(ApplicationResult&, const GraphicsLayerAnimationValue& from, const GraphicsLayerAnimationValue& to, float progress);
     Seconds computeTotalRunningTime(MonotonicTime);
+    const TimingFunction& timingFunctionForKeyframe(const GraphicsLayerAnimationValue& from) const;
 
     String m_name;
     GraphicsLayerKeyframeValueList m_keyframes { AnimatedProperty::Invalid };
     RefPtr<TimingFunction> m_timingFunction;
+    RefPtr<TimingFunction> m_defaultTimingFunctionForKeyframes;
     double m_iterationCount { 0 };
     double m_duration { 0 };
     GraphicsLayerAnimation::Direction m_direction { GraphicsLayerAnimation::Direction::Normal };


### PR DESCRIPTION
#### 2adf15d8b3acb372f854128702f2f2282fb78d6b
<pre>
Cherry-pick 320892@main (f6b9f5b24d8f). <a href="https://bugs.webkit.org/show_bug.cgi?id=323913">https://bugs.webkit.org/show_bug.cgi?id=323913</a>

    [JSC] Fix dead-lock in Structure::flattenDictionaryStructure
    <a href="https://bugs.webkit.org/show_bug.cgi?id=323913">https://bugs.webkit.org/show_bug.cgi?id=323913</a>
    <a href="https://rdar.apple.com/187149098">rdar://187149098</a>

    Reviewed by Keith Miller.

    It is extremely rare, but

    1. Locker&lt;JSCellLock&gt; cellLocker is holding a cellLock()
    2. GCSafeConcurrentJSLocker takes m_lock
    3. GCSafeConcurrentJSLocker gets destroyed first
    4. Deferred GC happens while we are taking a cellLock() here.

    Then GC will take a cellLock and getting a dead-lock. This patch places
    DeferGC to confirm that we do not do GC.

    * Source/JavaScriptCore/runtime/JSObject.cpp:
    (JSC::JSObject::shiftButterflyAfterFlattening):
    * Source/JavaScriptCore/runtime/JSObject.h:
    * Source/JavaScriptCore/runtime/Structure.cpp:
    (JSC::Structure::flattenDictionaryStructure):

    Canonical link: <a href="https://commits.webkit.org/320892@main">https://commits.webkit.org/320892@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.290@webkitglib/2.54">https://commits.webkit.org/317695.290@webkitglib/2.54</a>
</pre>
----------------------------------------------------------------------
#### 06f543c2d0e4b7c0e65194e3c05326c51ec8cf23
<pre>
Cherry-pick 320878@main (7b265b345c26). <a href="https://bugs.webkit.org/show_bug.cgi?id=323852">https://bugs.webkit.org/show_bug.cgi?id=323852</a>

    [GTK][WPE] `steps()` and `linear()` animations can be accelerated
    <a href="https://bugs.webkit.org/show_bug.cgi?id=323852">https://bugs.webkit.org/show_bug.cgi?id=323852</a>

    Reviewed by Carlos Garcia Campos.

    `steps()` and `linear()` easing functions are currently excluded from
    acceleration on all ports. This restriction only needs to apply to Apple
    ports, because accelerated animations running on the compositor are
    implemented using `CAMediaTimingFunction`, which cannot fully represent
    them. GTK and WPE use `TextureMapperAnimation`, which doesn&apos;t have this
    limitation, so these animations can be accelerated there.

    `TextureMapperAnimation` kept a single `m_timingFunction` field for two
    different things — the overall timing function of a Web Animation, and
    the CSS Animation&apos;s `animation-timing-function`, which only acts as a
    fallback for keyframes that don&apos;t specify their own easing.

    Because of this, that fallback easing could be applied to the whole
    animation progress instead of just to the individual keyframe interval,
    which produces the wrong `steps()`/`linear()` results.

    `TextureMapperAnimation` now keeps the fallback as a separate
    `m_defaultTimingFunctionForKeyframes` field, and a new
    `timingFunctionForKeyframe()` helper applies it only where it&apos;s supposed
    to.

    Test: webanimations/transform-animation-with-steps-timing-function.html

    Removed
    * Source/WebCore/animation/KeyframeEffect.cpp:
    (WebCore::KeyframeEffect::canBeAccelerated const):
    (WebCore::KeyframeEffect::updateAcceleratedActions):
    * Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.cpp:
    (WebCore::timingFunctionIsIdentity):
    (WebCore::TextureMapperAnimation::TextureMapperAnimation):
    (WebCore::TextureMapperAnimation::operator=):
    (WebCore::TextureMapperAnimation::apply):
    (WebCore::TextureMapperAnimation::applyTimingFunctionForKeyframe const):
    (WebCore::timingFunctionForAnimationValue): Deleted.
    (WebCore::TextureMapperAnimation::timingFunctionForKeyframe const):
    * Source/WebCore/platform/graphics/texmap/TextureMapperAnimation.h:
    * LayoutTests/platform/glib/TestExpectations:

    Canonical link: <a href="https://commits.webkit.org/320878@main">https://commits.webkit.org/320878@main</a>

Canonical link: <a href="https://commits.webkit.org/317695.289@webkitglib/2.54">https://commits.webkit.org/317695.289@webkitglib/2.54</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd209db603f72f35e395ef41eafde869e9722c3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186300 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/60185 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/53956 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196577 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150826 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188162 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/61566 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59895 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145568 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150826 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189255 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/61566 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/53956 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125912 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/61566 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/59895 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7746 "Passed tests") | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/168/builds/53956 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/61566 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53956 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7651 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/47528 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/52662 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/59895 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198564 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/59841 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/53956 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155134 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/60552 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/53956 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154776 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28284 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/60552 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132787 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/129995 "The change is no longer eligible for processing.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/58976 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/53956 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/58379 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58595 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/58444 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->