### PR TITLE
[AppKit Gestures] Cannot press and drag over some custom sliders

### DIFF
--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h
@@ -74,6 +74,7 @@ struct InteractionInformationAtPosition {
         bool isColorInput,
         bool isRangeInput,
         bool isARIASlider,
+        bool hasDirectionalResizeCursor,
         bool isNearMarkedText,
 #if PLATFORM(IOS_FAMILY)
         bool touchCalloutEnabled,
@@ -149,6 +150,10 @@ struct InteractionInformationAtPosition {
     bool isColorInput { false };
     bool isRangeInput { false };
     bool isARIASlider { false };
+
+    // `cursor` at the hit node is an axis-specific resize cursor (`ew-resize`, `ns-resize`, `col-resize`, `row-resize`).
+    // Web content uses this to mark something that is manipulated by dragging along that axis -- a slider, for example.
+    bool hasDirectionalResizeCursor { false };
 
     bool isNearMarkedText { false };
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm
@@ -46,6 +46,7 @@ InteractionInformationAtPosition::InteractionInformationAtPosition(
     bool isColorInput,
     bool isRangeInput,
     bool isARIASlider,
+    bool hasDirectionalResizeCursor,
     bool isNearMarkedText,
 #if PLATFORM(IOS_FAMILY)
     bool touchCalloutEnabled,
@@ -117,6 +118,7 @@ InteractionInformationAtPosition::InteractionInformationAtPosition(
     , isColorInput(isColorInput)
     , isRangeInput(isRangeInput)
     , isARIASlider(isARIASlider)
+    , hasDirectionalResizeCursor(hasDirectionalResizeCursor)
     , isNearMarkedText(isNearMarkedText)
 #if PLATFORM(IOS_FAMILY)
     , touchCalloutEnabled(touchCalloutEnabled)

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in
@@ -44,6 +44,7 @@ struct WebKit::InteractionInformationAtPosition {
     bool isColorInput;
     bool isRangeInput;
     bool isARIASlider;
+    bool hasDirectionalResizeCursor;
     bool isNearMarkedText;
 #if PLATFORM(IOS_FAMILY)
     bool touchCalloutEnabled;

--- a/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm
@@ -1224,7 +1224,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     const auto& information = _positionInformationManager->currentInformation();
 
     // FIXME: (rdar://181964604) Because of this logic, vertically scrolling over these elements likely will not work.
-    bool prefersInteraction = information.isRangeInput || information.isARIASlider;
+    bool prefersInteraction = information.isRangeInput || information.isARIASlider || information.hasDirectionalResizeCursor;
 #if ENABLE(MODEL_ELEMENT_STAGE_MODE)
     prefersInteraction = prefersInteraction || information.isInteractiveModel;
 #endif

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
@@ -445,6 +445,17 @@ static void selectionPositionInformation(WebPage& page, const InteractionInforma
             break;
     }
 
+    switch (renderer->style().cursorType()) {
+    case WebCore::CursorType::EWResize:
+    case WebCore::CursorType::NSResize:
+    case WebCore::CursorType::ColumnResize:
+    case WebCore::CursorType::RowResize:
+        info.hasDirectionalResizeCursor = true;
+        break;
+    default:
+        break;
+    }
+
 #if HAVE(APPKIT_GESTURES_SUPPORT)
     if (!info.isRangeInput) {
         constexpr auto sliderHitType = hitType | OptionSet {

--- a/Tools/TestWebKitAPI/Resources/cocoa/svg-drag-slider.html
+++ b/Tools/TestWebKitAPI/Resources/cocoa/svg-drag-slider.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body {
+        margin: 0;
+        width: 2000px;
+        height: 2000px;
+        font: 16px -apple-system, sans-serif;
+    }
+
+    #container {
+        padding: 20px;
+    }
+</style>
+</head>
+<body>
+    <div id="container"></div>
+
+<script>
+    const SVG_NS = "http://www.w3.org/2000/svg";
+    const TRACK_START = 20;
+    const TRACK_END = 620;
+    const MAX_VALUE = 10;
+    const INITIAL_VALUE = 5;
+
+    window.sliderValue = INITIAL_VALUE;
+    window.sliderEvents = [];
+
+    const container = document.getElementById("container");
+
+    // Inspired by https://github.com/johnwalley/d3-simple-slider.
+    function makeSVGSlider(options) {
+        const svg = document.createElementNS(SVG_NS, "svg");
+        svg.setAttribute("id", "slider");
+        svg.setAttribute("width", 640);
+        svg.setAttribute("height", 60);
+        container.appendChild(svg);
+
+        const group = document.createElementNS(SVG_NS, "g");
+        group.setAttribute("id", "slider-group");
+        if (options.cursor)
+            group.setAttribute("cursor", options.cursor);
+        svg.appendChild(group);
+
+        const track = document.createElementNS(SVG_NS, "line");
+        track.setAttribute("x1", TRACK_START);
+        track.setAttribute("x2", TRACK_END);
+        track.setAttribute("y1", 30);
+        track.setAttribute("y2", 30);
+        track.setAttribute("stroke", "#bbb");
+        track.setAttribute("stroke-width", 6);
+        group.appendChild(track);
+
+        const overlay = document.createElementNS(SVG_NS, "line");
+        overlay.setAttribute("x1", TRACK_START);
+        overlay.setAttribute("x2", TRACK_END);
+        overlay.setAttribute("y1", 30);
+        overlay.setAttribute("y2", 30);
+        overlay.setAttribute("stroke", "transparent");
+        overlay.setAttribute("stroke-width", 40);
+        if (options.roleOnShape)
+            overlay.setAttribute("role", "slider");
+        group.appendChild(overlay);
+
+        const handle = document.createElementNS(SVG_NS, "path");
+        handle.setAttribute("d", "M-5.5,-5.5v10l6,5.5l6,-5.5v-10z");
+        handle.setAttribute("fill", "white");
+        handle.setAttribute("stroke", "#777");
+        handle.setAttribute("aria-label", "handle");
+        handle.setAttribute("aria-valuemin", 0);
+        handle.setAttribute("aria-valuemax", MAX_VALUE);
+        handle.setAttribute("aria-orientation", "horizontal");
+        handle.setAttribute("tabindex", 0);
+        if (options.roleOnShape)
+            handle.setAttribute("role", "slider");
+        group.appendChild(handle);
+
+        function setValue(value) {
+            value = Math.max(0, Math.min(MAX_VALUE, value));
+            window.sliderValue = value;
+            handle.setAttribute("aria-valuenow", value);
+            const x = TRACK_START + (value / MAX_VALUE) * (TRACK_END - TRACK_START);
+            handle.setAttribute("transform", `translate(${x},30)`);
+        }
+
+        function setValueFromClientX(clientX) {
+            const rect = svg.getBoundingClientRect();
+            const x = clientX - rect.left;
+            setValue(Math.round((x - TRACK_START) / (TRACK_END - TRACK_START) * MAX_VALUE));
+        }
+
+        function noevent(event) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+        }
+
+        function mousemoved(event) {
+            noevent(event);
+            window.sliderEvents.push("mousemove");
+            setValueFromClientX(event.clientX);
+        }
+
+        function mouseupped(event) {
+            window.removeEventListener("mousemove", mousemoved, { capture: true });
+            window.removeEventListener("mouseup", mouseupped, { capture: true });
+            window.removeEventListener("dragstart", noevent, { capture: true });
+            window.removeEventListener("selectstart", noevent, { capture: true });
+            noevent(event);
+            window.sliderEvents.push("mouseup");
+            setValueFromClientX(event.clientX);
+        }
+
+        group.addEventListener("mousedown", event => {
+            if (event.ctrlKey || event.button)
+                return;
+
+            window.addEventListener("mousemove", mousemoved, { capture: true, passive: false });
+            window.addEventListener("mouseup", mouseupped, { capture: true, passive: false });
+            window.addEventListener("dragstart", noevent, { capture: true, passive: false });
+            window.addEventListener("selectstart", noevent, { capture: true, passive: false });
+            event.stopImmediatePropagation();
+
+            window.sliderEvents.push("mousedown");
+            setValueFromClientX(event.clientX);
+        });
+
+        setValue(INITIAL_VALUE);
+    }
+
+    const variants = {
+        "plain": () => makeSVGSlider({}),
+        "cursor": () => makeSVGSlider({ cursor: "ew-resize" }),
+        "role-on-shape": () => makeSVGSlider({ roleOnShape: true }),
+    };
+
+    const requested = new URLSearchParams(location.search).get("variant") ?? "plain";
+    const build = variants[requested];
+    if (!build)
+        throw new Error(`unknown variant "${requested}"; expected one of ${Object.keys(variants).join(", ")}`);
+    build();
+</script>
+</body>
+</html>

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift
@@ -1130,6 +1130,26 @@ extension AppKitGesturesTests.Basic {
     }
 
     @Test(
+        .bug("https://webkit.org/b/324040", "Cannot press and drag over some custom sliders"),
+        arguments: SVGSliderVariant.dragCases
+    )
+    func pressDragOverSVGSliderChangesValue(
+        variant: SVGSliderVariant,
+        isStyleAdjusted: Bool,
+        dragStart: SVGSliderDragStart
+    ) async throws {
+        try await loadSVGDragSlider(variant)
+        if isStyleAdjusted {
+            try await page.callJavaScript(
+                arguments: ["elementID": "slider-group", "interactive": false],
+                script: styleAdjustmentForCustomWidgetScript
+            )
+            await page.waitForNextPresentationUpdate()
+        }
+        try await expectDragReachesContent(startingFrom: dragStart)
+    }
+
+    @Test(
         .bug("https://webkit.org/b/323383", "<model> element in orbit stage mode does not rotate on press drag"),
         arguments: [false, true]
     )
@@ -1954,6 +1974,109 @@ extension AppKitGesturesTests.Basic {
             await document.getElementById("model").ready;
             """
         )
+    }
+
+    private func loadSVGDragSlider(_ variant: SVGSliderVariant) async throws {
+        let base = try #require(Bundle.testResources.url(forResource: "svg-drag-slider", withExtension: "html"))
+        let url = base.appending(queryItems: [URLQueryItem(name: "variant", value: variant.queryValue)])
+        try await page.load(url).wait()
+        await page.waitForNextPresentationUpdate()
+    }
+
+    struct SVGSliderVariant: Sendable, Equatable, CustomTestStringConvertible {
+        let queryValue: String
+
+        let testDescription: String
+
+        static let plain = Self(queryValue: "plain", testDescription: "plain")
+
+        /// `cursor: ew-resize`.
+        static let directionalCursor = Self(queryValue: "cursor", testDescription: "directional cursor")
+
+        /// `role="slider"`.
+        static let ariaRoleOnShape = Self(queryValue: "role-on-shape", testDescription: "ARIA role on shape")
+
+        /// The only invalid combination we want to filter out: .plain + !isStyleAdjusted
+        static let dragCases: [(Self, Bool, SVGSliderDragStart)] = {
+            var cases: [(Self, Bool, SVGSliderDragStart)] = []
+
+            for variant in [Self.directionalCursor, .ariaRoleOnShape, .plain] {
+                for isStyleAdjusted in [false, true] where variant != .plain || isStyleAdjusted {
+                    for dragStart in SVGSliderDragStart.allCases {
+                        cases.append((variant, isStyleAdjusted, dragStart))
+                    }
+                }
+            }
+
+            return cases
+        }()
+    }
+
+    enum SVGSliderDragStart: Sendable, CaseIterable, CustomTestStringConvertible {
+        case onHandle
+
+        case onTrack
+
+        var fractionAcrossSlider: Double {
+            switch self {
+            case .onHandle: 0.5
+            case .onTrack: 0.25
+            }
+        }
+
+        var testDescription: String {
+            switch self {
+            case .onHandle: "from handle"
+            case .onTrack: "from track"
+            }
+        }
+    }
+
+    private func expectDragReachesContent(startingFrom start: SVGSliderDragStart) async throws {
+        try await dragAcrossSVGSlider(from: start)
+
+        let value = try await sliderValue()
+        let events = try await sliderEvents()
+        let scroll = try await settledScrollPosition()
+
+        #expect(value == 0)
+        #expect(scroll == .zero)
+
+        #expect(events.first == "mousedown")
+        #expect(events.last == "mouseup")
+        #expect(Set(events) == ["mousedown", "mousemove", "mouseup"])
+    }
+
+    private func dragAcrossSVGSlider(from start: SVGSliderDragStart) async throws {
+        let bounds = try await screenBounds(ofElementWithID: "slider")
+
+        await recap.play { composer in
+            composer._wk_drag(
+                withStart: CGPoint(x: bounds.minX + bounds.width * start.fractionAcrossSlider, y: bounds.center.y),
+                end: CGPoint(x: bounds.minX, y: bounds.center.y),
+                duration: .seconds(0.2),
+                pressAndWait: .seconds(0.2)
+            )
+        }
+
+        await page.waitForPendingMouseEvents()
+        await page.waitForNextPresentationUpdate()
+    }
+
+    private func sliderValue() async throws -> Double {
+        try await page.callJavaScript(returning: Double.self) {
+            """
+            return window.sliderValue;
+            """
+        }
+    }
+
+    private func sliderEvents() async throws -> [String] {
+        try await page.callJavaScript(returning: [String].self) {
+            """
+            return window.sliderEvents;
+            """
+        }
     }
 
     private func entityTransform() async throws -> [Double] {


### PR DESCRIPTION
#### 1072fbe38fb10c4e11088f217eb21c079246203e
<pre>
[AppKit Gestures] Cannot press and drag over some custom sliders
<a href="https://bugs.webkit.org/show_bug.cgi?id=324040">https://bugs.webkit.org/show_bug.cgi?id=324040</a>
<a href="https://rdar.apple.com/187265835">rdar://187265835</a>

Reviewed by Wenson Hsieh and Richard Robinson.

Before the pan gesture is allowed to scroll, -_panShouldBeginAtLocation:
asks whether web content at the scroll point would rather have the
gesture itself. Right now, we answer that with two signals: the element
is an &lt;input type=range&gt;, or something under the point carries
role=&quot;slider&quot;.

Many custom sliders satisfy neither. These sliders may not be a native
control, and it is common for them to carry ARIA value attributes, such
as aria-valuenow, aria-valuemin, aria-valuemax, without a `role` value,
which renders the other attributes meaningless.

In some cases, these custom controls do declare a `cursor`. Often, an
axis-specific resize cursor indicates something manipulated by dragging
along that axis. In this patch, we make yet another class of custom
sliders disambiguate correctly between pan and mouse interaction by
recording (and reading) a new hasDirectionalResizeCursor bit off of the
interaction information structure that respects this intent.

Test: AppKitGesturesTests.Basic/pressDragOverSVGSliderChangesValue

* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h:
* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm:
(WebKit::InteractionInformationAtPosition::InteractionInformationAtPosition):
* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in:
* Source/WebKit/UIProcess/mac/AppKitGestures/WKAppKitGestureController.mm:
(-[WKAppKitGestureController _panShouldBeginAtLocation:]):
* Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm:
(WebKit::selectionPositionInformation):
* Tools/TestWebKitAPI/Resources/cocoa/svg-drag-slider.html: Added.
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKit Gesture Tests/BasicAppKitGesturesTests.swift:

Canonical link: <a href="https://commits.webkit.org/320992@main">https://commits.webkit.org/320992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64d95b80892cc4e425bd6901ba99c90e295c5331

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150984 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188408 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145728 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/100990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189501 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166238 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126105 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48149 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46079 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158494 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45836 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7891 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52845 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198808 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60065 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155326 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60776 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42386 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154961 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/28317 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49374 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132950 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130251 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59188 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20817 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58603 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58818 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58710 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->