### PR TITLE
[JSC] Unify JS Allocators

### DIFF
--- a/JSTests/stress/steal-empty-blocks-across-subspaces.js
+++ b/JSTests/stress/steal-empty-blocks-across-subspaces.js
@@ -1,0 +1,58 @@
+//@ runDefault("--stealEmptyBlocksFromOtherAllocators=1", "--useGenerationalGC=0", "--collectContinuously=1", "--verifyGC=1")
+
+// Fills one subspace, drops it, then fills a different one, so that the second round has to take
+// the MarkedBlocks the first round left behind. The two rounds pick cell types that land in
+// different BlockDirectories on the same AlignedMemoryAllocator: plain objects with a fixed shape,
+// closures, and butterflies. collectContinuously runs the sweeper against the allocator's list of
+// directories with empty blocks while all of this is happening.
+
+function makeObjects(count) {
+    let result = [];
+    for (let i = 0; i < count; ++i)
+        result.push({ a: i, b: i + 1, c: i + 2 });
+    return result;
+}
+
+function makeClosures(count) {
+    let result = [];
+    for (let i = 0; i < count; ++i)
+        result.push(() => i);
+    return result;
+}
+
+function makeArrays(count) {
+    let result = [];
+    for (let i = 0; i < count; ++i)
+        result.push(new Array(16).fill(i));
+    return result;
+}
+
+function makeDestructibleCells(count) {
+    // Maps and RegExps have destructors, so their blocks owe a destructor pass before anyone else
+    // can use them. Handing one of those over has to run the old owner's destructors first.
+    let result = [];
+    for (let i = 0; i < count; ++i) {
+        result.push(new Map([[i, i + 1]]));
+        result.push(new RegExp(`a{${i % 7}}b`, "g"));
+    }
+    return result;
+}
+
+const rounds = [makeObjects, makeClosures, makeArrays, makeDestructibleCells];
+const count = testLoopCount >> 3;
+
+for (let round = 0; round < 2 * rounds.length; ++round) {
+    let make = rounds[round % rounds.length];
+    let live = make(count);
+    let expected = make === makeDestructibleCells ? 2 * count : count;
+    if (live.length !== expected)
+        throw new Error(`round ${round} allocated ${live.length} cells, expected ${expected}`);
+
+    // Touch the tail so nothing above is optimized away, then drop the whole batch. The next round
+    // allocates a different cell type and has to reuse these blocks across subspaces.
+    if (live[expected - 1] === undefined)
+        throw new Error(`round ${round} lost its last cell`);
+    live = null;
+
+    gc();
+}

--- a/Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp
@@ -27,7 +27,6 @@
 #include "AlignedMemoryAllocator.h"
 
 #include "BlockDirectory.h"
-#include "HeapInlines.h"
 #include "Subspace.h"
 
 namespace JSC { 
@@ -36,23 +35,52 @@ AlignedMemoryAllocator::AlignedMemoryAllocator() = default;
 
 AlignedMemoryAllocator::~AlignedMemoryAllocator() = default;
 
-void AlignedMemoryAllocator::registerDirectory(JSC::Heap& heap, BlockDirectory* directory)
+void AlignedMemoryAllocator::addDirectoryWithEmptyBlocks(BlockDirectory* directory)
 {
-    RELEASE_ASSERT(!directory->nextDirectoryInAlignedMemoryAllocator());
-    
-    if (m_directories.isEmpty()) {
-        ASSERT_UNUSED(heap, !Thread::mayBeGCThread() || heap.worldIsStopped());
-        for (Subspace* subspace = m_subspaces.first(); subspace; subspace = subspace->nextSubspaceInAlignedMemoryAllocator())
-            subspace->didCreateFirstDirectory(directory);
-    }
-    
-    m_directories.append(std::mem_fn(&BlockDirectory::setNextDirectoryInAlignedMemoryAllocator), directory);
+    ASSERT(directory->subspace()->alignedMemoryAllocator() == this);
+
+    // Sweeping announces every block it finishes with, so the already-listed case is the common one
+    // and skips the lock. Reading the flag unlocked is sound because directories join and leave this
+    // list on the mutator, or on a sweeper holding the API lock, never from two threads at once. A
+    // wrong read would cost reuse rather than correctness anyway: a directory left off the list is
+    // simply not stealable from until its next empty block or the next prepareForAllocation re-adds
+    // it. See the concurrency FIXME in LocalAllocator::tryAllocateWithoutCollecting before allocating
+    // from a second thread.
+    if (directory->m_isOnEmptyBlocksList.loadRelaxed())
+        return;
+
+    Locker locker { m_directoriesWithEmptyBlocksLock };
+    if (directory->m_isOnEmptyBlocksList.loadRelaxed())
+        return;
+    directory->m_isOnEmptyBlocksList.storeRelaxed(true);
+    directory->m_nextDirectoryWithEmptyBlocks = m_firstDirectoryWithEmptyBlocks;
+    m_firstDirectoryWithEmptyBlocks = directory;
 }
 
-void AlignedMemoryAllocator::registerSubspace(Subspace* subspace)
+BlockDirectory* AlignedMemoryAllocator::takeDirectoryWithEmptyBlocks()
 {
-    RELEASE_ASSERT(!subspace->nextSubspaceInAlignedMemoryAllocator());
-    m_subspaces.append(std::mem_fn(&Subspace::setNextSubspaceInAlignedMemoryAllocator), subspace);
+    Locker locker { m_directoriesWithEmptyBlocksLock };
+    BlockDirectory* directory = m_firstDirectoryWithEmptyBlocks;
+    if (!directory)
+        return nullptr;
+    m_firstDirectoryWithEmptyBlocks = directory->m_nextDirectoryWithEmptyBlocks;
+    directory->m_nextDirectoryWithEmptyBlocks = nullptr;
+    directory->m_isOnEmptyBlocksList.storeRelaxed(false);
+    return directory;
+}
+
+MarkedBlock::Handle* AlignedMemoryAllocator::findEmptyBlockToSteal()
+{
+    // Popped before it is searched, not after: a directory that gains a block mid-search must be able
+    // to put itself back on, which it cannot do while the search still claims it. Directories
+    // announce themselves from under their own lock, so the list lock has to be dropped either way.
+    while (BlockDirectory* directory = takeDirectoryWithEmptyBlocks()) {
+        if (MarkedBlock::Handle* block = directory->findEmptyBlockToSteal()) {
+            addDirectoryWithEmptyBlocks(directory);
+            return block;
+        }
+    }
+    return nullptr;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/AlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/AlignedMemoryAllocator.h
@@ -25,14 +25,13 @@
 
 #pragma once
 
+#include <JavaScriptCore/MarkedBlock.h>
+#include <wtf/Lock.h>
 #include <wtf/PrintStream.h>
-#include <wtf/SinglyLinkedListWithTail.h>
 
 namespace JSC {
 
 class BlockDirectory;
-class Heap;
-class Subspace;
 
 class AlignedMemoryAllocator {
     WTF_MAKE_NONCOPYABLE(AlignedMemoryAllocator);
@@ -48,10 +47,9 @@ public:
     // FIXME: Make this virtual after we stop suppporting the Montery Clang.
     virtual void dump(PrintStream&) const { }
 
-    void registerDirectory(Heap&, BlockDirectory*);
-    BlockDirectory* firstDirectory() const LIFETIME_BOUND { return m_directories.first(); }
+    void addDirectoryWithEmptyBlocks(BlockDirectory*);
 
-    void registerSubspace(Subspace*);
+    MarkedBlock::Handle* findEmptyBlockToSteal();
 
     // Some of derived memory allocators do not have these features because they do not use them.
     // For example, IsoAlignedMemoryAllocator does not have "realloc" feature since it never extends / shrinks the allocated memory region.
@@ -60,9 +58,11 @@ public:
     virtual void* tryReallocateMemory(void*, size_t) = 0;
 
 private:
-    SinglyLinkedListWithTail<BlockDirectory> m_directories;
-    SinglyLinkedListWithTail<Subspace> m_subspaces;
+    BlockDirectory* takeDirectoryWithEmptyBlocks();
+
+    Lock m_directoriesWithEmptyBlocksLock;
+    BlockDirectory* m_firstDirectoryWithEmptyBlocks WTF_GUARDED_BY_LOCK(m_directoriesWithEmptyBlocksLock) { nullptr };
 };
 
-} // namespace WTF
+} // namespace JSC
 

--- a/Source/JavaScriptCore/heap/BlockDirectory.cpp
+++ b/Source/JavaScriptCore/heap/BlockDirectory.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "BlockDirectory.h"
 
+#include "AlignedMemoryAllocator.h"
 #include "BlockDirectoryInlines.h"
 #include "Heap.h"
 #include "HeapInlines.h"
@@ -63,12 +64,37 @@ void BlockDirectory::setSubspace(Subspace* subspace)
     m_subspace = subspace;
 }
 
+void BlockDirectory::noteBlockMayBeStealable(unsigned index)
+{
+    if (!isStealable(index))
+        return;
+
+    // The cursor only moves forward, so a block that falls empty behind it would stay invisible for
+    // the rest of the collection cycle and the heap would grow instead of reusing it.
+    m_emptyCursor = std::min<unsigned>(m_emptyCursor, index);
+    subspace()->alignedMemoryAllocator()->addDirectoryWithEmptyBlocks(this);
+}
+
 MarkedBlock::Handle* BlockDirectory::findEmptyBlockToSteal()
 {
     Locker locker(bitvectorLock());
-    m_emptyCursor = (emptyBits() & ~inUseBits()).findBit(m_emptyCursor, true);
-    if (m_emptyCursor >= m_blocks.size())
-        return nullptr;
+    auto stealable = stealableBits();
+    for (;;) {
+        m_emptyCursor = stealable.findBit(m_emptyCursor, true);
+        if (m_emptyCursor >= m_blocks.size())
+            return nullptr;
+
+        // A block still holding WeakBlocks is the expensive kind to hand over: the subspace taking it
+        // has no use for that capacity, and releasing it means chasing a cold pointer chain. Reading
+        // the head of the chain costs nothing, so pass over those and find one that is free to give.
+        //
+        // FIXME: We should explore the better way to handle it. We should have unified better WeakBlock
+        // allocator with pooling, instead of pooling in each MarkedBlock's WeakSet. Then, this becomes
+        // always empty.
+        if (!m_blocks[m_emptyCursor]->weakSet().head())
+            break;
+        m_emptyCursor++;
+    }
     dataLogLnIf(BlockDirectoryInternal::verbose, "Setting block ", m_emptyCursor, " in use (findEmptyBlockToSteal) for ", *this);
     setIsInUse(m_emptyCursor, true);
     return m_blocks[m_emptyCursor];
@@ -198,11 +224,16 @@ void BlockDirectory::prepareForAllocation()
         [&] (LocalAllocator* allocator) {
             allocator->prepareForAllocation();
         });
-    
+
     m_unsweptCursor = 0;
     m_emptyCursor = 0;
-    
+
     assertSweeperIsSuspended();
+    // endMarking recomputes the empty bits wholesale rather than block by block, so none of the blocks
+    // that fell empty there announced themselves the way didFinishUsingBlock does. Re-derive
+    // membership from the bits here, once m_emptyCursor above has been rewound to match them.
+    if (!stealableBits().isEmpty())
+        subspace()->alignedMemoryAllocator()->addDirectoryWithEmptyBlocks(this);
     edenBits().clearAll();
 
     if (Options::useImmortalObjects()) [[unlikely]] {
@@ -351,7 +382,7 @@ void BlockDirectory::sweep()
             block->sweep(nullptr);
         }
         ASSERT(!isUnswept(index));
-        setIsInUse(index, false);
+        didFinishUsingBlock(locker, block);
     }
 }
 
@@ -365,7 +396,7 @@ void BlockDirectory::shrink()
 
     Locker locker(bitvectorLock());
     for (size_t index = 0; index < m_blocks.size(); ++index) {
-        index = (emptyBits() & ~destructibleBits() & ~inUseBits()).findBit(index, true);
+        index = stealableBits().findBit(index, true);
         if (index >= m_blocks.size())
             break;
 
@@ -422,6 +453,7 @@ void BlockDirectory::didFinishUsingBlock(AbstractLocker&, MarkedBlock::Handle* h
 
     dataLogLnIf(BlockDirectoryInternal::verbose, "Setting block ", handle->index(), " not in use (didFinishUsingBlock) for ", *this);
     setIsInUse(handle, false);
+    noteBlockMayBeStealable(handle->index());
 }
 
 RefPtr<SharedTask<MarkedBlock::Handle*()>> BlockDirectory::parallelNotEmptyBlockSource()

--- a/Source/JavaScriptCore/heap/BlockDirectory.h
+++ b/Source/JavaScriptCore/heap/BlockDirectory.h
@@ -31,6 +31,7 @@
 #include <JavaScriptCore/JSExportMacros.h>
 #include <JavaScriptCore/LocalAllocator.h>
 #include <JavaScriptCore/MarkedBlock.h>
+#include <wtf/Atomics.h>
 #include <wtf/DataLog.h>
 #include <wtf/DebugHeap.h>
 #include <wtf/Lock.h>
@@ -112,6 +113,12 @@ public:
     FOR_EACH_BLOCK_DIRECTORY_BIT(BLOCK_DIRECTORY_BIT_ACCESSORS)
 #undef BLOCK_DIRECTORY_BIT_ACCESSORS
 
+    // A destructible block still owes its old owner a destructor pass over every one of its cells,
+    // and whoever took it would have to pay that inline, so it stays with the sweeper until the bit
+    // says the destructors have run.
+    auto stealableBits() const WTF_REQUIRES_SHARED_LOCK(m_bitvectorLock) { return emptyBitsView() & ~destructibleBitsView() & ~inUseBitsView(); }
+    bool isStealable(size_t index) const WTF_REQUIRES_SHARED_LOCK(m_bitvectorLock) { return stealableBits()[index]; }
+
     template<typename Func>
     void forEachBitVector(const Func& func) WTF_REQUIRES_LOCK(m_bitvectorLock)
     {
@@ -132,14 +139,15 @@ public:
     
     BlockDirectory* nextDirectory() const { return m_nextDirectory; }
     BlockDirectory* nextDirectoryInSubspace() const { return m_nextDirectoryInSubspace; }
-    BlockDirectory* nextDirectoryInAlignedMemoryAllocator() const { return m_nextDirectoryInAlignedMemoryAllocator; }
-    
+
     void setNextDirectory(BlockDirectory* directory) { m_nextDirectory = directory; }
     void setNextDirectoryInSubspace(BlockDirectory* directory) { m_nextDirectoryInSubspace = directory; }
-    void setNextDirectoryInAlignedMemoryAllocator(BlockDirectory* directory) { m_nextDirectoryInAlignedMemoryAllocator = directory; }
-    
+
     MarkedBlock::Handle* findEmptyBlockToSteal();
-    
+
+    // Callers must already have cleared the block's in-use bit.
+    void noteBlockMayBeStealable(unsigned index) WTF_REQUIRES_LOCK(m_bitvectorLock);
+
     inline MarkedBlock::Handle* findBlockToSweep();
     MarkedBlock::Handle* findBlockToSweep(unsigned& unsweptCursor);
 
@@ -156,6 +164,7 @@ public:
     void dumpBits(PrintStream& = WTF::dataFile()) WTF_REQUIRES_SHARED_LOCK(m_bitvectorLock);
 
 private:
+    friend class AlignedMemoryAllocator;
     friend class IsoCellSet;
     friend class LocalAllocator;
     friend class LocalSideAllocator;
@@ -182,13 +191,14 @@ private:
     // this number is bound by capacity of Vector m_blocks, which must be within unsigned.
     unsigned m_emptyCursor { 0 };
     unsigned m_unsweptCursor { 0 }; // Points to the next block that is a candidate for incremental sweeping.
-    
+
     // FIXME: All of these should probably be references.
     // https://bugs.webkit.org/show_bug.cgi?id=166988
     Subspace* m_subspace { nullptr };
     BlockDirectory* m_nextDirectory { nullptr };
     BlockDirectory* m_nextDirectoryInSubspace { nullptr };
-    BlockDirectory* m_nextDirectoryInAlignedMemoryAllocator { nullptr };
+    BlockDirectory* m_nextDirectoryWithEmptyBlocks { nullptr };
+    Atomic<bool> m_isOnEmptyBlocksList { false };
     
     SentinelLinkedList<LocalAllocator, BasicRawSentinelNode<LocalAllocator>> m_localAllocators;
 };

--- a/Source/JavaScriptCore/heap/CompleteSubspace.cpp
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "CompleteSubspace.h"
 
-#include "AlignedMemoryAllocator.h"
 #include "AllocatorInlines.h"
 #include "JSCellInlines.h"
 #include "LocalAllocatorInlines.h"
@@ -98,7 +97,6 @@ Allocator CompleteSubspace::allocatorForSlow(size_t size)
     }
     
     directory->setNextDirectoryInSubspace(m_firstDirectory);
-    m_alignedMemoryAllocator->registerDirectory(m_space.heap(), directory);
     WTF::storeStoreFence();
     m_firstDirectory = directory;
     return allocator;

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -338,7 +338,7 @@ private:
     , name ISO_SUBSPACE_INIT(*this, heapCellType, type)
 
 #define INIT_SERVER_STRUCTURE_ISO_SUBSPACE(name, heapCellType, type) \
-    , name(#name, *this, heapCellType, WTF::roundUpToMultipleOf<type::atomSize>(sizeof(type)), type::numberOfLowerTierPreciseCells, makeUnique<StructureAlignedMemoryAllocator>())
+    , name(#name, *this, heapCellType, WTF::roundUpToMultipleOf<type::atomSize>(sizeof(type)), type::numberOfLowerTierPreciseCells, structureAllocator.get())
 
 Heap::Heap(VM& vm, HeapType heapType)
     : m_heapType(heapType)
@@ -429,6 +429,7 @@ Heap::Heap(VM& vm, HeapType heapType)
     // AlignedMemoryAllocators
     , fastMallocAllocator(makeUnique<FastMallocAlignedMemoryAllocator>())
     , primitiveGigacageAllocator(makeUnique<GigacageAlignedMemoryAllocator>(Gigacage::Primitive))
+    , structureAllocator(makeUnique<StructureAlignedMemoryAllocator>())
 
     // Subspaces
     , primitiveGigacageAuxiliarySpace("Primitive Gigacage Auxiliary"_s, *this, auxiliaryHeapCellType, primitiveGigacageAllocator.get()) // Hash:0x3e7cd762

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -97,6 +97,7 @@ class RunningScope;
 class SlotVisitor;
 class SpaceTimeMutatorScheduler;
 class StopIfNecessaryTimer;
+class StructureAlignedMemoryAllocator;
 class SweepingScope;
 class VM;
 class VerifierSlotVisitor;
@@ -1111,6 +1112,7 @@ public:
     // AlignedMemoryAllocators
     std::unique_ptr<FastMallocAlignedMemoryAllocator> fastMallocAllocator;
     std::unique_ptr<GigacageAlignedMemoryAllocator> primitiveGigacageAllocator;
+    std::unique_ptr<StructureAlignedMemoryAllocator> structureAllocator;
 
     // Subspaces
     CompleteSubspace primitiveGigacageAuxiliarySpace; // Typed arrays, strings, bitvectors, etc go here.

--- a/Source/JavaScriptCore/heap/IsoSubspace.cpp
+++ b/Source/JavaScriptCore/heap/IsoSubspace.cpp
@@ -36,21 +36,19 @@ namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IsoSubspace);
 
-IsoSubspace::IsoSubspace(CString name, JSC::Heap& heap, const HeapCellType& heapCellType, size_t size, uint8_t numberOfLowerTierPreciseCells, std::unique_ptr<AlignedMemoryAllocator>&& allocator)
+IsoSubspace::IsoSubspace(CString name, JSC::Heap& heap, const HeapCellType& heapCellType, size_t size, uint8_t numberOfLowerTierPreciseCells, AlignedMemoryAllocator* allocator)
     : Subspace(SubspaceKind::IsoSubspace, name, heap)
     , m_directory(WTF::roundUpToMultipleOf<MarkedBlock::atomSize>(size))
-    , m_allocator(allocator ? WTF::move(allocator) : makeUnique<FastMallocAlignedMemoryAllocator>())
 {
     m_remainingLowerTierPreciseCount = numberOfLowerTierPreciseCells;
     ASSERT(WTF::roundUpToMultipleOf<MarkedBlock::atomSize>(size) == cellSize());
     ASSERT(m_remainingLowerTierPreciseCount <= MarkedBlock::maxNumberOfLowerTierPreciseCells);
 
-    initialize(heapCellType, m_allocator.get());
+    initialize(heapCellType, allocator ? allocator : heap.fastMallocAllocator.get());
 
     Locker locker { m_space.directoryLock() };
     m_directory.setSubspace(this);
     m_space.addBlockDirectory(locker, &m_directory);
-    m_alignedMemoryAllocator->registerDirectory(heap, &m_directory);
     m_firstDirectory = &m_directory;
 }
 

--- a/Source/JavaScriptCore/heap/IsoSubspace.h
+++ b/Source/JavaScriptCore/heap/IsoSubspace.h
@@ -42,7 +42,7 @@ class IsoSubspace;
 class IsoSubspace final : public Subspace {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(IsoSubspace, JS_EXPORT_PRIVATE);
 public:
-    JS_EXPORT_PRIVATE IsoSubspace(CString name, Heap&, const HeapCellType&, size_t, uint8_t numberOfLowerTierPreciseCells, std::unique_ptr<AlignedMemoryAllocator>&& = nullptr);
+    JS_EXPORT_PRIVATE IsoSubspace(CString name, Heap&, const HeapCellType&, size_t, uint8_t numberOfLowerTierPreciseCells, AlignedMemoryAllocator* = nullptr);
     JS_EXPORT_PRIVATE ~IsoSubspace() final;
 
     size_t cellSize() { return m_directory.cellSize(); }
@@ -66,7 +66,6 @@ private:
     void didBeginSweepingToFreeList(MarkedBlock::Handle*) final;
 
     BlockDirectory m_directory;
-    std::unique_ptr<AlignedMemoryAllocator> m_allocator;
     SentinelLinkedList<PreciseAllocation, BasicRawSentinelNode<PreciseAllocation>> m_lowerTierPreciseFreeList;
     SentinelLinkedList<IsoCellSet, BasicRawSentinelNode<IsoCellSet>> m_cellSets;
 };

--- a/Source/JavaScriptCore/heap/LocalAllocator.cpp
+++ b/Source/JavaScriptCore/heap/LocalAllocator.cpp
@@ -26,10 +26,12 @@
 #include "config.h"
 #include "LocalAllocator.h"
 
+#include "AlignedMemoryAllocator.h"
 #include "AllocatingScope.h"
 #include "FreeListInlines.h"
 #include "GCDeferralContext.h"
 #include "LocalAllocatorInlines.h"
+#include "MarkedBlockInlines.h"
 #include "Options.h"
 #include "ResourceExhaustion.h"
 #include "SuperSampler.h"
@@ -211,11 +213,17 @@ void* LocalAllocator::tryAllocateWithoutCollecting(size_t cellSize)
     }
     
     if (Options::stealEmptyBlocksFromOtherAllocators()) {
-        if (MarkedBlock::Handle* block = m_directory->m_subspace->findEmptyBlockToSteal()) {
-            RELEASE_ASSERT(block->alignedMemoryAllocator() == m_directory->m_subspace->alignedMemoryAllocator());
-            
+        AlignedMemoryAllocator* allocator = m_directory->m_subspace->alignedMemoryAllocator();
+        if (MarkedBlock::Handle* block = allocator->findEmptyBlockToSteal()) {
+            RELEASE_ASSERT(block->alignedMemoryAllocator() == allocator);
+
             block->sweep(nullptr);
-            
+
+            // findEmptyBlockToSteal only hands over blocks that have no WeakBlocks left, so there is
+            // no weak capacity to reclaim here. What this does is take the now-empty WeakSet off
+            // MarkedSpace's list of active ones before the block changes owner.
+            block->shrink();
+
             block->removeFromDirectory();
             m_directory->addBlock(block);
             return allocateIn(block, cellSize);

--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -488,12 +488,17 @@ Subspace* MarkedBlock::Handle::subspace() const
 
 void MarkedBlock::Handle::sweep(FreeList* freeList)
 {
-    SweepingScope sweepingScope(*heap());
     m_directory->assertIsMutatorOrMutatorIsStopped();
     ASSERT(m_directory->isInUse(this));
 
     SweepMode sweepMode = freeList ? SweepToFreeList : SweepOnly;
     bool needsDestruction = m_attributes.destruction != DoesNotNeedDestruction && m_directory->isDestructible(this);
+    // Nothing has been allocated into a block that is still swept, so no weak handle into it can have
+    // been created and died since; re-sweeping its weak set would find nothing.
+    if (sweepMode == SweepOnly && !needsDestruction && !m_directory->isUnswept(this))
+        return;
+
+    SweepingScope sweepingScope(*heap());
 
     m_weakSet.sweep();
 

--- a/Source/JavaScriptCore/heap/Subspace.cpp
+++ b/Source/JavaScriptCore/heap/Subspace.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "Subspace.h"
 
-#include "AlignedMemoryAllocator.h"
 #include "HeapCellType.h"
 #include "MarkedSpaceInlines.h"
 #include "ParallelSourceAdapter.h"
@@ -48,11 +47,9 @@ void Subspace::initialize(const HeapCellType& heapCellType, AlignedMemoryAllocat
 {
     m_heapCellType = &heapCellType;
     m_alignedMemoryAllocator = alignedMemoryAllocator;
-    m_directoryForEmptyAllocation = m_alignedMemoryAllocator->firstDirectory();
 
     JSC::Heap& heap = m_space.heap();
     heap.objectSpace().m_subspaces.append(this);
-    m_alignedMemoryAllocator->registerSubspace(this);
 }
 
 Subspace::~Subspace() = default;
@@ -73,17 +70,6 @@ void Subspace::prepareForAllocation()
         [&] (BlockDirectory& directory) {
             directory.prepareForAllocation();
         });
-
-    m_directoryForEmptyAllocation = m_alignedMemoryAllocator->firstDirectory();
-}
-
-MarkedBlock::Handle* Subspace::findEmptyBlockToSteal()
-{
-    for (; m_directoryForEmptyAllocation; m_directoryForEmptyAllocation = m_directoryForEmptyAllocation->nextDirectoryInAlignedMemoryAllocator()) {
-        if (MarkedBlock::Handle* block = m_directoryForEmptyAllocation->findEmptyBlockToSteal())
-            return block;
-    }
-    return nullptr;
 }
 
 Ref<SharedTask<BlockDirectory*()>> Subspace::parallelDirectorySource()

--- a/Source/JavaScriptCore/heap/Subspace.h
+++ b/Source/JavaScriptCore/heap/Subspace.h
@@ -64,11 +64,6 @@ public:
 
     void prepareForAllocation();
     
-    void didCreateFirstDirectory(BlockDirectory* directory) { m_directoryForEmptyAllocation = directory; }
-    
-    // Finds an empty block from any Subspace that agrees to trade blocks with us.
-    MarkedBlock::Handle* findEmptyBlockToSteal();
-    
     template<typename Func>
     void forEachDirectory(const Func&);
     
@@ -96,9 +91,6 @@ public:
     
     void sweepBlocks();
     
-    Subspace* nextSubspaceInAlignedMemoryAllocator() const { return m_nextSubspaceInAlignedMemoryAllocator; }
-    void setNextSubspaceInAlignedMemoryAllocator(Subspace* subspace) { m_nextSubspaceInAlignedMemoryAllocator = subspace; }
-    
     virtual void didResizeBits(unsigned newSize);
     virtual void didRemoveBlock(unsigned blockIndex);
     virtual void didBeginSweepingToFreeList(MarkedBlock::Handle*);
@@ -118,13 +110,10 @@ protected:
     AlignedMemoryAllocator* m_alignedMemoryAllocator { nullptr };
     
     BlockDirectory* m_firstDirectory { nullptr };
-    BlockDirectory* m_directoryForEmptyAllocation { nullptr }; // Uses the MarkedSpace linked list of blocks.
     SentinelLinkedList<PreciseAllocation, BasicRawSentinelNode<PreciseAllocation>> m_preciseAllocations;
 
     SubspaceKind m_kind;
     uint8_t m_remainingLowerTierPreciseCount { 0 }; // Lower tier is a precise allocation but we use the term lower to avoid confusion with precise-only.
-
-    Subspace* m_nextSubspaceInAlignedMemoryAllocator { nullptr };
 
     CString m_name;
 };


### PR DESCRIPTION
#### aa19dc61a03ee7712c6e3e11ec7c8d9410dbd70a
<pre>
[JSC] Unify JS Allocators
<a href="https://bugs.webkit.org/show_bug.cgi?id=324020">https://bugs.webkit.org/show_bug.cgi?id=324020</a>
<a href="https://rdar.apple.com/187253898">rdar://187253898</a>

Reviewed by Dan Hecht.

This patch unifies JS allocators. Previously each IsoSubspace had its
own allocator. But we no longer want to do it and we would like to unify
them into one. This unlocks making MarkedBlock stealing. However just
using it causes severe performance regressions due to several reasons.

1. We are stealing MarkedBlock with destructors. And we invoke sweep.
   This may slip the different type of cells&apos; destructors into different
   type of cells&apos; allocation. This is problematic: we are fine to pay
   JSString destruction cost when allocating a new JSString. But we are
   not fine to pay this cost when allocating JSArray. We intentionally
   skips MarkedBlock which requires destructor calls for stealing target.
   Keep them in the BlockDirectory and same type of cell will pay this
   cost when reusing this MarkedBlock.
2. We are skipping MarkedBlock w/ WeakSet as a stealing target right now.
   This sounds strange since WeakSet should be completely empty since
   MarkedBlock is empty. When WeakBlock is still including WeakImpl with
   dead values, then it should be chained to Heap as logically-empty.
   The problem is that we are pooling completely empty WeakBlocks to
   accelerate the further WeakBlock allocations for this MarkedBlock
   again, and WeakSet::sweep will iterate them, and as a piggy-backed work,
   we also do logically-empty WeakBlock sweeping! This is similar
   problem to (1): we accidentally pay completely unrelated JSCell&apos;s
   cost at different JSCell type&apos;s allocation path. For now, we
   intentionally skip MarkedBlock with WeakSet as a stealing target.
3. Previously m_emptyCursor and front BlockDirectory are monotonically
   forwarding. But this is very wrong: IncrementalSweeper will make some
   MarkedBlock empty even after m_emptyCursor skipped this block because
   at that time it was not empty. This patch fixes them by recording
   usable BlockDirectory in the allocator, and also resetting
   m_emptyCursor whenever lower-index MarkedBlock becomes empty.

* JSTests/stress/steal-empty-blocks-across-subspaces.js: Added.
(makeObjects):
(makeClosures):
(makeArrays):
(makeDestructibleCells):
* Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp:
(JSC::AlignedMemoryAllocator::addDirectoryWithEmptyBlocks):
(JSC::AlignedMemoryAllocator::takeDirectoryWithEmptyBlocks):
(JSC::AlignedMemoryAllocator::findEmptyBlockToSteal):
(JSC::AlignedMemoryAllocator::registerDirectory): Deleted.
(JSC::AlignedMemoryAllocator::registerSubspace): Deleted.
* Source/JavaScriptCore/heap/AlignedMemoryAllocator.h:
(JSC::AlignedMemoryAllocator::WTF_GUARDED_BY_LOCK):
(): Deleted.
* Source/JavaScriptCore/heap/BlockDirectory.cpp:
(JSC::BlockDirectory::noteBlockMayBeStealable):
(JSC::BlockDirectory::findEmptyBlockToSteal):
(JSC::BlockDirectory::prepareForAllocation):
(JSC::BlockDirectory::sweep):
(JSC::BlockDirectory::shrink):
(JSC::BlockDirectory::didFinishUsingBlock):
* Source/JavaScriptCore/heap/BlockDirectory.h:
(JSC::BlockDirectory::WTF_REQUIRES_SHARED_LOCK):
(JSC::BlockDirectory::nextDirectoryInAlignedMemoryAllocator const): Deleted.
(JSC::BlockDirectory::setNextDirectoryInAlignedMemoryAllocator): Deleted.
* Source/JavaScriptCore/heap/CompleteSubspace.cpp:
(JSC::CompleteSubspace::allocatorForSlow):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::Heap):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/IsoSubspace.cpp:
(JSC::IsoSubspace::IsoSubspace):
* Source/JavaScriptCore/heap/IsoSubspace.h:
* Source/JavaScriptCore/heap/LocalAllocator.cpp:
(JSC::LocalAllocator::tryAllocateWithoutCollecting):
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::Handle::sweep):
* Source/JavaScriptCore/heap/Subspace.cpp:
(JSC::Subspace::initialize):
(JSC::Subspace::prepareForAllocation):
(JSC::Subspace::findEmptyBlockToSteal): Deleted.
* Source/JavaScriptCore/heap/Subspace.h:
(JSC::Subspace::didCreateFirstDirectory): Deleted.
(JSC::Subspace::nextSubspaceInAlignedMemoryAllocator const): Deleted.
(JSC::Subspace::setNextSubspaceInAlignedMemoryAllocator): Deleted.

Canonical link: <a href="https://commits.webkit.org/321016@main">https://commits.webkit.org/321016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a664ca4aaa33e02945cd1e56a5a96a087146409e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/197008 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/151743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2ebb2ae0-6435-4504-b080-88fc7950b3c8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/62000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60320 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145883 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/151743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b52f9c5b-a9f3-4d4a-8250-b47e0486c6fa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126305 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/73d12405-fde5-450d-9c89-3fb31b286947) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48303 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46234 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/8068 "Passed tests") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/14918 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158648 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45988 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/8087 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47965 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/53039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/199006 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60258 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155497 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60971 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155132 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28328 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49527 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133139 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130539 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59376 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20971 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58794 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/59004 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58903 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->