### PR TITLE
[LBSE] A scrollable outermost <svg> never computes its scroll dimensions

### DIFF
--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-hixie-mixed-008-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-hixie-mixed-008-expected.txt
@@ -11,7 +11,7 @@ layer at (0,0) size 785x665
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-layer at (12,72) size 576x576 scrollWidth 480 scrollHeight 480
+layer at (12,72) size 576x576
   RenderSVGRoot {svg} at (0,0) size 576x576
     RenderSVGViewportContainer at (0,0) size 576x576
       RenderSVGRect {rect} at (0,0) size 400x400 [fill={[type=SOLID] [color=#0000FF]}] [x=0.00] [y=0.00] [width=400.00] [height=400.00]

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-hixie-mixed-009-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-hixie-mixed-009-expected.txt
@@ -11,7 +11,7 @@ layer at (0,0) size 800x435
       RenderBlock {div} at (0,233.31) size 576x172.80 [color=#000080] [bgcolor=#EEEEEE]
         RenderText {#text} at (0,0) size 344x166
           text run at (0,0) width 344: "TEST"
-layer at (12,55) size 576x173 backgroundClip at (12,55) size 576x172.80 clip at (12,55) size 576x172.80 scrollWidth 480 scrollHeight 144
+layer at (12,55) size 576x173 backgroundClip at (12,55) size 576x172.80 clip at (12,55) size 576x172.80
   RenderSVGRoot {svg} at (0,0) size 576x172.80
     RenderSVGViewportContainer at (0,0) size 576x172.80
       RenderSVGRect {rect} at (0,0) size 60x12 [fill={[type=SOLID] [color=#EEEEEE]}] [x=0.00] [y=0.00] [width=60.00] [height=12.00]

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-hixie-rendering-model-004-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-hixie-rendering-model-004-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x400
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
         RenderText {#text} at (0,0) size 0x0
-layer at (12,239) size 144x144 scrollWidth 120 scrollHeight 120
+layer at (12,239) size 144x144
   RenderSVGRoot {svg} at (0,0) size 144x144
 layer at (11.52,239.09) size 144x144
   RenderSVGViewportContainer at (0,0) size 144x144

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-svg-float-border-padding-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-svg-float-border-padding-expected.txt
@@ -24,7 +24,7 @@ layer at (0,0) size 785x767 backgroundClip at (0,0) size 785x766.84 clip at (0,0
           text run at (0,0) width 517: "There should be a red, white and blue pattern above this"
 layer at (11.52,414.17) size 762x2 backgroundClip at (11.52,414.17) size 761.97x2 clip at (0,0) size 0x0
   RenderBlock {hr} at (0,402.66) size 761.97x2 [color=#808080] [border: (1px inset #808080)]
-layer at (26,150) size 201x201 backgroundClip at (26,150) size 200.78x200.78 clip at (54.39,178.39) size 144x144 scrollWidth 144 scrollHeight 144
+layer at (26,150) size 201x201 backgroundClip at (26,150) size 200.78x200.78 clip at (54.39,178.39) size 144x144
   RenderSVGRoot {svg} at (14.39,138.45) size 200.78x200.78 [border: (14px solid #FF0000)]
 layer at (54.30,178.36) size 145x145 backgroundClip at (54.30,178.36) size 144x144 clip at (54.30,178.36) size 144x144
   RenderSVGViewportContainer at (28.39,28.39) size 144x144

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -50,6 +50,7 @@
 #include "SVGLayerTransformUpdater.h"
 #include "SVGSVGElement.h"
 #include "SVGViewSpec.h"
+#include "ScrollbarUpdateScope.h"
 #include "TransformState.h"
 #include "VisibleRectContext.h"
 #include <wtf/SetForScope.h>
@@ -271,6 +272,11 @@ void RenderSVGRoot::layout()
 
     invalidateBackgroundObscurationStatus();
     svgSVGElement().invalidateCachedViewportSizes();
+
+    if (!isDocumentElementRenderer()) {
+        if (CheckedPtr layer = this->layer(); layer && layer->scrollableArea())
+            layer->updateScrollInfoAfterLayout();
+    }
 
     repainter.repaintAfterLayout();
     clearNeedsLayout();


### PR DESCRIPTION
#### cb5ef650091f2a0c90845940031d455e45d0c7ed
<pre>
[LBSE] A scrollable outermost &lt;svg&gt; never computes its scroll dimensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=324037">https://bugs.webkit.org/show_bug.cgi?id=324037</a>

Reviewed by Anne van Kesteren.

ASSERTION FAILED: !m_scrollDimensionsDirty
Source/WebCore/rendering/RenderLayerScrollableArea.cpp(1216)

An outermost &lt;svg&gt; with a non-visible overflow gets a scrollable area, but
RenderSVGRoot::layout() never refreshes the scroll dimensions like RenderBlock
does.

Refresh them at the end of layout, after overvloew has been computed. The actual
scrolling logic needs to be revisited - it is neither spec compliant nor works
as intended. However, this is a first stab at fixing it properly in LBSE.

* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-hixie-mixed-008-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-hixie-mixed-009-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-hixie-rendering-model-004-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/zoom/page/zoom-svg-float-border-padding-expected.txt:
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::layout):

Canonical link: <a href="https://commits.webkit.org/320988@main">https://commits.webkit.org/320988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b13a237c58a8b95b40ff06ff647d63868aeb91a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196819 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150987 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60130 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145730 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166240 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126110 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48151 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46081 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158496 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45838 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7894 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198811 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60068 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155328 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60779 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154963 "Passed tests") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28314 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49376 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132953 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130260 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59191 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20819 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58606 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58821 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58713 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->