### PR TITLE
[cmake] Models don't render on macOS

### DIFF
--- a/Source/WebKit/PlatformCocoa.cmake
+++ b/Source/WebKit/PlatformCocoa.cmake
@@ -779,6 +779,182 @@ list(APPEND WebKit_DERIVED_SOURCES
 # Generated JSWebExtension*.mm IDL bindings need -fobjc-arc; route to WebKitARC.
 list(APPEND WebKit_ARC_SOURCES ${WebKit_DERIVED_SOURCES_DIR}/JSWebExtensionAPIUnified.mm)
 
+# libWebKitSwift
+
+set(_wks_dir "${WEBKIT_DIR}/WebKitSwift")
+
+set(WebKitSwift_LIBRARY_TYPE SHARED)
+WEBKIT_LIBRARY_DECLARE(WebKitSwift)
+
+set(WebKitSwift_SOURCES
+    ${_wks_dir}/WebKitSwift.swift
+    ${_wks_dir}/AVKit/WKSExperienceController.swift
+    ${_wks_dir}/CredentialUpdaterShim.swift
+    ${_wks_dir}/GroupActivities/WKGroupSession.swift
+    ${_wks_dir}/IdentityDocumentServices/ISO18013MobileDocumentRequest+Extras.swift
+    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentController.swift
+    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest.swift
+    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift
+    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentRawRequest.swift
+    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentRequest.swift
+    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentResponse.swift
+    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentRawRequestValidator.swift
+    ${_wks_dir}/LinearMediaKit/LinearMediaPlayer.swift
+    ${_wks_dir}/LinearMediaKit/LinearMediaTypes.swift
+    ${_wks_dir}/MarketplaceKit/WKMarketplaceKit.swift
+    ${_wks_dir}/Preview/WKPreviewWindowController.swift
+    ${_wks_dir}/RealityKit/WKRKEntity.swift
+    ${_wks_dir}/StageMode/WKStageMode.swift
+    ${_wks_dir}/TextAnimation/WKTextAnimationManagerIOS.swift
+    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentError.mm
+    ${WEBKIT_DIR}/GPUProcess/graphics/Model/ModelBridge.swift
+    ${WEBKIT_DIR}/GPUProcess/graphics/Model/ModelParameters.swift
+    ${WEBKIT_DIR}/GPUProcess/graphics/Model/ModelRenderer.swift
+    ${WEBKIT_DIR}/GPUProcess/graphics/Model/ModelUtils.swift
+    ${WEBKIT_DIR}/GPUProcess/graphics/Model/USDModel.swift
+    ${WEBKIT_DIR}/GPUProcess/graphics/Model/USDModel+Deformation.swift
+)
+
+set_target_properties(WebKitSwift PROPERTIES
+    OUTPUT_NAME WebKitSwift
+    PREFIX "lib"
+    SUFFIX ".dylib"
+    Swift_MODULE_NAME WebKitSwift
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
+    # INSTALL_NAME_DIR of Configurations/WebKitSwift.xcconfig.
+    MACOSX_RPATH OFF
+    BUILD_WITH_INSTALL_NAME_DIR ON
+    INSTALL_NAME_DIR "/System/Library/Frameworks/WebKit.framework/${WEBKIT_FRAMEWORK_VERSION_PATH}Frameworks"
+)
+
+# WebKitAdditions ships these Swift sources with a .swift.in extension so a build
+# without the internal SDK leaves them out. DerivedSources.make copies them into
+# the derived sources directory for the Xcode build; do the same here, or the
+# declarations they implement compile but have no implementation at runtime.
+if (WEBKIT_SDK_IS_IOS_FAMILY AND USE_APPLE_INTERNAL_SDK)
+    foreach (_additions_swift_source
+        AppKitGesturesExtras
+        TestWebKitAPILibraryAdditions
+        UIWindowScene+Extras
+        WKSExperienceController+Transitions
+        WKWebView+SystemTextExtraction)
+        add_custom_command(
+            OUTPUT ${WebKit_DERIVED_SOURCES_DIR}/${_additions_swift_source}.swift
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                ${WebKitAdditions_HEADERS_DIR}/${_additions_swift_source}.swift.in
+                ${WebKit_DERIVED_SOURCES_DIR}/${_additions_swift_source}.swift
+            DEPENDS
+                ${WebKitAdditions_HEADERS_DIR}/${_additions_swift_source}.swift.in
+                WebKitAdditions_CopyHeaders
+            COMMENT "Copying ${_additions_swift_source}.swift"
+            VERBATIM
+        )
+    endforeach ()
+
+    list(APPEND WebKit_SOURCES
+        ${WebKit_DERIVED_SOURCES_DIR}/AppKitGesturesExtras.swift
+        ${WebKit_DERIVED_SOURCES_DIR}/TestWebKitAPILibraryAdditions.swift
+        ${WebKit_DERIVED_SOURCES_DIR}/UIWindowScene+Extras.swift
+        ${WebKit_DERIVED_SOURCES_DIR}/WKWebView+SystemTextExtraction.swift
+    )
+    target_sources(WebKitSwift PRIVATE
+        ${WebKit_DERIVED_SOURCES_DIR}/WKSExperienceController+Transitions.swift
+    )
+endif ()
+
+target_include_directories(WebKitSwift PRIVATE
+    ${_wks_dir}
+    ${_wks_dir}/AVKit
+    ${_wks_dir}/GroupActivities
+    ${_wks_dir}/IdentityDocumentServices
+    ${_wks_dir}/LinearMediaKit
+    ${_wks_dir}/MarketplaceKit
+    ${_wks_dir}/Preview
+    ${_wks_dir}/RealityKit
+    ${_wks_dir}/StageMode
+    ${_wks_dir}/TextAnimation
+    ${_wks_dir}/WritingTools
+    ${WEBKIT_DIR}
+    ${WEBKIT_DIR}/Shared/Model
+    ${WEBKIT_DIR}/GPUProcess/graphics/Model
+    ${CMAKE_BINARY_DIR}
+    ${WTF_FRAMEWORK_HEADERS_DIR}
+    ${bmalloc_FRAMEWORK_HEADERS_DIR}
+)
+
+webkit_target_add_swift_options(WebKitSwift
+    -parse-as-library
+    "-library-level other"
+    "@${CMAKE_CURRENT_BINARY_DIR}/WebKit.platform-swift-args.resp"
+    -I${WEBKIT_DIR}/Platform/spi/Cocoa
+    -I${WEBKIT_DIR}/Platform/spi/Cocoa/Modules
+    -I${WEBKIT_DIR}/Platform/spi/ios
+    "-Xcc -DHAVE_CONFIG_H=1"
+    "-Xcc -I${CMAKE_BINARY_DIR}"
+    "-Xcc -I${WTF_FRAMEWORK_HEADERS_DIR}"
+    "-Xcc -I${bmalloc_FRAMEWORK_HEADERS_DIR}"
+)
+
+if (WEBKIT_SDK_IS_IOS_FAMILY)
+set(_swift_tba_resp "${CMAKE_CURRENT_BINARY_DIR}/swift-tba-availability-macros.resp")
+if (WEBKIT_SDK_IS_SIMULATOR)
+    set(_swift_tba_platform "iphonesimulator")
+else ()
+    set(_swift_tba_platform "iphoneos")
+endif ()
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -E env
+        WK_PLATFORM_NAME=${_swift_tba_platform}
+        IPHONEOS_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
+        # LLVM_TARGET_TRIPLE_OS_VERSION is only used by iOS code (to
+        # disambiguate between iOS and Catalyst).
+        LLVM_TARGET_TRIPLE_OS_VERSION=ios${CMAKE_OSX_DEPLOYMENT_TARGET}
+        MACOSX_DEPLOYMENT_TARGET=9999
+        XROS_DEPLOYMENT_TARGET=9999
+        BUILT_PRODUCTS_DIR=${CMAKE_BINARY_DIR}
+        SDKROOT=${CMAKE_OSX_SYSROOT}
+        SCRIPT_OUTPUT_FILE_0=${_swift_tba_resp}
+        WK_LIBRARY_HEADERS_FOLDER_PATH=/usr/local/include
+        WK_WEBKITADDITIONS_HEADERS_FOLDER_PATH=${CMAKE_OSX_SYSROOT}/usr/local/include/WebKitAdditions
+        bash ${WEBKIT_DIR}/Scripts/generate-swift-availability-macros
+    RESULT_VARIABLE _swift_tba_resp_result
+    OUTPUT_VARIABLE _swift_tba_resp_stdout
+    ERROR_VARIABLE _swift_tba_resp_stderr)
+if (NOT _swift_tba_resp_result EQUAL 0 OR NOT EXISTS "${_swift_tba_resp}")
+    message(FATAL_ERROR "generate-swift-availability-macros failed (exit ${_swift_tba_resp_result}).\nstdout:\n${_swift_tba_resp_stdout}\nstderr:\n${_swiftui_resp_stderr}")
+endif ()
+unset(_swift_tba_platform)
+unset(_swift_tba_resp_stdout)
+unset(_swift_tba_resp_stderr)
+unset(_swift_tba_resp_result)
+
+webkit_target_add_swift_options(WebKitSwift
+    "@${_swift_tba_resp}"
+)
+endif ()
+
+target_compile_options(WebKitSwift PRIVATE
+    "$<$<COMPILE_LANGUAGE:CXX,OBJCXX>:-std=c++2b>"
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-DHAVE_CONFIG_H=1>"
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-DBUILDING_WITH_CMAKE=1>"
+)
+
+target_compile_options(WebKitSwift PRIVATE
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${CMAKE_BINARY_DIR}>"
+    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-I${WebKit_FRAMEWORK_HEADERS_DIR}>"
+    "$<$<COMPILE_LANGUAGE:Swift>:-F${CMAKE_LIBRARY_OUTPUT_DIRECTORY}>"
+    ${WEBKIT_PRIVATE_FRAMEWORKS_COMPILE_FLAG}
+)
+
+target_link_libraries(WebKitSwift PRIVATE WebKit)
+add_dependencies(WebKitSwift WebKit)
+
+# WebKit.framework's own signature does not cover this file: the
+# Frameworks/libWebKitSwift.dylib inside the bundle is a symlink to it.
+WEBKIT_LIBRARY(WebKitSwift)
+
+unset(_wks_dir)
+
 # Platform-specific configuration, selected by the target SDK.
 # FIXME: Continue merging forked iOS/Mac code here.
 if (WEBKIT_SDK_IS_IOS_FAMILY)
@@ -1153,38 +1329,6 @@ set_target_properties(WebKit PROPERTIES
     OBJCXX_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN ON
 )
-
-set(_swift_tba_resp "${CMAKE_CURRENT_BINARY_DIR}/swift-tba-availability-macros.resp")
-if (WEBKIT_SDK_IS_SIMULATOR)
-    set(_swift_tba_platform "iphonesimulator")
-else ()
-    set(_swift_tba_platform "iphoneos")
-endif ()
-execute_process(
-    COMMAND ${CMAKE_COMMAND} -E env
-        WK_PLATFORM_NAME=${_swift_tba_platform}
-        IPHONEOS_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
-        # LLVM_TARGET_TRIPLE_OS_VERSION is only used by iOS code (to
-        # disambiguate between iOS and Catalyst).
-        LLVM_TARGET_TRIPLE_OS_VERSION=ios${CMAKE_OSX_DEPLOYMENT_TARGET}
-        MACOSX_DEPLOYMENT_TARGET=9999
-        XROS_DEPLOYMENT_TARGET=9999
-        BUILT_PRODUCTS_DIR=${CMAKE_BINARY_DIR}
-        SDKROOT=${CMAKE_OSX_SYSROOT}
-        SCRIPT_OUTPUT_FILE_0=${_swift_tba_resp}
-        WK_LIBRARY_HEADERS_FOLDER_PATH=/usr/local/include
-        WK_WEBKITADDITIONS_HEADERS_FOLDER_PATH=${CMAKE_OSX_SYSROOT}/usr/local/include/WebKitAdditions
-        bash ${WEBKIT_DIR}/Scripts/generate-swift-availability-macros
-    RESULT_VARIABLE _swift_tba_resp_result
-    OUTPUT_VARIABLE _swift_tba_resp_stdout
-    ERROR_VARIABLE _swift_tba_resp_stderr)
-if (NOT _swift_tba_resp_result EQUAL 0 OR NOT EXISTS "${_swift_tba_resp}")
-    message(FATAL_ERROR "generate-swift-availability-macros failed (exit ${_swift_tba_resp_result}).\nstdout:\n${_swift_tba_resp_stdout}\nstderr:\n${_swiftui_resp_stderr}")
-endif ()
-unset(_swift_tba_platform)
-unset(_swift_tba_resp_stdout)
-unset(_swift_tba_resp_stderr)
-unset(_swift_tba_resp_result)
 
 webkit_target_add_swift_options(WebKit
     # Match Xcode iOS WebKit Swift compile flags from
@@ -2232,140 +2376,6 @@ with open(sys.argv[2], 'wb') as f:
     add_dependencies(WebKitPostBuild WebKit WebProcess NetworkProcess
         WebProcessEnhancedSecurity WebProcessCaptivePortal)
 endfunction()
-
-# libWebKitSwift
-
-set(_wks_dir "${WEBKIT_DIR}/WebKitSwift")
-
-set(WebKitSwift_LIBRARY_TYPE SHARED)
-WEBKIT_LIBRARY_DECLARE(WebKitSwift)
-
-set(WebKitSwift_SOURCES
-    ${_wks_dir}/WebKitSwift.swift
-    ${_wks_dir}/AVKit/WKSExperienceController.swift
-    ${_wks_dir}/CredentialUpdaterShim.swift
-    ${_wks_dir}/GroupActivities/WKGroupSession.swift
-    ${_wks_dir}/IdentityDocumentServices/ISO18013MobileDocumentRequest+Extras.swift
-    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentController.swift
-    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest.swift
-    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift
-    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentRawRequest.swift
-    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentRequest.swift
-    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentResponse.swift
-    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentRawRequestValidator.swift
-    ${_wks_dir}/LinearMediaKit/LinearMediaPlayer.swift
-    ${_wks_dir}/LinearMediaKit/LinearMediaTypes.swift
-    ${_wks_dir}/MarketplaceKit/WKMarketplaceKit.swift
-    ${_wks_dir}/Preview/WKPreviewWindowController.swift
-    ${_wks_dir}/RealityKit/WKRKEntity.swift
-    ${_wks_dir}/StageMode/WKStageMode.swift
-    ${_wks_dir}/TextAnimation/WKTextAnimationManagerIOS.swift
-    ${_wks_dir}/IdentityDocumentServices/WKIdentityDocumentPresentmentError.mm
-)
-
-set_target_properties(WebKitSwift PROPERTIES
-    OUTPUT_NAME WebKitSwift
-    PREFIX "lib"
-    SUFFIX ".dylib"
-    Swift_MODULE_NAME WebKitSwift
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
-    # INSTALL_NAME_DIR of Configurations/WebKitSwift.xcconfig.
-    MACOSX_RPATH OFF
-    BUILD_WITH_INSTALL_NAME_DIR ON
-    INSTALL_NAME_DIR "/System/Library/Frameworks/WebKit.framework/${WEBKIT_FRAMEWORK_VERSION_PATH}Frameworks"
-)
-
-# WebKitAdditions ships these Swift sources with a .swift.in extension so a build
-# without the internal SDK leaves them out. DerivedSources.make copies them into
-# the derived sources directory for the Xcode build; do the same here, or the
-# declarations they implement compile but have no implementation at runtime.
-if (USE_APPLE_INTERNAL_SDK)
-    foreach (_additions_swift_source
-        AppKitGesturesExtras
-        TestWebKitAPILibraryAdditions
-        UIWindowScene+Extras
-        WKSExperienceController+Transitions
-        WKWebView+SystemTextExtraction)
-        add_custom_command(
-            OUTPUT ${WebKit_DERIVED_SOURCES_DIR}/${_additions_swift_source}.swift
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                ${WebKitAdditions_HEADERS_DIR}/${_additions_swift_source}.swift.in
-                ${WebKit_DERIVED_SOURCES_DIR}/${_additions_swift_source}.swift
-            DEPENDS
-                ${WebKitAdditions_HEADERS_DIR}/${_additions_swift_source}.swift.in
-                WebKitAdditions_CopyHeaders
-            COMMENT "Copying ${_additions_swift_source}.swift"
-            VERBATIM
-        )
-    endforeach ()
-
-    list(APPEND WebKit_SOURCES
-        ${WebKit_DERIVED_SOURCES_DIR}/AppKitGesturesExtras.swift
-        ${WebKit_DERIVED_SOURCES_DIR}/TestWebKitAPILibraryAdditions.swift
-        ${WebKit_DERIVED_SOURCES_DIR}/UIWindowScene+Extras.swift
-        ${WebKit_DERIVED_SOURCES_DIR}/WKWebView+SystemTextExtraction.swift
-    )
-    target_sources(WebKitSwift PRIVATE
-        ${WebKit_DERIVED_SOURCES_DIR}/WKSExperienceController+Transitions.swift
-    )
-endif ()
-
-target_include_directories(WebKitSwift PRIVATE
-    ${_wks_dir}
-    ${_wks_dir}/AVKit
-    ${_wks_dir}/GroupActivities
-    ${_wks_dir}/IdentityDocumentServices
-    ${_wks_dir}/LinearMediaKit
-    ${_wks_dir}/MarketplaceKit
-    ${_wks_dir}/Preview
-    ${_wks_dir}/RealityKit
-    ${_wks_dir}/StageMode
-    ${_wks_dir}/TextAnimation
-    ${_wks_dir}/WritingTools
-    ${WEBKIT_DIR}
-    ${WEBKIT_DIR}/Shared/Model
-    ${WEBKIT_DIR}/GPUProcess/graphics/Model
-    ${CMAKE_BINARY_DIR}
-    ${WTF_FRAMEWORK_HEADERS_DIR}
-    ${bmalloc_FRAMEWORK_HEADERS_DIR}
-)
-
-webkit_target_add_swift_options(WebKitSwift
-    -parse-as-library
-    "-library-level other"
-    "-Xfrontend -disable-cross-import-overlays"
-    "@${CMAKE_CURRENT_BINARY_DIR}/WebKit.platform-swift-args.resp"
-    "@${_swift_tba_resp}"
-    -I${WEBKIT_DIR}/Platform/spi/Cocoa
-    -I${WEBKIT_DIR}/Platform/spi/Cocoa/Modules
-    -I${WEBKIT_DIR}/Platform/spi/ios
-    "-Xcc -DHAVE_CONFIG_H=1"
-    "-Xcc -I${CMAKE_BINARY_DIR}"
-    "-Xcc -I${WTF_FRAMEWORK_HEADERS_DIR}"
-    "-Xcc -I${bmalloc_FRAMEWORK_HEADERS_DIR}"
-)
-
-target_compile_options(WebKitSwift PRIVATE
-    "$<$<COMPILE_LANGUAGE:CXX,OBJCXX>:-std=c++2b>"
-    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-DHAVE_CONFIG_H=1>"
-    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-DBUILDING_WITH_CMAKE=1>"
-)
-
-target_compile_options(WebKitSwift PRIVATE
-    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-iframework${CMAKE_BINARY_DIR}>"
-    "$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-I${WebKit_FRAMEWORK_HEADERS_DIR}>"
-    "$<$<COMPILE_LANGUAGE:Swift>:-F${CMAKE_LIBRARY_OUTPUT_DIRECTORY}>"
-    ${WEBKIT_PRIVATE_FRAMEWORKS_COMPILE_FLAG}
-)
-
-target_link_libraries(WebKitSwift PRIVATE WebKit)
-add_dependencies(WebKitSwift WebKit)
-
-# WebKit.framework's own signature does not cover this file: the
-# Frameworks/libWebKitSwift.dylib inside the bundle is a symlink to it.
-WEBKIT_LIBRARY(WebKitSwift)
-
-unset(_wks_dir)
 
 # _WebKit_SwiftUI
 


### PR DESCRIPTION
#### fc0bfff52e90f49ab427e129a655654022be7895
<pre>
[cmake] Models don&apos;t render on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=324044">https://bugs.webkit.org/show_bug.cgi?id=324044</a>
<a href="https://rdar.apple.com/187283621">rdar://187283621</a>

Reviewed by Mike Wyrzykowski.

The (Swift) model implementation wasn&apos;t part of the macOS build.
Since these are all `@objc @implementation`-style files, everything was
running properly and loading without crashing. But rendering completely
blank model elements from the objc stubs.

Move `libWebKitSwift` to the cross-platform section of the Cocoa
configuration and add the missing files.

* Source/WebKit/PlatformCocoa.cmake:
Move `libWebKitSwift` to the cross-platform Cocoa configuration and add
the missing files.
Keep the WKA-section iOS family only for now.
Remove `-disable-cross-import-overlays` since it doesn&apos;t match the
Xcode configuration.

Canonical link: <a href="https://commits.webkit.org/321009@main">https://commits.webkit.org/321009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a85bc090f7ae92be22d627a8d3b5998bd8d959ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196934 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/151101 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a1dca9ac-6e54-4d46-aee1-0d8ee459f4e3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60247 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145821 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/101057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/666ab86f-bf54-4dd0-a530-ba81a7893c82) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166332 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126226 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e7f10434-055e-40b0-87b5-8e47883490e4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48244 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46178 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158589 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45930 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/8010 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198928 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60185 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155429 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41629 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60897 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155063 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49469 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133070 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130425 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59307 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20911 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58722 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58937 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58830 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->