### PR TITLE
Make FileSystem::fileSystemRepresentation() return a UTF8CString and keep its consumers typed

### DIFF
--- a/Source/JavaScriptCore/API/JSScript.mm
+++ b/Source/JavaScriptCore/API/JSScript.mm
@@ -101,7 +101,7 @@ static bool validateBytecodeCachePath(NSURL* cachePath, NSError** error)
     }
 
 #if USE(APPLE_INTERNAL_SDK)
-    if (rootless_check_datavault_flag(FileSystem::fileSystemRepresentation(directory).data(), nullptr)) {
+    if (rootless_check_datavault_flag(FileSystem::fileSystemRepresentation(directory).legacyCStringPointer(), nullptr)) {
         createError([NSString stringWithFormat:@"Cache directory `%@` is not a data vault", directory.createNSString().get()], error);
         return false;
     }

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -1319,7 +1319,7 @@ void dumpJITMemory(const void* dst, const void* src, size_t size)
             if (fd == -1) {
                 auto path = String::fromLatin1(Options::dumpJITMemoryPath());
                 path = makeStringByReplacingAll(path, "%pid"_s, String::number(getCurrentProcessID()));
-                fd = open(FileSystem::fileSystemRepresentation(path).data(), O_CREAT | O_TRUNC | O_APPEND | O_WRONLY | O_EXLOCK | O_NONBLOCK, 0666);
+                fd = open(FileSystem::fileSystemRepresentation(path).legacyCStringPointer(), O_CREAT | O_TRUNC | O_APPEND | O_WRONLY | O_EXLOCK | O_NONBLOCK, 0666);
                 RELEASE_ASSERT(fd != -1);
             }
             auto writeSpan = buffer->mutableSpan().first(offset);

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -138,7 +138,7 @@ WTF_EXPORT_PRIVATE bool markPurgeable(const String&);
 WTF_EXPORT_PRIVATE Vector<String> listDirectory(const String& path); // Returns file names, not full paths.
 WTF_EXPORT_PRIVATE void traverseDirectory(const String& path, NOESCAPE const Function<void(const String& fileName, FileType)>&);
 
-WTF_EXPORT_PRIVATE CString fileSystemRepresentation(const String&);
+WTF_EXPORT_PRIVATE UTF8CString fileSystemRepresentation(const String&);
 #if !PLATFORM(WIN)
 WTF_EXPORT_PRIVATE String stringFromFileSystemRepresentation(const char*);
 #endif
@@ -156,7 +156,7 @@ WTF_EXPORT_PRIVATE std::optional<uint64_t> overwriteEntireFile(const String& pat
 WTF_EXPORT_PRIVATE std::pair<String, FileHandle> openTemporaryFile(StringView prefix, StringView suffix = { }, const String& temporaryDirectory = { });
 WTF_EXPORT_PRIVATE String createTemporaryFile(StringView prefix, StringView suffix = { });
 #if PLATFORM(COCOA)
-WTF_EXPORT_PRIVATE std::pair<FileHandle, CString> createTemporaryFileInDirectory(const String& directory, const String& suffix);
+WTF_EXPORT_PRIVATE std::pair<FileHandle, String> createTemporaryFileInDirectory(const String& directory, const String& suffix);
 #endif
 WTF_EXPORT_PRIVATE FileHandle openFile(const String& path, FileOpenMode, FileAccessPermission = FileAccessPermission::All, OptionSet<FileLockMode> = { }, bool failIfFileExists = false);
 
@@ -176,15 +176,19 @@ WTF_EXPORT_PRIVATE bool filesHaveSameVolume(const String&, const String&);
 WTF_EXPORT_PRIVATE RetainPtr<CFURLRef> pathAsURL(const String&);
 #endif
 
+// The name of the running executable, as reported by the platform.
+#if USE(GLIB) || PLATFORM(COCOA)
+WTF_EXPORT_PRIVATE UTF8CString currentExecutableName();
+#endif
+
 #if USE(GLIB)
 WTF_EXPORT_PRIVATE String filenameForDisplay(const String&);
-WTF_EXPORT_PRIVATE CString currentExecutablePath();
-WTF_EXPORT_PRIVATE CString currentExecutableName();
+WTF_EXPORT_PRIVATE UTF8CString currentExecutablePath();
 WTF_EXPORT_PRIVATE String userCacheDirectory();
 WTF_EXPORT_PRIVATE String userDataDirectory();
 WTF_EXPORT_PRIVATE String createTemporaryDirectory(const String& directoryPrefix = nullString());
 #if ENABLE(DEVELOPER_MODE)
-WTF_EXPORT_PRIVATE CString webkitTopLevelDirectory();
+WTF_EXPORT_PRIVATE UTF8CString webkitTopLevelDirectory();
 #endif
 #endif // USE(GLIB)
 

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1295,6 +1295,26 @@ template<typename T> requires (std::is_pointer_v<T>) inline T safePrintfType(T a
     dataLogF(format __VA_OPT__(, SAFE_PRINTF_TYPE(__VA_ARGS__))) \
     WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
+// WTFLogAlways() and the other WTF_ATTRIBUTE_NSSTRING functions accept %@ as well as the printf
+// conversions, and vprintf_stderr_common() routes a format containing %@ through
+// CFStringCreateWithFormatAndArguments(). An Objective-C object argument therefore has to arrive
+// unchanged: safePrintfType()'s NSString* overload would turn it into a const char*, handing
+// CoreFoundation a char pointer where it expects an object.
+#ifdef __OBJC__
+template<typename T> concept ObjectiveCObjectPointer = std::convertible_to<T, id>;
+#else
+template<typename T> concept ObjectiveCObjectPointer = false;
+#endif
+
+template<ObjectiveCObjectPointer T> inline T safeNSStringPrintfType(T argument) { return argument; }
+template<typename T> requires (!ObjectiveCObjectPointer<std::decay_t<T>>)
+inline decltype(auto) safeNSStringPrintfType(T&& argument) { return safePrintfType(std::forward<T>(argument)); }
+
+#define SAFE_NSSTRING_PRINTF_TYPE(...) WTF_FOR_EACH(WTF::safeNSStringPrintfType, __VA_ARGS__)
+
+#define SAFE_WTFLOGALWAYS(format, ...) \
+    WTFLogAlways(format __VA_OPT__(, SAFE_NSSTRING_PRINTF_TYPE(__VA_ARGS__)))
+
 template<typename T>
 concept NonConstByteType = CanBeConstByteType<T> && !std::is_const_v<T>;
 

--- a/Source/WTF/wtf/cf/FileSystemCF.cpp
+++ b/Source/WTF/wtf/cf/FileSystemCF.cpp
@@ -36,12 +36,12 @@
 
 namespace WTF {
 
-CString FileSystem::fileSystemRepresentation(const String& path)
+UTF8CString FileSystem::fileSystemRepresentation(const String& path)
 {
     RetainPtr<CFStringRef> cfString = path.createCFString();
 
     if (!cfString)
-        return CString();
+        return { };
 
     CFIndex size = CFStringGetMaximumSizeOfFileSystemRepresentation(cfString.get());
 
@@ -49,10 +49,11 @@ CString FileSystem::fileSystemRepresentation(const String& path)
 
     if (!CFStringGetFileSystemRepresentation(cfString.get(), buffer.mutableSpan().data(), buffer.size())) {
         LOG_ERROR("Failed to get filesystem representation to create CString from cfString");
-        return CString();
+        return { };
     }
 
-    return buffer.span().data();
+    // CFStringGetFileSystemRepresentation() produces UTF-8, null-terminated within the buffer.
+    return UTF8CString { byteCast<char8_t>(buffer.span().data()) };
 }
 
 String FileSystem::stringFromFileSystemRepresentation(const char* fileSystemRepresentation)

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -41,6 +41,7 @@
 #import <wtf/StdLibExtras.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/spi/cocoa/BOMSPI.h>
+#import <wtf/text/CString.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringCommon.h>
 
@@ -125,7 +126,7 @@ String extractTemporaryZipArchive(const String& path)
         };
 
         auto copier = BOMCopierNew();
-        if (BOMCopierCopyWithOptions(copier, newURL.path.fileSystemRepresentation, fileSystemRepresentation(temporaryDirectory).data(), bridge_cast(options)))
+        if (BOMCopierCopyWithOptions(copier, newURL.path.fileSystemRepresentation, fileSystemRepresentation(temporaryDirectory).legacyCStringPointer(), bridge_cast(options)))
             temporaryDirectory = nullString();
         BOMCopierFree(copier);
     }];
@@ -204,13 +205,13 @@ NSString *createTemporaryDirectory(NSString *directoryPrefix)
     return [[NSFileManager defaultManager] stringWithFileSystemRepresentation:path.span().data() length:length];
 }
 
-std::pair<FileHandle, CString> createTemporaryFileInDirectory(const String& directory, const String& suffix)
+std::pair<FileHandle, String> createTemporaryFileInDirectory(const String& directory, const String& suffix)
 {
     auto fsSuffix = fileSystemRepresentation(suffix);
     auto templatePath = pathByAppendingComponents(directory, { { makeString("XXXXXX"_s, suffix) } });
     auto fsTemplatePath = fileSystemRepresentation(templatePath);
-    auto fileHandle = FileHandle::adopt(mkstemps(fsTemplatePath.mutableSpanIncludingNullTerminator().data(), fsSuffix.length()));
-    return { WTF::move(fileHandle), WTF::move(fsTemplatePath) };
+    auto fileHandle = FileHandle::adopt(mkstemps(byteCast<char>(fsTemplatePath.mutableSpanIncludingNullTerminator()).data(), fsSuffix.length()));
+    return { WTF::move(fileHandle), String::fromUTF8(fsTemplatePath.span()) };
 }
 
 #ifdef IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES
@@ -303,13 +304,13 @@ bool setExcludedFromBackup(const String& path, bool excluded)
 
 bool markPurgeable(const String& path)
 {
-    CString fileSystemPath = fileSystemRepresentation(path);
+    auto fileSystemPath = fileSystemRepresentation(path);
     if (fileSystemPath.isNull())
         return false;
 
 #if HAVE(APFS_CACHEDELETE_PURGEABLE)
     uint64_t flags = APFS_MARK_PURGEABLE | APFS_PURGEABLE_DATA_TYPE | APFS_PURGEABLE_MARK_CHILDREN;
-    return !fsctl(fileSystemPath.data(), APFSIOC_MARK_PURGEABLE, &flags, 0);
+    return !fsctl(fileSystemPath.legacyCStringPointer(), APFSIOC_MARK_PURGEABLE, &flags, 0);
 #else
     return false;
 #endif
@@ -378,6 +379,11 @@ std::optional<String> homeDirectory()
     return String::fromUTF8(pwd.pw_dir);
 }
 #endif // PLATFORM(MAC) || PLATFORM(MACCATALYST)
+
+UTF8CString currentExecutableName()
+{
+    return UTF8CString { byteCast<char8_t>(getprogname()) };
+}
 
 } // namespace FileSystemImpl
 } // namespace WTF

--- a/Source/WTF/wtf/glib/FileSystemGlib.cpp
+++ b/Source/WTF/wtf/glib/FileSystemGlib.cpp
@@ -37,9 +37,9 @@ namespace WTF {
 
 namespace FileSystemImpl {
 
-bool validRepresentation(const CString& representation)
+bool validRepresentation(const UTF8CString& representation)
 {
-    auto* data = representation.data();
+    auto* data = representation.legacyCStringPointer();
     return !!data && data[0] != '\0';
 }
 
@@ -53,7 +53,7 @@ String filenameForDisplay(const String& string)
     if (!validRepresentation(filename))
         return string;
 
-    GUniquePtr<gchar> display(g_filename_display_name(filename.data()));
+    GUniquePtr<gchar> display(g_filename_display_name(filename.legacyCStringPointer()));
     if (!display)
         return string;
     return String::fromUTF8(display.get());
@@ -61,23 +61,23 @@ String filenameForDisplay(const String& string)
 }
 
 #if OS(LINUX)
-CString currentExecutablePath()
+UTF8CString currentExecutablePath()
 {
     static std::array<char, PATH_MAX> readLinkBuffer;
     ssize_t result = readlink("/proc/self/exe", readLinkBuffer.data(), readLinkBuffer.size());
     if (result <= 0)
         return { };
-    return CString(unsafeMakeSpan(readLinkBuffer.data(), static_cast<size_t>(result)));
+    return UTF8CString { byteCast<char8_t>(unsafeMakeSpan(readLinkBuffer.data(), static_cast<size_t>(result))) };
 }
 #elif OS(HURD)
-CString currentExecutablePath()
+UTF8CString currentExecutablePath()
 {
     return { };
 }
 #elif OS(QNX)
 #include <fcntl.h>
 
-CString currentExecutablePath()
+UTF8CString currentExecutablePath()
 {
     static char readBuffer[PATH_MAX];
     int selfFd = open("/proc/self/exefile", O_RDONLY);
@@ -85,7 +85,7 @@ CString currentExecutablePath()
     close(selfFd);
     if (result <= 0)
         return { };
-    return CString(unsafeMakeSpan(readBuffer, static_cast<size_t>(result)));
+    return UTF8CString { byteCast<char8_t>(unsafeMakeSpan(readBuffer, static_cast<size_t>(result))) };
 }
 #elif OS(UNIX)
 #if OS(NETBSD)
@@ -93,16 +93,16 @@ CString currentExecutablePath()
 #else
 #define _PROC_CURPROC_PATH "/proc/curproc/file"
 #endif
-CString currentExecutablePath()
+UTF8CString currentExecutablePath()
 {
     static char readLinkBuffer[PATH_MAX];
     ssize_t result = readlink(_PROC_CURPROC_PATH, readLinkBuffer, PATH_MAX);
     if (result <= 0)
         return { };
-    return CString(unsafeMakeSpan(readLinkBuffer, static_cast<size_t>(result)));
+    return UTF8CString { byteCast<char8_t>(unsafeMakeSpan(readLinkBuffer, static_cast<size_t>(result))) };
 }
 #elif OS(WINDOWS)
-CString currentExecutablePath()
+UTF8CString currentExecutablePath()
 {
     static WCHAR buffer[MAX_PATH];
     DWORD length = GetModuleFileNameW(0, buffer, MAX_PATH);
@@ -114,15 +114,15 @@ CString currentExecutablePath()
 }
 #endif
 
-CString currentExecutableName()
+UTF8CString currentExecutableName()
 {
     auto executablePath = currentExecutablePath();
     if (!executablePath.isNull()) {
-        GUniquePtr<char> basename(g_path_get_basename(executablePath.data()));
-        return basename.get();
+        GUniquePtr<char> basename(g_path_get_basename(executablePath.legacyCStringPointer()));
+        return UTF8CString { byteCast<char8_t>(basename.get()) };
     }
 
-    return g_get_prgname();
+    return UTF8CString { byteCast<char8_t>(g_get_prgname()) };
 }
 
 String userCacheDirectory()
@@ -149,18 +149,18 @@ String createTemporaryDirectory(const String& directoryPrefix)
 }
 
 #if ENABLE(DEVELOPER_MODE)
-CString webkitTopLevelDirectory()
+UTF8CString webkitTopLevelDirectory()
 {
     if (const char* topLevelDirectory = g_getenv("WEBKIT_TOP_LEVEL")) {
         if (g_file_test(topLevelDirectory, G_FILE_TEST_IS_DIR))
-            return topLevelDirectory;
+            return UTF8CString { byteCast<char8_t>(topLevelDirectory) };
     }
     // The tooling to run tests should provide the above environment variable with
     // the right value, but if that was not the case, then do an attempt to guess
     // it assuming that we were built in the standard WebKitBuild subdirectory.
-    GUniquePtr<char*> parentPath(g_strsplit(currentExecutablePath().data(), "/WebKitBuild", -1));
+    GUniquePtr<char*> parentPath(g_strsplit(currentExecutablePath().legacyCStringPointer(), "/WebKitBuild", -1));
     GUniquePtr<char> absoluteTopLevelPath(realpath(parentPath.get()[0], nullptr));
-    return absoluteTopLevelPath.get();
+    return UTF8CString { byteCast<char8_t>(absoluteTopLevelPath.get()) };
 }
 #endif
 

--- a/Source/WTF/wtf/playstation/FileSystemPlayStation.cpp
+++ b/Source/WTF/wtf/playstation/FileSystemPlayStation.cpp
@@ -42,14 +42,14 @@ namespace FileSystemImpl {
 enum class ShouldFollowSymbolicLinks : bool { No, Yes };
 static std::optional<FileType> fileTypePotentiallyFollowingSymLinks(const String& path, ShouldFollowSymbolicLinks shouldFollowSymbolicLinks)
 {
-    CString fsRep = fileSystemRepresentation(path);
+    auto fsRep = fileSystemRepresentation(path);
 
-    if (!fsRep.data() || fsRep.data()[0] == '\0')
+    if (!fsRep.legacyCStringPointer() || fsRep.legacyCStringPointer()[0] == '\0')
         return std::nullopt;
 
     auto statFunc = shouldFollowSymbolicLinks == ShouldFollowSymbolicLinks::Yes ? stat : lstat;
     struct stat fileInfo;
-    if (statFunc(fsRep.data(), &fileInfo))
+    if (statFunc(fsRep.legacyCStringPointer(), &fileInfo))
         return std::nullopt;
 
     if (S_ISDIR(fileInfo.st_mode))
@@ -69,13 +69,13 @@ bool moveFile(const String& oldPath, const String& newPath)
     if (newFilename.isNull())
         return false;
 
-    return rename(oldFilename.data(), newFilename.data()) != -1;
+    return rename(oldFilename.legacyCStringPointer(), newFilename.legacyCStringPointer()) != -1;
 }
 
 std::optional<uint64_t> volumeFreeSpace(const String& path)
 {
     struct statvfs fileSystemStat;
-    if (!statvfs(fileSystemRepresentation(path).data(), &fileSystemStat))
+    if (!statvfs(fileSystemRepresentation(path).legacyCStringPointer(), &fileSystemStat))
         return fileSystemStat.f_bavail * fileSystemStat.f_frsize;
     return std::nullopt;
 }
@@ -83,7 +83,7 @@ std::optional<uint64_t> volumeFreeSpace(const String& path)
 std::optional<uint64_t> volumeCapacity(const String& path)
 {
     struct statvfs fileSystemStat;
-    if (!statvfs(fileSystemRepresentation(path).data(), &fileSystemStat))
+    if (!statvfs(fileSystemRepresentation(path).legacyCStringPointer(), &fileSystemStat))
         return fileSystemStat.f_blocks * fileSystemStat.f_frsize;
     return std::nullopt;
 }
@@ -91,8 +91,8 @@ std::optional<uint64_t> volumeCapacity(const String& path)
 Vector<String> listDirectorySub(const String& path, bool fullPath)
 {
     Vector<String> entries;
-    CString cpath = fileSystemRepresentation(path);
-    DIR* dir = opendir(cpath.data());
+    auto cpath = fileSystemRepresentation(path);
+    DIR* dir = opendir(cpath.legacyCStringPointer());
     if (dir) {
         struct dirent* dp;
         while ((dp = readdir(dir))) {
@@ -143,8 +143,8 @@ bool deleteNonEmptyDirectory(const String& path)
 
 String realPath(const String& filePath)
 {
-    CString fsRep = fileSystemRepresentation(filePath);
-    std::unique_ptr<char, decltype(free)*> resolvedPath(realpath(fsRep.data(), nullptr), free);
+    auto fsRep = fileSystemRepresentation(filePath);
+    std::unique_ptr<char, decltype(free)*> resolvedPath(realpath(fsRep.legacyCStringPointer(), nullptr), free);
     return resolvedPath ? String::fromUTF8(resolvedPath.get()) : filePath;
 }
 

--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -57,7 +57,7 @@ namespace FileSystemImpl {
 
 FileHandle openFile(const String& path, FileOpenMode mode, FileAccessPermission permission, OptionSet<FileLockMode> lockMode, bool failIfFileExists)
 {
-    CString fsRep = fileSystemRepresentation(path);
+    auto fsRep = fileSystemRepresentation(path);
 
     if (fsRep.isNull())
         return { };
@@ -89,20 +89,20 @@ FileHandle openFile(const String& path, FileOpenMode mode, FileAccessPermission 
     else if (permission == FileAccessPermission::All)
         permissionFlag |= (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
 
-    return FileHandle::adopt(open(fsRep.data(), platformFlag, permissionFlag), lockMode);
+    return FileHandle::adopt(open(fsRep.legacyCStringPointer(), platformFlag, permissionFlag), lockMode);
 }
 
 std::optional<WallTime> fileCreationTime(const String& path)
 {
 #if (OS(LINUX) && HAVE(STATX)) || OS(DARWIN) || OS(OPENBSD) || OS(NETBSD) || OS(FREEBSD)
-    CString fsRep = fileSystemRepresentation(path);
-    if (!fsRep.data() || fsRep.data()[0] == '\0')
+    auto fsRep = fileSystemRepresentation(path);
+    if (!fsRep.legacyCStringPointer() || fsRep.legacyCStringPointer()[0] == '\0')
         return std::nullopt;
 
 #if OS(LINUX) && HAVE(STATX)
     struct statx fileInfo;
 
-    if (statx(-1, fsRep.data(), 0, STATX_BTIME, &fileInfo) == -1)
+    if (statx(-1, fsRep.legacyCStringPointer(), 0, STATX_BTIME, &fileInfo) == -1)
         return std::nullopt;
 
     return WallTime::fromRawSeconds(fileInfo.stx_btime.tv_sec);
@@ -128,7 +128,7 @@ bool fileIDsAreEqual(std::optional<PlatformFileID> a, std::optional<PlatformFile
 std::optional<uint32_t> volumeFileBlockSize(const String& path)
 {
     struct statvfs fileStat;
-    if (!statvfs(fileSystemRepresentation(path).data(), &fileStat))
+    if (!statvfs(fileSystemRepresentation(path).legacyCStringPointer(), &fileStat))
         return fileStat.f_frsize;
 
     return std::nullopt;
@@ -143,7 +143,7 @@ String stringFromFileSystemRepresentation(const char* path)
     return String::fromUTF8(path);
 }
 
-CString fileSystemRepresentation(const String& path)
+UTF8CString fileSystemRepresentation(const String& path)
 {
     return path.utf8();
 }
@@ -210,13 +210,13 @@ std::optional<int32_t> getFileDeviceId(const String& path)
 
 bool fileExists(const String& path)
 {
-    return access(fileSystemRepresentation(path).data(), F_OK) != -1;
+    return access(fileSystemRepresentation(path).legacyCStringPointer(), F_OK) != -1;
 }
 
 bool deleteFile(const String& path)
 {
     // unlink(...) returns 0 on successful deletion of the path and non-zero in any other case (including invalid permissions or non-existent file)
-    bool unlinked = !unlink(fileSystemRepresentation(path).data());
+    bool unlinked = !unlink(fileSystemRepresentation(path).legacyCStringPointer());
     if (!unlinked && errno != ENOENT)
         LOG_ERROR("File failed to delete. Error message: %s", safeStrerror(errno).data());
 
@@ -230,24 +230,24 @@ bool makeAllDirectories(const String& path)
     if (!length)
         return false;
 
-    if (!access(fullPath.data(), F_OK))
+    if (!access(fullPath.legacyCStringPointer(), F_OK))
         return true;
 
-    auto p = fullPath.mutableSpanIncludingNullTerminator().subspan(1);
+    auto p = byteCast<char>(fullPath.mutableSpanIncludingNullTerminator()).subspan(1);
     if (p[length - 1] == '/')
         p[length - 1] = '\0';
     for (; p[0]; skip(p, 1)) {
         if (p[0] == '/') {
             p[0] = '\0';
-            if (access(fullPath.data(), F_OK)) {
-                if (mkdir(fullPath.data(), S_IRWXU))
+            if (access(fullPath.legacyCStringPointer(), F_OK)) {
+                if (mkdir(fullPath.legacyCStringPointer(), S_IRWXU))
                     return false;
             }
             p[0] = '/';
         }
     }
-    if (access(fullPath.data(), F_OK)) {
-        if (mkdir(fullPath.data(), S_IRWXU))
+    if (access(fullPath.legacyCStringPointer(), F_OK)) {
+        if (mkdir(fullPath.legacyCStringPointer(), S_IRWXU))
             return false;
     }
 

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -256,6 +256,20 @@ public:
     // FIXME: Should go away once callers that only need bytes have moved to span().
     const char* legacyCStringPointer() const LIFETIME_BOUND requires (!std::same_as<CharacterType, Latin1Character>) { return CString::data(); }
 
+#if USE(FOUNDATION) && defined(__OBJC__)
+    // Converts a null string to an empty string, like String::createNSString(). ASCII decodes as
+    // Latin-1, matching how the comparison operators below treat it, so that an ASCIICString holding
+    // a mislabeled non-ASCII byte round-trips instead of failing.
+    RetainPtr<NSString> createNSString() const
+    {
+        auto characters = span();
+        if (characters.empty())
+            return @"";
+        constexpr auto encoding = std::same_as<CharacterType, char8_t> ? NSUTF8StringEncoding : NSISOLatin1StringEncoding;
+        return adoptNS([[NSString alloc] initWithBytes:characters.data() length:characters.size() encoding:encoding]);
+    }
+#endif
+
 private:
     explicit CStringWithEncoding(CStringBuffer* buffer)
         : CString(buffer)

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -87,15 +87,15 @@ std::optional<WallTime> fileCreationTime(const String& path)
     return WallTime::fromRawSeconds(time);
 }
 
-CString fileSystemRepresentation(const String& path)
+UTF8CString fileSystemRepresentation(const String& path)
 {
     auto characters = StringView(path).upconvertedCharacters();
-    int size = WideCharToMultiByte(CP_ACP, 0, wcharFrom(characters), path.length(), 0, 0, 0, 0);
+    int size = WideCharToMultiByte(CP_UTF8, 0, wcharFrom(characters), path.length(), 0, 0, 0, 0);
 
-    std::span<char> buffer;
-    CString string = CString::newUninitialized(size, buffer);
+    std::span<char8_t> buffer;
+    auto string = UTF8CString::newUninitialized(size, buffer);
 
-    WideCharToMultiByte(CP_ACP, 0, wcharFrom(characters), path.length(), buffer.data(), buffer.size(), 0, 0);
+    WideCharToMultiByte(CP_UTF8, 0, wcharFrom(characters), path.length(), byteCast<char>(buffer).data(), buffer.size(), 0, 0);
 
     return string;
 }

--- a/Source/WebCore/PAL/pal/system/glib/SleepDisablerGLib.cpp
+++ b/Source/WebCore/PAL/pal/system/glib/SleepDisablerGLib.cpp
@@ -95,7 +95,7 @@ void SleepDisablerGLib::acquireInhibitor()
     } else if (const gchar* prgname = g_get_prgname()) {
         parameters = g_variant_new("(ss)", prgname, m_reason.utf8().legacyCStringPointer());
     } else if (const auto executablePath = FileSystem::currentExecutablePath(); !executablePath.isNull()) {
-        GUniquePtr<char> executableName(g_path_get_basename(executablePath.data()));
+        GUniquePtr<char> executableName(g_path_get_basename(executablePath.legacyCStringPointer()));
         parameters = g_variant_new("(ss)", executableName.get(), m_reason.utf8().legacyCStringPointer());
     } else
         return;

--- a/Source/WebCore/platform/glib/FileMonitorGLib.cpp
+++ b/Source/WebCore/platform/glib/FileMonitorGLib.cpp
@@ -39,7 +39,7 @@ FileMonitor::FileMonitor(const String& path, Ref<WorkQueue>&& handlerQueue, Func
         return;
 
     Function<void ()> createPlatformMonitor = [&] {
-        GRefPtr file = adoptGRef(g_file_new_for_path(FileSystem::fileSystemRepresentation(path).data()));
+        GRefPtr file = adoptGRef(g_file_new_for_path(FileSystem::fileSystemRepresentation(path).legacyCStringPointer()));
         GUniqueOutPtr<GError> error;
         m_platformMonitor = adoptGRef(g_file_monitor(file.get(), G_FILE_MONITOR_NONE, nullptr, &error.outPtr()));
         if (m_platformMonitor)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -492,7 +492,7 @@ bool ensureGStreamerInitialized()
         int argc = parameters.size() + 1;
         char** argv = g_new0(char*, argc + 1);
         auto argvSpan = unsafeMakeSpan(argv, argc);
-        argvSpan[0] = g_strdup(FileSystem::currentExecutableName().data());
+        argvSpan[0] = g_strdup(FileSystem::currentExecutableName().legacyCStringPointer());
         for (auto [arg, parameter] : zippedRange(argvSpan.subspan(1), parameters))
             arg = g_strdup(parameter.utf8().legacyCStringPointer());
 

--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -186,8 +186,8 @@ void SoupNetworkSession::setHSTSPersistentStorage(const String& directory)
         return;
     }
 
-    CString storagePath = FileSystem::fileSystemRepresentation(directory);
-    GUniquePtr<char> dbFilename(g_build_filename(storagePath.data(), "hsts-storage.sqlite", nullptr));
+    auto storagePath = FileSystem::fileSystemRepresentation(directory);
+    GUniquePtr<char> dbFilename(g_build_filename(storagePath.legacyCStringPointer(), "hsts-storage.sqlite", nullptr));
     GRefPtr<SoupHSTSEnforcer> enforcer = adoptGRef(soup_hsts_enforcer_db_new(dbFilename.get()));
     soup_session_remove_feature_by_type(m_soupSession.get(), SOUP_TYPE_HSTS_ENFORCER);
     soup_session_add_feature(m_soupSession.get(), SOUP_SESSION_FEATURE(enforcer.get()));
@@ -242,12 +242,12 @@ static inline bool stringIsNumeric(const std::string_view& str)
 // Old versions of WebKit created this cache.
 void SoupNetworkSession::clearOldSoupCache(const String& cacheDirectory)
 {
-    CString cachePath = FileSystem::fileSystemRepresentation(cacheDirectory);
-    GUniquePtr<char> cacheFile(g_build_filename(cachePath.data(), "soup.cache2", nullptr));
+    auto cachePath = FileSystem::fileSystemRepresentation(cacheDirectory);
+    GUniquePtr<char> cacheFile(g_build_filename(cachePath.legacyCStringPointer(), "soup.cache2", nullptr));
     if (!g_file_test(cacheFile.get(), G_FILE_TEST_IS_REGULAR))
         return;
 
-    GUniquePtr<GDir> dir(g_dir_open(cachePath.data(), 0, nullptr));
+    GUniquePtr<GDir> dir(g_dir_open(cachePath.legacyCStringPointer(), 0, nullptr));
     if (!dir)
         return;
 
@@ -256,7 +256,7 @@ void SoupNetworkSession::clearOldSoupCache(const String& cacheDirectory)
         if (!nameView.starts_with("soup.cache") && !stringIsNumeric(nameView))
             continue;
 
-        GUniquePtr<gchar> filename(g_build_filename(cachePath.data(), name, nullptr));
+        GUniquePtr<gchar> filename(g_build_filename(cachePath.legacyCStringPointer(), name, nullptr));
         if (g_file_test(filename.get(), G_FILE_TEST_IS_REGULAR))
             g_unlink(filename.get());
     }

--- a/Source/WebCore/platform/network/soup/WebKitFormDataInputStream.cpp
+++ b/Source/WebCore/platform/network/soup/WebKitFormDataInputStream.cpp
@@ -65,7 +65,7 @@ static bool webkitFormDataInputStreamCreateNextStream(WebKitFormDataInputStream*
             priv->currentStream = adoptGRef(g_memory_input_stream_new_from_bytes(bytes.get()));
         }, [priv, cancellable] (const FormDataElement::EncodedFileData& fileData) {
             if (fileData.fileModificationTimeMatchesExpectation()) {
-                GRefPtr<GFile> file = adoptGRef(g_file_new_for_path(FileSystem::fileSystemRepresentation(fileData.filename).data()));
+                GRefPtr<GFile> file = adoptGRef(g_file_new_for_path(FileSystem::fileSystemRepresentation(fileData.filename).legacyCStringPointer()));
                 priv->currentStream = adoptGRef(G_INPUT_STREAM(g_file_read(file.get(), cancellable, nullptr)));
                 if (G_IS_SEEKABLE(priv->currentStream.get()) && fileData.fileStart > 0)
                     g_seekable_seek(G_SEEKABLE(priv->currentStream.get()), fileData.fileStart, G_SEEK_SET, cancellable, nullptr);

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -157,7 +157,7 @@ bool SQLiteDatabase::open(const String& filename, OpenMode openMode, OptionSet<O
         int result = SQLITE_OK;
         {
             SQLiteTransactionInProgressAutoCounter transactionCounter;
-            result = sqlite3_open_v2(FileSystem::fileSystemRepresentation(filename).data(), &m_db, flags, nullptr);
+            result = sqlite3_open_v2(FileSystem::fileSystemRepresentation(filename).legacyCStringPointer(), &m_db, flags, nullptr);
 #if PLATFORM(COCOA)
             if (result == SQLITE_OK && options.contains(OpenOptions::CanSuspendWhileLocked))
                 SQLiteFileSystem::setCanSuspendLockedFileAttribute(filename);

--- a/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
+++ b/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
@@ -102,7 +102,7 @@ void SQLiteFileSystem::setCanSuspendLockedFileAttribute(const String& filePath)
     for (auto suffix : databaseFileSuffixes) {
         auto path = makeString(filePath, suffix);
         char excluded = 0xff;
-        auto result = setxattr(FileSystem::fileSystemRepresentation(path).data(), "com.apple.runningboard.can-suspend-locked", &excluded, sizeof(excluded), 0, 0);
+        auto result = setxattr(FileSystem::fileSystemRepresentation(path).legacyCStringPointer(), "com.apple.runningboard.can-suspend-locked", &excluded, sizeof(excluded), 0, 0);
         if (result < 0 && suffix == ""_s)
             RELEASE_LOG_ERROR(SQLDatabase, "SQLiteFileSystem::setCanSuspendLockedFileAttribute: setxattr failed: %" PUBLIC_LOG_STRING, strerror(errno));
     }

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -37,6 +37,7 @@
 #import <wtf/FileSystem.h>
 #import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/text/CString.h>
 
 #define DOWNLOAD_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "[downloadID=%" PRIu64 "] Download::" fmt, m_downloadID.toUInt64(), ##__VA_ARGS__)
 #define DOWNLOAD_RELEASE_LOG_ERROR(fmt, ...) RELEASE_LOG_ERROR(Network, "[downloadID=%" PRIu64 "] Download::" fmt, m_downloadID.toUInt64(), ##__VA_ARGS__)
@@ -82,7 +83,7 @@ void Download::resume(std::span<const uint8_t> resumeData, const String& path, S
 #if HAVE(MODERN_DOWNLOADPROGRESS)
     if (RetainPtr<NSData> placeholderURLBookmark = [dictionary objectForKey:@"ResumePlaceholderURLBookmarkData"]) {
         RetainPtr nsActivityAccessToken = toNSData(activityAccessToken);
-        RetainPtr pathString  = adoptNS([[NSString alloc] initWithUTF8String:WTF::FileSystemImpl::fileSystemRepresentation(path).data()]);
+        RetainPtr pathString = WTF::FileSystemImpl::fileSystemRepresentation(path).createNSString();
         RetainPtr destinationURL = adoptNS([[NSURL alloc] initFileURLWithPath:pathString.get() isDirectory:NO]);
 
         BOOL bookmarkDataIsStale = NO;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -143,8 +143,8 @@ Cache::Cache(NetworkProcess& networkProcess, const String& storageDirectory, Ref
 #endif
 #if PLATFORM(GTK) || PLATFORM(WPE)
         // Triggers with "touch $cachePath/dump".
-        CString dumpFilePath = fileSystemRepresentation(pathByAppendingComponent(m_storage->basePathIsolatedCopy(), "dump"_s));
-        GRefPtr<GFile> dumpFile = adoptGRef(g_file_new_for_path(dumpFilePath.data()));
+        auto dumpFilePath = fileSystemRepresentation(pathByAppendingComponent(m_storage->basePathIsolatedCopy(), "dump"_s));
+        GRefPtr<GFile> dumpFile = adoptGRef(g_file_new_for_path(dumpFilePath.legacyCStringPointer()));
         GFileMonitor* monitor = g_file_monitor_file(dumpFile.get(), G_FILE_MONITOR_NONE, nullptr, nullptr);
         g_signal_connect_swapped(monitor, "changed", G_CALLBACK(dumpFileChanged), this);
 #endif

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheFileSystem.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheFileSystem.cpp
@@ -69,7 +69,7 @@ FileTimes fileTimes(const String& path)
     return { WallTime::fromRawSeconds(fileInfo.st_birthtime), WallTime::fromRawSeconds(fileInfo.st_mtime) };
 #elif USE(SOUP)
     // There's no st_birthtime in some operating systems like Linux, so we use xattrs to set/get the creation time.
-    GRefPtr<GFile> file = adoptGRef(g_file_new_for_path(FileSystem::fileSystemRepresentation(path).data()));
+    GRefPtr<GFile> file = adoptGRef(g_file_new_for_path(FileSystem::fileSystemRepresentation(path).legacyCStringPointer()));
     GRefPtr<GFileInfo> fileInfo = adoptGRef(g_file_query_info(file.get(), "xattr::birthtime,time::modified", G_FILE_QUERY_INFO_NONE, nullptr, nullptr));
     if (!fileInfo)
         return { };

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
@@ -62,7 +62,7 @@ IOChannel::IOChannel(const String& filePath, Type type, std::optional<WorkQueue:
     switch (type) {
     case Type::Create:
         // We don't want to truncate any existing file (with O_TRUNC) as another thread might be mapping it.
-        unlink(path.data());
+        unlink(path.legacyCStringPointer());
         oflag = O_RDWR | O_CREAT | O_NONBLOCK;
         mode = S_IRUSR | S_IWUSR;
         dispatchQOS = qos.value_or(WorkQueue::QOS::Background);
@@ -78,7 +78,7 @@ IOChannel::IOChannel(const String& filePath, Type type, std::optional<WorkQueue:
         dispatchQOS = qos.value_or(WorkQueue::QOS::Default);
     }
 
-    int fd = ::open(path.data(), oflag, mode);
+    int fd = ::open(path.legacyCStringPointer(), oflag, mode);
     m_dispatchIO = adoptOSObject(dispatch_io_create(DISPATCH_IO_RANDOM, fd, globalDispatchQueueSingleton(dispatchQueueIdentifier(dispatchQOS), 0), [fd](int) {
         close(fd);
     }));

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp
@@ -39,7 +39,7 @@ namespace NetworkCache {
 IOChannel::IOChannel(const String& filePath, Type type, std::optional<WorkQueue::QOS> qos)
 {
     auto path = FileSystem::fileSystemRepresentation(filePath);
-    GRefPtr<GFile> file = adoptGRef(g_file_new_for_path(path.data()));
+    GRefPtr<GFile> file = adoptGRef(g_file_new_for_path(path.legacyCStringPointer()));
 
     Locker locker { m_lock };
     switch (type) {

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -36,7 +36,7 @@
 
 namespace WebKit {
 
-std::unique_ptr<SandboxExtensionImpl> SandboxExtensionImpl::create(const char* path, SandboxExtension::Type type, std::optional<audit_token_t> auditToken, OptionSet<SandboxExtension::Flags> flags)
+std::unique_ptr<SandboxExtensionImpl> SandboxExtensionImpl::create(const UTF8CString& path, SandboxExtension::Type type, std::optional<audit_token_t> auditToken, OptionSet<SandboxExtension::Flags> flags)
 {
     std::unique_ptr<SandboxExtensionImpl> impl { new SandboxExtensionImpl(path, type, auditToken, flags) };
     if (!impl->m_token.length())
@@ -81,8 +81,9 @@ std::span<const uint8_t> SandboxExtensionImpl::getSerializedFormat()
     return byteCast<uint8_t>(m_token.span());
 }
 
-CString SandboxExtensionImpl::sandboxExtensionForType(const char* path, SandboxExtension::Type type, std::optional<audit_token_t> auditToken, OptionSet<SandboxExtension::Flags> flags)
+CString SandboxExtensionImpl::sandboxExtensionForType(const UTF8CString& path, SandboxExtension::Type type, std::optional<audit_token_t> auditToken, OptionSet<SandboxExtension::Flags> flags)
 {
+    auto* pathPointer = path.legacyCStringPointer();
     auto sandboxExtension = [&] {
         uint32_t extensionFlags = 0;
         if (flags & SandboxExtension::Flags::NoReport)
@@ -92,33 +93,33 @@ CString SandboxExtensionImpl::sandboxExtensionForType(const char* path, SandboxE
 
         switch (type) {
         case SandboxExtension::Type::ReadOnly:
-            return std::unique_ptr<char, decltype(free)*>(sandbox_extension_issue_file(APP_SANDBOX_READ, path, extensionFlags), free);
+            return std::unique_ptr<char, decltype(free)*>(sandbox_extension_issue_file(APP_SANDBOX_READ, pathPointer, extensionFlags), free);
         case SandboxExtension::Type::ReadWrite:
-            return std::unique_ptr<char, decltype(free)*>(sandbox_extension_issue_file(APP_SANDBOX_READ_WRITE, path, extensionFlags), free);
+            return std::unique_ptr<char, decltype(free)*>(sandbox_extension_issue_file(APP_SANDBOX_READ_WRITE, pathPointer, extensionFlags), free);
         case SandboxExtension::Type::Mach:
             if (!auditToken)
-                return std::unique_ptr<char, decltype(free)*>(sandbox_extension_issue_mach("com.apple.webkit.extension.mach", path, extensionFlags), free);
-            return std::unique_ptr<char, decltype(free)*>(sandbox_extension_issue_mach_to_process("com.apple.webkit.extension.mach", path, extensionFlags, *auditToken), free);
+                return std::unique_ptr<char, decltype(free)*>(sandbox_extension_issue_mach("com.apple.webkit.extension.mach", pathPointer, extensionFlags), free);
+            return std::unique_ptr<char, decltype(free)*>(sandbox_extension_issue_mach_to_process("com.apple.webkit.extension.mach", pathPointer, extensionFlags, *auditToken), free);
         case SandboxExtension::Type::IOKit:
             if (!auditToken)
-                return std::unique_ptr<char, decltype(free)*>(sandbox_extension_issue_iokit_registry_entry_class("com.apple.webkit.extension.iokit", path, extensionFlags), free);
-            return std::unique_ptr<char, decltype(free)*>(sandbox_extension_issue_iokit_registry_entry_class_to_process("com.apple.webkit.extension.iokit", path, extensionFlags, *auditToken), free);
+                return std::unique_ptr<char, decltype(free)*>(sandbox_extension_issue_iokit_registry_entry_class("com.apple.webkit.extension.iokit", pathPointer, extensionFlags), free);
+            return std::unique_ptr<char, decltype(free)*>(sandbox_extension_issue_iokit_registry_entry_class_to_process("com.apple.webkit.extension.iokit", pathPointer, extensionFlags, *auditToken), free);
         case SandboxExtension::Type::Generic:
-            return std::unique_ptr<char, decltype(free)*>(sandbox_extension_issue_generic(path, extensionFlags), free);
+            return std::unique_ptr<char, decltype(free)*>(sandbox_extension_issue_generic(pathPointer, extensionFlags), free);
         case SandboxExtension::Type::ReadByProcess:
             if (!auditToken)
                 return std::unique_ptr<char, decltype(free)*>(nullptr, free);
 #if PLATFORM(MAC)
             extensionFlags |= SANDBOX_EXTENSION_USER_INTENT;
 #endif
-            return std::unique_ptr<char, decltype(free)*>(sandbox_extension_issue_file_to_process(APP_SANDBOX_READ, path, extensionFlags, *auditToken), free);
+            return std::unique_ptr<char, decltype(free)*>(sandbox_extension_issue_file_to_process(APP_SANDBOX_READ, pathPointer, extensionFlags, *auditToken), free);
         }
     }();
 
     return CString(sandboxExtension.get());
 }
 
-SandboxExtensionImpl::SandboxExtensionImpl(const char* path, SandboxExtension::Type type, std::optional<audit_token_t> auditToken, OptionSet<SandboxExtension::Flags> flags)
+SandboxExtensionImpl::SandboxExtensionImpl(const UTF8CString& path, SandboxExtension::Type type, std::optional<audit_token_t> auditToken, OptionSet<SandboxExtension::Flags> flags)
     : m_token { sandboxExtensionForType(path, type, auditToken, flags) }
 {
 }
@@ -185,7 +186,7 @@ auto SandboxExtension::createHandleWithoutResolvingPath(StringView path, Type ty
     Handle handle;
     ASSERT(!handle.m_sandboxExtension);
 
-    handle.m_sandboxExtension = SandboxExtensionImpl::create(path.utf8().legacyCStringPointer(), type, std::nullopt, Flags::DoNotCanonicalize);
+    handle.m_sandboxExtension = SandboxExtensionImpl::create(path.utf8(), type, std::nullopt, Flags::DoNotCanonicalize);
     if (!handle.m_sandboxExtension) {
         RELEASE_LOG_ERROR(Sandbox, "Could not create a sandbox extension for '%{private}s'", path.utf8().legacyCStringPointer());
         return std::nullopt;
@@ -252,7 +253,7 @@ auto SandboxExtension::createHandleForTemporaryFile(StringView prefix, Type type
     if (pathString.isNull())
         return std::nullopt;
     
-    handle.m_sandboxExtension = SandboxExtensionImpl::create(FileSystem::fileSystemRepresentation(pathString).data(), type);
+    handle.m_sandboxExtension = SandboxExtensionImpl::create(FileSystem::fileSystemRepresentation(pathString), type);
 
     if (!handle.m_sandboxExtension) {
         WTFLogAlways("Could not create a sandbox extension for temporary file '%s'", pathString.utf8().legacyCStringPointer());
@@ -266,7 +267,7 @@ auto SandboxExtension::createHandleForGenericExtension(ASCIILiteral extensionCla
     Handle handle;
     ASSERT(!handle.m_sandboxExtension);
 
-    handle.m_sandboxExtension = SandboxExtensionImpl::create(extensionClass.characters(), Type::Generic);
+    handle.m_sandboxExtension = SandboxExtensionImpl::create(extensionClass, Type::Generic);
     if (!handle.m_sandboxExtension) {
         WTFLogAlways("Could not create a '%s' sandbox extension", extensionClass.characters());
         return std::nullopt;
@@ -288,7 +289,7 @@ auto SandboxExtension::createHandleForMachLookup(ASCIILiteral service, std::opti
     Handle handle;
     ASSERT(!handle.m_sandboxExtension);
     
-    handle.m_sandboxExtension = SandboxExtensionImpl::create(service.characters(), Type::Mach, auditToken, flags);
+    handle.m_sandboxExtension = SandboxExtensionImpl::create(service, Type::Mach, auditToken, flags);
     if (!handle.m_sandboxExtension) {
         WTFLogAlways("Could not create a '%s' sandbox extension", service.characters());
         return std::nullopt;
@@ -322,7 +323,7 @@ auto SandboxExtension::createHandleForReadByAuditToken(StringView path, audit_to
     Handle handle;
     ASSERT(!handle.m_sandboxExtension);
 
-    handle.m_sandboxExtension = SandboxExtensionImpl::create(path.utf8().legacyCStringPointer(), Type::ReadByProcess, auditToken);
+    handle.m_sandboxExtension = SandboxExtensionImpl::create(path.utf8(), Type::ReadByProcess, auditToken);
     if (!handle.m_sandboxExtension) {
         RELEASE_LOG_ERROR(Sandbox, "Could not create a sandbox extension for '%{private}s'", path.utf8().legacyCStringPointer());
         return std::nullopt;
@@ -337,7 +338,7 @@ auto SandboxExtension::createHandleForIOKitClassExtension(ASCIILiteral ioKitClas
     Handle handle;
     ASSERT(!handle.m_sandboxExtension);
 
-    handle.m_sandboxExtension = SandboxExtensionImpl::create(ioKitClass.characters(), Type::IOKit, auditToken);
+    handle.m_sandboxExtension = SandboxExtensionImpl::create(ioKitClass, Type::IOKit, auditToken);
     if (!handle.m_sandboxExtension) {
         RELEASE_LOG_ERROR(Sandbox, "Could not create a sandbox extension for '%s'", ioKitClass.characters());
         return std::nullopt;

--- a/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.cpp
@@ -171,7 +171,7 @@ bool WebExtensionSQLiteDatabase::openWithAccessType(AccessType accessType, RefPt
         }
     }
 
-    int result = sqlite3_open_v2(FileSystem::fileSystemRepresentation(databasePath).data(), &m_db, flags, vfs.isEmpty() ? nullptr : vfs.utf8().legacyCStringPointer());
+    int result = sqlite3_open_v2(FileSystem::fileSystemRepresentation(databasePath).legacyCStringPointer(), &m_db, flags, vfs.isEmpty() ? nullptr : vfs.utf8().legacyCStringPointer());
     if (result == SQLITE_OK)
         return true;
 

--- a/Source/WebKit/Shared/SandboxExtension.h
+++ b/Source/WebKit/Shared/SandboxExtension.h
@@ -57,7 +57,7 @@ enum class SandboxExtensionType : uint8_t {
 class SandboxExtensionImpl {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(SandboxExtensionImpl);
 public:
-    static std::unique_ptr<SandboxExtensionImpl> create(const char* path, SandboxExtensionType, std::optional<audit_token_t> = std::nullopt, OptionSet<SandboxExtensionFlags> = SandboxExtensionFlags::Default);
+    static std::unique_ptr<SandboxExtensionImpl> create(const UTF8CString& path, SandboxExtensionType, std::optional<audit_token_t> = std::nullopt, OptionSet<SandboxExtensionFlags> = SandboxExtensionFlags::Default);
     SandboxExtensionImpl(std::span<const uint8_t>);
     ~SandboxExtensionImpl();
 
@@ -69,9 +69,9 @@ public:
         : m_token(std::exchange(other.m_token, CString()))
         , m_handle(std::exchange(other.m_handle, 0)) { }
 private:
-    CString sandboxExtensionForType(const char* path, SandboxExtensionType, std::optional<audit_token_t>, OptionSet<SandboxExtensionFlags>);
+    CString sandboxExtensionForType(const UTF8CString& path, SandboxExtensionType, std::optional<audit_token_t>, OptionSet<SandboxExtensionFlags>);
 
-    SandboxExtensionImpl(const char* path, SandboxExtensionType, std::optional<audit_token_t>, OptionSet<SandboxExtensionFlags>);
+    SandboxExtensionImpl(const UTF8CString& path, SandboxExtensionType, std::optional<audit_token_t>, OptionSet<SandboxExtensionFlags>);
 
     CString m_token;
     int64_t m_handle { 0 };

--- a/Source/WebKit/Shared/glib/ProcessExecutablePathGLib.cpp
+++ b/Source/WebKit/Shared/glib/ProcessExecutablePathGLib.cpp
@@ -35,9 +35,9 @@ namespace WebKit {
 #if ENABLE(DEVELOPER_MODE)
 static String getExecutablePath()
 {
-    CString executablePath = FileSystem::currentExecutablePath();
+    auto executablePath = FileSystem::currentExecutablePath();
     if (!executablePath.isNull())
-        return FileSystem::parentPath(FileSystem::stringFromFileSystemRepresentation(executablePath.data()));
+        return FileSystem::parentPath(FileSystem::stringFromFileSystemRepresentation(executablePath.legacyCStringPointer()));
     return { };
 }
 #endif

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -60,6 +60,7 @@
 #import <wtf/spi/darwin/DataVaultSPI.h>
 #import <wtf/spi/darwin/SandboxSPI.h>
 #import <wtf/text/Base64.h>
+#import <wtf/text/CStringView.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/StringBuilder.h>
 #import <wtf/text/cf/StringConcatenateCF.h>
@@ -235,7 +236,7 @@ static std::optional<CString> setAndSerializeSandboxParameters(const SandboxInit
         const char* name = initializationParameters.name(i);
         const char* value = initializationParameters.value(i);
         if (sandbox_set_param(sandboxParameters.get(), name, value)) {
-            WTFLogAlways("%s: Could not set sandbox parameter: %s\n", getprogname(), safeStrerror(errno).data());
+            SAFE_WTFLOGALWAYS("%s: Could not set sandbox parameter: %s\n", FileSystem::currentExecutableName(), safeStrerror(errno));
             CRASH();
         }
         builder.append(unsafeSpan(name), ':', unsafeSpan(value), ':');
@@ -296,21 +297,21 @@ static bool ensureSandboxCacheDirectory(const SandboxInfo& info)
     if (FileSystem::fileTypeFollowingSymlinks(info.parentDirectoryPath) != FileSystem::FileType::Directory) {
         FileSystem::makeAllDirectories(info.parentDirectoryPath);
         if (FileSystem::fileTypeFollowingSymlinks(info.parentDirectoryPath) != FileSystem::FileType::Directory) {
-            WTFLogAlways("%s: Could not create sandbox directory\n", getprogname());
+            SAFE_WTFLOGALWAYS("%s: Could not create sandbox directory\n", FileSystem::currentExecutableName());
             return false;
         }
     }
 
 #if USE(APPLE_INTERNAL_SDK)
     auto storageClass = processStorageClass(info.processType);
-    CString directoryPath = FileSystem::fileSystemRepresentation(info.directoryPath);
+    auto directoryPath = FileSystem::fileSystemRepresentation(info.directoryPath);
     if (directoryPath.isNull())
         return false;
 
     auto makeDataVault = [&] {
         do {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-            if (!rootless_mkdir_datavault(directoryPath.data(), 0700, storageClass))
+            if (!rootless_mkdir_datavault(directoryPath.legacyCStringPointer(), 0700, storageClass))
                 return true;
 ALLOW_DEPRECATED_DECLARATIONS_END
         } while (errno == EAGAIN);
@@ -324,7 +325,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         // The directory already exists. First we'll check if it is a data vault. If it is then
         // we are the ones who created it and we can continue. If it is not a datavault then we'll just
         // delete it and try to make a new one.
-        if (!rootless_check_datavault_flag(directoryPath.data(), storageClass))
+        if (!rootless_check_datavault_flag(directoryPath.legacyCStringPointer(), storageClass))
             return true;
 
         if (FileSystem::fileType(info.directoryPath) == FileSystem::FileType::Directory) {
@@ -338,7 +339,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         if (!makeDataVault())
             return false;
     } else {
-        WTFLogAlways("%s: Sandbox directory couldn't be created: %s", getprogname(), safeStrerror(errno).data());
+        SAFE_WTFLOGALWAYS("%s: Sandbox directory couldn't be created: %s", FileSystem::currentExecutableName(), safeStrerror(errno));
         return false;
     }
 #else
@@ -385,12 +386,12 @@ static SandboxProfilePtr compileAndCacheSandboxProfile(const SandboxInfo& info)
         return nullptr;
 
     char* error = nullptr;
-    CString profileOrProfilePath = info.isProfilePath ? FileSystem::fileSystemRepresentation(info.profileOrProfilePath) : info.profileOrProfilePath.utf8();
+    auto profileOrProfilePath = info.isProfilePath ? FileSystem::fileSystemRepresentation(info.profileOrProfilePath) : info.profileOrProfilePath.utf8();
     if (profileOrProfilePath.isNull())
         return nullptr;
-    SandboxProfilePtr sandboxProfile { info.isProfilePath ? sandbox_compile_file(profileOrProfilePath.data(), info.sandboxParameters.get(), &error) : sandbox_compile_string(profileOrProfilePath.data(), info.sandboxParameters.get(), &error) };
+    SandboxProfilePtr sandboxProfile { info.isProfilePath ? sandbox_compile_file(profileOrProfilePath.legacyCStringPointer(), info.sandboxParameters.get(), &error) : sandbox_compile_string(profileOrProfilePath.legacyCStringPointer(), info.sandboxParameters.get(), &error) };
     if (!sandboxProfile) {
-        WTFLogAlways("%s: Could not compile WebContent sandbox: %s\n", getprogname(), error);
+        SAFE_WTFLOGALWAYS("%s: Could not compile WebContent sandbox: %s\n", FileSystem::currentExecutableName(), CStringView::unsafeFromUTF8(error));
         return nullptr;
     }
 
@@ -426,17 +427,17 @@ static SandboxProfilePtr compileAndCacheSandboxProfile(const SandboxInfo& info)
     cacheFile.append(unsafeMakeSpan(sandboxProfile->data, cachedHeader.dataSize));
 
     if (!writeSandboxDataToCacheFile(info, cacheFile))
-        WTFLogAlways("%s: Unable to cache compiled sandbox\n", getprogname());
+        SAFE_WTFLOGALWAYS("%s: Unable to cache compiled sandbox\n", FileSystem::currentExecutableName());
 
     return sandboxProfile;
 }
 
 static bool tryApplyCachedSandbox(const SandboxInfo& info)
 {
-    CString directoryPath = FileSystem::fileSystemRepresentation(info.directoryPath);
+    auto directoryPath = FileSystem::fileSystemRepresentation(info.directoryPath);
     if (directoryPath.isNull())
         return false;
-    if (rootless_check_datavault_flag(directoryPath.data(), processStorageClass(info.processType)))
+    if (rootless_check_datavault_flag(directoryPath.legacyCStringPointer(), processStorageClass(info.processType)))
         return false;
 
     auto contents = fileContents(info.filePath);
@@ -496,7 +497,7 @@ static bool tryApplyCachedSandbox(const SandboxInfo& info)
     profile.data = sandboxData.data();
 
     if (sandbox_apply(&profile)) {
-        WTFLogAlways("%s: Could not apply cached sandbox: %s\n", getprogname(), safeStrerror(errno).data());
+        SAFE_WTFLOGALWAYS("%s: Could not apply cached sandbox: %s\n", FileSystem::currentExecutableName(), safeStrerror(errno));
         return false;
     }
 
@@ -531,13 +532,13 @@ static void getSandboxProfileOrProfilePath(const SandboxInitializationParameters
 static bool compileAndApplySandboxSlowCase(const String& profileOrProfilePath, bool isProfilePath, const SandboxInitializationParameters& parameters)
 {
     char* errorBuf;
-    CString temp = isProfilePath ? FileSystem::fileSystemRepresentation(profileOrProfilePath) : profileOrProfilePath.utf8();
+    auto temp = isProfilePath ? FileSystem::fileSystemRepresentation(profileOrProfilePath) : profileOrProfilePath.utf8();
     uint64_t flags = isProfilePath ? SANDBOX_NAMED_EXTERNAL : 0;
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if (sandbox_init_with_parameters(temp.data(), flags, parameters.namedParameterVector().span().data(), &errorBuf)) {
+    if (sandbox_init_with_parameters(temp.legacyCStringPointer(), flags, parameters.namedParameterVector().span().data(), &errorBuf)) {
 ALLOW_DEPRECATED_DECLARATIONS_END
-        WTFLogAlways("%s: Could not initialize sandbox profile [%s], error '%s'\n", getprogname(), temp.data(), errorBuf);
+        SAFE_WTFLOGALWAYS("%s: Could not initialize sandbox profile [%s], error '%s'\n", FileSystem::currentExecutableName(), temp, CStringView::unsafeFromUTF8(errorBuf));
         for (size_t i = 0, count = parameters.count(); i != count; ++i) {
             WTFLogAlways("%s=%s\n", parameters.name(i).characters(), parameters.value(i));
         }
@@ -552,7 +553,7 @@ static bool applySandbox(const AuxiliaryProcessInitializationParameters& paramet
     bool isProfilePath;
     getSandboxProfileOrProfilePath(sandboxInitializationParameters, profileOrProfilePath, isProfilePath);
     if (profileOrProfilePath.isEmpty()) {
-        WTFLogAlways("%s: Profile path is invalid\n", getprogname());
+        SAFE_WTFLOGALWAYS("%s: Profile path is invalid\n", FileSystem::currentExecutableName());
         CRASH();
     }
 
@@ -568,12 +569,12 @@ static bool applySandbox(const AuxiliaryProcessInitializationParameters& paramet
 
     SandboxParametersPtr sandboxParameters { sandbox_create_params() };
     if (!sandboxParameters) {
-        WTFLogAlways("%s: Could not create sandbox parameters\n", getprogname());
+        SAFE_WTFLOGALWAYS("%s: Could not create sandbox parameters\n", FileSystem::currentExecutableName());
         CRASH();
     }
     auto header = setAndSerializeSandboxParameters(sandboxInitializationParameters, sandboxParameters, profileOrProfilePath, isProfilePath);
     if (!header) {
-        WTFLogAlways("%s: Sandbox parameters are invalid\n", getprogname());
+        SAFE_WTFLOGALWAYS("%s: Sandbox parameters are invalid\n", FileSystem::currentExecutableName());
         return compileAndApplySandboxSlowCase(profileOrProfilePath, isProfilePath, sandboxInitializationParameters);
     }
 
@@ -599,7 +600,7 @@ static bool applySandbox(const AuxiliaryProcessInitializationParameters& paramet
         return compileAndApplySandboxSlowCase(profileOrProfilePath, isProfilePath, sandboxInitializationParameters);
 
     if (sandbox_apply(sandboxProfile.get())) {
-        WTFLogAlways("%s: Could not apply compiled sandbox: %s\n", getprogname(), safeStrerror(errno).data());
+        SAFE_WTFLOGALWAYS("%s: Could not apply compiled sandbox: %s\n", FileSystem::currentExecutableName(), safeStrerror(errno));
         CRASH();
     }
 
@@ -638,13 +639,13 @@ static void populateSandboxInitializationParameters(SandboxInitializationParamet
     RELEASE_ASSERT(!sandboxParameters.userDirectorySuffix().isNull());
 
     // Use private temporary and cache directories.
-    CString userDirectorySuffixString = FileSystem::fileSystemRepresentation(sandboxParameters.userDirectorySuffix());
-    if (!_set_user_dir_suffix(userDirectorySuffixString.data()))
+    auto userDirectorySuffixString = FileSystem::fileSystemRepresentation(sandboxParameters.userDirectorySuffix());
+    if (!_set_user_dir_suffix(userDirectorySuffixString.legacyCStringPointer()))
         RELEASE_LOG_ERROR(Process, "Unable to set user dir suffix");
 
     char temporaryDirectory[PATH_MAX];
     if (!confstr(_CS_DARWIN_USER_TEMP_DIR, temporaryDirectory, sizeof(temporaryDirectory))) {
-        WTFLogAlways("%s: couldn't retrieve private temporary directory path: %d\n", getprogname(), errno);
+        SAFE_WTFLOGALWAYS("%s: couldn't retrieve private temporary directory path: %d\n", FileSystem::currentExecutableName(), errno);
         exitProcess(EX_NOPERM);
     }
 
@@ -668,7 +669,7 @@ static void populateSandboxInitializationParameters(SandboxInitializationParamet
     
     sandboxParameters.addPathParameter("HOME_DIR"_s, homeDirectory->utf8().legacyCStringPointer());
     String path = FileSystem::pathByAppendingComponents(*homeDirectory, std::initializer_list<StringView>({ "Library"_s, "Preferences"_s }));
-    sandboxParameters.addPathParameter("HOME_LIBRARY_PREFERENCES_DIR"_s, FileSystem::fileSystemRepresentation(path).data());
+    sandboxParameters.addPathParameter("HOME_LIBRARY_PREFERENCES_DIR"_s, FileSystem::fileSystemRepresentation(path).legacyCStringPointer());
 
 #if CPU(X86_64)
     sandboxParameters.addParameter("CPU"_s, "x86_64"_span);
@@ -708,7 +709,7 @@ void AuxiliaryProcess::initializeSandbox(const AuxiliaryProcessInitializationPar
     populateSandboxInitializationParameters(sandboxParameters);
 
     if (!applySandbox(parameters, sandboxParameters, dataVaultParentDirectory)) {
-        WTFLogAlways("%s: Unable to apply sandbox\n", getprogname());
+        SAFE_WTFLOGALWAYS("%s: Unable to apply sandbox\n", FileSystem::currentExecutableName());
         CRASH();
     }
 
@@ -716,7 +717,7 @@ void AuxiliaryProcess::initializeSandbox(const AuxiliaryProcessInitializationPar
         // This will override LSFileQuarantineEnabled from Info.plist unless sandbox quarantine is globally disabled.
         OSStatus error = enableSandboxStyleFileQuarantine();
         if (error) {
-            WTFLogAlways("%s: Couldn't enable sandbox style file quarantine: %ld\n", getprogname(), static_cast<long>(error));
+            SAFE_WTFLOGALWAYS("%s: Couldn't enable sandbox style file quarantine: %ld\n", FileSystem::currentExecutableName(), static_cast<long>(error));
             exitProcess(EX_NOPERM);
         }
     }

--- a/Source/WebKit/UIProcess/API/glib/WebKitFileChooserRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFileChooserRequest.cpp
@@ -367,8 +367,8 @@ const gchar* const* webkit_file_chooser_request_get_selected_files(WebKitFileCho
         RefPtr webFileName = downcast<API::String>(selectedFileNames->at(i));
         if (webFileName->stringView().isEmpty())
             continue;
-        CString filename = FileSystem::fileSystemRepresentation(webFileName->string());
-        g_ptr_array_add(request->priv->selectedFiles.get(), g_strdup(filename.data()));
+        auto filename = FileSystem::fileSystemRepresentation(webFileName->string());
+        g_ptr_array_add(request->priv->selectedFiles.get(), g_strdup(filename.legacyCStringPointer()));
     }
     g_ptr_array_add(request->priv->selectedFiles.get(), 0);
 

--- a/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
@@ -980,10 +980,10 @@ GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const Proces
         bindIfExists(sandboxArgs, parentDir.utf8().legacyCStringPointer());
     }
 
-    CString executablePath = FileSystem::currentExecutablePath();
+    auto executablePath = FileSystem::currentExecutablePath();
     if (!executablePath.isNull()) {
         // Our executable is `/foo/bar/bin/Process`, we want `/foo/bar` as a usable prefix
-        auto parentDir = FileSystem::parentPath(FileSystem::parentPath(FileSystem::stringFromFileSystemRepresentation(executablePath.data())));
+        auto parentDir = FileSystem::parentPath(FileSystem::parentPath(FileSystem::stringFromFileSystemRepresentation(executablePath.legacyCStringPointer())));
         bindIfExists(sandboxArgs, parentDir.utf8().legacyCStringPointer());
     }
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2208,7 +2208,7 @@ void WebPageProxy::maybeInitializeSandboxExtensionHandle(WebProcessProxy& proces
         if (checkAssumedReadAccessToResourceURL && process.hasAssumedReadAccessToURL(resourceDirectoryURL)) {
 #if PLATFORM(COCOA)
             // Check the actual access to this directory in the WebContent process, since a sandbox extension created earlier could have been revoked in the WebContent process by now.
-            if (!sandbox_check(process.processID(), "file-read-data", static_cast<enum sandbox_filter_type>(SANDBOX_FILTER_PATH | SANDBOX_CHECK_NO_REPORT), FileSystem::fileSystemRepresentation(resourceDirectoryURL.fileSystemPath()).data())) {
+            if (!sandbox_check(process.processID(), "file-read-data", static_cast<enum sandbox_filter_type>(SANDBOX_FILTER_PATH | SANDBOX_CHECK_NO_REPORT), FileSystem::fileSystemRepresentation(resourceDirectoryURL.fileSystemPath()).legacyCStringPointer())) {
                 WEBPAGEPROXY_RELEASE_LOG(Sandbox, "maybeInitializeSandboxExtensionHandle: has sandbox access to resource directory");
                 return completionHandler(std::nullopt);
             }

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -624,14 +624,14 @@ static RetainPtr<NSString> pathToPDFOnDisk(const String& suggestedFilename)
 
     RetainPtr fileManager = [NSFileManager defaultManager];
     if ([fileManager fileExistsAtPath:path.get()]) {
-        auto [fileHandle, pathTemplateRepresentation] = FileSystem::createTemporaryFileInDirectory(pdfDirectoryPath.get(), makeString('-', suggestedFilename));
+        auto [fileHandle, temporaryFilePath] = FileSystem::createTemporaryFileInDirectory(pdfDirectoryPath.get(), makeString('-', suggestedFilename));
         if (!fileHandle) {
             WTFLogAlways("Cannot create PDF file in the temporary directory (%s).", suggestedFilename.utf8().legacyCStringPointer());
             return nil;
         }
 
         fileHandle = { };
-        path = [fileManager stringWithFileSystemRepresentation:pathTemplateRepresentation.data() length:pathTemplateRepresentation.length()];
+        path = temporaryFilePath.createNSString();
     }
 
     // Reject any path that resolves outside the temporary PDF directory.

--- a/Source/WebKit/WebProcess/InjectedBundle/glib/InjectedBundleGlib.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/glib/InjectedBundleGlib.cpp
@@ -36,7 +36,7 @@ namespace WebKit {
 
 bool InjectedBundle::initialize(const WebProcessCreationParameters&, RefPtr<API::Object>&& initializationUserData)
 {
-    m_platformBundle = g_module_open(FileSystem::fileSystemRepresentation(m_path).data(), G_MODULE_BIND_LOCAL);
+    m_platformBundle = g_module_open(FileSystem::fileSystemRepresentation(m_path).legacyCStringPointer(), G_MODULE_BIND_LOCAL);
     if (!m_platformBundle) {
         g_warning("Error loading the injected bundle (%s): %s", m_path.utf8().legacyCStringPointer(), g_module_error());
         return false;

--- a/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPDFView.mm
@@ -1291,14 +1291,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     
     path = [temporaryPDFDirectoryPath stringByAppendingPathComponent:filename];
     if ([manager fileExistsAtPath:path]) {
-        auto [fileHandle, pathTemplateRepresentation] = FileSystem::createTemporaryFileInDirectory(temporaryPDFDirectoryPath, makeString('-', filename));
+        auto [fileHandle, temporaryFilePath] = FileSystem::createTemporaryFileInDirectory(temporaryPDFDirectoryPath, makeString('-', filename));
         if (!fileHandle) {
             // Couldn't create a temporary file! Should never happen; if it does we'll fail silently on non-debug builds.
             ASSERT_NOT_REACHED();
             path = nil;
         } else {
             fileHandle = { };
-            path = [manager stringWithFileSystemRepresentation:pathTemplateRepresentation.data() length:pathTemplateRepresentation.length()];
+            path = temporaryFilePath.createNSString().autorelease();
         }
     }
     

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1221,6 +1221,7 @@
 				WTF/CheckedPtr.cpp,
 				WTF/CheckedRef.cpp,
 				WTF/cocoa/BlockPtr.mm,
+				WTF/cocoa/CStringCocoa.mm,
 				WTF/cocoa/ContextualizedNSString.mm,
 				WTF/cocoa/LoggerCocoa.mm,
 				WTF/cocoa/RetainPtr.mm,

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/CStringCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/CStringCocoa.mm
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import <wtf/text/CString.h>
+
+#import <Foundation/Foundation.h>
+#import <array>
+#import <wtf/RetainPtr.h>
+#import <wtf/StdLibExtras.h>
+
+namespace TestWebKitAPI {
+
+// A requires-expression on a concrete type is evaluated eagerly, so the absence of the member has to
+// be checked through a template parameter to be a substitution failure rather than an error.
+template<typename StringType> concept HasCreateNSString = requires(const StringType& string) {
+    string.createNSString();
+};
+
+TEST(WTF, CStringWithEncodingCreateNSString)
+{
+    // The encoding is in the type, so each alias picks the right NSStringEncoding.
+    UTF8CString utf8String { u8"Water🍉Melon"_span };
+    EXPECT_TRUE([utf8String.createNSString().get() isEqualToString:@"Water🍉Melon"]);
+
+    constexpr auto latin1Cafe = WTF::toArray<Latin1Character>({ 'c', 'a', 'f', 0xE9 });
+    Latin1CString latin1String { std::span<const Latin1Character> { latin1Cafe } };
+    EXPECT_TRUE([latin1String.createNSString().get() isEqualToString:@"café"]);
+
+    ASCIICString asciiString { "cafe"_s };
+    EXPECT_TRUE([asciiString.createNSString().get() isEqualToString:@"cafe"]);
+
+    // Null and empty strings both become an empty NSString, like String::createNSString().
+    UTF8CString nullString;
+    EXPECT_TRUE([nullString.createNSString().get() isEqualToString:@""]);
+    UTF8CString emptyString { u8""_span };
+    EXPECT_TRUE([emptyString.createNSString().get() isEqualToString:@""]);
+
+    // An untyped CString has no encoding to convert from, so it has no createNSString().
+    static_assert(HasCreateNSString<UTF8CString>);
+    static_assert(HasCreateNSString<Latin1CString>);
+    static_assert(HasCreateNSString<ASCIICString>);
+    static_assert(!HasCreateNSString<CString>);
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/FetchLocalFile.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/FetchLocalFile.mm
@@ -64,7 +64,7 @@ TEST(WebKit, FetchLocalFile)
     tempFileHandle.write(fileDataSpan);
     tempFileHandle = { };
 
-    URL fileURL = URL::fileURLWithFileSystemPath(tempFilePath.span());
+    URL fileURL = URL::fileURLWithFileSystemPath(tempFilePath);
     RetainPtr payload = adoptNS([[NSString alloc] initWithFormat:HTML_FORMAT_STRING, fileURL.string().utf8().legacyCStringPointer()]);
 
     auto [fetchFilePath, fetchFileHandle] = FileSystem::openTemporaryFile("fetch"_s, ".html"_s);
@@ -89,7 +89,7 @@ TEST(WebKit, FetchLocalFile)
 
     TestWebKitAPI::Util::run(&done);
 
-    FileSystem::deleteFile(String::fromUTF8(tempFilePath.span()));
+    FileSystem::deleteFile(tempFilePath);
     FileSystem::deleteFile(fetchFilePath);
 }
 
@@ -110,7 +110,7 @@ TEST(WebKit, FetchLocalFileInParentDirectory)
     tempFileHandle.write(fileDataSpan);
     tempFileHandle = { };
 
-    RetainPtr tempFileName = FileSystem::pathFileName(String::fromUTF8(tempFilePath.span())).createNSString();
+    RetainPtr tempFileName = FileSystem::pathFileName(tempFilePath).createNSString();
 
     RetainPtr tempDirectory = [networkProcessTempDirectory stringByAppendingPathComponent:@"FetchLocalFileInParentDirectory"];
     FileSystem::makeAllDirectories(tempDirectory.get());
@@ -122,7 +122,7 @@ TEST(WebKit, FetchLocalFileInParentDirectory)
     auto [fetchFileHandle, fetchFilePath] = FileSystem::createTemporaryFileInDirectory(tempDirectory.get(), ".html"_s);
     fetchFileHandle.write(String(payload.get()).span8());
     fetchFileHandle = { };
-    URL fetchFileURL = URL::fileURLWithFileSystemPath(fetchFilePath.span());
+    URL fetchFileURL = URL::fileURLWithFileSystemPath(fetchFilePath);
 
     RetainPtr nsFetchFileURL = fetchFileURL.createNSURL();
 
@@ -141,8 +141,8 @@ TEST(WebKit, FetchLocalFileInParentDirectory)
 
     TestWebKitAPI::Util::run(&done);
 
-    FileSystem::deleteFile(String::fromUTF8(tempFilePath.span()));
-    FileSystem::deleteFile(String::fromUTF8(fetchFilePath.span()));
+    FileSystem::deleteFile(tempFilePath);
+    FileSystem::deleteFile(fetchFilePath);
     FileSystem::deleteEmptyDirectory(tempDirectory.get());
 }
 #endif // ENABLE(BLOCKING_OF_LOCAL_FILE_LOADS_WITHOUT_SANDBOX_EXTENSION) && !PLATFORM(IOS_SIMULATOR)

--- a/Tools/TestWebKitAPI/glib/WPEPlatform/WPEPlatformTestMain.cpp
+++ b/Tools/TestWebKitAPI/glib/WPEPlatform/WPEPlatformTestMain.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv)
 {
     g_test_init(&argc, &argv, nullptr);
 
-    g_set_prgname(FileSystem::currentExecutableName().data());
+    g_set_prgname(FileSystem::currentExecutableName().legacyCStringPointer());
     g_setenv("LC_ALL", "C", TRUE);
     g_setenv("GIO_USE_VFS", "local", TRUE);
     g_setenv("GSETTINGS_BACKEND", "memory", TRUE);

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp
@@ -143,7 +143,7 @@ int main(int argc, char** argv)
     parseWPEArgs(argc, argv);
 #endif
 
-    g_set_prgname(FileSystem::currentExecutableName().data());
+    g_set_prgname(FileSystem::currentExecutableName().legacyCStringPointer());
     g_setenv("WEBKIT_EXEC_PATH", WEBKIT_EXEC_PATH, FALSE);
     g_setenv("WEBKIT_INJECTED_BUNDLE_PATH", WEBKIT_INJECTED_BUNDLE_PATH, FALSE);
     g_setenv("WEBKIT_INSPECTOR_RESOURCES_PATH", WEBKIT_INSPECTOR_RESOURCES_PATH, FALSE);

--- a/Tools/WebKitTestRunner/InjectedBundle/glib/ActivateFontsGlib.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/glib/ActivateFontsGlib.cpp
@@ -46,7 +46,7 @@ void activateFonts()
     if (appFontSet && numFonts && appFontSet->nfont == numFonts)
         return;
 
-    GUniquePtr<gchar> absoluteFontsDir(g_build_filename(FileSystem::webkitTopLevelDirectory().data(), "Tools", "WebKitTestRunner", "glib", "fonts", nullptr));
+    GUniquePtr<gchar> absoluteFontsDir(g_build_filename(FileSystem::webkitTopLevelDirectory().legacyCStringPointer(), "Tools", "WebKitTestRunner", "glib", "fonts", nullptr));
 
     // Load our configuration file, which sets up proper aliases for family
     // names like sans, serif and monospace.

--- a/Tools/WebKitTestRunner/InjectedBundle/gtk/TestRunnerGtk.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/gtk/TestRunnerGtk.cpp
@@ -48,7 +48,7 @@ JSRetainPtr<JSStringRef> TestRunner::pathToLocalResource(JSStringRef url)
         return JSStringRetain(url);
 
     const gchar* layoutTestsSuffix = urlString.get() + strlen("file:///tmp/");
-    GUniquePtr<gchar> testPath(g_build_filename(FileSystem::webkitTopLevelDirectory().data(), layoutTestsSuffix, nullptr));
+    GUniquePtr<gchar> testPath(g_build_filename(FileSystem::webkitTopLevelDirectory().legacyCStringPointer(), layoutTestsSuffix, nullptr));
     GUniquePtr<gchar> testURI(g_filename_to_uri(testPath.get(), 0, 0));
     return JSStringCreateWithUTF8CString(testURI.get());
 }

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2548,10 +2548,10 @@ static WKRetainPtr<WKURLRef> makeOpenPanelURL(WKURLRef baseURL, const String& fi
 {
 #if OS(WINDOWS)
     auto cFilePath = FileSystem::fileSystemRepresentation(filePath);
-    if (!PathIsRelativeA(cFilePath.data())) {
+    if (!PathIsRelativeA(cFilePath.legacyCStringPointer())) {
         char fileURI[INTERNET_MAX_PATH_LENGTH];
         DWORD fileURILength = INTERNET_MAX_PATH_LENGTH;
-        UrlCreateFromPathA(cFilePath.data(), fileURI, &fileURILength, 0);
+        UrlCreateFromPathA(cFilePath.legacyCStringPointer(), fileURI, &fileURILength, 0);
         return adoptWK(WKURLCreateWithUTF8CString(fileURI));
     }
 #else


### PR DESCRIPTION
#### 25f7ce345ae8a6d20feb88f72db51f9757c26bb3
<pre>
Make FileSystem::fileSystemRepresentation() return a UTF8CString and keep its consumers typed
<a href="https://bugs.webkit.org/show_bug.cgi?id=324034">https://bugs.webkit.org/show_bug.cgi?id=324034</a>

Reviewed by Yusuke Suzuki.

Follow-up to 320652@main and 320980@main. JavaScriptCore has no bare-CString producers left;
FileSystem.h has the largest remaining cluster.

fileSystemRepresentation() is already UTF-8 wherever it is implemented. The POSIX version, used by the
GLib and PlayStation ports, is literally &quot;return path.utf8()&quot;, so it was slicing the encoding straight
back off. The CF version uses CFStringGetFileSystemRepresentation(), and Darwin&apos;s representation is
UTF-8 - canonically decomposed, but UTF-8. Only Windows disagreed, converting with CP_ACP, the active
ANSI code page; it now uses CP_UTF8 to match the type. currentExecutableName(), currentExecutablePath()
and webkitTopLevelDirectory() are typed alongside it.

Consumers that hand the bytes to a C interface - open(), unlink(), statvfs(), sqlite3_open_v2(),
sandbox_*(), g_file_new_for_path() and friends - adopt legacyCStringPointer(), which is the irreducible
remainder 320917@main describes. Everywhere else a caller reaching for const char* means missing API,
so the rest of this patch adds it.

createTemporaryFileInDirectory() returned the representation even though none of its five callers
wanted bytes; it was an implementation detail of mkstemps() needing a mutable buffer. It returns a
String now, like openTemporaryFile() above it, converting once with String::fromUTF8() - equivalent
here, since CFStringCreateWithFileSystemRepresentation() is a plain UTF-8 decode. Every use of the
result gets shorter, and FetchLocalFile.mm now handles its paths identically whichever factory
produced them. Dropping .span() also fixes a latent bug: StringView&apos;s std::span&lt;const char&gt;
constructor was decoding those UTF-8 path bytes as Latin-1.

CStringWithEncoding gains createNSString(), which picks the NSStringEncoding from the type. ASCII
decodes as Latin-1, as ASCIILiteral::createNSString() already does, because NSASCIIStringEncoding
returns nil for the mislabeled byte only newUninitialized() can introduce.

SandboxExtensionImpl::create() forwarded a const char* to sandbox_extension_issue_*(), so six callers
each unwrapped a string for it; it takes a UTF8CString and unwraps once.

WTFLogAlways() has no SAFE_ variant today, unlike printf(), fprintf(), snprintf() and dataLogF(),
because it is annotated WTF_ATTRIBUTE_NSSTRING: %@ reaches CFStringCreateWithFormatAndArguments(), and
safePrintfType()&apos;s NSString* overload would hand that a char pointer where it expects an object,
breaking the 41 call sites using %@. SAFE_WTFLOGALWAYS therefore goes through a new
safeNSStringPrintfType(), which passes object pointers through untouched and delegates everything else,
so the 14 getprogname() sites in AuxiliaryProcessMac.mm can be typed via the new Cocoa
currentExecutableName().

Tests: Tools/TestWebKitAPI/Tests/WTF/cocoa/CStringCocoa.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/FetchLocalFile.mm

* Source/JavaScriptCore/API/JSScript.mm:
(validateBytecodeCachePath):
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::dumpJITMemory):
* Source/WTF/wtf/FileSystem.h:
* Source/WTF/wtf/StdLibExtras.h:
(WTF::safeNSStringPrintfType):
* Source/WTF/wtf/cf/FileSystemCF.cpp:
(WTF::FileSystem::fileSystemRepresentation):
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::extractTemporaryZipArchive):
(WTF::FileSystemImpl::createTemporaryFileInDirectory):
(WTF::FileSystemImpl::markPurgeable):
(WTF::FileSystemImpl::currentExecutableName):
* Source/WTF/wtf/glib/FileSystemGlib.cpp:
(WTF::FileSystemImpl::validRepresentation):
(WTF::FileSystemImpl::filenameForDisplay):
(WTF::FileSystemImpl::currentExecutablePath):
(WTF::FileSystemImpl::currentExecutableName):
(WTF::FileSystemImpl::webkitTopLevelDirectory):
* Source/WTF/wtf/playstation/FileSystemPlayStation.cpp:
(WTF::FileSystemImpl::fileTypePotentiallyFollowingSymLinks):
(WTF::FileSystemImpl::volumeFreeSpace):
(WTF::FileSystemImpl::volumeCapacity):
(WTF::FileSystemImpl::listDirectorySub):
(WTF::FileSystemImpl::realPath):
* Source/WTF/wtf/posix/FileSystemPOSIX.cpp:
(WTF::FileSystemImpl::openFile):
(WTF::FileSystemImpl::fileCreationTime):
(WTF::FileSystemImpl::volumeFileBlockSize):
(WTF::FileSystemImpl::fileSystemRepresentation):
(WTF::FileSystemImpl::fileExists):
(WTF::FileSystemImpl::deleteFile):
(WTF::FileSystemImpl::makeAllDirectories):
* Source/WTF/wtf/text/CString.h:
* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::fileSystemRepresentation):
* Source/WebCore/platform/glib/FileMonitorGLib.cpp:
(WebCore::FileMonitor::FileMonitor):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::ensureGStreamerInitialized):
* Source/WebCore/platform/network/soup/SoupNetworkSession.cpp:
(WebCore::SoupNetworkSession::setHSTSPersistentStorage):
(WebCore::SoupNetworkSession::clearOldSoupCache):
* Source/WebCore/platform/network/soup/WebKitFormDataInputStream.cpp:
(webkitFormDataInputStreamCreateNextStream):
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::open):
* Source/WebCore/platform/sql/SQLiteFileSystem.cpp:
(WebCore::SQLiteFileSystem::setCanSuspendLockedFileAttribute):
* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::resume):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::Cache):
* Source/WebKit/NetworkProcess/cache/NetworkCacheFileSystem.cpp:
(WebKit::NetworkCache::fileTimes):
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm:
(WebKit::NetworkCache::IOChannel::IOChannel):
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtensionImpl::create):
(WebKit::SandboxExtensionImpl::sandboxExtensionForType):
(WebKit::SandboxExtensionImpl::SandboxExtensionImpl):
(WebKit::SandboxExtension::createHandleWithoutResolvingPath):
(WebKit::SandboxExtension::createHandleForTemporaryFile):
(WebKit::SandboxExtension::createHandleForGenericExtension):
(WebKit::SandboxExtension::createHandleForMachLookup):
(WebKit::SandboxExtension::createHandleForReadByAuditToken):
(WebKit::SandboxExtension::createHandleForIOKitClassExtension):
* Source/WebKit/Shared/Extensions/WebExtensionSQLiteDatabase.cpp:
(WebExtensionSQLiteDatabase::openWithAccessType):
* Source/WebKit/Shared/SandboxExtension.h:
* Source/WebKit/Shared/glib/ProcessExecutablePathGLib.cpp:
(WebKit::getExecutablePath):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::setAndSerializeSandboxParameters):
(WebKit::ensureSandboxCacheDirectory):
(WebKit::compileAndCacheSandboxProfile):
(WebKit::tryApplyCachedSandbox):
(WebKit::compileAndApplySandboxSlowCase):
(WebKit::applySandbox):
(WebKit::populateSandboxInitializationParameters):
(WebKit::AuxiliaryProcess::initializeSandbox):
* Source/WebKit/UIProcess/API/glib/WebKitFileChooserRequest.cpp:
(webkit_file_chooser_request_get_selected_files):
* Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp:
(WebKit::bubblewrapSpawn):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::maybeInitializeSandboxExtensionHandle):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::pathToPDFOnDisk):
* Source/WebKit/WebProcess/InjectedBundle/glib/InjectedBundleGlib.cpp:
(WebKit::InjectedBundle::initialize):
* Source/WebKitLegacy/mac/WebView/WebPDFView.mm:
(-[WebPDFView _path]):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/cocoa/CStringCocoa.mm: Added.
(TestWebKitAPI::requires):
(TestWebKitAPI::TEST(WTF, CStringWithEncodingCreateNSString)):
* Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/FetchLocalFile.mm:
(TEST(WebKit, FetchLocalFile)):
(TEST(WebKit, FetchLocalFileInParentDirectory)):
* Tools/TestWebKitAPI/glib/WPEPlatform/WPEPlatformTestMain.cpp:
(main):
* Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.cpp:
(main):
* Tools/WebKitTestRunner/InjectedBundle/glib/ActivateFontsGlib.cpp:
(WTR::activateFonts):
* Tools/WebKitTestRunner/InjectedBundle/gtk/TestRunnerGtk.cpp:
(WTR::TestRunner::pathToLocalResource):

Canonical link: <a href="https://commits.webkit.org/320998@main">https://commits.webkit.org/320998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fe1035db568568930fd65c49507009f393ae718

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186544 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196814 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150983 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/50625c05-3b92-478b-b47e-ee2eb7a8447a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188406 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60125 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145727 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/fb699c48-2ee0-4233-9533-dfcb7ca1a993) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166237 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126104 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e51e6fb7-ca97-44ad-b1a6-b926e9bec3f9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48148 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46078 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7910 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14765 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158493 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45835 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7889 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47767 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198806 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60063 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155325 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60774 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154960 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28320 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49373 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132948 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130248 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59186 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20816 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58601 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58816 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58708 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->