### PR TITLE
[JSC] Rewrite WeakGCMap like JS WeakMap

### DIFF
--- a/JSTests/stress/weak-gc-map-keeps-live-values.js
+++ b/JSTests/stress/weak-gc-map-keeps-live-values.js
@@ -1,0 +1,32 @@
+// Symbol.for observes VM::symbolImplToSymbolMap, one of the WeakGCMaps, directly: if a reachable
+// entry is dropped, the next lookup builds a fresh Symbol cell for the same key and the two are not
+// identical. Eden and full collections reconcile those maps by different paths, so exercise both.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}`);
+}
+
+const symbols = [];
+for (let i = 0; i < 128; ++i)
+    symbols.push(Symbol.for(`key-${i}`));
+
+for (let i = 0; i < 32; ++i) {
+    // Churn structure transitions, prototype structures, and interned strings, so that the weak
+    // tables gain entries between collections.
+    for (let j = 0; j < 512; ++j) {
+        const object = {};
+        object[`p${j & 31}`] = j;
+        object.tail = j;
+        Object.create(object);
+        `a,b,c-${j}`.split(",");
+    }
+
+    if (i & 1)
+        edenGC();
+    else
+        gc();
+
+    for (let j = 0; j < symbols.length; ++j)
+        shouldBe(Symbol.for(`key-${j}`), symbols[j]);
+}

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1815,7 +1815,7 @@ NEVER_INLINE bool Heap::runEndPhase(GCConductor conn)
 
         cancelDeferredWorkIfNeeded();
         reapWeakHandles();
-        pruneStaleEntriesFromWeakGCHashTables();
+        reconcileWeakGCHashTables();
         sweepArrayBuffers();
         snapshotUnswept();
         reconcileWeakReferencesAtGCEnd(); // Must precede clearCurrentlyExecuting: CodeBlock::reconcileWeakReferencesAtGCEnd queries which CodeBlocks are currently executing.
@@ -2522,12 +2522,24 @@ void Heap::reapWeakHandles()
     m_objectSpace.reapWeakSets();
 }
 
-void Heap::pruneStaleEntriesFromWeakGCHashTables()
+void Heap::reconcileWeakGCHashTables()
 {
-    if (!m_collectionScope || m_collectionScope.value() != CollectionScope::Full)
+    CollectionScope collectionScope = m_collectionScope.value_or(CollectionScope::Full);
+    if (collectionScope == CollectionScope::Full) {
+        for (auto* weakGCHashTable : m_weakGCHashTables)
+            weakGCHashTable->reconcileWeakReferencesAtGCEnd(vm(), collectionScope);
+        m_dirtyWeakGCHashTables.forEach([](WeakGCHashTable* weakGCHashTable) {
+            weakGCHashTable->remove();
+        });
         return;
-    for (auto* weakGCHashTable : m_weakGCHashTables)
-        weakGCHashTable->pruneStaleEntries();
+    }
+
+    // Only a table that gained an entry since the last collection can hold an entry that dies here:
+    // everything that survived that collection is old, and an eden collection cannot free it.
+    m_dirtyWeakGCHashTables.forEach([&](WeakGCHashTable* weakGCHashTable) {
+        weakGCHashTable->remove();
+        weakGCHashTable->reconcileWeakReferencesAtGCEnd(vm(), collectionScope);
+    });
 }
 
 void Heap::sweepArrayBuffers()
@@ -3027,7 +3039,20 @@ void Heap::registerWeakGCHashTable(WeakGCHashTable* weakGCHashTable)
 
 void Heap::unregisterWeakGCHashTable(WeakGCHashTable* weakGCHashTable)
 {
+    if (weakGCHashTable->isOnList())
+        weakGCHashTable->remove();
     m_weakGCHashTables.remove(weakGCHashTable);
+}
+
+void Heap::addDirtyWeakGCHashTable(WeakGCHashTable* weakGCHashTable)
+{
+    ASSERT(!weakGCHashTable->isOnList());
+    m_dirtyWeakGCHashTables.append(weakGCHashTable);
+}
+
+void WeakGCHashTable::addToDirtyList(VM& vm)
+{
+    vm.heap.addDirtyWeakGCHashTable(this);
 }
 
 void Heap::didAllocateBlock(size_t capacity)

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -56,6 +56,7 @@
 #include <wtf/NotFound.h>
 #include <wtf/ParallelHelperPool.h>
 #include <wtf/SegmentedVector.h>
+#include <wtf/SentinelLinkedList.h>
 #include <wtf/Threading.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -509,6 +510,7 @@ public:
 
     JS_EXPORT_PRIVATE void registerWeakGCHashTable(WeakGCHashTable*);
     JS_EXPORT_PRIVATE void unregisterWeakGCHashTable(WeakGCHashTable*);
+    void addDirtyWeakGCHashTable(WeakGCHashTable*);
 
     void addLogicallyEmptyWeakBlock(WeakBlock*);
 
@@ -767,7 +769,7 @@ private:
 
     void cancelDeferredWorkIfNeeded();
     void reapWeakHandles();
-    void pruneStaleEntriesFromWeakGCHashTables();
+    void reconcileWeakGCHashTables();
     void sweepArrayBuffers();
     void snapshotUnswept();
     void deleteSourceProviderCaches();
@@ -955,6 +957,7 @@ private:
     unsigned m_deferralDepth { 0 };
 
     UncheckedKeyHashSet<WeakGCHashTable*> m_weakGCHashTables;
+    SentinelLinkedList<WeakGCHashTable, BasicRawSentinelNode<WeakGCHashTable>> m_dirtyWeakGCHashTables;
     
 #if ENABLE(WEBASSEMBLY)
     UncheckedKeyHashSet<Ref<Wasm::Callee>> m_wasmCalleesPendingDestruction WTF_GUARDED_BY_LOCK(m_wasmCalleesPendingDestructionLock);

--- a/Source/JavaScriptCore/runtime/WeakGCHashTable.h
+++ b/Source/JavaScriptCore/runtime/WeakGCHashTable.h
@@ -25,12 +25,32 @@
 
 #pragma once
 
+#include <JavaScriptCore/CollectionScope.h>
+#include <wtf/SentinelLinkedList.h>
+
 namespace JSC {
 
-class WeakGCHashTable {
+class VM;
+
+// A hash table holding weak references to JSCells, reconciled against the marking results at the
+// end of every collection. The sentinel node links it into Heap's list of tables that gained an
+// entry since the last collection; only those tables can have an entry die in an eden collection,
+// so an eden collection visits just them.
+class WeakGCHashTable : public BasicRawSentinelNode<WeakGCHashTable> {
 public:
-    virtual ~WeakGCHashTable() { }
-    virtual void pruneStaleEntries() = 0;
+    virtual ~WeakGCHashTable() = default;
+    virtual void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope) = 0;
+
+protected:
+    void markDirty(VM& vm)
+    {
+        if (!isOnList())
+            addToDirtyList(vm);
+    }
+
+private:
+    // Out of line because this header is reached through VM.h, so Heap is not complete here.
+    JS_EXPORT_PRIVATE void addToDirtyList(VM&);
 };
 
 }

--- a/Source/JavaScriptCore/runtime/WeakGCMap.h
+++ b/Source/JavaScriptCore/runtime/WeakGCMap.h
@@ -26,19 +26,20 @@
 #pragma once
 
 #include <JavaScriptCore/DeferGC.h>
-#include <JavaScriptCore/Weak.h>
 #include <JavaScriptCore/WeakGCHashTable.h>
 #include <wtf/HashMap.h>
 
 namespace JSC {
 
-// A UncheckedKeyHashMap with Weak<JSCell> values, which automatically removes values once they're garbage collected.
+// A UncheckedKeyHashMap holding JSCell values weakly. A value is dropped once a collection proves it
+// unreachable: eden collections null the entry out, leaving it behind for find() and ensureValue()
+// to treat as absent, and full collections remove it outright.
 
 template<typename KeyArg, typename ValueArg, typename HashArg = DefaultHash<KeyArg>, typename KeyTraitsArg = HashTraits<KeyArg>>
 class WeakGCMap final : public WeakGCHashTable {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(WeakGCMap);
     WTF_MAKE_NONCOPYABLE(WeakGCMap);
-    typedef Weak<ValueArg> ValueType;
+    typedef ValueArg* ValueType;
     typedef UncheckedKeyHashMap<KeyArg, ValueType, HashArg, KeyTraitsArg> HashMapType;
 
 public:
@@ -57,7 +58,9 @@ public:
 
     AddResult set(const KeyType& key, ValueType value)
     {
-        return m_map.set(key, WTF::move(value));
+        AddResult result = m_map.set(key, value);
+        markDirty(m_vm);
+        return result;
     }
 
     template<typename Functor>
@@ -67,11 +70,14 @@ public:
         // The functor must not invoke GC.
         AssertNoGC assertNoGC;
         AddResult result = m_map.ensure(key, functor);
-        ValueArg* value = result.iterator->value.get();
-        if (!result.isNewEntry && !value) {
+        ValueArg* value = result.iterator->value;
+        if (!result.isNewEntry) {
+            if (value)
+                return value;
             value = functor();
-            result.iterator->value = WTF::move(value);
+            result.iterator->value = value;
         }
+        markDirty(m_vm);
         return value;
     }
 
@@ -85,24 +91,13 @@ public:
         m_map.clear();
     }
 
-    bool isEmpty() const
-    {
-        const_iterator it = m_map.begin();
-        const_iterator end = m_map.end();
-        while (it != end) {
-            if (it->value)
-                return true;
-        }
-        return false;
-    }
-
     inline iterator find(const KeyType& key);
 
     inline const_iterator find(const KeyType& key) const;
 
     inline bool contains(const KeyType& key) const;
 
-    void pruneStaleEntries() final;
+    void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope) final;
 
     template<typename Func>
     void forEach(Func);

--- a/Source/JavaScriptCore/runtime/WeakGCMapInlines.h
+++ b/Source/JavaScriptCore/runtime/WeakGCMapInlines.h
@@ -27,7 +27,6 @@
 
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/WeakGCMap.h>
-#include <JavaScriptCore/WeakInlines.h>
 #include <wtf/IterationStatus.h>
 
 namespace JSC {
@@ -68,11 +67,22 @@ inline bool WeakGCMap<KeyArg, ValueArg, HashArg, KeyTraitsArg>::contains(const K
 }
 
 template<typename KeyArg, typename ValueArg, typename HashArg, typename KeyTraitsArg>
-NEVER_INLINE void WeakGCMap<KeyArg, ValueArg, HashArg, KeyTraitsArg>::pruneStaleEntries()
+NEVER_INLINE void WeakGCMap<KeyArg, ValueArg, HashArg, KeyTraitsArg>::reconcileWeakReferencesAtGCEnd(VM& vm, CollectionScope collectionScope)
 {
-    m_map.removeIf([](const typename HashMapType::KeyValuePairType& entry) {
-        return !entry.value;
-    });
+    if (collectionScope == CollectionScope::Full) {
+        m_map.removeIf([&](const typename HashMapType::KeyValuePairType& entry) {
+            return !entry.value || !vm.heap.isMarked(entry.value);
+        });
+        return;
+    }
+
+    // Rehashing here would have to run without allocating or touching the heap, and an eden
+    // collection frees little enough that it is not worth it. Leave a zombie entry for the next
+    // full collection to remove.
+    for (auto& entry : m_map) {
+        if (entry.value && !vm.heap.isMarked(entry.value))
+            entry.value = nullptr;
+    }
 }
 
 template<typename KeyArg, typename ValueArg, typename HashArg, typename KeyTraitsArg>
@@ -82,7 +92,7 @@ inline void WeakGCMap<KeyArg, ValueArg, HashArg, KeyTraitsArg>::forEach(Func fun
     ASSERT(m_vm.heap.isDeferred());
     for (auto& entry : m_map) {
         if (entry.value) {
-            if (func(entry.value.get()) == IterationStatus::Done)
+            if (func(entry.value) == IterationStatus::Done)
                 return;
         }
     }

--- a/Source/JavaScriptCore/runtime/WeakGCSet.h
+++ b/Source/JavaScriptCore/runtime/WeakGCSet.h
@@ -104,7 +104,8 @@ public:
     // FIXME: Add support for find/contains/remove from a ValueArg* via a HashTranslator.
 
 private:
-    void pruneStaleEntries() final;
+    void reconcileWeakReferencesAtGCEnd(VM&, CollectionScope) final;
+    NEVER_INLINE void pruneStaleEntries();
 
     HashSetType m_set;
     VM& m_vm;

--- a/Source/JavaScriptCore/runtime/WeakGCSetInlines.h
+++ b/Source/JavaScriptCore/runtime/WeakGCSetInlines.h
@@ -45,6 +45,15 @@ inline WeakGCSet<ValueArg, HashArg, TraitsArg>::~WeakGCSet()
 }
 
 template<typename ValueArg, typename HashArg, typename TraitsArg>
+inline void WeakGCSet<ValueArg, HashArg, TraitsArg>::reconcileWeakReferencesAtGCEnd(VM&, CollectionScope collectionScope)
+{
+    // Entries hold Weak<>, which WeakBlock::reap has already nulled out. Only the removal is left,
+    // and it is deferred to full collections because removing rehashes the set.
+    if (collectionScope == CollectionScope::Full)
+        pruneStaleEntries();
+}
+
+template<typename ValueArg, typename HashArg, typename TraitsArg>
 NEVER_INLINE void WeakGCSet<ValueArg, HashArg, TraitsArg>::pruneStaleEntries()
 {
     m_set.removeIf([](auto& entry) {


### PR DESCRIPTION
#### 8ae0649a809b4eb3c69f1e9883d2c7717f4b12ae
<pre>
[JSC] Rewrite WeakGCMap like JS WeakMap
<a href="https://bugs.webkit.org/show_bug.cgi?id=323958">https://bugs.webkit.org/show_bug.cgi?id=323958</a>
<a href="https://rdar.apple.com/187190421">rdar://187190421</a>

Reviewed by Tadeu Zagallo.

WeakGCMap / WeakGCSet were using Weak&lt;&gt; for values, but Weak is
double-pointer and its management is costly. This patch changes them to
similar to JS WeakMap design: we clear values when GC ends. At GC end
phase, we know whether vlaue is dead or marked, so we can clean them up.

The problem is that we do not want to scan during Eden GC repeatedly.
Previously WeakGCMap was cleaned up only during Full GC. And each Weak&lt;&gt;
cell clean up is done for each GC cycle, tied to MarkedBlock. But now we
need to use isMarked information to clean things up for each GC end phase.
But the key is that &quot;once your value survives Eden GC, now mark bit is
sticky so it is alive in the next Eden GC too&quot;. This means that we
should scan WeakGCMap only when it gets modified during this Eden GC
cycle. So we can reduce clean up cost in GC end phase. didAddValue will
chain the WeakGCMap to the heap list and we scan this chained WeakGCMap.

Test: JSTests/stress/weak-gc-map-keeps-live-values.js

* JSTests/stress/weak-gc-map-keeps-live-values.js: Added.
(shouldBe):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::clearConcurrentRetainedDataIfPossible):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/runtime/WeakGCHashTable.h:
(JSC::WeakGCHashTable::markDirty):
(JSC::WeakGCHashTable::~WeakGCHashTable): Deleted.
* Source/JavaScriptCore/runtime/WeakGCMap.h:
* Source/JavaScriptCore/runtime/WeakGCMapInlines.h:
(JSC::KeyTraitsArg&gt;::reconcileWeakReferencesAtGCEnd):
(JSC::KeyTraitsArg&gt;::forEach):
(JSC::KeyTraitsArg&gt;::pruneStaleEntries): Deleted.
* Source/JavaScriptCore/runtime/WeakGCSet.h:
* Source/JavaScriptCore/runtime/WeakGCSetInlines.h:
(JSC::TraitsArg&gt;::reconcileWeakReferencesAtGCEnd):

Canonical link: <a href="https://commits.webkit.org/320942@main">https://commits.webkit.org/320942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f5faa5ee2c917122a2c7beb0471690b92388fae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196585 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150830 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1e238baf-1fd1-42a2-8101-64367ec68a8c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145575 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74148082-8ed8-422c-b39c-bf16acde51c5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166091 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125919 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3b07d5b-88bb-448c-ab6a-db07ac6672c2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47975 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45940 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7753 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14617 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158326 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45687 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7659 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47536 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198572 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59849 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155138 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60560 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154781 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28294 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49211 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132791 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130006 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58984 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20666 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58387 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58603 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58452 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->