### PR TITLE
[scroll-animations] make `subject` a required parameter when constructing a `ViewTimeline`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/idlharness.window-expected.txt
@@ -20,7 +20,7 @@ PASS Stringification of new ScrollTimeline()
 PASS ScrollTimeline interface: new ScrollTimeline() must inherit property "source" with the proper type
 PASS ScrollTimeline interface: new ScrollTimeline() must inherit property "axis" with the proper type
 PASS ViewTimeline interface: existence and properties of interface object
-FAIL ViewTimeline interface object length assert_equals: wrong value for ViewTimeline.length expected 1 but got 0
+PASS ViewTimeline interface object length
 PASS ViewTimeline interface object name
 PASS ViewTimeline interface: existence and properties of interface prototype object
 PASS ViewTimeline interface: existence and properties of interface prototype object's "constructor" property

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/TimelineTrigger/constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/TimelineTrigger/constructor-expected.txt
@@ -2,5 +2,5 @@
 FAIL Default values when no property bag is supplied Can't find variable: TimelineTrigger
 FAIL Default values when an empty property bag is supplied. Can't find variable: TimelineTrigger
 FAIL All values supplied (scroll timeline). Can't find variable: TimelineTrigger
-FAIL All values supplied (view timeline). Can't find variable: TimelineTrigger
+FAIL All values supplied (view timeline). Not enough arguments
 

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -60,9 +60,8 @@ ExceptionOr<Ref<ViewTimeline>> ViewTimeline::create(Document& document, ViewTime
 
     auto viewTimeline = ViewTimeline::create({ nullAtom() }, options.axis, WTF::move(*insets), Style::ZoomFactor::none());
 
-    viewTimeline->setSubject(options.subject.get());
-    if (auto subject = options.subject)
-        protect(subject->document())->updateLayoutIgnorePendingStylesheets();
+    viewTimeline->setSubject(options.subject.ptr());
+    protect(options.subject->document())->updateLayoutIgnorePendingStylesheets();
     viewTimeline->cacheCurrentTime();
 
     return viewTimeline;

--- a/Source/WebCore/animation/ViewTimeline.idl
+++ b/Source/WebCore/animation/ViewTimeline.idl
@@ -27,7 +27,7 @@
 [
     Exposed=Window
 ] interface ViewTimeline : ScrollTimeline {
-    [CallWith=CurrentDocument] constructor(optional ViewTimelineOptions options = {});
+    [CallWith=CurrentDocument] constructor(ViewTimelineOptions options);
     // FIXME: `subject` should not be nullable.
     readonly attribute Element? subject;
     readonly attribute CSSNumericValue startOffset;

--- a/Source/WebCore/animation/ViewTimelineOptions.h
+++ b/Source/WebCore/animation/ViewTimelineOptions.h
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 struct ViewTimelineOptions {
-    RefPtr<Element> subject;
+    Ref<Element> subject;
     ScrollAxis axis;
     ViewTimelineInsetValue inset;
 };

--- a/Source/WebCore/animation/ViewTimelineOptions.idl
+++ b/Source/WebCore/animation/ViewTimelineOptions.idl
@@ -27,7 +27,7 @@ typedef (DOMString or CSSOMKeywordValue) CSSOMKeywordish;
 
 // https://drafts.csswg.org/scroll-animations/#dictdef-viewtimelineoptions
 dictionary ViewTimelineOptions {
-    Element subject;
+    required Element subject;
     ScrollAxis axis = "block";
     (DOMString or sequence<(CSSNumericValue or CSSOMKeywordish)>) inset = "auto";
 };


### PR DESCRIPTION
#### a7a09ee4d7fc6b8714452a0a73286c5cc7c5d3ff
<pre>
[scroll-animations] make `subject` a required parameter when constructing a `ViewTimeline`
<a href="https://bugs.webkit.org/show_bug.cgi?id=323965">https://bugs.webkit.org/show_bug.cgi?id=323965</a>
<a href="https://rdar.apple.com/187200265">rdar://187200265</a>

Reviewed by Anne van Kesteren.

The CSS WG resolved recently [0] to make the `subject` parameter when constructing a `ViewTimeline`.

[0] <a href="https://bugs.webkit.org/show_bug.cgi?id=323965">https://bugs.webkit.org/show_bug.cgi?id=323965</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/idlharness.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/TimelineTrigger/constructor-expected.txt:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::create):
* Source/WebCore/animation/ViewTimeline.idl:
* Source/WebCore/animation/ViewTimelineOptions.h:
* Source/WebCore/animation/ViewTimelineOptions.idl:

Canonical link: <a href="https://commits.webkit.org/320969@main">https://commits.webkit.org/320969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb74418fb94d113a533afba55163378e6aac9722

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60233 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54004 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196625 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150856 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/678aef56-ceb1-439b-b4e0-34541df2091d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145593 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/358a3c82-1a4e-47fc-93cf-e1073bbedaf3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166109 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125940 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7dc96f46-6074-49dc-b40c-e4f4629033b7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48000 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45960 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158350 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45706 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7699 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52698 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198612 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59889 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155170 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60600 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42267 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154808 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28306 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49233 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132816 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130063 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59024 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20685 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58427 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58643 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58492 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->