### PR TITLE
BlobResourceHandle truncates read length through int for file-backed blob ranges over 2 GB

### DIFF
--- a/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -229,9 +229,7 @@ int BlobResourceHandle::readFileSync(const BlobDataItem& item, BlobDataFileRefer
     ASSERT(!async());
 
     if (!isFileOpen()) {
-        auto bytesToRead = lengthOfItemBeingRead() - currentItemReadSize();
-        if (bytesToRead > totalRemainingSize())
-            bytesToRead = totalRemainingSize();
+        auto bytesToRead = clampReadSizeToRemaining(lengthOfItemBeingRead() - currentItemReadSize(), totalRemainingSize());
         bool success = syncStream()->openForRead(file.path(), item.offset() + currentItemReadSize(), bytesToRead);
         setCurrentItemReadSize(0);
         if (!success) {

--- a/Source/WebCore/platform/network/BlobResourceHandleBase.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandleBase.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,7 @@
 #include "HTTPHeaderNames.h"
 #include "ResourceRequest.h"
 #include "ResourceResponse.h"
+#include <algorithm>
 #include <wtf/MainThread.h>
 #include <wtf/WeakPtr.h>
 
@@ -53,6 +54,11 @@ BlobResourceHandleBase::BlobResourceHandleBase(bool async, RefPtr<BlobData>&& bl
 }
 
 BlobResourceHandleBase::~BlobResourceHandleBase() = default;
+
+uint64_t BlobResourceHandleBase::clampReadSizeToRemaining(uint64_t requested, uint64_t totalRemaining)
+{
+    return std::min<uint64_t>(requested, totalRemaining);
+}
 
 auto BlobResourceHandleBase::adjustAndValidateRangeBounds() -> std::optional<Error>
 {
@@ -286,9 +292,7 @@ bool BlobResourceHandleBase::readDataAsync(const BlobDataItem& item, DataSegment
     ASSERT(isMainThread());
 
     ASSERT(m_currentItemReadSize <= static_cast<uint64_t>(item.length()));
-    uint64_t bytesToRead = static_cast<uint64_t>(item.length()) - m_currentItemReadSize;
-    if (bytesToRead > m_totalRemainingSize)
-        bytesToRead = m_totalRemainingSize;
+    auto bytesToRead = clampReadSizeToRemaining(item.length() - m_currentItemReadSize, m_totalRemainingSize);
 
     auto span = data.span().subspan(item.offset() + m_currentItemReadSize, bytesToRead);
     m_currentItemReadSize = 0;
@@ -318,9 +322,7 @@ void BlobResourceHandleBase::readFileAsync(const BlobDataItem& item, BlobDataFil
         return;
     }
 
-    uint64_t bytesToRead = lengthOfItemBeingRead() - m_currentItemReadSize;
-    if (bytesToRead > m_totalRemainingSize)
-        bytesToRead = static_cast<int>(m_totalRemainingSize);
+    auto bytesToRead = clampReadSizeToRemaining(lengthOfItemBeingRead() - m_currentItemReadSize, m_totalRemainingSize);
     asyncStream()->openForRead(file.path(), item.offset() + m_currentItemReadSize, bytesToRead);
     m_isFileOpen = true;
     m_currentItemReadSize = 0;

--- a/Source/WebCore/platform/network/BlobResourceHandleBase.h
+++ b/Source/WebCore/platform/network/BlobResourceHandleBase.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -76,6 +76,8 @@ protected:
     AsyncFileStream* asyncStream() const;
     WEBCORE_EXPORT void resizeBuffer(size_t);
     const Vector<uint8_t>& buffer() const LIFETIME_BOUND { return *m_buffer; }
+
+    static uint64_t clampReadSizeToRemaining(uint64_t requested, uint64_t totalRemaining);
 
 private:
     void getSizeForNext();


### PR DESCRIPTION
#### 4f6534779648190628bb5f642a9d3100c49f3557
<pre>
BlobResourceHandle truncates read length through int for file-backed blob ranges over 2 GB
<a href="https://bugs.webkit.org/show_bug.cgi?id=323970">https://bugs.webkit.org/show_bug.cgi?id=323970</a>
<a href="https://rdar.apple.com/187207663">rdar://187207663</a>

Reviewed by Alex Christensen.

BlobResourceHandleBase::readFileAsync() clamped the number of bytes to
read to the total remaining size with `bytesToRead = static_cast&lt;int&gt;(m_totalRemainingSize)`,
narrowing a uint64_t through a 32-bit signed int. For a file-backed blob
range of 2 GB or more, m_totalRemainingSize exceeds INT_MAX, so the cast
wraps to a negative int and sign-extends back into the uint64_t, corrupting
the length handed to AsyncFileStream::openForRead(). FileStream then
computes a non-positive remaining count and reads nothing, producing a
truncated or empty response body.

The sync sibling BlobResourceHandle::readFileSync() and the in-memory
data path BlobResourceHandleBase::readDataAsync() clamped correctly in
full 64-bit precision, so only the async file path was affected.

Fix the clamp and route all three sites through a single
BlobResourceHandleBase::clampReadSizeToRemaining() helper that uses
std::min&lt;uint64_t&gt;, so the invariant is defined in one place and cannot
be re-narrowed independently. The helper is a protected static member
declared in the header and defined out of line in the implementation
file to keep &lt;algorithm&gt; out of the header.

* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandle::readFileSync):
* Source/WebCore/platform/network/BlobResourceHandleBase.cpp:
(WebCore::BlobResourceHandleBase::clampReadSizeToRemaining):
(WebCore::BlobResourceHandleBase::readDataAsync):
(WebCore::BlobResourceHandleBase::readFileAsync):
* Source/WebCore/platform/network/BlobResourceHandleBase.h:

Canonical link: <a href="https://commits.webkit.org/320981@main">https://commits.webkit.org/320981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80cf446227acd1c1ef86ed6243fe19325d50f060

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196731 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150929 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0a70c7a9-d55b-438e-9ebd-b7d01cbd0668) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145668 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6e911bc1-b9ae-402d-9f44-ea5121eb4922) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166179 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126028 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/94d8b1a2-edcb-4879-8dd7-8e3aeac795e0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48081 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46026 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158428 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45776 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7803 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52780 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198718 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59986 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155256 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41608 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60698 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154894 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49310 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132891 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130162 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59118 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20755 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58525 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58754 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58637 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->