### PR TITLE
Make WTF::UUID unable to hold an invalid value, so one cannot be sent over IPC

### DIFF
--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -126,7 +126,7 @@ static_assert(fixedExecutableMemoryPoolSize < 4 * GB, "ExecutableMemoryHandle as
 
 #if HAVE(KDEBUG_H)
 // 325696c8-e7cc-11ee-9f4e-325096b39f47
-static constexpr WTF::UUID jscJITNamespace { static_cast<UInt128>(0x325696c8e7cc11eeULL) << 64 | (0x9f4e325096b39f47ULL) };
+static constexpr WTF::UUID jscJITNamespace = WTF::UUID::createConstant(0x325696c8e7cc11eeULL, 0x9f4e325096b39f47ULL);
 #endif
 
 static bool NODELETE isJITEnabled()

--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -70,27 +70,30 @@ public:
     WTF_EXPORT_PRIVATE static std::optional<UUID> parse(StringView);
     WTF_EXPORT_PRIVATE static std::optional<UUID> parseVersion4(StringView);
 
-    explicit UUID(std::span<const uint8_t, 16> span)
+    static std::optional<UUID> tryCreate(std::span<const uint8_t> span)
     {
-        memcpySpan(asMutableByteSpan(m_data), span);
+        if (span.size() != 16)
+            return std::nullopt;
+        UUID uuid { span.first<16>() };
+        if (!uuid.isValid())
+            return std::nullopt;
+        return uuid;
     }
 
-    explicit UUID(std::span<const uint8_t> span)
+    // Used by the generated IPC decoder, see WTFArgumentCoders.serialization.in.
+    static std::optional<UUID> tryCreate(uint64_t high, uint64_t low)
     {
-        RELEASE_ASSERT(span.size() == 16);
-        memcpySpan(asMutableByteSpan(m_data), span);
+        auto data = (static_cast<UInt128>(high) << 64) | low;
+        if (data == emptyValue || data == deletedValue)
+            return std::nullopt;
+        return UUID { data };
     }
 
-    explicit constexpr UUID(UInt128 data)
-        : m_data(data)
+    // For hardcoded UUID constants. consteval, so a reserved value is a build error rather than a
+    // crash, and raw values still have no way in at runtime other than the fallible factories.
+    static consteval UUID createConstant(uint64_t high, uint64_t low)
     {
-        RELEASE_ASSERT(data != emptyValue && data != deletedValue);
-    }
-
-    explicit UUID(uint64_t high, uint64_t low)
-        : m_data((static_cast<UInt128>(high) << 64) | low)
-    {
-        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(isValid());
+        return UUID { (static_cast<UInt128>(high) << 64) | low };
     }
 
     std::span<const uint8_t, 16> span() const LIFETIME_BOUND
@@ -99,12 +102,6 @@ public:
     }
 
     friend bool operator==(const UUID&, const UUID&) = default;
-
-    static bool isValid(uint64_t high, uint64_t low)
-    {
-        auto data = (static_cast<UInt128>(high) << 64) | low;
-        return data != deletedValue && data != emptyValue;
-    }
 
     // Public so that composite types can build their own hash traits. Unlike the empty value, the deleted
     // value is not a usable "no UUID" sentinel, since Markable and HashTraits both treat it as engaged.
@@ -135,6 +132,18 @@ private:
     // "no UUID" should use Markable<WTF::UUID> or std::optional<WTF::UUID> rather than naming these.
     static constexpr UInt128 emptyValue = 0;
     static constexpr UInt128 deletedValue = 1;
+
+    // Private so that raw bytes can only enter through tryCreate(), which rejects the reserved values.
+    explicit UUID(std::span<const uint8_t, 16> span)
+    {
+        memcpySpan(asMutableByteSpan(m_data), span);
+    }
+
+    explicit constexpr UUID(UInt128 data)
+        : m_data(data)
+    {
+        RELEASE_ASSERT(data != emptyValue && data != deletedValue);
+    }
 
     explicit constexpr UUID(HashTableEmptyValueType)
         : m_data(emptyValue)

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -2216,13 +2216,9 @@ IDBError SQLiteIDBBackingStore::getFileSystemHandleRecordsForObjectStoreRecord(i
         auto kindInt = statement->columnInt(1);
         auto path = statement->columnText(2);
         auto name = statement->columnText(3);
-        if (blob.size() != 16) {
-            LOG_ERROR("FileSystemHandleRecords row has invalid identifier blob size %zu", blob.size());
-            return IDBError { ExceptionCode::UnknownError, "FileSystemHandleRecords row corrupt"_s };
-        }
-        auto uuid = WTF::UUID(blob.span());
+        auto uuid = WTF::UUID::tryCreate(blob.span());
         if (!uuid) {
-            LOG_ERROR("FileSystemHandleRecords row has empty UUID");
+            LOG_ERROR("FileSystemHandleRecords row has invalid identifier blob of size %zu", blob.size());
             return IDBError { ExceptionCode::UnknownError, "FileSystemHandleRecords row corrupt"_s };
         }
         if (kindInt != static_cast<int>(FileSystemHandleKind::File) && kindInt != static_cast<int>(FileSystemHandleKind::Directory)) {
@@ -2230,7 +2226,7 @@ IDBError SQLiteIDBBackingStore::getFileSystemHandleRecordsForObjectStoreRecord(i
             return IDBError { ExceptionCode::UnknownError, "FileSystemHandleRecords row corrupt"_s };
         }
         records.append(FileSystemHandleRecord {
-            FileSystemHandleGlobalIdentifier { uuid },
+            FileSystemHandleGlobalIdentifier { *uuid },
             static_cast<FileSystemHandleKind>(kindInt),
             WTF::move(path),
             WTF::move(name),

--- a/Source/WebCore/Modules/push-api/PushDatabase.cpp
+++ b/Source/WebCore/Modules/push-api/PushDatabase.cpp
@@ -367,14 +367,6 @@ static std::span<const uint8_t> NODELETE uuidToSpan(const std::optional<WTF::UUI
     return uuid->span();
 }
 
-static std::optional<WTF::UUID> uuidFromSpan(std::span<const uint8_t> span)
-{
-    if (span.size() != 16)
-        return std::nullopt;
-
-    return WTF::UUID(span.first<16>());
-}
-
 static SQLValue expirationTimeToValue(std::optional<EpochTimeStamp> timestamp)
 {
     if (!timestamp)
@@ -578,7 +570,7 @@ static PushRecord makePushRecordFromRow(SQLiteStatementAutoResetScope& sql, int 
         .subscriptionSetIdentifier = {
             .bundleIdentifier = sql->columnText(columnIndex + 1),
             .pushPartition = sql->columnText(columnIndex + 2),
-            .dataStoreIdentifier = uuidFromSpan(sql->columnBlobAsSpan(columnIndex + 3))
+            .dataStoreIdentifier = WTF::UUID::tryCreate(sql->columnBlobAsSpan(columnIndex + 3))
         },
         .securityOrigin = sql->columnText(columnIndex + 4),
         .scope = sql->columnText(columnIndex + 5),
@@ -681,7 +673,7 @@ void PushDatabase::getPushSubscriptionSetRecords(CompletionHandler<void(Vector<P
             PushSubscriptionSetIdentifier identifier {
                 .bundleIdentifier = sql->columnText(0),
                 .pushPartition = sql->columnText(1),
-                .dataStoreIdentifier = uuidFromSpan(sql->columnBlobAsSpan(2))
+                .dataStoreIdentifier = WTF::UUID::tryCreate(sql->columnBlobAsSpan(2))
             };
             String securityOrigin = sql->columnText(3);
             bool enabled = static_cast<SubscriptionSetsStateColumn>(sql->columnInt(4)) == SubscriptionSetsStateColumn::Enabled;

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -3537,14 +3537,14 @@ private:
             fail();
             return JSValue();
         }
-        auto uuid = WTF::UUID(m_data.first(uuidSize));
+        auto uuid = WTF::UUID::tryCreate(m_data.first(uuidSize));
         skip(m_data, uuidSize);
         if (!uuid) {
             SERIALIZE_TRACE("FAIL readFileSystemHandle: invalid UUID");
             fail();
             return JSValue();
         }
-        auto globalIdentifier = FileSystemHandleGlobalIdentifier(uuid);
+        auto globalIdentifier = FileSystemHandleGlobalIdentifier(*uuid);
 
         CachedStringRef origin;
         if (!readStringData(origin)) {

--- a/Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.h
@@ -31,6 +31,8 @@
 #include "WebExtensionFrameIdentifier.h"
 #include "WebExtensionTabParameters.h"
 #include <wtf/Forward.h>
+#include <wtf/Markable.h>
+#include <wtf/UUID.h>
 
 namespace WebKit {
 
@@ -41,7 +43,7 @@ struct WebExtensionMessageSenderParameters {
     WebPageProxyIdentifier pageProxyIdentifier;
     WebExtensionContentWorldType contentWorldType { WebExtensionContentWorldType::ContentScript };
     URL url;
-    WTF::UUID documentIdentifier { 0 };
+    Markable<WTF::UUID> documentIdentifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.serialization.in
@@ -29,7 +29,7 @@ struct WebKit::WebExtensionMessageSenderParameters {
     WebKit::WebPageProxyIdentifier pageProxyIdentifier;
     WebKit::WebExtensionContentWorldType contentWorldType;
     URL url;
-    WTF::UUID documentIdentifier;
+    Markable<WTF::UUID> documentIdentifier;
 };
 
 #endif

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -58,9 +58,9 @@ header: <wtf/text/AtomString.h>
     String string()
 }
 
-[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WTF::UUID {
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder, CreateUsing=tryCreate] class WTF::UUID {
     uint64_t high();
-    [Validator='WTF::UUID::isValid(*high, *low)'] uint64_t low();
+    uint64_t low();
 }
 
 header: <wtf/JSONValues.h>

--- a/Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp
@@ -57,11 +57,11 @@ void WKNotificationManagerProviderDidClickNotification(WKNotificationManagerRef 
 
 void WKNotificationManagerProviderDidClickNotification_b(WKNotificationManagerRef managerRef, WKDataRef identifier)
 {
-    auto span = toImpl(identifier)->span();
-    if (span.size() != 16)
+    auto uuid = WTF::UUID::tryCreate(toImpl(identifier)->span());
+    if (!uuid)
         return;
 
-    protect(toImpl(managerRef))->providerDidClickNotification(WTF::UUID { std::span<const uint8_t, 16> { span } });
+    protect(toImpl(managerRef))->providerDidClickNotification(*uuid);
 }
 
 void WKNotificationManagerProviderDidCloseNotifications(WKNotificationManagerRef managerRef, WKArrayRef notificationIDs)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -573,8 +573,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
         uuid_t proxyIdentifier;
         nw_proxy_config_get_identifier(proxyConfig, proxyIdentifier);
 
-        WTF::UUID uuid { std::span<const uint8_t, 16> { proxyIdentifier } };
-        configDataVector.append({ makeVector(agentData.get()), uuid.isValid() ? std::optional { uuid } : std::nullopt });
+        configDataVector.append({ makeVector(agentData.get()), WTF::UUID::tryCreate(proxyIdentifier) });
     }
 
     protect(*_websiteDataStore)->setProxyConfigData(WTF::move(configDataVector));

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -1090,7 +1090,10 @@ static String navigationIDToProtocolString(std::optional<WebCore::NavigationIden
         return nullString();
 
     uint64_t id = navigationID->toUInt64();
-    return WTF::UUID(id, id).toString();
+    auto uuid = WTF::UUID::tryCreate(id, id);
+    if (!uuid)
+        return nullString();
+    return uuid->toString();
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -249,11 +249,9 @@ void WebNotificationManagerProxy::providerDidCloseNotifications(API::Array* glob
             if (!dataValue)
                 continue;
 
-            auto span = dataValue->span();
-            if (span.size() != 16)
+            coreNotificationID = WTF::UUID::tryCreate(dataValue->span());
+            if (!coreNotificationID)
                 continue;
-
-            coreNotificationID = WTF::UUID { std::span<const uint8_t, 16> { span } };
         }
 
         ASSERT(coreNotificationID);

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -46,6 +46,7 @@
 #include <array>
 #include <pal/crypto/CryptoDigest.h>
 #include <wtf/EnumTraits.h>
+#include <wtf/HexNumber.h>
 #include <wtf/RunLoop.h>
 #include <wtf/text/Base64.h>
 #include <wtf/text/MakeString.h>
@@ -747,9 +748,35 @@ Vector<AuthenticatorTransport> CtapAuthenticator::transports() const
     return Vector { driver().transport() };
 }
 
+// An AAGUID is 16 arbitrary vendor bytes, commonly all-zero, so it is not a UUID and cannot be held
+// in one. It is only formatted like one.
+static String aaguidToString(std::span<const std::byte, aaguidLength> aaguid)
+{
+    auto group = [&](size_t offset, size_t length) {
+        uint64_t value = 0;
+        for (auto byte : aaguid.subspan(offset, length))
+            value = (value << 8) | std::to_integer<uint8_t>(byte);
+        return value;
+    };
+
+    return makeString(
+        hex(group(0, 4), 8, Lowercase),
+        '-',
+        hex(group(4, 2), 4, Lowercase),
+        '-',
+        hex(group(6, 2), 4, Lowercase),
+        '-',
+        hex(group(8, 2), 4, Lowercase),
+        '-',
+        hex(group(10, 6), 12, Lowercase));
+}
+
 String CtapAuthenticator::aaguidForDebugging() const
 {
-    return WTF::UUID { std::span<const uint8_t, 16> { m_info.aaguid() } }.toString();
+    auto aaguid = m_info.aaguid().span();
+    if (aaguid.size() != aaguidLength)
+        return { };
+    return aaguidToString(std::as_bytes(aaguid.first<aaguidLength>()));
 }
 
 bool CtapAuthenticator::isUVSetup() const

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -113,8 +113,8 @@ JSValueRef toWebAPI(JSContextRef context, const WebExtensionMessageSenderParamet
         JSObjectSetProperty(context, result, toJSString(originKey).get(), toJSValueRef(context, WebCore::SecurityOrigin::create(parameters.url)->toString()), 0, nullptr);
     }
 
-    if (parameters.documentIdentifier.isValid())
-        JSObjectSetProperty(context, result, toJSString(documentIdKey).get(), toJSValueRef(context, parameters.documentIdentifier.toString()), 0, nullptr);
+    if (parameters.documentIdentifier)
+        JSObjectSetProperty(context, result, toJSString(documentIdKey).get(), toJSValueRef(context, parameters.documentIdentifier->toString()), 0, nullptr);
 
     return result;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -1007,7 +1007,7 @@ void WebExtensionAPITabs::sendMessage(WebFrame& frame, double tabID, const Strin
         frame.page()->webPageProxyIdentifier(),
         contentWorldType(),
         frame.url(),
-        documentIdentifier.value(),
+        documentIdentifier,
     };
 
     bool userGesture = WebCore::UserGestureIndicator::processingUserGesture();
@@ -1049,7 +1049,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPITabs::connect(WebFrame& frame, JSCont
         frame.page()->webPageProxyIdentifier(),
         contentWorldType(),
         frame.url(),
-        documentIdentifier.value(),
+        documentIdentifier,
     };
 
     Ref port = WebExtensionAPIPort::create(*this, frame.page()->webPageProxyIdentifier(), WebExtensionContentWorldType::ContentScript, resolvedName);

--- a/Tools/TestWebKitAPI/Tests/WTF/UUID.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/UUID.cpp
@@ -114,3 +114,43 @@ TEST(WTF, TestUUIDVersion4MakeString)
 
     EXPECT_EQ(WTF::StringTypeAdapter<WTF::UUID>(uuid.value()).length(), 36U);
 }
+
+// tryCreate() is the only way to build a UUID out of raw bytes, so it has to reject
+// everything the reserved empty and deleted values would otherwise let through.
+TEST(WTF, UUIDTryCreateFromSpan)
+{
+    constexpr auto valid = WTF::toArray<uint8_t>({ 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0x4d, 0xe0, 0x89, 0xab, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab });
+    constexpr auto empty = WTF::toArray<uint8_t>({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
+    constexpr auto seventeenBytes = WTF::toArray<uint8_t>({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 });
+
+    EXPECT_FALSE(!!WTF::UUID::tryCreate({ }));
+    EXPECT_FALSE(!!WTF::UUID::tryCreate(std::span { valid }.first(15)));
+    EXPECT_FALSE(!!WTF::UUID::tryCreate(seventeenBytes));
+    EXPECT_FALSE(!!WTF::UUID::tryCreate(empty));
+
+    // The deleted value is 1 as a UInt128, whose byte pattern depends on endianness.
+    UInt128 deletedValue = 1;
+    EXPECT_FALSE(!!WTF::UUID::tryCreate(asByteSpan(deletedValue)));
+
+    auto uuid = WTF::UUID::tryCreate(valid);
+    EXPECT_TRUE(!!uuid);
+    EXPECT_TRUE(equalSpans(uuid->span(), std::span { valid }));
+}
+
+// The generated IPC decoder builds a UUID out of the two halves it decoded, so that overload
+// has to reject the reserved values just like the span one does.
+TEST(WTF, UUIDTryCreateFromHighAndLow)
+{
+    EXPECT_FALSE(!!WTF::UUID::tryCreate(0, 0));
+    EXPECT_FALSE(!!WTF::UUID::tryCreate(0, 1));
+
+    EXPECT_TRUE(!!WTF::UUID::tryCreate(0, 2));
+    EXPECT_TRUE(!!WTF::UUID::tryCreate(1, 0));
+    EXPECT_TRUE(!!WTF::UUID::tryCreate(1, 1));
+
+    auto uuid = WTF::UUID::tryCreate(0x123456789abc4de0ULL, 0x89ab0123456789abULL);
+    EXPECT_TRUE(!!uuid);
+    EXPECT_EQ(uuid->high(), 0x123456789abc4de0ULL);
+    EXPECT_EQ(uuid->low(), 0x89ab0123456789abULL);
+    EXPECT_EQ(makeString(*uuid), "12345678-9abc-4de0-89ab-0123456789ab"_s);
+}

--- a/Tools/WebKitTestRunner/DataFunctions.h
+++ b/Tools/WebKitTestRunner/DataFunctions.h
@@ -43,7 +43,9 @@ inline WKDataRef dataValue(WKTypeRef value)
 
 inline WTF::UUID dataToUUID(WKDataRef data)
 {
-    return WTF::UUID { WKDataGetSpan(data) };
+    auto uuid = WTF::UUID::tryCreate(WKDataGetSpan(data));
+    RELEASE_ASSERT(uuid);
+    return *uuid;
 }
 
 inline WKRetainPtr<WKDataRef> uuidToData(const WTF::UUID& uuid)


### PR DESCRIPTION
#### a371ed314175328578fc843fa4914cb114715964
<pre>
Make WTF::UUID unable to hold an invalid value, so one cannot be sent over IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=324032">https://bugs.webkit.org/show_bug.cgi?id=324032</a>

Reviewed by Darin Adler.

320928@main privatised UUID&apos;s reserved empty and deleted values and made the UInt128
and (uint64_t, uint64_t) constructors assert, but the two std::span constructors
still took arbitrary bytes, so an invalid UUID stayed constructible and could reach
an encoder.

Every constructor that takes raw bits becomes private, behind a fallible
UUID::tryCreate() returning std::nullopt for a wrong size or for either reserved
value, alongside the existing parse() and fromNSUUID(). An asserting constructor
does keep an invalid UUID from existing, but only by killing the process, and
nothing stops a future caller from handing it bytes off the wire. With no producer
of an invalid value left, a bare WTF::UUID on the wire is valid by construction, and
&quot;no UUID&quot; has to be spelled Markable&lt;WTF::UUID&gt; or std::optional&lt;WTF::UUID&gt;. No
encode-time check is added, as with ObjectIdentifier; the decode-time one stays,
since it guards against a compromised or fuzzed peer.

The decoder reaches the (uint64_t, uint64_t) overload with [CreateUsing=tryCreate]
in place of the [Validator], which also retires isValid(uint64_t, uint64_t). Its one
other caller, WebAutomationSession::navigationIDToProtocolString(), returns a null
string instead of crashing, which it could already return. JSC&apos;s jscJITNamespace,
the only user of the UInt128 constructor, uses a consteval createConstant(), so a
reserved value there is a build error and there is no runtime path in.

Eight call sites move to tryCreate(). Three read bytes they do not control and
already coped with failure: CloneDeserializer::readFileSystemHandle() and the SQLite
blob reads in SQLiteIDBBackingStore and PushDatabase. Folding their hand-rolled
checks into the factory is a strict improvement, since a size check plus if (!uuid)
rejects only the empty value and lets the deleted one through; PushDatabase&apos;s
uuidFromSpan() is now exactly tryCreate() and is deleted. Three call sites were also
narrowing a dynamically sized container to std::span&lt;const uint8_t, 16&gt; unchecked,
which is a release assert under hardened libc++.

WebExtensionMessageSenderParameters::documentIdentifier becomes Markable&lt;WTF::UUID&gt;.
Its { 0 } default member initializer would RELEASE_ASSERT since 320928@main. Nothing
reaches it today, since both construction sites initialize all seven members, but
its only consumer already spelled &quot;absent&quot; as documentIdentifier.isValid(), and the
sibling fields in WebExtensionMessageTargetParameters and WebExtensionFrameParameters
are already Markable. The other bare WTF::UUID members that cross IPC come from
createVersion4() and genuinely are not optional.

A FIDO AAGUID is 16 arbitrary vendor bytes, commonly all-zero, so it is not a UUID
and stops being put into one: CtapAuthenticator::aaguidForDebugging() formats the
bytes with a local aaguidToString(), and checks their size. That also fixes the
string it logs, since the byte-span path memcpys into a UInt128 and so rendered the
AAGUID reversed on a little-endian host: a YubiKey 5, published as
cb69481e-8ff7-4039-93ec-0a2729a154a8, logged as a854a129-270a-ec93-3940-f78f1e4869cb.
WebKitTestRunner&apos;s dataToUUID() keeps returning WTF::UUID and RELEASE_ASSERTs, since
its input always comes from WKNotificationCopyCoreIDForTesting().

Test: Tools/TestWebKitAPI/Tests/WTF/UUID.cpp

* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
* Source/WTF/wtf/UUID.h:
(WTF::UUID::tryCreate):
(WTF::UUID::createConstant):
(WTF::UUID::UUID):
(WTF::UUID::isValid): Deleted.
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::getFileSystemHandleRecordsForObjectStoreRecord):
* Source/WebCore/Modules/push-api/PushDatabase.cpp:
(WebCore::makePushRecordFromRow):
(WebCore::PushDatabase::getPushSubscriptionSetRecords):
(WebCore::uuidFromSpan): Deleted.
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readFileSystemHandle):
* Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.h:
* Source/WebKit/Shared/Extensions/WebExtensionMessageSenderParameters.serialization.in:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp:
(WKNotificationManagerProviderDidClickNotification_b):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore setProxyConfigurations:]):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::navigationIDToProtocolString):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::WebNotificationManagerProxy::providerDidCloseNotifications):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::aaguidToString):
(WebKit::CtapAuthenticator::aaguidForDebugging const):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::toWebAPI):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::sendMessage):
(WebKit::WebExtensionAPITabs::connect):
* Tools/TestWebKitAPI/Tests/WTF/UUID.cpp:
(TEST(WTF, UUIDTryCreateFromSpan)):
(TEST(WTF, UUIDTryCreateFromHighAndLow)):
* Tools/WebKitTestRunner/DataFunctions.h:
(WTR::dataToUUID):

Canonical link: <a href="https://commits.webkit.org/320991@main">https://commits.webkit.org/320991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08ba6bd545c182f73404a7bd19d4e8cdbb4db0b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196825 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150993 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bffee7b3-e75e-4fa3-9353-3a2dab8fa47c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188417 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60136 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145736 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a15eb630-2a50-4af3-9df6-a7fad3754d8d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189510 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49428 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166245 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126119 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2e4b6577-b41e-4702-8465-801db3fa38d6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48156 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46086 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7919 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14773 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158501 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45843 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7900 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47778 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198817 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60074 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155333 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41614 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60785 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42393 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154968 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49381 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132959 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130269 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59197 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20824 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58612 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58827 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58719 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->