### PR TITLE
CredentialStorage::removeCredentialsWithOrigin fails to purge HTTPS credentials with default port

### DIFF
--- a/Source/WebCore/platform/network/CredentialStorage.cpp
+++ b/Source/WebCore/platform/network/CredentialStorage.cpp
@@ -90,9 +90,9 @@ void CredentialStorage::removeCredentialsWithOrigin(const SecurityOriginData& or
 {
     m_protectionSpaceToCredentialMap.removeIf([&](auto& keyValuePair) {
         auto& protectionSpace = keyValuePair.key.second;
+        auto expectedPort = origin.port() ? origin.port() : WTF::defaultPortForProtocol(origin.protocol());
         return protectionSpace.host() == origin.host()
-            && ((origin.port() && protectionSpace.port() == *origin.port())
-                || (!origin.port() && protectionSpace.port() == 80))
+            && expectedPort && protectionSpace.port() == *expectedPort
             && ((protectionSpace.serverType() == ProtectionSpace::ServerType::HTTP && origin.protocol() == "http"_s)
                 || (protectionSpace.serverType() == ProtectionSpace::ServerType::HTTPS && origin.protocol() == "https"_s));
     });

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -270,6 +270,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/ComplexTextController.cpp
         Tests/WebCore/ContextMenuAction.cpp
         Tests/WebCore/CookieJar.cpp
+        Tests/WebCore/CredentialStorage.cpp
         Tests/WebCore/CryptoDigest.cpp
         Tests/WebCore/CtapPinTest.cpp
         Tests/WebCore/CtapRequestTest.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -775,6 +775,7 @@
 				WebCore/ContentExtensions.cpp,
 				WebCore/ContextMenuAction.cpp,
 				WebCore/CookieJar.cpp,
+				WebCore/CredentialStorage.cpp,
 				WebCore/CryptoDigest.cpp,
 				WebCore/CSSParser.cpp,
 				WebCore/CSSParserFastPaths.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/CredentialStorage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CredentialStorage.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/Credential.h>
+#include <WebCore/CredentialStorage.h>
+#include <WebCore/ProtectionSpace.h>
+#include <WebCore/SecurityOriginData.h>
+#include <wtf/URL.h>
+
+namespace TestWebKitAPI {
+
+static WebCore::Credential testCredential()
+{
+    return WebCore::Credential { "user"_s, "password"_s, WebCore::CredentialPersistence::None };
+}
+
+TEST(CredentialStorage, RemoveCredentialsWithHTTPSOriginDefaultPort)
+{
+    WebCore::CredentialStorage storage;
+    WebCore::ProtectionSpace protectionSpace { "example.com"_s, 443, WebCore::ProtectionSpace::ServerType::HTTPS, "realm"_s, WebCore::ProtectionSpace::AuthenticationScheme::Default };
+    storage.set(emptyString(), testCredential(), protectionSpace, URL { "https://example.com/index.html"_str });
+
+    EXPECT_FALSE(storage.get(emptyString(), protectionSpace).isEmpty());
+
+    // An origin built from a URL has its default port stripped to std::nullopt, mirroring what the
+    // NetworkProcess passes in when clearing website data by origin.
+    WebCore::SecurityOriginData origin { "https"_s, "example.com"_s, std::nullopt };
+    storage.removeCredentialsWithOrigin(origin);
+
+    EXPECT_TRUE(storage.get(emptyString(), protectionSpace).isEmpty());
+}
+
+TEST(CredentialStorage, RemoveCredentialsWithHTTPOriginDefaultPort)
+{
+    WebCore::CredentialStorage storage;
+    WebCore::ProtectionSpace protectionSpace { "example.com"_s, 80, WebCore::ProtectionSpace::ServerType::HTTP, "realm"_s, WebCore::ProtectionSpace::AuthenticationScheme::Default };
+    storage.set(emptyString(), testCredential(), protectionSpace, URL { "http://example.com/index.html"_str });
+
+    EXPECT_FALSE(storage.get(emptyString(), protectionSpace).isEmpty());
+
+    WebCore::SecurityOriginData origin { "http"_s, "example.com"_s, std::nullopt };
+    storage.removeCredentialsWithOrigin(origin);
+
+    EXPECT_TRUE(storage.get(emptyString(), protectionSpace).isEmpty());
+}
+
+TEST(CredentialStorage, RemoveCredentialsWithExplicitPort)
+{
+    WebCore::CredentialStorage storage;
+    WebCore::ProtectionSpace protectionSpace { "example.com"_s, 8443, WebCore::ProtectionSpace::ServerType::HTTPS, "realm"_s, WebCore::ProtectionSpace::AuthenticationScheme::Default };
+    storage.set(emptyString(), testCredential(), protectionSpace, URL { "https://example.com:8443/index.html"_str });
+
+    EXPECT_FALSE(storage.get(emptyString(), protectionSpace).isEmpty());
+
+    WebCore::SecurityOriginData origin { "https"_s, "example.com"_s, 8443 };
+    storage.removeCredentialsWithOrigin(origin);
+
+    EXPECT_TRUE(storage.get(emptyString(), protectionSpace).isEmpty());
+}
+
+TEST(CredentialStorage, RemoveCredentialsWithOriginDoesNotAffectOtherScheme)
+{
+    WebCore::CredentialStorage storage;
+    WebCore::ProtectionSpace httpsSpace { "example.com"_s, 443, WebCore::ProtectionSpace::ServerType::HTTPS, "realm"_s, WebCore::ProtectionSpace::AuthenticationScheme::Default };
+    storage.set(emptyString(), testCredential(), httpsSpace, URL { "https://example.com/index.html"_str });
+
+    // Removing the http origin must not purge the https credential.
+    WebCore::SecurityOriginData httpOrigin { "http"_s, "example.com"_s, std::nullopt };
+    storage.removeCredentialsWithOrigin(httpOrigin);
+
+    EXPECT_FALSE(storage.get(emptyString(), httpsSpace).isEmpty());
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 740242c22311be0bb9ac4237000df8d10f326240
<pre>
CredentialStorage::removeCredentialsWithOrigin fails to purge HTTPS credentials with default port
<a href="https://bugs.webkit.org/show_bug.cgi?id=323973">https://bugs.webkit.org/show_bug.cgi?id=323973</a>
<a href="https://rdar.apple.com/187210150">rdar://187210150</a>

Reviewed by Alex Christensen.

removeCredentialsWithOrigin matched the protection space port against a
hardcoded 80 whenever the origin had no explicit port. But a
SecurityOriginData built from a URL has its default port stripped to
std::nullopt in SecurityOrigin::initializeShared(), so an https origin
such as <a href="https://example.com">https://example.com</a> has port() == nullopt and fell into the
== 80 branch, which never matches an HTTPS protection space (port 443).
As a result, HTTPS credentials were silently never purged when clearing
website data by origin.

Fall back to the default port for the origin&apos;s scheme via
WTF::defaultPortForProtocol() (80 for http, 443 for https) instead of
assuming 80.

Test: Tools/TestWebKitAPI/Tests/WebCore/CredentialStorage.cpp

* Source/WebCore/platform/network/CredentialStorage.cpp:
(WebCore::CredentialStorage::removeCredentialsWithOrigin):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/CredentialStorage.cpp: Added.
(TestWebKitAPI::testCredential):
(TestWebKitAPI::TEST(CredentialStorage, RemoveCredentialsWithHTTPSOriginDefaultPort)):
(TestWebKitAPI::TEST(CredentialStorage, RemoveCredentialsWithHTTPOriginDefaultPort)):
(TestWebKitAPI::TEST(CredentialStorage, RemoveCredentialsWithExplicitPort)):
(TestWebKitAPI::TEST(CredentialStorage, RemoveCredentialsWithOriginDoesNotAffectOtherScheme)):

Canonical link: <a href="https://commits.webkit.org/320968@main">https://commits.webkit.org/320968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d24cb5ae30807a078f3efd11d3789ccb2269f0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196649 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150873 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/728c702d-d871-4420-9d28-5b041b6495f0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/59967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145603 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e74f8e54-6919-4063-aebe-670b33650d13) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125952 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7d9b178d-640e-44bd-9607-3f4f28a110cd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48016 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/45975 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158364 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45723 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7723 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50456 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198636 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59913 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155220 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41597 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60624 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42282 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154827 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49252 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132833 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130090 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59048 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20702 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58451 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58516 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->