### PR TITLE
CertificateInfo::containsNonRootSHA1SignedCertificate() bounds the certificate chain loop with a count from a separate SecTrust call

### DIFF
--- a/Source/WebCore/platform/network/cf/CertificateInfoCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/CertificateInfoCFNet.cpp
@@ -72,16 +72,18 @@ RetainPtr<CFArrayRef> CertificateInfo::certificateChainFromSecTrust(SecTrustRef 
 
 bool CertificateInfo::containsNonRootSHA1SignedCertificate() const
 {
-    if (m_trust) {
-        auto chain = adoptCF(SecTrustCopyCertificateChain(trust().get()));
-        // Allow only the root certificate (the last in the chain) to be SHA1.
-        for (CFIndex i = 0, size = SecTrustGetCertificateCount(trust().get()) - 1; i < size; ++i) {
-            RetainPtr certificate = checked_cf_cast<SecCertificateRef>(CFArrayGetValueAtIndex(chain.get(), i));
-            if (SecCertificateGetSignatureHashAlgorithm(certificate.get()) == kSecSignatureHashAlgorithmSHA1)
-                return true;
-        }
-
+    if (!m_trust)
         return false;
+
+    RetainPtr chain = adoptCF(SecTrustCopyCertificateChain(trust()));
+    if (!chain)
+        return false;
+
+    // Allow only the root certificate (the last in the chain) to be SHA1.
+    for (CFIndex i = 0, size = CFArrayGetCount(chain) - 1; i < size; ++i) {
+        RetainPtr certificate = checked_cf_cast<SecCertificateRef>(CFArrayGetValueAtIndex(chain, i));
+        if (SecCertificateGetSignatureHashAlgorithm(certificate) == kSecSignatureHashAlgorithmSHA1)
+            return true;
     }
 
     return false;


### PR DESCRIPTION
#### 560f0ec3582807f0a2867481e85a2cf112972eba
<pre>
CertificateInfo::containsNonRootSHA1SignedCertificate() bounds the certificate chain loop with a count from a separate SecTrust call
<a href="https://bugs.webkit.org/show_bug.cgi?id=324031">https://bugs.webkit.org/show_bug.cgi?id=324031</a>
<a href="https://rdar.apple.com/187261119">rdar://187261119</a>

Reviewed by Chris Dumez.

containsNonRootSHA1SignedCertificate() indexed the certificate array
returned by SecTrustCopyCertificateChain() using a count obtained from a
separate SecTrustGetCertificateCount() call. Since the count and the
array came from two independent Security-framework calls, a mismatch
could index out of bounds. The result of SecTrustCopyCertificateChain()
was also never null-checked, and trust().get() was re-evaluated on every
loop iteration.

Derive the loop bound from CFArrayGetCount() on the same array being
indexed, null-check the copied chain, and evaluate the trust once.

* Source/WebCore/platform/network/cf/CertificateInfoCFNet.cpp:
(WebCore::CertificateInfo::containsNonRootSHA1SignedCertificate const):

Canonical link: <a href="https://commits.webkit.org/321001@main">https://commits.webkit.org/321001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc0c9cd5aa80a6362253abbb8420458a2a7a6605

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54145 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196795 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150971 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188387 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145707 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189480 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126074 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48130 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46066 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158475 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45820 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7870 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198787 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60044 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155308 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41622 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60755 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154943 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49357 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132935 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130221 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59167 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20799 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58583 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58798 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58689 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->