### PR TITLE
[JSC] Use Vector+InlineCapacity in LiveRange in AirAllocateRegistersByGreedy

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -199,34 +199,56 @@ static constexpr unsigned spillCostSizeBias = 25000 * PointOffsets::PointsPerIns
 
 class LiveRange {
 public:
+    // Nearly every Tmp gets a live range and nearly every range is a handful of intervals, so an
+    // out-of-line buffer here would be one malloc per Tmp. A contiguous buffer also suits the
+    // conflict queries, which iterate the intervals and are by far the hottest reader.
+    using Intervals = Vector<Interval, 4>;
+
     LiveRange() = default;
 
-    inline void NODELETE validate()
+    inline void NODELETE validate(bool isDescending = false)
     {
 #if ASSERT_ENABLED
         size_t size = 0;
         Interval* prevInterval = nullptr;
         for (auto& interval : m_intervals) {
             ASSERT(interval.begin() < interval.end());
-            ASSERT(!prevInterval || prevInterval->end() < interval.begin());
+            if (prevInterval)
+                ASSERT(isDescending ? interval.end() < prevInterval->begin() : prevInterval->end() < interval.begin());
             size += interval.distance();
             prevInterval = &interval;
         }
         ASSERT(size == m_size);
+#else
+        UNUSED_PARAM(isDescending);
 #endif
     }
 
-    // interval must come before all the intervals already in this LiveRange.
-    void prepend(Interval interval)
+    // Adds an interval to a range being built by a backwards walk over the code. The intervals are
+    // held in descending order until finishDescendingBuild() puts them the right way round, so that
+    // what would be a front insertion is an append. Only lowestSoFar() may read the range while it
+    // is in this state.
+    void prependDescending(Interval interval)
     {
         ASSERT(interval);
-        if (m_intervals.isEmpty() || interval.end() < m_intervals.first().begin())
-            m_intervals.prepend(interval);
+        if (m_intervals.isEmpty() || interval.end() < m_intervals.last().begin())
+            m_intervals.append(interval);
         else {
-            ASSERT(interval.end() == m_intervals.first().begin());
-            m_intervals.first() |= interval;
+            ASSERT(interval.end() == m_intervals.last().begin());
+            m_intervals.last() |= interval;
         }
         m_size += interval.distance();
+        validate(true);
+    }
+
+    const Interval& NODELETE lowestSoFar() const
+    {
+        return m_intervals.last();
+    }
+
+    void finishDescendingBuild()
+    {
+        m_intervals.reverse();
         validate();
     }
 
@@ -244,7 +266,7 @@ public:
         validate();
     }
 
-    const Deque<Interval>& NODELETE intervals() const
+    const Intervals& NODELETE intervals() const
     {
         return m_intervals;
     }
@@ -370,7 +392,7 @@ public:
     }
 
 private:
-    Deque<Interval> m_intervals;
+    Intervals m_intervals;
     size_t m_size { 0 }; // Sum of the distances over m_intervals
 };
 
@@ -676,7 +698,9 @@ private:
         }
     };
 
-    Vector<Entry> m_entries;
+    // Most Tmps that are coalescable at all have just one or two partners, and this list lives in
+    // the per-Tmp map, so an out-of-line buffer here is another malloc per Tmp.
+    Vector<Entry, 2> m_entries;
 #if ASSERT_ENABLED
     bool m_isSorted { false };
 #endif
@@ -1340,10 +1364,10 @@ private:
             if (activeEnds[tmp])
                 return true;
             // Tmp may have had a dead def at point (e.g. clobber).
-            auto& intervals = m_map[tmp].liveRange.intervals();
-            if (intervals.isEmpty())
+            const LiveRange& liveRange = m_map[tmp].liveRange;
+            if (liveRange.intervals().isEmpty())
                 return false;
-            return intervals.first().contains(point);
+            return liveRange.lowestSoFar().contains(point);
         };
 
         auto assertPinnedRegsAreLive = [&]() {
@@ -1385,7 +1409,7 @@ private:
             Point end = activeEnds[tmp];
             if (!end) [[unlikely]]
                 end = point + 1; // Dead def / clobber
-            m_map[tmp].liveRange.prepend({ point, end });
+            m_map[tmp].liveRange.prependDescending({ point, end });
             activeEnds[tmp] = 0;
         };
 
@@ -1554,7 +1578,11 @@ private:
         m_code.pinnedRegisters().forEachReg([&](Reg reg) {
             Tmp tmp = Tmp(reg);
             ASSERT(activeEnds[tmp] == funcEndPoint + 1 && !m_map[tmp].liveRange.size());
-            m_map[tmp].liveRange.prepend({ 0, activeEnds[tmp] });
+            m_map[tmp].liveRange.prependDescending({ 0, activeEnds[tmp] });
+        });
+
+        m_map.forEachValue([](TmpData& data) {
+            data.liveRange.finishDescendingBuild();
         });
 
 #if ASSERT_ENABLED
@@ -2216,7 +2244,7 @@ private:
         m_map.append(tmp, TmpData());
         TmpData& tmpData = m_map[tmp];
         if (interval)
-            tmpData.liveRange.prepend(interval);
+            tmpData.liveRange.append(interval);
         tmpData.useDefCost = useDefCost;
         tmpData.validate();
         return tmp;

--- a/Source/JavaScriptCore/b3/air/AirTmpMap.h
+++ b/Source/JavaScriptCore/b3/air/AirTmpMap.h
@@ -97,6 +97,14 @@ public:
             m_fp.append(tmp, std::forward<PassedValue>(value));
     }
 
+    void forEachValue(NOESCAPE const Invocable<void(Value&)> auto& func)
+    {
+        for (size_t i = 0; i < m_gp.size(); ++i)
+            func(m_gp[i]);
+        for (size_t i = 0; i < m_fp.size(); ++i)
+            func(m_fp[i]);
+    }
+
 private:
     IndexMap<Tmp::AbsolutelyIndexed<GP>, Value> m_gp;
     IndexMap<Tmp::AbsolutelyIndexed<FP>, Value> m_fp;


### PR DESCRIPTION
#### 95cec227dfcf9eaad9bda91f9c618f09881366d7
<pre>
[JSC] Use Vector+InlineCapacity in LiveRange in AirAllocateRegistersByGreedy
<a href="https://bugs.webkit.org/show_bug.cgi?id=324009">https://bugs.webkit.org/show_bug.cgi?id=324009</a>
<a href="https://rdar.apple.com/187246753">rdar://187246753</a>

Reviewed by Keith Miller.

Use Vector with InlineCapacity in AirAllocateRegistersByGreedy&apos;s
LiveRange construction.

1. Use InlineCapacity to avoid repeated alloc &amp; free calls. Most of
   cases, this size 4 is enough.
2. Use Vector instead of Deque. And during construction, we append
   instead of prepend, and then when finalizing, we just reverse it.
   Deque is faster for this prepend, but Vector iteration etc. is
   faster than Deque due to Deque&apos;s iterator handles round-trip.
   And read-side is more heavy in this LiveRange data structure.

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::LiveRange::validate):
(JSC::B3::Air::Greedy::LiveRange::prependDescending):
(JSC::B3::Air::Greedy::LiveRange::lowestSoFar const):
(JSC::B3::Air::Greedy::LiveRange::finishDescendingBuild):
(JSC::B3::Air::Greedy::LiveRange::intervals const):
(JSC::B3::Air::Greedy::GreedyAllocator::buildLiveRanges):
(JSC::B3::Air::Greedy::GreedyAllocator::addTmpImpl):
(JSC::B3::Air::Greedy::LiveRange::prepend): Deleted.
* Source/JavaScriptCore/b3/air/AirTmpMap.h:
(JSC::B3::Air::TmpMap::forEachValue):

Canonical link: <a href="https://commits.webkit.org/321011@main">https://commits.webkit.org/321011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01eda5532fb153e3495ba57aa613fa38ba1bac6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196755 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150945 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/f4ac15c0-e311-41fe-87fa-357f9f869e62) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145682 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100970 "3 flakes 15 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/71df4fa1-1bea-44fc-985f-9897032cfea4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49374 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166194 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126044 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ae4fedac-43e0-43fd-a62d-8bae5600a8be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48102 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46043 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7864 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14721 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158450 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45791 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7829 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47708 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198743 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60006 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155274 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60718 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42346 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154912 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28327 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49326 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132907 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130180 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59135 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20770 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58546 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58770 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58654 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->