### PR TITLE
Rework relationship between the RenderTree and images

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1982,6 +1982,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/cache/KeepaliveRequestTracker.h
     loader/cache/MemoryCache.h
     loader/cache/TrustedFonts.h
+    loader/cache/VisibleInViewportState.h
 
     page/ActivityState.h
     page/ActivityStateChangeObserver.h
@@ -3397,6 +3398,9 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/images/StyleObjectViewBox.h
 
     style/values/images/kinds/StyleImage.h
+    style/values/images/kinds/StyleImageClient.h
+    style/values/images/kinds/StyleImageContainerContext.h
+    style/values/images/kinds/StyleImageContainerContextKey.h
 
     style/values/inline/StyleLineFitEdge.h
     style/values/inline/StyleLineHeight.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3505,6 +3505,8 @@ style/values/images/kinds/StyleCursorImage.cpp
 style/values/images/kinds/StyleFilterImage.cpp @header:RenderStyleGetters @cost:6
 style/values/images/kinds/StyleGeneratedImage.cpp @header:RenderStyleGetters @cost:6
 style/values/images/kinds/StyleGradientImage.cpp @header:RenderStyleGetters @cost:6
+style/values/images/kinds/StyleImage.cpp
+style/values/images/kinds/StyleImageClient.cpp
 style/values/images/kinds/StyleImageSet.cpp
 style/values/images/kinds/StyleInvalidImage.cpp
 style/values/images/kinds/StyleMultiImage.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -2684,11 +2684,6 @@
 		5C7C88D81D0F1F4A009D2F6D /* SocketProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C7C88D71D0F1F2B009D2F6D /* SocketProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5C907ECA2952E20800B3402D /* FrameView.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C907EB829528A4300B3402D /* FrameView.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5C9C2DB52241A67B00996B0B /* ContentRuleListResults.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C9C2DB32241A67300996B0B /* ContentRuleListResults.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5CA1B0121234567890ABCDEF /* CookieChangeObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA1B0111234567890ABCDEF /* CookieChangeObserver.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		9158E3FF13F91BF55935613D /* CookieStorageSession.h in Headers */ = {isa = PBXBuildFile; fileRef = A9BA293E41C3380893631716 /* CookieStorageSession.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5CA1B0141234567890ABCDEF /* ThirdPartyCookieBlockingMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA1B0131234567890ABCDEF /* ThirdPartyCookieBlockingMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5CA1B0161234567890ABCDEF /* TrackingPreventionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA1B0151234567890ABCDEF /* TrackingPreventionTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5CA1B0021234567890ABCDEF /* StorageAccessQuirks.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA1B0011234567890ABCDEF /* StorageAccessQuirks.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5C9EF2F321F06190003BDC56 /* StorageSessionProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C9EF2F221F06171003BDC56 /* StorageSessionProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5CA126B328DBA3AB00B65AD3 /* AttributionTriggerData.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA126B028DBA3AA00B65AD3 /* AttributionTriggerData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5CA126B428DBA3AB00B65AD3 /* EphemeralNonce.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA126B128DBA3AB00B65AD3 /* EphemeralNonce.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2696,6 +2691,10 @@
 		5CA126B728DBA4DC00B65AD3 /* AttributionSecondsUntilSendData.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA126B628DBA4DB00B65AD3 /* AttributionSecondsUntilSendData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5CA126B928DBA6EC00B65AD3 /* PCMTokens.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA126B828DBA6EC00B65AD3 /* PCMTokens.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5CA126C128DBCE2900B65AD3 /* PCMSites.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA126C028DBCE2800B65AD3 /* PCMSites.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5CA1B0021234567890ABCDEF /* StorageAccessQuirks.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA1B0011234567890ABCDEF /* StorageAccessQuirks.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5CA1B0121234567890ABCDEF /* CookieChangeObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA1B0111234567890ABCDEF /* CookieChangeObserver.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5CA1B0141234567890ABCDEF /* ThirdPartyCookieBlockingMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA1B0131234567890ABCDEF /* ThirdPartyCookieBlockingMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5CA1B0161234567890ABCDEF /* TrackingPreventionTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA1B0151234567890ABCDEF /* TrackingPreventionTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5CA1DEC61F71F1C700E71BD3 /* HTTPHeaderField.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA1DEC41F71E68700E71BD3 /* HTTPHeaderField.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5CB05C9329CA1C2800CC1AA0 /* LegacyWebSocketInspectorInstrumentation.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CB05C9129CA1C2800CC1AA0 /* LegacyWebSocketInspectorInstrumentation.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5CB37FFF1C62D2A100F20188 /* ScrollbarsControllerMock.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CB37FFD1C62D27800F20188 /* ScrollbarsControllerMock.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -3169,10 +3168,8 @@
 		7ABA251028B40FE7005D4F6D /* ReportingScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ABA250C28ADA68D005D4F6D /* ReportingScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7ABA251128B41C64005D4F6D /* Report.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ABA24E528A5C8D1005D4F6D /* Report.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7ABA251228B4457C005D4F6D /* ReportBody.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ABA24E728A5C90A005D4F6D /* ReportBody.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		05D4770CFFB4C18C6BA6928C /* QuirkTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 05D4770BFFB4C18C6BA6928C /* QuirkTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		7ABB0F622CE7C170009A837F /* QuirkBehaviors.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ABB0F5D2CE7C170009A837F /* QuirkBehaviors.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7ABB0F602CE7C170009A837D /* QuirksData.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ABB0F5F2CE7C170009A837D /* QuirksData.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		7ABB0F622CE7C170009A837F /* QuirkNames.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ABB0F5D2CE7C170009A837F /* QuirkNames.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7ABB0F622CE7C170009A837F /* QuirkBehaviors.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ABB0F5D2CE7C170009A837F /* QuirkBehaviors.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7AC09F4728C0122C004568FC /* TestReportBody.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AC09F4528C00E5D004568FC /* TestReportBody.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7AD41E7E2C7607AF00ED9467 /* ScrollingPlatformLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AD41E7D2C7607AA00ED9467 /* ScrollingPlatformLayer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7ADE722610CBBB9B006B3B3A /* ContextMenuProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ADE722510CBBB9B006B3B3A /* ContextMenuProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -3713,6 +3710,7 @@
 		91278D5E21DEDAD600B57184 /* PageAuditAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 91278D5C21DEDAD500B57184 /* PageAuditAgent.h */; };
 		91278D6221DEDAF000B57184 /* WorkerAuditAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 91278D6021DEDAF000B57184 /* WorkerAuditAgent.h */; };
 		913FE59C2362799A00F9446A /* InspectorAnimationAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 913FE59A2362799900F9446A /* InspectorAnimationAgent.h */; };
+		9158E3FF13F91BF55935613D /* CookieStorageSession.h in Headers */ = {isa = PBXBuildFile; fileRef = A9BA293E41C3380893631716 /* CookieStorageSession.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9175CE5C21E281ED00DF2C27 /* InspectorAuditDOMObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 9175CE5821E281EC00DF2C27 /* InspectorAuditDOMObject.h */; };
 		9175CE5C21E281ED00DF2C28 /* JSInspectorAuditDOMObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 9175CE5821E281EC00DF2C28 /* JSInspectorAuditDOMObject.h */; };
 		9175CE5E21E281ED00DF2C27 /* InspectorAuditAccessibilityObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 9175CE5A21E281ED00DF2C27 /* InspectorAuditAccessibilityObject.h */; };
@@ -5093,8 +5091,6 @@
 		BA6920702E0E93A80014E98A /* SpeculationRulesMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = BA69206E2E0E939C0014E98A /* SpeculationRulesMatcher.h */; };
 		BA96836B2E8FDAA30035D494 /* LoadableSpeculationRules.h in Headers */ = {isa = PBXBuildFile; fileRef = BA9683692E8FDA9A0035D494 /* LoadableSpeculationRules.h */; };
 		BC000BE72C6011020033AA75 /* CSSCalcTree.h in Headers */ = {isa = PBXBuildFile; fileRef = BC000BDB2C5A9D4F0033AA75 /* CSSCalcTree.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		BCA1C5000000000000000006 /* CSSCalcSizeFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA1C5000000000000000005 /* CSSCalcSizeFunction.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		BCA1C5000000000000000003 /* CSSCalcSizeValue.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA1C5000000000000000002 /* CSSCalcSizeValue.h */; };
 		BC000BE82C60110B0033AA75 /* CSSCalcType.h in Headers */ = {isa = PBXBuildFile; fileRef = BC000BD82C5A96850033AA75 /* CSSCalcType.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC00F0150E0A189500FD04E3 /* JSFile.h in Headers */ = {isa = PBXBuildFile; fileRef = BC00F0110E0A189500FD04E3 /* JSFile.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC00F0170E0A189500FD04E3 /* JSFileList.h in Headers */ = {isa = PBXBuildFile; fileRef = BC00F0130E0A189500FD04E3 /* JSFileList.h */; };
@@ -5289,6 +5285,11 @@
 		BC452A912ED24DE500FD066C /* StyleTextAlign.h in Headers */ = {isa = PBXBuildFile; fileRef = BC452A8A2ED2493700FD066C /* StyleTextAlign.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC452A922ED24DE500FD066C /* StyleTextAlignLast.h in Headers */ = {isa = PBXBuildFile; fileRef = BC452A8B2ED2493700FD066C /* StyleTextAlignLast.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC452A962ED2528000FD066C /* StyleMaskMode.h in Headers */ = {isa = PBXBuildFile; fileRef = BC452A932ED250B700FD066C /* StyleMaskMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC45A1AE30532839001A8DD1 /* StyleImageClient.h in Headers */ = {isa = PBXBuildFile; fileRef = BC45A1AC30532446001A8DD1 /* StyleImageClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC45A1B330546F0A001A8DD1 /* StyleImageContainerContextKey.h in Headers */ = {isa = PBXBuildFile; fileRef = BC45A1B230546EC1001A8DD1 /* StyleImageContainerContextKey.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC45A1B430546FA5001A8DD1 /* StyleImageContainerContext.h in Headers */ = {isa = PBXBuildFile; fileRef = BC45A1B130546EC1001A8DD1 /* StyleImageContainerContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC45A1B630547B84001A8DD1 /* StyleImageSizeOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = BC45A1B530547A91001A8DD1 /* StyleImageSizeOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BC45A1B830548CC4001A8DD1 /* VisibleInViewportState.h in Headers */ = {isa = PBXBuildFile; fileRef = BC45A1B730548C9C001A8DD1 /* VisibleInViewportState.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC46306E2E9B0F6500EA911F /* StyleCalculationValue.h in Headers */ = {isa = PBXBuildFile; fileRef = BC4630652E9B098600EA911F /* StyleCalculationValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC4630702E9B0F8B00EA911F /* StyleCalculationTree.h in Headers */ = {isa = PBXBuildFile; fileRef = BC46305E2E9B098600EA911F /* StyleCalculationTree.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC46307C2E9C18D100EA911F /* ModelPlayerIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = BC46307B2E9C18CB00EA911F /* ModelPlayerIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5560,6 +5561,8 @@
 		BCA088F5264E1C08003E2A6C /* ImageDataSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA088F2264E1BF9003E2A6C /* ImageDataSettings.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCA088F5264E1C09003E2A6C /* ImageDataPixelFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA088F2264E1BFA003E2A6C /* ImageDataPixelFormat.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCA169A30BFD55B40019CA76 /* JSHTMLTableCaptionElement.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA169A10BFD55B40019CA76 /* JSHTMLTableCaptionElement.h */; };
+		BCA1C5000000000000000003 /* CSSCalcSizeValue.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA1C5000000000000000002 /* CSSCalcSizeValue.h */; };
+		BCA1C5000000000000000006 /* CSSCalcSizeFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA1C5000000000000000005 /* CSSCalcSizeFunction.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCA1C6000000000000000002 /* StyleSizeOrKeyword.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA1C6000000000000000001 /* StyleSizeOrKeyword.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCA2B061105047600043BD1C /* UserScript.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA2B0601050475F0043BD1C /* UserScript.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BCA2B08B10505BCD0043BD1C /* UserScriptTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = BCA2B08A10505BCD0043BD1C /* UserScriptTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -10161,6 +10164,7 @@
 		1DEF06DC233D2E1C00EE228D /* DocumentPictureInPicture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DocumentPictureInPicture.cpp; sourceTree = "<group>"; };
 		1DEF06DD233D2E1C00EE228D /* DocumentPictureInPicture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DocumentPictureInPicture.h; sourceTree = "<group>"; };
 		1DEF06DE233D2E1C00EE228D /* Document+PictureInPicture.idl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Document+PictureInPicture.idl"; sourceTree = "<group>"; };
+		1E177CEEB040E8C9436CBB2D /* CookieStorageSessionCFNet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CookieStorageSessionCFNet.cpp; sourceTree = "<group>"; };
 		1EC57482ED01054BFAD1ADBD /* ElementInlinesLight.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ElementInlinesLight.h; sourceTree = "<group>"; };
 		1F2E3D4C5B6A79880716253F /* PortalAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PortalAction.h; sourceTree = "<group>"; };
 		1F36EA9A1E21BA1700621E25 /* WebBackgroundTaskController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebBackgroundTaskController.h; sourceTree = "<group>"; };
@@ -12375,8 +12379,6 @@
 		499B3EDC128DB50100E726C2 /* PlatformCAAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlatformCAAnimation.h; sourceTree = "<group>"; };
 		49AE2D8C134EE50C0072920A /* CSSCalcValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CSSCalcValue.cpp; sourceTree = "<group>"; };
 		49AE2D8D134EE50C0072920A /* CSSCalcValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSSCalcValue.h; sourceTree = "<group>"; };
-		BCA1C5000000000000000001 /* CSSCalcSizeValue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSCalcSizeValue.cpp; sourceTree = "<group>"; };
-		BCA1C5000000000000000002 /* CSSCalcSizeValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSCalcSizeValue.h; sourceTree = "<group>"; };
 		49AF2D6814435D050016A784 /* DisplayRefreshMonitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DisplayRefreshMonitor.h; sourceTree = "<group>"; };
 		49AF2D6B14435D210016A784 /* LegacyDisplayRefreshMonitorMac.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LegacyDisplayRefreshMonitorMac.cpp; sourceTree = "<group>"; };
 		49B53D402B1AA58A0056A172 /* RenderTreeUpdaterViewTransition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderTreeUpdaterViewTransition.h; sourceTree = "<group>"; };
@@ -13773,15 +13775,6 @@
 		5C9C2DB32241A67300996B0B /* ContentRuleListResults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContentRuleListResults.h; sourceTree = "<group>"; };
 		5C9EF16F1DFF719900A452E3 /* XPathGrammar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = XPathGrammar.cpp; sourceTree = "<group>"; };
 		5C9EF1701DFF719900A452E3 /* XPathGrammar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XPathGrammar.h; sourceTree = "<group>"; };
-		5CA1B0031234567890ABCDEF /* StorageAccessQuirks.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StorageAccessQuirks.cpp; sourceTree = "<group>"; };
-		5CA1B0111234567890ABCDEF /* CookieChangeObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CookieChangeObserver.h; sourceTree = "<group>"; };
-		A9BA293E41C3380893631716 /* CookieStorageSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CookieStorageSession.h; sourceTree = "<group>"; };
-		B41977FF79DEB947BDA0FF56 /* CookieStorageSession.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CookieStorageSession.cpp; sourceTree = "<group>"; };
-		1E177CEEB040E8C9436CBB2D /* CookieStorageSessionCFNet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CookieStorageSessionCFNet.cpp; sourceTree = "<group>"; };
-		8231F4A1D94A93E35B0A28F7 /* CookieStorageSessionCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CookieStorageSessionCocoa.mm; sourceTree = "<group>"; };
-		5CA1B0131234567890ABCDEF /* ThirdPartyCookieBlockingMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThirdPartyCookieBlockingMode.h; sourceTree = "<group>"; };
-		5CA1B0151234567890ABCDEF /* TrackingPreventionTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TrackingPreventionTypes.h; sourceTree = "<group>"; };
-		5CA1B0011234567890ABCDEF /* StorageAccessQuirks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StorageAccessQuirks.h; sourceTree = "<group>"; };
 		5C9EF2F221F06171003BDC56 /* StorageSessionProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StorageSessionProvider.h; sourceTree = "<group>"; };
 		5CA126B028DBA3AA00B65AD3 /* AttributionTriggerData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AttributionTriggerData.h; sourceTree = "<group>"; };
 		5CA126B128DBA3AB00B65AD3 /* EphemeralNonce.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EphemeralNonce.h; sourceTree = "<group>"; };
@@ -13790,6 +13783,11 @@
 		5CA126B828DBA6EC00B65AD3 /* PCMTokens.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PCMTokens.h; sourceTree = "<group>"; };
 		5CA126BA28DBA7CF00B65AD3 /* AttributionTriggerData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AttributionTriggerData.cpp; sourceTree = "<group>"; };
 		5CA126C028DBCE2800B65AD3 /* PCMSites.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PCMSites.h; sourceTree = "<group>"; };
+		5CA1B0011234567890ABCDEF /* StorageAccessQuirks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StorageAccessQuirks.h; sourceTree = "<group>"; };
+		5CA1B0031234567890ABCDEF /* StorageAccessQuirks.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StorageAccessQuirks.cpp; sourceTree = "<group>"; };
+		5CA1B0111234567890ABCDEF /* CookieChangeObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CookieChangeObserver.h; sourceTree = "<group>"; };
+		5CA1B0131234567890ABCDEF /* ThirdPartyCookieBlockingMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThirdPartyCookieBlockingMode.h; sourceTree = "<group>"; };
+		5CA1B0151234567890ABCDEF /* TrackingPreventionTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TrackingPreventionTypes.h; sourceTree = "<group>"; };
 		5CA1DEC21F71E68600E71BD3 /* HTTPHeaderField.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HTTPHeaderField.cpp; sourceTree = "<group>"; };
 		5CA1DEC41F71E68700E71BD3 /* HTTPHeaderField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTTPHeaderField.h; sourceTree = "<group>"; };
 		5CABDBF12735F4B700B88BCB /* ContentExtensionActions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ContentExtensionActions.cpp; sourceTree = "<group>"; };
@@ -15616,6 +15614,7 @@
 		81C71BB55DE07F0C78F8DC8F /* ContentRuleListBlockedLoadInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContentRuleListBlockedLoadInfo.h; sourceTree = "<group>"; };
 		81F65FF513788FAA00FF6F2D /* DragState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DragState.h; sourceTree = "<group>"; };
 		8225432CA9D4B4CF4628EC7F /* JSBeforeUnloadEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSBeforeUnloadEvent.cpp; sourceTree = "<group>"; };
+		8231F4A1D94A93E35B0A28F7 /* CookieStorageSessionCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CookieStorageSessionCocoa.mm; sourceTree = "<group>"; };
 		82AB176F125C826700C5069D /* InspectorStyleSheet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorStyleSheet.cpp; sourceTree = "<group>"; };
 		82AB1770125C826700C5069D /* InspectorStyleSheet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InspectorStyleSheet.h; sourceTree = "<group>"; };
 		82E3D8DC122EA0D1003AE5BC /* CSSPropertySourceData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CSSPropertySourceData.cpp; sourceTree = "<group>"; };
@@ -18317,6 +18316,7 @@
 		A8FA6E5C0E4CFDED00D5CF49 /* Pattern.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Pattern.cpp; sourceTree = "<group>"; };
 		A9787CB21F5F599200C551C6 /* AccessibilityMediaHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccessibilityMediaHelpers.h; sourceTree = "<group>"; };
 		A9787CB31F5F5C6500C551C6 /* AccessibilityMediaHelpers.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AccessibilityMediaHelpers.cpp; sourceTree = "<group>"; };
+		A9BA293E41C3380893631716 /* CookieStorageSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CookieStorageSession.h; sourceTree = "<group>"; };
 		A9C6E4E10D745E05006442E9 /* DOMMimeType.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = DOMMimeType.cpp; sourceTree = "<group>"; };
 		A9C6E4E20D745E05006442E9 /* DOMMimeType.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = DOMMimeType.h; sourceTree = "<group>"; };
 		A9C6E4E50D745E18006442E9 /* DOMMimeTypeArray.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = DOMMimeTypeArray.cpp; sourceTree = "<group>"; };
@@ -19062,6 +19062,7 @@
 		B2FA3D2F0AB75A6F000E5AC4 /* JSSVGViewElement.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = JSSVGViewElement.h; sourceTree = "<group>"; };
 		B3EC871297BD15E272BE6D00 /* StylePortalTransform.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StylePortalTransform.cpp; sourceTree = "<group>"; };
 		B4059720D99B652A638A10FB /* UnifiedSource8-header-RenderStyleGetters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "UnifiedSource8-header-RenderStyleGetters.cpp"; sourceTree = "<group>"; };
+		B41977FF79DEB947BDA0FF56 /* CookieStorageSession.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CookieStorageSession.cpp; sourceTree = "<group>"; };
 		B5072BE12210266CE7E320FC /* Airplay.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = Airplay.svg; sourceTree = "<group>"; };
 		B50F5B800E96CD9900AD71A6 /* WebCoreObjCExtras.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebCoreObjCExtras.mm; sourceTree = "<group>"; };
 		B51A2F3E17D7D3A40072517A /* ImageQualityController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageQualityController.h; sourceTree = "<group>"; };
@@ -19479,7 +19480,6 @@
 		BC2C0C902D32F3F200FCFBA0 /* CSSPrimitiveNumericOrKeyword.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSPrimitiveNumericOrKeyword.h; sourceTree = "<group>"; };
 		BC2C0C912D32F46F00FCFBA0 /* StylePrimitiveNumeric.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StylePrimitiveNumeric.h; sourceTree = "<group>"; };
 		BC2C0C922D32F54500FCFBA0 /* StylePrimitiveNumericOrKeyword.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StylePrimitiveNumericOrKeyword.h; sourceTree = "<group>"; };
-		BCA1C6000000000000000001 /* StyleSizeOrKeyword.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleSizeOrKeyword.h; sourceTree = "<group>"; };
 		BC2CBF4B140F1A65003879BE /* JSWebGLContextEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebGLContextEvent.h; sourceTree = "<group>"; };
 		BC2CBF7A140F1D58003879BE /* JSWebGLContextEvent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSWebGLContextEvent.cpp; sourceTree = "<group>"; };
 		BC2CCA0E2655DDB200B8C035 /* ColorSpace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ColorSpace.h; sourceTree = "<group>"; };
@@ -19685,6 +19685,13 @@
 		BC452A8F2ED24DDB00FD066C /* StyleResize.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleResize.cpp; sourceTree = "<group>"; };
 		BC452A932ED250B700FD066C /* StyleMaskMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleMaskMode.h; sourceTree = "<group>"; };
 		BC452A942ED250B700FD066C /* StyleMaskMode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleMaskMode.cpp; sourceTree = "<group>"; };
+		BC45A1AB30532446001A8DD1 /* StyleImage.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleImage.cpp; sourceTree = "<group>"; };
+		BC45A1AC30532446001A8DD1 /* StyleImageClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleImageClient.h; sourceTree = "<group>"; };
+		BC45A1AD30532639001A8DD1 /* StyleImageClient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleImageClient.cpp; sourceTree = "<group>"; };
+		BC45A1B130546EC1001A8DD1 /* StyleImageContainerContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleImageContainerContext.h; sourceTree = "<group>"; };
+		BC45A1B230546EC1001A8DD1 /* StyleImageContainerContextKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleImageContainerContextKey.h; sourceTree = "<group>"; };
+		BC45A1B530547A91001A8DD1 /* StyleImageSizeOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleImageSizeOptions.h; sourceTree = "<group>"; };
+		BC45A1B730548C9C001A8DD1 /* VisibleInViewportState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VisibleInViewportState.h; sourceTree = "<group>"; };
 		BC46305E2E9B098600EA911F /* StyleCalculationTree.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleCalculationTree.h; sourceTree = "<group>"; };
 		BC46305F2E9B098600EA911F /* StyleCalculationTree.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleCalculationTree.cpp; sourceTree = "<group>"; };
 		BC4630602E9B098600EA911F /* StyleCalculationTree+Copy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StyleCalculationTree+Copy.h"; sourceTree = "<group>"; };
@@ -20300,6 +20307,13 @@
 		BCA088F4264E1BFA003E2A6C /* ImageDataPixelFormat.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = ImageDataPixelFormat.idl; sourceTree = "<group>"; };
 		BCA169A00BFD55B40019CA76 /* JSHTMLTableCaptionElement.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = JSHTMLTableCaptionElement.cpp; sourceTree = "<group>"; };
 		BCA169A10BFD55B40019CA76 /* JSHTMLTableCaptionElement.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = JSHTMLTableCaptionElement.h; sourceTree = "<group>"; };
+		BCA1C5000000000000000001 /* CSSCalcSizeValue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSCalcSizeValue.cpp; sourceTree = "<group>"; };
+		BCA1C5000000000000000002 /* CSSCalcSizeValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSCalcSizeValue.h; sourceTree = "<group>"; };
+		BCA1C5000000000000000004 /* CSSCalcSizeFunction.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSCalcSizeFunction.cpp; sourceTree = "<group>"; };
+		BCA1C5000000000000000005 /* CSSCalcSizeFunction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSCalcSizeFunction.h; sourceTree = "<group>"; };
+		BCA1C5000000000000000007 /* CSSPropertyParserConsumer+CalcSize.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "CSSPropertyParserConsumer+CalcSize.cpp"; sourceTree = "<group>"; };
+		BCA1C5000000000000000008 /* CSSPropertyParserConsumer+CalcSize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CSSPropertyParserConsumer+CalcSize.h"; sourceTree = "<group>"; };
+		BCA1C6000000000000000001 /* StyleSizeOrKeyword.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StyleSizeOrKeyword.h; sourceTree = "<group>"; };
 		BCA1C6000000000000000003 /* StyleSizeOrKeyword+CSSValueConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StyleSizeOrKeyword+CSSValueConversion.h"; sourceTree = "<group>"; };
 		BCA2B0601050475F0043BD1C /* UserScript.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserScript.h; sourceTree = "<group>"; };
 		BCA2B0601050485F0043BD1C /* UserScript.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserScript.cpp; sourceTree = "<group>"; };
@@ -20404,8 +20418,6 @@
 		BCB271A02CBD7D4C00265123 /* CSSGradient.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSGradient.cpp; sourceTree = "<group>"; };
 		BCB271A22CBD7D4C00265123 /* CSSCircleFunction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSCircleFunction.h; sourceTree = "<group>"; };
 		BCB271A32CBD7D4C00265123 /* CSSCircleFunction.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSCircleFunction.cpp; sourceTree = "<group>"; };
-		BCA1C5000000000000000004 /* CSSCalcSizeFunction.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSCalcSizeFunction.cpp; sourceTree = "<group>"; };
-		BCA1C5000000000000000005 /* CSSCalcSizeFunction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSCalcSizeFunction.h; sourceTree = "<group>"; };
 		BCB271A42CBD7D4C00265123 /* CSSEllipseFunction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSEllipseFunction.h; sourceTree = "<group>"; };
 		BCB271A52CBD7D4C00265123 /* CSSEllipseFunction.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CSSEllipseFunction.cpp; sourceTree = "<group>"; };
 		BCB271A62CBD7D4C00265123 /* CSSInsetFunction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSSInsetFunction.h; sourceTree = "<group>"; };
@@ -20779,8 +20791,6 @@
 		BCE411DF2CF2B6F000731E47 /* CSSPropertyParserConsumer+Scrollbars.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CSSPropertyParserConsumer+Scrollbars.h"; sourceTree = "<group>"; };
 		BCE411E02CF2B6F000731E47 /* CSSPropertyParserConsumer+Scrollbars.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "CSSPropertyParserConsumer+Scrollbars.cpp"; sourceTree = "<group>"; };
 		BCE411E12CF2B70300731E47 /* CSSPropertyParserConsumer+Display.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CSSPropertyParserConsumer+Display.h"; sourceTree = "<group>"; };
-		BCA1C5000000000000000007 /* CSSPropertyParserConsumer+CalcSize.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "CSSPropertyParserConsumer+CalcSize.cpp"; sourceTree = "<group>"; };
-		BCA1C5000000000000000008 /* CSSPropertyParserConsumer+CalcSize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CSSPropertyParserConsumer+CalcSize.h"; sourceTree = "<group>"; };
 		BCE411E22CF2B70300731E47 /* CSSPropertyParserConsumer+Display.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "CSSPropertyParserConsumer+Display.cpp"; sourceTree = "<group>"; };
 		BCE411E72CF2B86300731E47 /* CSSPropertyParserConsumer+UI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CSSPropertyParserConsumer+UI.h"; sourceTree = "<group>"; };
 		BCE411E82CF2B86300731E47 /* CSSPropertyParserConsumer+UI.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "CSSPropertyParserConsumer+UI.cpp"; sourceTree = "<group>"; };
@@ -36097,6 +36107,7 @@
 				BCB16BFF0979C3BD00467741 /* MemoryCache.h */,
 				4C5BEFD529489295006E05E5 /* TrustedFonts.cpp */,
 				4C15D8CF294786F000A220AD /* TrustedFonts.h */,
+				BC45A1B730548C9C001A8DD1 /* VisibleInViewportState.h */,
 			);
 			path = cache;
 			sourceTree = "<group>";
@@ -37705,9 +37716,15 @@
 				BC1777712F42418A00E318C5 /* StyleGeneratedImage.h */,
 				BC1777742F42418A00E318C5 /* StyleGradientImage.cpp */,
 				BC1777732F42418A00E318C5 /* StyleGradientImage.h */,
+				BC45A1AB30532446001A8DD1 /* StyleImage.cpp */,
 				BC1777752F42418A00E318C5 /* StyleImage.h */,
+				BC45A1AD30532639001A8DD1 /* StyleImageClient.cpp */,
+				BC45A1AC30532446001A8DD1 /* StyleImageClient.h */,
+				BC45A1B130546EC1001A8DD1 /* StyleImageContainerContext.h */,
+				BC45A1B230546EC1001A8DD1 /* StyleImageContainerContextKey.h */,
 				BC1777772F42418A00E318C5 /* StyleImageSet.cpp */,
 				BC1777762F42418A00E318C5 /* StyleImageSet.h */,
+				BC45A1B530547A91001A8DD1 /* StyleImageSizeOptions.h */,
 				BC1777792F42418A00E318C5 /* StyleInvalidImage.cpp */,
 				BC1777782F42418A00E318C5 /* StyleInvalidImage.h */,
 				BC17777B2F42418A00E318C5 /* StyleMultiImage.cpp */,
@@ -38885,6 +38902,15 @@
 			path = position;
 			sourceTree = "<group>";
 		};
+		BCA1C5000000000000000009 /* sizing */ = {
+			isa = PBXGroup;
+			children = (
+				BCA1C5000000000000000004 /* CSSCalcSizeFunction.cpp */,
+				BCA1C5000000000000000005 /* CSSCalcSizeFunction.h */,
+			);
+			path = sizing;
+			sourceTree = "<group>";
+		};
 		BCA407D82C9DF4CF006B037F /* values */ = {
 			isa = PBXGroup;
 			children = (
@@ -39245,15 +39271,6 @@
 				BCB271B02CBD7D4C00265123 /* CSSXywhFunction.h */,
 			);
 			path = shapes;
-			sourceTree = "<group>";
-		};
-		BCA1C5000000000000000009 /* sizing */ = {
-			isa = PBXGroup;
-			children = (
-				BCA1C5000000000000000004 /* CSSCalcSizeFunction.cpp */,
-				BCA1C5000000000000000005 /* CSSCalcSizeFunction.h */,
-			);
-			path = sizing;
 			sourceTree = "<group>";
 		};
 		BCB271B52CBD7D6B00265123 /* images */ = {
@@ -49370,8 +49387,12 @@
 				BC092AAF2E317441002ACB2C /* StyleHyphenateLimitEdge.h in Headers */,
 				BC092AA92E31573F002ACB2C /* StyleHyphenateLimitLines.h in Headers */,
 				BC1777832F42513300E318C5 /* StyleImage.h in Headers */,
+				BC45A1AE30532839001A8DD1 /* StyleImageClient.h in Headers */,
+				BC45A1B430546FA5001A8DD1 /* StyleImageContainerContext.h in Headers */,
+				BC45A1B330546F0A001A8DD1 /* StyleImageContainerContextKey.h in Headers */,
 				BC4631762EA854B700EA911F /* StyleImageOrientation.h in Headers */,
 				BC731E752E636D8700A6584F /* StyleImageOrNone.h in Headers */,
+				BC45A1B630547B84001A8DD1 /* StyleImageSizeOptions.h in Headers */,
 				BC22AA9E2E36A2BD009AC0C3 /* StyleImageWrapper.h in Headers */,
 				BC63AD3E2F084C2F007B62C4 /* StyleInheritedData.h in Headers */,
 				BC63AD512F08565F007B62C4 /* StyleInheritedRareData.h in Headers */,
@@ -50166,6 +50187,7 @@
 				F4FC07D62BB3A6220090B808 /* VisibilityAdjustment.h in Headers */,
 				83407FC11E8D9C1700E048D3 /* VisibilityChangeClient.h in Headers */,
 				46CA9C441F97BBE9004CFC3A /* VisibilityState.h in Headers */,
+				BC45A1B830548CC4001A8DD1 /* VisibleInViewportState.h in Headers */,
 				93309E20099E64920056E581 /* VisiblePosition.h in Headers */,
 				BCAE82302E7C71B300F30967 /* VisibleRectContext.h in Headers */,
 				A883DF280F3D045D00F19BF6 /* VisibleSelection.h in Headers */,

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1268,7 +1268,7 @@ bool AccessibilityRenderObject::computeIsIgnored() const
 
             // check whether rendered image was stretched from one-dimensional file image
             if (image->cachedImage()) {
-                LayoutSize imageSize = protect(image->cachedImage())->imageSizeForRenderer(image.get(), image->view().pageZoomFactor());
+                LayoutSize imageSize = protect(image->cachedImage())->imageSizeForRenderer(image, image->view().pageZoomFactor());
                 return imageSize.height() <= 1 || imageSize.width() <= 1;
             }
         }

--- a/Source/WebCore/css/CSSImageValue.cpp
+++ b/Source/WebCore/css/CSSImageValue.cpp
@@ -178,7 +178,7 @@ bool CSSImageValue::knownToBeOpaque(const RenderElement& renderer) const
     if (!m_cachedImage)
         return false;
     RefPtr cacheImage = m_cachedImage->get();
-    return cacheImage && cacheImage->currentFrameKnownToBeOpaque(&renderer);
+    return cacheImage && cacheImage->currentFrameKnownToBeOpaqueForRenderer(renderer);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -79,7 +79,7 @@ public:
 private:
     DragImageLoader(DataTransfer&, const Document&);
 
-    void imageChanged(CachedImage*, const IntRect*) override;
+    void imageChanged(CachedImage&, const IntRect*) override;
 
     WeakPtr<DataTransfer> m_dataTransfer;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
@@ -676,7 +676,7 @@ void DragImageLoader::stopLoading(CachedResourceHandle<WebCore::CachedImage>& im
     protect(image)->removeClient(*this);
 }
 
-void DragImageLoader::imageChanged(CachedImage*, const IntRect*)
+void DragImageLoader::imageChanged(CachedImage&, const IntRect*)
 {
     RefPtr document = m_document.get();
     if (RefPtr dataTransfer = m_dataTransfer.get())

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9294,7 +9294,7 @@ LargestContentfulPaintData& Document::largestContentfulPaintData() const
     return *m_largestContentfulPaintData;
 }
 
-void Document::didLoadImage(Element& element, CachedImage* image) const
+void Document::didLoadImage(Element& element, const Style::Image* image) const
 {
     if (!supportsLargestContentfulPaint())
         return;
@@ -9302,7 +9302,7 @@ void Document::didLoadImage(Element& element, CachedImage* image) const
     largestContentfulPaintData().didLoadImage(element, image);
 }
 
-void Document::didPaintImage(Element& element, CachedImage* image, FloatRect localRect) const
+void Document::didPaintImage(Element& element, const Style::Image* image, FloatRect localRect) const
 {
     if (!supportsLargestContentfulPaint())
         return;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -381,6 +381,7 @@ struct RandomCachingKey;
 namespace Style {
 class ComputedStyle;
 class CustomPropertyRegistry;
+class Image;
 class Resolver;
 class Scope;
 class DocumentScope;
@@ -1532,8 +1533,8 @@ public:
     const DocumentEventTiming& eventTiming() const LIFETIME_BOUND { return m_eventTiming; }
 
     LargestContentfulPaintData& largestContentfulPaintData() const;
-    void didLoadImage(Element&, CachedImage*) const;
-    void didPaintImage(Element&, CachedImage*, FloatRect localRect) const;
+    void didLoadImage(Element&, const Style::Image*) const;
+    void didPaintImage(Element&, const Style::Image*, FloatRect localRect) const;
     void didPaintText(const RenderBlockFlow&, FloatRect localRect, bool isOnlyTextBoxForElement) const;
 
     int requestAnimationFrame(Ref<RequestAnimationFrameCallback>&&);

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -222,11 +222,12 @@ HashSet<Ref<Element>> CanvasBase::cssCanvasClients() const
         if (!image)
             continue;
 
-        for (auto entry : image->clients()) {
-            CheckedRef client = entry.key;
-            if (RefPtr element = client->element())
-                cssCanvasClients.add(element.releaseNonNull());
-        }
+        // FIXME: Implement.
+        //        for (auto entry : image->clients()) {
+        //            CheckedRef client = entry.key;
+        //            if (RefPtr element = client->element())
+        //                cssCanvasClients.add(element.releaseNonNull());
+        //        }
     }
     return cssCanvasClients;
 }

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -670,7 +670,7 @@ unsigned HTMLImageElement::width()
 
         // if the image is available, use its width
         if (RefPtr image = m_imageLoader->image())
-            return image->imageSizeForRenderer(nullptr, 1.0f, CachedImage::IntrinsicSize).width().toUnsigned();
+            return image->imageSize(ImageSizeOptions { .type = ImageSizeType::Intrinsic }).width().toUnsigned();
     }
 
     CheckedPtr box = renderBox();
@@ -693,7 +693,7 @@ unsigned HTMLImageElement::height()
 
         // if the image is available, use its height
         if (RefPtr image = m_imageLoader->image())
-            return image->imageSizeForRenderer(nullptr, 1.0f, CachedImage::IntrinsicSize).height().toUnsigned();
+            return image->imageSize(ImageSizeOptions { .type = ImageSizeType::Intrinsic }).height().toUnsigned();
     }
 
     CheckedPtr box = renderBox();
@@ -708,7 +708,7 @@ unsigned HTMLImageElement::naturalWidth() const
     RefPtr image = m_imageLoader->image();
     if (!image)
         return 0;
-    return image->unclampedImageSizeForRenderer(protect(renderer()).get(), 1.0f, CachedImage::IntrinsicSize, m_imageDevicePixelRatio).width().toUnsigned();
+    return image->unclampedImageSizeForRenderer(protect(renderer()).get(), 1.0f, ImageSizeType::Intrinsic, m_imageDevicePixelRatio).width().toUnsigned();
 }
 
 unsigned HTMLImageElement::naturalHeight() const
@@ -716,7 +716,7 @@ unsigned HTMLImageElement::naturalHeight() const
     RefPtr image = m_imageLoader->image();
     if (!image)
         return 0;
-    return image->unclampedImageSizeForRenderer(protect(renderer()).get(), 1.0f, CachedImage::IntrinsicSize, m_imageDevicePixelRatio).height().toUnsigned();
+    return image->unclampedImageSizeForRenderer(protect(renderer()).get(), 1.0f, ImageSizeType::Intrinsic, m_imageDevicePixelRatio).height().toUnsigned();
 }
 
 bool HTMLImageElement::isURLAttribute(const Attribute& attribute) const

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -413,7 +413,7 @@ void ImageBitmap::createCompletionHandler(ScriptExecutionContext& scriptExecutio
     //    resizeHeight options are not specified, then return a promise rejected with
     //    an "InvalidStateError" DOMException and abort these steps.
 
-    auto imageSize = cachedImage->imageSizeForRenderer(renderer, 1.0f);
+    auto imageSize = cachedImage->imageSizeForRenderer(renderer);
     if ((!imageSize.width() || !imageSize.height()) && (!options.resizeWidth || !options.resizeHeight)) {
         completionHandler(Exception { ExceptionCode::InvalidStateError, "Cannot create ImageBitmap from a source with no intrinsic size without providing resize dimensions"_s });
         return;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1545,23 +1545,24 @@ bool CanvasRenderingContext2DBase::shouldDrawShadows() const
     return state().shadowColor.isVisible() && (state().shadowBlur || !state().shadowOffset.isZero());
 }
 
-enum class ImageSizeType { AfterDevicePixelRatio, BeforeDevicePixelRatio };
-static LayoutSize size(CachedImage* cachedImage, RenderElement* renderer, ImageSizeType sizeType = ImageSizeType::BeforeDevicePixelRatio)
+enum class CanvasImageSizeType { AfterDevicePixelRatio, BeforeDevicePixelRatio };
+
+static LayoutSize size(CachedImage* cachedImage, RenderElement* renderer, CanvasImageSizeType sizeType = CanvasImageSizeType::BeforeDevicePixelRatio)
 {
     if (!cachedImage)
         return { };
-    LayoutSize size = cachedImage->imageSizeForRenderer(renderer, 1.0f); // FIXME: Not sure about this.
-    if (auto* renderImage = dynamicDowncast<RenderImage>(renderer); sizeType == ImageSizeType::AfterDevicePixelRatio && renderImage && cachedImage->image() && !protect(cachedImage->image())->hasRelativeWidth())
+    auto size = cachedImage->imageSizeForRenderer(renderer); // FIXME: Not sure about this.
+    if (auto* renderImage = dynamicDowncast<RenderImage>(renderer); sizeType == CanvasImageSizeType::AfterDevicePixelRatio && renderImage && cachedImage->image() && !protect(cachedImage->image())->hasRelativeWidth())
         size.scale(renderImage->imageDevicePixelRatio());
     return size;
 }
 
-static LayoutSize size(HTMLImageElement& element, ImageSizeType sizeType = ImageSizeType::BeforeDevicePixelRatio)
+static LayoutSize size(HTMLImageElement& element, CanvasImageSizeType sizeType = CanvasImageSizeType::BeforeDevicePixelRatio)
 {
     return size(protect(element.cachedImage()), protect(element.renderer()).get(), sizeType);
 }
 
-static LayoutSize size(SVGImageElement& element, ImageSizeType sizeType = ImageSizeType::BeforeDevicePixelRatio)
+static LayoutSize size(SVGImageElement& element, CanvasImageSizeType sizeType = CanvasImageSizeType::BeforeDevicePixelRatio)
 {
     return size(protect(element.cachedImage()), protect(element.renderer()).get(), sizeType);
 }
@@ -1593,8 +1594,7 @@ static inline FloatSize size(CSSStyleImageValue& image)
     RefPtr cachedImage = image.image();
     if (!cachedImage)
         return FloatSize();
-
-    return cachedImage->imageSizeForRenderer(nullptr, 1.0f);
+    return cachedImage->imageSize();
 }
 
 #if ENABLE(WEB_CODECS)
@@ -1608,13 +1608,13 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasImageSource&& im
 {
     return WTF::switchOn(image,
         [&](Ref<HTMLImageElement>& imageElement) -> ExceptionOr<void> {
-            LayoutSize destRectSize = size(imageElement, ImageSizeType::AfterDevicePixelRatio);
-            LayoutSize sourceRectSize = size(imageElement, ImageSizeType::BeforeDevicePixelRatio);
+            LayoutSize destRectSize = size(imageElement, CanvasImageSizeType::AfterDevicePixelRatio);
+            LayoutSize sourceRectSize = size(imageElement, CanvasImageSizeType::BeforeDevicePixelRatio);
             return this->drawImage(imageElement, FloatRect { 0, 0, sourceRectSize.width(), sourceRectSize.height() }, FloatRect { dx, dy, destRectSize.width(), destRectSize.height() });
         },
         [&](Ref<SVGImageElement>& imageElement) -> ExceptionOr<void> {
-            LayoutSize destRectSize = size(imageElement, ImageSizeType::AfterDevicePixelRatio);
-            LayoutSize sourceRectSize = size(imageElement, ImageSizeType::BeforeDevicePixelRatio);
+            LayoutSize destRectSize = size(imageElement, CanvasImageSizeType::AfterDevicePixelRatio);
+            LayoutSize sourceRectSize = size(imageElement, CanvasImageSizeType::BeforeDevicePixelRatio);
             return this->drawImage(imageElement, FloatRect { 0, 0, sourceRectSize.width(), sourceRectSize.height() }, FloatRect { dx, dy, destRectSize.width(), destRectSize.height() });
         },
         [&](auto& element) -> ExceptionOr<void> {
@@ -1660,7 +1660,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(HTMLImageElement& imag
     if (cachedImage->status() == CachedImage::Status::DecodeError)
         return Exception { ExceptionCode::InvalidStateError, "The HTMLImageElement provided is in the 'broken' state."_s };
 
-    auto imageRect = FloatRect(FloatPoint(), size(imageElement, ImageSizeType::BeforeDevicePixelRatio));
+    auto imageRect = FloatRect(FloatPoint(), size(imageElement, CanvasImageSizeType::BeforeDevicePixelRatio));
 
     auto orientation = ImageOrientation::Orientation::FromImage;
     if (imageElement.allowsOrientationOverride()) {
@@ -1691,7 +1691,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(SVGImageElement& image
     if (cachedImage->status() == CachedImage::Status::DecodeError)
         return Exception { ExceptionCode::InvalidStateError, "The SVGImageElement provided is in the 'broken' state."_s };
 
-    auto imageRect = FloatRect(FloatPoint(), size(imageElement, ImageSizeType::BeforeDevicePixelRatio));
+    auto imageRect = FloatRect(FloatPoint(), size(imageElement, CanvasImageSizeType::BeforeDevicePixelRatio));
 
     auto result = drawImage(protect(imageElement.document()).get(), *cachedImage, protect(imageElement.renderer()).get(), imageRect, srcRect, dstRect, op, blendMode);
 

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -765,7 +765,7 @@ void ImageLoader::resetLazyImageLoading(Document& document)
     m_lazyImageLoadState = LazyImageLoadState::None;
 }
 
-VisibleInViewportState ImageLoader::imageVisibleInViewport(const Document& document) const
+VisibleInViewportState ImageLoader::imageVisibleInViewport(CachedImage&, const Document& document) const
 {
     if (&element().document() != &document)
         return VisibleInViewportState::No;

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -129,7 +129,7 @@ private:
 
     void setImageCompleteAndMaybeUpdateRenderer();
 
-    VisibleInViewportState imageVisibleInViewport(const Document&) const override;
+    VisibleInViewportState imageVisibleInViewport(CachedImage&, const Document&) const override;
 
     WeakRef<Element, WeakPtrImplWithEventTargetData> m_element;
     CachedResourceHandle<CachedImage> m_image;

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -41,7 +41,6 @@
 #include "MemoryCache.h"
 #include "NativeImage.h"
 #include "RenderElement.h"
-#include "RenderImage.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGImage.h"
 #include "SecurityOrigin.h"
@@ -129,7 +128,7 @@ void CachedImage::didAddClient(CachedResourceClient& client)
 
     ASSERT(client.resourceClientType() == CachedImageClient::expectedType());
     if (m_image && !protect(m_image)->isNull())
-        downcast<CachedImageClient>(client).imageChanged(this);
+        downcast<CachedImageClient>(client).imageChanged(*this);
 
     if (RefPtr image = m_image)
         image->startAnimationAsynchronously();
@@ -141,11 +140,8 @@ void CachedImage::didRemoveClient(CachedResourceClient& client)
 {
     ASSERT(client.resourceClientType() == CachedImageClient::expectedType());
 
-    m_pendingContainerContextRequests.remove(&downcast<CachedImageClient>(client));
+    // m_pendingContainerContextRequests.remove(&downcast<CachedImageClient>(client));
     m_clientsWaitingForAsyncDecoding.remove(downcast<CachedImageClient>(client));
-
-    if (m_svgImageCache)
-        m_svgImageCache->removeClientFromCache(&downcast<CachedImageClient>(client));
 
     CachedResource::didRemoveClient(client);
 
@@ -187,7 +183,7 @@ void CachedImage::removeAllClientsWaitingForAsyncDecoding()
     bitmapImage->stopDecoderWorkQueue();
 
     for (Ref client : m_clientsWaitingForAsyncDecoding)
-        client->imageChanged(this);
+        client->imageChanged(*this);
     m_clientsWaitingForAsyncDecoding.clear();
 }
 
@@ -206,14 +202,15 @@ void CachedImage::switchClientsToRevalidatedResource()
     ASSERT(is<CachedImage>(resourceToRevalidate()));
     // Pending container size requests need to be transferred to the revalidated resource.
     if (!m_pendingContainerContextRequests.isEmpty()) {
-        // A copy of pending size requests is needed as they are deleted during CachedResource::switchClientsToRevalidateResouce().
+        // A copy of pending size requests is needed as they are deleted during CachedResource::switchClientsToRevalidateResource().
         ContainerContextRequests switchContainerContextRequests;
         for (auto& request : m_pendingContainerContextRequests)
             switchContainerContextRequests.set(request.key, request.value);
+
         CachedResource::switchClientsToRevalidatedResource();
         RefPtr revalidatedCachedImage = downcast<CachedImage>(*resourceToRevalidate());
         for (auto& request : switchContainerContextRequests)
-            revalidatedCachedImage->setContainerContextForClient(request.key, request.value.containerSize, request.value.containerZoom, request.value.imageURL, request.value.linkParameters);
+            revalidatedCachedImage->registerContainerContext(request.key, WTF::move(request.value));
         return;
     }
 
@@ -228,7 +225,7 @@ void CachedImage::allClientsRemoved()
         image->resetAnimation();
 }
 
-std::pair<WeakPtr<Image>, float> CachedImage::brokenImage(float deviceScaleFactor) const
+std::pair<WeakPtr<Image>, float> CachedImage::brokenImage(float deviceScaleFactor)
 {
     if (deviceScaleFactor >= 3) {
         static NeverDestroyed<Image*> brokenImageVeryHiRes(&ImageAdapter::loadPlatformResource("missingImage@3x").leakRef());
@@ -264,7 +261,7 @@ Image* CachedImage::image() const
     return &Image::nullImage();
 }
 
-Image* CachedImage::imageForRenderer(const RenderObject* renderer)
+Image* CachedImage::imageForKey(const ImageContainerContextKey* key)
 {
     if (errorOccurred() && m_shouldPaintBrokenImage) {
         // Returning the 1x broken image is non-ideal, but we cannot reliably access the appropriate
@@ -277,32 +274,39 @@ Image* CachedImage::imageForRenderer(const RenderObject* renderer)
         return &Image::nullImage();
 
     if (m_image->drawsSVGImage()) {
-        SUPPRESS_UNCOUNTED_LOCAL if (auto* image = m_svgImageCache->imageForRenderer(renderer); image != &Image::nullImage())
+        SUPPRESS_UNCOUNTED_LOCAL if (auto* image = m_svgImageCache->imageForKey(key); image != &Image::nullImage())
             return image;
     }
     return m_image.get();
 }
 
-void CachedImage::setContainerContextForClient(const CachedImageClient& client, const LayoutSize& containerSize, float containerZoom, const URL& imageURL, const Style::LinkParameters& linkParameters)
+Image* CachedImage::imageForRenderer(const RenderObject* renderer)
 {
-    if (containerSize.isEmpty())
+    return imageForKey(renderer ? &renderer->imageContainerContextKey() : nullptr);
+}
+
+void CachedImage::registerContainerContext(const ImageContainerContextKey& key, ImageContainerContext&& context)
+{
+    if (context.containerSize.isEmpty())
         return;
-    ASSERT(containerZoom);
+
+    ASSERT(context.containerZoom);
+
     RefPtr image = m_image;
     if (!image) {
-        m_pendingContainerContextRequests.set(client, ContainerContext { containerSize, containerZoom, imageURL, linkParameters });
+        m_pendingContainerContextRequests.set(key, WTF::move(context));
         return;
     }
 
     if (!image->drawsSVGImage()) {
-        image->setContainerSize(containerSize);
+        image->setContainerSize(context.containerSize);
         return;
     }
 
-    m_svgImageCache->setContainerContextForClient(client, containerSize, containerZoom, imageURL, linkParameters);
+    m_svgImageCache->registerContainerContext(key, WTF::move(context));
 }
 
-FloatSize CachedImage::internalImageSizeForRenderer(const RenderElement* renderer, float multiplier, SizeType sizeType, float density) const
+FloatSize CachedImage::internalImageSize(const ImageContainerContextKey* key, const ImageSizeOptions& options) const
 {
     RefPtr image = m_image;
     if (!image)
@@ -310,26 +314,24 @@ FloatSize CachedImage::internalImageSizeForRenderer(const RenderElement* rendere
 
     if (RefPtr svgImage = dynamicDowncast<SVGImage>(*image)) {
         FloatSize size;
-        if (sizeType == UsedSize) {
+        if (options.type == ImageSizeType::Used) {
             // The SVG cache size is already in CSS pixels (set by the layout
-            // system via setContainerContextForClient), so density does not apply.
-            size = m_svgImageCache->imageSizeForRenderer(renderer);
+            // system via registerContainerContext), so density does not apply.
+            size = m_svgImageCache->imageSizeForKey(key);
         } else
-            size = svgImage->resolvedIntrinsicSize(density);
-        if (multiplier != 1.0f)
-            size.scale(multiplier);
+            size = svgImage->resolvedIntrinsicSize(options.density);
+        if (options.multiplier != 1.0f)
+            size.scale(options.multiplier);
         return size;
     }
 
     FloatSize imageSize;
-#if ENABLE(MULTI_REPRESENTATION_HEIC)
-    if (CheckedPtr renderImage = dynamicDowncast<RenderImage>(renderer); renderImage && renderImage->isMultiRepresentationHEIC())
-        imageSize = renderImage->style().fontCascade().primaryFont().metricsForMultiRepresentationHEIC().size();
+    if (options.overrideImageSize)
+        imageSize = *options.overrideImageSize;
     else
-#endif
-        imageSize = image->size(renderer ? renderer->imageOrientation() : ImageOrientation(ImageOrientation::Orientation::FromImage));
+        imageSize = image->size(options.orientation);
 
-    float scaleFactor = multiplier * density;
+    float scaleFactor = options.multiplier * options.density;
     float widthScale = image->hasRelativeWidth() ? 1.0f : scaleFactor;
     float heightScale = image->hasRelativeHeight() ? 1.0f : scaleFactor;
     if (widthScale != 1.0f || heightScale != 1.0f)
@@ -337,28 +339,73 @@ FloatSize CachedImage::internalImageSizeForRenderer(const RenderElement* rendere
     return imageSize;
 }
 
-FloatSize CachedImage::imageSizeForRenderer(const RenderElement* renderer) const
+FloatSize CachedImage::imageFloatSize(const ImageSizeOptions& options) const
 {
-    return internalImageSizeForRenderer(renderer, 1.0f, UsedSize, 1.0f);
+    return internalImageSize(nullptr, options);
 }
 
-LayoutSize CachedImage::unclampedImageSizeForRenderer(const RenderElement* renderer, float multiplier, SizeType sizeType, float density) const
+FloatSize CachedImage::imageFloatSizeForKey(const ImageContainerContextKey& key, const ImageSizeOptions& options) const
 {
-    return LayoutSize(internalImageSizeForRenderer(renderer, multiplier, sizeType, density));
+    return internalImageSize(&key, options);
 }
 
-LayoutSize CachedImage::imageSizeForRenderer(const RenderElement* renderer, float multiplier, SizeType sizeType, float density) const
+LayoutSize CachedImage::unclampedImageSize(const ImageSizeOptions& options) const
 {
-    auto imageSize = unclampedImageSizeForRenderer(renderer, multiplier, sizeType, density);
-    if (imageSize.isEmpty() || multiplier == 1.0f)
+    return LayoutSize(internalImageSize(nullptr, options));
+}
+
+LayoutSize CachedImage::unclampedImageSizeForKey(const ImageContainerContextKey& key, const ImageSizeOptions& options) const
+{
+    return LayoutSize(internalImageSize(&key, options));
+}
+
+LayoutSize CachedImage::imageSize(const ImageSizeOptions& options) const
+{
+    auto imageSize = unclampedImageSize(options);
+    if (imageSize.isEmpty() || options.multiplier == 1.0f)
         return imageSize;
 
     // Don't let images that have a width/height >= 1 shrink below 1 when zoomed.
     LayoutSize minimumSize(imageSize.width() > 0 ? 1 : 0, imageSize.height() > 0 ? 1 : 0);
     imageSize.clampToMinimumSize(minimumSize);
 
-    ASSERT(multiplier != 1.0f || (imageSize.width().fraction() == 0.0f && imageSize.height().fraction() == 0.0f));
+    ASSERT(options.multiplier != 1.0f || (imageSize.width().fraction() == 0.0f && imageSize.height().fraction() == 0.0f));
     return imageSize;
+}
+
+LayoutSize CachedImage::imageSizeForKey(const ImageContainerContextKey& key, const ImageSizeOptions& options) const
+{
+    auto imageSize = unclampedImageSizeForKey(key, options);
+    if (imageSize.isEmpty() || options.multiplier == 1.0f)
+        return imageSize;
+
+    // Don't let images that have a width/height >= 1 shrink below 1 when zoomed.
+    LayoutSize minimumSize(imageSize.width() > 0 ? 1 : 0, imageSize.height() > 0 ? 1 : 0);
+    imageSize.clampToMinimumSize(minimumSize);
+
+    ASSERT(options.multiplier != 1.0f || (imageSize.width().fraction() == 0.0f && imageSize.height().fraction() == 0.0f));
+    return imageSize;
+}
+
+FloatSize CachedImage::imageFloatSizeForRenderer(const RenderElement* renderer, float multiplier, ImageSizeType type, float density) const
+{
+    if (renderer)
+        return imageFloatSizeForKey(renderer->imageContainerContextKey(), renderer->imageSizeOptions(multiplier, type, density));
+    return imageFloatSize(ImageSizeOptions { .multiplier = multiplier, .type = type, .density = density });
+}
+
+LayoutSize CachedImage::imageSizeForRenderer(const RenderElement* renderer, float multiplier, ImageSizeType type, float density) const
+{
+    if (renderer)
+        return imageSizeForKey(renderer->imageContainerContextKey(), renderer->imageSizeOptions(multiplier, type, density));
+    return imageSize(ImageSizeOptions { .multiplier = multiplier, .type = type, .density = density });
+}
+
+LayoutSize CachedImage::unclampedImageSizeForRenderer(const RenderElement* renderer, float multiplier, ImageSizeType type, float density) const
+{
+    if (renderer)
+        return unclampedImageSizeForKey(renderer->imageContainerContextKey(), renderer->imageSizeOptions(multiplier, type, density));
+    return unclampedImageSize(ImageSizeOptions { .multiplier = multiplier, .type = type, .density = density });
 }
 
 void CachedImage::computeIntrinsicDimensions(float& intrinsicWidth, float& intrinsicHeight, FloatSize& intrinsicRatio)
@@ -376,7 +423,7 @@ void CachedImage::notifyObservers(const IntRect* changeRect)
 {
     CachedResourceClientWalker<CachedImageClient> walker(*this);
     while (RefPtr client = walker.next())
-        client->imageChanged(this, changeRect);
+        client->imageChanged(*this, changeRect);
 }
 
 void CachedImage::checkShouldPaintBrokenImage()
@@ -413,7 +460,7 @@ inline void CachedImage::createImage()
         // Send queued container size requests.
         if (image->usesContainerSize()) {
             for (auto& request : m_pendingContainerContextRequests)
-                setContainerContextForClient(request.key, request.value.containerSize, request.value.containerZoom, request.value.imageURL, request.value.linkParameters);
+                registerContainerContext(request.key, WTF::move(request.value));
         }
         m_pendingContainerContextRequests.clear();
         m_clientsWaitingForAsyncDecoding.clear();
@@ -800,16 +847,26 @@ bool CachedImage::allowsAnimation(const Image& image) const
     return true;
 }
 
-bool CachedImage::currentFrameKnownToBeOpaque(const RenderElement* renderer)
+bool CachedImage::currentFrameKnownToBeOpaqueForKey(const ImageContainerContextKey& key)
 {
-    RefPtr image = imageForRenderer(renderer);
+    RefPtr image = imageForKey(&key);
     return image->currentFrameKnownToBeOpaque();
 }
 
-bool CachedImage::currentFrameIsComplete(const RenderElement* renderer)
+bool CachedImage::currentFrameKnownToBeOpaqueForRenderer(const RenderObject& renderer)
 {
-    RefPtr image = imageForRenderer(renderer);
+    return currentFrameKnownToBeOpaqueForKey(renderer.imageContainerContextKey());
+}
+
+bool CachedImage::currentFrameIsCompleteForKey(const ImageContainerContextKey& key)
+{
+    RefPtr image = imageForKey(&key);
     return image->currentFrameIsComplete();
+}
+
+bool CachedImage::currentFrameIsCompleteForRenderer(const RenderObject& renderer)
+{
+    return currentFrameIsCompleteForKey(renderer.imageContainerContextKey());
 }
 
 bool CachedImage::isOriginClean(SecurityOrigin* origin)
@@ -847,7 +904,7 @@ bool CachedImage::isVisibleInViewport(const Document& document) const
 {
     CachedResourceClientWalker<CachedImageClient> walker(*this);
     while (RefPtr client = walker.next()) {
-        if (client->imageVisibleInViewport(document) == VisibleInViewportState::Yes)
+        if (client->imageVisibleInViewport(const_cast<CachedImage&>(*this), document) == VisibleInViewportState::Yes)
             return true;
     }
     return false;

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -29,7 +29,9 @@
 #include <WebCore/IntRect.h>
 #include <WebCore/LayoutSize.h>
 #include <WebCore/SVGImageCache.h>
-#include <WebCore/StyleLinkParameters.h>
+#include <WebCore/StyleImageContainerContext.h>
+#include <WebCore/StyleImageContainerContextKey.h>
+#include <WebCore/StyleImageSizeOptions.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 
@@ -53,20 +55,27 @@ public:
     virtual ~CachedImage();
 
     WEBCORE_EXPORT Image* image() const; // Returns the nullImage() if the image is not available yet.
+    WEBCORE_EXPORT Image* imageForKey(const ImageContainerContextKey*); // Returns the nullImage() if the image is not available yet.
     WEBCORE_EXPORT Image* imageForRenderer(const RenderObject*); // Returns the nullImage() if the image is not available yet.
-    bool hasImage() const { return m_image.get(); }
-    bool currentFrameKnownToBeOpaque(const RenderElement*);
-    bool currentFrameIsComplete(const RenderElement*);
 
-    std::pair<WeakPtr<Image>, float> brokenImage(float deviceScaleFactor) const; // Returns an image and the image's resolution scale factor.
+    bool hasImage() const { return m_image.get(); }
+
+    bool currentFrameKnownToBeOpaqueForKey(const ImageContainerContextKey&);
+    bool currentFrameKnownToBeOpaqueForRenderer(const RenderObject&);
+
+    bool currentFrameIsCompleteForKey(const ImageContainerContextKey&);
+    bool currentFrameIsCompleteForRenderer(const RenderObject&);
+
+    static std::pair<WeakPtr<Image>, float> brokenImage(float deviceScaleFactor); // Returns an image and the image's resolution scale factor.
     bool NODELETE willPaintBrokenImage() const;
 
     bool canRender(const RenderElement* renderer, float multiplier) { return !errorOccurred() && !imageSizeForRenderer(renderer, multiplier).isEmpty(); }
+    bool canRender(const ImageContainerContextKey& key, const ImageSizeOptions& options) { return !errorOccurred() && !imageSizeForKey(key, options).isEmpty(); }
 
     void setAllowsOrientationOverride(bool b) { m_allowsOrientationOverride = b; }
     bool allowsOrientationOverride() const { return m_allowsOrientationOverride; }
 
-    void setContainerContextForClient(const CachedImageClient&, const LayoutSize&, float, const URL&, const Style::LinkParameters&);
+    void registerContainerContext(const ImageContainerContextKey&, ImageContainerContext&&);
     bool usesImageContainerSize() const { return m_image && m_image->usesContainerSize(); }
     bool imageHasNaturalAspectRatio() const { return m_image && m_image->hasNaturalAspectRatio(); }
     bool imageHasRelativeWidth() const { return m_image && m_image->hasRelativeWidth(); }
@@ -75,14 +84,18 @@ public:
     void updateBuffer(const FragmentedSharedBuffer&) override;
     void finishLoading(const FragmentedSharedBuffer*, const NetworkLoadMetrics&) override;
 
-    enum SizeType {
-        UsedSize,
-        IntrinsicSize
-    };
-    WEBCORE_EXPORT FloatSize imageSizeForRenderer(const RenderElement*) const;
-    // This method takes a zoom multiplier that can be used to increase the natural size of the image by the zoom.
-    LayoutSize imageSizeForRenderer(const RenderElement*, float multiplier, SizeType = UsedSize, float density = 1.0f) const;
-    LayoutSize unclampedImageSizeForRenderer(const RenderElement*, float multiplier, SizeType = UsedSize, float density = 1.0f) const;
+    LayoutSize imageSize(const ImageSizeOptions& = ImageSizeOptions { }) const;
+    LayoutSize imageSizeForKey(const ImageContainerContextKey&, const ImageSizeOptions&) const;
+    LayoutSize imageSizeForRenderer(const RenderElement*, float multiplier = 1.0f, ImageSizeType type = ImageSizeType::Used, float density = 1.0f) const;
+
+    LayoutSize unclampedImageSize(const ImageSizeOptions& = ImageSizeOptions { }) const;
+    LayoutSize unclampedImageSizeForKey(const ImageContainerContextKey&, const ImageSizeOptions&) const;
+    LayoutSize unclampedImageSizeForRenderer(const RenderElement*, float multiplier = 1.0f, ImageSizeType type = ImageSizeType::Used, float density = 1.0f) const;
+
+    WEBCORE_EXPORT FloatSize imageFloatSize(const ImageSizeOptions& = ImageSizeOptions { }) const;
+    WEBCORE_EXPORT FloatSize imageFloatSizeForKey(const ImageContainerContextKey&, const ImageSizeOptions&) const;
+    WEBCORE_EXPORT FloatSize imageFloatSizeForRenderer(const RenderElement*, float multiplier = 1.0f, ImageSizeType type = ImageSizeType::Used, float density = 1.0f) const;
+
     void computeIntrinsicDimensions(float& intrinsicWidth, float& intrinsicHeight, FloatSize& intrinsicRatio);
 
     bool hasHDRContent() const;
@@ -115,7 +128,7 @@ public:
 #endif
 
 private:
-    FloatSize internalImageSizeForRenderer(const RenderElement*, float multiplier, SizeType, float density) const;
+    FloatSize internalImageSize(const ImageContainerContextKey*, const ImageSizeOptions&) const;
 
     void clear();
 
@@ -193,14 +206,7 @@ private:
 
     void didReplaceSharedBufferContents() override;
 
-    struct ContainerContext {
-        LayoutSize containerSize;
-        float containerZoom;
-        URL imageURL;
-        Style::LinkParameters linkParameters { CSS::Keyword::None { } };
-    };
-
-    using ContainerContextRequests = HashMap<SingleThreadWeakRef<const CachedImageClient>, ContainerContext>;
+    using ContainerContextRequests = HashMap<SingleThreadWeakRef<const ImageContainerContextKey>, ImageContainerContext>;
     ContainerContextRequests m_pendingContainerContextRequests;
 
     SingleThreadWeakHashSet<CachedImageClient> m_clientsWaitingForAsyncDecoding;

--- a/Source/WebCore/loader/cache/CachedImageClient.cpp
+++ b/Source/WebCore/loader/cache/CachedImageClient.cpp
@@ -32,7 +32,7 @@ CachedImageClient::CachedImageClient() = default;
 
 VisibleInViewportState CachedImageClient::imageFrameAvailable(CachedImage& image, ImageAnimatingState, const IntRect* changeRect)
 {
-    imageChanged(&image, changeRect);
+    imageChanged(image, changeRect);
     return VisibleInViewportState::No;
 }
 

--- a/Source/WebCore/loader/cache/CachedImageClient.h
+++ b/Source/WebCore/loader/cache/CachedImageClient.h
@@ -24,6 +24,7 @@
 
 #include <WebCore/CachedResourceClient.h>
 #include <WebCore/ImageTypes.h>
+#include <WebCore/VisibleInViewportState.h>
 #include <wtf/CheckedPtr.h>
 
 namespace WebCore {
@@ -31,8 +32,6 @@ namespace WebCore {
 class CachedImage;
 class Document;
 class IntRect;
-
-enum class VisibleInViewportState { Unknown, Yes, No };
 
 class CachedImageClient : public CachedResourceClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(CachedImageClient);
@@ -43,14 +42,14 @@ public:
 
     // Called whenever a frame of an image changes because we got more data from the network.
     // If not null, the IntRect is the changed rect of the image.
-    virtual void imageChanged(CachedImage*, const IntRect* = nullptr) { }
+    virtual void imageChanged(CachedImage&, const IntRect* = nullptr) { }
 
     virtual bool canDestroyDecodedData() const { return true; }
     virtual bool useSystemDarkAppearance() const { return false; }
 
     // Called when a new decoded frame for a large image is available or when an animated image is ready to advance to the next frame.
     WEBCORE_EXPORT virtual VisibleInViewportState imageFrameAvailable(CachedImage&, ImageAnimatingState, const IntRect*);
-    virtual VisibleInViewportState imageVisibleInViewport(const Document&) const { return VisibleInViewportState::No; }
+    virtual VisibleInViewportState imageVisibleInViewport(CachedImage&, const Document&) const { return VisibleInViewportState::No; }
 
     virtual void didRemoveCachedImageClient(CachedImage&) { }
     virtual void imageContentChanged(CachedImage&) { }

--- a/Source/WebCore/loader/cache/VisibleInViewportState.h
+++ b/Source/WebCore/loader/cache/VisibleInViewportState.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
  * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,43 +26,8 @@
 
 #pragma once
 
-#include "StyleCustomIdent.h"
-#include "StyleGeneratedImage.h"
-
 namespace WebCore {
-namespace Style {
 
-class NamedImage final : public GeneratedImage {
-public:
-    static Ref<NamedImage> create(CustomIdent&& name)
-    {
-        return adoptRef(*new NamedImage(WTF::move(name)));
-    }
-    virtual ~NamedImage();
+enum class VisibleInViewportState : uint8_t { Unknown, Yes, No };
 
-    bool operator==(const Image&) const final;
-    bool NODELETE equals(const NamedImage&) const;
-
-    static constexpr bool isFixedSize = false;
-
-private:
-    explicit NamedImage(CustomIdent&&);
-
-    Ref<CSSValue> computedStyleValue(const Style::ComputedStyle&) const final;
-    Ref<DeprecatedCSSOMValue> computedStyleDeprecatedCSSOMValue(CSSValuePool&, const Style::ComputedStyle&, CSSStyleDeclaration&) const final;
-    bool isPending() const final;
-    void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<WebCore::Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
-    bool knownToBeOpaque(const RenderElement&) const final;
-    FloatSize fixedSize(const RenderElement&) const final;
-    void didAddClient(ImageClient&) final { }
-    void didRemoveClient(ImageClient&) final { }
-
-    CustomIdent m_name;
-};
-
-} // namespace Style
 } // namespace WebCore
-
-SPECIALIZE_TYPE_TRAITS_STYLE_IMAGE(NamedImage, isNamedImage)
-

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1752,7 +1752,7 @@ std::optional<Cursor> EventHandler::selectCursor(const HitTestResult& result, bo
                     float deviceScale = page ? page->deviceScaleFactor() : 1.0f;
 
                     FloatSize scaledSize = image->size() * deviceScale;
-                    styleImage->setContainerContextForRenderer(*renderElement, scaledSize, deviceScale);
+                    styleImage->registerContainerContext(renderElement->imageContainerContextKey(), renderElement->imageContainerContext(scaledSize, deviceScale));
 
                     renderer = renderElement;
                     scale *= deviceScale;

--- a/Source/WebCore/page/LargestContentfulPaintData.cpp
+++ b/Source/WebCore/page/LargestContentfulPaintData.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "LargestContentfulPaintData.h"
 
-#include "CachedImage.h"
 #include "ContainerNodeInlines.h"
 #include "DocumentView.h"
 #include "ElementInlines.h"
@@ -50,6 +49,7 @@
 #include "RenderSVGImage.h"
 #include "RenderText.h"
 #include "RenderView.h"
+#include "StyleImage.h"
 #include "VisibleRectContext.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Ref.h>
@@ -109,7 +109,7 @@ bool LargestContentfulPaintData::canCompareWithLargestPaintArea(const Element& e
 }
 
 // https://w3c.github.io/largest-contentful-paint/#sec-effective-visual-size
-std::optional<float> LargestContentfulPaintData::effectiveVisualArea(const Element& element, CachedImage* image, FloatRect imageLocalRect, FloatRect intersectionRect, FloatSize viewportSize)
+std::optional<float> LargestContentfulPaintData::effectiveVisualArea(const Element& element, const Style::Image* image, FloatRect imageLocalRect, FloatRect intersectionRect, FloatSize viewportSize)
 {
     RefPtr frameView = element.document().view();
     if (!frameView)
@@ -129,7 +129,7 @@ std::optional<float> LargestContentfulPaintData::effectiveVisualArea(const Eleme
         auto intersectingContentRect = intersection(absoluteContentRect, intersectionRect);
         area = intersectingContentRect.area();
 
-        auto naturalSize = image->imageSizeForRenderer(renderer.get(), 1);
+        auto naturalSize = image->imageSize(renderer.get(), 1);
         if (naturalSize.isEmpty())
             return { };
 
@@ -144,7 +144,7 @@ std::optional<float> LargestContentfulPaintData::effectiveVisualArea(const Eleme
 }
 
 // https://w3c.github.io/largest-contentful-paint/#sec-add-lcp-entry
-void LargestContentfulPaintData::potentiallyAddLargestContentfulPaintEntry(Element& element, CachedImage* image, FloatRect imageLocalRect, FloatRect intersectionRect, MonotonicTime loadTime, DOMHighResTimeStamp paintTimestamp, std::optional<FloatSize>& viewportSize)
+void LargestContentfulPaintData::potentiallyAddLargestContentfulPaintEntry(Element& element, const Style::Image* image, FloatRect imageLocalRect, FloatRect intersectionRect, MonotonicTime loadTime, DOMHighResTimeStamp paintTimestamp, std::optional<FloatSize>& viewportSize)
 {
     if (!image) {
         // For text we have to accumulate rectangles for a single element from possibly multiple text boxes, so we can only mark an element as being in the content set after all the painting is done.
@@ -152,7 +152,7 @@ void LargestContentfulPaintData::potentiallyAddLargestContentfulPaintEntry(Eleme
         element.setInLargestContentfulPaintTextContentSet();
     }
 
-    LOG_WITH_STREAM(LargestContentfulPaint, stream << "LargestContentfulPaintData " << this << " potentiallyAddLargestContentfulPaintEntry() " << element << " image " << (image ? image->url().string() : emptyString()) << " rect " << intersectionRect);
+    LOG_WITH_STREAM(LargestContentfulPaint, stream << "LargestContentfulPaintData " << this << " potentiallyAddLargestContentfulPaintEntry() " << element << " image " << (image ? image->url().resolved.string() : emptyString()) << " rect " << intersectionRect);
 
     if (intersectionRect.isEmpty())
         return;
@@ -195,7 +195,7 @@ void LargestContentfulPaintData::potentiallyAddLargestContentfulPaintEntry(Eleme
     pendingEntry->setSize(std::round<unsigned>(m_largestPaintArea));
 
     if (image) {
-        pendingEntry->setURLString(image->url().string());
+        pendingEntry->setURLString(image->url().resolved.string());
         auto loadTimestamp = protect(window->performance())->relativeTimeFromTimeOriginInReducedResolution(loadTime);
         pendingEntry->setLoadTime(loadTimestamp);
 
@@ -213,7 +213,7 @@ void LargestContentfulPaintData::potentiallyAddLargestContentfulPaintEntry(Eleme
     if (element.hasID())
         pendingEntry->setID(element.getIdAttribute().string());
 
-    LOG_WITH_STREAM(LargestContentfulPaint, stream << " making new entry for " << element << " image " << (image ? image->url().string() : emptyString()) << " id " << pendingEntry->id() <<
+    LOG_WITH_STREAM(LargestContentfulPaint, stream << " making new entry for " << element << " image " << (image ? image->url().resolved.string() : emptyString()) << " id " << pendingEntry->id() <<
         ": entry size " << pendingEntry->size() << ", loadTime " << pendingEntry->loadTime() << ", renderTime " << pendingEntry->renderTime());
 
     m_pendingEntry = RefPtr { WTF::move(pendingEntry) };
@@ -341,16 +341,16 @@ FloatRect LargestContentfulPaintData::computeViewportIntersectionRectForTextCont
     return intersectionRect;
 }
 
-void LargestContentfulPaintData::didLoadImage(Element& element, CachedImage* image)
+void LargestContentfulPaintData::didLoadImage(Element& element, const Style::Image* image)
 {
     if (!image)
         return;
 
     // `loadTime` isn't interesting for a data URI, so let's avoid the overhead of tracking it.
-    if (image->url().protocolIsData())
+    if (image->url().resolved.protocolIsData())
         return;
 
-    LOG_WITH_STREAM(LargestContentfulPaint, stream << "LargestContentfulPaintData " << this << " didLoadImage() " << element << " image " << (image ? image->url().string() : emptyString()));
+    LOG_WITH_STREAM(LargestContentfulPaint, stream << "LargestContentfulPaintData " << this << " didLoadImage() " << element << " image " << image->url().resolved.string());
 
     auto& lcpData = element.ensureLargestContentfulPaintData();
     auto findIndex = lcpData.imageData.findIf([&](auto& value) {
@@ -371,9 +371,9 @@ void LargestContentfulPaintData::didLoadImage(Element& element, CachedImage* ima
         lcpData.imageData[findIndex].loadTime = now;
 }
 
-void LargestContentfulPaintData::didPaintImage(Element& element, CachedImage* image, FloatRect localRect)
+void LargestContentfulPaintData::didPaintImage(Element& element, const Style::Image* image, FloatRect localRect)
 {
-    LOG_WITH_STREAM(LargestContentfulPaint, stream << "LargestContentfulPaintData " << this << " didPaintImage() " << element << " image " << (image ? image->url().string() : emptyString()) << " localRect " << localRect);
+    LOG_WITH_STREAM(LargestContentfulPaint, stream << "LargestContentfulPaintData " << this << " didPaintImage() " << element << " image " << (image ? image->url().resolved.string() : emptyString()) << " localRect " << localRect);
 
     if (!image)
         return;
@@ -411,7 +411,7 @@ void LargestContentfulPaintData::didPaintImage(Element& element, CachedImage* im
         imageData.rect = localRect;
 
     m_pendingImageRecords.ensure(element, [] {
-        return Vector<WeakPtr<CachedImage>> { };
+        return Vector<WeakPtr<const Style::Image>> { };
     }).iterator->value.append(*image);
 
     scheduleRenderingUpdateIfNecessary(element);

--- a/Source/WebCore/page/LargestContentfulPaintData.h
+++ b/Source/WebCore/page/LargestContentfulPaintData.h
@@ -34,7 +34,10 @@
 
 namespace WebCore {
 
-class CachedImage;
+namespace Style {
+class Image;
+}
+
 class Element;
 class HTMLImageElement;
 class LargestContentfulPaint;
@@ -46,7 +49,7 @@ class WeakPtrImplWithEventTargetData;
 using DOMHighResTimeStamp = double;
 
 struct PerElementImageData {
-    WeakPtr<CachedImage> image;
+    WeakPtr<const Style::Image> image;
     FloatRect rect;
     Markable<MonotonicTime> loadTime;
     bool inContentSet { false };
@@ -64,8 +67,8 @@ public:
     LargestContentfulPaintData();
     ~LargestContentfulPaintData();
 
-    void didLoadImage(Element&, CachedImage*);
-    void didPaintImage(Element&, CachedImage*, FloatRect localRect);
+    void didLoadImage(Element&, const Style::Image*);
+    void didPaintImage(Element&, const Style::Image*, FloatRect localRect);
     void didPaintText(const RenderBlockFlow& formattingContextRoot, FloatRect localRect, bool isOnlyTextBoxForElement);
 
     RefPtr<LargestContentfulPaint> generateLargestContentfulPaintEntry(DOMHighResTimeStamp);
@@ -74,7 +77,7 @@ public:
 
 private:
 
-    static std::optional<float> effectiveVisualArea(const Element&, CachedImage*, FloatRect imageLocalRect, FloatRect intersectionRect, FloatSize viewportSize);
+    static std::optional<float> effectiveVisualArea(const Element&, const Style::Image*, FloatRect imageLocalRect, FloatRect intersectionRect, FloatSize viewportSize);
 
     static FloatRect computeViewportIntersectionRect(Element&, FloatRect localRect);
     static FloatRect computeViewportIntersectionRectForTextContainer(Element&, const WeakHashSet<Text, WeakPtrImplWithEventTargetData>&);
@@ -82,14 +85,14 @@ private:
     static bool NODELETE isEligibleForLargestContentfulPaint(const Element&, float effectiveVisualArea);
     static bool NODELETE canCompareWithLargestPaintArea(const Element&);
 
-    void potentiallyAddLargestContentfulPaintEntry(Element&, CachedImage*, FloatRect imageLocalRect, FloatRect intersectionRect, MonotonicTime loadTime, DOMHighResTimeStamp paintTimestamp, std::optional<FloatSize>& viewportSize);
+    void potentiallyAddLargestContentfulPaintEntry(Element&, const Style::Image*, FloatRect imageLocalRect, FloatRect intersectionRect, MonotonicTime loadTime, DOMHighResTimeStamp paintTimestamp, std::optional<FloatSize>& viewportSize);
 
     void scheduleRenderingUpdateIfNecessary(Element&);
 
     float m_largestPaintArea { 0 };
 
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_paintedTextRecords;
-    WeakHashMap<Element, Vector<WeakPtr<CachedImage>>, WeakPtrImplWithEventTargetData> m_pendingImageRecords;
+    WeakHashMap<Element, Vector<WeakPtr<const Style::Image>>, WeakPtrImplWithEventTargetData> m_pendingImageRecords;
 
     RefPtr<LargestContentfulPaint> m_pendingEntry;
     bool m_haveNewCandidate { false };

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -251,8 +251,8 @@ template<typename Layer> void BackgroundPainter::paintFillLayerImpl(const Color&
     }
 
     if (context.invalidatingImagesWithAsyncDecodes()) {
-        if (shouldPaintBackgroundImage && bgImage->cachedImage()->isClientWaitingForAsyncDecoding(m_renderer.cachedImageClient()))
-            protect(bgImage->cachedImage())->removeAllClientsWaitingForAsyncDecoding();
+        if (shouldPaintBackgroundImage && bgImage->isClientWaitingForAsyncDecoding(m_renderer.styleImageClient()))
+            bgImage->removeAllClientsWaitingForAsyncDecoding();
         return;
     }
 
@@ -536,7 +536,8 @@ template<typename Layer> void BackgroundPainter::paintFillLayerImpl(const Color&
         auto geometry = calculateFillLayerImageGeometry(m_renderer, m_paintInfo.paintContainer, layer.layer, layer.zoom, paintOffset, imageRect, m_overrideOrigin);
 
         auto& clientForBackgroundImage = backgroundObject ? *backgroundObject : m_renderer;
-        bgImage->setContainerContextForRenderer(clientForBackgroundImage, geometry.tileSizeWithoutPixelSnapping, m_renderer.style().usedZoom());
+
+        bgImage->registerContainerContext(clientForBackgroundImage.imageContainerContextKey(), clientForBackgroundImage.imageContainerContext(geometry.tileSizeWithoutPixelSnapping, m_renderer.style().usedZoom()));
 
         geometry.clip(LayoutRect(pixelSnappedRect));
         RefPtr<Image> image;
@@ -576,16 +577,16 @@ template<typename Layer> void BackgroundPainter::paintFillLayerImpl(const Color&
             auto drawResult = context.drawTiledImage(*imageToDraw, geometry.destinationRect, toLayoutPoint(geometry.relativePhase()), geometry.tileSize, geometry.spaceSize, options);
             if (drawResult == ImageDrawResult::DidRequestDecoding) {
                 ASSERT(bgImage->hasCachedImage());
-                protect(bgImage->cachedImage())->addClientWaitingForAsyncDecoding(protect(m_renderer)->cachedImageClient());
+                bgImage->addClientWaitingForAsyncDecoding(protect(m_renderer)->styleImageClient());
             }
 
             if (!context.paintingDisabled()) {
                 if (m_renderer.element())
                     protect(m_renderer)->element()->setHasEverPaintedImages(true);
 
-                if (RefPtr image = bgImage->cachedImage(); image && image->currentFrameIsComplete(&m_renderer)) {
+                if (bgImage->currentFrameIsComplete(m_renderer)) {
                     if (auto styleable = Styleable::fromRenderer(m_renderer))
-                        document().didPaintImage(protect(styleable->element), image, geometry.destinationRect);
+                        document().didPaintImage(protect(styleable->element), bgImage, geometry.destinationRect);
                 }
             }
         }

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -458,7 +458,7 @@ bool BorderPainter::paintNinePieceImageImpl(const LayoutRect& rect, const Style:
     auto source = modelObject->calculateImageIntrinsicDimensions(image.get(), destination.size(), RenderBoxModelObject::ScaleByUsedZoom::No);
 
     // If both values are ‘auto’ then the intrinsic width and/or height of the image should be used, if any.
-    image->setContainerContextForRenderer(m_renderer, source, style.usedZoom());
+    image->registerContainerContext(m_renderer->imageContainerContextKey(), m_renderer->imageContainerContext(source, style.usedZoom()));
 
     NinePieceImagePainter::paint(ninePieceImage, m_paintInfo.context(), m_renderer.ptr(), style, destination, source, deviceScaleFactor, options);
     return true;

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2219,22 +2219,22 @@ LayoutRect RenderBox::maskClipRect(const LayoutPoint& paintOffset)
     return result;
 }
 
-void RenderBox::imageChanged(WrappedImagePtr image, const IntRect*)
+void RenderBox::imageChanged(const Style::Image& image, const IntRect*)
 {
-    if (RefPtr source = style().borderImageSource().tryStyleImage(); source && source->data() == image) {
+    if (RefPtr source = style().borderImageSource().tryStyleImage(); source && source->isOrContains(image)) {
         if (parent())
             repaint();
         return;
     }
 
-    if (RefPtr source = style().maskBorderSource().tryStyleImage(); source && source->data() == image) {
+    if (RefPtr source = style().maskBorderSource().tryStyleImage(); source && source->isOrContains(image)) {
         if (parent())
             repaint();
         return;
     }
 
     if (!view().frameView().layoutContext().isInRenderTreeLayout() && isFloating()) {
-        if (RefPtr shapeOutsideImage = style().shapeOutside().image(); shapeOutsideImage && shapeOutsideImage->data() == image) {
+        if (RefPtr shapeOutsideImage = style().shapeOutside().tryStyleImage(); shapeOutsideImage && shapeOutsideImage->isOrContains(image)) {
             ensureShapeOutsideInfo().markShapeAsDirty();
             markShapeOutsideDependentsForLayout();
         }
@@ -2262,7 +2262,7 @@ void RenderBox::imageChanged(WrappedImagePtr image, const IntRect*)
     if (styleImage && isNonEmpty) {
         incrementVisuallyNonEmptyPixelCountIfNeeded(flooredIntSize(styleImage->imageSize(this, style().usedZoom())));
         if (auto styleable = Styleable::fromRenderer(*this))
-            protect(document())->didLoadImage(protect(styleable->element).get(), protect(styleImage->cachedImage()));
+            protect(document())->didLoadImage(protect(styleable->element).get(), styleImage);
     }
 
     if (!isComposited())
@@ -2285,13 +2285,13 @@ void RenderBox::incrementVisuallyNonEmptyPixelCountIfNeeded(const IntSize& size)
 }
 
 template<typename Layers>
-bool RenderBox::repaintLayerRectsForImage(WrappedImagePtr image, const Layers& layers, Style::ZoomFactor zoom, bool drawingBackground)
+bool RenderBox::repaintLayerRectsForImage(const Style::Image& image, const Layers& layers, Style::ZoomFactor zoom, bool drawingBackground)
 {
     LayoutRect rendererRect;
     RenderBox* layerRenderer = nullptr;
 
     for (auto& layer : layers.usedValues()) {
-        if (RefPtr layerImage = layer.image().tryStyleImage(); layerImage && layerImage->data() == image && (layerImage->isLoaded(this) || layerImage->canRender(this, style().usedZoom()))) {
+        if (RefPtr layerImage = layer.image().tryStyleImage(); layerImage && layerImage->isOrContains(image) && (layerImage->isLoaded(this) || layerImage->canRender(this, style().usedZoom()))) {
             // Now that we know this image is being used, compute the renderer and the rect if we haven't already.
             bool drawingRootBackground = drawingBackground && (isDocumentElementRenderer() || (isBody() && !document().documentElement()->renderer()->hasBackground()));
             if (!layerRenderer) {

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -483,7 +483,7 @@ public:
     virtual void paintBoxDecorations(PaintInfo&, const LayoutPoint&);
     virtual void paintMask(PaintInfo&, const LayoutPoint&);
     virtual void paintClippingMask(PaintInfo&, const LayoutPoint&);
-    void imageChanged(WrappedImagePtr, const IntRect* = nullptr) override;
+    void imageChanged(const Style::Image&, const IntRect* = nullptr) override;
 
     virtual void adjustBorderBoxRectForPainting(LayoutRect&) { };
 
@@ -688,7 +688,7 @@ private:
     bool isScrollableOrRubberbandableBox() const override;
 
     // Returns true if we did a full repaint.
-    template<typename Layers> bool repaintLayerRectsForImage(WrappedImagePtr, const Layers&, Style::ZoomFactor, bool drawingBackground);
+    template<typename Layers> bool repaintLayerRectsForImage(const Style::Image&, const Layers&, Style::ZoomFactor, bool drawingBackground);
 
     void computeOutOfFlowPositionedLogicalHeight(LogicalExtentComputedValues&) const;
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -104,8 +104,10 @@
 #include "ScrollAnchoringController.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
+#include "StyleCachedImage.h"
 #include "StyleComputedStyle+SettersInlines.h"
 #include "StyleDifference.h"
+#include "StyleImageContainerContext.h"
 #include "StylePendingResources.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StyleResolver.h"
@@ -439,7 +441,7 @@ template<typename FillLayers> void RenderElement::updateFillImages(const FillLay
         if (!newLayers)
             return true;
         for (auto& layer : newLayers->usedValues()) {
-            if (RefPtr image = layer.image().tryStyleImage(); image && !image->hasClient(*this))
+            if (RefPtr image = layer.image().tryStyleImage(); image && !image->hasClient(this->styleImageClient()))
                 return false;
         }
         return true;
@@ -454,13 +456,13 @@ template<typename FillLayers> void RenderElement::updateFillImages(const FillLay
     if (newLayers) {
         for (auto& layer : newLayers->usedValues()) {
             if (RefPtr image = layer.image().tryStyleImage())
-                image->addClient(*this);
+                image->addClient(this->styleImageClient());
         }
     }
     if (oldLayers) {
         for (auto& layer : oldLayers->usedValues()) {
             if (RefPtr image = layer.image().tryStyleImage())
-                image->removeClient(*this);
+                image->removeClient(this->styleImageClient());
         }
     }
 }
@@ -470,15 +472,15 @@ void RenderElement::updateImage(Style::Image* oldImage, Style::Image* newImage)
     if (oldImage == newImage)
         return;
     if (oldImage)
-        oldImage->removeClient(*this);
+        oldImage->removeClient(this->styleImageClient());
     if (newImage)
-        newImage->addClient(*this);
+        newImage->addClient(this->styleImageClient());
 }
 
 void RenderElement::updateShapeImage(const Style::ShapeOutside* oldShapeValue, const Style::ShapeOutside* newShapeValue)
 {
     if (oldShapeValue || newShapeValue)
-        updateImage(oldShapeValue ? oldShapeValue->image().get() : nullptr, newShapeValue ? newShapeValue->image().get() : nullptr);
+        updateImage(oldShapeValue ? oldShapeValue->tryStyleImage().get() : nullptr, newShapeValue ? newShapeValue->tryStyleImage().get() : nullptr);
 }
 
 bool RenderElement::repaintBeforeStyleChange(Style::Difference diff, const Style::ComputedStyle& oldStyle, const Style::ComputedStyle& newStyle)
@@ -1331,7 +1333,7 @@ void RenderElement::willBeDestroyed()
 
     auto unregisterImage = [this](auto* image) {
         if (image)
-            image->removeClient(*this);
+            image->removeClient(this->styleImageClient());
     };
 
     auto unregisterImages = [&](auto& style) {
@@ -1341,7 +1343,7 @@ void RenderElement::willBeDestroyed()
             unregisterImage(maskLayer.image().tryStyleImage().get());
         unregisterImage(style.borderImageSource().tryStyleImage().get());
         unregisterImage(style.maskBorderSource().tryStyleImage().get());
-        unregisterImage(style.shapeOutside().image().get());
+        unregisterImage(style.shapeOutside().tryStyleImage().get());
     };
 
     if (hasInitializedStyle()) {
@@ -1842,24 +1844,24 @@ bool RenderElement::isVisibleInViewport() const
     return isVisibleInDocumentRect(visibleRect);
 }
 
-bool RenderElement::useSystemDarkAppearance() const
+bool RenderElement::useSystemDarkAppearance(const Style::CachedImage&) const
 {
     if (RefPtr page = document().page())
         return page->useDarkAppearance();
     return false;
 }
 
-VisibleInViewportState RenderElement::imageFrameAvailable(CachedImage& image, ImageAnimatingState animatingState, const IntRect* changeRect)
+VisibleInViewportState RenderElement::imageFrameAvailable(const Style::CachedImage& image, ImageAnimatingState animatingState, const IntRect* changeRect)
 {
     bool isVisible = isVisibleInViewport();
 
-    if (!isVisible && animatingState == ImageAnimatingState::Yes)
-        protect(view())->addRendererWithPausedImageAnimations(*this, image);
+    if (!isVisible && animatingState == ImageAnimatingState::Yes && image.cachedImage())
+        protect(view())->addRendererWithPausedImageAnimations(*this, protect(*image.cachedImage()));
 
     // Static images should repaint even if they are outside the viewport rectangle
     // because they should be inside the TileCoverageRect.
     if (isVisible || animatingState == ImageAnimatingState::No)
-        imageChanged(&image, changeRect);
+        imageChanged(image, changeRect);
 
     if (element() && protect(image)->image()->isBitmapImage())
         protect(element())->dispatchWebKitImageReadyEventForTesting();
@@ -1867,7 +1869,7 @@ VisibleInViewportState RenderElement::imageFrameAvailable(CachedImage& image, Im
     return isVisible ? VisibleInViewportState::Yes : VisibleInViewportState::No;
 }
 
-VisibleInViewportState RenderElement::imageVisibleInViewport(const Document& document) const
+VisibleInViewportState RenderElement::imageVisibleInViewport(const Style::CachedImage&, const Document& document) const
 {
     if (&this->document() != &document)
         return VisibleInViewportState::No;
@@ -1875,28 +1877,21 @@ VisibleInViewportState RenderElement::imageVisibleInViewport(const Document& doc
     return isVisibleInViewport() ? VisibleInViewportState::Yes : VisibleInViewportState::No;
 }
 
-void RenderElement::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
+void RenderElement::notifyFinished(const Style::CachedImage& newImage)
 {
-    if (auto* cachedImage = dynamicDowncast<CachedImage>(resource))
-        imageContentChanged(*cachedImage);
+    imageContentChanged(newImage);
 
-    protect(protect(document())->cachedResourceLoader())->notifyFinished(resource);
+    if (newImage.cachedImage())
+        protect(protect(document())->cachedResourceLoader())->notifyFinished(protect(*newImage.cachedImage()));
 }
 
-bool RenderElement::allowsAnimation() const
+void RenderElement::didRemoveCachedImageClient(const Style::CachedImage& cachedImage)
 {
-    if (RefPtr imageElement = dynamicDowncast<HTMLImageElement>(element()))
-        return imageElement->allowsAnimation();
-    return page().imageAnimationEnabled();
+    if (hasPausedImageAnimations() && cachedImage.cachedImage())
+        protect(view())->removeRendererWithPausedImageAnimations(*this, protect(*cachedImage.cachedImage()));
 }
 
-void RenderElement::didRemoveCachedImageClient(CachedImage& cachedImage)
-{
-    if (hasPausedImageAnimations())
-        protect(view())->removeRendererWithPausedImageAnimations(*this, cachedImage);
-}
-
-void RenderElement::imageContentChanged(CachedImage& cachedImage)
+void RenderElement::imageContentChanged(const Style::CachedImage& cachedImage)
 {
 #if HAVE(SUPPORT_HDR_DISPLAY)
     if (!document().hasHDRContent()) {
@@ -1921,10 +1916,17 @@ void RenderElement::imageContentChanged(CachedImage& cachedImage)
 #endif
 }
 
-void RenderElement::scheduleRenderingUpdateForImage(CachedImage&)
+void RenderElement::scheduleRenderingUpdateForImage(const Style::CachedImage&)
 {
     if (RefPtr page = document().page())
         page->scheduleRenderingUpdate(RenderingUpdateStep::Images);
+}
+
+bool RenderElement::allowsAnimation() const
+{
+    if (RefPtr imageElement = dynamicDowncast<HTMLImageElement>(element()))
+        return imageElement->allowsAnimation();
+    return page().imageAnimationEnabled();
 }
 
 bool RenderElement::repaintForPausedImageAnimationsIfNeeded(const IntRect& visibleRect, CachedImage& cachedImage)
@@ -2902,4 +2904,33 @@ void RenderElement::layoutIfNeeded()
         Style::AnchorPositionEvaluator::captureScrollSnapshots(downcast<RenderBox>(*this));
 }
 
+ImageContainerContext RenderElement::imageContainerContext(const FloatSize& containerSize, float containerZoom, const WTF::URL& imageURL) const
+{
+    return ImageContainerContext {
+        .containerSize = containerSize,
+        .containerZoom = containerZoom,
+        .imageURL = imageURL,
+        .linkParameters = style().linkParameters(),
+    };
 }
+
+ImageSizeOptions RenderElement::imageSizeOptions(float multiplier, ImageSizeType type, float density) const
+{
+    auto computedOverrideImageSize = [&] -> std::optional<FloatSize> {
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+        if (CheckedPtr renderImage = dynamicDowncast<RenderImage>(*this); renderImage && renderImage->isMultiRepresentationHEIC())
+            return renderImage->style().fontCascade().primaryFont().metricsForMultiRepresentationHEIC().size();
+#endif
+        return std::nullopt;
+    };
+
+    return ImageSizeOptions {
+        .multiplier = multiplier,
+        .type = type,
+        .density = density,
+        .orientation = imageOrientation(),
+        .overrideImageSize = computedOverrideImageSize(),
+    };
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -28,12 +28,15 @@
 #include <WebCore/RenderPtr.h>
 #include <WebCore/StyleComputedStyle.h>
 #include <WebCore/StyleDifference.h>
+#include <WebCore/StyleImageSizeOptions.h>
+#include <WebCore/VisibleInViewportState.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Packed.h>
 
 namespace WebCore {
 
+class CachedImage;
 class ContainerNode;
 class BlendingKeyframes;
 class GraphicsLayerAnimation;
@@ -41,6 +44,7 @@ class ReferencedSVGResources;
 class RenderBlock;
 class RenderTreeBuilder;
 class SVGElement;
+struct ImageContainerContext;
 struct ImageOrientation;
 
 struct MarginRect {
@@ -246,7 +250,7 @@ public:
     bool scrollAnchoringSuppressionStyleChanged() const { return m_scrollAnchoringSuppressionStyleChanged; }
     void setScrollAnchoringSuppressionStyleChanged(bool b) { m_scrollAnchoringSuppressionStyleChanged = b; }
 
-    bool allowsAnimation() const final;
+    bool allowsAnimation() const;
     bool repaintForPausedImageAnimationsIfNeeded(const IntRect& visibleRect, CachedImage&);
     bool hasPausedImageAnimations() const { return m_hasPausedImageAnimations; }
     void setHasPausedImageAnimations(bool b) { m_hasPausedImageAnimations = b; }
@@ -357,6 +361,9 @@ public:
 
     bool addReferencedSVGResourceIfNeeded(SVGElement&, const AtomString&);
 
+    ImageContainerContext imageContainerContext(const FloatSize& containerSize, float containerZoom, const WTF::URL& url = WTF::URL()) const;
+    ImageSizeOptions imageSizeOptions(float multiplier = 1.0f, ImageSizeType = ImageSizeType::Used, float density = 1.0f) const;
+
 protected:
     RenderElement(Type, Element&, Style::ComputedStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);
     RenderElement(Type, Document&, Style::ComputedStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);
@@ -379,7 +386,7 @@ protected:
     void insertedIntoTree() override;
     void willBeRemovedFromTree() override;
     void willBeDestroyed() override;
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) override;
+    void notifyFinished(const Style::CachedImage&) override;
 
     void pushOntoGeometryMap(RenderGeometryMap&, const RenderLayerModelObject* repaintContainer, RenderElement* container, bool containerSkipped) const;
 
@@ -433,13 +440,14 @@ private:
 
     Style::Difference adjustStyleDifference(Style::Difference) const;
 
-    bool canDestroyDecodedData() const final { return !isVisibleInViewport(); }
-    bool useSystemDarkAppearance() const final;
-    VisibleInViewportState imageFrameAvailable(CachedImage&, ImageAnimatingState, const IntRect* changeRect) final;
-    VisibleInViewportState imageVisibleInViewport(const Document&) const final;
-    void didRemoveCachedImageClient(CachedImage&) final;
-    void imageContentChanged(CachedImage&) final;
-    void scheduleRenderingUpdateForImage(CachedImage&) final;
+    bool allowsAnimation(const Style::CachedImage&) const final { return allowsAnimation(); }
+    bool canDestroyDecodedData(const Style::CachedImage&) const final { return !isVisibleInViewport(); }
+    bool useSystemDarkAppearance(const Style::CachedImage&) const final;
+    VisibleInViewportState imageFrameAvailable(const Style::CachedImage&, ImageAnimatingState, const IntRect* changeRect) final;
+    VisibleInViewportState imageVisibleInViewport(const Style::CachedImage&, const Document&) const final;
+    void didRemoveCachedImageClient(const Style::CachedImage&) final;
+    void imageContentChanged(const Style::CachedImage&) final;
+    void scheduleRenderingUpdateForImage(const Style::CachedImage&) final;
 
     bool getLeadingCorner(FloatPoint& output, bool& insideFixed) const;
     bool getTrailingCorner(FloatPoint& output, bool& insideFixed) const;

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -69,6 +69,7 @@
 #include "SVGSVGElement.h"
 #include "SelectionGeometry.h"
 #include "Settings.h"
+#include "StyleCachedImage.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StyleComputedStyle+InitialInlines.h"
 #include "TextPainter.h"
@@ -308,7 +309,7 @@ LayoutUnit RenderImage::computeReplacedLogicalHeight(std::optional<LayoutUnit> e
     return RenderReplaced::computeReplacedLogicalHeight(estimatedUsedWidth);
 }
 
-void RenderImage::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
+void RenderImage::imageChanged(const Style::Image& newImage, const IntRect* rect)
 {
     if (renderTreeBeingDestroyed())
         return;
@@ -327,7 +328,7 @@ void RenderImage::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
         setNeedsLayout();
     }
 
-    if (newImage != imageResource().imagePtr() || !newImage)
+    if (!imageResource().isOrContains(newImage))
         return;
 
     // At a zoom level of 1 the image is guaranteed to have an integer size.
@@ -351,15 +352,25 @@ void RenderImage::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
     if (CheckedPtr cache = protect(document())->existingAXObjectCache())
         cache->deferRecomputeIsIgnoredIfNeeded(protect(element()));
 
-    if (RefPtr image = cachedImage(); image && image->currentFrameIsComplete(this)) {
+    if (RefPtr styleImage = imageResource().styleImage(); styleImage && styleImage->currentFrameIsComplete(*this)) {
         if (auto styleable = Styleable::fromRenderer(*this))
-            protect(document())->didLoadImage(protect(styleable->element).get(), image);
+            protect(document())->didLoadImage(protect(styleable->element).get(), styleImage);
     }
+}
+
+void RenderImage::intrinsicSizeChanged()
+{
+    if (RefPtr styleImage = imageResource().styleImage())
+        imageChanged(*styleImage);
+
+    // FIXME: Implement no style image case..
+    // else
+    //    oof();
 }
 
 void RenderImage::updateIntrinsicSizeIfNeeded(const LayoutSize& newSize)
 {
-    if (imageResource().errorOccurred() || !m_imageResource->cachedImage())
+    if (imageResource().errorOccurred() || !imageResource().styleImage())
         return;
     setIntrinsicSize(newSize);
 }
@@ -375,7 +386,7 @@ void RenderImage::updateInnerContentRect()
         URL imageSourceURL;
         if (RefPtr imageElement = dynamicDowncast<HTMLImageElement>(element()))
             imageSourceURL = imageElement->currentURL();
-        imageResource().setContainerContext(containerSize, imageSourceURL);
+        imageResource().registerContainerContext(containerSize, imageSourceURL);
     }
 }
 
@@ -404,7 +415,7 @@ void RenderImage::repaintOrMarkForLayout(ImageSizeChangeType imageSizeChange, co
         // may need values from the containing block, though, so make sure that we're not too
         // early. It may be that layout hasn't even taken place once yet.
 
-        // FIXME: we should not have to trigger another call to setContainerContextForRenderer()
+        // FIXME: we should not have to trigger another call to registerContainerContext()
         // from here, since it's already being done during layout.
         updateInnerContentRect();
     }
@@ -426,14 +437,14 @@ void RenderImage::repaintOrMarkForLayout(ImageSizeChangeType imageSizeChange, co
     contentChanged(ContentChangeType::Image);
 }
 
-void RenderImage::notifyFinished(CachedResource& newImage, const NetworkLoadMetrics& metrics, LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
+void RenderImage::notifyFinished(const Style::CachedImage& newImage)
 {
     if (renderTreeBeingDestroyed())
         return;
 
     invalidateBackgroundObscurationStatus();
 
-    if (&newImage == cachedImage()) {
+    if (imageResource().isOrContains(newImage)) {
         // tell any potential compositing layers
         // that the image is done and they can reference it directly.
         contentChanged(ContentChangeType::Image);
@@ -442,7 +453,7 @@ void RenderImage::notifyFinished(CachedResource& newImage, const NetworkLoadMetr
     if (RefPtr image = dynamicDowncast<HTMLImageElement>(element()))
         protect(page())->didFinishLoadingImageForElement(*image);
 
-    RenderReplaced::notifyFinished(newImage, metrics, loadWillContinueInAnotherProcess);
+    RenderReplaced::notifyFinished(newImage);
 }
 
 void RenderImage::setImageDevicePixelRatio(float factor)
@@ -659,8 +670,8 @@ void RenderImage::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
 
     GraphicsContext& context = paintInfo.context();
     if (context.invalidatingImagesWithAsyncDecodes()) {
-        if (cachedImage() && cachedImage()->isClientWaitingForAsyncDecoding(cachedImageClient()))
-            protect(cachedImage())->removeAllClientsWaitingForAsyncDecoding();
+        if (RefPtr styleImage = imageResource().styleImage(); styleImage && styleImage->isClientWaitingForAsyncDecoding(styleImageClient()))
+            styleImage->removeAllClientsWaitingForAsyncDecoding();
         return;
     }
 
@@ -672,7 +683,7 @@ void RenderImage::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
         return;
 
     if (context.detectingContentfulPaint()) {
-        if (!context.contentfulPaintDetected() && cachedImage() && protect(cachedImage())->canRender(this, deviceScaleFactor) && !contentBoxRect.isEmpty())
+        if (!context.contentfulPaintDetected() && imageResource().styleImage() && protect(imageResource().styleImage())->canRender(this, deviceScaleFactor) && !contentBoxRect.isEmpty())
             context.setContentfulPaintDetected();
         return;
     }
@@ -721,23 +732,23 @@ void RenderImage::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
 
     ImageDrawResult result = paintIntoRect(paintInfo, snapRectToDevicePixels(paintRect, deviceScaleFactor));
 
-    if (showBorderForIncompleteImage && (result != ImageDrawResult::DidDraw || (cachedImage() && cachedImage()->isLoading())))
+    if (showBorderForIncompleteImage && (result != ImageDrawResult::DidDraw || (imageResource().styleImage() && imageResource().styleImage()->isLoading())))
         paintIncompleteImageOutline(paintInfo, paintOffset, missingImageBorderWidth);
 
-    if (cachedImage() && paintInfo.phase == PaintPhase::Foreground && !context.paintingDisabled()) {
+    if (RefPtr styleImage = imageResource().styleImage(); styleImage && paintInfo.phase == PaintPhase::Foreground && !context.paintingDisabled()) {
         // For now, count images as unpainted if they are still progressively loading. We may want
         // to refine this in the future to account for the portion of the image that has painted.
         LayoutRect visibleRect = intersection(replacedContentRect, contentBoxRect);
-        if (cachedImage()->isLoading() || result == ImageDrawResult::DidRequestDecoding)
+        if (styleImage->isLoading() || result == ImageDrawResult::DidRequestDecoding)
             protect(page())->addRelevantUnpaintedObject(*this, visibleRect);
         else
             protect(page())->addRelevantRepaintedObject(*this, visibleRect);
 
-        if (protect(cachedImage())->currentFrameIsComplete(this)) {
+        if (styleImage->currentFrameIsComplete(*this)) {
             if (auto styleable = Styleable::fromRenderer(*this)) {
                 auto localVisibleRect = visibleRect;
                 localVisibleRect.moveBy(-paintOffset);
-                protect(document())->didPaintImage(protect(styleable->element), protect(cachedImage()), localVisibleRect);
+                protect(document())->didPaintImage(protect(styleable->element), styleImage, localVisibleRect);
             }
         }
     }
@@ -843,7 +854,7 @@ ImageDrawResult RenderImage::paintIntoRect(PaintInfo& paintInfo, const FloatRect
         drawResult = paintInfo.context().drawImage(*img, rect, options);
 
     if (drawResult == ImageDrawResult::DidRequestDecoding)
-        protect(imageResource().cachedImage())->addClientWaitingForAsyncDecoding(protect(cachedImageClient()));
+        protect(imageResource().styleImage())->addClientWaitingForAsyncDecoding(protect(styleImageClient()));
 
 #if USE(SYSTEM_PREVIEW)
     RefPtr imageElement = dynamicDowncast<HTMLImageElement>(element());
@@ -886,7 +897,7 @@ bool RenderImage::foregroundIsKnownToBeOpaqueInRect(const LayoutRect& localRect,
         return false;
 
     // Check for image with alpha.
-    return cachedImage() && protect(cachedImage())->currentFrameKnownToBeOpaque(this);
+    return imageResource().styleImage() && protect(imageResource().styleImage())->knownToBeOpaque(*this);
 }
 
 bool RenderImage::computeBackgroundIsKnownToBeObscured(const LayoutPoint& paintOffset)

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -100,16 +100,12 @@ protected:
     void styleWillChange(Style::Difference, const Style::ComputedStyle& newStyle) override;
     void styleDidChange(Style::Difference, const Style::ComputedStyle*) override;
 
-    void imageChanged(WrappedImagePtr, const IntRect* = nullptr) override;
+    void imageChanged(const Style::Image&, const IntRect* = nullptr) override;
+    void intrinsicSizeChanged() override;
 
     ImageDrawResult paintIntoRect(PaintInfo&, const FloatRect&);
     void paint(PaintInfo&, const LayoutPoint&) final;
     void layout() override;
-
-    void intrinsicSizeChanged() override
-    {
-        imageChanged(imageResource().imagePtr());
-    }
 
 private:
     ASCIILiteral renderName() const override { return "RenderImage"_s; }
@@ -126,7 +122,7 @@ private:
 
     LayoutUnit minimumReplacedHeight() const override;
 
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
+    void notifyFinished(const Style::CachedImage&) final;
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) final;
 
     IntSize imageSizeForError(CachedImage*) const;

--- a/Source/WebCore/rendering/RenderImageResource.cpp
+++ b/Source/WebCore/rendering/RenderImageResource.cpp
@@ -56,7 +56,7 @@ void RenderImageResource::initialize(RenderElement& renderer)
 
     m_renderer = renderer;
     if (m_styleImage)
-        protect(m_styleImage)->addClient(renderer);
+        protect(m_styleImage)->addClient(renderer.styleImageClient());
 }
 
 void RenderImageResource::willBeDestroyed()
@@ -64,7 +64,7 @@ void RenderImageResource::willBeDestroyed()
     RefPtr cachedImage = this->cachedImage();
     Ref image = this->image();
     if (m_styleImage && m_renderer)
-        protect(m_styleImage)->removeClient(*m_renderer);
+        protect(m_styleImage)->removeClient(m_renderer->styleImageClient());
     if (image->isAnimated() && cachedImage && !cachedImage->hasRendererClients())
         image->stopAnimation();
 }
@@ -75,7 +75,7 @@ void RenderImageResource::clearCachedImage()
         return;
 
     if (m_renderer)
-        protect(m_styleImage)->removeClient(*m_renderer);
+        protect(m_styleImage)->removeClient(m_renderer->styleImageClient());
 
     m_styleImage = nullptr;
 }
@@ -88,7 +88,7 @@ void RenderImageResource::setCachedImage(CachedImage* newImage)
 
     if (m_styleImage && m_renderer) {
         RefPtr styleImage = m_styleImage;
-        styleImage->removeClient(*m_renderer);
+        styleImage->removeClient(m_renderer->styleImageClient());
     }
 
     if (!m_renderer) {
@@ -103,11 +103,16 @@ void RenderImageResource::setCachedImage(CachedImage* newImage)
         m_styleImage = Style::CachedImage::create(*newImage);
 
         RefPtr styleImage = m_styleImage;
-        styleImage->addClient(*m_renderer);
+        styleImage->addClient(m_renderer->styleImageClient());
 
         if (styleImage->errorOccurred())
-            m_renderer->imageChanged(styleImage->cachedImage());
+            m_renderer->imageChanged(*styleImage);
     }
+}
+
+bool RenderImageResource::isOrContains(const Style::Image& image) const
+{
+    return m_styleImage && m_styleImage->isOrContains(image);
 }
 
 void RenderImageResource::resetAnimation()
@@ -138,21 +143,15 @@ Ref<Image> RenderImageResource::image(const IntSize& size) const
     return image.releaseNonNull();
 }
 
-bool RenderImageResource::currentFrameIsComplete() const
-{
-    if (!m_styleImage)
-        return false;
-    return protect(m_styleImage)->currentFrameIsComplete(m_renderer.get());
-}
-
-void RenderImageResource::setContainerContext(const IntSize& imageContainerSize, const URL& url)
+void RenderImageResource::registerContainerContext(const IntSize& imageContainerSize, const URL& url)
 {
     if (!m_styleImage || !m_renderer)
         return;
-    protect(m_styleImage)->setContainerContextForRenderer(*m_renderer, imageContainerSize, m_renderer->style().usedZoom(), url);
+
+    protect(m_styleImage)->registerContainerContext(m_renderer->imageContainerContextKey(), m_renderer->imageContainerContext(imageContainerSize, m_renderer->style().usedZoom(), url));
 }
 
-LayoutSize RenderImageResource::imageSize(float multiplier, CachedImage::SizeType type) const
+LayoutSize RenderImageResource::imageSize(float multiplier, ImageSizeType type) const
 {
     if (!m_styleImage)
         return { };

--- a/Source/WebCore/rendering/RenderImageResource.h
+++ b/Source/WebCore/rendering/RenderImageResource.h
@@ -53,25 +53,27 @@ public:
     void setCachedImage(CachedImage*);
     CachedImage* cachedImage() const { return m_styleImage ? m_styleImage->cachedImage() : nullptr; }
     bool hasStyleImage() const { return !!m_styleImage; }
+    Style::Image* styleImage() const { return m_styleImage.get(); }
+
+    bool isOrContains(const Style::Image&) const;
 
     void resetAnimation();
 
     Ref<Image> image(const IntSize& size = { }) const;
-    bool currentFrameIsComplete() const;
     bool errorOccurred() const { return m_styleImage && m_styleImage->errorOccurred(); }
 
-    void setContainerContext(const IntSize&, const URL&);
+    void registerContainerContext(const IntSize&, const URL&);
 
     bool imageHasRelativeWidth() const { return m_styleImage && m_styleImage->imageHasRelativeWidth(); }
     bool imageHasRelativeHeight() const { return m_styleImage && m_styleImage->imageHasRelativeHeight(); }
 
-    inline LayoutSize imageSize(float multiplier) const { return imageSize(multiplier, CachedImage::UsedSize); }
-    inline LayoutSize intrinsicSize(float multiplier) const { return imageSize(multiplier, CachedImage::IntrinsicSize); }
+    inline LayoutSize imageSize(float multiplier) const { return imageSize(multiplier, ImageSizeType::Used); }
+    inline LayoutSize intrinsicSize(float multiplier) const { return imageSize(multiplier, ImageSizeType::Intrinsic); }
 
     WrappedImagePtr imagePtr() const { return m_styleImage ? m_styleImage->data() : nullptr; }
 
 private:
-    LayoutSize imageSize(float multiplier, CachedImage::SizeType) const;
+    LayoutSize imageSize(float multiplier, ImageSizeType) const;
 
     SingleThreadWeakPtr<RenderElement> m_renderer;
     RefPtr<Style::Image> m_styleImage;

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -677,7 +677,7 @@ LayoutSize RenderInline::offsetForInFlowPositionedInline(const RenderBox* child)
     return writingMode().isHorizontal() ? logicalOffset : logicalOffset.transposedSize();
 }
 
-void RenderInline::imageChanged(WrappedImagePtr image, const IntRect*)
+void RenderInline::imageChanged(const Style::Image& image, const IntRect*)
 {
     if (!parent())
         return;
@@ -686,7 +686,7 @@ void RenderInline::imageChanged(WrappedImagePtr image, const IntRect*)
     RefPtr styleImage = Style::findLayerUsedImage(style().backgroundLayers(), image, isNonEmpty);
     if (styleImage && isNonEmpty) {
         if (auto styleable = Styleable::fromRenderer(*this))
-            protect(document())->didLoadImage(protect(styleable->element).get(), protect(styleImage->cachedImage()));
+            protect(document())->didLoadImage(protect(styleable->element).get(), styleImage);
     }
 
     // FIXME: We can do better.

--- a/Source/WebCore/rendering/RenderInline.h
+++ b/Source/WebCore/rendering/RenderInline.h
@@ -117,7 +117,7 @@ private:
 
     LayoutRect frameRectForStickyPositioning() const final { return linesBoundingBox(); }
 
-    void imageChanged(WrappedImagePtr, const IntRect* = 0) final;
+    void imageChanged(const Style::Image&, const IntRect* = 0) final;
 };
 
 bool isEmptyInline(const RenderInline&);

--- a/Source/WebCore/rendering/RenderListOutsideMarker.cpp
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.cpp
@@ -79,7 +79,7 @@ RenderListOutsideMarker::~RenderListOutsideMarker() = default;
 void RenderListOutsideMarker::willBeDestroyed()
 {
     if (RefPtr image = style().listStyleImage().tryStyleImage())
-        image->removeClient(*this);
+        image->removeClient(this->styleImageClient());
     RenderBox::willBeDestroyed();
 }
 
@@ -113,9 +113,9 @@ void RenderListOutsideMarker::styleDidChange(Style::Difference diff, const Style
     RefPtr newImage = style().listStyleImage().tryStyleImage();
     if (oldImage != newImage) {
         if (oldImage)
-            oldImage->removeClient(*this);
+            oldImage->removeClient(this->styleImageClient());
         if (newImage)
-            newImage->addClient(*this);
+            newImage->addClient(this->styleImageClient());
     }
 }
 
@@ -239,11 +239,10 @@ void RenderListOutsideMarker::layoutContentContainer(RenderBlockFlow& container)
     addVisualOverflow(contentVisualOverflow);
 }
 
-void RenderListOutsideMarker::imageChanged(WrappedImagePtr o, const IntRect* rect)
+void RenderListOutsideMarker::imageChanged(const Style::Image& newImage, const IntRect* rect)
 {
     if (parent()) {
-        RefPtr image = style().listStyleImage().tryStyleImage();
-        if (image && o == image->data()) {
+        if (RefPtr image = style().listStyleImage().tryStyleImage(); image && image->isOrContains(newImage)) {
             if (image->errorOccurred()) {
                 // A failed image turns this into a text marker, and that text needs renderers the marker was not built with.
                 RefPtr element = m_listItem ? m_listItem->element() : nullptr;
@@ -259,7 +258,7 @@ void RenderListOutsideMarker::imageChanged(WrappedImagePtr o, const IntRect* rec
                 repaint();
         }
     }
-    RenderBox::imageChanged(o, rect);
+    RenderBox::imageChanged(newImage, rect);
 }
 
 void RenderListOutsideMarker::updateInlineMarginsAndContent()

--- a/Source/WebCore/rendering/RenderListOutsideMarker.h
+++ b/Source/WebCore/rendering/RenderListOutsideMarker.h
@@ -91,7 +91,7 @@ private:
     bool canHaveGeneratedChildren() const final { return true; }
     void paint(PaintInfo&, const LayoutPoint&) final;
     void layout() final;
-    void imageChanged(WrappedImagePtr, const IntRect*) final;
+    void imageChanged(const Style::Image&, const IntRect*) final;
     LayoutRect NODELETE selectionRectForRepaint(const RenderLayerModelObject* repaintContainer, bool clipToVisibleContent) final;
     bool canBeSelectionLeaf() const final { return true; }
     void styleWillChange(Style::Difference, const Style::ComputedStyle& newStyle) final;

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -93,6 +93,7 @@
 #include "ScrollAnchoringController.h"
 #include "SelectionGeometry.h"
 #include "Settings.h"
+#include "StyleCachedImage.h"
 #include "StyleResolver.h"
 #include "StyleTransformResolver.h"
 #include "TransformState.h"
@@ -111,7 +112,7 @@ using namespace HTMLNames;
 
 WTF_MAKE_PREFERABLY_COMPACT_TZONE_ALLOCATED_IMPL(RenderObject);
 WTF_MAKE_PREFERABLY_COMPACT_TZONE_ALLOCATED_IMPL(RenderObject::RenderObjectRareData);
-WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderObject::CachedImageListener);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderObject::StyleImageClientProxy);
 
 #if ASSERT_ENABLED
 
@@ -3063,84 +3064,89 @@ TextStream& operator<<(TextStream& ts, const RenderObject::RepaintRects& repaint
     return ts;
 }
 
-auto RenderObject::CachedImageListener::create(RenderObject& renderer) -> Ref<CachedImageListener>
+auto RenderObject::StyleImageClientProxy::create(RenderObject& renderer) -> Ref<StyleImageClientProxy>
 {
-    return adoptRef(*new CachedImageListener(renderer));
+    return adoptRef(*new StyleImageClientProxy(renderer));
 }
 
-RenderObject::CachedImageListener::CachedImageListener(RenderObject& renderer)
+RenderObject::StyleImageClientProxy::StyleImageClientProxy(RenderObject& renderer)
     : m_renderer(renderer)
 {
 }
 
-void RenderObject::CachedImageListener::notifyFinished(CachedResource& resource, const NetworkLoadMetrics& metrics, LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
+void RenderObject::StyleImageClientProxy::imageChanged(const Style::Image& image, const IntRect* rect) const
 {
     if (CheckedPtr renderer = m_renderer.get())
-        renderer->notifyFinished(resource, metrics, loadWillContinueInAnotherProcess);
+        renderer->imageChanged(image, rect);
 }
 
-void RenderObject::CachedImageListener::imageChanged(CachedImage* image, const IntRect* rect)
+void RenderObject::StyleImageClientProxy::notifyFinished(const Style::CachedImage& image) const
 {
     if (CheckedPtr renderer = m_renderer.get())
-        renderer->imageChanged(static_cast<WrappedImagePtr>(image), rect);
+        renderer->notifyFinished(image);
 }
 
-bool RenderObject::CachedImageListener::allowsAnimation() const
+bool RenderObject::StyleImageClientProxy::allowsAnimation(const Style::CachedImage& image) const
 {
     if (CheckedPtr renderer = m_renderer.get())
-        return renderer->allowsAnimation();
+        return renderer->allowsAnimation(image);
     return true;
 }
 
-bool RenderObject::CachedImageListener::useSystemDarkAppearance() const
+bool RenderObject::StyleImageClientProxy::useSystemDarkAppearance(const Style::CachedImage& image) const
 {
     if (CheckedPtr renderer = m_renderer.get())
-        return renderer->useSystemDarkAppearance();
+        return renderer->useSystemDarkAppearance(image);
     return false;
 }
 
-bool RenderObject::CachedImageListener::canDestroyDecodedData() const
+bool RenderObject::StyleImageClientProxy::canDestroyDecodedData(const Style::CachedImage& image) const
 {
     if (CheckedPtr renderer = m_renderer.get())
-        return renderer->canDestroyDecodedData();
+        return renderer->canDestroyDecodedData(image);
     return true;
 }
 
-VisibleInViewportState RenderObject::CachedImageListener::imageFrameAvailable(CachedImage& image, ImageAnimatingState state, const IntRect* rect)
+VisibleInViewportState RenderObject::StyleImageClientProxy::imageFrameAvailable(const Style::CachedImage& image, ImageAnimatingState state, const IntRect* rect) const
 {
     if (CheckedPtr renderer = m_renderer.get())
         return renderer->imageFrameAvailable(image, state, rect);
     return VisibleInViewportState::No;
 }
 
-VisibleInViewportState RenderObject::CachedImageListener::imageVisibleInViewport(const Document& document) const
+VisibleInViewportState RenderObject::StyleImageClientProxy::imageVisibleInViewport(const Style::CachedImage& image, const Document& document) const
 {
     if (CheckedPtr renderer = m_renderer.get())
-        return renderer->imageVisibleInViewport(document);
+        return renderer->imageVisibleInViewport(image, document);
     return VisibleInViewportState::No;
 }
 
-void RenderObject::CachedImageListener::didRemoveCachedImageClient(CachedImage& image)
+void RenderObject::StyleImageClientProxy::didRemoveCachedImageClient(const Style::CachedImage& image) const
 {
     if (CheckedPtr renderer = m_renderer.get())
         renderer->didRemoveCachedImageClient(image);
 }
 
-void RenderObject::CachedImageListener::imageContentChanged(CachedImage& image)
+void RenderObject::StyleImageClientProxy::imageContentChanged(const Style::CachedImage& image) const
 {
     if (CheckedPtr renderer = m_renderer.get())
         renderer->imageContentChanged(image);
 }
 
-void RenderObject::CachedImageListener::scheduleRenderingUpdateForImage(CachedImage& image)
+void RenderObject::StyleImageClientProxy::scheduleRenderingUpdateForImage(const Style::CachedImage& image) const
 {
     if (CheckedPtr renderer = m_renderer.get())
         renderer->scheduleRenderingUpdateForImage(image);
 }
 
-VisibleInViewportState RenderObject::imageFrameAvailable(CachedImage& image, ImageAnimatingState, const IntRect* changeRect)
+VisibleInViewportState RenderObject::imageFrameAvailable(const Style::CachedImage& image, ImageAnimatingState, const IntRect* changeRect)
 {
-    imageChanged(static_cast<WrappedImagePtr>(&image), changeRect);
+    imageChanged(image, changeRect);
+    return VisibleInViewportState::No;
+}
+
+VisibleInViewportState RenderObject::imageVisibleInViewport(const Style::CachedImage&, const Document&) const
+{
     return VisibleInViewportState::No;
 }
 

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -25,13 +25,14 @@
 
 #pragma once
 
-#include <WebCore/CachedImageClient.h>
 #include <WebCore/LayoutRect.h>
 #include <WebCore/PlatformLayerIdentifier.h>
 #include <WebCore/Position.h>
 #include <WebCore/RenderObjectEnums.h>
 #include <WebCore/RenderStyleConstants.h>
 #include <WebCore/RepaintRectCalculation.h>
+#include <WebCore/StyleImageClient.h>
+#include <WebCore/StyleImageContainerContextKey.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/EnumSet.h>
 #include <wtf/Platform.h>
@@ -85,6 +86,7 @@ class TreeScope;
 class VisiblePosition;
 class WeakPtrImplWithEventTargetData;
 
+struct ImageContainerContext;
 struct InlineBoxAndOffset;
 struct PaintInfo;
 struct ScrollRectToVisibleOptions;
@@ -1056,18 +1058,20 @@ public:
     virtual int previousOffsetForBackwardDeletion(int current) const;
     virtual int nextOffset(int current) const;
 
-    // CachedImageClient emulation.
-    virtual void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) { }
-    virtual void imageChanged(WrappedImagePtr, const IntRect* = nullptr) { }
-    virtual bool allowsAnimation() const { return true; }
-    virtual bool canDestroyDecodedData() const { return true; }
-    virtual bool useSystemDarkAppearance() const { return false; }
-    virtual VisibleInViewportState imageFrameAvailable(CachedImage&, ImageAnimatingState, const IntRect*);
-    virtual VisibleInViewportState imageVisibleInViewport(const Document&) const { return VisibleInViewportState::No; }
-    virtual void didRemoveCachedImageClient(CachedImage&) { }
-    virtual void imageContentChanged(CachedImage&) { }
-    virtual void scheduleRenderingUpdateForImage(CachedImage&) { }
-    CachedImageClient& cachedImageClient() const;
+    // Style::ImageClient emulation.
+    virtual void imageChanged(const Style::Image&, const IntRect* = nullptr) { }
+    virtual void notifyFinished(const Style::CachedImage&) { }
+    virtual bool allowsAnimation(const Style::CachedImage&) const { return true; }
+    virtual bool canDestroyDecodedData(const Style::CachedImage&) const { return true; }
+    virtual bool useSystemDarkAppearance(const Style::CachedImage&) const { return false; }
+    virtual VisibleInViewportState imageFrameAvailable(const Style::CachedImage&, ImageAnimatingState, const IntRect*);
+    virtual VisibleInViewportState imageVisibleInViewport(const Style::CachedImage&, const Document&) const;
+    virtual void didRemoveCachedImageClient(const Style::CachedImage&) { }
+    virtual void imageContentChanged(const Style::CachedImage&) { }
+    virtual void scheduleRenderingUpdateForImage(const Style::CachedImage&) { }
+
+    Style::ImageClient& styleImageClient() const;
+    ImageContainerContextKey& imageContainerContextKey() const;
 
     // Map points and quads through elements, potentially via 3d transforms. You should never need to call these directly; use
     // localToAbsolute/absoluteToLocal methods instead.
@@ -1135,35 +1139,33 @@ protected:
 
 private:
     // This class is to avoid making RenderObject refcounted.
-    class CachedImageListener final : public CachedImageClient, public RefCounted<CachedImageListener> {
-        WTF_MAKE_TZONE_ALLOCATED(CachedImageListener);
+    class StyleImageClientProxy final : public Style::ImageClient, public ImageContainerContextKey, public RefCounted<StyleImageClientProxy> {
+        WTF_MAKE_TZONE_ALLOCATED(StyleImageClientProxy);
     public:
-        static Ref<CachedImageListener> create(RenderObject&);
+        static Ref<StyleImageClientProxy> create(RenderObject&);
 
-        // CachedImageClient.
         void ref() const final { RefCounted::ref(); }
         void deref() const final { RefCounted::deref(); }
 
-    private:
-        // CachedResourceClient.
-        void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
+        void imageChanged(const Style::Image&, const IntRect*) const final;
+        void notifyFinished(const Style::CachedImage&) const final;
+        bool allowsAnimation(const Style::CachedImage&) const final;
+        bool canDestroyDecodedData(const Style::CachedImage&) const final;
+        bool useSystemDarkAppearance(const Style::CachedImage&) const final;
+        VisibleInViewportState imageFrameAvailable(const Style::CachedImage&, ImageAnimatingState, const IntRect*) const final;
+        VisibleInViewportState imageVisibleInViewport(const Style::CachedImage&, const Document&) const final;
+        void didRemoveCachedImageClient(const Style::CachedImage&) const final;
+        void imageContentChanged(const Style::CachedImage&) const final;
+        void scheduleRenderingUpdateForImage(const Style::CachedImage&) const final;
 
-        // CachedImageClient.
-        void imageChanged(CachedImage*, const IntRect* = nullptr) final;
-        bool allowsAnimation() const final;
-        bool canDestroyDecodedData() const final;
-        bool useSystemDarkAppearance() const final;
-        VisibleInViewportState imageFrameAvailable(CachedImage&, ImageAnimatingState, const IntRect*) final;
-        VisibleInViewportState imageVisibleInViewport(const Document&) const final;
-        void didRemoveCachedImageClient(CachedImage&) final;
-        void imageContentChanged(CachedImage&) final;
-        void scheduleRenderingUpdateForImage(CachedImage&) final;
         bool isRendererClient() const final { return true; }
 
-        explicit CachedImageListener(RenderObject&);
+    private:
+        explicit StyleImageClientProxy(RenderObject&);
 
         SingleThreadWeakPtr<RenderObject> m_renderer;
     };
+    StyleImageClientProxy& styleImageClientProxy() const;
 
     virtual RepaintRects localRectsForRepaint(RepaintOutlineBounds) const;
 
@@ -1281,7 +1283,7 @@ private:
     const TypeSpecificFlags m_typeSpecificFlags;
 
     CheckedPtr<Layout::Box> m_layoutBox;
-    const RefPtr<CachedImageListener> m_cachedImageClient;
+    const RefPtr<StyleImageClientProxy> m_styleImageClient;
 
     // FIXME: This should be RenderElementRareData.
     class RenderObjectRareData {
@@ -1475,11 +1477,21 @@ inline bool RenderObject::usesBoundaryCaching() const
         || (m_typeSpecificFlags.kind() == TypeSpecificFlags::Kind::SVGModelObject && m_typeSpecificFlags.svgFlags().contains(SVGModelObjectFlag::UsesBoundaryCaching));
 }
 
-inline CachedImageClient& RenderObject::cachedImageClient() const
+inline RenderObject::StyleImageClientProxy& RenderObject::styleImageClientProxy() const
 {
-    if (!m_cachedImageClient)
-        lazyInitialize(m_cachedImageClient, CachedImageListener::create(*const_cast<RenderObject*>(this)));
-    return *m_cachedImageClient.get();
+    if (!m_styleImageClient)
+        lazyInitialize(m_styleImageClient, StyleImageClientProxy::create(*const_cast<RenderObject*>(this)));
+    return *m_styleImageClient.get();
+}
+
+inline Style::ImageClient& RenderObject::styleImageClient() const
+{
+    return styleImageClientProxy();
+}
+
+inline ImageContainerContextKey& RenderObject::imageContainerContextKey() const
+{
+    return styleImageClientProxy();
 }
 
 std::partial_ordering renderTreeOrder(const RenderObject&, const RenderObject&);

--- a/Source/WebCore/rendering/RenderScrollbarPart.cpp
+++ b/Source/WebCore/rendering/RenderScrollbarPart.cpp
@@ -149,7 +149,7 @@ void RenderScrollbarPart::styleDidChange(Style::Difference diff, const Style::Co
         m_scrollbar->theme().invalidatePart(protect(*m_scrollbar), m_part);
 }
 
-void RenderScrollbarPart::imageChanged(WrappedImagePtr image, const IntRect* rect)
+void RenderScrollbarPart::imageChanged(const Style::Image& image, const IntRect* rect)
 {
     if (m_scrollbar && m_part != NoPart)
         m_scrollbar->theme().invalidatePart(protect(*m_scrollbar), m_part);

--- a/Source/WebCore/rendering/RenderScrollbarPart.h
+++ b/Source/WebCore/rendering/RenderScrollbarPart.h
@@ -54,7 +54,7 @@ public:
 
 private:
     void styleDidChange(Style::Difference, const Style::ComputedStyle* oldStyle) override;
-    void imageChanged(WrappedImagePtr, const IntRect* = nullptr) override;
+    void imageChanged(const Style::Image&, const IntRect* = nullptr) override;
 
     void layoutHorizontalPart();
     void layoutVerticalPart();

--- a/Source/WebCore/rendering/RenderTableCol.cpp
+++ b/Source/WebCore/rendering/RenderTableCol.cpp
@@ -158,7 +158,7 @@ auto RenderTableCol::rectsForRepaintingAfterLayout(const RenderLayerModelObject*
     return { clippedOverflowRect(repaintContainer, visibleRectContextForRepaint()) };
 }
 
-void RenderTableCol::imageChanged(WrappedImagePtr, const IntRect*)
+void RenderTableCol::imageChanged(const Style::Image&, const IntRect*)
 {
     // FIXME: Repaint only the rect the image paints in.
     if (!parent())

--- a/Source/WebCore/rendering/RenderTableCol.h
+++ b/Source/WebCore/rendering/RenderTableCol.h
@@ -83,7 +83,7 @@ private:
     LayoutRect clippedOverflowRect(const RenderLayerModelObject* repaintContainer, const VisibleRectContext&) const override;
     RepaintRects rectsForRepaintingAfterLayout(const RenderLayerModelObject* repaintContainer, RepaintOutlineBounds) const override;
 
-    void imageChanged(WrappedImagePtr, const IntRect* = 0) override;
+    void imageChanged(const Style::Image&, const IntRect* = 0) override;
 
     void styleDidChange(Style::Difference, const Style::ComputedStyle* oldStyle) override;
     void paint(PaintInfo&, const LayoutPoint&) override { }

--- a/Source/WebCore/rendering/RenderTableRow.cpp
+++ b/Source/WebCore/rendering/RenderTableRow.cpp
@@ -283,7 +283,7 @@ void RenderTableRow::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
         table->paintCollapsedBordersForRow(paintInfo, *this, adjustedPaintOffset);
 }
 
-void RenderTableRow::imageChanged(WrappedImagePtr, const IntRect*)
+void RenderTableRow::imageChanged(const Style::Image&, const IntRect*)
 {
     // FIXME: Examine cells and repaint only the rect the image paints in.
     if (!parent())

--- a/Source/WebCore/rendering/RenderTableRow.h
+++ b/Source/WebCore/rendering/RenderTableRow.h
@@ -86,7 +86,7 @@ private:
 
     bool requiresLayer() const final;
     void paint(PaintInfo&, const LayoutPoint&) override;
-    void imageChanged(WrappedImagePtr, const IntRect* = 0) override;
+    void imageChanged(const Style::Image&, const IntRect* = 0) override;
     void styleDidChange(Style::Difference, const Style::ComputedStyle* oldStyle) override;
 
     void firstChild() const = delete;

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -1521,7 +1521,7 @@ void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& pa
         paintDirtyCells();
 }
 
-void RenderTableSection::imageChanged(WrappedImagePtr, const IntRect*)
+void RenderTableSection::imageChanged(const Style::Image&, const IntRect*)
 {
     // FIXME: Examine cells and repaint only the rect the image paints in.
     if (!parent())

--- a/Source/WebCore/rendering/RenderTableSection.h
+++ b/Source/WebCore/rendering/RenderTableSection.h
@@ -184,7 +184,7 @@ private:
 
     std::pair<LayoutUnit, LayoutUnit> computeIntrinsicLogicalWidths() const override { return { }; }
 
-    void imageChanged(WrappedImagePtr, const IntRect* = 0) override;
+    void imageChanged(const Style::Image&, const IntRect* = 0) override;
 
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
 

--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -181,7 +181,7 @@ LayoutSize RenderVideo::calculateIntrinsicSize()
     return calculatedIntrinsicSize;
 }
 
-void RenderVideo::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
+void RenderVideo::imageChanged(const Style::Image& newImage, const IntRect* rect)
 {
     RenderMedia::imageChanged(newImage, rect);
 
@@ -398,7 +398,7 @@ void RenderVideo::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
     if (paintInfo.phase == PaintPhase::Foreground) {
         page->addRelevantRepaintedObject(*this, rect);
         if (displayingPoster && !context.paintingDisabled())
-            protect(document())->didPaintImage(videoElement.get(), protect(cachedImage()), videoBoxRect);
+            protect(document())->didPaintImage(videoElement.get(), protect(imageResource().styleImage()), videoBoxRect);
     }
 
     if (context.detectingContentfulPaint()) {

--- a/Source/WebCore/rendering/RenderVideo.h
+++ b/Source/WebCore/rendering/RenderVideo.h
@@ -81,7 +81,7 @@ private:
     std::optional<LayoutRect> objectFitContentsRectForFullscreenCompositing(const LayoutRect&) const;
     LayoutSize posterAwareIntrinsicSize() const;
 
-    void imageChanged(WrappedImagePtr, const IntRect*) final;
+    void imageChanged(const Style::Image&, const IntRect*) final;
 
     ASCIILiteral renderName() const final { return "RenderVideo"_s; }
 

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
@@ -270,7 +270,7 @@ Ref<const LayoutShape> makeShapeForShapeOutside(const RenderBox& renderer)
 
             Ref styleImage = shapeImage.image.value;
             auto logicalImageSize = renderer.calculateImageIntrinsicDimensions(styleImage.ptr(), boxSize, RenderImage::ScaleByUsedZoom::Yes);
-            styleImage->setContainerContextForRenderer(renderer, logicalImageSize, style.usedZoom());
+            styleImage->registerContainerContext(renderer.imageContainerContextKey(), renderer.imageContainerContext(logicalImageSize, style.usedZoom()));
 
             auto logicalMarginRect = shapeImageMarginRect(renderer, boxSize);
             auto* renderImage = dynamicDowncast<RenderImage>(renderer);

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -45,6 +45,7 @@
 #include "SVGImageElement.h"
 #include "SVGImageIntrinsicSizing.h"
 #include "SVGVisitedRendererTracking.h"
+#include "StyleCachedImage.h"
 #include "Settings.h"
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -166,7 +167,7 @@ ImageDrawResult RenderSVGImage::paintIntoRect(PaintInfo& paintInfo, const FloatR
 
     auto drawResult = paintInfo.context().drawImage(*image, rect, sourceRect, options);
     if (drawResult == ImageDrawResult::DidRequestDecoding)
-        protect(imageResource().cachedImage())->addClientWaitingForAsyncDecoding(protect(cachedImageClient()));
+        protect(imageResource().styleImage())->addClientWaitingForAsyncDecoding(protect(styleImageClient()));
 
     return drawResult;
 }
@@ -175,12 +176,12 @@ void RenderSVGImage::paintForeground(PaintInfo& paintInfo, const LayoutPoint& pa
 {
     GraphicsContext& context = paintInfo.context();
     if (context.invalidatingImagesWithAsyncDecodes()) {
-        if (cachedImage() && cachedImage()->isClientWaitingForAsyncDecoding(cachedImageClient()))
-            protect(cachedImage())->removeAllClientsWaitingForAsyncDecoding();
+        if (imageResource().styleImage() && imageResource().styleImage()->isClientWaitingForAsyncDecoding(styleImageClient()))
+            protect(imageResource().styleImage())->removeAllClientsWaitingForAsyncDecoding();
         return;
     }
 
-    if (!imageResource().cachedImage()) {
+    if (!imageResource().styleImage()) {
         protect(page())->addRelevantUnpaintedObject(*this, visualOverflowRectEquivalent());
         return;
     }
@@ -199,19 +200,19 @@ void RenderSVGImage::paintForeground(PaintInfo& paintInfo, const LayoutPoint& pa
 
     ImageDrawResult result = paintIntoRect(paintInfo, contentBoxRect, replacedContentRect);
 
-    if (cachedImage() && !context.paintingDisabled()) {
+    if (RefPtr styleImage = imageResource().styleImage(); styleImage && !context.paintingDisabled()) {
         // For now, count images as unpainted if they are still progressively loading. We may want
         // to refine this in the future to account for the portion of the image that has painted.
         replacedContentRect.moveBy(paintOffset);
         auto visibleRect = intersection(replacedContentRect, contentBoxRect);
-        if (cachedImage()->isLoading() || result == ImageDrawResult::DidRequestDecoding)
+        if (styleImage->isLoading() || result == ImageDrawResult::DidRequestDecoding)
             protect(page())->addRelevantUnpaintedObject(*this, enclosingLayoutRect(visibleRect));
         else
             protect(page())->addRelevantRepaintedObject(*this, enclosingLayoutRect(visibleRect));
 
         auto localVisibleRect = visibleRect;
         localVisibleRect.moveBy(-paintOffset);
-        protect(document())->didPaintImage(protect(imageElement()).get(), protect(cachedImage()), localVisibleRect);
+        protect(document())->didPaintImage(protect(imageElement()).get(), styleImage, localVisibleRect);
     }
 }
 
@@ -271,9 +272,9 @@ bool RenderSVGImage::updateImageViewport()
     // See: http://www.w3.org/TR/SVG/single-page.html, 7.8 The ‘preserveAspectRatio’ attribute.
     if (imageElement->preserveAspectRatio().align() == SVGPreserveAspectRatioValue::SVG_PRESERVEASPECTRATIO_NONE) {
         if (RefPtr cachedImage = imageResource().cachedImage()) {
-            LayoutSize intrinsicSize = cachedImage->imageSizeForRenderer(nullptr, style().usedZoom());
+            LayoutSize intrinsicSize = cachedImage->imageSize(ImageSizeOptions { .multiplier = style().usedZoom() });
             if (intrinsicSize != imageResource().imageSize(style().usedZoom())) {
-                imageResource().setContainerContext(roundedIntSize(intrinsicSize), imageSourceURL);
+                imageResource().registerContainerContext(roundedIntSize(intrinsicSize), imageSourceURL);
                 updatedViewport = true;
             }
         }
@@ -281,7 +282,7 @@ bool RenderSVGImage::updateImageViewport()
 
     if (oldBoundaries != m_objectBoundingBox) {
         if (!updatedViewport)
-            imageResource().setContainerContext(enclosingIntRect(m_objectBoundingBox).size(), imageSourceURL);
+            imageResource().registerContainerContext(enclosingIntRect(m_objectBoundingBox).size(), imageSourceURL);
         updatedViewport = true;
     }
 
@@ -312,24 +313,24 @@ void RenderSVGImage::repaintOrMarkForLayout(const IntRect* rect)
         layer()->contentChanged(ContentChangeType::Image);
 }
 
-void RenderSVGImage::notifyFinished(CachedResource& newImage, const NetworkLoadMetrics& metrics, LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
+void RenderSVGImage::notifyFinished(const Style::CachedImage& newImage)
 {
     if (renderTreeBeingDestroyed())
         return;
 
     invalidateBackgroundObscurationStatus();
 
-    if (&newImage == cachedImage()) {
+    if (imageResource().isOrContains(newImage)) {
         // tell any potential compositing layers
         // that the image is done and they can reference it directly.
         if (hasLayer())
             layer()->contentChanged(ContentChangeType::Image);
     }
 
-    RenderSVGModelObject::notifyFinished(newImage, metrics, loadWillContinueInAnotherProcess);
+    RenderSVGModelObject::notifyFinished(newImage);
 }
 
-void RenderSVGImage::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
+void RenderSVGImage::imageChanged(const Style::Image& newImage, const IntRect* rect)
 {
     if (renderTreeBeingDestroyed() || !parent())
         return;
@@ -339,7 +340,7 @@ void RenderSVGImage::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
     if (hasVisibleBoxDecorations() || hasMask() || hasShapeOutside())
         RenderSVGModelObject::imageChanged(newImage, rect);
 
-    if (newImage != imageResource().imagePtr() || !newImage)
+    if (!imageResource().isOrContains(newImage))
         return;
 
     repaintOrMarkForLayout(rect);
@@ -347,9 +348,9 @@ void RenderSVGImage::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
     if (CheckedPtr cache = protect(document())->existingAXObjectCache())
         cache->deferRecomputeIsIgnoredIfNeeded(protect(imageElement()).ptr());
 
-    if (RefPtr image = imageResource().cachedImage(); image && image->currentFrameIsComplete(this)) {
+    if (newImage.currentFrameIsComplete(*this)) {
         if (auto styleable = Styleable::fromRenderer(*this))
-            protect(document())->didLoadImage(protect(styleable->element).get(), image);
+            protect(document())->didLoadImage(protect(styleable->element).get(), &newImage);
     }
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.h
@@ -64,7 +64,7 @@ private:
     FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
     FloatRect decoratedBoundingBox() const final { return m_objectBoundingBox; }
 
-    void imageChanged(WrappedImagePtr, const IntRect* = nullptr) final;
+    void imageChanged(const Style::Image&, const IntRect* = nullptr) final;
 
     void layout() final;
     void paint(PaintInfo&, const LayoutPoint&) final;
@@ -75,7 +75,7 @@ private:
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) final;
 
     void repaintOrMarkForLayout(const IntRect* = nullptr);
-    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
+    void notifyFinished(const Style::CachedImage&) final;
     bool bufferForeground(PaintInfo&, const LayoutPoint&);
 
     bool needsHasSVGTransformFlags() const final;

--- a/Source/WebCore/rendering/svg/SVGImageIntrinsicSizing.cpp
+++ b/Source/WebCore/rendering/svg/SVGImageIntrinsicSizing.cpp
@@ -36,7 +36,7 @@ SVGImageIntrinsicSizing resolveSVGImageIntrinsicSizing(CachedImage& cachedImage,
 
     // Raster (non-SVG) sources: the intrinsic size *is* the ratio.
     if (!image || !image->isSVGImage()) {
-        FloatSize size = cachedImage.imageSizeForRenderer(nullptr, usedZoom);
+        FloatSize size = cachedImage.imageSize(ImageSizeOptions { .multiplier = usedZoom });
         return { size, size, size.isEmpty() ? HasRatio::No : HasRatio::Yes };
     }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -61,7 +61,7 @@ LegacyRenderSVGImage::LegacyRenderSVGImage(SVGImageElement& element, Style::Comp
 
 LegacyRenderSVGImage::~LegacyRenderSVGImage() = default;
 
-void LegacyRenderSVGImage::notifyFinished(CachedResource& newImage, const NetworkLoadMetrics& metrics, LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
+void LegacyRenderSVGImage::notifyFinished(const Style::CachedImage& newImage)
 {
     if (renderTreeBeingDestroyed())
         return;
@@ -69,7 +69,7 @@ void LegacyRenderSVGImage::notifyFinished(CachedResource& newImage, const Networ
     if (RefPtr image = dynamicDowncast<SVGImageElement>(LegacyRenderSVGModelObject::element()))
         protect(page())->didFinishLoadingImageForSVGImage(*image);
 
-    LegacyRenderSVGModelObject::notifyFinished(newImage, metrics, loadWillContinueInAnotherProcess);
+    LegacyRenderSVGModelObject::notifyFinished(newImage);
 }
 
 void LegacyRenderSVGImage::willBeDestroyed()
@@ -101,9 +101,9 @@ bool LegacyRenderSVGImage::updateImageViewport()
     // See: http://www.w3.org/TR/SVG/single-page.html, 7.8 The ‘preserveAspectRatio’ attribute.
     if (imageElement().preserveAspectRatio().align() == SVGPreserveAspectRatioValue::SVG_PRESERVEASPECTRATIO_NONE) {
         if (RefPtr cachedImage = imageResource().cachedImage()) {
-            LayoutSize intrinsicSize = cachedImage->imageSizeForRenderer(nullptr, style().usedZoom());
+            LayoutSize intrinsicSize = cachedImage->imageSize(ImageSizeOptions { .multiplier = style().usedZoom() });
             if (intrinsicSize != imageResource().imageSize(style().usedZoom())) {
-                imageResource().setContainerContext(roundedIntSize(intrinsicSize), imageSourceURL);
+                imageResource().registerContainerContext(roundedIntSize(intrinsicSize), imageSourceURL);
                 updatedViewport = true;
             }
         }
@@ -111,7 +111,7 @@ bool LegacyRenderSVGImage::updateImageViewport()
 
     if (oldBoundaries != m_objectBoundingBox) {
         if (!updatedViewport)
-            imageResource().setContainerContext(enclosingIntRect(m_objectBoundingBox).size(), imageSourceURL);
+            imageResource().registerContainerContext(enclosingIntRect(m_objectBoundingBox).size(), imageSourceURL);
         updatedViewport = true;
         m_needsBoundariesUpdate = true;
     }
@@ -215,9 +215,8 @@ void LegacyRenderSVGImage::paintForeground(PaintInfo& paintInfo)
     auto& context = paintInfo.context();
     context.drawImage(*image, destRect, srcRect, options);
 
-    RefPtr cachedImage = imageResource().cachedImage();
-    if (cachedImage && !context.paintingDisabled())
-        protect(document())->didPaintImage(imageElement(), cachedImage, destRect);
+    if (RefPtr styleImage = imageResource().styleImage(); styleImage && !context.paintingDisabled())
+        protect(document())->didPaintImage(imageElement(), styleImage, destRect);
 }
 
 void LegacyRenderSVGImage::invalidateBufferedForeground()
@@ -257,7 +256,7 @@ bool LegacyRenderSVGImage::nodeAtFloatPoint(const HitTestRequest& request, HitTe
     return false;
 }
 
-void LegacyRenderSVGImage::imageChanged(WrappedImagePtr, const IntRect*)
+void LegacyRenderSVGImage::imageChanged(const Style::Image&, const IntRect*)
 {
     if (!parent())
         return;
@@ -279,9 +278,9 @@ void LegacyRenderSVGImage::imageChanged(WrappedImagePtr, const IntRect*)
 
     repaint();
 
-    if (RefPtr image = imageResource().cachedImage(); image && image->currentFrameIsComplete(this)) {
+    if (RefPtr styleImage = imageResource().styleImage(); styleImage && styleImage->currentFrameIsComplete(*this)) {
         if (auto styleable = Styleable::fromRenderer(*this))
-            protect(document())->didLoadImage(protect(styleable->element).get(), image);
+            protect(document())->didLoadImage(protect(styleable->element).get(), styleImage);
     }
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
@@ -64,7 +64,7 @@ private:
 
     const AffineTransform& localToParentTransform() const LIFETIME_BOUND override { return m_localTransform; }
 
-    void notifyFinished(CachedResource& newImage, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) override;
+    void notifyFinished(const Style::CachedImage&) override;
 
     FloatRect calculateObjectBoundingBox() const;
     FloatRect objectBoundingBox() const override { return m_objectBoundingBox; }
@@ -74,7 +74,7 @@ private:
 
     void addFocusRingRects(Vector<LayoutRect>&, const LayoutPoint& additionalOffset, const RenderLayerModelObject* paintContainer = nullptr) const override;
 
-    void imageChanged(WrappedImagePtr, const IntRect* = nullptr) override;
+    void imageChanged(const Style::Image&, const IntRect* = nullptr) override;
 
     void layout() override;
     void paint(PaintInfo&, const LayoutPoint&) override;

--- a/Source/WebCore/style/StylePendingResources.cpp
+++ b/Source/WebCore/style/StylePendingResources.cpp
@@ -178,8 +178,7 @@ void loadPendingResources(Style::ComputedStyle& style, Document& document, const
     for (auto& maskLayer : style.maskLayers().usedValues())
         loadPendingImage(document, maskLayer.image().tryStyleImage().get(), element, LoadPolicy::CORS);
 
-    if (RefPtr shapeValueImage = style.shapeOutside().image())
-        loadPendingImage(document, shapeValueImage.get(), element, LoadPolicy::Anonymous);
+    loadPendingImage(document, style.shapeOutside().tryStyleImage().get(), element, LoadPolicy::Anonymous);
 
     if (document.settings().svgExternalResourcesEnabled()) {
         // Paint servers and markers resolve through SVGResources, which only applies to SVG elements.

--- a/Source/WebCore/style/values/backgrounds/StyleFillLayers.h
+++ b/Source/WebCore/style/values/backgrounds/StyleFillLayers.h
@@ -116,11 +116,11 @@ bool hasAnyBackgroundClipText(const CoordinatedValueList<T>& list)
 }
 
 template<FillLayer T>
-RefPtr<Image> findLayerUsedImage(const CoordinatedValueList<T>& list, WrappedImagePtr image, bool& isNonEmpty)
+RefPtr<Image> findLayerUsedImage(const CoordinatedValueList<T>& list, const Style::Image& image, bool& isNonEmpty)
 {
     for (auto& layer : list.usedValues()) {
         RefPtr layerImage = layer.image().tryStyleImage();
-        if (!layerImage || layerImage->data() != image)
+        if (!layerImage || !layerImage->isOrContains(image))
             continue;
 
         // FIXME: This really needs to compute the tile rect with BackgroundPainter::calculateFillTileSize().

--- a/Source/WebCore/style/values/images/kinds/StyleCachedImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleCachedImage.cpp
@@ -224,6 +224,11 @@ bool CachedImage::isPending() const
     return m_isPending;
 }
 
+bool CachedImage::isLoading() const
+{
+    return m_cachedImage && m_cachedImage->isLoaded();
+}
+
 bool CachedImage::isLoaded(const RenderElement* renderer) const
 {
     if (isRenderSVGResource(renderer))
@@ -240,7 +245,7 @@ bool CachedImage::errorOccurred() const
     return m_cachedImage->errorOccurred();
 }
 
-FloatSize CachedImage::imageSize(const RenderElement* renderer, float multiplier, WebCore::CachedImage::SizeType sizeType) const
+FloatSize CachedImage::imageSize(const RenderElement* renderer, float multiplier, ImageSizeType sizeType) const
 {
     if (isRenderSVGResource(renderer))
         return m_containerSize;
@@ -273,6 +278,11 @@ bool CachedImage::imageHasNaturalAspectRatio() const
     return m_cachedImage->imageHasNaturalAspectRatio();
 }
 
+bool CachedImage::hasHDRContent() const
+{
+    return m_cachedImage && m_cachedImage->hasHDRContent();
+}
+
 void CachedImage::computeIntrinsicDimensions(const RenderElement* renderer, float& intrinsicWidth, float& intrinsicHeight, FloatSize& intrinsicRatio)
 {
     // In case of an SVG resource, we should return the container size.
@@ -297,36 +307,16 @@ bool CachedImage::usesImageContainerSize() const
     return protect(m_cachedImage)->usesImageContainerSize();
 }
 
-void CachedImage::setContainerContextForRenderer(const RenderElement& renderer, const FloatSize& containerSize, float containerZoom, const WTF::URL& url)
+void CachedImage::registerContainerContext(const ImageContainerContextKey& key, ImageContainerContext&& containerContext)
 {
-    m_containerSize = containerSize;
+    m_containerSize = containerContext.containerSize;
     if (!m_cachedImage)
         return;
-    protect(m_cachedImage)->setContainerContextForClient(protect(renderer.cachedImageClient()), LayoutSize(containerSize), containerZoom, !url.isNull() ? url : m_url.resolved, renderer.style().linkParameters());
-}
 
-void CachedImage::addClient(RenderElement& renderer)
-{
-    ASSERT(!m_isPending);
-    if (!m_cachedImage)
-        return;
-    protect(m_cachedImage)->addClient(protect(renderer.cachedImageClient()));
-}
+    if (containerContext.imageURL.isNull())
+        containerContext.imageURL = m_url.resolved;
 
-void CachedImage::removeClient(RenderElement& renderer)
-{
-    ASSERT(!m_isPending);
-    if (!m_cachedImage)
-        return;
-    protect(m_cachedImage)->removeClient(protect(renderer.cachedImageClient()));
-}
-
-bool CachedImage::hasClient(RenderElement& renderer) const
-{
-    ASSERT(!m_isPending);
-    if (!m_cachedImage)
-        return false;
-    return m_cachedImage->hasClient(renderer.cachedImageClient());
+    protect(m_cachedImage)->registerContainerContext(key, WTF::move(containerContext));
 }
 
 bool CachedImage::hasImage() const
@@ -334,6 +324,13 @@ bool CachedImage::hasImage() const
     if (!m_cachedImage)
         return false;
     return m_cachedImage->hasImage();
+}
+
+RefPtr<WebCore::Image> CachedImage::image() const
+{
+    if (!m_cachedImage)
+        return nullptr;
+    return protect(m_cachedImage)->image();
 }
 
 RefPtr<WebCore::Image> CachedImage::image(const RenderElement* renderer, const FloatSize&, const GraphicsContext&, bool) const
@@ -352,9 +349,9 @@ RefPtr<WebCore::Image> CachedImage::image(const RenderElement* renderer, const F
     return protect(m_cachedImage)->imageForRenderer(renderer);
 }
 
-bool CachedImage::currentFrameIsComplete(const RenderElement* renderer) const
+bool CachedImage::currentFrameIsComplete(const RenderElement& renderer) const
 {
-    return m_cachedImage && protect(m_cachedImage)->currentFrameIsComplete(renderer);
+    return m_cachedImage && protect(m_cachedImage)->currentFrameIsCompleteForKey(renderer.imageContainerContextKey());
 }
 
 float CachedImage::imageScaleFactor() const
@@ -364,12 +361,129 @@ float CachedImage::imageScaleFactor() const
 
 bool CachedImage::knownToBeOpaque(const RenderElement& renderer) const
 {
-    return m_cachedImage && protect(m_cachedImage)->currentFrameKnownToBeOpaque(&renderer);
+    return m_cachedImage && protect(m_cachedImage)->currentFrameKnownToBeOpaqueForKey(renderer.imageContainerContextKey());
 }
 
 bool CachedImage::usesDataProtocol() const
 {
     return m_url.resolved.protocolIsData();
+}
+
+// MARK: - CachedImageClient
+
+void CachedImage::notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->notifyFinished(*this);
+    }
+}
+
+void CachedImage::imageChanged(WebCore::CachedImage&, const IntRect* changeRect)
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->imageChanged(*this, changeRect);
+    }
+}
+
+bool CachedImage::allowsAnimation() const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->allowsAnimation(*this))
+            return true;
+    }
+    return false;
+}
+
+bool CachedImage::canDestroyDecodedData() const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (!client->canDestroyDecodedData(*this))
+            return false;
+    }
+    return false;
+}
+
+bool CachedImage::useSystemDarkAppearance() const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->useSystemDarkAppearance(*this))
+            return true;
+    }
+    return false;
+}
+
+VisibleInViewportState CachedImage::imageFrameAvailable(WebCore::CachedImage& cachedImage, ImageAnimatingState animatingState, const IntRect* changeRect)
+{
+    if (&cachedImage != m_cachedImage)
+        return VisibleInViewportState::No;
+
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->imageFrameAvailable(*this, animatingState, changeRect) == VisibleInViewportState::Yes)
+            return VisibleInViewportState::Yes;
+    }
+    return VisibleInViewportState::No;
+}
+
+VisibleInViewportState CachedImage::imageVisibleInViewport(WebCore::CachedImage& cachedImage, const Document& document) const
+{
+    if (&cachedImage != m_cachedImage)
+        return VisibleInViewportState::No;
+
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->imageVisibleInViewport(*this, document) == VisibleInViewportState::Yes)
+            return VisibleInViewportState::Yes;
+    }
+    return VisibleInViewportState::No;
+}
+
+void CachedImage::didRemoveCachedImageClient(WebCore::CachedImage& cachedImage)
+{
+    if (&cachedImage != m_cachedImage)
+        return;
+
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->didRemoveCachedImageClient(*this);
+    }
+}
+
+void CachedImage::imageContentChanged(WebCore::CachedImage& cachedImage)
+{
+    if (&cachedImage != m_cachedImage)
+        return;
+
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->imageContentChanged(*this);
+    }
+}
+
+void CachedImage::scheduleRenderingUpdateForImage(WebCore::CachedImage& cachedImage)
+{
+    if (&cachedImage != m_cachedImage)
+        return;
+
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->scheduleRenderingUpdateForImage(*this);
+    }
+}
+
+bool CachedImage::isRendererClient() const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->isRendererClient())
+            return true;
+    }
+    return false;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/images/kinds/StyleCachedImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleCachedImage.h
@@ -42,7 +42,7 @@ class TreeScope;
 
 namespace Style {
 
-class CachedImage final : public Image {
+class CachedImage final : public Image, public CachedImageClient {
     WTF_MAKE_TZONE_ALLOCATED(CachedImage);
 public:
     static Ref<CachedImage> create(URL&&, Ref<CSSImageValue>&&, float scaleFactor = 1);
@@ -50,6 +50,10 @@ public:
     static Ref<CachedImage> create(WebCore::CachedImage&, float scaleFactor = 1);
     static Ref<CachedImage> copyOverridingScaleFactor(CachedImage&, float scaleFactor);
     virtual ~CachedImage();
+
+    // CachedImageClient.
+    void ref() const final { Image::ref(); }
+    void deref() const final { Image::deref(); }
 
     bool operator==(const Image&) const final;
     bool equals(const CachedImage&) const;
@@ -63,25 +67,27 @@ public:
 
     bool canRender(const RenderElement*, float multiplier) const final;
     bool isPending() const final;
+    bool isLoading() const final;
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
     bool isLoaded(const RenderElement*) const final;
     bool errorOccurred() const final;
-    FloatSize imageSize(const RenderElement*, float multiplier, WebCore::CachedImage::SizeType = WebCore::CachedImage::UsedSize) const final;
+    FloatSize imageSize(const RenderElement*, float multiplier, ImageSizeType = ImageSizeType::Used) const final;
     bool imageHasRelativeWidth() const final;
     bool imageHasRelativeHeight() const final;
     bool imageHasNaturalAspectRatio() const final;
+    bool hasHDRContent() const final;
     void computeIntrinsicDimensions(const RenderElement*, float& intrinsicWidth, float& intrinsicHeight, FloatSize& intrinsicRatio) final;
     bool usesImageContainerSize() const final;
-    void setContainerContextForRenderer(const RenderElement&, const FloatSize&, float, const WTF::URL& = WTF::URL()) final;
-    void addClient(RenderElement&) final;
-    void removeClient(RenderElement&) final;
-    bool hasClient(RenderElement&) const final;
+    void registerContainerContext(const ImageContainerContextKey&, ImageContainerContext&&) final;
     bool hasImage() const final;
+    RefPtr<WebCore::Image> image() const final;
     RefPtr<WebCore::Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
-    bool currentFrameIsComplete(const RenderElement*) const final;
+    bool currentFrameIsComplete(const RenderElement&) const final;
     float imageScaleFactor() const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     bool usesDataProtocol() const final;
+    void didAddClient(ImageClient&) final { }
+    void didRemoveClient(ImageClient&) final { }
 
     URL url() const final;
 
@@ -93,6 +99,19 @@ private:
     LegacyRenderSVGResourceContainer* legacyRenderSVGResource(const RenderElement*) const;
     RenderSVGResourceContainer* renderSVGResource(const RenderElement*) const;
     bool isRenderSVGResource(const RenderElement*) const;
+
+    // CachedImageClient.
+    void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) final;
+    void imageChanged(WebCore::CachedImage&, const IntRect* = nullptr) final;
+    bool allowsAnimation() const final;
+    bool canDestroyDecodedData() const final;
+    bool useSystemDarkAppearance() const final;
+    VisibleInViewportState imageFrameAvailable(WebCore::CachedImage&, ImageAnimatingState, const IntRect*) final;
+    VisibleInViewportState imageVisibleInViewport(WebCore::CachedImage&, const Document&) const final;
+    void didRemoveCachedImageClient(WebCore::CachedImage&) final;
+    void imageContentChanged(WebCore::CachedImage&) final;
+    void scheduleRenderingUpdateForImage(WebCore::CachedImage&) final;
+    bool isRendererClient() const final;
 
     URL m_url;
     const Ref<CSSImageValue> m_cssValue;

--- a/Source/WebCore/style/values/images/kinds/StyleCanvasImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleCanvasImage.cpp
@@ -87,7 +87,6 @@ RefPtr<WebCore::Image> CanvasImage::image(const RenderElement* renderer, const F
     if (!renderer)
         return &WebCore::Image::nullImage();
 
-    ASSERT(clients().contains(const_cast<RenderElement&>(*renderer)));
     RefPtr element = this->element(protect(renderer->document()));
     if (!element)
         return nullptr;
@@ -107,16 +106,18 @@ FloatSize CanvasImage::fixedSize(const RenderElement& renderer) const
     return { };
 }
 
-void CanvasImage::didAddClient(RenderElement& renderer)
+void CanvasImage::didAddClient(ImageClient&)
 {
-    if (RefPtr element = this->element(protect(renderer.document())))
-        InspectorInstrumentation::didChangeCSSCanvasClientNodes(*element);
+    // FIXME: Implement
+    //    if (RefPtr element = this->element(protect(renderer.document())))
+    //        InspectorInstrumentation::didChangeCSSCanvasClientNodes(*element);
 }
 
-void CanvasImage::didRemoveClient(RenderElement& renderer)
+void CanvasImage::didRemoveClient(ImageClient&)
 {
-    if (RefPtr element = this->element(protect(renderer.document())))
-        InspectorInstrumentation::didChangeCSSCanvasClientNodes(*element);
+    // FIXME: Implement
+    //    if (RefPtr element = this->element(protect(renderer.document())))
+    //        InspectorInstrumentation::didChangeCSSCanvasClientNodes(*element);
 }
 
 void CanvasImage::canvasContentsWillChange(CanvasBase& canvasBase, const FloatRect& changingRect)
@@ -125,9 +126,9 @@ void CanvasImage::canvasContentsWillChange(CanvasBase& canvasBase, const FloatRe
     ASSERT_UNUSED(canvasBase, m_element == &downcast<HTMLCanvasElement>(canvasBase));
 
     auto imageChangeRect = enclosingIntRect(changingRect);
-    for (auto entry : clients()) {
+    for (auto entry : m_clients) {
         auto& client = entry.key;
-        client.imageChanged(static_cast<WrappedImagePtr>(this), &imageChangeRect);
+        client.imageChanged(*this, &imageChangeRect);
     }
 }
 
@@ -136,9 +137,9 @@ void CanvasImage::canvasResized(CanvasBase& canvasBase)
     ASSERT_UNUSED(canvasBase, is<HTMLCanvasElement>(canvasBase));
     ASSERT_UNUSED(canvasBase, m_element == &downcast<HTMLCanvasElement>(canvasBase));
 
-    for (auto entry : clients()) {
+    for (auto entry : m_clients) {
         auto& client = entry.key;
-        client.imageChanged(static_cast<WrappedImagePtr>(this));
+        client.imageChanged(*this, nullptr);
     }
 }
 

--- a/Source/WebCore/style/values/images/kinds/StyleCanvasImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleCanvasImage.h
@@ -69,8 +69,9 @@ private:
     RefPtr<WebCore::Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     FloatSize fixedSize(const RenderElement&) const final;
-    void didAddClient(RenderElement&) final;
-    void didRemoveClient(RenderElement&) final;
+
+    void didAddClient(ImageClient&) final;
+    void didRemoveClient(ImageClient&) final;
 
     // CanvasObserver.
     bool isStyleCanvasImage() const final { return true; }

--- a/Source/WebCore/style/values/images/kinds/StyleColorImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleColorImage.h
@@ -54,8 +54,8 @@ private:
     RefPtr<WebCore::Image> image(const RenderElement*, const FloatSize&, const GraphicsContext&, bool isForFirstLine) const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     FloatSize fixedSize(const RenderElement&) const final;
-    void didAddClient(RenderElement&) final { }
-    void didRemoveClient(RenderElement&) final { }
+    void didAddClient(ImageClient&) final { }
+    void didRemoveClient(ImageClient&) final { }
 
     Color m_color;
 };

--- a/Source/WebCore/style/values/images/kinds/StyleCrossfadeImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleCrossfadeImage.cpp
@@ -52,14 +52,18 @@ CrossfadeImage::CrossfadeImage(RefPtr<Image>&& from, RefPtr<Image>&& to, Progres
     , m_isPrefixed { isPrefixed }
     , m_inputImagesAreReady { false }
 {
+    if (m_from)
+        protect(m_from)->addClient(*this);
+    if (m_to)
+        protect(m_to)->addClient(*this);
 }
 
 CrossfadeImage::~CrossfadeImage()
 {
-    if (m_cachedFromImage)
-        protect(m_cachedFromImage)->removeClient(*this);
-    if (m_cachedToImage)
-        protect(m_cachedToImage)->removeClient(*this);
+    if (m_from)
+        protect(m_from)->removeClient(*this);
+    if (m_to)
+        protect(m_to)->removeClient(*this);
 }
 
 bool CrossfadeImage::operator==(const Image& other) const
@@ -83,10 +87,6 @@ bool CrossfadeImage::equalInputImages(const CrossfadeImage& other) const
 RefPtr<CrossfadeImage> CrossfadeImage::blend(const CrossfadeImage& from, const BlendingContext& context) const
 {
     ASSERT(equalInputImages(from));
-
-    if (!m_cachedToImage || !m_cachedFromImage)
-        return nullptr;
-
     auto newProgress = Style::blend(from.m_progress, m_progress, context);
     return CrossfadeImage::create(m_from, m_to, newProgress, from.m_isPrefixed && m_isPrefixed);
 }
@@ -118,40 +118,19 @@ bool CrossfadeImage::isPending() const
     return false;
 }
 
+bool CrossfadeImage::isLoading() const
+{
+    if (m_from && protect(m_from)->isLoading())
+        return true;
+    if (m_to && protect(m_to)->isLoading())
+        return true;
+    return false;
+}
+
 void CrossfadeImage::load(CachedResourceLoader& loader, const ResourceLoaderOptions& options)
 {
-    auto oldCachedFromImage = m_cachedFromImage;
-    auto oldCachedToImage = m_cachedToImage;
-
-    if (m_from) {
-        RefPtr from = m_from;
-        if (from->isPending())
-            from->load(loader, options);
-        m_cachedFromImage = from->cachedImage();
-    } else
-        m_cachedFromImage = nullptr;
-
-    if (m_to) {
-        RefPtr to = m_to;
-        if (to->isPending())
-            to->load(loader, options);
-        m_cachedToImage = to->cachedImage();
-    } else
-        m_cachedToImage = nullptr;
-
-    if (m_cachedFromImage != oldCachedFromImage) {
-        if (oldCachedFromImage)
-            protect(oldCachedFromImage)->removeClient(*this);
-        if (m_cachedFromImage)
-            protect(m_cachedFromImage)->addClient(*this);
-    }
-
-    if (m_cachedToImage != oldCachedToImage) {
-        if (oldCachedToImage)
-            protect(oldCachedToImage)->removeClient(*this);
-        if (m_cachedToImage)
-            protect(m_cachedToImage)->addClient(*this);
-    }
+    protect(m_from)->load(loader, options);
+    protect(m_to)->load(loader, options);
 
     m_inputImagesAreReady = true;
 }
@@ -176,19 +155,20 @@ RefPtr<WebCore::Image> CrossfadeImage::image(const RenderElement* renderer, cons
     RefPtr protectedFromImage = fromImage;
     RefPtr protectedToImage = toImage;
 
-    if (RefPtr fromSVGImage = dynamicDowncast<SVGImage>(protectedFromImage)) {
-        auto fromURL = m_cachedFromImage ? protect(m_cachedFromImage)->url() : WTF::URL();
-        protectedFromImage = SVGImageForContainer::create(fromSVGImage.get(), { .containerSize = size, .initialFragmentURL = fromURL });
-    }
-    if (RefPtr toSVGImage = dynamicDowncast<SVGImage>(protectedToImage)) {
-        auto toURL = m_cachedToImage ? protect(m_cachedToImage)->url() : WTF::URL();
-        protectedToImage = SVGImageForContainer::create(toSVGImage.get(), { .containerSize = size, .initialFragmentURL = toURL });
-    }
+    // FIXME: Come back here.
+//    if (RefPtr fromSVGImage = dynamicDowncast<SVGImage>(protectedFromImage)) {
+//        auto fromURL = m_cachedFromImage ? protect(m_cachedFromImage)->url() : WTF::URL();
+//        protectedFromImage = SVGImageForContainer::create(fromSVGImage.get(), { .containerSize = size, .initialFragmentURL = fromURL });
+//    }
+//    if (RefPtr toSVGImage = dynamicDowncast<SVGImage>(protectedToImage)) {
+//        auto toURL = m_cachedToImage ? protect(m_cachedToImage)->url() : WTF::URL();
+//        protectedToImage = SVGImageForContainer::create(toSVGImage.get(), { .containerSize = size, .initialFragmentURL = toURL });
+//    }
 
     return CrossfadeGeneratedImage::create(*protectedFromImage, *protectedToImage, m_progress.value.value, fixedSize(*renderer), size);
 }
 
-bool CrossfadeImage::currentFrameIsComplete(const RenderElement* renderer) const
+bool CrossfadeImage::currentFrameIsComplete(const RenderElement& renderer) const
 {
     if (m_from && !protect(m_from)->currentFrameIsComplete(renderer))
         return false;
@@ -225,14 +205,123 @@ FloatSize CrossfadeImage::fixedSize(const RenderElement& renderer) const
     return fromImageSize * inverseProgress + toImageSize * progress;
 }
 
-void CrossfadeImage::imageChanged(WebCore::CachedImage*, const IntRect*)
+void CrossfadeImage::registerContainerContext(const ImageContainerContextKey& key, ImageContainerContext&& context)
 {
-    if (!m_inputImagesAreReady)
-        return;
-    for (auto entry : clients()) {
-        CheckedRef client = entry.key;
-        client->imageChanged(static_cast<WrappedImagePtr>(this));
+    if (m_from)
+        protect(m_from)->registerContainerContext(key, ImageContainerContext { context });
+    if (m_to)
+        protect(m_to)->registerContainerContext(key, ImageContainerContext { context });
+
+    GeneratedImage::registerContainerContext(key, WTF::move(context));
+}
+
+bool CrossfadeImage::contains(const Image& image) const
+{
+    return (m_to && protect(m_to)->isOrContains(image))
+        || (m_from && protect(m_from)->isOrContains(image));
+}
+
+void CrossfadeImage::imageChanged(const Image& image, const IntRect* changeRect) const
+{
+    //    if (!m_inputImagesAreReady)
+    //        return;
+
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->imageChanged(image, changeRect);
     }
+}
+
+void CrossfadeImage::notifyFinished(const CachedImage& image) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->notifyFinished(image);
+    }
+}
+
+bool CrossfadeImage::allowsAnimation(const CachedImage& image) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->allowsAnimation(image))
+            return true;
+    }
+    return ImageClient::allowsAnimation(image);
+}
+
+bool CrossfadeImage::canDestroyDecodedData(const CachedImage& image) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (!client->canDestroyDecodedData(image))
+            return false;
+    }
+    return ImageClient::canDestroyDecodedData(image);
+}
+
+bool CrossfadeImage::useSystemDarkAppearance(const CachedImage& image) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->useSystemDarkAppearance(image))
+            return true;
+    }
+    return ImageClient::useSystemDarkAppearance(image);
+}
+
+VisibleInViewportState CrossfadeImage::imageFrameAvailable(const CachedImage& image, ImageAnimatingState animatingState, const IntRect* changeRect) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->imageFrameAvailable(image, animatingState, changeRect) == VisibleInViewportState::Yes)
+            return VisibleInViewportState::Yes;
+    }
+    return ImageClient::imageFrameAvailable(image, animatingState, changeRect);
+}
+
+VisibleInViewportState CrossfadeImage::imageVisibleInViewport(const CachedImage& image, const Document& document) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->imageVisibleInViewport(image, document) == VisibleInViewportState::Yes)
+            return VisibleInViewportState::Yes;
+    }
+    return ImageClient::imageVisibleInViewport(image, document);
+}
+
+void CrossfadeImage::didRemoveCachedImageClient(const CachedImage& image) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->didRemoveCachedImageClient(image);
+    }
+}
+
+void CrossfadeImage::imageContentChanged(const CachedImage& image) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->imageContentChanged(image);
+    }
+}
+
+void CrossfadeImage::scheduleRenderingUpdateForImage(const CachedImage& image) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->imageContentChanged(image);
+    }
+}
+
+bool CrossfadeImage::isRendererClient() const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->isRendererClient())
+            return true;
+    }
+    return ImageClient::isRendererClient();
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/images/kinds/StyleCrossfadeImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleCrossfadeImage.h
@@ -27,8 +27,6 @@
 
 #pragma once
 
-#include "CachedImageClient.h"
-#include "CachedResourceHandle.h"
 #include "StyleGeneratedImage.h"
 #include "StylePrimitiveNumericTypes.h"
 
@@ -38,7 +36,7 @@ struct BlendingContext;
 
 namespace Style {
 
-class CrossfadeImage final : public GeneratedImage, private CachedImageClient {
+class CrossfadeImage final : public GeneratedImage, private ImageClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(CrossfadeImage);
 public:
     using Progress = NumberOrPercentageResolvedToNumber<CSS::ClosedUnitRangeClampBoth, CSS::ClosedPercentageRangeClampBoth>;
@@ -49,7 +47,7 @@ public:
     }
     virtual ~CrossfadeImage();
 
-    // CachedResourceClient.
+    // ImageClient.
     void ref() const final { GeneratedImage::ref(); }
     void deref() const final { GeneratedImage::deref(); }
 
@@ -67,28 +65,34 @@ private:
     Ref<CSSValue> computedStyleValue(const Style::ComputedStyle&) const final;
     Ref<DeprecatedCSSOMValue> computedStyleDeprecatedCSSOMValue(CSSValuePool&, const Style::ComputedStyle&, CSSStyleDeclaration&) const final;
     bool isPending() const final;
+    bool isLoading() const final;
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
     RefPtr<WebCore::Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
-    bool currentFrameIsComplete(const RenderElement*) const final;
+    bool currentFrameIsComplete(const RenderElement&) const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     FloatSize fixedSize(const RenderElement&) const final;
-    void didAddClient(RenderElement&) final { }
-    void didRemoveClient(RenderElement&) final { }
+    void registerContainerContext(const ImageContainerContextKey&, ImageContainerContext&&) final;
+    bool contains(const Image&) const final;
+    void didAddClient(ImageClient&) final { }
+    void didRemoveClient(ImageClient&) final { }
 
-    // CachedImageClient.
-    void imageChanged(WebCore::CachedImage*, const IntRect*) final;
+    // ImageClient.
+    void imageChanged(const Image&, const IntRect*) const final;
+    void notifyFinished(const CachedImage&) const final;
+    bool allowsAnimation(const CachedImage&) const final;
+    bool canDestroyDecodedData(const CachedImage&) const final;
+    bool useSystemDarkAppearance(const CachedImage&) const final;
+    VisibleInViewportState imageFrameAvailable(const CachedImage&, ImageAnimatingState, const IntRect*) const final;
+    VisibleInViewportState imageVisibleInViewport(const CachedImage&, const Document&) const final;
+    void didRemoveCachedImageClient(const CachedImage&) const final;
+    void imageContentChanged(const CachedImage&) const final;
+    void scheduleRenderingUpdateForImage(const CachedImage&) const final;
+    bool isRendererClient() const final;
 
     RefPtr<Image> m_from;
     RefPtr<Image> m_to;
     Progress m_progress;
     bool m_isPrefixed;
-
-    // FIXME: Rather than caching and tracking the input image via WebCore::CachedImages, we should
-    // instead use a new, Style::Image specific notification, to allow correct tracking of
-    // nested images (e.g. one of the input images for a Style::CrossfadeImage is a Style::FilterImage
-    // where its input image is a Style::CachedImage).
-    CachedResourceHandle<WebCore::CachedImage> m_cachedFromImage;
-    CachedResourceHandle<WebCore::CachedImage> m_cachedToImage;
     bool m_inputImagesAreReady;
 };
 

--- a/Source/WebCore/style/values/images/kinds/StyleCursorImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleCursorImage.cpp
@@ -113,11 +113,9 @@ ImageWithScale CursorImage::selectBestFitImage(const Document& document)
     return { m_image.ptr(), 1_css_dppx, std::nullopt };
 }
 
-void CursorImage::setContainerContextForRenderer(const RenderElement& renderer, const FloatSize& containerSize, float containerZoom, const WTF::URL& url)
+void CursorImage::registerContainerContext(const ImageContainerContextKey& key, ImageContainerContext&& context)
 {
-    if (!hasCachedImage())
-        return;
-    protect(cachedImage())->setContainerContextForClient(renderer.cachedImageClient(), LayoutSize(containerSize), containerZoom, !url.isNull() ? url : m_originalURL.resolved, renderer.style().linkParameters());
+    m_image->registerContainerContext(key, WTF::move(context));
 }
 
 bool CursorImage::usesDataProtocol() const

--- a/Source/WebCore/style/values/images/kinds/StyleCursorImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleCursorImage.h
@@ -56,9 +56,9 @@ private:
     explicit CursorImage(const Ref<Image>&, std::optional<HotSpot>, const URL&);
     explicit CursorImage(Ref<Image>&&, std::optional<HotSpot>, URL&&);
 
-    void setContainerContextForRenderer(const RenderElement& renderer, const FloatSize& containerSize, float containerZoom, const WTF::URL& = WTF::URL()) final;
-    Ref<CSSValue> computedStyleValue(const Style::ComputedStyle&) const final;
-    Ref<DeprecatedCSSOMValue> computedStyleDeprecatedCSSOMValue(CSSValuePool&, const Style::ComputedStyle&, CSSStyleDeclaration&) const final;
+    void registerContainerContext(const ImageContainerContextKey&, ImageContainerContext&&) final;
+    Ref<CSSValue> computedStyleValue(const ComputedStyle&) const final;
+    Ref<DeprecatedCSSOMValue> computedStyleDeprecatedCSSOMValue(CSSValuePool&, const ComputedStyle&, CSSStyleDeclaration&) const final;
     ImageWithScale selectBestFitImage(const Document&) final;
 
     const Ref<Image> m_image;

--- a/Source/WebCore/style/values/images/kinds/StyleFilterImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleFilterImage.cpp
@@ -53,12 +53,14 @@ FilterImage::FilterImage(RefPtr<Image>&& image, Filter&& filter)
     , m_filter { WTF::move(filter) }
     , m_inputImageIsReady { false }
 {
+    if (m_image)
+        protect(m_image)->addClient(*this);
 }
 
 FilterImage::~FilterImage()
 {
-    if (RefPtr cachedImage = m_cachedImage)
-        cachedImage->removeClient(*this);
+    if (m_image)
+        protect(m_image)->removeClient(*this);
 }
 
 bool FilterImage::operator==(const Image& other) const
@@ -93,26 +95,18 @@ Ref<DeprecatedCSSOMValue> FilterImage::computedStyleDeprecatedCSSOMValue(CSSValu
 
 bool FilterImage::isPending() const
 {
-    RefPtr image = m_image;
-    return image && image->isPending();
+    return m_image && protect(m_image)->isPending();
+}
+
+bool FilterImage::isLoading() const
+{
+    return m_image && protect(m_image)->isLoading();
 }
 
 void FilterImage::load(CachedResourceLoader& cachedResourceLoader, const ResourceLoaderOptions& options)
 {
-    RefPtr oldCachedImage = m_cachedImage;
-
-    if (RefPtr image = m_image) {
-        image->load(cachedResourceLoader, options);
-        m_cachedImage = image->cachedImage();
-    } else
-        m_cachedImage = nullptr;
-
-    if (m_cachedImage != oldCachedImage) {
-        if (oldCachedImage)
-            oldCachedImage->removeClient(*this);
-        if (RefPtr cachedImage = m_cachedImage)
-            cachedImage->addClient(*this);
-    }
+    if (m_image)
+        protect(m_image)->load(cachedResourceLoader, options);
 
     for (auto& value : m_filter) {
         WTF::switchOn(value,
@@ -176,20 +170,125 @@ bool FilterImage::knownToBeOpaque(const RenderElement&) const
 
 FloatSize FilterImage::fixedSize(const RenderElement& renderer) const
 {
-    if (RefPtr image = m_image)
-        return image->imageSize(&renderer, 1);
+    if (m_image)
+        return protect(m_image)->imageSize(&renderer, 1);
     return { };
 }
 
-void FilterImage::imageChanged(WebCore::CachedImage*, const IntRect*)
+void FilterImage::registerContainerContext(const ImageContainerContextKey& key, ImageContainerContext&& context)
 {
-    if (!m_inputImageIsReady)
-        return;
+    if (m_image)
+        protect(m_image)->registerContainerContext(key, ImageContainerContext { context });
 
-    for (auto entry : clients()) {
-        CheckedRef client = entry.key;
-        client->imageChanged(static_cast<WrappedImagePtr>(this));
+    GeneratedImage::registerContainerContext(key, WTF::move(context));
+}
+
+bool FilterImage::contains(const Image& image) const
+{
+    return m_image && protect(m_image)->isOrContains(image);
+}
+
+void FilterImage::imageChanged(const Image& image, const IntRect* changeRect) const
+{
+    //    if (!m_inputImageIsReady)
+    //        return;
+
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->imageChanged(image, changeRect);
     }
+}
+
+void FilterImage::notifyFinished(const CachedImage& image) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->notifyFinished(image);
+    }
+}
+
+bool FilterImage::allowsAnimation(const CachedImage& image) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->allowsAnimation(image))
+            return true;
+    }
+    return ImageClient::allowsAnimation(image);
+}
+
+bool FilterImage::canDestroyDecodedData(const CachedImage& image) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (!client->canDestroyDecodedData(image))
+            return false;
+    }
+    return ImageClient::canDestroyDecodedData(image);
+}
+
+bool FilterImage::useSystemDarkAppearance(const CachedImage& image) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->useSystemDarkAppearance(image))
+            return true;
+    }
+    return ImageClient::useSystemDarkAppearance(image);
+}
+
+VisibleInViewportState FilterImage::imageFrameAvailable(const CachedImage& image, ImageAnimatingState animatingState, const IntRect* changeRect) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->imageFrameAvailable(image, animatingState, changeRect) == VisibleInViewportState::Yes)
+            return VisibleInViewportState::Yes;
+    }
+    return ImageClient::imageFrameAvailable(image, animatingState, changeRect);
+}
+
+VisibleInViewportState FilterImage::imageVisibleInViewport(const CachedImage& image, const Document& document) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->imageVisibleInViewport(image, document) == VisibleInViewportState::Yes)
+            return VisibleInViewportState::Yes;
+    }
+    return ImageClient::imageVisibleInViewport(image, document);
+}
+
+void FilterImage::didRemoveCachedImageClient(const CachedImage& image) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->didRemoveCachedImageClient(image);
+    }
+}
+
+void FilterImage::imageContentChanged(const CachedImage& image) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->imageContentChanged(image);
+    }
+}
+
+void FilterImage::scheduleRenderingUpdateForImage(const CachedImage& image) const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->imageContentChanged(image);
+    }
+}
+
+bool FilterImage::isRendererClient() const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->isRendererClient())
+            return true;
+    }
+    return ImageClient::isRendererClient();
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/images/kinds/StyleFilterImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleFilterImage.h
@@ -27,15 +27,13 @@
 
 #pragma once
 
-#include "CachedImageClient.h"
-#include "CachedResourceHandle.h"
 #include "StyleFilter.h"
 #include "StyleGeneratedImage.h"
 
 namespace WebCore {
 namespace Style {
 
-class FilterImage final : public GeneratedImage, private CachedImageClient {
+class FilterImage final : public GeneratedImage, private ImageClient {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(FilterImage);
 public:
     static Ref<FilterImage> create(RefPtr<Image> image, Filter filter)
@@ -44,7 +42,7 @@ public:
     }
     virtual ~FilterImage();
 
-    // CachedResourceClient.
+    // ImageClient.
     void ref() const final { GeneratedImage::ref(); }
     void deref() const final { GeneratedImage::deref(); }
 
@@ -63,24 +61,31 @@ private:
     Ref<CSSValue> computedStyleValue(const Style::ComputedStyle&) const final;
     Ref<DeprecatedCSSOMValue> computedStyleDeprecatedCSSOMValue(CSSValuePool&, const Style::ComputedStyle&, CSSStyleDeclaration&) const final;
     bool isPending() const final;
+    bool isLoading() const final;
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
     RefPtr<WebCore::Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     FloatSize fixedSize(const RenderElement&) const final;
-    void didAddClient(RenderElement&) final { }
-    void didRemoveClient(RenderElement&) final { }
+    void registerContainerContext(const ImageContainerContextKey&, ImageContainerContext&&) final;
+    bool contains(const Image&) const final;
+    void didAddClient(ImageClient&) final { }
+    void didRemoveClient(ImageClient&) final { }
 
-    // CachedImageClient.
-    void imageChanged(WebCore::CachedImage*, const IntRect* = nullptr) final;
+    // ImageClient.
+    void imageChanged(const Image&, const IntRect*) const final;
+    void notifyFinished(const CachedImage&) const final;
+    bool allowsAnimation(const CachedImage&) const final;
+    bool canDestroyDecodedData(const CachedImage&) const final;
+    bool useSystemDarkAppearance(const CachedImage&) const final;
+    VisibleInViewportState imageFrameAvailable(const CachedImage&, ImageAnimatingState, const IntRect*) const final;
+    VisibleInViewportState imageVisibleInViewport(const CachedImage&, const Document&) const final;
+    void didRemoveCachedImageClient(const CachedImage&) const final;
+    void imageContentChanged(const CachedImage&) const final;
+    void scheduleRenderingUpdateForImage(const CachedImage&) const final;
+    bool isRendererClient() const final;
 
     RefPtr<Image> m_image;
     Filter m_filter;
-
-    // FIXME: Rather than caching and tracking the input image via WebCore::CachedImages, we should
-    // instead use a new, Style::Image specific notification, to allow correct tracking of
-    // nested images (e.g. the input image for a Style::FilterImage is a Style::CrossfadeImage
-    // where one of the inputs to the Style::CrossfadeImage is a Style::CachedImage).
-    CachedResourceHandle<WebCore::CachedImage> m_cachedImage;
     bool m_inputImageIsReady;
 };
 

--- a/Source/WebCore/style/values/images/kinds/StyleGeneratedImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleGeneratedImage.cpp
@@ -105,7 +105,7 @@ void GeneratedImage::evictCachedGeneratedImage(FloatSize size)
     m_images.remove(size);
 }
 
-FloatSize GeneratedImage::imageSize(const RenderElement* renderer, float multiplier, WebCore::CachedImage::SizeType) const
+FloatSize GeneratedImage::imageSize(const RenderElement* renderer, float multiplier, ImageSizeType) const
 {
     if (!m_fixedSize)
         return m_containerSize;
@@ -139,33 +139,9 @@ void GeneratedImage::computeIntrinsicDimensions(const RenderElement* renderer, f
     intrinsicRatio = size;
 }
 
-// MARK: Client support.
-
-void GeneratedImage::addClient(RenderElement& renderer)
+void GeneratedImage::registerContainerContext(const ImageContainerContextKey&, ImageContainerContext&& context)
 {
-    if (m_clients.isEmptyIgnoringNullReferences())
-        ref();
-
-    m_clients.add(renderer);
-
-    this->didAddClient(renderer);
-}
-
-void GeneratedImage::removeClient(RenderElement& renderer)
-{
-    ASSERT(m_clients.contains(renderer));
-    if (!m_clients.remove(renderer))
-        return;
-
-    this->didRemoveClient(renderer);
-
-    if (m_clients.isEmptyIgnoringNullReferences())
-        deref();
-}
-
-bool GeneratedImage::hasClient(RenderElement& renderer) const
-{
-    return m_clients.contains(renderer);
+    m_containerSize = context.containerSize;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/images/kinds/StyleGeneratedImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleGeneratedImage.h
@@ -42,31 +42,20 @@ struct ResourceLoaderOptions;
 namespace Style {
 
 class GeneratedImage : public Image {
-public:
-    const SingleThreadWeakHashCountedSet<RenderElement>& clients() const LIFETIME_BOUND { return m_clients; }
-
 protected:
     explicit GeneratedImage(Image::Type, bool fixedSize);
     virtual ~GeneratedImage();
 
     WrappedImagePtr data() const final { return this; }
 
-    FloatSize imageSize(const RenderElement*, float multiplier, WebCore::CachedImage::SizeType = WebCore::CachedImage::UsedSize) const final;
+    FloatSize imageSize(const RenderElement*, float multiplier, ImageSizeType = ImageSizeType::Used) const final;
     void computeIntrinsicDimensions(const RenderElement*, float& intrinsicWidth, float& intrinsicHeight, FloatSize& intrinsicRatio) final;
     bool imageHasRelativeWidth() const final { return !m_fixedSize; }
     bool imageHasRelativeHeight() const final { return !m_fixedSize; }
     bool usesImageContainerSize() const final { return !m_fixedSize; }
-    void setContainerContextForRenderer(const RenderElement&, const FloatSize& containerSize, float, const WTF::URL& = WTF::URL()) final { m_containerSize = containerSize; }
+    void registerContainerContext(const ImageContainerContextKey&, ImageContainerContext&&) override;
     bool imageHasNaturalDimensions() const final { return !usesImageContainerSize(); }
     bool imageHasNaturalAspectRatio() const final { return !usesImageContainerSize(); }
-
-    void addClient(RenderElement&) final;
-    void removeClient(RenderElement&) final;
-    bool hasClient(RenderElement&) const final;
-
-    // Allow subclasses to react to clients being added/removed.
-    virtual void didAddClient(RenderElement&) = 0;
-    virtual void didRemoveClient(RenderElement&) = 0;
 
     // All generated images must be able to compute their fixed size.
     virtual FloatSize fixedSize(const RenderElement&) const = 0;
@@ -78,7 +67,6 @@ protected:
 
     FloatSize m_containerSize;
     bool m_fixedSize;
-    SingleThreadWeakHashCountedSet<RenderElement> m_clients;
     HashMap<FloatSize, std::unique_ptr<CachedGeneratedImage>> m_images;
 };
 

--- a/Source/WebCore/style/values/images/kinds/StyleImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleImage.cpp
@@ -1,5 +1,4 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
  * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,45 +24,38 @@
  * SUCH DAMAGE.
  */
 
-#pragma once
-
-#include "StyleCustomIdent.h"
-#include "StyleGeneratedImage.h"
+#include "config.h"
+#include "StyleImage.h"
 
 namespace WebCore {
 namespace Style {
 
-class NamedImage final : public GeneratedImage {
-public:
-    static Ref<NamedImage> create(CustomIdent&& name)
-    {
-        return adoptRef(*new NamedImage(WTF::move(name)));
-    }
-    virtual ~NamedImage();
+void Image::addClient(ImageClient& client)
+{
+    if (m_clients.isEmptyIgnoringNullReferences())
+        ref();
 
-    bool operator==(const Image&) const final;
-    bool NODELETE equals(const NamedImage&) const;
+    m_clients.add(client);
 
-    static constexpr bool isFixedSize = false;
+    this->didAddClient(client);
+}
 
-private:
-    explicit NamedImage(CustomIdent&&);
+void Image::removeClient(ImageClient& client)
+{
+    ASSERT(m_clients.contains(client));
+    if (!m_clients.remove(client))
+        return;
 
-    Ref<CSSValue> computedStyleValue(const Style::ComputedStyle&) const final;
-    Ref<DeprecatedCSSOMValue> computedStyleDeprecatedCSSOMValue(CSSValuePool&, const Style::ComputedStyle&, CSSStyleDeclaration&) const final;
-    bool isPending() const final;
-    void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<WebCore::Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
-    bool knownToBeOpaque(const RenderElement&) const final;
-    FloatSize fixedSize(const RenderElement&) const final;
-    void didAddClient(ImageClient&) final { }
-    void didRemoveClient(ImageClient&) final { }
+    this->didRemoveClient(client);
 
-    CustomIdent m_name;
-};
+    if (m_clients.isEmptyIgnoringNullReferences())
+        deref();
+}
+
+bool Image::hasClient(ImageClient& client) const
+{
+    return m_clients.contains(client);
+}
 
 } // namespace Style
 } // namespace WebCore
-
-SPECIALIZE_TYPE_TRAITS_STYLE_IMAGE(NamedImage, isNamedImage)
-

--- a/Source/WebCore/style/values/images/kinds/StyleImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleImage.h
@@ -29,6 +29,9 @@
 #include <WebCore/FloatSize.h>
 #include <WebCore/Image.h>
 #include <WebCore/RenderObject.h>
+#include <WebCore/StyleImageClient.h>
+#include <WebCore/StyleImageContainerContextKey.h>
+#include <WebCore/StyleImageSizeOptions.h>
 #include <WebCore/StyleURL.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefPtr.h>
@@ -43,8 +46,10 @@ class CSSStyleDeclaration;
 class CSSValue;
 class CSSValuePool;
 class Document;
+class ImageContainerContextKey;
 class RenderElement;
 class RenderObject;
+struct ImageContainerContext;
 struct ResourceLoaderOptions;
 
 namespace Style {
@@ -66,6 +71,7 @@ public:
 
     // Loading.
     virtual bool isPending() const = 0;
+    virtual bool isLoading() const { return false; }
     virtual void load(CachedResourceLoader&, const ResourceLoaderOptions&) = 0;
     virtual bool isLoaded(const RenderElement*) const { return true; }
     virtual bool errorOccurred() const { return false; }
@@ -74,12 +80,14 @@ public:
     virtual URL url() const { return { }; }
 
     // Clients.
-    virtual void addClient(RenderElement&) = 0;
-    virtual void removeClient(RenderElement&) = 0;
-    virtual bool hasClient(RenderElement&) const = 0;
+    void addClient(ImageClient&);
+    void removeClient(ImageClient&);
+    bool hasClient(ImageClient&) const;
+    virtual void didAddClient(ImageClient&) = 0;
+    virtual void didRemoveClient(ImageClient&) = 0;
 
     // Size / scale.
-    virtual FloatSize imageSize(const RenderElement*, float multiplier, WebCore::CachedImage::SizeType = WebCore::CachedImage::UsedSize) const = 0;
+    virtual FloatSize imageSize(const RenderElement*, float multiplier, ImageSizeType = ImageSizeType::Used) const = 0;
     virtual bool usesImageContainerSize() const = 0;
     virtual void computeIntrinsicDimensions(const RenderElement*, float& intrinsicWidth, float& intrinsicHeight, FloatSize& intrinsicRatio) = 0;
     virtual bool imageHasRelativeWidth() const = 0;
@@ -87,19 +95,29 @@ public:
     virtual float imageScaleFactor() const { return 1; }
     virtual bool imageHasNaturalDimensions() const { return true; }
     virtual bool imageHasNaturalAspectRatio() const { return true; }
+    virtual bool hasHDRContent() const { return false; }
 
     // Platform Image.
+    virtual RefPtr<WebCore::Image> image() const { return nullptr; } // Returns the source backing image - see CachedImage::image().
     virtual RefPtr<WebCore::Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine = false) const = 0;
     virtual WebCore::CachedImage* cachedImage() const { return nullptr; }
-    virtual bool currentFrameIsComplete(const RenderElement*) const { return true; }
+    virtual bool currentFrameIsComplete(const RenderElement&) const { return true; }
+
+    virtual void addClientWaitingForAsyncDecoding(ImageClient&) { }
+    virtual void removeAllClientsWaitingForAsyncDecoding() { }
+    virtual bool isClientWaitingForAsyncDecoding(ImageClient&) const { return false; }
 
     // Multiple Image selection.
     virtual Image* selectedImage() { return this; }
     virtual const Image* selectedImage() const { return this; }
 
+    // Children.
+    virtual bool contains(const Image&) const { return false; }
+    bool isOrContains(const Image& other) const { return this == &other || contains(other); }
+
     // Rendering.
     virtual bool canRender(const RenderElement*, float /*multiplier*/) const { return true; }
-    virtual void setContainerContextForRenderer(const RenderElement&, const FloatSize&, float, const WTF::URL& = WTF::URL()) = 0;
+    virtual void registerContainerContext(const ImageContainerContextKey&, ImageContainerContext&&) = 0;
     virtual bool knownToBeOpaque(const RenderElement&) const = 0;
 
     // Derived type.
@@ -139,6 +157,7 @@ protected:
     }
 
     Type m_type;
+    SingleThreadWeakHashCountedSet<ImageClient> m_clients;
 };
 
 } // namespace Style

--- a/Source/WebCore/style/values/images/kinds/StyleImageClient.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleImageClient.cpp
@@ -1,5 +1,4 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
  * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,45 +24,66 @@
  * SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "StyleImageClient.h"
 
-#include "StyleCustomIdent.h"
-#include "StyleGeneratedImage.h"
+#include "CachedImageClient.h"
 
 namespace WebCore {
 namespace Style {
 
-class NamedImage final : public GeneratedImage {
-public:
-    static Ref<NamedImage> create(CustomIdent&& name)
-    {
-        return adoptRef(*new NamedImage(WTF::move(name)));
-    }
-    virtual ~NamedImage();
+ImageClient::ImageClient() = default;
+ImageClient::~ImageClient() = default;
 
-    bool operator==(const Image&) const final;
-    bool NODELETE equals(const NamedImage&) const;
+void ImageClient::imageChanged(const Image&, const IntRect*) const
+{
+}
 
-    static constexpr bool isFixedSize = false;
+void ImageClient::notifyFinished(const CachedImage&) const
+{
+}
 
-private:
-    explicit NamedImage(CustomIdent&&);
+bool ImageClient::allowsAnimation(const CachedImage&) const
+{
+    return true;
+}
 
-    Ref<CSSValue> computedStyleValue(const Style::ComputedStyle&) const final;
-    Ref<DeprecatedCSSOMValue> computedStyleDeprecatedCSSOMValue(CSSValuePool&, const Style::ComputedStyle&, CSSStyleDeclaration&) const final;
-    bool isPending() const final;
-    void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<WebCore::Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
-    bool knownToBeOpaque(const RenderElement&) const final;
-    FloatSize fixedSize(const RenderElement&) const final;
-    void didAddClient(ImageClient&) final { }
-    void didRemoveClient(ImageClient&) final { }
+bool ImageClient::canDestroyDecodedData(const CachedImage&) const
+{
+    return true;
+}
 
-    CustomIdent m_name;
-};
+bool ImageClient::useSystemDarkAppearance(const CachedImage&) const
+{
+    return false;
+}
+
+VisibleInViewportState ImageClient::imageFrameAvailable(const CachedImage&, ImageAnimatingState, const IntRect*) const
+{
+    return VisibleInViewportState::No;
+}
+
+VisibleInViewportState ImageClient::imageVisibleInViewport(const CachedImage&, const Document&) const
+{
+    return VisibleInViewportState::No;
+}
+
+void ImageClient::didRemoveCachedImageClient(const CachedImage&) const
+{
+}
+
+void ImageClient::imageContentChanged(const CachedImage&) const
+{
+}
+
+void ImageClient::scheduleRenderingUpdateForImage(const CachedImage&) const
+{
+}
+
+bool ImageClient::isRendererClient() const
+{
+    return false;
+}
 
 } // namespace Style
 } // namespace WebCore
-
-SPECIALIZE_TYPE_TRAITS_STYLE_IMAGE(NamedImage, isNamedImage)
-

--- a/Source/WebCore/style/values/images/kinds/StyleImageClient.h
+++ b/Source/WebCore/style/values/images/kinds/StyleImageClient.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
  * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,45 +26,46 @@
 
 #pragma once
 
-#include "StyleGeneratedImage.h"
-#include "StyleGradient.h"
+#include <wtf/AbstractRefCounted.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
+
+class Document;
+class IntRect;
+
+enum class ImageAnimatingState : bool;
+enum class VisibleInViewportState : uint8_t;
+
 namespace Style {
 
-class GradientImage final : public GeneratedImage {
+class Image;
+class CachedImage;
+
+class ImageClient : public CanMakeSingleThreadWeakPtr<ImageClient>, public AbstractRefCounted {
+    WTF_MAKE_NONCOPYABLE(ImageClient);
 public:
-    static Ref<GradientImage> create(Gradient gradient)
-    {
-        return adoptRef(*new GradientImage(WTF::move(gradient)));
-    }
-    virtual ~GradientImage();
+    virtual ~ImageClient();
 
-    bool operator==(const Image&) const final;
-    bool equals(const GradientImage&) const;
+    virtual void imageChanged(const Image&, const IntRect*) const;
 
-    static constexpr bool isFixedSize = false;
+    // Called for any Style::CachedImage children.
+    virtual void notifyFinished(const CachedImage&) const;
+    virtual bool allowsAnimation(const CachedImage&) const;
+    virtual bool canDestroyDecodedData(const CachedImage&) const;
+    virtual bool useSystemDarkAppearance(const CachedImage&) const;
+    virtual VisibleInViewportState imageFrameAvailable(const CachedImage&, ImageAnimatingState, const IntRect*) const;
+    virtual VisibleInViewportState imageVisibleInViewport(const CachedImage&, const Document&) const;
+    virtual void didRemoveCachedImageClient(const CachedImage&) const;
+    virtual void imageContentChanged(const CachedImage&) const;
+    virtual void scheduleRenderingUpdateForImage(const CachedImage&) const;
 
-    const Gradient& gradient() const LIFETIME_BOUND { return m_gradient; }
+    virtual bool isRendererClient() const;
 
-private:
-    explicit GradientImage(Gradient&&);
-
-    Ref<CSSValue> computedStyleValue(const Style::ComputedStyle&) const final;
-    Ref<DeprecatedCSSOMValue> computedStyleDeprecatedCSSOMValue(CSSValuePool&, const Style::ComputedStyle&, CSSStyleDeclaration&) const final;
-    bool isPending() const final;
-    void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<WebCore::Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
-    bool knownToBeOpaque(const RenderElement&) const final;
-    FloatSize fixedSize(const RenderElement&) const final;
-    void didAddClient(ImageClient&) final { }
-    void didRemoveClient(ImageClient&) final { }
-
-    Gradient m_gradient;
-    bool m_knownCacheableBarringFilter { false };
+protected:
+    ImageClient();
 };
 
 } // namespace Style
 } // namespace WebCore
-
-SPECIALIZE_TYPE_TRAITS_STYLE_IMAGE(GradientImage, isGradientImage)

--- a/Source/WebCore/style/values/images/kinds/StyleImageContainerContext.h
+++ b/Source/WebCore/style/values/images/kinds/StyleImageContainerContext.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
  * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,43 +26,18 @@
 
 #pragma once
 
-#include "StyleCustomIdent.h"
-#include "StyleGeneratedImage.h"
+#include <WebCore/FloatSize.h>
+#include <WebCore/StyleLinkParameters.h>
+#include <wtf/URL.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
-namespace Style {
 
-class NamedImage final : public GeneratedImage {
-public:
-    static Ref<NamedImage> create(CustomIdent&& name)
-    {
-        return adoptRef(*new NamedImage(WTF::move(name)));
-    }
-    virtual ~NamedImage();
-
-    bool operator==(const Image&) const final;
-    bool NODELETE equals(const NamedImage&) const;
-
-    static constexpr bool isFixedSize = false;
-
-private:
-    explicit NamedImage(CustomIdent&&);
-
-    Ref<CSSValue> computedStyleValue(const Style::ComputedStyle&) const final;
-    Ref<DeprecatedCSSOMValue> computedStyleDeprecatedCSSOMValue(CSSValuePool&, const Style::ComputedStyle&, CSSStyleDeclaration&) const final;
-    bool isPending() const final;
-    void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<WebCore::Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
-    bool knownToBeOpaque(const RenderElement&) const final;
-    FloatSize fixedSize(const RenderElement&) const final;
-    void didAddClient(ImageClient&) final { }
-    void didRemoveClient(ImageClient&) final { }
-
-    CustomIdent m_name;
+struct ImageContainerContext {
+    FloatSize containerSize;
+    float containerZoom;
+    URL imageURL;
+    Style::LinkParameters linkParameters { CSS::Keyword::None { } };
 };
 
-} // namespace Style
 } // namespace WebCore
-
-SPECIALIZE_TYPE_TRAITS_STYLE_IMAGE(NamedImage, isNamedImage)
-

--- a/Source/WebCore/style/values/images/kinds/StyleImageContainerContextKey.h
+++ b/Source/WebCore/style/values/images/kinds/StyleImageContainerContextKey.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
  * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,43 +26,18 @@
 
 #pragma once
 
-#include "StyleCustomIdent.h"
-#include "StyleGeneratedImage.h"
+#include <wtf/AbstractRefCounted.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
-namespace Style {
 
-class NamedImage final : public GeneratedImage {
+class ImageContainerContextKey : public CanMakeSingleThreadWeakPtr<ImageContainerContextKey>, public AbstractRefCounted {
 public:
-    static Ref<NamedImage> create(CustomIdent&& name)
-    {
-        return adoptRef(*new NamedImage(WTF::move(name)));
-    }
-    virtual ~NamedImage();
+    ~ImageContainerContextKey() = default;
 
-    bool operator==(const Image&) const final;
-    bool NODELETE equals(const NamedImage&) const;
-
-    static constexpr bool isFixedSize = false;
-
-private:
-    explicit NamedImage(CustomIdent&&);
-
-    Ref<CSSValue> computedStyleValue(const Style::ComputedStyle&) const final;
-    Ref<DeprecatedCSSOMValue> computedStyleDeprecatedCSSOMValue(CSSValuePool&, const Style::ComputedStyle&, CSSStyleDeclaration&) const final;
-    bool isPending() const final;
-    void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<WebCore::Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
-    bool knownToBeOpaque(const RenderElement&) const final;
-    FloatSize fixedSize(const RenderElement&) const final;
-    void didAddClient(ImageClient&) final { }
-    void didRemoveClient(ImageClient&) final { }
-
-    CustomIdent m_name;
+protected:
+    ImageContainerContextKey() = default;
 };
 
-} // namespace Style
 } // namespace WebCore
-
-SPECIALIZE_TYPE_TRAITS_STYLE_IMAGE(NamedImage, isNamedImage)
-

--- a/Source/WebCore/style/values/images/kinds/StyleImageSizeOptions.h
+++ b/Source/WebCore/style/values/images/kinds/StyleImageSizeOptions.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
  * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,43 +26,23 @@
 
 #pragma once
 
-#include "StyleCustomIdent.h"
-#include "StyleGeneratedImage.h"
+#include <WebCore/FloatSize.h>
+#include <WebCore/ImageOrientation.h>
+#include <optional>
 
 namespace WebCore {
-namespace Style {
 
-class NamedImage final : public GeneratedImage {
-public:
-    static Ref<NamedImage> create(CustomIdent&& name)
-    {
-        return adoptRef(*new NamedImage(WTF::move(name)));
-    }
-    virtual ~NamedImage();
-
-    bool operator==(const Image&) const final;
-    bool NODELETE equals(const NamedImage&) const;
-
-    static constexpr bool isFixedSize = false;
-
-private:
-    explicit NamedImage(CustomIdent&&);
-
-    Ref<CSSValue> computedStyleValue(const Style::ComputedStyle&) const final;
-    Ref<DeprecatedCSSOMValue> computedStyleDeprecatedCSSOMValue(CSSValuePool&, const Style::ComputedStyle&, CSSStyleDeclaration&) const final;
-    bool isPending() const final;
-    void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
-    RefPtr<WebCore::Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
-    bool knownToBeOpaque(const RenderElement&) const final;
-    FloatSize fixedSize(const RenderElement&) const final;
-    void didAddClient(ImageClient&) final { }
-    void didRemoveClient(ImageClient&) final { }
-
-    CustomIdent m_name;
+enum class ImageSizeType : bool {
+    Used,
+    Intrinsic
 };
 
-} // namespace Style
+struct ImageSizeOptions {
+    float multiplier = 1;
+    ImageSizeType type = ImageSizeType::Used;
+    float density = 1;
+    ImageOrientation orientation = ImageOrientation(ImageOrientation::Orientation::FromImage);
+    std::optional<FloatSize> overrideImageSize = std::nullopt;
+};
+
 } // namespace WebCore
-
-SPECIALIZE_TYPE_TRAITS_STYLE_IMAGE(NamedImage, isNamedImage)
-

--- a/Source/WebCore/style/values/images/kinds/StyleInvalidImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleInvalidImage.h
@@ -47,8 +47,8 @@ public:
     static constexpr bool isFixedSize = true;
 
 protected:
-    void didAddClient(RenderElement&) final { }
-    void didRemoveClient(RenderElement&) final { }
+    void didAddClient(ImageClient&) final { }
+    void didRemoveClient(ImageClient&) final { }
 
     FloatSize fixedSize(const RenderElement&) const final { return { }; }
 

--- a/Source/WebCore/style/values/images/kinds/StyleMultiImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleMultiImage.cpp
@@ -55,7 +55,11 @@ MultiImage::MultiImage(Type type)
 {
 }
 
-MultiImage::~MultiImage() = default;
+MultiImage::~MultiImage()
+{
+    if (m_selectedImage)
+        protect(m_selectedImage)->removeClient(*this);
+}
 
 bool MultiImage::equals(const MultiImage& other) const
 {
@@ -74,17 +78,25 @@ void MultiImage::load(CachedResourceLoader& loader, const ResourceLoaderOptions&
     ASSERT(is<CachedImage>(bestFitImage.image) || is<GeneratedImage>(bestFitImage.image));
 
     if (is<GeneratedImage>(bestFitImage.image)) {
+        if (m_selectedImage)
+            protect(m_selectedImage)->removeClient(*this);
+
         m_selectedImage = bestFitImage.image;
+        protect(m_selectedImage)->addClient(*this);
         protect(m_selectedImage)->load(loader, options);
         return;
     }
 
     if (RefPtr styleCachedImage = dynamicDowncast<CachedImage>(bestFitImage.image)) {
+        if (m_selectedImage)
+            protect(m_selectedImage)->removeClient(*this);
+
         if (styleCachedImage->imageScaleFactor() == bestFitImage.scaleFactor.value)
             m_selectedImage = WTF::move(styleCachedImage);
         else
             m_selectedImage = CachedImage::copyOverridingScaleFactor(*styleCachedImage, bestFitImage.scaleFactor.value);
 
+        protect(m_selectedImage)->addClient(*this);
         if (protect(m_selectedImage)->isPending())
             protect(m_selectedImage)->load(loader, options);
         return;
@@ -110,6 +122,11 @@ bool MultiImage::canRender(const RenderElement* renderer, float multiplier) cons
     return m_selectedImage && protect(m_selectedImage)->canRender(renderer, multiplier);
 }
 
+bool MultiImage::isLoading() const
+{
+    return m_selectedImage && protect(m_selectedImage)->isLoading();
+}
+
 bool MultiImage::isLoaded(const RenderElement* renderer) const
 {
     return m_selectedImage && protect(m_selectedImage)->isLoaded(renderer);
@@ -120,7 +137,7 @@ bool MultiImage::errorOccurred() const
     return m_selectedImage && protect(m_selectedImage)->errorOccurred();
 }
 
-FloatSize MultiImage::imageSize(const RenderElement* renderer, float multiplier, WebCore::CachedImage::SizeType sizeType) const
+FloatSize MultiImage::imageSize(const RenderElement* renderer, float multiplier, ImageSizeType sizeType) const
 {
     if (!m_selectedImage)
         return { };
@@ -149,32 +166,11 @@ bool MultiImage::usesImageContainerSize() const
     return m_selectedImage && protect(m_selectedImage)->usesImageContainerSize();
 }
 
-void MultiImage::setContainerContextForRenderer(const RenderElement& renderer, const FloatSize& containerSize, float containerZoom, const WTF::URL& url)
+void MultiImage::registerContainerContext(const ImageContainerContextKey& key, ImageContainerContext&& context)
 {
     if (!m_selectedImage)
         return;
-    protect(m_selectedImage)->setContainerContextForRenderer(renderer, containerSize, containerZoom, url);
-}
-
-void MultiImage::addClient(RenderElement& renderer)
-{
-    if (!m_selectedImage)
-        return;
-    protect(m_selectedImage)->addClient(renderer);
-}
-
-void MultiImage::removeClient(RenderElement& renderer)
-{
-    if (!m_selectedImage)
-        return;
-    protect(m_selectedImage)->removeClient(renderer);
-}
-
-bool MultiImage::hasClient(RenderElement& renderer) const
-{
-    if (!m_selectedImage)
-        return false;
-    return protect(m_selectedImage)->hasClient(renderer);
+    protect(m_selectedImage)->registerContainerContext(key, WTF::move(context));
 }
 
 RefPtr<WebCore::Image> MultiImage::image(const RenderElement* renderer, const FloatSize& size, const GraphicsContext& destinationContext, bool isForFirstLine) const
@@ -184,7 +180,7 @@ RefPtr<WebCore::Image> MultiImage::image(const RenderElement* renderer, const Fl
     return protect(m_selectedImage)->image(renderer, size, destinationContext, isForFirstLine);
 }
 
-bool MultiImage::currentFrameIsComplete(const RenderElement* renderer) const
+bool MultiImage::currentFrameIsComplete(const RenderElement& renderer) const
 {
     return m_selectedImage && protect(m_selectedImage)->currentFrameIsComplete(renderer);
 }
@@ -199,6 +195,141 @@ float MultiImage::imageScaleFactor() const
 bool MultiImage::knownToBeOpaque(const RenderElement& renderer) const
 {
     return m_selectedImage && protect(m_selectedImage)->knownToBeOpaque(renderer);
+}
+
+bool MultiImage::contains(const Image& image) const
+{
+    return m_selectedImage && protect(m_selectedImage)->isOrContains(image);
+}
+
+void MultiImage::imageChanged(const Image& image, const IntRect* changeRect) const
+{
+    if (!m_selectedImage || !m_selectedImage->isOrContains(image))
+        return;
+
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->imageChanged(image, changeRect);
+    }
+}
+
+void MultiImage::notifyFinished(const CachedImage& image) const
+{
+    if (!m_selectedImage || !m_selectedImage->isOrContains(image))
+        return;
+
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->notifyFinished(image);
+    }
+}
+
+bool MultiImage::allowsAnimation(const CachedImage& image) const
+{
+    if (!m_selectedImage || !m_selectedImage->isOrContains(image))
+        return ImageClient::allowsAnimation(image);
+
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->allowsAnimation(image))
+            return true;
+    }
+    return ImageClient::allowsAnimation(image);
+}
+
+bool MultiImage::canDestroyDecodedData(const CachedImage& image) const
+{
+    if (!m_selectedImage || !m_selectedImage->isOrContains(image))
+        return ImageClient::canDestroyDecodedData(image);
+
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (!client->canDestroyDecodedData(image))
+            return false;
+    }
+    return ImageClient::canDestroyDecodedData(image);
+}
+
+bool MultiImage::useSystemDarkAppearance(const CachedImage& image) const
+{
+    if (!m_selectedImage || !m_selectedImage->isOrContains(image))
+        return ImageClient::useSystemDarkAppearance(image);
+
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->useSystemDarkAppearance(image))
+            return true;
+    }
+    return ImageClient::useSystemDarkAppearance(image);
+}
+
+VisibleInViewportState MultiImage::imageFrameAvailable(const CachedImage& image, ImageAnimatingState animatingState, const IntRect* changeRect) const
+{
+    if (!m_selectedImage || !m_selectedImage->isOrContains(image))
+        return ImageClient::imageFrameAvailable(image, animatingState, changeRect);
+
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->imageFrameAvailable(image, animatingState, changeRect) == VisibleInViewportState::Yes)
+            return VisibleInViewportState::Yes;
+    }
+    return ImageClient::imageFrameAvailable(image, animatingState, changeRect);
+}
+
+VisibleInViewportState MultiImage::imageVisibleInViewport(const CachedImage& image, const Document& document) const
+{
+    if (!m_selectedImage || !m_selectedImage->isOrContains(image))
+        return ImageClient::imageVisibleInViewport(image, document);
+
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->imageVisibleInViewport(image, document) == VisibleInViewportState::Yes)
+            return VisibleInViewportState::Yes;
+    }
+    return ImageClient::imageVisibleInViewport(image, document);
+}
+
+void MultiImage::didRemoveCachedImageClient(const CachedImage& image) const
+{
+    if (!m_selectedImage || !m_selectedImage->isOrContains(image))
+        return;
+
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->didRemoveCachedImageClient(image);
+    }
+}
+
+void MultiImage::imageContentChanged(const CachedImage& image) const
+{
+    if (!m_selectedImage || !m_selectedImage->isOrContains(image))
+        return;
+
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->imageContentChanged(image);
+    }
+}
+
+void MultiImage::scheduleRenderingUpdateForImage(const CachedImage& image) const
+{
+    if (!m_selectedImage || !m_selectedImage->isOrContains(image))
+        return;
+
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        client->imageContentChanged(image);
+    }
+}
+
+bool MultiImage::isRendererClient() const
+{
+    for (auto entry : m_clients) {
+        Ref client = entry.key;
+        if (client->isRendererClient())
+            return true;
+    }
+    return ImageClient::isRendererClient();
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/images/kinds/StyleMultiImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleMultiImage.h
@@ -48,10 +48,14 @@ struct ImageWithScale {
     }
 };
 
-class MultiImage : public Image {
+class MultiImage : public Image, private ImageClient {
     WTF_MAKE_TZONE_ALLOCATED(MultiImage);
 public:
     virtual ~MultiImage();
+
+    // ImageClient.
+    void ref() const final { Image::ref(); }
+    void deref() const final { Image::deref(); }
 
 protected:
     MultiImage(Type);
@@ -66,24 +70,38 @@ private:
 
     bool canRender(const RenderElement*, float multiplier) const final;
     bool isPending() const final { return m_isPending; }
+    bool isLoading() const final;
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
     bool isLoaded(const RenderElement*) const final;
     bool errorOccurred() const final;
-    FloatSize imageSize(const RenderElement*, float multiplier, WebCore::CachedImage::SizeType = WebCore::CachedImage::UsedSize) const final;
+    FloatSize imageSize(const RenderElement*, float multiplier, ImageSizeType = ImageSizeType::Used) const final;
     bool imageHasRelativeWidth() const final;
     bool imageHasRelativeHeight() const final;
     void computeIntrinsicDimensions(const RenderElement*, float& intrinsicWidth, float& intrinsicHeight, FloatSize& intrinsicRatio) final;
     bool usesImageContainerSize() const final;
-    void setContainerContextForRenderer(const RenderElement&, const FloatSize&, float, const WTF::URL& = WTF::URL());
-    void addClient(RenderElement&) final;
-    void removeClient(RenderElement&) final;
-    bool hasClient(RenderElement&) const final;
+    void registerContainerContext(const ImageContainerContextKey&, ImageContainerContext&&);
     RefPtr<WebCore::Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
-    bool currentFrameIsComplete(const RenderElement*) const final;
+    bool currentFrameIsComplete(const RenderElement&) const final;
     float imageScaleFactor() const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     const Image* selectedImage() const final { return m_selectedImage.get(); }
     Image* selectedImage() final { return m_selectedImage.get(); }
+    bool contains(const Image&) const final;
+    void didAddClient(ImageClient&) final { }
+    void didRemoveClient(ImageClient&) final { }
+
+    // ImageClient.
+    void imageChanged(const Image&, const IntRect*) const final;
+    void notifyFinished(const CachedImage&) const final;
+    bool allowsAnimation(const CachedImage&) const final;
+    bool canDestroyDecodedData(const CachedImage&) const final;
+    bool useSystemDarkAppearance(const CachedImage&) const final;
+    VisibleInViewportState imageFrameAvailable(const CachedImage&, ImageAnimatingState, const IntRect*) const final;
+    VisibleInViewportState imageVisibleInViewport(const CachedImage&, const Document&) const final;
+    void didRemoveCachedImageClient(const CachedImage&) const final;
+    void imageContentChanged(const CachedImage&) const final;
+    void scheduleRenderingUpdateForImage(const CachedImage&) const final;
+    bool isRendererClient() const final;
 
     RefPtr<Image> m_selectedImage;
     bool m_isPending { true };

--- a/Source/WebCore/style/values/images/kinds/StylePaintImage.h
+++ b/Source/WebCore/style/values/images/kinds/StylePaintImage.h
@@ -58,8 +58,8 @@ private:
     RefPtr<WebCore::Image> image(const RenderElement*, const FloatSize&, const GraphicsContext& destinationContext, bool isForFirstLine) const final;
     bool knownToBeOpaque(const RenderElement&) const final;
     FloatSize fixedSize(const RenderElement&) const final;
-    void didAddClient(RenderElement&) final { }
-    void didRemoveClient(RenderElement&) final { }
+    void didAddClient(ImageClient&) final { }
+    void didRemoveClient(ImageClient&) final { }
 
     CustomIdent m_name;
     const Ref<CSSVariableData> m_arguments;

--- a/Source/WebCore/style/values/shapes/StyleShapeOutside.h
+++ b/Source/WebCore/style/values/shapes/StyleShapeOutside.h
@@ -93,7 +93,7 @@ struct ShapeOutside {
 
     const BasicShape* shape() const { RefPtr value = m_value; return value ? value->shape() : nullptr; }
     CSSBoxType effectiveCSSBox() const { RefPtr value = m_value; return value ? value->effectiveCSSBox() : CSSBoxType::BoxMissing; }
-    RefPtr<Style::Image> image() const { RefPtr value = m_value; return value ? value->image() : nullptr; }
+    RefPtr<Style::Image> tryStyleImage() const { RefPtr value = m_value; return value ? value->image() : nullptr; }
 
     bool operator==(const ShapeOutside& other) const
     {

--- a/Source/WebCore/svg/IsolatedSVGDocumentContext.cpp
+++ b/Source/WebCore/svg/IsolatedSVGDocumentContext.cpp
@@ -73,7 +73,7 @@ SVGDocument* IsolatedSVGDocumentContext::document() const
     return localMainFrame ? dynamicDowncast<SVGDocument>(localMainFrame->document()) : nullptr;
 }
 
-void IsolatedSVGDocumentContext::imageChanged(CachedImage*, const IntRect*)
+void IsolatedSVGDocumentContext::imageChanged(CachedImage&, const IntRect*)
 {
     // The isolated document just finished loading and laying out. Force referencing renderers to
     // rebuild their SVGResources so paint servers re-resolve.

--- a/Source/WebCore/svg/IsolatedSVGDocumentContext.h
+++ b/Source/WebCore/svg/IsolatedSVGDocumentContext.h
@@ -56,7 +56,7 @@ public:
 private:
     IsolatedSVGDocumentContext(CachedImage&, Document&);
 
-    void imageChanged(CachedImage*, const IntRect*) final;
+    void imageChanged(CachedImage&, const IntRect*) final;
 
     const CachedResourceHandle<CachedImage> m_cachedImage;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_owningDocument;

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -66,7 +66,7 @@
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StyleDocumentScope.h"
 #include "StyleEnvironmentVariables.h"
-#include "StyleLinkParameters.h"
+#include "StyleImageContainerContext.h"
 #include "StyleScope.h"
 #include "TypedElementDescendantIteratorInlines.h"
 #include <JavaScriptCore/JSCInlines.h>
@@ -226,7 +226,7 @@ IntSize SVGImage::containerSize() const
     return IntSize(currentSize);
 }
 
-ImageDrawResult SVGImage::drawForContainer(GraphicsContext& context, const ContainerContext& containerContext, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions options)
+ImageDrawResult SVGImage::drawForContainer(GraphicsContext& context, const ImageContainerContext& containerContext, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
     if (!m_page)
         return ImageDrawResult::DidNothing;
@@ -247,7 +247,7 @@ ImageDrawResult SVGImage::drawForContainer(GraphicsContext& context, const Conta
     scaledSrc.setSize(adjustedSrcSize);
 
     applyLinkParameters(containerContext.linkParameters);
-    protect(frameView())->scrollToFragment(containerContext.initialFragmentURL);
+    protect(frameView())->scrollToFragment(containerContext.imageURL);
 
     return draw(context, dstRect, scaledSrc, options);
 }
@@ -307,7 +307,7 @@ RefPtr<NativeImage> SVGImage::nativeImage(const FloatSize& size, const ColorSpac
     return ImageBuffer::sinkIntoNativeImage(WTF::move(imageBuffer));
 }
 
-void SVGImage::drawPatternForContainer(GraphicsContext& context, const ContainerContext& containerContext, const FloatRect& srcRect,
+void SVGImage::drawPatternForContainer(GraphicsContext& context, const ImageContainerContext& containerContext, const FloatRect& srcRect,
     const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, const FloatRect& dstRect, ImagePaintingOptions options)
 {
     FloatRect zoomedContainerRect = FloatRect(FloatPoint(), containerContext.containerSize);

--- a/Source/WebCore/svg/graphics/SVGImage.h
+++ b/Source/WebCore/svg/graphics/SVGImage.h
@@ -42,16 +42,10 @@ class SVGSVGElement;
 class SVGImageChromeClient;
 class SVGImageForContainer;
 class Settings;
+struct ImageContainerContext;
 
 class SVGImage final : public Image {
 public:
-    struct ContainerContext {
-        FloatSize containerSize { };
-        float containerZoom { 1 };
-        URL initialFragmentURL { };
-        Style::LinkParameters linkParameters { CSS::Keyword::None { } };
-    };
-
     static Ref<SVGImage> create(ImageObserver* observer) { return adoptRef(*new SVGImage(observer)); }
     WEBCORE_EXPORT static void tryCreateFromData(std::span<const uint8_t>, CompletionHandler<void(RefPtr<SVGImage>&&)>&&);
     WEBCORE_EXPORT static bool isDataDecodable(const Settings&, std::span<const uint8_t>);
@@ -119,8 +113,8 @@ private:
 
     WEBCORE_EXPORT explicit SVGImage(ImageObserver*);
     ImageDrawResult draw(GraphicsContext&, const FloatRect& destination, const FloatRect& source, ImagePaintingOptions = { }) final;
-    ImageDrawResult drawForContainer(GraphicsContext&, const ContainerContext&, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions = { });
-    void drawPatternForContainer(GraphicsContext&, const ContainerContext&, const FloatRect& srcRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, const FloatRect& dstRect, ImagePaintingOptions = { });
+    ImageDrawResult drawForContainer(GraphicsContext&, const ImageContainerContext&, const FloatRect& dstRect, const FloatRect& srcRect, ImagePaintingOptions = { });
+    void drawPatternForContainer(GraphicsContext&, const ImageContainerContext&, const FloatRect& srcRect, const AffineTransform&, const FloatPoint& phase, const FloatSize& spacing, const FloatRect& dstRect, ImagePaintingOptions = { });
 
     void applyLinkParameters(const Style::LinkParameters&);
 

--- a/Source/WebCore/svg/graphics/SVGImageCache.cpp
+++ b/Source/WebCore/svg/graphics/SVGImageCache.cpp
@@ -45,49 +45,39 @@ SVGImageCache::~SVGImageCache()
     m_imageForContainerMap.clear();
 }
 
-void SVGImageCache::removeClientFromCache(const CachedImageClient* client)
+void SVGImageCache::registerContainerContext(const ImageContainerContextKey& key, ImageContainerContext&& containerContext)
 {
-    ASSERT(client);
-
-    m_imageForContainerMap.remove(client);
-}
-
-void SVGImageCache::setContainerContextForClient(const CachedImageClient& client, const LayoutSize& containerSize, float containerZoom, const URL& imageURL, const Style::LinkParameters& linkParameters)
-{
-    ASSERT(!containerSize.isEmpty());
-    ASSERT(containerZoom);
+    ASSERT(!containerContext.containerSize.isEmpty());
+    ASSERT(containerContext.containerZoom);
 
     // SVG container has width or height less than 1 pixel.
-    if (flooredIntSize(containerSize).isEmpty())
+    if (flooredIntSize(containerContext.containerSize).isEmpty())
         return;
 
-    FloatSize containerSizeWithoutZoom(containerSize);
-    containerSizeWithoutZoom.scale(1 / containerZoom);
+    FloatSize containerSizeWithoutZoom(containerContext.containerSize);
+    containerSizeWithoutZoom.scale(1 / containerContext.containerZoom);
 
-    m_imageForContainerMap.set(&client, SVGImageForContainer::create(protect(m_svgImage).get(), {
-        .containerSize = containerSizeWithoutZoom,
-        .containerZoom = containerZoom,
-        .initialFragmentURL = imageURL,
-        .linkParameters = linkParameters
-    }));
+    containerContext.containerSize = containerSizeWithoutZoom;
+
+    m_imageForContainerMap.set(key, SVGImageForContainer::create(protect(m_svgImage).get(), WTF::move(containerContext)));
 }
 
-Image* SVGImageCache::findImageForRenderer(const RenderObject* renderer) const
+Image* SVGImageCache::findImageForKey(const ImageContainerContextKey* key) const
 {
-    return renderer ? m_imageForContainerMap.get(&renderer->cachedImageClient()) : nullptr;
+    return key ? m_imageForContainerMap.get(*key) : nullptr;
 }
 
-FloatSize SVGImageCache::imageSizeForRenderer(const RenderObject* renderer) const
+FloatSize SVGImageCache::imageSizeForKey(const ImageContainerContextKey* key) const
 {
-    SUPPRESS_UNCOUNTED_LOCAL auto* image = findImageForRenderer(renderer);
+    SUPPRESS_UNCOUNTED_LOCAL auto* image = findImageForKey(key);
     return image ? image->size() : protect(m_svgImage)->size();
 }
 
 // FIXME: This doesn't take into account the animation timeline so animations will not
 // restart on page load, nor will two animations in different pages have different timelines.
-Image* SVGImageCache::imageForRenderer(const RenderObject* renderer) const
+Image* SVGImageCache::imageForKey(const ImageContainerContextKey* key) const
 {
-    if (Image* image = findImageForRenderer(renderer)) {
+    if (Image* image = findImageForKey(key)) {
         ASSERT(!image->size().isEmpty());
         return image;
     }

--- a/Source/WebCore/svg/graphics/SVGImageCache.h
+++ b/Source/WebCore/svg/graphics/SVGImageCache.h
@@ -19,25 +19,18 @@
 
 #pragma once
 
-#include <WebCore/FloatSize.h>
 #include <WebCore/Image.h>
+#include <WebCore/StyleImageContainerContext.h>
+#include <WebCore/StyleImageContainerContextKey.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
-namespace Style {
-struct LinkParameters;
-}
-
-class CachedImage;
-class CachedImageClient;
 class ImageBuffer;
-class LayoutSize;
 class SVGImage;
 class SVGImageForContainer;
-class RenderObject;
 
 class SVGImageCache {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(SVGImageCache, WEBCORE_EXPORT);
@@ -45,17 +38,15 @@ public:
     explicit SVGImageCache(SVGImage*);
     ~SVGImageCache();
 
-    void removeClientFromCache(const CachedImageClient*);
+    void registerContainerContext(const ImageContainerContextKey&, ImageContainerContext&&);
 
-    void setContainerContextForClient(const CachedImageClient&, const LayoutSize&, float, const URL&, const Style::LinkParameters&);
-    FloatSize imageSizeForRenderer(const RenderObject*) const;
-
-    Image* imageForRenderer(const RenderObject*) const;
+    FloatSize imageSizeForKey(const ImageContainerContextKey*) const;
+    Image* imageForKey(const ImageContainerContextKey*) const;
 
 private:
-    Image* findImageForRenderer(const RenderObject*) const;
+    Image* findImageForKey(const ImageContainerContextKey*) const;
 
-    using ImageForContainerMap = HashMap<const CachedImageClient*, Ref<SVGImageForContainer>>;
+    using ImageForContainerMap = HashMap<SingleThreadWeakRef<const ImageContainerContextKey>, Ref<SVGImageForContainer>>;
 
     WeakPtr<SVGImage> m_svgImage;
     ImageForContainerMap m_imageForContainerMap;

--- a/Source/WebCore/svg/graphics/SVGImageForContainer.cpp
+++ b/Source/WebCore/svg/graphics/SVGImageForContainer.cpp
@@ -28,7 +28,7 @@
 
 namespace WebCore {
 
-SVGImageForContainer::SVGImageForContainer(SVGImage* image, SVGImage::ContainerContext&& containerContext)
+SVGImageForContainer::SVGImageForContainer(SVGImage* image, ImageContainerContext&& containerContext)
     : m_image(image)
     , m_containerContext(WTF::move(containerContext))
 {

--- a/Source/WebCore/svg/graphics/SVGImageForContainer.h
+++ b/Source/WebCore/svg/graphics/SVGImageForContainer.h
@@ -27,17 +27,15 @@
 
 #include <WebCore/AffineTransform.h>
 #include <WebCore/FloatRect.h>
-#include <WebCore/FloatSize.h>
 #include <WebCore/Image.h>
 #include <WebCore/SVGImage.h>
-#include <WebCore/StyleLinkParameters.h>
-#include <wtf/URL.h>
+#include <WebCore/StyleImageContainerContext.h>
 
 namespace WebCore {
 
 class SVGImageForContainer final : public Image {
 public:
-    static Ref<SVGImageForContainer> create(SVGImage* image, SVGImage::ContainerContext&& containerContext)
+    static Ref<SVGImageForContainer> create(SVGImage* image, ImageContainerContext&& containerContext)
     {
         return adoptRef(*new SVGImageForContainer(image, WTF::move(containerContext)));
     }
@@ -65,10 +63,10 @@ public:
     RefPtr<NativeImage> currentNativeImage() final;
 
 private:
-    WEBCORE_EXPORT SVGImageForContainer(SVGImage*, SVGImage::ContainerContext&&);
+    WEBCORE_EXPORT SVGImageForContainer(SVGImage*, ImageContainerContext&&);
 
     WeakPtr<SVGImage> m_image;
-    const SVGImage::ContainerContext m_containerContext;
+    const ImageContainerContext m_containerContext;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
@@ -92,7 +92,7 @@ RefPtr<ShareableBitmap> createShareableBitmap(RenderImage& renderImage, CreateSh
     if (options.allowAnimatedImages == AllowAnimatedImages::No && image->isAnimated())
         return { };
 
-    auto bitmapSize = cachedImage->imageSizeForRenderer(&renderImage);
+    auto bitmapSize = cachedImage->imageFloatSizeForRenderer(&renderImage);
     if (options.screenSizeInPixels) {
         auto scaledSize = largestRectWithAspectRatioInsideRect(bitmapSize.width() / bitmapSize.height(), { FloatPoint(), *options.screenSizeInPixels }).size();
         bitmapSize = scaledSize.width() < bitmapSize.width() ? scaledSize : bitmapSize;

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -75,6 +75,7 @@
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <WebCore/CSSStyleProperties.h>
 #import <WebCore/CachedImage.h>
+#import <WebCore/CachedImageClient.h>
 #import <WebCore/CachedResourceClient.h>
 #import <WebCore/Chrome.h>
 #import <WebCore/ColorMac.h>


### PR DESCRIPTION
#### 9faf8743858342f0d07df640760c5980b9772327
<pre>
Rework relationship between the RenderTree and images
<a href="https://bugs.webkit.org/show_bug.cgi?id=324001">https://bugs.webkit.org/show_bug.cgi?id=324001</a>

Reviewed by NOBODY (OOPS!).

VERY EARLY WIP.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
* Source/WebCore/css/CSSImageValue.cpp:
* Source/WebCore/dom/DataTransfer.cpp:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/CanvasBase.cpp:
* Source/WebCore/html/HTMLImageElement.cpp:
* Source/WebCore/html/ImageBitmap.cpp:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
* Source/WebCore/loader/ImageLoader.cpp:
* Source/WebCore/loader/ImageLoader.h:
* Source/WebCore/loader/cache/CachedImage.cpp:
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/loader/cache/CachedImageClient.cpp:
* Source/WebCore/loader/cache/CachedImageClient.h:
* Source/WebCore/loader/cache/VisibleInViewportState.h: Added.
* Source/WebCore/page/EventHandler.cpp:
* Source/WebCore/page/LargestContentfulPaintData.cpp:
* Source/WebCore/page/LargestContentfulPaintData.h:
* Source/WebCore/rendering/BackgroundPainter.cpp:
* Source/WebCore/rendering/BorderPainter.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderElement.cpp:
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderImage.cpp:
* Source/WebCore/rendering/RenderImage.h:
* Source/WebCore/rendering/RenderImageResource.cpp:
* Source/WebCore/rendering/RenderImageResource.h:
* Source/WebCore/rendering/RenderInline.cpp:
* Source/WebCore/rendering/RenderInline.h:
* Source/WebCore/rendering/RenderListOutsideMarker.cpp:
* Source/WebCore/rendering/RenderListOutsideMarker.h:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/RenderScrollbarPart.cpp:
* Source/WebCore/rendering/RenderScrollbarPart.h:
* Source/WebCore/rendering/RenderTableCol.cpp:
* Source/WebCore/rendering/RenderTableCol.h:
* Source/WebCore/rendering/RenderTableRow.cpp:
* Source/WebCore/rendering/RenderTableRow.h:
* Source/WebCore/rendering/RenderTableSection.cpp:
* Source/WebCore/rendering/RenderTableSection.h:
* Source/WebCore/rendering/RenderVideo.cpp:
* Source/WebCore/rendering/RenderVideo.h:
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp:
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
* Source/WebCore/rendering/svg/RenderSVGImage.h:
* Source/WebCore/rendering/svg/SVGImageIntrinsicSizing.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h:
* Source/WebCore/style/StylePendingResources.cpp:
* Source/WebCore/style/values/backgrounds/StyleFillLayers.h:
* Source/WebCore/style/values/images/kinds/StyleCachedImage.cpp:
* Source/WebCore/style/values/images/kinds/StyleCachedImage.h:
* Source/WebCore/style/values/images/kinds/StyleCanvasImage.cpp:
* Source/WebCore/style/values/images/kinds/StyleCanvasImage.h:
* Source/WebCore/style/values/images/kinds/StyleColorImage.h:
* Source/WebCore/style/values/images/kinds/StyleCrossfadeImage.cpp:
* Source/WebCore/style/values/images/kinds/StyleCrossfadeImage.h:
* Source/WebCore/style/values/images/kinds/StyleCursorImage.cpp:
* Source/WebCore/style/values/images/kinds/StyleCursorImage.h:
* Source/WebCore/style/values/images/kinds/StyleFilterImage.cpp:
* Source/WebCore/style/values/images/kinds/StyleFilterImage.h:
* Source/WebCore/style/values/images/kinds/StyleGeneratedImage.cpp:
* Source/WebCore/style/values/images/kinds/StyleGeneratedImage.h:
* Source/WebCore/style/values/images/kinds/StyleGradientImage.h:
* Source/WebCore/style/values/images/kinds/StyleImage.cpp: Added.
* Source/WebCore/style/values/images/kinds/StyleImage.h:
* Source/WebCore/style/values/images/kinds/StyleImageClient.cpp: Added.
* Source/WebCore/style/values/images/kinds/StyleImageClient.h: Added.
* Source/WebCore/style/values/images/kinds/StyleImageContainerContext.h: Added.
* Source/WebCore/style/values/images/kinds/StyleImageContainerContextKey.h: Added.
* Source/WebCore/style/values/images/kinds/StyleImageSizeOptions.h: Added.
* Source/WebCore/style/values/images/kinds/StyleInvalidImage.h:
* Source/WebCore/style/values/images/kinds/StyleMultiImage.cpp:
* Source/WebCore/style/values/images/kinds/StyleMultiImage.h:
* Source/WebCore/style/values/images/kinds/StyleNamedImage.h:
* Source/WebCore/style/values/images/kinds/StylePaintImage.h:
* Source/WebCore/style/values/shapes/StyleShapeOutside.h:
* Source/WebCore/svg/IsolatedSVGDocumentContext.cpp:
* Source/WebCore/svg/IsolatedSVGDocumentContext.h:
* Source/WebCore/svg/graphics/SVGImage.cpp:
* Source/WebCore/svg/graphics/SVGImage.h:
* Source/WebCore/svg/graphics/SVGImageCache.cpp:
* Source/WebCore/svg/graphics/SVGImageCache.h:
* Source/WebCore/svg/graphics/SVGImageForContainer.cpp:
* Source/WebCore/svg/graphics/SVGImageForContainer.h:
* Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp:
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9faf8743858342f0d07df640760c5980b9772327

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186455 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54092 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196729 "Hash 9faf8743 for PR 73810 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150927 "Hash 9faf8743 for PR 73810 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60040 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/196729 "Hash 9faf8743 for PR 73810 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/150927 "Hash 9faf8743 for PR 73810 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189410 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49350 "Found 60 new test failures: accessibility/embedded-image-description.html accessibility/image-data.html accessibility/image-load-on-delay.html accessibility/image-overlay-elements-presentational.html accessibility/ios-simulator/attributed-string-for-range.html accessibility/ios-simulator/image-overlay-elements.html accessibility/ios-simulator/inline-prediction-attributed-string.html compositing/fixed-image-loading.html compositing/hdr/hdr-background-image.html compositing/hdr/hdr-basic-image-dynamic-range-limit.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166178 "Found 50 new API test failures: TestWebKitAPI.ContextMenuTests.HitTestResultLinkLocalResourceResponse, TestWebKitAPI.WebKitLegacy.AccessingImageInPastedRTFD, TestWebKitAPI.DragAndDropTests.DataTransferTypesOnDragStartForLink, TestWebKitAPI.DragAndDropTests.DataTransferTypesOnDragStartForImage, TestWebKitAPI.WKAttachmentTestsMac.DraggingAttachmentBackedImagePreservesRangedSelection, TestWebKitAPI.ImageAnalysisTests.AnalyzeImagesInSubframes, TestWebKitAPI.WKAttachmentTestsMac.DropImageOverImageWithControls, TestWebKitAPI.PasteImage.PastePNGImage, TestWebKitAPI.SiteIsolation.IframeImageTranslationIfIframeIsAddedAfterTranslationCall, TestWebKitAPI.WKAttachmentTests.MovePastedImageByDragging ... (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/196729 "Hash 9faf8743 for PR 73810 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48078 "Found 60 new test failures: imported/w3c/web-platform-tests/css/CSS2/css1/c414-flt-fit-001.xht imported/w3c/web-platform-tests/css/CSS2/css1/c414-flt-wrap-001.xht imported/w3c/web-platform-tests/css/CSS2/css1/c43-rpl-bbx-002.xht imported/w3c/web-platform-tests/css/CSS2/css1/c5502-mrgn-r-000.xht imported/w3c/web-platform-tests/css/CSS2/css1/c5504-mrgn-l-000.xht imported/w3c/web-platform-tests/css/CSS2/css1/c5505-mrgn-000.xht imported/w3c/web-platform-tests/css/CSS2/css1/c5525-fltwidth-001.xht imported/w3c/web-platform-tests/css/CSS2/linebox/line-box-height-002.xht imported/w3c/web-platform-tests/css/CSS2/linebox/line-height-129.xht imported/w3c/web-platform-tests/css/CSS2/normal-flow/block-formatting-context-height-001.xht ... (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46025 "2 api tests failed or timed out") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/196729 "Hash 9faf8743 for PR 73810 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158425 "Found 60 new API test failures (failure limit exceeded): TestWebKitAPI.WKAttachmentTestsIOS.InsertDroppedAttributedStringContainingAttachment, TestWebKitAPI.ImageAnalysisTests.PerformRemoveBackgroundWithWebPImages, TestWebKitAPI.DragAndDropTests.DataTransferTypesOnDragStartForImage, TestWebKitAPI.ImageAnalysisTests.AnalyzeImagesInSubframes, TestWebKitAPI._WKActivatedElementInfo.InfoForRotatedImage, TestWebKitAPI.ImageAnalysisTests.RemoveBackgroundUsingContextMenu, TestWebKitAPI.ImageAnalysisTests.PerformRemoveBackground, TestWebKitAPI.PasteImage.PastePNGImage, TestWebKitAPI.ImageAnalysisTests.AvoidRedundantTextRecognitionRequests, TestWebKitAPI.WKAttachmentTestsIOS.InsertDroppedImageAsAttachment ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45775 "Found 60 new test failures: accessibility/embedded-image-description.html accessibility/mac/dynamic-transform-relative-frame.html accessibility/mac/empty-group-computation.html animations/animation-initial-inheritance.html compositing/backing/backface-visibility-flip.html compositing/fixed-image-loading.html compositing/hdr/hdr-background-image.html compositing/hdr/hdr-basic-image-dynamic-range-limit.html compositing/hdr/hdr-basic-image.html compositing/hdr/hdr-border-image.html ... (failure)") | [❌ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7801 "Hash 9faf8743 for PR 73810 does not build (failure)") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52778 "Failed to build and analyze WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50516 "Found 60 new test failures: accessibility/mac/dynamic-transform-relative-frame.html compositing/fixed-image-loading.html compositing/hdr/hdr-background-image.html compositing/hdr/hdr-basic-image-dynamic-range-limit.html compositing/hdr/hdr-basic-image.html compositing/hdr/hdr-border-image.html compositing/hdr/hdr-image-positioned.html compositing/hdr/hdr-in-shared-backing.html compositing/hdr/hdr-pseudo-before-image.html compositing/hdr/hdr-svg-inline-image.html ... (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198716 "Hash 9faf8743 for PR 73810 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/59984 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/198716 "Hash 9faf8743 for PR 73810 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60696 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42330 "Found 60 new test failures: compositing/backing/backface-visibility-flip.html compositing/fixed-image-loading.html compositing/hdr/hdr-background-image.html compositing/hdr/hdr-basic-image-dynamic-range-limit.html compositing/hdr/hdr-basic-image.html compositing/hdr/hdr-border-image.html compositing/hdr/hdr-image-positioned.html compositing/hdr/hdr-in-shared-backing.html compositing/hdr/hdr-pseudo-before-image.html compositing/hdr/hdr-svg-inline-image.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/198716 "Hash 9faf8743 for PR 73810 does not build (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49308 "Found 4 new test failures: interaction-region/clip-path.html interaction-region/content-hint.html interaction-region/icon-masking.html pdf/fullscreen.html (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132889 "Failed to build and analyze WebKit") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130160 "Hash 9faf8743 for PR 73810 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59116 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20754 "Found 60 new test failures: imported/w3c/web-platform-tests/density-size-correction/density-corrected-image-svg.html imported/w3c/web-platform-tests/density-size-correction/density-corrected-size-img.html imported/w3c/web-platform-tests/density-size-correction/density-corrected-various-elements.html imported/w3c/web-platform-tests/dom/events/scrolling/save-iframe-scroll-offset-when-display-none.html imported/w3c/web-platform-tests/fetch/api/redirect/redirect-keepalive.https.any.html imported/w3c/web-platform-tests/fetch/nosniff/image.html imported/w3c/web-platform-tests/fetch/orb/tentative/img-mime-types-coverage.tentative.sub.html imported/w3c/web-platform-tests/fetch/stale-while-revalidate/revalidate-not-blocked-by-csp.html imported/w3c/web-platform-tests/fetch/stale-while-revalidate/stale-image.html imported/w3c/web-platform-tests/html/canvas/element/manual/compositing/canvas_compositing_globalcompositeoperation_001.htm ... (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58523 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58752 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58635 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->