### PR TITLE
[JSC] Throwing an exception causes a CPA2 failure in LLInt slow paths

### DIFF
--- a/Source/JavaScriptCore/llint/LLIntExceptions.h
+++ b/Source/JavaScriptCore/llint/LLIntExceptions.h
@@ -47,6 +47,11 @@ namespace LLInt {
 // interpreter's exception handler.
 JSInstruction* NODELETE returnToThrow(VM&);
 
+// A slow path reports a pending exception to its LLInt caller by returning this
+// in the second result register in place of a meaningful second result.
+// restoreStateAfterCCall() tests for it and branches to the throw trampoline
+// instead of rebuilding PC.
+inline void* exceptionSignal() { return std::bit_cast<void*>(static_cast<uintptr_t>(-1)); }
 // Use this when you're throwing to a call thunk.
 MacroAssemblerCodeRef<ExceptionHandlerPtrTag> callToThrow(VM&);
 

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -114,17 +114,19 @@ static inline JSValue NODELETE getOperand(CallFrame* callFrame, VirtualRegister 
 
 #define LLINT_END_IMPL() LLINT_RETURN_TWO(pc, nullptr)
 
-#define LLINT_THROW(exceptionToThrow) do {                        \
-        throwException(globalObject, throwScope, exceptionToThrow);       \
-        pc = returnToThrow(vm);                                 \
-        LLINT_END_IMPL();                                         \
+#define LLINT_THROW_IMPL() LLINT_RETURN_TWO(pc, exceptionSignal())
+
+#define LLINT_THROW(exceptionToThrow) do {                          \
+        throwException(globalObject, throwScope, exceptionToThrow); \
+        pc = returnToThrow(vm);                                     \
+        LLINT_THROW_IMPL();                                         \
     } while (false)
 
 #define LLINT_CHECK_EXCEPTION() do {                    \
         doExceptionFuzzingIfEnabled(globalObject, throwScope, "LLIntSlowPaths", pc);    \
         if (throwScope.exception()) [[unlikely]] {      \
             pc = returnToThrow(vm);                     \
-            LLINT_END_IMPL();                           \
+            LLINT_THROW_IMPL();                         \
         }                                               \
     } while (false)
 
@@ -2344,6 +2346,10 @@ LLINT_SLOW_PATH_DECL(slow_path_handle_exception)
     VM& vm = callFrame->deprecatedVM();
     SlowPathFrameTracer tracer(vm, callFrame);
     genericUnwind(vm, callFrame);
+    // We use LLINT_END_IMPL here instead of LLINT_THROW_IMPL because the throw
+    // trampoline (which is what LLINT_THROW_IMPL eventually triggers) comes
+    // here via callSlowPath(). If we used LLINT_THROW_IMPL, then the throw
+    // trampoline would keep calling itself forever.
     LLINT_END_IMPL();
 }
 

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -1551,16 +1551,23 @@ end
     move cfr, a0
     move PC, a1
     cCall3(_llint_check_stack_and_vm_traps)
+
+    # Normally we'd use the exceptionSignal convention that restoreStateAfterCCall()
+    # checks for, but this slow path reports a throw by putting a CallFrame pointer
+    # in r1. Therefore, we need to test it here before PC is rebuilt, because r0 has
+    # a differently tagged sentinel value that must not have PB subtracted from it.
+    bpneq r1, 0, .stackCheckThrewException
     restoreStateAfterCCall()
+    jmp .stackHeightOKGetCodeBlock
 
-    bpeq r1, 0, .stackHeightOKGetCodeBlock
-
+.stackCheckThrewException:
     # We're throwing before the frame is fully set up. This frame will be
     # ignored by the unwinder. So, let's restore the callee saves before we
     # start unwinding. We need to do this before we change the cfr.
     restoreCalleeSavesUsedByLLInt()
 
     move r1, cfr
+    move 0, PC
     jmp _llint_throw_from_slow_path_trampoline
 
 .stackHeightOKGetCodeBlock:
@@ -2855,8 +2862,11 @@ op(checkpoint_osr_exit_from_inlined_call_trampoline, macro ()
         cCall2(_llint_slow_path_checkpoint_osr_exit_from_inlined_call)
 
         setupReturnToBaselineAfterCheckpointExitIfNeeded()
-        restoreStateAfterCCall()
+        # At this point, a throw would've been reported via VM::m_exception, not via the
+        # exceptionSignal convention that's checked in restoreStateAfterCCall(). Therefore,
+        # we need to check for exceptions accordingly here first, not through restoreStateAfterCCall().
         branchIfException(_llint_throw_from_slow_path_trampoline)
+        restoreStateAfterCCallWithoutExceptionCheck() # Exceptions have already been checked above.
 
         if ARM64E
             move r1, a0
@@ -2880,8 +2890,12 @@ op(checkpoint_osr_exit_trampoline, macro ()
         # We don't call saveStateForCCall() because we are going to use the bytecodeIndex from our side state.
         cCall2(_llint_slow_path_checkpoint_osr_exit)
         setupReturnToBaselineAfterCheckpointExitIfNeeded()
-        restoreStateAfterCCall()
+        # At this point, a throw would've been reported via VM::m_exception, not via the
+        # exceptionSignal convention that's checked in restoreStateAfterCCall(). Therefore,
+        # we need to check for exceptions accordingly here first, not through restoreStateAfterCCall().
         branchIfException(_llint_throw_from_slow_path_trampoline)
+        restoreStateAfterCCallWithoutExceptionCheck() # Exceptions have already been checked above.
+
         if ARM64E
             move r1, a0
             leap _g_config, a2
@@ -2906,8 +2920,12 @@ op(array_sort_comparator_return_trampoline, macro ()
         cCall2(_llint_slow_path_array_sort_comparator_return)
 
         setupReturnToBaselineAfterCheckpointExitIfNeeded()
-        restoreStateAfterCCall()
+        # At this point, a throw would've been reported via VM::m_exception, not via the
+        # exceptionSignal convention that's checked in restoreStateAfterCCall(). Therefore,
+        # we need to check for exceptions accordingly here first, not through restoreStateAfterCCall().
         branchIfException(_llint_throw_from_slow_path_trampoline)
+        restoreStateAfterCCallWithoutExceptionCheck() # Exceptions have already been checked above.
+
         if ARM64E
             move r1, a0
             leap _g_config, a2

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -405,7 +405,19 @@ macro prepareStateForCCall()
     addp PB, PC
 end
 
+macro restoreStateAfterCCallWithoutExceptionCheck()
+    move r0, PC
+    subp PB, PC
+end
+
 macro restoreStateAfterCCall()
+    # Slow paths report pending exceptions by returning LLInt::exceptionSignal
+    # (all ones) in r1. In such cases, r0 contains a sentinel bytecode pointer
+    # that lives in a different allocation from this CodeBlock's instruction
+    # buffer. Therefore, PB and PC have different MTE tags that don't cancel
+    # when subtracted and we need to check for exceptionSignal here to jump
+    # straight to the throw trampoline.
+    bpeq r1, -1, _llint_throw_from_slow_path_trampoline
     move r0, PC
     subp PB, PC
 end

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -103,17 +103,19 @@ namespace JSC {
 
 #define END_IMPL() RETURN_TWO(pc, callFrame)
 
+#define THROW_IMPL() RETURN_TWO(pc, LLInt::exceptionSignal())
+
 #define THROW(exceptionToThrow) do {                        \
         throwException(globalObject, throwScope, exceptionToThrow); \
         RETURN_TO_THROW(pc);                          \
-        END_IMPL();                                         \
+        THROW_IMPL();                                       \
     } while (false)
 
 #define CHECK_EXCEPTION() do {                    \
         doExceptionFuzzingIfEnabled(globalObject, throwScope, "CommonSlowPaths", pc);   \
         if (throwScope.exception()) [[unlikely]] {   \
             RETURN_TO_THROW(pc);                     \
-            END_IMPL();                              \
+            THROW_IMPL();                            \
         }                                            \
     } while (false)
 


### PR DESCRIPTION
#### b9c0ed5b8c51f209410cbc18059d00add9fce06e
<pre>
[JSC] Throwing an exception causes a CPA2 failure in LLInt slow paths
<a href="https://bugs.webkit.org/show_bug.cgi?id=323984">https://bugs.webkit.org/show_bug.cgi?id=323984</a>
<a href="https://rdar.apple.com/185182086">rdar://185182086</a>

Reviewed by Keith Miller.

On CPA2-supporting architectures, we need to bypass the reconstruction of PC
in LLInt when an exception is thrown in a slow path. This patch does this by
introducing a sentinel value (all ones) returned in r1 that we test for to
jump straight to the throw trampoline when necessary.

No new tests because this can&apos;t be tested in software.

* Source/JavaScriptCore/llint/LLIntExceptions.h:
(JSC::LLInt::exceptionSignal):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::LLINT_SLOW_PATH_DECL):
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/runtime/CommonSlowPaths.cpp:

Canonical link: <a href="https://commits.webkit.org/320973@main">https://commits.webkit.org/320973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33dc7be236e2c6ae3def1a5d990d7612dfc2e2e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186416 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196691 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/150902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60005 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145635 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/150902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/5a60316c-c2b8-483c-a7d4-e069d2cce49f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49321 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166154 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/125991 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90d0b793-9746-4185-a44b-5c435f1f4d6e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48049 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/46002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7817 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14681 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158397 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45751 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7766 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47644 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50489 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198679 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59949 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155225 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41602 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60661 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154863 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49283 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/132862 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130127 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59082 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20730 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58488 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/58727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58607 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->