### PR TITLE
[threaded-animations] updating keyframes of an accelerated animation's effect to unresolved offsets should disable acceleration

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/updating-keyframes-to-unresolved-offsets-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/updating-keyframes-to-unresolved-offsets-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Updating an accelerated animation to use unresolved offset disables the accelerated animation.
+

--- a/LayoutTests/webanimations/threaded-animations/updating-keyframes-to-unresolved-offsets.html
+++ b/LayoutTests/webanimations/threaded-animations/updating-keyframes-to-unresolved-offsets.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html><!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=true ] -->
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="threaded-animations-utils.js"></script>
+<style>
+
+#target {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+</style>
+</body>
+
+<div id="target"></div>
+
+<script>
+
+promise_test(async test => {
+    const target = document.getElementById("target");
+
+    // Create an animation that, initially, can be accelerated.
+    const animation = target.animate({ opacity: [1, 0] }, { duration: 1000*1000 });
+    await animationAcceleration(animation);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 1);
+
+    // Now change its effect's keyframes to use a range which will disable acceleration.
+    animation.effect.setKeyframes([
+        { offset: { rangeName: "entry", offset: CSS.percent(0) }, opacity: 1 },
+        { offset: { rangeName: "entry", offset: CSS.percent(100) }, opacity: 0 }
+    ]);
+    await threadedAnimationsCommit();
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
+}, "Updating an accelerated animation to use unresolved offset disables the accelerated animation.");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1355,6 +1355,7 @@ void KeyframeEffect::setBlendingKeyframes(BlendingKeyframes&& blendingKeyframes)
 
     checkForMatchingTransformFunctionLists();
 
+    updateComputedKeyframeOffsetsIfNeeded();
     updateAcceleratedAnimationIfNecessary();
 }
 
@@ -3322,7 +3323,7 @@ void KeyframeEffect::timelineAccelerationAbilityDidChange()
 
 Ref<AcceleratedEffect> KeyframeEffect::acceleratedRepresentation(const IntRect& borderBoxRect, const AcceleratedEffectValues& baseValues, OptionSet<AcceleratedEffectProperty>& disallowedProperties)
 {
-    updateComputedKeyframeOffsetsIfNeeded();
+    ASSERT(canBeAccelerated());
     Ref acceleratedEffect = AcceleratedEffect::create(*this, borderBoxRect, baseValues, disallowedProperties);
     m_acceleratedRepresentation = acceleratedEffect.ptr();
     return acceleratedEffect;


### PR DESCRIPTION
#### f7bae2e3e663c54e292ed5331c810183638613d6
<pre>
[threaded-animations] updating keyframes of an accelerated animation&apos;s effect to unresolved offsets should disable acceleration
<a href="https://bugs.webkit.org/show_bug.cgi?id=323967">https://bugs.webkit.org/show_bug.cgi?id=323967</a>
<a href="https://rdar.apple.com/187202092">rdar://187202092</a>

Reviewed by Anne van Kesteren.

During analysis of bug 323307, Claude identified a lingering issue where updating an acceleration animation
to use keyframes with unresolved offsets retained acceleration but yielded a crash because we&apos;re not expecting
such keyframes in the remote layer tree.

We address this issue by resolving computed offsets prior to considering acceleration for an effect. We also
add an assertion in `KeyframeEffect::acceleratedRepresentation()` to ensure that by the time we request an
effect&apos;s accelerated representation the effect is indeed fine to accelerate, which would have caught this
issue in the web process.

Test: webanimations/threaded-animations/updating-keyframes-to-unresolved-offsets.html

* LayoutTests/webanimations/threaded-animations/updating-keyframes-to-unresolved-offsets-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/updating-keyframes-to-unresolved-offsets.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::setBlendingKeyframes):
(WebCore::KeyframeEffect::acceleratedRepresentation):

Canonical link: <a href="https://commits.webkit.org/320941@main">https://commits.webkit.org/320941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/741a70982bdff8f1d906157c4ca04fc6bd1f54b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/53998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196619 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150852 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/74a22748-6194-4cd6-9973-c92980a15eb8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145589 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a4e3ec51-3aa2-4df0-85c5-9060226db6b5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49265 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125935 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/959384b5-d967-42d2-8ef6-c455471b09d4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/47994 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45957 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158345 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45705 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7693 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52692 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198606 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59883 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165637 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155166 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60594 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154805 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28293 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49229 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132812 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130053 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59018 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20684 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58421 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58637 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58486 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->