### PR TITLE
REGRESSION(319181@main?): [iOS] TestWebKitAPI.WebAuthenticationPanel.LAMakeCredentialAllowLocalAuthenticator is a flaky timeout

### DIFF
--- a/TestExpectations/apitests
+++ b/TestExpectations/apitests
@@ -264,7 +264,6 @@ webkit.org/b/318267 [ ios ] TestWebKitAPI.WebAuthenticationPanel.GetAssertionPin
 webkit.org/b/317891 [ ios ] TestWebKitAPI.WebAuthenticationPanel.GetAssertionPinProtocol2 [ Skip ]
 rdar://145102423 [ mac debug ] TestWebKitAPI.WebAuthenticationPanel.LAGetAssertionNoMockNoUserGesture [ Skip ]
 rdar://145102423 [ ios debug ] TestWebKitAPI.WebAuthenticationPanel.LAGetAssertionNoMockNoUserGesture [ Skip ]
-webkit.org/b/323143 [ ios ] TestWebKitAPI.WebAuthenticationPanel.LAMakeCredentialAllowLocalAuthenticator [ Pass Timeout ]
 rdar://145102423 [ mac debug ] TestWebKitAPI.WebAuthenticationPanel.MakeCredentialSPITimeout [ Skip ]
 rdar://145102423 [ ios debug ] TestWebKitAPI.WebAuthenticationPanel.MakeCredentialSPITimeout [ Skip ]
 webkit.org/b/318267 [ ios ] TestWebKitAPI.WebAuthenticationPanel.MultipleAccounts [ Skip ]

--- a/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-make-credential-la.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/web-authentication-make-credential-la.html
@@ -53,7 +53,7 @@
             challenge: new Uint8Array(16),
             pubKeyCredParams: [{ type: "public-key", alg: -7 }],
             attestation: "direct",
-            timeout: 100,
+            timeout: 10000,
         }
     };
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm
@@ -1306,7 +1306,7 @@ TEST(WebAuthenticationPanel, LAMakeCredentialAllowLocalAuthenticator)
 
     localAuthenticatorPolicy = _WKLocalAuthenticatorPolicyAllow;
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
-    [webView waitForMessage:@"Succeeded!"];
+    [webView waitForMessages:@[@"Succeeded!"]];
     checkPanel([delegate panel], @"", @[adoptNS([[NSNumber alloc] initWithInt:_WKWebAuthenticationTransportUSB]).get(), adoptNS([[NSNumber alloc] initWithInt:_WKWebAuthenticationTransportInternal]).get()], _WKWebAuthenticationTypeCreate);
     cleanUpKeychain();
 }


### PR DESCRIPTION
#### 57e38ddd39ed242177d3fdc13d2073e16048580a
<pre>
REGRESSION(<a href="https://commits.webkit.org/319181@main">319181@main</a>?): [iOS] TestWebKitAPI.WebAuthenticationPanel.LAMakeCredentialAllowLocalAuthenticator is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=323143">https://bugs.webkit.org/show_bug.cgi?id=323143</a>
<a href="https://rdar.apple.com/186402508">rdar://186402508</a>

Reviewed by NOBODY (OOPS!).

Increase the timeout passed to web authentication credential API.
Very likely the <a href="https://commits.webkit.org/319181@main">319181@main</a> make GPUP initialization faster, less
blocking and this caused the credential api request start up faster.

Use message checking API that detects the timeout error message.
Previously the result checking API used was just waiting for the
exact message, hanging indefinitively.

* Tools/TestWebKitAPI/Resources/cocoa/web-authentication-make-credential-la.html:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST(WebAuthenticationPanel, LAMakeCredentialAllowLocalAuthenticator)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57e38ddd39ed242177d3fdc13d2073e16048580a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186339 "60 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60224 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196616 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150849 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3b2744f-25a5-432b-8bda-522cf981f632) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145585 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100912 "1 flakes 17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3aa5602a-8065-4ecf-aa9b-65c0da61a54a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125931 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0b9d369d-576b-4cdf-8c1c-049625332b79) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47992 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45953 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45696 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7690 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198603 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59880 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155169 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60591 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154802 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49225 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130049 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59015 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20675 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58418 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58634 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58483 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->