### PR TITLE
Rename toCString() to toUTF8CString() and stop PrintStream from printing an untyped CString

### DIFF
--- a/Source/JavaScriptCore/API/JSMarkingConstraintPrivate.cpp
+++ b/Source/JavaScriptCore/API/JSMarkingConstraintPrivate.cpp
@@ -72,8 +72,8 @@ void JSContextGroupAddMarkingConstraint(JSContextGroupRef group, JSMarkingConstr
     ConstraintVolatility volatility = ConstraintVolatility::GreyedByMarking;
     
     auto constraint = makeUnique<SimpleMarkingConstraint>(
-        toCString("Amc", constraintIndex, "(", RawPointer(constraintCallback), ")"),
-        toCString("API Marking Constraint #", constraintIndex, " (", RawPointer(constraintCallback), ", ", RawPointer(userData), ")"),
+        toUTF8CString("Amc", constraintIndex, "(", RawPointer(constraintCallback), ")"),
+        toUTF8CString("API Marking Constraint #", constraintIndex, " (", RawPointer(constraintCallback), ", ", RawPointer(userData), ")"),
         MAKE_MARKING_CONSTRAINT_EXECUTOR_PAIR(([constraintCallback, userData] (AbstractSlotVisitor& visitor) {
             Marker marker;
             marker.IsMarked = isMarked;

--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -123,7 +123,7 @@ void LinkBuffer::logJITCodeForJITDump(CodeRef<LinkBufferPtrTag>& codeRef, ASCIIL
         dumpSimpleName(out, simpleName);
         break;
     }
-    auto finalName = out.toCString();
+    auto finalName = out.toUTF8CString();
 
     if (Options::useGdbJITInfo()) [[unlikely]]
         GdbJIT::log(finalName, codeRef);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.cpp
@@ -45,12 +45,12 @@ bool MacroAssemblerCodeRefBase::tryToDisassemble(CodePtr<DisassemblyPtrTag> code
     return tryToDisassemble(codePtr, size, prefix, WTF::dataFile());
 }
 
-CString MacroAssemblerCodeRefBase::disassembly(CodePtr<DisassemblyPtrTag> codePtr, size_t size)
+UTF8CString MacroAssemblerCodeRefBase::disassembly(CodePtr<DisassemblyPtrTag> codePtr, size_t size)
 {
     StringPrintStream out;
     if (!tryToDisassemble(codePtr, size, "", out))
-        return CString();
-    return out.toCString();
+        return { };
+    return out.toUTF8CString();
 }
 
 bool shouldDumpDisassemblyFor(CodeBlock* codeBlock)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.h
@@ -53,7 +53,7 @@ class MacroAssemblerCodeRefBase {
 protected:
     static bool tryToDisassemble(CodePtr<DisassemblyPtrTag>, size_t, const char* prefix, PrintStream& out);
     static bool tryToDisassemble(CodePtr<DisassemblyPtrTag>, size_t, const char* prefix);
-    JS_EXPORT_PRIVATE static CString disassembly(CodePtr<DisassemblyPtrTag>, size_t);
+    JS_EXPORT_PRIVATE static UTF8CString disassembly(CodePtr<DisassemblyPtrTag>, size_t);
 };
 
 template<PtrTag tag>
@@ -133,7 +133,7 @@ public:
         return tryToDisassemble(retaggedCode<DisassemblyPtrTag>(), size(), prefix);
     }
     
-    CString disassembly() const
+    UTF8CString disassembly() const
     {
         return MacroAssemblerCodeRefBase::disassembly(retaggedCode<DisassemblyPtrTag>(), size());
     }

--- a/Source/JavaScriptCore/assembler/PerfLog.cpp
+++ b/Source/JavaScriptCore/assembler/PerfLog.cpp
@@ -204,7 +204,7 @@ void PerfLog::flush(const AbstractLocker&)
     m_file.flush();
 }
 
-void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> code, std::unique_ptr<IRDumpDebugInfo>&& irDebugInfo, std::unique_ptr<SourceCodeDumpDebugInfo>&& sourceCodeDebugInfo)
+void PerfLog::log(const UTF8CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> code, std::unique_ptr<IRDumpDebugInfo>&& irDebugInfo, std::unique_ptr<SourceCodeDumpDebugInfo>&& sourceCodeDebugInfo)
 {
     auto timestamp = ProfilerSupport::generateTimestamp();
     auto tid = ProfilerSupport::getCurrentThreadID();
@@ -247,9 +247,9 @@ void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> c
                 for (auto& irLine : irDebugInfo->irLines) {
                     CString line;
                     if (irLine.opName)
-                        line = toCString("  ", irLine.opName, "\n");
+                        line = toUTF8CString("  ", irLine.opName, "\n");
                     else
-                        line = toCString("BB#", irLine.blockIndex, "\n");
+                        line = toUTF8CString("BB#", irLine.blockIndex, "\n");
                     handle.write(WTF::asByteSpan(line.span()));
                 }
                 handle.flush();
@@ -329,7 +329,7 @@ void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> c
         record.codeIndex = logger.m_codeIndex++;
 
         logger.write(locker, unsafeMakeSpan(std::bit_cast<char*>(&record), sizeof(JITDump::CodeLoadRecord)));
-        logger.write(locker, name.spanIncludingNullTerminator());
+        logger.write(locker, byteCast<uint8_t>(name.spanIncludingNullTerminator()));
         logger.write(locker, unsafeMakeSpan(executableAddress, size));
         logger.flush(locker);
 

--- a/Source/JavaScriptCore/assembler/PerfLog.h
+++ b/Source/JavaScriptCore/assembler/PerfLog.h
@@ -45,7 +45,7 @@ class PerfLog {
     WTF_MAKE_NONCOPYABLE(PerfLog);
     friend class LazyNeverDestroyed<PerfLog>;
 public:
-    static void log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag>, std::unique_ptr<IRDumpDebugInfo>&& = nullptr, std::unique_ptr<SourceCodeDumpDebugInfo>&& = nullptr);
+    static void log(const UTF8CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag>, std::unique_ptr<IRDumpDebugInfo>&& = nullptr, std::unique_ptr<SourceCodeDumpDebugInfo>&& = nullptr);
 
 private:
     PerfLog();

--- a/Source/JavaScriptCore/b3/B3PhaseScope.cpp
+++ b/Source/JavaScriptCore/b3/B3PhaseScope.cpp
@@ -47,14 +47,14 @@ PhaseScope::PhaseScope(Procedure& procedure, ASCIILiteral name)
     }
 
     if (shouldSaveIRBeforePhase())
-        m_dumpBefore = toCString(procedure);
+        m_dumpBefore = toUTF8CString(procedure);
 }
 
 PhaseScope::~PhaseScope()
 {
     m_procedure.setLastPhaseName(m_name);
     if (shouldValidateIRAtEachPhase())
-        validate(m_procedure, m_dumpBefore.data());
+        validate(m_procedure, m_dumpBefore.legacyCStringPointer());
 
     if (Options::dumpIonGraph()) [[unlikely]]
         m_procedure.appendIonGraphPass(m_name);

--- a/Source/JavaScriptCore/b3/B3PhaseScope.h
+++ b/Source/JavaScriptCore/b3/B3PhaseScope.h
@@ -45,7 +45,7 @@ private:
     Procedure& m_procedure;
     ASCIILiteral m_name;
     CompilerTimingScope m_timingScope;
-    CString m_dumpBefore;
+    UTF8CString m_dumpBefore;
 };
 
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3Procedure.cpp
+++ b/Source/JavaScriptCore/b3/B3Procedure.cpp
@@ -567,7 +567,7 @@ void Procedure::appendIonGraphPass(ASCIILiteral passName)
                 value->dumpMeta(comma, stream);
                 auto effects = value->effects();
                 {
-                    CString string = toCString(effects);
+                    auto string = toUTF8CString(effects);
                     if (string.length())
                         stream.print(comma, string);
                 }

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -62,7 +62,7 @@ public:
 #define VALIDATE(condition, message) do {                               \
         if (condition)                                                  \
             break;                                                      \
-        fail(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, #condition, toCString message); \
+        fail(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, #condition, toUTF8CString message); \
     } while (false)
 
     void run()
@@ -1134,16 +1134,16 @@ private:
 
     NO_RETURN_DUE_TO_CRASH void fail(
         const char* filename, int lineNumber, const char* function, const char* condition,
-        CString message)
+        UTF8CString message)
     {
-        CString failureMessage;
+        UTF8CString failureMessage;
         {
             StringPrintStream out;
             out.print("B3 VALIDATION FAILURE\n");
             out.print("    ", condition, " (", filename, ":", lineNumber, ")\n");
             out.print("    ", message, "\n");
             out.print("    After ", m_procedure.lastPhaseName(), "\n");
-            failureMessage = out.toCString();
+            failureMessage = out.toUTF8CString();
         }
 
         dataLog(failureMessage);

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -284,7 +284,7 @@ void Value::deepDump(const Procedure* proc, PrintStream& out) const
     dumpMeta(comma, out);
 
     {
-        CString string = toCString(effects());
+        auto string = toUTF8CString(effects());
         if (string.length())
             out.print(comma, string);
     }

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -2308,7 +2308,7 @@ private:
                     StringPrintStream out;
                     out.println("Pop: ", entry, " tmp: ", tmpData);
                     dumpRegRanges<bank>(out);
-                    dataLog(out.toCString());
+                    dataLog(out.toUTF8CString());
                 }
                 switch (tmpData.stage) {
                 case Stage::Unspillable:
@@ -2432,7 +2432,7 @@ private:
             }
             out.println("Code:", m_code);
             out.println("Register Allocator State:\n", pointerDump(this));
-            dataLogLn(out.toCString());
+            dataLogLn(out.toUTF8CString());
             RELEASE_ASSERT_NOT_REACHED();
         };
 

--- a/Source/JavaScriptCore/b3/air/AirLogRegisterPressure.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLogRegisterPressure.cpp
@@ -47,7 +47,7 @@ void logRegisterPressure(Code& code)
 
         block->dumpHeader(WTF::dataFile());
 
-        Vector<CString> instDumps;
+        Vector<UTF8CString> instDumps;
         for (unsigned instIndex = block->size(); instIndex--;) {
             Inst& inst = block->at(instIndex);
             Inst* prevInst = block->get(instIndex - 1);
@@ -69,9 +69,9 @@ void logRegisterPressure(Code& code)
             if (set.numberOfSetRegisters()) {
                 set.forEach(
                     [&] (Reg reg) {
-                        CString text = toCString(" ", reg);
+                        auto text = toUTF8CString(" ", reg);
                         if (text.length() + lineOut.length() > totalColumns) {
-                            instOut.print(lineOut.toCString(), "\n");
+                            instOut.print(lineOut.toUTF8CString(), "\n");
                             lineOut.reset();
                             lineOut.print("       ");
                         }
@@ -80,15 +80,15 @@ void logRegisterPressure(Code& code)
                 lineOut.print(":");
             }
             if (lineOut.length() > registerColumns) {
-                instOut.print(lineOut.toCString(), "\n");
+                instOut.print(lineOut.toUTF8CString(), "\n");
                 lineOut.reset();
             }
             while (lineOut.length() < registerColumns)
                 lineOut.print(" ");
             lineOut.print(" ");
             lineOut.print(inst);
-            instOut.print(lineOut.toCString(), "\n");
-            instDumps.append(instOut.toCString());
+            instOut.print(lineOut.toUTF8CString(), "\n");
+            instDumps.append(instOut.toUTF8CString());
         }
 
         for (unsigned i = instDumps.size(); i--;)

--- a/Source/JavaScriptCore/b3/air/AirPhaseScope.cpp
+++ b/Source/JavaScriptCore/b3/air/AirPhaseScope.cpp
@@ -46,14 +46,14 @@ PhaseScope::PhaseScope(Code& code, ASCIILiteral name)
     }
 
     if (shouldSaveIRBeforePhase())
-        m_dumpBefore = toCString(code);
+        m_dumpBefore = toUTF8CString(code);
 }
 
 PhaseScope::~PhaseScope()
 {
     m_code.setLastPhaseName(m_name);
     if (shouldValidateIRAtEachPhase())
-        validate(m_code, m_dumpBefore.data());
+        validate(m_code, m_dumpBefore.legacyCStringPointer());
 
     if (Options::dumpIonGraph()) [[unlikely]]
         m_code.appendIonGraphPass(m_name);

--- a/Source/JavaScriptCore/b3/air/AirPhaseScope.h
+++ b/Source/JavaScriptCore/b3/air/AirPhaseScope.h
@@ -45,7 +45,7 @@ private:
     Code& m_code;
     ASCIILiteral m_name;
     CompilerTimingScope m_timingScope;
-    CString m_dumpBefore;
+    UTF8CString m_dumpBefore;
 };
 
 } } } // namespace JSC::B3::Air

--- a/Source/JavaScriptCore/b3/air/AirSpecial.cpp
+++ b/Source/JavaScriptCore/b3/air/AirSpecial.cpp
@@ -42,11 +42,11 @@ Special::Special() = default;
 
 Special::~Special() = default;
 
-CString Special::name() const
+UTF8CString Special::name() const
 {
     StringPrintStream out;
     dumpImpl(out);
-    return out.toCString();
+    return out.toUTF8CString();
 }
 
 std::optional<unsigned> Special::shouldTryAliasingDef(Inst&)

--- a/Source/JavaScriptCore/b3/air/AirSpecial.h
+++ b/Source/JavaScriptCore/b3/air/AirSpecial.h
@@ -53,7 +53,7 @@ public:
 
     Code& code() const { return *m_code; }
 
-    CString name() const;
+    UTF8CString name() const;
 
     virtual void forEachArg(Inst&, const ScopedLambda<Inst::EachArgCallback>&) = 0;
     virtual bool isValid(Inst&) = 0;

--- a/Source/JavaScriptCore/b3/air/AirValidate.cpp
+++ b/Source/JavaScriptCore/b3/air/AirValidate.cpp
@@ -48,7 +48,7 @@ public:
 #define VALIDATE(condition, message) do {                               \
         if (condition)                                                  \
             break;                                                      \
-        fail(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, #condition, toCString message); \
+        fail(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, #condition, toUTF8CString message); \
     } while (false)
     
     void run()
@@ -144,16 +144,16 @@ public:
 private:
     NO_RETURN_DUE_TO_CRASH void fail(
         const char* filename, int lineNumber, const char* function, const char* condition,
-        CString message)
+        UTF8CString message)
     {
-        CString failureMessage;
+        UTF8CString failureMessage;
         {
             StringPrintStream out;
             out.print("AIR VALIDATION FAILURE\n");
             out.print("    ", condition, " (", filename, ":", lineNumber, ")\n");
             out.print("    ", message, "\n");
             out.print("    After ", m_code.lastPhaseName(), "\n");
-            failureMessage = out.toCString();
+            failureMessage = out.toUTF8CString();
         }
 
         dataLog(failureMessage);

--- a/Source/JavaScriptCore/b3/air/testair.cpp
+++ b/Source/JavaScriptCore/b3/air/testair.cpp
@@ -2230,7 +2230,7 @@ void testElideSimpleMove()
         root->append(Ret32, nullptr, Tmp(GPRInfo::returnValueGPR));
 
         auto compilation = compile(proc);
-        CString disassembly = compilation->disassembly();
+        auto disassembly = compilation->disassembly();
         std::regex findRRMove(isARM64() ? "mov\\s+x\\d+, x\\d+\\n" : "mov %\\w+, %\\w+\\n");
         auto result = matchAll(disassembly, findRRMove);
         if (isARM64()) {

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -124,7 +124,7 @@ extern Lock crashLock;
     if (__x == __y) \
         break; \
     crashLock.lock(); \
-    WTFReportAssertionFailure(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, toCString(#x " == " #y, " (" #x " == ", __x, ", " #y " == ", __y, ")").data()); \
+    WTFReportAssertionFailure(__FILE__, __LINE__, WTF_PRETTY_FUNCTION, toUTF8CString(#x " == " #y, " (" #x " == ", __x, ", " #y " == ", __y, ")").legacyCStringPointer()); \
     CRASH(); \
 } while (false)
 
@@ -132,28 +132,28 @@ extern Lock crashLock;
 
 #define RUN(test)                                           \
     do {                                                    \
-        CString testStr = toCString(PREFIX #test);          \
-        if (!shouldRun(config, testStr.data()))             \
+        auto testStr = toUTF8CString(PREFIX #test);          \
+        if (!shouldRun(config, testStr.legacyCStringPointer()))             \
             break;                                          \
         tasks.append(                                       \
             createSharedTask<void()>(                       \
                 [=]() {                                     \
-                    dataLog(toCString(testStr, "...\n"));   \
+                    dataLog(toUTF8CString(testStr, "...\n"));   \
                     test;                                   \
-                    dataLog(toCString(testStr, ": OK!\n")); \
+                    dataLog(toUTF8CString(testStr, ": OK!\n")); \
                 }));                                        \
     } while (false);
 
 #define RUN_UNARY(test, values) \
     for (auto a : values) {                             \
-        CString testStr = toCString(PREFIX #test, "(", a.name, ")"); \
-        if (!shouldRun(config, testStr.data()))         \
+        auto testStr = toUTF8CString(PREFIX #test, "(", a.name, ")"); \
+        if (!shouldRun(config, testStr.legacyCStringPointer()))         \
             continue;                                   \
         tasks.append(createSharedTask<void()>(          \
             [=] () {                                    \
-                dataLog(toCString(testStr, "...\n"));   \
+                dataLog(toUTF8CString(testStr, "...\n"));   \
                 test(a.value);                          \
-                dataLog(toCString(testStr, ": OK!\n")); \
+                dataLog(toUTF8CString(testStr, ": OK!\n")); \
             }));                                        \
     }
 
@@ -178,14 +178,14 @@ extern Lock crashLock;
 #define RUN_BINARY(test, valuesA, valuesB) \
     for (auto a : valuesA) {                                \
         for (auto b : valuesB) {                            \
-            CString testStr = toCString(PREFIX #test, "(", a.name, ", ", b.name, ")"); \
-            if (!shouldRun(config, testStr.data()))         \
+            auto testStr = toUTF8CString(PREFIX #test, "(", a.name, ", ", b.name, ")"); \
+            if (!shouldRun(config, testStr.legacyCStringPointer()))         \
                 continue;                                   \
             tasks.append(createSharedTask<void()>(          \
                 [=] () {                                    \
-                    dataLog(toCString(testStr, "...\n"));   \
+                    dataLog(toUTF8CString(testStr, "...\n"));   \
                     test(a.value, b.value);                 \
-                    dataLog(toCString(testStr, ": OK!\n")); \
+                    dataLog(toUTF8CString(testStr, ": OK!\n")); \
                 }));                                        \
         }                                                   \
     }
@@ -193,14 +193,14 @@ extern Lock crashLock;
     for (auto a : valuesA) {                                    \
         for (auto b : valuesB) {                                \
             for (auto c : valuesC) {                            \
-                CString testStr = toCString(PREFIX #test, "(", a.name, ", ", b.name, ",", c.name, ")"); \
-                if (!shouldRun(config, testStr.data()))         \
+                auto testStr = toUTF8CString(PREFIX #test, "(", a.name, ", ", b.name, ",", c.name, ")"); \
+                if (!shouldRun(config, testStr.legacyCStringPointer()))         \
                     continue;                                   \
                 tasks.append(createSharedTask<void()>(          \
                     [=] () {                                    \
-                        dataLog(toCString(testStr, "...\n"));   \
+                        dataLog(toUTF8CString(testStr, "...\n"));   \
                         test(a.value, b.value, c.value);        \
-                        dataLog(toCString(testStr, ": OK!\n")); \
+                        dataLog(toUTF8CString(testStr, ": OK!\n")); \
                     }));                                        \
             }                                                   \
         }                                                       \
@@ -266,10 +266,10 @@ inline void lowerToAirForTesting(Procedure& proc)
 }
 
 template<typename Func>
-void checkDisassembly(Compilation& compilation, const Func& func, const CString& failText)
+void checkDisassembly(Compilation& compilation, const Func& func, const UTF8CString& failText)
 {
-    CString disassembly = compilation.disassembly();
-    if (func(disassembly.data()))
+    auto disassembly = compilation.disassembly();
+    if (func(disassembly.legacyCStringPointer()))
         return;
     
     crashLock.lock();
@@ -289,7 +289,7 @@ inline void checkUsesInstruction(Compilation& compilation, const char* text, boo
                 return std::regex_match(disassembly, std::regex(text, std::regex::extended));
             return strstr(disassembly, text);
         },
-        toCString("Expected to find ", text, " but didnt!"));
+        toUTF8CString("Expected to find ", text, " but didnt!"));
 }
 
 inline void checkDoesNotUseInstruction(Compilation& compilation, const char* text)
@@ -299,7 +299,7 @@ inline void checkDoesNotUseInstruction(Compilation& compilation, const char* tex
         [&] (const char* disassembly) -> bool {
             return !strstr(disassembly, text);
         },
-        toCString("Did not expected to find ", text, " but it's there!"));
+        toUTF8CString("Did not expected to find ", text, " but it's there!"));
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/b3/testb3_4.cpp
+++ b/Source/JavaScriptCore/b3/testb3_4.cpp
@@ -2373,7 +2373,7 @@ void testComplex(unsigned numVars, unsigned numConstructs)
     compileProc(proc);
 
     MonotonicTime after = MonotonicTime::now();
-    dataLog(toCString("    That took ", (after - before).milliseconds(), " ms.\n"));
+    dataLog(toUTF8CString("    That took ", (after - before).milliseconds(), " ms.\n"));
 }
 
 void testBranchBitTest32TmpImm(uint32_t value, uint32_t imm)

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -221,7 +221,7 @@ void testX86LeaAddShlLeftScale1()
                 return strstr(disassembly, "lea (%rdi,%rsi,1), %rax")
                     || strstr(disassembly, "lea (%rsi,%rdi,1), %rax");
             },
-            "Expected to find something like lea (%rdi,%rsi,1), %rax but didn't!");
+            "Expected to find something like lea (%rdi,%rsi,1), %rax but didn't!"_s);
     }
 }
 

--- a/Source/JavaScriptCore/bytecode/ArrayProfile.cpp
+++ b/Source/JavaScriptCore/bytecode/ArrayProfile.cpp
@@ -174,13 +174,13 @@ void ArrayProfile::observeIndexedRead(JSCell* cell, unsigned index)
     }
 }
 
-CString ArrayProfile::briefDescription(CodeBlock* codeBlock)
+UTF8CString ArrayProfile::briefDescription(CodeBlock* codeBlock)
 {
     computeUpdatedPrediction(codeBlock);
     return briefDescriptionWithoutUpdating();
 }
 
-CString ArrayProfile::briefDescriptionWithoutUpdating()
+UTF8CString ArrayProfile::briefDescriptionWithoutUpdating()
 {
     StringPrintStream out;
     CommaPrinter comma;
@@ -198,7 +198,7 @@ CString ArrayProfile::briefDescriptionWithoutUpdating()
     if (!m_arrayProfileFlags.contains(ArrayProfileFlag::MayBeResizableOrGrowableSharedTypedArray))
         out.print(comma, "Resizable"_s);
 
-    return out.toCString();
+    return out.toUTF8CString();
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/ArrayProfile.h
+++ b/Source/JavaScriptCore/bytecode/ArrayProfile.h
@@ -261,8 +261,8 @@ public:
 
     bool mayBeRegExpMatchesArray() const { return m_arrayProfileFlags.contains(ArrayProfileFlag::MayBeRegExpMatchesArray); }
 
-    CString briefDescription(CodeBlock*);
-    CString briefDescriptionWithoutUpdating();
+    UTF8CString briefDescription(CodeBlock*);
+    UTF8CString briefDescriptionWithoutUpdating();
     
 private:
     friend class LLIntOffsetsExtractor;

--- a/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeDumper.cpp
@@ -51,7 +51,7 @@ void BytecodeDumperBase<InstructionStreamType>::printLocationAndOp(typename Inst
 template<typename InstructionStreamType>
 void BytecodeDumperBase<InstructionStreamType>::dumpValue(VirtualRegister reg)
 {
-    m_out.printf("%s", registerName(reg).data());
+    m_out.printf("%s", registerName(reg).legacyCStringPointer());
 }
 
 template<typename InstructionStreamType>
@@ -68,12 +68,12 @@ void BytecodeDumperBase<InstructionStreamType>::dumpValue(GenericBoundLabel<Trai
 template void BytecodeDumperBase<JSInstructionStream>::dumpValue(GenericBoundLabel<JSGeneratorTraits>);
 
 template<class Block>
-CString BytecodeDumper<Block>::registerName(VirtualRegister r) const
+UTF8CString BytecodeDumper<Block>::registerName(VirtualRegister r) const
 {
     if (r.isConstant())
         return constantName(r);
 
-    return toCString(r);
+    return toUTF8CString(r);
 }
 
 template <class Block>
@@ -83,12 +83,12 @@ int BytecodeDumper<Block>::outOfLineJumpOffset(JSInstructionStream::Offset offse
 }
 
 template<class Block>
-CString BytecodeDumper<Block>::constantName(VirtualRegister reg) const
+UTF8CString BytecodeDumper<Block>::constantName(VirtualRegister reg) const
 {
     if (reg.toConstantIndex() >= (int) block()->constantRegisters().size())
-        return toCString("INVALID_CONSTANT(", reg, ")");
+        return toUTF8CString("INVALID_CONSTANT(", reg, ")");
     auto value = block()->getConstant(reg);
-    return toCString(value, "(", reg, ")");
+    return toUTF8CString(value, "(", reg, ")");
 }
 
 template<class Block>
@@ -152,7 +152,7 @@ void CodeBlockBytecodeDumper<Block>::dumpConstants()
                 sourceCodeRepresentationDescription = ": in source as link-time-constant";
                 break;
             }
-            this->m_out.printf("   k%u = %s%s\n", static_cast<unsigned>(i), toCString(constant.get()).data(), sourceCodeRepresentationDescription);
+            this->m_out.printf("   k%u = %s%s\n", static_cast<unsigned>(i), toUTF8CString(constant.get()).legacyCStringPointer(), sourceCodeRepresentationDescription);
             ++i;
         }
     }

--- a/Source/JavaScriptCore/bytecode/BytecodeDumper.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeDumper.h
@@ -67,7 +67,7 @@ public:
     void dumpValue(T v) { m_out.print(v); }
 
 protected:
-    virtual CString registerName(VirtualRegister) const = 0;
+    virtual UTF8CString registerName(VirtualRegister) const = 0;
     virtual int outOfLineJumpOffset(typename InstructionStreamType::Offset) const = 0;
 
     BytecodeDumperBase(PrintStream& out)
@@ -99,11 +99,11 @@ protected:
 
     void dumpBytecode(const JSInstructionStream::Ref& it, const ICStatusMap&);
 
-    CString registerName(VirtualRegister) const override;
+    UTF8CString registerName(VirtualRegister) const override;
     int outOfLineJumpOffset(JSInstructionStream::Offset) const override;
 
 private:
-    virtual CString constantName(VirtualRegister) const;
+    virtual UTF8CString constantName(VirtualRegister) const;
 
     Block* m_block;
 };

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -109,20 +109,20 @@ const ClassInfo CodeBlock::s_info = {
     CREATE_METHOD_TABLE(CodeBlock)
 };
 
-CString CodeBlock::inferredName() const
+UTF8CString CodeBlock::inferredName() const
 {
     switch (codeType()) {
     case GlobalCode:
-        return "<global>"_span;
+        return "<global>"_s;
     case EvalCode:
-        return "<eval>"_span;
+        return "<eval>"_s;
     case FunctionCode:
         return uncheckedDowncast<FunctionExecutable>(ownerExecutable())->ecmaName().utf8();
     case ModuleCode:
-        return "<module>"_span;
+        return "<module>"_s;
     default:
         CRASH();
-        return ""_span;
+        return ""_s;
     }
 }
 
@@ -164,7 +164,7 @@ CodeBlockHash CodeBlock::hash() const
     return m_hash;
 }
 
-CString CodeBlock::sourceCodeForTools() const
+UTF8CString CodeBlock::sourceCodeForTools() const
 {
     if (codeType() != FunctionCode)
         return ownerExecutable()->source().toUTF8();
@@ -175,7 +175,7 @@ CString CodeBlock::sourceCodeForTools() const
         executable->parametersStartOffset() + executable->source().length()).utf8();
 }
 
-CString CodeBlock::sourceCodeOnOneLine() const
+UTF8CString CodeBlock::sourceCodeOnOneLine() const
 {
     return reduceWhitespace(sourceCodeForTools());
 }
@@ -3832,7 +3832,7 @@ void CodeBlock::dumpMathICStats()
 
 void setPrinter(Printer::PrintRecord& record, CodeBlock* codeBlock)
 {
-    Printer::setPrinter(record, toCString(codeBlock));
+    Printer::setPrinter(record, toUTF8CString(codeBlock));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -181,12 +181,12 @@ public:
 
     UnlinkedCodeBlock* unlinkedCodeBlock() const LIFETIME_BOUND { return m_unlinkedCode.get(); }
 
-    CString inferredName() const;
+    UTF8CString inferredName() const;
     String inferredNameWithHash() const;
     CodeBlockHash hash() const;
     bool NODELETE hasHash() const;
-    CString sourceCodeForTools() const;
-    CString sourceCodeOnOneLine() const; // As sourceCodeForTools(), but replaces all whitespace runs with a single space.
+    UTF8CString sourceCodeForTools() const;
+    UTF8CString sourceCodeOnOneLine() const; // As sourceCodeForTools(), but replaces all whitespace runs with a single space.
     void dumpAssumingJITType(PrintStream&, JITType) const;
     JS_EXPORT_PRIVATE void dump(PrintStream&) const;
 
@@ -1056,7 +1056,7 @@ void ScriptExecutable::prepareForExecution(VM& vm, JSFunction* function, JSScope
 #define CODEBLOCK_LOG_EVENT(codeBlock, summary, details) \
     do { \
         if (codeBlock) \
-            (codeBlock->vm().logEvent(codeBlock, summary, [&] () { return toCString details; })); \
+            (codeBlock->vm().logEvent(codeBlock, summary, [&] () { return toUTF8CString details; })); \
     } while (0)
 
 

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -5214,7 +5214,7 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
 
     dataLogLnIf(InlineCacheCompilerInternal::verbose, FullCodeOrigin(codeBlock, m_propertyCache.codeOrigin), ": Generating polymorphic access stub for ", listDump(keys));
 
-    MacroAssemblerCodeRef<JITStubRoutinePtrTag> code = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, categoryName(m_propertyCache.accessType), "%s", toCString("Access stub for ", *codeBlock, " ", m_propertyCache.codeOrigin, " with start: ", repatchingIC.startLocation, " with return point ", successLabel, ": ", listDump(keys)).data());
+    MacroAssemblerCodeRef<JITStubRoutinePtrTag> code = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, categoryName(m_propertyCache.accessType), "%s", toUTF8CString("Access stub for ", *codeBlock, " ", m_propertyCache.codeOrigin, " with start: ", repatchingIC.startLocation, " with return point ", successLabel, ": ", listDump(keys)).legacyCStringPointer());
 
     CodeBlock* owner = codeBlock;
     FixedVector<StructureID> weakStructures(WTF::move(m_weakStructures));
@@ -8054,7 +8054,7 @@ AccessGenerationResult InlineCacheCompiler::compileOneAccessCaseHandler(const Ve
     auto keys = FixedVector<Ref<AccessCase>> { Ref { accessCase } };
     dataLogLnIf(InlineCacheCompilerInternal::verbose, FullCodeOrigin(codeBlock, m_propertyCache.codeOrigin), ": Generating polymorphic access stub handler for ", listDump(keys));
 
-    MacroAssemblerCodeRef<JITStubRoutinePtrTag> code = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, categoryName(m_propertyCache.accessType), "%s", toCString("Access stub handler for ", *codeBlock, " ", m_propertyCache.codeOrigin, ": ", listDump(keys)).data());
+    MacroAssemblerCodeRef<JITStubRoutinePtrTag> code = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, categoryName(m_propertyCache.accessType), "%s", toUTF8CString("Access stub handler for ", *codeBlock, " ", m_propertyCache.codeOrigin, ": ", listDump(keys)).legacyCStringPointer());
 
     if (statelessType) {
         auto stub = createPreCompiledICJITStubRoutine(WTF::move(code), vm, codeBlock);

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
@@ -51,7 +51,7 @@ CodeBlockHash InlineCallFrame::hash() const
     return baselineCodeBlock->hash();
 }
 
-CString InlineCallFrame::inferredName() const
+UTF8CString InlineCallFrame::inferredName() const
 {
     return uncheckedDowncast<FunctionExecutable>(baselineCodeBlock->ownerExecutable())->ecmaName().utf8();
 }

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.h
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.h
@@ -230,7 +230,7 @@ struct InlineCallFrame {
     // Get the callee given a machine call frame to which this InlineCallFrame belongs.
     JSFunction* calleeForCallFrame(CallFrame*) const;
     
-    CString inferredName() const;
+    UTF8CString inferredName() const;
     String inferredNameWithHash() const;
     CodeBlockHash hash() const;
     

--- a/Source/JavaScriptCore/bytecode/ReduceWhitespace.cpp
+++ b/Source/JavaScriptCore/bytecode/ReduceWhitespace.cpp
@@ -33,11 +33,11 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
-CString reduceWhitespace(const CString& input)
+UTF8CString reduceWhitespace(const UTF8CString& input)
 {
     StringPrintStream out;
     
-    const char* data = input.data();
+    const char* data = input.legacyCStringPointer();
     
     for (unsigned i = 0; i < input.length();) {
         if (isUnicodeCompatibleASCIIWhitespace(data[i])) {
@@ -50,7 +50,7 @@ CString reduceWhitespace(const CString& input)
         ++i;
     }
     
-    return out.toCString();
+    return out.toUTF8CString();
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/ReduceWhitespace.h
+++ b/Source/JavaScriptCore/bytecode/ReduceWhitespace.h
@@ -30,6 +30,6 @@
 namespace JSC {
 
 // Replace all whitespace runs with a single space.
-CString reduceWhitespace(const CString&);
+UTF8CString reduceWhitespace(const UTF8CString&);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -363,7 +363,7 @@ void dumpSpeculation(PrintStream& outStream, SpeculatedType value)
     else if (isTop)
         out.print("Top");
     else
-        out.print(strStream.toCString());
+        out.print(strStream.toUTF8CString());
 }
 
 // We don't expose this because we don't want anyone relying on the fact that this method currently

--- a/Source/JavaScriptCore/bytecode/ValueProfile.h
+++ b/Source/JavaScriptCore/bytecode/ValueProfile.h
@@ -84,13 +84,13 @@ struct ValueProfileBase {
 
     bool isSampledBefore() const { return m_prediction != SpecNone; }
     
-    CString briefDescription()
+    UTF8CString briefDescription()
     {
         SpeculatedType prediction = computeUpdatedPrediction();
         
         StringPrintStream out;
         out.print("predicting ", SpeculationDump(prediction));
-        return out.toCString();
+        return out.toUTF8CString();
     }
     
     void dump(PrintStream& out)

--- a/Source/JavaScriptCore/corpse/tests/CorpseProcessTest.cpp
+++ b/Source/JavaScriptCore/corpse/tests/CorpseProcessTest.cpp
@@ -52,7 +52,7 @@ static pid_t reapedChildPid()
     if (!child)
         _exit(0);
     if (child < 0) {
-        dataLogLn("    could not fork: ", safeStrerror(errno));
+        dataLogLn("    could not fork: ", safeStrerror(errno).data());
         return 0;
     }
 
@@ -65,7 +65,7 @@ static pid_t reapedChildPid()
 
     if (waited != child) {
         dataLogLn("    could not reap child ", child, ": waitpid returned ", waited,
-            ", errno ", errno, " (", safeStrerror(errno), ")");
+            ", errno ", errno, " (", safeStrerror(errno).data(), ")");
         return 0;
     }
     return child;

--- a/Source/JavaScriptCore/debugger/DebuggerCallFrame.cpp
+++ b/Source/JavaScriptCore/debugger/DebuggerCallFrame.cpp
@@ -136,7 +136,7 @@ String DebuggerCallFrame::functionName(VM& vm) const
     if (isTailDeleted()) {
         if (JSFunction* func = dynamicDowncast<JSFunction>(m_shadowChickenFrame.callee))
             return func->calculatedDisplayName(vm);
-        return String::fromLatin1(m_shadowChickenFrame.codeBlock->inferredName().data());
+        return String::fromUTF8(m_shadowChickenFrame.codeBlock->inferredName().span());
     }
 
     return m_validMachineFrame->friendlyFunctionName();

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -211,15 +211,15 @@ void AbstractInterpreter<AbstractStateType>::verifyEdge(Node* node, Edge edge)
     if (edge.node()->isTuple()) {
         if (edge.useKind() == UntypedUse && node->op() == ExtractFromTuple)
             return;
-        DFG_CRASH(m_graph, node, toCString("Tuple edge verification error: ", node, "->", edge, " was expected to have Untyped use kind (had ", edge.useKind(),
-            "). Has type ", SpeculationDump(m_state.forTupleNodeWithoutFastForward(edge.node(), node->extractOffset()).m_type)).data(),
+        DFG_CRASH(m_graph, node, toUTF8CString("Tuple edge verification error: ", node, "->", edge, " was expected to have Untyped use kind (had ", edge.useKind(),
+            "). Has type ", SpeculationDump(m_state.forTupleNodeWithoutFastForward(edge.node(), node->extractOffset()).m_type)).legacyCStringPointer(),
             AbstractInterpreterInvalidType, node->op(), edge->op(), edge.useKind(), m_state.forNodeWithoutFastForward(node).m_type);
     }
 
     if (!(m_state.forNodeWithoutFastForward(edge).m_type & ~typeFilterFor(edge.useKind())))
         return;
     
-    DFG_CRASH(m_graph, node, toCString("Edge verification error: ", node, "->", edge, " was expected to have type ", SpeculationDump(typeFilterFor(edge.useKind())), " but has type ", SpeculationDump(forNode(edge).m_type), " (", forNode(edge).m_type, ")").data(), AbstractInterpreterInvalidType, node->op(), edge->op(), edge.useKind(), forNode(edge).m_type);
+    DFG_CRASH(m_graph, node, toUTF8CString("Edge verification error: ", node, "->", edge, " was expected to have type ", SpeculationDump(typeFilterFor(edge.useKind())), " but has type ", SpeculationDump(forNode(edge).m_type), " (", forNode(edge).m_type, ")").legacyCStringPointer(), AbstractInterpreterInvalidType, node->op(), edge->op(), edge.useKind(), forNode(edge).m_type);
 }
 
 template<typename AbstractStateType>

--- a/Source/JavaScriptCore/dfg/DFGAbstractValue.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAbstractValue.cpp
@@ -139,7 +139,7 @@ void AbstractValue::fixTypeForRepresentation(Graph& graph, NodeFlags representat
             m_type |= SpecAnyIntAsDouble;
         }
         if (m_type & ~SpecFullDouble)
-            DFG_CRASH(graph, node, toCString("Abstract value ", *this, " for double node has type outside SpecFullDouble.\n").data());
+            DFG_CRASH(graph, node, toUTF8CString("Abstract value ", *this, " for double node has type outside SpecFullDouble.\n").legacyCStringPointer());
     } else if (representation == NodeResultInt52) {
         if (m_type & SpecAnyIntAsDouble) {
             // AnyIntAsDouble can produce i32 or i52. SpecAnyIntAsDouble doesn't bound the magnitude of the value.
@@ -158,7 +158,7 @@ void AbstractValue::fixTypeForRepresentation(Graph& graph, NodeFlags representat
         }
 
         if (m_type & ~SpecInt52Any)
-            DFG_CRASH(graph, node, toCString("Abstract value ", *this, " for int52 node has type outside SpecInt52Any.\n").data());
+            DFG_CRASH(graph, node, toUTF8CString("Abstract value ", *this, " for int52 node has type outside SpecInt52Any.\n").legacyCStringPointer());
 
         if (m_value) {
             DFG_ASSERT(graph, node, m_value.isAnyInt());
@@ -174,7 +174,7 @@ void AbstractValue::fixTypeForRepresentation(Graph& graph, NodeFlags representat
             m_type |= SpecAnyIntAsDouble;
         }
         if (m_type & ~SpecBytecodeTop)
-            DFG_CRASH(graph, node, toCString("Abstract value ", *this, " for value node has type outside SpecBytecodeTop.\n").data());
+            DFG_CRASH(graph, node, toUTF8CString("Abstract value ", *this, " for value node has type outside SpecBytecodeTop.\n").legacyCStringPointer());
     }
     
     checkConsistency();

--- a/Source/JavaScriptCore/dfg/DFGAvailabilityMap.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAvailabilityMap.cpp
@@ -123,10 +123,10 @@ void AvailabilityMap::validateAvailability(Graph& graph, Node* where) const
 
                     if (localAvailability.flushedAt().virtualRegister() == heapFlushLocation.virtualRegister()) {
                         if (localAvailability.hasNode() && heapPair.value.node() != localAvailability.node())
-                            DFG_CRASH(graph, where, toCString("Materialization flushed availability ", heapPair.value, " and local flushed availability ", localAvailability, " disagree on which DFG node the same stack slot holds in ", *this).data());
+                            DFG_CRASH(graph, where, toUTF8CString("Materialization flushed availability ", heapPair.value, " and local flushed availability ", localAvailability, " disagree on which DFG node the same stack slot holds in ", *this).legacyCStringPointer());
 
                         if (heapFlushLocation.format() != localAvailability.flushedAt().format())
-                            DFG_CRASH(graph, where, toCString("Materialization should be flushed (", heapPair.value, ") but corresponding local doesn't exist or match (", localAvailability, ") in ", *this).data());
+                            DFG_CRASH(graph, where, toUTF8CString("Materialization should be flushed (", heapPair.value, ") but corresponding local doesn't exist or match (", localAvailability, ") in ", *this).legacyCStringPointer());
                         break;
                     }
                 }

--- a/Source/JavaScriptCore/dfg/DFGCFAPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCFAPhase.cpp
@@ -231,7 +231,7 @@ private:
             
             if (ASSERT_ENABLED
                 && m_state.didClobberOrFolded() != writesOverlap(m_graph, node, JSCell_structureID))
-                DFG_CRASH(m_graph, node, toCString("AI-clobberize disagreement; AI says ", m_state.clobberState(), " while clobberize says ", writeSet(m_graph, node)).data());
+                DFG_CRASH(m_graph, node, toUTF8CString("AI-clobberize disagreement; AI says ", m_state.clobberState(), " while clobberize says ", writeSet(m_graph, node)).legacyCStringPointer());
         }
         if (m_verbose) {
             WTF::dataFile().atomically([&](auto&) {

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -2726,7 +2726,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
     }
     
-    DFG_CRASH(graph, node, toCString("Unrecognized node type: ", Graph::opName(node->op())).data());
+    DFG_CRASH(graph, node, toUTF8CString("Unrecognized node type: ", Graph::opName(node->op())).legacyCStringPointer());
 }
 
 class NoOpClobberize {

--- a/Source/JavaScriptCore/dfg/DFGDisassembler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDisassembler.cpp
@@ -83,7 +83,7 @@ void Disassembler::dumpHeader(PrintStream& out, LinkBuffer& linkBuffer)
 
 void Disassembler::append(Vector<Disassembler::DumpedOp>& result, StringPrintStream& out, CodeOrigin& previousOrigin)
 {
-    result.append(DumpedOp(previousOrigin, out.toCString()));
+    result.append(DumpedOp(previousOrigin, out.toUTF8CString()));
     previousOrigin = CodeOrigin();
     out.reset();
 }

--- a/Source/JavaScriptCore/dfg/DFGDisassembler.h
+++ b/Source/JavaScriptCore/dfg/DFGDisassembler.h
@@ -77,14 +77,14 @@ private:
     void dumpHeader(PrintStream&, LinkBuffer&);
     
     struct DumpedOp {
-        DumpedOp(CodeOrigin codeOrigin, CString text)
+        DumpedOp(CodeOrigin codeOrigin, UTF8CString text)
             : codeOrigin(codeOrigin)
             , text(text)
         {
         }
         
         CodeOrigin codeOrigin;
-        CString text;
+        UTF8CString text;
     };
     void append(Vector<DumpedOp>&, StringPrintStream&, CodeOrigin&);
     Vector<DumpedOp> createDumpList(LinkBuffer&);

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -242,7 +242,7 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
         });
     }
 
-    if (toCString(NodeFlagsDump(node->flags())) != "<empty>"_s)
+    if (toUTF8CString(NodeFlagsDump(node->flags())) != "<empty>"_s)
         out.print(comma, NodeFlagsDump(node->flags()));
     if (node->prediction())
         out.print(comma, SpeculationDump(node->prediction()));
@@ -568,7 +568,7 @@ void Graph::dumpBlockHeader(PrintStream& out, const char* prefixStr, BasicBlock*
                 continue;
 
             out.print(" D@", phiNode->index(), "<", phiNode->operand(), ",", phiNode->refCount());
-            if (toCString(NodeFlagsDump(phiNode->flags())) != "<empty>"_s)
+            if (toUTF8CString(NodeFlagsDump(phiNode->flags())) != "<empty>"_s)
                 out.print(", ", NodeFlagsDump(phiNode->flags()));
             out.print(">->(");
             if (phiNode->child1()) {
@@ -693,7 +693,7 @@ void Graph::dump(PrintStream& out, DumpContext* context)
     if (!myContext.isEmpty()) {
         StringPrintStream prefixStr;
         prefixStr.print(prefix);
-        myContext.dump(out, prefixStr.toCString().data());
+        myContext.dump(out, prefixStr.toUTF8CString().legacyCStringPointer());
         out.print("\n");
     }
 }
@@ -1826,11 +1826,11 @@ void Graph::assertIsRegistered(Structure* structure)
     if (m_plan.watchpoints().isRegisteredNotWatched(structure))
         return;
 
-    DFG_CRASH(*this, nullptr, toCString("Structure ", pointerDump(structure), " is watchable but isn't being watched.").data());
+    DFG_CRASH(*this, nullptr, toUTF8CString("Structure ", pointerDump(structure), " is watchable but isn't being watched.").legacyCStringPointer());
 }
 
 static void logDFGAssertionFailure(
-    Graph& graph, const CString& whileText, const char* file, int line, const char* function,
+    Graph& graph, const UTF8CString& whileText, const char* file, int line, const char* function,
     const char* assertion)
 {
     startCrashing();
@@ -1857,13 +1857,13 @@ void Graph::logAssertionFailure(
 void Graph::logAssertionFailure(
     Node* node, const char* file, int line, const char* function, const char* assertion)
 {
-    logDFGAssertionFailure(*this, toCString("While handling node ", node, "\n\n"), file, line, function, assertion);
+    logDFGAssertionFailure(*this, toUTF8CString("While handling node ", node, "\n\n"), file, line, function, assertion);
 }
 
 void Graph::logAssertionFailure(
     BasicBlock* block, const char* file, int line, const char* function, const char* assertion)
 {
-    logDFGAssertionFailure(*this, toCString("While handling block ", pointerDump(block), "\n\n"), file, line, function, assertion);
+    logDFGAssertionFailure(*this, toUTF8CString("While handling block ", pointerDump(block), "\n\n"), file, line, function, assertion);
 }
 
 CPSCFG& Graph::ensureCPSCFG()

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -4147,13 +4147,13 @@ struct NodeComparator {
 };
 
 template<typename T>
-CString nodeListDump(const T& nodeList)
+UTF8CString nodeListDump(const T& nodeList)
 {
     return sortedListDump(nodeList, NodeComparator());
 }
 
 template<typename T>
-CString nodeMapDump(const T& nodeMap, DumpContext* context = nullptr)
+UTF8CString nodeMapDump(const T& nodeMap, DumpContext* context = nullptr)
 {
     Vector<typename T::KeyType> keys;
     for (
@@ -4165,11 +4165,11 @@ CString nodeMapDump(const T& nodeMap, DumpContext* context = nullptr)
     CommaPrinter comma;
     for(unsigned i = 0; i < keys.size(); ++i)
         out.print(comma, keys[i], "=>"_s, inContext(nodeMap.get(keys[i]), context));
-    return out.toCString();
+    return out.toUTF8CString();
 }
 
 template<typename T>
-CString nodeValuePairListDump(const T& nodeValuePairList, DumpContext* context = nullptr)
+UTF8CString nodeValuePairListDump(const T& nodeValuePairList, DumpContext* context = nullptr)
 {
     T sortedList = nodeValuePairList;
     std::ranges::sort(sortedList, [](const auto& a, const auto& b) {
@@ -4180,7 +4180,7 @@ CString nodeValuePairListDump(const T& nodeValuePairList, DumpContext* context =
     CommaPrinter comma;
     for (const auto& pair : sortedList)
         out.print(comma, pair.node, "=>"_s, inContext(pair.value, context));
-    return out.toCString();
+    return out.toUTF8CString();
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGNodeFlags.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNodeFlags.cpp
@@ -122,7 +122,7 @@ void dumpNodeFlags(PrintStream& actualOut, NodeFlags flags)
     if (flags & NodeIsFlushed)
         out.print(comma, "IsFlushed"_s);
     
-    CString string = out.toCString();
+    auto string = out.toUTF8CString();
     if (!string.length())
         actualOut.print("<empty>"_s);
     else

--- a/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
@@ -195,7 +195,7 @@ public:
                             dataLogLn();
                         }
 
-                        DFG_CRASH(m_graph, node, toCString("Live bytecode local not available: operand = ", operand, ", availabilityMap = ", availabilityMap, ", origin = ", exitOrigin).data());
+                        DFG_CRASH(m_graph, node, toUTF8CString("Live bytecode local not available: operand = ", operand, ", availabilityMap = ", availabilityMap, ", origin = ", exitOrigin).legacyCStringPointer());
                     }
                 }
             }

--- a/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
@@ -211,9 +211,9 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompileOSRExit, void, (CallFrame* cal
             shouldDumpDisassembly() || Options::verboseOSR() || Options::verboseDFGOSRExit(),
             patchBuffer, OSRExitPtrTag, nullptr,
             "DFG OSR exit #%u (D@%u, %s, %s) from %s, with operands = %s",
-                exitIndex, exit.m_dfgNodeIndex, toCString(exit.m_codeOrigin).data(),
-                toCString(exit.m_kind).data(), toCString(*codeBlock).data(),
-                toCString(ignoringContext<DumpContext>(operands)).data());
+                exitIndex, exit.m_dfgNodeIndex, toUTF8CString(exit.m_codeOrigin).legacyCStringPointer(),
+                toUTF8CString(exit.m_kind).legacyCStringPointer(), toUTF8CString(*codeBlock).legacyCStringPointer(),
+                toUTF8CString(ignoringContext<DumpContext>(operands)).legacyCStringPointer());
         codeBlock->dfgJITData()->setExitCode(exitIndex, exitCode);
     }
 

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -822,11 +822,11 @@ private:
         performOSRAvailabilityAnalysis(m_graph);
         m_combinedLiveness = CombinedLiveness(m_graph);
 
-        CString graphBeforeSinking;
+        UTF8CString graphBeforeSinking;
         if (Options::verboseValidationFailure() && Options::validateGraphAtEachPhase()) [[unlikely]] {
             StringPrintStream out;
             m_graph.dump(out);
-            graphBeforeSinking = out.toCString();
+            graphBeforeSinking = out.toUTF8CString();
         }
 
         dataLogIf(Options::verboseObjectAllocationSinking(), "Graph before elimination:\n", m_graph);

--- a/Source/JavaScriptCore/dfg/DFGPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPhase.cpp
@@ -43,7 +43,7 @@ void Phase::beginPhase()
     if (Options::verboseValidationFailure()) {
         StringPrintStream out;
         m_graph.dump(out);
-        m_graphDumpBeforePhase = out.toCString();
+        m_graphDumpBeforePhase = out.toUTF8CString();
     }
 
     dataLogIf(shouldDumpGraphAtEachPhase(m_graph),

--- a/Source/JavaScriptCore/dfg/DFGPhase.h
+++ b/Source/JavaScriptCore/dfg/DFGPhase.h
@@ -75,7 +75,7 @@ private:
     void endPhase();
 
     bool m_disableGraphValidation { false };
-    CString m_graphDumpBeforePhase;
+    UTF8CString m_graphDumpBeforePhase;
 };
 
 template<typename PhaseType>

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -188,7 +188,7 @@ void SpeculativeJIT::compile()
 
     disassemble(linkBuffer);
 
-    auto codeRef = FINALIZE_DFG_CODE(linkBuffer, JSEntryPtrTag, "DFG JIT code for %s", toCString(CodeBlockWithJITType(m_codeBlock, JITType::DFGJIT)).data());
+    auto codeRef = FINALIZE_DFG_CODE(linkBuffer, JSEntryPtrTag, "DFG JIT code for %s", toUTF8CString(CodeBlockWithJITType(m_codeBlock, JITType::DFGJIT)).legacyCStringPointer());
     m_jitCode->initializeCodeRefForDFG(codeRef, codeRef.code());
     m_jitCode->variableEventStream = finalizeEventStream();
 
@@ -297,7 +297,7 @@ void SpeculativeJIT::compileFunction()
     CodePtr<JSEntryPtrTag> withArityCheck = linkBuffer.locationOf<JSEntryPtrTag>(arityCheck);
 
     m_jitCode->initializeCodeRefForDFG(
-        FINALIZE_DFG_CODE(linkBuffer, JSEntryPtrTag, "DFG JIT code for %s", toCString(CodeBlockWithJITType(m_codeBlock, JITType::DFGJIT)).data()),
+        FINALIZE_DFG_CODE(linkBuffer, JSEntryPtrTag, "DFG JIT code for %s", toUTF8CString(CodeBlockWithJITType(m_codeBlock, JITType::DFGJIT)).legacyCStringPointer()),
         withArityCheck);
     m_jitCode->variableEventStream = finalizeEventStream();
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -1419,9 +1419,9 @@ FPRReg SpeculativeJIT::fillSpeculateDouble(Edge edge)
         DataFormat spillFormat = info.spillFormat();
         if (spillFormat != DataFormatDouble) {
             DFG_CRASH(
-                m_graph, m_currentNode, toCString(
+                m_graph, m_currentNode, toUTF8CString(
                     "Expected ", edge, " to have double format but instead it is spilled as ",
-                    dataFormatToString(spillFormat)).data());
+                    dataFormatToString(spillFormat)).legacyCStringPointer());
         }
         DFG_ASSERT(m_graph, m_currentNode, spillFormat == DataFormatDouble, spillFormat);
         FPRReg fpr = fprAllocate();

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -43,7 +43,7 @@ namespace {
 
 class Validate {
 public:
-    Validate(Graph& graph, GraphDumpMode graphDumpMode, CString graphDumpBeforePhase)
+    Validate(Graph& graph, GraphDumpMode graphDumpMode, UTF8CString graphDumpBeforePhase)
         : m_graph(graph)
         , m_graphDumpMode(graphDumpMode)
         , m_graphDumpBeforePhase(graphDumpBeforePhase)
@@ -1145,7 +1145,7 @@ private:
 
     Graph& m_graph;
     GraphDumpMode m_graphDumpMode;
-    CString m_graphDumpBeforePhase;
+    UTF8CString m_graphDumpBeforePhase;
 
     UncheckedKeyHashMap<Node*, unsigned> m_myRefCounts;
     Vector<uint32_t> m_myTupleRefCounts;
@@ -1154,7 +1154,7 @@ private:
 
 } // End anonymous namespace.
 
-void validate(Graph& graph, GraphDumpMode graphDumpMode, CString graphDumpBeforePhase)
+void validate(Graph& graph, GraphDumpMode graphDumpMode, UTF8CString graphDumpBeforePhase)
 {
     Validate validationObject(graph, graphDumpMode, graphDumpBeforePhase);
     validationObject.validate();

--- a/Source/JavaScriptCore/dfg/DFGValidate.h
+++ b/Source/JavaScriptCore/dfg/DFGValidate.h
@@ -33,7 +33,7 @@ namespace JSC { namespace DFG {
 
 enum GraphDumpMode { DontDumpGraph, DumpGraph };
 
-void validate(Graph&, GraphDumpMode = DumpGraph, CString graphDumpBeforePhase = CString());
+void validate(Graph&, GraphDumpMode = DumpGraph, UTF8CString graphDumpBeforePhase = { });
 
 } } // namespace JSC::DFG
 

--- a/Source/JavaScriptCore/ftl/FTLCompile.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCompile.cpp
@@ -344,7 +344,7 @@ void compile(State& state, Safepoint::Result& safepointResult)
     if (compilation) [[unlikely]] {
         compilation->addDescription(
             Profiler::OriginStack(),
-            toCString("Generated FTL DFG IR for ", CodeBlockWithJITType(codeBlock, JITType::FTLJIT), ", instructions size = ", graph.m_codeBlock->instructionsSize(), ":\n"));
+            toUTF8CString("Generated FTL DFG IR for ", CodeBlockWithJITType(codeBlock, JITType::FTLJIT), ", instructions size = ", graph.m_codeBlock->instructionsSize(), ":\n"));
 
         graph.ensureSSADominators();
         graph.ensureSSANaturalLoops();
@@ -360,7 +360,7 @@ void compile(State& state, Safepoint::Result& safepointResult)
                 continue;
 
             graph.dumpBlockHeader(out, prefix, block, Graph::DumpLivePhisOnly, &dumpContext);
-            compilation->addDescription(Profiler::OriginStack(), out.toCString());
+            compilation->addDescription(Profiler::OriginStack(), out.toUTF8CString());
             out.reset();
 
             for (size_t nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {
@@ -374,12 +374,12 @@ void compile(State& state, Safepoint::Result& safepointResult)
                 }
 
                 if (graph.dumpCodeOrigin(out, prefix, lastNode, node, &dumpContext)) {
-                    compilation->addDescription(stack, out.toCString());
+                    compilation->addDescription(stack, out.toUTF8CString());
                     out.reset();
                 }
 
                 graph.dump(out, prefix, node, &dumpContext);
-                compilation->addDescription(stack, out.toCString());
+                compilation->addDescription(stack, out.toUTF8CString());
                 out.reset();
 
                 if (node->origin.semantic.isSet())
@@ -388,18 +388,18 @@ void compile(State& state, Safepoint::Result& safepointResult)
         }
 
         dumpContext.dump(out, prefix);
-        compilation->addDescription(Profiler::OriginStack(), out.toCString());
+        compilation->addDescription(Profiler::OriginStack(), out.toUTF8CString());
         out.reset();
 
         out.print("\n\n\n    FTL B3/Air Disassembly:\n");
-        compilation->addDescription(Profiler::OriginStack(), out.toCString());
+        compilation->addDescription(Profiler::OriginStack(), out.toUTF8CString());
         out.reset();
 
         state.dumpDisassembly(out, *state.b3CodeLinkBuffer, [&] (DFG::Node*) {
-            compilation->addDescription({ }, out.toCString());
+            compilation->addDescription({ }, out.toUTF8CString());
             out.reset();
         });
-        compilation->addDescription({ }, out.toCString());
+        compilation->addDescription({ }, out.toUTF8CString());
         out.reset();
 
         state.jitCode->common.compilation = compilation;

--- a/Source/JavaScriptCore/ftl/FTLLink.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLink.cpp
@@ -65,7 +65,7 @@ void link(State& state)
 
         MacroAssemblerCodeRef<JSEntryPtrTag> b3CodeRef =
             FINALIZE_CODE_IF(dumpDisassembly, *state.b3CodeLinkBuffer, JSEntryPtrTag, nullptr,
-                "FTL B3 code for %s", toCString(CodeBlockWithJITType(codeBlock, JITType::FTLJIT)).data());
+                "FTL B3 code for %s", toUTF8CString(CodeBlockWithJITType(codeBlock, JITType::FTLJIT)).legacyCStringPointer());
 
         state.jitCode->initializeB3Code(b3CodeRef);
         state.jitCode->common.m_jumpReplacements = WTF::move(state.jumpReplacements);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -218,7 +218,7 @@ public:
 
         CString name;
         if (verboseCompilationEnabled()) {
-            name = toCString(
+            name = toUTF8CString(
                 "jsBody_", ++compileCounter, "_", codeBlock()->inferredName(),
                 "_", codeBlock()->hash());
         } else
@@ -27424,7 +27424,7 @@ IGNORE_CLANG_WARNINGS_END
             if (Options::validateFTLOSRExitLiveness()) [[unlikely]] {
                 if (m_graph.m_plan.mode() != JITCompilationMode::FTLForOSREntry) {
                     if (availability.isDead() && m_graph.isLiveInBytecode(operand, exitOrigin))
-                        DFG_CRASH(m_graph, m_node, toCString("Live bytecode local not available: operand = ", operand, ", availability = ", availability, ", origin = ", exitOrigin).data());
+                        DFG_CRASH(m_graph, m_node, toUTF8CString("Live bytecode local not available: operand = ", operand, ", availability = ", availability, ", origin = ", exitOrigin).legacyCStringPointer());
                 }
             }
             ExitValue exitValue = exitValueForAvailability(arguments, map, availability);
@@ -27438,7 +27438,7 @@ IGNORE_CLANG_WARNINGS_END
             Node* node = heapPair.key.base();
             ExitTimeObjectMaterialization* materialization = map.get(node);
             if (!materialization)
-                DFG_CRASH(m_graph, m_node, toCString("Could not find materialization for ", node, " in ", availabilityMap).data());
+                DFG_CRASH(m_graph, m_node, toUTF8CString("Could not find materialization for ", node, " in ", availabilityMap).legacyCStringPointer());
 
             ExitValue exitValue = exitValueForAvailability(arguments, map, heapPair.value);
             if (exitValue.hasIndexInStackmapLocations())
@@ -27553,7 +27553,7 @@ IGNORE_CLANG_WARNINGS_END
         if (isValid(value))
             return exitArgument(arguments, DataFormatStorage, value.value());
 
-        DFG_CRASH(m_graph, m_node, toCString("Cannot find value for node: ", node).data());
+        DFG_CRASH(m_graph, m_node, toUTF8CString("Cannot find value for node: ", node).legacyCStringPointer());
         return ExitValue::dead();
     }
 
@@ -27592,7 +27592,7 @@ IGNORE_CLANG_WARNINGS_END
             return exitArgument(arguments, DataFormatJS, boxBoolean(value.value()));
 
         // Doubles and Int52 have been converted by ValueRep()
-        DFG_CRASH(m_graph, m_node, toCString("Cannot find value for node: ", node).data());
+        DFG_CRASH(m_graph, m_node, toUTF8CString("Cannot find value for node: ", node).legacyCStringPointer());
     }
 
     void setInt32(Node* node, LValue value)

--- a/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
@@ -652,9 +652,9 @@ static MacroAssemblerCodeRef<OSRExitPtrTag> compileStub(VM& vm, unsigned exitID,
         shouldDumpDisassembly() || Options::verboseOSR() || Options::verboseFTLOSRExit(),
         patchBuffer, OSRExitPtrTag, nullptr,
         "FTL OSR exit #%u (D@%u, %s, %s) from %s, with operands = %s",
-            exitID, exit.m_dfgNodeIndex, toCString(exit.m_codeOrigin).data(),
-            toCString(exit.m_kind).data(), toCString(*codeBlock).data(),
-            toCString(ignoringContext<DumpContext>(exitValues)).data()
+            exitID, exit.m_dfgNodeIndex, toUTF8CString(exit.m_codeOrigin).legacyCStringPointer(),
+            toUTF8CString(exit.m_kind).legacyCStringPointer(), toUTF8CString(*codeBlock).legacyCStringPointer(),
+            toUTF8CString(ignoringContext<DumpContext>(exitValues)).legacyCStringPointer()
         );
 }
 

--- a/Source/JavaScriptCore/ftl/FTLThunks.cpp
+++ b/Source/JavaScriptCore/ftl/FTLThunks.cpp
@@ -242,7 +242,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> slowPathCallThunkGenerator(VM& vm, const S
     jit.ret();
 
     LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::FTLThunk);
-    return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, nullptr, "FTL slow path call thunk for %s", toCString(key).data());
+    return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, nullptr, "FTL slow path call thunk for %s", toUTF8CString(key).legacyCStringPointer());
 }
 
 } } // namespace JSC::FTL

--- a/Source/JavaScriptCore/heap/CompleteSubspace.cpp
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.cpp
@@ -70,7 +70,7 @@ Allocator CompleteSubspace::allocatorForSlow(size_t size)
         return allocator;
 
     if (false)
-        dataLog("Creating BlockDirectory/LocalAllocator for ", m_name, ", ", attributes(), ", ", sizeClass, ".\n");
+        dataLog("Creating BlockDirectory/LocalAllocator for ", name(), ", ", attributes(), ", ", sizeClass, ".\n");
     
     std::unique_ptr<BlockDirectory> uniqueDirectory = makeUnique<BlockDirectory>(sizeClass);
     BlockDirectory* directory = uniqueDirectory.get();

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -452,7 +452,7 @@ Heap::Heap(VM& vm, HeapType heapType)
     m_worldState.store(0);
 
     for (unsigned i = 0, numberOfParallelThreads = heapHelperPool().numberOfThreads(); i < numberOfParallelThreads; ++i) {
-        std::unique_ptr<SlotVisitor> visitor = makeUnique<SlotVisitor>(*this, toCString("P", i + 1));
+        std::unique_ptr<SlotVisitor> visitor = makeUnique<SlotVisitor>(*this, toUTF8CString("P", i + 1));
         if (Options::optimizeParallelSlotVisitorsForStoppedMutator())
             visitor->optimizeForStoppedMutator();
         m_availableParallelSlotVisitors.append(visitor.get());
@@ -1560,8 +1560,8 @@ NEVER_INLINE bool Heap::runBeginPhase(GCConductor conn)
     if (Options::useGCSignpost()) [[unlikely]] {
         StringPrintStream stream;
         stream.print("GC:(", RawPointer(this), "),mode:(", (isFullGC ? "Full" : "Eden"), "),version:(", m_gcVersion, "),conn:(", gcConductorShortName(conn), "),capacity(", capacity() / 1024, "kb)");
-        m_signpostMessage = stream.toCString();
-        WTFBeginSignpost(this, JSCGarbageCollector, "%" PUBLIC_LOG_STRING, m_signpostMessage.data() ? m_signpostMessage.data() : "(nullptr)");
+        m_signpostMessage = stream.toUTF8CString();
+        WTFBeginSignpost(this, JSCGarbageCollector, "%" PUBLIC_LOG_STRING, m_signpostMessage.legacyCStringPointer() ? m_signpostMessage.legacyCStringPointer() : "(nullptr)");
     }
 
     prepareForMarking();
@@ -1866,7 +1866,7 @@ NEVER_INLINE bool Heap::runEndPhase(GCConductor conn)
 
     dataLogLnIf(Options::logGC(), "GC END!");
     if (Options::useGCSignpost()) [[unlikely]] {
-        WTFEndSignpost(this, JSCGarbageCollector, "%" PUBLIC_LOG_STRING, m_signpostMessage.data() ? m_signpostMessage.data() : "(nullptr)");
+        WTFEndSignpost(this, JSCGarbageCollector, "%" PUBLIC_LOG_STRING, m_signpostMessage.legacyCStringPointer() ? m_signpostMessage.legacyCStringPointer() : "(nullptr)");
         m_signpostMessage = { };
     }
 

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -1267,7 +1267,7 @@ public:
     FOR_EACH_JSC_WEBASSEMBLY_DYNAMIC_NON_ISO_SUBSPACE(DEFINE_NON_ISO_SUBSPACE_MEMBER)
 #undef DEFINE_NON_ISO_SUBSPACE_MEMBER
 
-    CString m_signpostMessage;
+    UTF8CString m_signpostMessage;
 };
 
 namespace GCClient {

--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -588,9 +588,9 @@ NO_RETURN_DUE_TO_CRASH NEVER_INLINE static void crashDueToGarbageCollectorClient
         "WebKit developers: check for missing write barriers, incomplete visitChildren implementations, "
         "or unrooted GC objects.",
         heapCell);
-    auto message = out.toCString();
-    WTF::setCrashLogMessage(message.data());
-    dataLogLn(message.data());
+    auto message = out.toUTF8CString();
+    WTF::setCrashLogMessage(message.legacyCStringPointer());
+    dataLogLn(message);
 #endif
     CRASH_WITH_INFO(heapCell, cellFirst8Bytes, zeroCounts, bitfield, subspaceHash, blockVM, actualVM);
 }
@@ -624,9 +624,9 @@ NO_RETURN_DUE_TO_CRASH NEVER_INLINE void MarkedBlock::analyzeInvalidHandleAndCra
         StringPrintStream out;
         out.printf("Suspected memory corruption: invalid handle [line=%d]: markedBlock=%p; heapCell=%p; cellFirst8Bytes=%#llx; subspaceHash=%#x; contiguousZeros=%lu; totalZeros=%lu; blockVM=%p; actualVM=%p; isBlockVMValid=%d; isBlockInSet=%d; isBlockInDir=%d; foundInBlockVM=%d;",
             line, this, heapCell, cellFirst8Bytes, subspaceHash, contiguousZeroBytesHeadOfBlock, totalZeroBytesInBlock, blockVM, actualVM, isBlockVMValid, isBlockInSet, isBlockInDirectory, foundInBlockVM);
-        auto message = out.toCString();
-        WTF::setCrashLogMessage(message.data());
-        dataLogLn(message.data());
+        auto message = out.toUTF8CString();
+        WTF::setCrashLogMessage(message.legacyCStringPointer());
+        dataLogLn(message);
 #else
         UNUSED_PARAM(line);
 #endif

--- a/Source/JavaScriptCore/heap/SlotVisitor.cpp
+++ b/Source/JavaScriptCore/heap/SlotVisitor.cpp
@@ -804,7 +804,7 @@ void SlotVisitor::donateAndDrain(MonotonicTime timeout)
 
 void SlotVisitor::didRace(const VisitRaceKey& race)
 {
-    dataLogLnIf(Options::verboseVisitRace(), toCString("GC visit race: ", race));
+    dataLogLnIf(Options::verboseVisitRace(), toUTF8CString("GC visit race: ", race));
     
     Locker locker { heap()->m_raceMarkStackLock };
     JSCell* cell = race.cell();

--- a/Source/JavaScriptCore/interpreter/CallFrame.cpp
+++ b/Source/JavaScriptCore/interpreter/CallFrame.cpp
@@ -355,7 +355,7 @@ const char* CallFrame::describeFrame()
 
     dump(stringStream);
 
-    strncpy(buffer, stringStream.toCString().data(), bufferSize);
+    strncpy(buffer, stringStream.toUTF8CString().legacyCStringPointer(), bufferSize);
     buffer[bufferSize] = '\0';
 
     return buffer;

--- a/Source/JavaScriptCore/jit/CallFrameShuffler.cpp
+++ b/Source/JavaScriptCore/jit/CallFrameShuffler.cpp
@@ -127,11 +127,11 @@ void CallFrameShuffler::dump(PrintStream& out) const
             out.print("        ");
         if (isValidOld(old)) {
             if (getOld(old)) {
-                auto str = toCString(old);
+                auto str = toUTF8CString(old);
                 if (isValidNew(newReg) && isDangerNew(newReg))
-                    out.printf(" X      %18s       X ", str.data());
+                    out.printf(" X      %18s       X ", str.legacyCStringPointer());
                 else
-                    out.printf(" |      %18s       | ", str.data());
+                    out.printf(" |      %18s       | ", str.legacyCStringPointer());
             } else if (isValidNew(newReg) && isDangerNew(newReg))
                 out.printf(" X%30s X ", "");
             else
@@ -140,17 +140,17 @@ void CallFrameShuffler::dump(PrintStream& out) const
             out.print(emptySpace);
         if (isValidNew(newReg)) {
             const char d = isDangerNew(newReg) ? 'X' : '|';
-            auto str = toCString(newReg);
+            auto str = toUTF8CString(newReg);
             if (getNew(newReg)) {
                 if (getNew(newReg)->recovery().isConstant())
-                    out.printf(" %c%8s <-           constant %c ", d, str.data(), d);
+                    out.printf(" %c%8s <-           constant %c ", d, str.legacyCStringPointer(), d);
                 else {
-                    auto recoveryStr = toCString(getNew(newReg)->recovery());
-                    out.printf(" %c%8s <- %18s %c ", d, str.data(),
-                        recoveryStr.data(), d);
+                    auto recoveryStr = toUTF8CString(getNew(newReg)->recovery());
+                    out.printf(" %c%8s <- %18s %c ", d, str.legacyCStringPointer(),
+                        recoveryStr.legacyCStringPointer(), d);
                 }
             } else if (newReg == VirtualRegister { CallFrameSlot::argumentCountIncludingThis })
-                out.printf(" %c%8s <- %18zu %c ", d, str.data(), argCount(), d);
+                out.printf(" %c%8s <- %18zu %c ", d, str.legacyCStringPointer(), argCount(), d);
             else
                 out.printf(" %c%30s %c ", d, "", d);
         } else
@@ -172,8 +172,8 @@ void CallFrameShuffler::dump(PrintStream& out) const
             continue;
         out.print("          ");
         if (oldCachedRecovery) {
-            auto str = toCString(reg);
-            out.printf("         %8s                  ", str.data());
+            auto str = toUTF8CString(reg);
+            out.printf("         %8s                  ", str.legacyCStringPointer());
         } else
             out.print(emptySpace);
         if (newCachedRecovery)

--- a/Source/JavaScriptCore/jit/GdbJIT.cpp
+++ b/Source/JavaScriptCore/jit/GdbJIT.cpp
@@ -1388,7 +1388,7 @@ static void removeJITCodeEntries(GdbJITCodeMap& map, const std::span<const uint8
 
 // Insert the entry into the map and register it with GDB.
 static void addJITCodeEntry(GdbJITCodeMap& map, std::span<const uint8_t> region,
-    JITCodeEntry* entry, bool shouldDump, const CString& nameHint)
+    JITCodeEntry* entry, bool shouldDump, const UTF8CString& nameHint)
 {
     static int fileNum = 0;
     if (shouldDump) {
@@ -1398,14 +1398,14 @@ static void addJITCodeEntry(GdbJITCodeMap& map, std::span<const uint8_t> region,
         else
             filename.print("/tmp");
         filename.print("/jit-", getCurrentProcessID(), fileNum++, nameHint, ".o");
-        auto fd = open(filename.toCString().data(), O_CREAT | O_TRUNC | O_RDWR, 0666);
+        auto fd = open(filename.toUTF8CString().legacyCStringPointer(), O_CREAT | O_TRUNC | O_RDWR, 0666);
         RELEASE_ASSERT(fd != -1);
         auto file = fdopen(fd, "wb");
         RELEASE_ASSERT(file);
 
         fwrite(entry->symfileAddr, entry->symfileSize, 1, file);
         fflush(file);
-        dataLogLnIf(GdbJITInternal::verbose, "GDBInfo dumped: ", nameHint, " ", RawPointer(region.data()), "-", RawPointer(std::to_address(region.end())), " ", region.size(), " ", filename.toCString().data());
+        dataLogLnIf(GdbJITInternal::verbose, "GDBInfo dumped: ", nameHint, " ", RawPointer(region.data()), "-", RawPointer(std::to_address(region.end())), " ", region.size(), " ", filename.toUTF8CString().legacyCStringPointer());
     }
 
     auto result = map.emplace(region, entry);
@@ -1414,7 +1414,7 @@ static void addJITCodeEntry(GdbJITCodeMap& map, std::span<const uint8_t> region,
     registerCodeEntry(entry);
 }
 
-void GdbJIT::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> code)
+void GdbJIT::log(const UTF8CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> code)
 {
     if (!Options::useGdbJITInfo())
         return;
@@ -1455,7 +1455,7 @@ GdbJIT& GdbJIT::singleton()
     return logger.get();
 }
 
-void GdbJIT::log(const CString&, MacroAssemblerCodeRef<LinkBufferPtrTag>) { }
+void GdbJIT::log(const UTF8CString&, MacroAssemblerCodeRef<LinkBufferPtrTag>) { }
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/jit/GdbJIT.h
+++ b/Source/JavaScriptCore/jit/GdbJIT.h
@@ -60,7 +60,7 @@ class GdbJIT {
     WTF_MAKE_NONCOPYABLE(GdbJIT);
     friend class LazyNeverDestroyed<GdbJIT>;
 public:
-    static void log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag>);
+    static void log(const UTF8CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag>);
 
 private:
     GdbJIT() = default;

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -616,8 +616,8 @@ void JIT::privateCompileSlowCases()
         if (JITInternal::verbose)
             dataLog("At ", firstTo, " slow: ", iter - m_slowCases.begin(), "\n");
 
-        RELEASE_ASSERT_WITH_MESSAGE(iter == m_slowCases.end() || firstTo.offset() != iter->to.offset(), "Not enough jumps linked in slow case codegen while handling %s.", toCString(currentInstruction->opcodeID()).data());
-        RELEASE_ASSERT_WITH_MESSAGE(firstTo.offset() == (iter - 1)->to.offset(), "Too many jumps linked in slow case codegen while handling %s.", toCString(currentInstruction->opcodeID()).data());
+        RELEASE_ASSERT_WITH_MESSAGE(iter == m_slowCases.end() || firstTo.offset() != iter->to.offset(), "Not enough jumps linked in slow case codegen while handling %s.", toUTF8CString(currentInstruction->opcodeID()).legacyCStringPointer());
+        RELEASE_ASSERT_WITH_MESSAGE(firstTo.offset() == (iter - 1)->to.offset(), "Too many jumps linked in slow case codegen while handling %s.", toUTF8CString(currentInstruction->opcodeID()).legacyCStringPointer());
 
         jump().linkTo(fastPathResumePoint(), this);
         ++bytecodeCountHavingSlowCase;
@@ -991,7 +991,7 @@ RefPtr<BaselineJITCode> JIT::link(LinkBuffer& patchBuffer)
     // FIXME: Make a version of CodeBlockWithJITType that knows about UnlinkedCodeBlock.
     CodeRef<JSEntryPtrTag> result = FINALIZE_BASELINE_CODE(
         patchBuffer, JSEntryPtrTag,
-        "Baseline JIT code for %s", toCString(CodeBlockWithJITType(m_profiledCodeBlock, JITType::BaselineJIT)).data());
+        "Baseline JIT code for %s", toUTF8CString(CodeBlockWithJITType(m_profiledCodeBlock, JITType::BaselineJIT)).legacyCStringPointer());
     
     CodePtr<JSEntryPtrTag> withArityCheck = patchBuffer.locationOf<JSEntryPtrTag>(m_arityCheck);
     auto jitCode = adoptRef(*new BaselineJITCode(result, withArityCheck));

--- a/Source/JavaScriptCore/jit/JITCompilation.h
+++ b/Source/JavaScriptCore/jit/JITCompilation.h
@@ -53,7 +53,7 @@ public:
     CodePtr<JITCompilationPtrTag> code() const { return m_codeRef.code(); }
     MacroAssemblerCodeRef<JITCompilationPtrTag> codeRef() const { return m_codeRef; }
     
-    CString disassembly() const { return m_codeRef.disassembly(); }
+    UTF8CString disassembly() const { return m_codeRef.disassembly(); }
 
 private:
     MacroAssemblerCodeRef<JITCompilationPtrTag> m_codeRef;

--- a/Source/JavaScriptCore/jit/JITDisassembler.cpp
+++ b/Source/JavaScriptCore/jit/JITDisassembler.cpp
@@ -85,10 +85,10 @@ void JITDisassembler::reportToProfiler(Profiler::Compilation* compilation, LinkB
     StringPrintStream out;
     
     dumpHeader(out, linkBuffer);
-    compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), out.toCString()));
+    compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), out.toUTF8CString()));
     out.reset();
     dumpDisassembly(out, linkBuffer, m_startOfCode, m_labelForBytecodeIndexInMainPath[0].first);
-    compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), out.toCString()));
+    compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), out.toUTF8CString()));
     
     reportInstructions(compilation, linkBuffer, "    ", m_labelForBytecodeIndexInMainPath, firstSlowLabel());
     compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), "    (End Of Main Path)\n"_s));
@@ -96,7 +96,7 @@ void JITDisassembler::reportToProfiler(Profiler::Compilation* compilation, LinkB
     compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), "    (End Of Slow Path)\n"_s));
     out.reset();
     dumpDisassembly(out, linkBuffer, m_endOfSlowPath, m_endOfCode);
-    compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), out.toCString()));
+    compilation->addDescription(Profiler::CompiledBytecode(Profiler::OriginStack(), out.toUTF8CString()));
 }
 
 void JITDisassembler::dumpHeader(PrintStream& out, LinkBuffer& linkBuffer)
@@ -118,7 +118,7 @@ MacroAssembler::Label JITDisassembler::firstSlowLabel()
     return firstSlowLabel.isSet() ? firstSlowLabel : m_endOfSlowPath;
 }
 
-Vector<JITDisassembler::DumpedOp> JITDisassembler::dumpVectorForInstructions(LinkBuffer& linkBuffer, const char* prefix, Vector<std::pair<MacroAssembler::Label, CString>>& labels, MacroAssembler::Label endLabel)
+Vector<JITDisassembler::DumpedOp> JITDisassembler::dumpVectorForInstructions(LinkBuffer& linkBuffer, const char* prefix, Vector<std::pair<MacroAssembler::Label, UTF8CString>>& labels, MacroAssembler::Label endLabel)
 {
     StringPrintStream out;
     Vector<DumpedOp> result;
@@ -138,12 +138,12 @@ Vector<JITDisassembler::DumpedOp> JITDisassembler::dumpVectorForInstructions(Lin
         for (unsigned nextIndex = i + 1; ; nextIndex++) {
             if (nextIndex >= labels.size()) {
                 dumpDisassembly(out, linkBuffer, labels[i].first, endLabel);
-                result.last().disassembly = out.toCString();
+                result.last().disassembly = out.toUTF8CString();
                 return result;
             }
             if (labels[nextIndex].first.isSet()) {
                 dumpDisassembly(out, linkBuffer, labels[i].first, labels[nextIndex].first);
-                result.last().disassembly = out.toCString();
+                result.last().disassembly = out.toUTF8CString();
                 i = nextIndex;
                 break;
             }
@@ -153,7 +153,7 @@ Vector<JITDisassembler::DumpedOp> JITDisassembler::dumpVectorForInstructions(Lin
     return result;
 }
 
-void JITDisassembler::dumpForInstructions(PrintStream& out, LinkBuffer& linkBuffer, const char* prefix, Vector<std::pair<MacroAssembler::Label, CString>>& labels, MacroAssembler::Label endLabel)
+void JITDisassembler::dumpForInstructions(PrintStream& out, LinkBuffer& linkBuffer, const char* prefix, Vector<std::pair<MacroAssembler::Label, UTF8CString>>& labels, MacroAssembler::Label endLabel)
 {
     Vector<DumpedOp> dumpedOps = dumpVectorForInstructions(linkBuffer, prefix, labels, endLabel);
     
@@ -161,7 +161,7 @@ void JITDisassembler::dumpForInstructions(PrintStream& out, LinkBuffer& linkBuff
         out.print(dumpedOps[i].disassembly);
 }
 
-void JITDisassembler::reportInstructions(Profiler::Compilation* compilation, LinkBuffer& linkBuffer, const char* prefix, Vector<std::pair<MacroAssembler::Label, CString>>& labels, MacroAssembler::Label endLabel)
+void JITDisassembler::reportInstructions(Profiler::Compilation* compilation, LinkBuffer& linkBuffer, const char* prefix, Vector<std::pair<MacroAssembler::Label, UTF8CString>>& labels, MacroAssembler::Label endLabel)
 {
     Vector<DumpedOp> dumpedOps = dumpVectorForInstructions(linkBuffer, prefix, labels, endLabel);
     

--- a/Source/JavaScriptCore/jit/JITDisassembler.h
+++ b/Source/JavaScriptCore/jit/JITDisassembler.h
@@ -51,11 +51,11 @@ public:
     ~JITDisassembler();
     
     void setStartOfCode(MacroAssembler::Label label) { m_startOfCode = label; }
-    void setForBytecodeMainPath(unsigned bytecodeIndex, MacroAssembler::Label label, const CString& string = CString())
+    void setForBytecodeMainPath(unsigned bytecodeIndex, MacroAssembler::Label label, const UTF8CString& string = { })
     {
         m_labelForBytecodeIndexInMainPath[bytecodeIndex] = std::make_pair(label, string);
     }
-    void setForBytecodeSlowPath(unsigned bytecodeIndex, MacroAssembler::Label label, const CString& string = CString())
+    void setForBytecodeSlowPath(unsigned bytecodeIndex, MacroAssembler::Label label, const UTF8CString& string = { })
     {
         m_labelForBytecodeIndexInSlowPath[bytecodeIndex] = std::make_pair(label, string);
     }
@@ -73,19 +73,19 @@ private:
     
     struct DumpedOp {
         BytecodeIndex bytecodeIndex;
-        CString disassembly;
+        UTF8CString disassembly;
     };
-    Vector<DumpedOp> dumpVectorForInstructions(LinkBuffer&, const char* prefix, Vector<std::pair<MacroAssembler::Label, CString>>& labels, MacroAssembler::Label endLabel);
+    Vector<DumpedOp> dumpVectorForInstructions(LinkBuffer&, const char* prefix, Vector<std::pair<MacroAssembler::Label, UTF8CString>>& labels, MacroAssembler::Label endLabel);
 
-    void dumpForInstructions(PrintStream&, LinkBuffer&, const char* prefix, Vector<std::pair<MacroAssembler::Label, CString>>& labels, MacroAssembler::Label endLabel);
-    void reportInstructions(Profiler::Compilation*, LinkBuffer&, const char* prefix, Vector<std::pair<MacroAssembler::Label, CString>>& labels, MacroAssembler::Label endLabel);
+    void dumpForInstructions(PrintStream&, LinkBuffer&, const char* prefix, Vector<std::pair<MacroAssembler::Label, UTF8CString>>& labels, MacroAssembler::Label endLabel);
+    void reportInstructions(Profiler::Compilation*, LinkBuffer&, const char* prefix, Vector<std::pair<MacroAssembler::Label, UTF8CString>>& labels, MacroAssembler::Label endLabel);
     
     void dumpDisassembly(PrintStream&, LinkBuffer&, MacroAssembler::Label from, MacroAssembler::Label to);
     
     CodeBlock* const m_codeBlock;
     MacroAssembler::Label m_startOfCode;
-    Vector<std::pair<MacroAssembler::Label, CString>> m_labelForBytecodeIndexInMainPath;
-    Vector<std::pair<MacroAssembler::Label, CString>> m_labelForBytecodeIndexInSlowPath;
+    Vector<std::pair<MacroAssembler::Label, UTF8CString>> m_labelForBytecodeIndexInMainPath;
+    Vector<std::pair<MacroAssembler::Label, UTF8CString>> m_labelForBytecodeIndexInSlowPath;
     MacroAssembler::Label m_endOfSlowPath;
     MacroAssembler::Label m_endOfCode;
     void* m_codeStart { nullptr };

--- a/Source/JavaScriptCore/jit/JITPlan.cpp
+++ b/Source/JavaScriptCore/jit/JITPlan.cpp
@@ -196,13 +196,13 @@ static inline void* NODELETE signpostId(JITPlan& plan)
     return std::bit_cast<void*>(id);
 }
 
-CString JITPlan::signpostMessage()
+UTF8CString JITPlan::signpostMessage()
 {
     if (!Options::useCompilerSignpost()) [[likely]]
-        return CString();
+        return { };
     StringPrintStream stream;
     stream.print(m_mode, " ", *m_codeBlock);
-    return stream.toCString();
+    return stream.toUTF8CString();
 }
 
 void JITPlan::beginSignpostImpl()
@@ -213,15 +213,15 @@ void JITPlan::beginSignpostImpl()
     String detalString;
     switch (m_stage) {
     case JITPlanStage::Preparing:
-        WTFBeginSignpost(id, JSCJITPlanQueued, "%" PUBLIC_LOG_STRING, m_signpostMessage.data());
+        WTFBeginSignpost(id, JSCJITPlanQueued, "%" PUBLIC_LOG_STRING, m_signpostMessage.legacyCStringPointer());
         detalString = makeString("JSCJITPlanQueued:"_s, m_signpostMessage);
         break;
     case JITPlanStage::Compiling:
-        WTFBeginSignpost(id, JSCJITCompiler, "%" PUBLIC_LOG_STRING, m_signpostMessage.data());
+        WTFBeginSignpost(id, JSCJITCompiler, "%" PUBLIC_LOG_STRING, m_signpostMessage.legacyCStringPointer());
         detalString = makeString("JSCJITCompiler:"_s, m_signpostMessage);
         break;
     case JITPlanStage::Ready:
-        WTFBeginSignpost(id, JSCJITPlanReady, "%" PUBLIC_LOG_STRING, m_signpostMessage.data());
+        WTFBeginSignpost(id, JSCJITPlanReady, "%" PUBLIC_LOG_STRING, m_signpostMessage.legacyCStringPointer());
         detalString = makeString("JSCJITPlanReady:"_s, m_signpostMessage);
         break;
     case JITPlanStage::Canceled:
@@ -242,15 +242,15 @@ void JITPlan::endSignpostImpl(JITPlan::SignpostDetail detail)
     String detalString;
     switch (m_stage) {
     case JITPlanStage::Preparing:
-        WTFEndSignpost(id, JSCJITPlanQueued, "%" PUBLIC_LOG_STRING " %" PUBLIC_LOG_STRING, m_signpostMessage.data(), detailStr.characters());
+        WTFEndSignpost(id, JSCJITPlanQueued, "%" PUBLIC_LOG_STRING " %" PUBLIC_LOG_STRING, m_signpostMessage.legacyCStringPointer(), detailStr.characters());
         detalString = makeString("JSCJITPlanQueued:"_s, m_signpostMessage, " "_s, detailStr);
         break;
     case JITPlanStage::Compiling:
-        WTFEndSignpost(id, JSCJITCompiler, "%" PUBLIC_LOG_STRING " %" PUBLIC_LOG_STRING, m_signpostMessage.data(), detailStr.characters());
+        WTFEndSignpost(id, JSCJITCompiler, "%" PUBLIC_LOG_STRING " %" PUBLIC_LOG_STRING, m_signpostMessage.legacyCStringPointer(), detailStr.characters());
         detalString = makeString("JSCJITCompiler:"_s, m_signpostMessage, " "_s, detailStr);
         break;
     case JITPlanStage::Ready:
-        WTFEndSignpost(id, JSCJITPlanReady, "%" PUBLIC_LOG_STRING " %" PUBLIC_LOG_STRING, m_signpostMessage.data(), detailStr.characters());
+        WTFEndSignpost(id, JSCJITPlanReady, "%" PUBLIC_LOG_STRING " %" PUBLIC_LOG_STRING, m_signpostMessage.legacyCStringPointer(), detailStr.characters());
         detalString = makeString("JSCJITPlanReady:"_s, m_signpostMessage, " "_s, detailStr);
         break;
     case JITPlanStage::Canceled:
@@ -264,13 +264,13 @@ void JITPlan::compileInThread(JITWorklistThread* thread)
     SetForScope threadScope(m_thread, thread);
 
     MonotonicTime before;
-    CString codeBlockName;
+    UTF8CString codeBlockName;
 
     bool computeCompileTimes = this->computeCompileTimes();
     if (computeCompileTimes) [[unlikely]] {
         before = MonotonicTime::now();
         if (reportCompileTimes())
-            codeBlockName = toCString(*m_codeBlock);
+            codeBlockName = toUTF8CString(*m_codeBlock);
     }
 
     CompilationScope compilationScope;

--- a/Source/JavaScriptCore/jit/JITPlan.h
+++ b/Source/JavaScriptCore/jit/JITPlan.h
@@ -109,7 +109,7 @@ public:
 
     enum class SignpostDetail { None, Canceled };
 
-    CString signpostMessage();
+    UTF8CString signpostMessage();
 
     void beginSignpost()
     {
@@ -140,7 +140,7 @@ protected:
     CodeBlock* m_codeBlock;
     CheckedPtr<JITWorklistThread> m_thread;
     Vector<Ref<SharedTask<void()>>> m_mainThreadFinalizationTasks;
-    CString m_signpostMessage; // Non-null iff Options::useCompilerSignpost()
+    UTF8CString m_signpostMessage; // Non-null iff Options::useCompilerSignpost()
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/ThunkGenerators.cpp
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.cpp
@@ -506,7 +506,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> nativeForGenerator(VM& vm, ThunkFun
     jit.jumpToExceptionHandler(vm);
 
     LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::Thunk);
-    return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "CallTrampoline"_s, "%s %s%s%s trampoline", thunkFunctionType == ThunkFunctionType::JSFunction ? "native" : "internal", entryType == EnterViaJumpWithSavedTags ? "Tail With Saved Tags " : entryType == EnterViaJumpWithoutSavedTags ? "Tail Without Saved Tags " : "", toCString(kind).data(), includeDebuggerHook == IncludeDebuggerHook::Yes ? " Debugger" : "");
+    return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "CallTrampoline"_s, "%s %s%s%s trampoline", thunkFunctionType == ThunkFunctionType::JSFunction ? "native" : "internal", entryType == EnterViaJumpWithSavedTags ? "Tail With Saved Tags " : entryType == EnterViaJumpWithoutSavedTags ? "Tail Without Saved Tags " : "", toUTF8CString(kind).legacyCStringPointer(), includeDebuggerHook == IncludeDebuggerHook::Yes ? " Debugger" : "");
 }
 
 MacroAssemblerCodeRef<JITThunkPtrTag> nativeCallGenerator(VM& vm)

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1571,7 +1571,7 @@ void GlobalObject::promiseRejectionTracker(JSGlobalObject*, JSPromise*, JSPromis
 
 #endif // ENABLE(FUZZILLI)
 
-static UTF8CString toCString(JSGlobalObject* globalObject, ThrowScope& scope, std::expected<UTF8CString, UTF8ConversionError> expectedString)
+static UTF8CString toUTF8CString(JSGlobalObject* globalObject, ThrowScope& scope, std::expected<UTF8CString, UTF8ConversionError> expectedString)
 {
     if (expectedString)
         return expectedString.value();
@@ -1587,9 +1587,9 @@ static UTF8CString toCString(JSGlobalObject* globalObject, ThrowScope& scope, st
     return { };
 }
 
-template<typename T> static UTF8CString toCString(JSGlobalObject* globalObject, ThrowScope& scope, T& string)
+template<typename T> static UTF8CString toUTF8CString(JSGlobalObject* globalObject, ThrowScope& scope, T& string)
 {
-    return toCString(globalObject, scope, string.tryGetUTF8());
+    return toUTF8CString(globalObject, scope, string.tryGetUTF8());
 }
 
 static EncodedJSValue printInternal(JSGlobalObject* globalObject, CallFrame* callFrame, FILE* out, bool pretty)
@@ -1612,7 +1612,7 @@ static EncodedJSValue printInternal(JSGlobalObject* globalObject, CallFrame* cal
 
         String string = pretty ? callFrame->uncheckedArgument(i).toWTFStringForConsole(globalObject) : callFrame->uncheckedArgument(i).toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, { });
-        auto cString = toCString(globalObject, scope, string);
+        auto cString = toUTF8CString(globalObject, scope, string);
         RETURN_IF_EXCEPTION(scope, { });
         fwrite(cString.data(), sizeof(char), cString.length(), out);
         if (ferror(out))
@@ -1725,7 +1725,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDebug, (JSGlobalObject* globalObject, CallFrame
     RETURN_IF_EXCEPTION(scope, { });
     auto view = jsString->view(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
-    auto string = toCString(globalObject, scope, view.data);
+    auto string = toUTF8CString(globalObject, scope, view.data);
     RETURN_IF_EXCEPTION(scope, { });
     fputs("--> ", stderr);
     fwrite(string.data(), sizeof(char), string.length(), stderr);
@@ -3684,7 +3684,7 @@ int main(int argc, char** argv)
         CommaPrinter space(" "_s);
         for (int i = 0; i < argc; ++i)
             out.print(space, argv[i]);
-        WTF::setCrashLogMessage(out.toCString().data());
+        WTF::setCrashLogMessage(out.toUTF8CString().legacyCStringPointer());
     }
 #endif
 

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -276,7 +276,7 @@ extern "C" UGPRPair SYSV_ABI llint_trace_value(CallFrame* callFrame, const JSIns
         operand.offset(),
         u.bits.tag,
         u.bits.payload,
-        toCString(value).data());
+        toUTF8CString(value).legacyCStringPointer());
     LLINT_END_IMPL();
 }
 

--- a/Source/JavaScriptCore/lol/LOLJIT.cpp
+++ b/Source/JavaScriptCore/lol/LOLJIT.cpp
@@ -276,7 +276,7 @@ void LOLJIT::privateCompileMainPass()
         ASSERT(m_currentInstruction->size());
 
         if (m_disassembler)
-            m_disassembler->setForBytecodeMainPath(m_bytecodeIndex.offset(), label(), toCString("Allocator State Before: ", m_fastAllocator));
+            m_disassembler->setForBytecodeMainPath(m_bytecodeIndex.offset(), label(), toUTF8CString("Allocator State Before: ", m_fastAllocator));
         m_pcToCodeOriginMapBuilder.appendItem(label(), CodeOrigin(m_bytecodeIndex));
         m_labels[m_bytecodeIndex.offset()] = label();
 
@@ -610,7 +610,7 @@ void LOLJIT::privateCompileSlowCases()
         BytecodeIndex firstTo = iter->to;
 
         if (m_disassembler)
-            m_disassembler->setForBytecodeSlowPath(m_bytecodeIndex.offset(), label(), toCString("Allocator State Before: ", m_replayAllocator));
+            m_disassembler->setForBytecodeSlowPath(m_bytecodeIndex.offset(), label(), toUTF8CString("Allocator State Before: ", m_replayAllocator));
 
         std::optional<JITSizeStatistics::Marker> sizeMarker;
         if (Options::dumpBaselineJITSizeStatistics()) [[unlikely]] {
@@ -769,8 +769,8 @@ void LOLJIT::privateCompileSlowCases()
             dataLogLn("At ", firstTo, " linked ", iter - iterStart, " slow cases");
 
         if (firstTo.offset() == m_bytecodeIndex.offset()) {
-            RELEASE_ASSERT_WITH_MESSAGE(iter == m_slowCases.end() || firstTo.offset() != iter->to.offset(), "Not enough jumps linked in slow case codegen while handling %s.", toCString(currentInstruction->opcodeID()).data());
-            RELEASE_ASSERT_WITH_MESSAGE(firstTo.offset() == (iter - 1)->to.offset(), "Too many jumps linked in slow case codegen while handling %s.", toCString(currentInstruction->opcodeID()).data());
+            RELEASE_ASSERT_WITH_MESSAGE(iter == m_slowCases.end() || firstTo.offset() != iter->to.offset(), "Not enough jumps linked in slow case codegen while handling %s.", toUTF8CString(currentInstruction->opcodeID()).legacyCStringPointer());
+            RELEASE_ASSERT_WITH_MESSAGE(firstTo.offset() == (iter - 1)->to.offset(), "Too many jumps linked in slow case codegen while handling %s.", toUTF8CString(currentInstruction->opcodeID()).legacyCStringPointer());
         }
 
         jump().linkTo(fastPathResumePoint(), this);

--- a/Source/JavaScriptCore/parser/UnlinkedSourceCode.cpp
+++ b/Source/JavaScriptCore/parser/UnlinkedSourceCode.cpp
@@ -30,10 +30,10 @@
 
 namespace JSC {
 
-CString UnlinkedSourceCode::toUTF8() const
+UTF8CString UnlinkedSourceCode::toUTF8() const
 {
     if (!m_provider)
-        return ""_span;
+        return ""_s;
     
     return m_provider->source().substring(m_startOffset, m_endOffset - m_startOffset).utf8();
 }

--- a/Source/JavaScriptCore/parser/UnlinkedSourceCode.h
+++ b/Source/JavaScriptCore/parser/UnlinkedSourceCode.h
@@ -92,7 +92,7 @@ namespace JSC {
             return m_provider->getRange(m_startOffset, m_endOffset);
         }
         
-        CString toUTF8() const;
+        UTF8CString toUTF8() const;
         
         bool isNull() const { return !m_provider; }
         int startOffset() const { return m_startOffset; }

--- a/Source/JavaScriptCore/profiler/ProfilerBytecode.h
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecode.h
@@ -44,7 +44,7 @@ public:
     {
     }
     
-    Bytecode(unsigned bytecodeIndex, OpcodeID opcodeID, const CString& description)
+    Bytecode(unsigned bytecodeIndex, OpcodeID opcodeID, const UTF8CString& description)
         : m_bytecodeIndex(bytecodeIndex)
         , m_opcodeID(opcodeID)
         , m_description(description)
@@ -53,13 +53,13 @@ public:
     
     unsigned bytecodeIndex() const { return m_bytecodeIndex; }
     OpcodeID opcodeID() const { return m_opcodeID; }
-    const CString& description() const LIFETIME_BOUND { return m_description; }
+    const UTF8CString& description() const LIFETIME_BOUND { return m_description; }
     
     Ref<JSON::Value> toJSON(Dumper&) const;
 private:
     unsigned m_bytecodeIndex;
     OpcodeID m_opcodeID;
-    CString m_description;
+    UTF8CString m_description;
 };
 
 inline unsigned getBytecodeIndexForBytecode(Bytecode* bytecode) { return bytecode->bytecodeIndex(); }

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.cpp
@@ -40,12 +40,12 @@ BytecodeSequence::BytecodeSequence(CodeBlock* codeBlock)
     {
         unsigned index = 0;
         for (auto& profile : codeBlock->argumentValueProfiles()) {
-            CString description = profile.briefDescription();
+            auto description = profile.briefDescription();
             if (!description.length())
                 continue;
             out.reset();
             out.print("arg", index++, ": ", description);
-            m_header.append(out.toCString());
+            m_header.append(out.toUTF8CString());
         }
     }
     
@@ -57,7 +57,7 @@ BytecodeSequence::BytecodeSequence(CodeBlock* codeBlock)
         codeBlock->dumpBytecode(out, bytecodeIndex, statusMap);
         auto instruction = codeBlock->instructions().at(bytecodeIndex);
         OpcodeID opcodeID = instruction->opcodeID();
-        m_sequence.append(Bytecode(bytecodeIndex, opcodeID, out.toCString()));
+        m_sequence.append(Bytecode(bytecodeIndex, opcodeID, out.toUTF8CString()));
         bytecodeIndex += instruction->size();
     }
 }

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.h
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.h
@@ -54,7 +54,7 @@ protected:
     void addSequenceProperties(Dumper&, JSON::Object&) const;
     
 private:
-    Vector<CString> m_header;
+    Vector<UTF8CString> m_header;
     Vector<Bytecode> m_sequence;
 };
 

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodes.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodes.cpp
@@ -66,7 +66,7 @@ Ref<JSON::Value> Bytecodes::toJSON(Dumper& dumper) const
             sourceCode = makeString(StringView(sourceCode).left(size - 1), horizontalEllipsis);
     }
     result->setString(dumper.keys().m_sourceCode, WTF::move(sourceCode));
-    result->setString(dumper.keys().m_hash, String::fromUTF8(toCString(m_hash).span()));
+    result->setString(dumper.keys().m_hash, String::fromUTF8(toUTF8CString(m_hash).span()));
     result->setDouble(dumper.keys().m_instructionCount, m_instructionCount);
     addSequenceProperties(dumper, result.get());
 

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodes.h
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodes.h
@@ -39,8 +39,8 @@ public:
     ~Bytecodes();
     
     size_t id() const { return m_id; }
-    const CString& inferredName() const LIFETIME_BOUND { return m_inferredName; }
-    const CString& sourceCode() const LIFETIME_BOUND { return m_sourceCode; }
+    const UTF8CString& inferredName() const LIFETIME_BOUND { return m_inferredName; }
+    const UTF8CString& sourceCode() const LIFETIME_BOUND { return m_sourceCode; }
     unsigned instructionCount() const { return m_instructionCount; }
     CodeBlockHash hash() const { return m_hash; }
 
@@ -50,8 +50,8 @@ public:
     
 private:
     size_t m_id;
-    CString m_inferredName;
-    CString m_sourceCode;
+    UTF8CString m_inferredName;
+    UTF8CString m_sourceCode;
     CodeBlockHash m_hash;
     unsigned m_instructionCount;
 };

--- a/Source/JavaScriptCore/profiler/ProfilerCompilation.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerCompilation.cpp
@@ -69,7 +69,7 @@ void Compilation::addDescription(const CompiledBytecode& compiledBytecode)
     m_descriptions.append(compiledBytecode);
 }
 
-void Compilation::addDescription(const OriginStack& stack, const CString& description)
+void Compilation::addDescription(const OriginStack& stack, const UTF8CString& description)
 {
     addDescription(CompiledBytecode(stack, description));
 }
@@ -101,9 +101,9 @@ void Compilation::setJettisonReason(JettisonReason jettisonReason, const FireDet
     
     m_jettisonReason = jettisonReason;
     if (detail)
-        m_additionalJettisonReason = toCString(*detail);
+        m_additionalJettisonReason = toUTF8CString(*detail);
     else
-        m_additionalJettisonReason = CString();
+        m_additionalJettisonReason = { };
 }
 
 void Compilation::dump(PrintStream& out) const
@@ -115,7 +115,7 @@ Ref<JSON::Value> Compilation::toJSON(Dumper& dumper) const
 {
     auto result = JSON::Object::create();
     result->setDouble(dumper.keys().m_bytecodesID, m_bytecodes->id());
-    result->setString(dumper.keys().m_compilationKind, String::fromUTF8(toCString(m_kind).span()));
+    result->setString(dumper.keys().m_compilationKind, String::fromUTF8(toUTF8CString(m_kind).span()));
 
     auto profiledBytecodes = JSON::Array::create();
     for (const auto& bytecode : m_profiledBytecodes)
@@ -149,7 +149,7 @@ Ref<JSON::Value> Compilation::toJSON(Dumper& dumper) const
     result->setDouble(dumper.keys().m_numInlinedGetByIds, m_numInlinedGetByIds);
     result->setDouble(dumper.keys().m_numInlinedPutByIds, m_numInlinedPutByIds);
     result->setDouble(dumper.keys().m_numInlinedCalls, m_numInlinedCalls);
-    result->setString(dumper.keys().m_jettisonReason, String::fromUTF8(toCString(m_jettisonReason).span()));
+    result->setString(dumper.keys().m_jettisonReason, String::fromUTF8(toUTF8CString(m_jettisonReason).span()));
     if (!m_additionalJettisonReason.isNull())
         result->setString(dumper.keys().m_additionalJettisonReason, String::fromUTF8(m_additionalJettisonReason.span()));
 

--- a/Source/JavaScriptCore/profiler/ProfilerCompilation.h
+++ b/Source/JavaScriptCore/profiler/ProfilerCompilation.h
@@ -70,7 +70,7 @@ public:
     CompilationKind kind() const { return m_kind; }
     
     void addDescription(const CompiledBytecode&);
-    void addDescription(const OriginStack&, const CString& description);
+    void addDescription(const OriginStack&, const UTF8CString& description);
     ExecutionCounter* executionCounterFor(const OriginStack&);
     void addOSRExitSite(const Vector<CodePtr<JSInternalPtrTag>>& codeAddresses);
     OSRExit* addOSRExit(unsigned id, const OriginStack&, ExitKind, bool isWatchpoint);
@@ -94,7 +94,7 @@ private:
     unsigned m_numInlinedPutByIds;
     unsigned m_numInlinedCalls;
     JettisonReason m_jettisonReason;
-    CString m_additionalJettisonReason;
+    UTF8CString m_additionalJettisonReason;
     UID m_uid;
 };
 

--- a/Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.cpp
@@ -32,7 +32,7 @@
 
 namespace JSC { namespace Profiler {
 
-CompiledBytecode::CompiledBytecode(const OriginStack& origin, const CString& description)
+CompiledBytecode::CompiledBytecode(const OriginStack& origin, const UTF8CString& description)
     : m_origin(origin)
     , m_description(description)
 {

--- a/Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.h
+++ b/Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.h
@@ -35,17 +35,17 @@ class CompiledBytecode {
 public:
     // It's valid to have an empty OriginStack, which indicates that this is some
     // sort of non-bytecode-related machine code.
-    CompiledBytecode(const OriginStack&, const CString& description);
+    CompiledBytecode(const OriginStack&, const UTF8CString& description);
     ~CompiledBytecode();
     
     const OriginStack& originStack() const LIFETIME_BOUND { return m_origin; }
-    const CString& description() const LIFETIME_BOUND { return m_description; }
+    const UTF8CString& description() const LIFETIME_BOUND { return m_description; }
 
     Ref<JSON::Value> toJSON(Dumper&) const;
 
 private:
     OriginStack m_origin;
-    CString m_description;
+    UTF8CString m_description;
 };
 
 } } // namespace JSC::Profiler

--- a/Source/JavaScriptCore/profiler/ProfilerDatabase.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerDatabase.cpp
@@ -138,7 +138,7 @@ void Database::registerToSaveAtExit(const char* filename)
     m_shouldSaveAtExit = true;
 }
 
-void Database::logEvent(CodeBlock* codeBlock, const char* summary, const CString& detail)
+void Database::logEvent(CodeBlock* codeBlock, const char* summary, const UTF8CString& detail)
 {
     Locker locker { m_lock };
     

--- a/Source/JavaScriptCore/profiler/ProfilerDatabase.h
+++ b/Source/JavaScriptCore/profiler/ProfilerDatabase.h
@@ -65,7 +65,7 @@ public:
 
     void registerToSaveAtExit(const char* filename);
     
-    JS_EXPORT_PRIVATE void logEvent(CodeBlock* codeBlock, const char* summary, const CString& detail);
+    JS_EXPORT_PRIVATE void logEvent(CodeBlock*, const char* summary, const UTF8CString& detail);
     
 private:
     Bytecodes* ensureBytecodesFor(const AbstractLocker&, CodeBlock*) WTF_REQUIRES_LOCK(m_lock);

--- a/Source/JavaScriptCore/profiler/ProfilerEvent.h
+++ b/Source/JavaScriptCore/profiler/ProfilerEvent.h
@@ -42,7 +42,7 @@ public:
     {
     }
     
-    Event(WallTime time, Bytecodes* bytecodes, Compilation* compilation, const char* summary, const CString& detail)
+    Event(WallTime time, Bytecodes* bytecodes, Compilation* compilation, const char* summary, const UTF8CString& detail)
         : m_time(time)
         , m_bytecodes(bytecodes)
         , m_compilation(compilation)
@@ -60,7 +60,7 @@ public:
     Bytecodes* bytecodes() const { return m_bytecodes; }
     Compilation* compilation() const { return m_compilation; }
     const char* summary() const { return m_summary; }
-    const CString& detail() const LIFETIME_BOUND { return m_detail; }
+    const UTF8CString& detail() const LIFETIME_BOUND { return m_detail; }
     
     void dump(PrintStream&) const;
     Ref<JSON::Value> toJSON(Dumper&) const;
@@ -70,7 +70,7 @@ private:
     Bytecodes* m_bytecodes { nullptr };
     Compilation* m_compilation { nullptr };
     const char* m_summary { nullptr };
-    CString m_detail;
+    UTF8CString m_detail;
 };
 
 } } // namespace JSC::Profiler

--- a/Source/JavaScriptCore/runtime/ExceptionScope.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionScope.cpp
@@ -51,7 +51,7 @@ ExceptionScope::~ExceptionScope()
     m_vm.m_topExceptionScope = m_previousScope;
 }
 
-CString ExceptionScope::unexpectedExceptionMessage()
+UTF8CString ExceptionScope::unexpectedExceptionMessage()
 {
     StringPrintStream out;
 
@@ -60,7 +60,7 @@ CString ExceptionScope::unexpectedExceptionMessage()
     out.print(StackTracePrinter { *currentStack, "    " });
 
     if (!m_vm.nativeStackTraceOfLastThrow())
-        return CString();
+        return { };
     
     out.println("The exception was thrown from thread ", *m_vm.throwingThread(), " at:");
     out.print(StackTracePrinter { *m_vm.nativeStackTraceOfLastThrow(), "    " });
@@ -70,7 +70,7 @@ CString ExceptionScope::unexpectedExceptionMessage()
     else
         out.println("non-Error Exception: ", exception()->value());
 
-    return out.toCString();
+    return out.toUTF8CString();
 }
 
 #endif // ENABLE(EXCEPTION_SCOPE_VERIFICATION)

--- a/Source/JavaScriptCore/runtime/ExceptionScope.h
+++ b/Source/JavaScriptCore/runtime/ExceptionScope.h
@@ -58,10 +58,10 @@ public:
     unsigned recursionDepth() const { return m_recursionDepth; }
     ALWAYS_INLINE Exception* exception() const { return m_vm.exception(); }
 
-    ALWAYS_INLINE void assertNoException() { RELEASE_ASSERT_WITH_MESSAGE(!exception(), "%s", unexpectedExceptionMessage().data()); }
-    ALWAYS_INLINE void releaseAssertNoException() { RELEASE_ASSERT_WITH_MESSAGE(!exception(), "%s", unexpectedExceptionMessage().data()); }
-    ALWAYS_INLINE void assertNoExceptionExceptTermination() { RELEASE_ASSERT_WITH_MESSAGE(!exception() || m_vm.hasPendingTerminationException(), "%s", unexpectedExceptionMessage().data()); }
-    ALWAYS_INLINE void releaseAssertNoExceptionExceptTermination() { RELEASE_ASSERT_WITH_MESSAGE(!exception() || m_vm.hasPendingTerminationException(), "%s", unexpectedExceptionMessage().data()); }
+    ALWAYS_INLINE void assertNoException() { RELEASE_ASSERT_WITH_MESSAGE(!exception(), "%s", unexpectedExceptionMessage().legacyCStringPointer()); }
+    ALWAYS_INLINE void releaseAssertNoException() { RELEASE_ASSERT_WITH_MESSAGE(!exception(), "%s", unexpectedExceptionMessage().legacyCStringPointer()); }
+    ALWAYS_INLINE void assertNoExceptionExceptTermination() { RELEASE_ASSERT_WITH_MESSAGE(!exception() || m_vm.hasPendingTerminationException(), "%s", unexpectedExceptionMessage().legacyCStringPointer()); }
+    ALWAYS_INLINE void releaseAssertNoExceptionExceptTermination() { RELEASE_ASSERT_WITH_MESSAGE(!exception() || m_vm.hasPendingTerminationException(), "%s", unexpectedExceptionMessage().legacyCStringPointer()); }
 
 #if ASAN_ENABLED || ENABLE(C_LOOP)
     const void* stackPosition() const {  return m_location.stackPosition; }
@@ -77,7 +77,7 @@ protected:
     ExceptionScope(ExceptionScope&&) = default;
     ~ExceptionScope();
 
-    JS_EXPORT_PRIVATE CString unexpectedExceptionMessage();
+    JS_EXPORT_PRIVATE UTF8CString unexpectedExceptionMessage();
 
     VM& m_vm;
     ExceptionScope* m_previousScope;
@@ -110,7 +110,7 @@ protected:
     ExceptionScope(const ExceptionScope&) = delete;
     ExceptionScope(ExceptionScope&&) = default;
 
-    ALWAYS_INLINE CString unexpectedExceptionMessage() { return { }; }
+    ALWAYS_INLINE UTF8CString unexpectedExceptionMessage() { return { }; }
 
     VM& m_vm;
 };

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -98,7 +98,7 @@ public:
 
     int length() const { return m_string.length(); }
 
-    CString ascii() const { return m_string.string().ascii(); }
+    ASCIICString ascii() const { return m_string.string().ascii(); }
     UTF8CString utf8() const { return m_string.string().utf8(); }
 
     // There's 2 functions to construct Identifier from string, (1) fromString and (2) fromUid.

--- a/Source/JavaScriptCore/runtime/IntlCollator.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCollator.cpp
@@ -206,7 +206,7 @@ void IntlCollator::initializeCollator(JSGlobalObject* globalObject, JSValue loca
     RETURN_IF_EXCEPTION(scope, void());
 
     // UCollator does not offer an option to configure "usage" via ucol_setAttribute. So we need to pass this option via locale.
-    CString dataLocaleWithExtensions;
+    UTF8CString dataLocaleWithExtensions;
     switch (m_usage) {
     case Usage::Sort:
         if (collation.isNull())
@@ -225,7 +225,7 @@ void IntlCollator::initializeCollator(JSGlobalObject* globalObject, JSValue loca
     dataLogLnIf(IntlCollatorInternal::verbose, "locale:(", resolved.locale, "),dataLocaleWithExtensions:(", dataLocaleWithExtensions, ")");
 
     UErrorCode status = U_ZERO_ERROR;
-    m_collator = std::unique_ptr<UCollator, UCollatorDeleter>(ucol_open(dataLocaleWithExtensions.data(), &status));
+    m_collator = std::unique_ptr<UCollator, UCollatorDeleter>(ucol_open(dataLocaleWithExtensions.legacyCStringPointer(), &status));
     if (U_FAILURE(status)) {
         throwTypeError(globalObject, scope, "failed to initialize Collator"_s);
         return;

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -846,7 +846,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
             localeBuilder.append("-nu-"_s, impl->m_numberingSystem);
     }
     impl->m_dataLocaleWithExtensions = localeBuilder.toString().utf8();
-    const CString& dataLocaleWithExtensions = impl->m_dataLocaleWithExtensions;
+    const UTF8CString& dataLocaleWithExtensions = impl->m_dataLocaleWithExtensions;
 
     JSValue tzValue = jsUndefined();
     if (options) {
@@ -976,7 +976,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
         UErrorCode status = U_ZERO_ERROR;
         String timeZoneForICU = impl->m_timeZone.toICUString();
         StringView timeZoneView(timeZoneForICU);
-        auto dateFormatFromStyle = std::unique_ptr<UDateFormat, UDateFormatDeleter>(udat_open(parseUDateFormatStyle(impl->m_timeStyle), parseUDateFormatStyle(impl->m_dateStyle), dataLocaleWithExtensions.data(), timeZoneView.upconvertedCharacters(), timeZoneView.length(), nullptr, -1, &status));
+        auto dateFormatFromStyle = std::unique_ptr<UDateFormat, UDateFormatDeleter>(udat_open(parseUDateFormatStyle(impl->m_timeStyle), parseUDateFormatStyle(impl->m_dateStyle), dataLocaleWithExtensions.legacyCStringPointer(), timeZoneView.upconvertedCharacters(), timeZoneView.length(), nullptr, -1, &status));
         if (U_FAILURE(status)) [[unlikely]] {
             throwTypeError(globalObject, scope, "failed to initialize DateTimeFormat"_s);
             return;

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
@@ -233,7 +233,7 @@ public:
 
     String m_locale;
     String m_dataLocale;
-    CString m_dataLocaleWithExtensions;
+    UTF8CString m_dataLocaleWithExtensions;
     mutable String m_calendar;
     mutable String m_numberingSystem;
     TimeZone m_timeZone;

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -677,7 +677,7 @@ UNumberFormatter* IntlDurationFormat::createNumberFormatterIfNecessary(JSGlobalO
     StringView skeletonView(skeleton);
     auto upconverted = skeletonView.upconvertedCharacters();
     UErrorCode status = U_ZERO_ERROR;
-    formatter = std::unique_ptr<UNumberFormatter, UNumberFormatterDeleter>(unumf_openForSkeletonAndLocale(upconverted.get(), skeletonView.length(), m_dataLocaleWithExtensions.data(), &status));
+    formatter = std::unique_ptr<UNumberFormatter, UNumberFormatterDeleter>(unumf_openForSkeletonAndLocale(upconverted.get(), skeletonView.length(), m_dataLocaleWithExtensions.legacyCStringPointer(), &status));
     if (U_FAILURE(status)) [[unlikely]] {
         formatter = nullptr;
         throwTypeError(globalObject, scope, "Failed to initialize NumberFormat"_s);

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.h
@@ -93,7 +93,7 @@ public:
     const UnitData* units() const { return m_units; }
     unsigned fractionalDigits() const { return m_fractionalDigits; }
     const String& numberingSystem() const LIFETIME_BOUND;
-    const CString& dataLocaleWithExtensions() const LIFETIME_BOUND { return m_dataLocaleWithExtensions; }
+    const UTF8CString& dataLocaleWithExtensions() const LIFETIME_BOUND { return m_dataLocaleWithExtensions; }
 
     UNumberFormatter* createNumberFormatterIfNecessary(JSGlobalObject*, TemporalUnit, const String& skeleton) const;
 
@@ -116,7 +116,7 @@ private:
     String m_locale;
     String m_dataLocale;
     mutable String m_numberingSystem;
-    CString m_dataLocaleWithExtensions;
+    UTF8CString m_dataLocaleWithExtensions;
     unsigned m_fractionalDigits { 0 };
     Style m_style { Style::Long };
     UnitData m_units[numberOfTemporalUnits] { };

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -566,7 +566,7 @@ UNumberRangeFormatter* IntlNumberFormat::createNumberRangeFormatterIfNecessary(J
     auto upconverted = skeletonView.upconvertedCharacters();
 
     UErrorCode status = U_ZERO_ERROR;
-    m_numberRangeFormatter = std::unique_ptr<UNumberRangeFormatter, UNumberRangeFormatterDeleter>(unumrf_openForSkeletonWithCollapseAndIdentityFallback(upconverted.get(), skeletonView.length(), UNUM_RANGE_COLLAPSE_AUTO, UNUM_IDENTITY_FALLBACK_APPROXIMATELY, m_dataLocaleWithExtensions.data(), nullptr, &status));
+    m_numberRangeFormatter = std::unique_ptr<UNumberRangeFormatter, UNumberRangeFormatterDeleter>(unumrf_openForSkeletonWithCollapseAndIdentityFallback(upconverted.get(), skeletonView.length(), UNUM_RANGE_COLLAPSE_AUTO, UNUM_IDENTITY_FALLBACK_APPROXIMATELY, m_dataLocaleWithExtensions.legacyCStringPointer(), nullptr, &status));
     if (U_FAILURE(status)) {
         throwTypeError(globalObject, scope, "failed to initialize NumberFormat"_s);
         return nullptr;

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.h
@@ -225,7 +225,7 @@ private:
     std::unique_ptr<UNumberFormatter, UNumberFormatterDeleter> m_numberFormatter;
     std::unique_ptr<UNumberRangeFormatter, UNumberRangeFormatterDeleter> m_numberRangeFormatter;
     String m_numberFormatterSkeleton;
-    CString m_dataLocaleWithExtensions;
+    UTF8CString m_dataLocaleWithExtensions;
 
     String m_locale;
     String m_dataLocale;

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -488,7 +488,7 @@ JSC_DEFINE_HOST_FUNCTION(assertCall, (JSGlobalObject* globalObject, CallFrame* c
         return IterationStatus::Done;
     });
     RELEASE_ASSERT(!!codeBlock);
-    RELEASE_ASSERT_WITH_MESSAGE(false, "JS assertion failed at line %u in:\n%s\n", lineColumn.line, codeBlock->sourceCodeForTools().data());
+    RELEASE_ASSERT_WITH_MESSAGE(false, "JS assertion failed at line %u in:\n%s\n", lineColumn.line, codeBlock->sourceCodeForTools().legacyCStringPointer());
     return JSValue::encode(jsUndefined());
 }
 #endif // ASSERT_ENABLED

--- a/Source/JavaScriptCore/runtime/ProfilerSupport.cpp
+++ b/Source/JavaScriptCore/runtime/ProfilerSupport.cpp
@@ -115,7 +115,7 @@ uint32_t ProfilerSupport::getCurrentThreadID()
 
 void ProfilerSupport::write(const AbstractLocker&, uint64_t start, uint64_t end, const CString& message)
 {
-    auto header = toCString(start, " ", end, " ");
+    auto header = toUTF8CString(start, " ", end, " ");
     m_file.write(WTF::asByteSpan(header.span()));
     m_file.write(WTF::asByteSpan(message.span()));
     m_file.write(WTF::asByteSpan("\n"_span));

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -664,7 +664,7 @@ void RegExp::dumpToStream(const JSCell* cell, PrintStream& out)
 {
     // This function can be called concurrently. So we must not ref m_pattern.
     auto* regExp = uncheckedDowncast<RegExp>(cell);
-    out.print(toCString("/", regExp->pattern().impl(), "/", Yarr::flagsString(regExp->flags()).data()));
+    out.print(toUTF8CString("/", regExp->pattern().impl(), "/", Yarr::flagsString(regExp->flags()).data()));
 }
 
 template <typename CharacterType>

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -1199,7 +1199,7 @@ void SamplingProfiler::reportDataToOptionFile()
         StringPrintStream pathOut;
         pathOut.print(path, "/");
         pathOut.print("JSCSampilingProfile-", reinterpret_cast<uintptr_t>(this), ".txt");
-        auto out = FilePrintStream::open(pathOut.toCString().data(), "w");
+        auto out = FilePrintStream::open(pathOut.toUTF8CString().legacyCStringPointer(), "w");
         reportTopFunctions(*out);
         reportTopBytecodes(*out);
     }
@@ -1315,7 +1315,7 @@ void SamplingProfiler::reportTopBytecodes(PrintStream& out)
         auto frameDescription = makeString(frame.displayName(m_vm), descriptionForLocation(frame.semanticLocation, frame.wasmCompilationMode, frame.wasmOffset));
         if (std::optional<std::pair<StackFrame::CodeLocation, CodeBlock*>> machineLocation = frame.machineLocation) {
             frameDescription = makeString(frameDescription, " <-- "_s,
-                unsafeSpan(machineLocation->second->inferredName().data()), descriptionForLocation(machineLocation->first, std::nullopt, BytecodeIndex()));
+                machineLocation->second->inferredName(), descriptionForLocation(machineLocation->first, std::nullopt, BytecodeIndex()));
         }
         bytecodeCounts.add(frameDescription, 0).iterator->value++;
 

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -1588,7 +1588,7 @@ void Structure::dumpInContext(PrintStream& out, DumpContext* context) const
         dump(out);
 }
 
-void Structure::dumpBrief(PrintStream& out, const CString& string) const
+void Structure::dumpBrief(PrintStream& out, const ASCIICString& string) const
 {
     out.print("%", string, ":", classInfoForCells()->className);
     if (indexingType() & IndexingShapeMask)

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -765,7 +765,7 @@ public:
     
     void dump(PrintStream&) const;
     void dumpInContext(PrintStream&, DumpContext*) const;
-    void dumpBrief(PrintStream&, const CString&) const;
+    void dumpBrief(PrintStream&, const ASCIICString&) const;
     
     static void dumpContextHeader(PrintStream&);
     

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -463,7 +463,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         else
             pathOut.print("/tmp/");
         pathOut.print("JSCProfile-", getCurrentProcessID(), "-", m_perBytecodeProfiler->databaseID(), ".json");
-        static NeverDestroyed<CString> pathOutString = pathOut.toCString();
+        static NeverDestroyed<UTF8CString> pathOutString = pathOut.toUTF8CString();
 
 #if PLATFORM(COCOA)
         static std::once_flag registerFlag;
@@ -476,7 +476,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             int token;
             notify_register_dispatch(key, &token, mainDispatchQueueSingleton(), ^(int) {
                 dataLogLn("<BYTECODE.STAT><", pid, "> Dumping");
-                if (!m_perBytecodeProfiler->save(pathOutString->data()))
+                if (!m_perBytecodeProfiler->save(pathOutString->legacyCStringPointer()))
                     dataLogLn("<BYTECODE.STAT><", pid, "> Failed to dump to ", pathOutString.get(), ". Do you need to add a sandbox extension? ((allow file-write* (subpath \"/private/tmp/\")) in WebProcess.sb.in");
                 else
                     dataLogLn("<BYTECODE.STAT><", pid, "> Dumped to ", pathOutString.get());
@@ -486,7 +486,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 
         if (Options::dumpProfilerDataAtExit()) [[unlikely]]
-            m_perBytecodeProfiler->registerToSaveAtExit(pathOutString->data());
+            m_perBytecodeProfiler->registerToSaveAtExit(pathOutString->legacyCStringPointer());
     }
 
     // Initialize this last, as a free way of asserting that VM initialization itself
@@ -1581,7 +1581,7 @@ void VM::verifyExceptionCheckNeedIsSatisfied(unsigned recursionDepth, ExceptionE
         out.println("Unchecked exception detected at:");
         out.println(StackTracePrinter { *currentTrace, "    " });
 
-        dataLog(out.toCString());
+        dataLog(out.toUTF8CString());
         RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("exception check validation failed");
     }
 }

--- a/Source/JavaScriptCore/tools/VMInspector.cpp
+++ b/Source/JavaScriptCore/tools/VMInspector.cpp
@@ -325,9 +325,9 @@ SUPPRESS_ASAN void VMInspector::dumpRegisters(CallFrame* callFrame)
 
     VM& vm = *vmPtr;
 
-    auto valueAsString = [&] (JSValue v) -> CString {
+    auto valueAsString = [&] (JSValue v) -> UTF8CString {
         if (!v.isCell() || VMInspector::isValidCell(&vm.heap, reinterpret_cast<JSCell*>(JSValue::encode(v))))
-            return toCString(v);
+            return toUTF8CString(v);
         return ""_s;
     };
 
@@ -398,7 +398,7 @@ SUPPRESS_ASAN void VMInspector::dumpRegisters(CallFrame* callFrame)
         while (it < startOfVars) {
             JSValue v = it->jsValue();
             String name = codeBlock->nameForRegister(VirtualRegister(registerNumber));
-            dataLogF("% 4d  %-16s : %10p  0x%llx %s\n", registerNumber++, name.ascii().data(), it++, (long long)JSValue::encode(v), valueAsString(v).data());
+            dataLogF("% 4d  %-16s : %10p  0x%llx %s\n", registerNumber++, name.ascii().data(), it++, (long long)JSValue::encode(v), valueAsString(v).legacyCStringPointer());
         }
         
         dataLogF("--------------------------------------------------------------- Variables ---\n");
@@ -410,14 +410,14 @@ SUPPRESS_ASAN void VMInspector::dumpRegisters(CallFrame* callFrame)
         while (it < endOfCalleeSaves) {
             JSValue v = it->jsValue();
             String name = codeBlock->nameForRegister(VirtualRegister(registerNumber));
-            dataLogF("% 4d  %-16s : %10p  0x%llx %s\n", registerNumber++, name.ascii().data(), it++, (long long)JSValue::encode(v), valueAsString(v).data());
+            dataLogF("% 4d  %-16s : %10p  0x%llx %s\n", registerNumber++, name.ascii().data(), it++, (long long)JSValue::encode(v), valueAsString(v).legacyCStringPointer());
         }
         
         dataLogF("------------------------------------------------------------ Callee Saves ---\n");
         
         while (it != callFrameTop) {
             JSValue v = it->jsValue();
-            dataLogF("% 4d  %-16s : %10p  0x%llx %s\n", registerNumber++, "CalleeSaveReg", it++, (long long)JSValue::encode(v), valueAsString(v).data());
+            dataLogF("% 4d  %-16s : %10p  0x%llx %s\n", registerNumber++, "CalleeSaveReg", it++, (long long)JSValue::encode(v), valueAsString(v).legacyCStringPointer());
         }
     }
 
@@ -432,7 +432,7 @@ SUPPRESS_ASAN void VMInspector::dumpRegisters(CallFrame* callFrame)
     dataLogLn(codeBlock);
     long long calleeBits = (long long)callFrame->callee().rawPtr();
     auto calleeString = valueAsString(it->jsValue());
-    dataLogF("% 4d  Callee           : %10p  0x%llx %s\n", registerNumber++, it++, calleeBits, calleeString.data());
+    dataLogF("% 4d  Callee           : %10p  0x%llx %s\n", registerNumber++, it++, calleeBits, calleeString.legacyCStringPointer());
     
     StackVisitor::visit(callFrame, vm, [&] (StackVisitor& visitor) {
         if (visitor->callFrame() == callFrame) {
@@ -450,7 +450,7 @@ SUPPRESS_ASAN void VMInspector::dumpRegisters(CallFrame* callFrame)
     while (it <= bottom) {
         JSValue v = it->jsValue();
         String name = codeBlock ? codeBlock->nameForRegister(VirtualRegister(registerNumber)) : emptyString();
-        dataLogF("% 4d  %-16s : %10p  0x%llx %s\n", registerNumber++, name.ascii().data(), it++, (long long)JSValue::encode(v), valueAsString(v).data());
+        dataLogF("% 4d  %-16s : %10p  0x%llx %s\n", registerNumber++, name.ascii().data(), it++, (long long)JSValue::encode(v), valueAsString(v).legacyCStringPointer());
     }
     
     dataLogF("--------------------------------------------------------------------- End ---\n");

--- a/Source/JavaScriptCore/wasm/WasmBBQDisassembler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQDisassembler.cpp
@@ -86,11 +86,11 @@ Vector<BBQDisassembler::DumpedOp> BBQDisassembler::dumpVectorForInstructions(Lin
         unsigned nextIndex = i + 1;
         if (nextIndex >= labels.size()) {
             dumpDisassembly(out, linkBuffer, std::get<0>(labels[i]), endLabel);
-            result.last().disassembly = out.toCString();
+            result.last().disassembly = out.toUTF8CString();
             return result;
         }
         dumpDisassembly(out, linkBuffer, std::get<0>(labels[i]), std::get<0>(labels[nextIndex]));
-        result.last().disassembly = out.toCString();
+        result.last().disassembly = out.toUTF8CString();
         i = nextIndex;
     }
 

--- a/Source/JavaScriptCore/wasm/WasmBBQDisassembler.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQDisassembler.h
@@ -64,7 +64,7 @@ private:
     void dumpHeader(PrintStream&, LinkBuffer&);
 
     struct DumpedOp {
-        CString disassembly;
+        UTF8CString disassembly;
     };
     Vector<DumpedOp> dumpVectorForInstructions(LinkBuffer&, const char* prefix, Vector<std::tuple<MacroAssembler::Label, OpcodeOrigin>>& labels, MacroAssembler::Label endLabel);
 

--- a/Source/JavaScriptCore/wasm/WasmPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmPlan.cpp
@@ -141,20 +141,19 @@ void Plan::failAtFunction(FunctionCodeIndex functionIndex, String&& errorMessage
 
 Plan::~Plan() = default;
 
-CString Plan::signpostMessage(CompilationMode compilationMode, uint32_t functionIndexSpace) const
+UTF8CString Plan::signpostMessage(CompilationMode compilationMode, uint32_t functionIndexSpace) const
 {
-    CString signpostMessage;
     const FunctionData& function = m_moduleInformation->functions[functionIndexSpace - m_moduleInformation->importFunctionTypeSignatureIndices.size()];
     StringPrintStream stream;
     stream.print(compilationMode, " ", makeString(IndexOrName(functionIndexSpace, m_moduleInformation->nameSection().get(functionIndexSpace))), " instructions size = ", function.data.size());
-    return stream.toCString();
+    return stream.toUTF8CString();
 }
 
 void Plan::beginCompilerSignpost(CompilationMode compilationMode, uint32_t functionIndexSpace) const
 {
     if (Options::useCompilerSignpost()) [[unlikely]] {
         auto message = signpostMessage(compilationMode, functionIndexSpace);
-        WTFBeginSignpost(this, JSCJITCompiler, "%" PUBLIC_LOG_STRING, message.data() ? message.data() : "(nullptr)");
+        WTFBeginSignpost(this, JSCJITCompiler, "%" PUBLIC_LOG_STRING, message.legacyCStringPointer() ? message.legacyCStringPointer() : "(nullptr)");
     }
 }
 
@@ -167,7 +166,7 @@ void Plan::endCompilerSignpost(CompilationMode compilationMode, uint32_t functio
 {
     if (Options::useCompilerSignpost()) [[unlikely]] {
         auto message = signpostMessage(compilationMode, functionIndexSpace);
-        WTFEndSignpost(this, JSCJITCompiler, "%" PUBLIC_LOG_STRING, message.data() ? message.data() : "(nullptr)");
+        WTFEndSignpost(this, JSCJITCompiler, "%" PUBLIC_LOG_STRING, message.legacyCStringPointer() ? message.legacyCStringPointer() : "(nullptr)");
     }
 }
 

--- a/Source/JavaScriptCore/wasm/WasmPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmPlan.h
@@ -87,7 +87,7 @@ protected:
     virtual bool isComplete() const = 0;
     virtual void complete() WTF_REQUIRES_LOCK(m_lock) = 0;
 
-    CString signpostMessage(CompilationMode, uint32_t functionIndexSpace) const;
+    UTF8CString signpostMessage(CompilationMode, uint32_t functionIndexSpace) const;
     void beginCompilerSignpost(CompilationMode, uint32_t functionIndexSpace) const;
     void beginCompilerSignpost(const Callee&) const;
     void endCompilerSignpost(CompilationMode, uint32_t functionIndexSpace) const;

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -725,7 +725,7 @@ CodePtr<JSEntryPtrTag> RTT::jsToWasmICEntrypoint() const
     if (linkBuffer.didFailToAllocate()) [[unlikely]]
         return nullptr;
 
-    auto code = FINALIZE_WASM_CODE(linkBuffer, JSEntryPtrTag, nullptr, "JS->Wasm IC %s", WTF::toCString(*this).data());
+    auto code = FINALIZE_WASM_CODE(linkBuffer, JSEntryPtrTag, nullptr, "JS->Wasm IC %s", WTF::toUTF8CString(*this).legacyCStringPointer());
     jsToWasmICCallee->setEntrypoint(WTF::move(code));
     WTF::storeStoreFence();
     m_jsToWasmICCallee = WTF::move(jsToWasmICCallee);

--- a/Source/JavaScriptCore/yarr/YarrDisassembler.cpp
+++ b/Source/JavaScriptCore/yarr/YarrDisassembler.cpp
@@ -122,12 +122,12 @@ Vector<YarrDisassembler::DumpedOp> YarrDisassembler::dumpVectorForInstructions(L
         for (unsigned nextIndex = i + 1; ; nextIndex++) {
             if (nextIndex >= labels.size()) {
                 dumpDisassembly(out, indentString(), linkBuffer, labels[realIndex(i)], endLabel);
-                result.last().disassembly = out.toCString();
+                result.last().disassembly = out.toUTF8CString();
                 return result;
             }
             if (labels[realIndex(nextIndex)].isSet()) {
                 dumpDisassembly(out, indentString(), linkBuffer, labels[realIndex(i)], labels[realIndex(nextIndex)]);
-                result.last().disassembly = out.toCString();
+                result.last().disassembly = out.toUTF8CString();
                 i = nextIndex;
                 break;
             }

--- a/Source/JavaScriptCore/yarr/YarrDisassembler.h
+++ b/Source/JavaScriptCore/yarr/YarrDisassembler.h
@@ -85,7 +85,7 @@ private:
 
     struct DumpedOp {
         unsigned index;
-        CString disassembly;
+        UTF8CString disassembly;
     };
 
     const char* indentString(unsigned);

--- a/Source/WTF/wtf/BackwardsGraph.h
+++ b/Source/WTF/wtf/BackwardsGraph.h
@@ -147,7 +147,7 @@ public:
         return m_graph.numNodes() + 1;
     }
 
-    CString dump(Node node) const
+    UTF8CString dump(Node node) const
     {
         StringPrintStream out;
         if (!node)
@@ -156,7 +156,7 @@ public:
             out.print(Node::rootName());
         else
             out.print(m_graph.dump(node.node()));
-        return out.toCString();
+        return out.toUTF8CString();
     }
 
     void dump(PrintStream& out) const

--- a/Source/WTF/wtf/ListDump.h
+++ b/Source/WTF/wtf/ListDump.h
@@ -107,7 +107,7 @@ PointerListDump<T> pointerListDump(const T& list, ASCIILiteral comma = ", "_s)
 }
 
 template<typename T, typename Comparator>
-CString sortedListDump(const T& list, const Comparator& comparator, ASCIILiteral comma = ", "_s)
+UTF8CString sortedListDump(const T& list, const Comparator& comparator, ASCIILiteral comma = ", "_s)
 {
     Vector<typename T::ValueType> myList;
     myList.appendRange(list.begin(), list.end());
@@ -116,11 +116,11 @@ CString sortedListDump(const T& list, const Comparator& comparator, ASCIILiteral
     CommaPrinter commaPrinter(comma);
     for (unsigned i = 0; i < myList.size(); ++i)
         out.print(commaPrinter, myList[i]);
-    return out.toCString();
+    return out.toUTF8CString();
 }
 
 template<typename T>
-CString sortedListDump(const T& list, ASCIILiteral comma = ", "_s)
+UTF8CString sortedListDump(const T& list, ASCIILiteral comma = ", "_s)
 {
     return sortedListDump(list, std::less<>(), comma);
 }
@@ -132,7 +132,7 @@ MapDump<T> mapDump(const T& map, ASCIILiteral arrow = "=>"_s, ASCIILiteral comma
 }
 
 template<typename T, typename Comparator>
-CString sortedMapDump(const T& map, const Comparator& comparator, ASCIILiteral arrow = "=>"_s, ASCIILiteral comma = ", "_s)
+UTF8CString sortedMapDump(const T& map, const Comparator& comparator, ASCIILiteral arrow = "=>"_s, ASCIILiteral comma = ", "_s)
 {
     Vector<typename T::KeyType> keys;
     for (auto iter = map.begin(); iter != map.end(); ++iter)
@@ -142,7 +142,7 @@ CString sortedMapDump(const T& map, const Comparator& comparator, ASCIILiteral a
     CommaPrinter commaPrinter(comma);
     for (unsigned i = 0; i < keys.size(); ++i)
         out.print(commaPrinter, keys[i], arrow, map.get(keys[i]));
-    return out.toCString();
+    return out.toUTF8CString();
 }
 
 template<typename T, typename U>

--- a/Source/WTF/wtf/LoggingHashMap.h
+++ b/Source/WTF/wtf/LoggingHashMap.h
@@ -129,7 +129,7 @@ public:
         else
             string.print("    RELEASE_ASSERT(iter != ", m_id, "->end());\n");
         string.print("}\n");
-        dataLog(string.toCString());
+        dataLog(string.toUTF8CString());
         return result;
     }
     
@@ -146,7 +146,7 @@ public:
         else
             string.print("    RELEASE_ASSERT(iter != ", m_id, "->end());\n");
         string.print("}\n");
-        dataLog(string.toCString());
+        dataLog(string.toUTF8CString());
         return result;
     }
     
@@ -176,7 +176,7 @@ public:
         string.print(", ");
         LoggingValueTraits::print(string, passedValue);
         string.print(");\n");
-        dataLog(string.toCString());
+        dataLog(string.toUTF8CString());
         return set(key, std::forward<PassedType>(passedValue));
     }
     
@@ -189,7 +189,7 @@ public:
         string.print(", ");
         LoggingValueTraits::print(string, passedValue);
         string.print(");\n");
-        dataLog(string.toCString());
+        dataLog(string.toUTF8CString());
         return set(WTF::move(key), std::forward<PassedType>(passedValue));
     }
     
@@ -202,7 +202,7 @@ public:
         string.print(", ");
         LoggingValueTraits::print(string, passedValue);
         string.print(");\n");
-        dataLog(string.toCString());
+        dataLog(string.toUTF8CString());
         return add(key, std::forward<PassedType>(passedValue));
     }
     
@@ -215,7 +215,7 @@ public:
         string.print(", ");
         LoggingValueTraits::print(string, passedValue);
         string.print(");\n");
-        dataLog(string.toCString());
+        dataLog(string.toUTF8CString());
         return add(WTF::move(key), std::forward<PassedType>(passedValue));
     }
     
@@ -251,7 +251,7 @@ public:
         if (!didCallFunctor)
             LoggingValueTraits::print(string, MappedTraitsArg::emptyValue());
         string.print("; });\n");
-        dataLog(string.toCString());
+        dataLog(string.toUTF8CString());
         return result;
     }
     
@@ -275,7 +275,7 @@ public:
         if (!didCallFunctor)
             LoggingValueTraits::print(string, MappedTraitsArg::emptyValue());
         string.print("; });\n");
-        dataLog(string.toCString());
+        dataLog(string.toUTF8CString());
         return result;
     }
     
@@ -285,7 +285,7 @@ public:
         string.print(m_id, "->remove(");
         LoggingKeyTraits::print(string, key);
         string.print(");\n");
-        dataLog(string.toCString());
+        dataLog(string.toUTF8CString());
         return m_map.remove(key);
     }
     

--- a/Source/WTF/wtf/LoggingHashSet.h
+++ b/Source/WTF/wtf/LoggingHashSet.h
@@ -117,7 +117,7 @@ public:
         else
             string.print("    RELEASE_ASSERT(iter != ", m_id, "->end());\n");
         string.print("}\n");
-        dataLog(string.toCString());
+        dataLog(string.toUTF8CString());
         return result;
     }
     
@@ -134,7 +134,7 @@ public:
         string.print(m_id, "->add(");
         LoggingTraits::print(string, value);
         string.print(");\n");
-        dataLog(string.toCString());
+        dataLog(string.toUTF8CString());
         return m_set.add(value);
     }
 
@@ -144,7 +144,7 @@ public:
         string.print(m_id, "->add(");
         LoggingTraits::print(string, value);
         string.print(");\n");
-        dataLog(string.toCString());
+        dataLog(string.toUTF8CString());
         return m_set.add(WTF::move(value));
     }
     
@@ -154,7 +154,7 @@ public:
         string.print(m_id, "->addVoid(");
         LoggingTraits::print(string, value);
         string.print(");\n");
-        dataLog(string.toCString());
+        dataLog(string.toUTF8CString());
         m_set.addVoid(value);
     }
 
@@ -164,7 +164,7 @@ public:
         string.print(m_id, "->addVoid(");
         LoggingTraits::print(string, value);
         string.print(");\n");
-        dataLog(string.toCString());
+        dataLog(string.toUTF8CString());
         m_set.addVoid(WTF::move(value));
     }
     
@@ -191,7 +191,7 @@ public:
         string.print(m_id, "->remove(");
         LoggingTraits::print(string, value);
         string.print(");\n");
-        dataLog(string.toCString());
+        dataLog(string.toUTF8CString());
         return m_set.remove(value);
     }
     
@@ -209,7 +209,7 @@ public:
         string.print(m_id, "->remove(");
         LoggingTraits::print(string, value);
         string.print(");\n");
-        dataLog(string.toCString());
+        dataLog(string.toUTF8CString());
         return m_set.take(value);
     }
     

--- a/Source/WTF/wtf/PrintStream.cpp
+++ b/Source/WTF/wtf/PrintStream.cpp
@@ -27,6 +27,7 @@
 #include <wtf/PrintStream.h>
 
 #include <inttypes.h>
+#include <wtf/text/ASCIIFastPath.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
@@ -102,15 +103,43 @@ void printInternal(PrintStream& out, StringView string)
     printExpectedCStringHelper(out, "StringView", string.tryGetUTF8());
 }
 
-void printInternal(PrintStream& out, const CString& string)
+// The stream's bytes are read back as UTF-8, so only ASCII and UTF-8 can be written through
+// unchanged. This mirrors CStringWithEncoding::legacyCStringPointer(), which is offered for those
+// two encodings and withheld from Latin-1 for the same reason.
+template<typename CharacterType>
+static void printCStringSpan(PrintStream& out, std::span<const CharacterType> characters)
 {
-    if (out.truncatesLongStrings() && string.length() > stringLengthThresholdToTriggerTruncation) [[unlikely]] {
-        size_t lengthNotPrinted = string.length() - stringLengthToTruncateToForPrinting;
-        auto subString = makeString(string.span().first(stringLengthToTruncateToForPrinting), "...["_s, lengthNotPrinted, " characters not shown]"_s);
+    if (out.truncatesLongStrings() && characters.size() > stringLengthThresholdToTriggerTruncation) [[unlikely]] {
+        size_t lengthNotPrinted = characters.size() - stringLengthToTruncateToForPrinting;
+        auto subString = makeString(characters.first(stringLengthToTruncateToForPrinting), "...["_s, lengthNotPrinted, " characters not shown]"_s);
         printInternal(out, subString);
         return;
     }
-    printInternal(out, string.data());
+
+    if constexpr (std::same_as<CharacterType, Latin1Character>) {
+        if (!charactersAreAllASCII(characters)) [[unlikely]] {
+            printExpectedCStringHelper(out, "Latin1CString", String { characters }.tryGetUTF8());
+            return;
+        }
+    }
+    // The span is the contents of a null-terminated CString buffer, so this is safe and, as before,
+    // stops at an embedded null rather than writing one into the stream.
+    printInternal(out, byteCast<char>(characters).data());
+}
+
+void printInternal(PrintStream& out, const UTF8CString& string)
+{
+    printCStringSpan(out, string.span());
+}
+
+void printInternal(PrintStream& out, const Latin1CString& string)
+{
+    printCStringSpan(out, string.span());
+}
+
+void printInternal(PrintStream& out, const ASCIICString& string)
+{
+    printCStringSpan(out, string.span());
 }
 
 void printInternal(PrintStream& out, const String& string)

--- a/Source/WTF/wtf/PrintStream.h
+++ b/Source/WTF/wtf/PrintStream.h
@@ -114,13 +114,18 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, StringView);
-WTF_EXPORT_PRIVATE void printInternal(PrintStream&, const CString&);
+// A PrintStream's contents are read back as UTF-8 (see StringPrintStream::toString()), so Latin-1
+// is transcoded on the way in. A CString does not know its encoding and therefore cannot be
+// printed: use one of the CStringWithEncoding aliases below.
+void printInternal(PrintStream&, const CString&) = delete;
+WTF_EXPORT_PRIVATE void printInternal(PrintStream&, const UTF8CString&);
+WTF_EXPORT_PRIVATE void printInternal(PrintStream&, const Latin1CString&);
+WTF_EXPORT_PRIVATE void printInternal(PrintStream&, const ASCIICString&);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, const String&);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, const AtomString&);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, const StringImpl*);
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, std::span<const char8_t>);
 inline void printInternal(PrintStream& out, char* value) { printInternal(out, static_cast<const char*>(value)); }
-inline void printInternal(PrintStream& out, CString& value) { printInternal(out, static_cast<const CString&>(value)); }
 inline void printInternal(PrintStream& out, String& value) { printInternal(out, static_cast<const String&>(value)); }
 inline void printInternal(PrintStream& out, StringImpl* value) { printInternal(out, static_cast<const StringImpl*>(value)); }
 

--- a/Source/WTF/wtf/ScopedPrintStream.h
+++ b/Source/WTF/wtf/ScopedPrintStream.h
@@ -40,7 +40,7 @@ public:
 
     ~ScopedPrintStream() final
     {
-        m_out.print(m_buffer.toCString());
+        m_out.print(m_buffer.toUTF8CString());
         m_out.flush();
     }
 

--- a/Source/WTF/wtf/SingleRootGraph.h
+++ b/Source/WTF/wtf/SingleRootGraph.h
@@ -243,7 +243,7 @@ public:
         return m_graph.numNodes() + 1;
     }
 
-    CString dump(Node node) const
+    UTF8CString dump(Node node) const
     {
         StringPrintStream out;
         if (!node)
@@ -252,7 +252,7 @@ public:
             out.print(Node::rootName());
         else
             out.print(m_graph.dump(node.node()));
-        return out.toCString();
+        return out.toUTF8CString();
     }
 
     void dump(PrintStream& out) const

--- a/Source/WTF/wtf/StringHashDumpContext.h
+++ b/Source/WTF/wtf/StringHashDumpContext.h
@@ -38,17 +38,17 @@ class StringHashDumpContext {
 public:
     StringHashDumpContext() { }
     
-    CString getID(const T* value)
+    ASCIICString getID(const T* value)
     {
-        typename HashMap<const T*, CString>::iterator iter = m_forwardMap.find(value);
+        typename HashMap<const T*, ASCIICString>::iterator iter = m_forwardMap.find(value);
         if (iter != m_forwardMap.end())
             return iter->value;
         
-        for (unsigned hashValue = toCString(*value).hash(); ; hashValue++) {
-            CString fullHash = std::span<const char> { integerToSixCharacterHashString(hashValue) };
+        for (unsigned hashValue = toUTF8CString(*value).hash(); ; hashValue++) {
+            ASCIICString fullHash { std::span<const char> { integerToSixCharacterHashString(hashValue) } };
             
             for (unsigned length = 2; length < 6; ++length) {
-                CString shortHash { fullHash.span().first(length) };
+                ASCIICString shortHash { fullHash.span().first(length) };
                 if (!m_backwardMap.contains(shortHash)) {
                     m_forwardMap.add(value, shortHash);
                     m_backwardMap.add(shortHash, value);
@@ -63,11 +63,11 @@ public:
         value->dumpBrief(out, getID(value));
     }
     
-    CString brief(const T* value)
+    UTF8CString brief(const T* value)
     {
         StringPrintStream out;
         dumpBrief(value, out);
-        return out.toCString();
+        return out.toUTF8CString();
     }
     
     bool isEmpty() const { return m_forwardMap.isEmpty(); }
@@ -78,10 +78,10 @@ public:
         T::dumpContextHeader(out);
         out.print("\n"_s);
         
-        Vector<CString> keys;
+        Vector<ASCIICString> keys;
         unsigned maxKeySize = 0;
         for (
-            typename HashMap<CString, const T*>::const_iterator iter = m_backwardMap.begin();
+            typename HashMap<ASCIICString, const T*>::const_iterator iter = m_backwardMap.begin();
             iter != m_backwardMap.end();
             ++iter) {
             keys.append(iter->key);
@@ -93,7 +93,7 @@ public:
         for (unsigned i = 0; i < keys.size(); ++i) {
             const T* value = m_backwardMap.get(keys[i]);
             out.print(prefix, "    "_s);
-            CString briefString = brief(value, keys[i]);
+            auto briefString = brief(value, keys[i]);
             out.print(briefString);
             for (unsigned n = briefString.length(); n < maxKeySize; ++n)
                 out.print(" "_s);
@@ -102,15 +102,15 @@ public:
     }
     
 private:
-    static CString brief(const T* value, const CString& string)
+    static UTF8CString brief(const T* value, const ASCIICString& string)
     {
         StringPrintStream out;
         value->dumpBrief(out, string);
-        return out.toCString();
+        return out.toUTF8CString();
     }
     
-    HashMap<const T*, CString> m_forwardMap;
-    HashMap<CString, const T*> m_backwardMap;
+    HashMap<const T*, ASCIICString> m_forwardMap;
+    HashMap<ASCIICString, const T*> m_backwardMap;
 };
 
 } // namespace WTF

--- a/Source/WTF/wtf/StringPrintStream.cpp
+++ b/Source/WTF/wtf/StringPrintStream.cpp
@@ -75,10 +75,10 @@ void StringPrintStream::vprintf(const char* format, va_list passedArgList)
     }
 }
 
-CString StringPrintStream::toCString() const
+UTF8CString StringPrintStream::toUTF8CString() const
 {
     ASSERT(m_length == strlenSpan(m_buffer));
-    return CString(m_buffer.first(m_length));
+    return UTF8CString { byteCast<char8_t>(m_buffer.first(m_length)) };
 }
 
 void StringPrintStream::reset()

--- a/Source/WTF/wtf/StringPrintStream.h
+++ b/Source/WTF/wtf/StringPrintStream.h
@@ -40,7 +40,7 @@ public:
 
     size_t length() const { return m_length; }
     
-    WTF_EXPORT_PRIVATE CString toCString() const;
+    WTF_EXPORT_PRIVATE UTF8CString toUTF8CString() const;
     WTF_EXPORT_PRIVATE std::expected<String, UTF8ConversionError> tryToString() const;
     WTF_EXPORT_PRIVATE String toString() const;
     WTF_EXPORT_PRIVATE String toStringWithLatin1Fallback() const;
@@ -57,11 +57,11 @@ private:
 // Stringify any type T that has a WTF::printInternal(PrintStream&, const T&)
 
 template<typename... Types>
-CString toCString(const Types&... values)
+UTF8CString toUTF8CString(const Types&... values)
 {
     StringPrintStream stream;
     stream.print(values...);
-    return stream.toCString();
+    return stream.toUTF8CString();
 }
 
 template<typename... Types>
@@ -85,6 +85,6 @@ std::optional<String> toStringWithBoundsCheck(const Types&... values)
 } // namespace WTF
 
 using WTF::StringPrintStream;
-using WTF::toCString;
+using WTF::toUTF8CString;
 using WTF::toString;
 using WTF::toStringWithBoundsCheck;

--- a/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
+++ b/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
@@ -143,7 +143,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     stream.vprintf(format, argList);
     va_end(argList);
 
-    os_log_error(m_osLog, "%{public}s", stream.toCString().data());
+    os_log_error(m_osLog, "%{public}s", stream.toUTF8CString().legacyCStringPointer());
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -92,7 +92,7 @@ constexpr float attachmentIconSize = 52;
 #define ATTACHMENT_LOG_DOCUMENT_TRAFFIC !RELEASE_LOG_DISABLED
 #if ATTACHMENT_LOG_DOCUMENT_TRAFFIC
 // Given a StackTrace, output one minimally-sized function identifier per line, so that more frames can fit in a log message.
-static CString compactStackTrace(StackTrace& stackTrace)
+static UTF8CString compactStackTrace(StackTrace& stackTrace)
 {
     StringPrintStream stack;
     stackTrace.forEachFrame([&stack](int, void*, const char* fullName) {
@@ -148,7 +148,7 @@ static CString compactStackTrace(StackTrace& stackTrace)
 
         stack.print("\n> "_s, name);
     });
-    return stack.toCString();
+    return stack.toUTF8CString();
 }
 #endif // ATTACHMENT_LOG_DOCUMENT_TRAFFIC
 
@@ -666,12 +666,12 @@ Node::NeedsPostConnectionSteps HTMLAttachmentElement::insertionSteps(InsertionTy
         auto now = WTF::MonotonicTime::now();
         if (lastInsertion && lastRemoval && lastRemoval.attachment() != reinterpret_cast<uintptr_t>(this) && lastRemoval.document() == reinterpret_cast<uintptr_t>(document.ptr())) {
             RELEASE_LOG(Editing, "HTMLAttachmentElement - quick insert(A)-remove(A)-insert(B) within %fs of the first document[%p] load, stacks below:", document->monotonicTimestamp(), reinterpret_cast<const void*>(lastRemoval.document()));
-            RELEASE_LOG(Editing, "HTMLAttachmentElement[%p uuid=%s] - 1st insertion %fms ago:%s", reinterpret_cast<const void*>(lastInsertion.attachment()), lastInsertion.uniqueIdentifier().utf8().legacyCStringPointer(), (now - lastInsertion.time()).milliseconds(), compactStackTrace(lastInsertion.stackTrace()).data());
+            RELEASE_LOG(Editing, "HTMLAttachmentElement[%p uuid=%s] - 1st insertion %fms ago:%s", reinterpret_cast<const void*>(lastInsertion.attachment()), lastInsertion.uniqueIdentifier().utf8().legacyCStringPointer(), (now - lastInsertion.time()).milliseconds(), compactStackTrace(lastInsertion.stackTrace()).legacyCStringPointer());
             lastInsertion.reset();
-            RELEASE_LOG(Editing, "HTMLAttachmentElement[%p uuid=%s] - removal %fms ago:%s", reinterpret_cast<const void*>(lastRemoval.attachment()), lastRemoval.uniqueIdentifier().utf8().legacyCStringPointer(), (now - lastRemoval.time()).milliseconds(), compactStackTrace(lastRemoval.stackTrace()).data());
+            RELEASE_LOG(Editing, "HTMLAttachmentElement[%p uuid=%s] - removal %fms ago:%s", reinterpret_cast<const void*>(lastRemoval.attachment()), lastRemoval.uniqueIdentifier().utf8().legacyCStringPointer(), (now - lastRemoval.time()).milliseconds(), compactStackTrace(lastRemoval.stackTrace()).legacyCStringPointer());
             lastRemoval.reset();
             lastInsertion.capture(*this, now);
-            RELEASE_LOG(Editing, "HTMLAttachmentElement[%p uuid=%s] - 2nd insertion:%s", reinterpret_cast<const void*>(lastInsertion.attachment()), lastInsertion.uniqueIdentifier().utf8().legacyCStringPointer(), compactStackTrace(lastInsertion.stackTrace()).data());
+            RELEASE_LOG(Editing, "HTMLAttachmentElement[%p uuid=%s] - 2nd insertion:%s", reinterpret_cast<const void*>(lastInsertion.attachment()), lastInsertion.uniqueIdentifier().utf8().legacyCStringPointer(), compactStackTrace(lastInsertion.stackTrace()).legacyCStringPointer());
         } else {
             lastInsertion.capture(*this, now);
             lastRemoval.reset();

--- a/Tools/TestWebKitAPI/Tests/WTF/CString.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CString.cpp
@@ -28,6 +28,7 @@
 #include <array>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/StringPrintStream.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringCommon.h>
@@ -471,4 +472,34 @@ TEST(WTF, CStringWithEncodingMakeString)
     Latin1CString latin1String { std::span<const Latin1Character> { latin1Cafe } };
     EXPECT_EQ(makeString(latin1String), String::fromUTF8(u8"café"_span));
     EXPECT_EQ(makeString(latin1String).length(), 4U);
+}
+
+template<typename StringType> concept PrintableToStream = requires(StringPrintStream& out, const StringType& string) {
+    WTF::printInternal(out, string);
+};
+
+TEST(WTF, CStringWithEncodingPrintStream)
+{
+    // A PrintStream holds UTF-8, so printing transcodes whatever it is given. An untyped CString
+    // has no encoding to transcode from, so printing one does not compile.
+    static_assert(PrintableToStream<UTF8CString>);
+    static_assert(PrintableToStream<Latin1CString>);
+    static_assert(PrintableToStream<ASCIICString>);
+    static_assert(!PrintableToStream<CString>);
+
+    auto print = [](const auto& string) {
+        StringPrintStream out;
+        out.print(string);
+        return out.toString();
+    };
+
+    UTF8CString utf8String { u8"Water🍉Melon"_span };
+    EXPECT_EQ(print(utf8String), String::fromUTF8(u8"Water🍉Melon"_span));
+
+    constexpr auto latin1Cafe = WTF::toArray<Latin1Character>({ 'c', 'a', 'f', 0xE9 });
+    Latin1CString latin1String { std::span<const Latin1Character> { latin1Cafe } };
+    EXPECT_EQ(print(latin1String), String::fromUTF8(u8"café"_span));
+
+    ASCIICString asciiString { "cafe"_s };
+    EXPECT_EQ(print(asciiString), "cafe"_s);
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/Time.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Time.cpp
@@ -36,31 +36,31 @@ namespace WTF {
 
 std::basic_ostream<char>& operator<<(std::basic_ostream<char>& out, Seconds value)
 {
-    out << toCString(value).data();
+    out << toUTF8CString(value).legacyCStringPointer();
     return out;
 }
 
 std::basic_ostream<char>& operator<<(std::basic_ostream<char>& out, WallTime value)
 {
-    out << toCString(value).data();
+    out << toUTF8CString(value).legacyCStringPointer();
     return out;
 }
 
 std::basic_ostream<char>& operator<<(std::basic_ostream<char>& out, MonotonicTime value)
 {
-    out << toCString(value).data();
+    out << toUTF8CString(value).legacyCStringPointer();
     return out;
 }
 
 std::basic_ostream<char>& operator<<(std::basic_ostream<char>& out, ApproximateTime value)
 {
-    out << toCString(value).data();
+    out << toUTF8CString(value).legacyCStringPointer();
     return out;
 }
 
 std::basic_ostream<char>& operator<<(std::basic_ostream<char>& out, TimeWithDynamicClockType value)
 {
-    out << toCString(value).data();
+    out << toUTF8CString(value).legacyCStringPointer();
     return out;
 }
 


### PR DESCRIPTION
#### 7189f73167efc53070a0a61736981d79fef5dfea
<pre>
Rename toCString() to toUTF8CString() and stop PrintStream from printing an untyped CString
<a href="https://bugs.webkit.org/show_bug.cgi?id=323960">https://bugs.webkit.org/show_bug.cgi?id=323960</a>

Reviewed by Yusuke Suzuki.

Follow-up to 320652@main, which introduced CStringWithEncoding, and to 320795@main, 320803@main
and 320905@main, which migrated the String conversions. Every String-shaped producer is typed now;
the largest remaining cluster of bare CStrings is the dump machinery hanging off StringPrintStream.

A StringPrintStream&apos;s buffer holds UTF-8. That is not a new claim: toString() and tryToString()
already decode it with String::fromUTF8 unconditionally, and every String-family printer reaches the
buffer through printExpectedCStringHelper, which takes the std::expected&lt;UTF8CString, ...&gt; from
tryGetUTF8() and emits an ASCII diagnostic when the conversion fails. toCString() was the one
accessor that handed those same bytes back as a CString, which by definition does not know its
encoding, so makeString(toCString(...)) reinterpreted UTF-8 as Latin-1 - exactly the mojibake
320652@main exists to prevent.

StringPrintStream::toCString() and WTF::toCString(...) therefore return a UTF8CString, and are
renamed to toUTF8CString() to match: a name that says CString on a function that returns UTF-8 is
the same mismatch in prose that this series is removing from the type system. The two local
toCString() overloads in jsc.cpp, which already returned a UTF8CString, are renamed with them.

The new return type propagates on its own through most of JSC, because nearly every dump helper is
a wrapper around out.toUTF8CString(): CodeBlock::inferredName() and sourceCodeForTools(),
MacroAssemblerCodeRef::disassembly(), BytecodeDumper::registerName(),
ArrayProfile::briefDescription(), the DumpedOp structs in the four disassemblers,
Plan::signpostMessage(), sortedListDump() and the graph dump() helpers, and the Profiler classes
that already had to call String::fromUTF8 on their own members to make sense of them. Three call
sites were silently mojibaking non-ASCII function names and are fixed as a consequence:
CodeBlock::inferredNameWithHash(), SamplingProfiler::reportTopBytecodes(), and
DebuggerCallFrame::functionName(), which decoded UTF-8 bytes with String::fromLatin1.

The UTF-8 invariant was only an assumption while printInternal(PrintStream&amp;, const CString&amp;)
existed, though, because it wrote its bytes straight into the stream with %s. A Latin1CString sliced
to its base class and injected bytes that are not valid UTF-8, at which point toString() returns a
null String and the message is lost rather than merely garbled - which is why
StringPrintStream::toStringWithLatin1Fallback() exists. Rather than reinterpret those bytes, which
would only paper over the missing encoding for a type that is on its way out, that overload is
deleted. Printing a CString no longer compiles; callers name an encoding instead.

The three encoding-aware overloads that replace it follow the same split as
CStringWithEncoding::legacyCStringPointer(), which is offered for UTF-8 and ASCII and withheld from
Latin-1: UTF-8 and ASCII bytes are written through unchanged, and Latin-1 is transcoded, behind a
charactersAreAllASCII() fast path so the common case still does not allocate. Printing keeps using
%s on the null-terminated buffer rather than the length-carrying span overload, so that an embedded
null still truncates instead of being written into a stream whose length is asserted against
strlenSpan(). The truncation path for very long strings now decodes with the same rules as the
non-truncated one; previously it read the bytes as Latin-1 while its sibling passed them through, so
one CString could produce two different results depending on its length.

* Source/*:

Canonical link: <a href="https://commits.webkit.org/320980@main">https://commits.webkit.org/320980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ddaa845452bced0f2ca4b2c4211afa31f750c1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186320 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196597 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150837 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59915 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145584 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49253 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125930 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47982 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45945 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7762 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14619 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158333 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45689 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7671 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Compiled WebKit (warnings)") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47548 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52674 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198584 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59861 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155153 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41606 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60572 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154790 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49216 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132797 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130024 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/58996 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20668 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58399 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58615 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58464 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->