### PR TITLE
Web Inspector: automatically `release` dangling `WI.RemoteObject`

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js
@@ -63,6 +63,14 @@ WI.RemoteObject = class RemoteObject
                 this._functionDescription = this._description;
                 this._description = "class " + className;
             }
+
+            if (!this._isFakeObject()) {
+                this._unregisterToken = Symbol();
+                WI.RemoteObject._finalizationRegistry.register(this, {
+                    targetWeakRef: new WeakRef(this._target),
+                    objectId: this._objectId,
+                }, this._unregisterToken);
+            }
         } else {
             // Primitive, BigInt, or null.
             console.assert(type !== "object" || value === null);
@@ -539,8 +547,16 @@ WI.RemoteObject = class RemoteObject
 
     release()
     {
-        if (this._objectId && !this._isFakeObject())
-            this._target.RuntimeAgent.releaseObject(this._objectId);
+        if (!this._objectId || this._isFakeObject())
+            return;
+
+        if (!this._unregisterToken)
+            return;
+
+        this._target.RuntimeAgent.releaseObject(this._objectId);
+
+        WI.RemoteObject._finalizationRegistry.unregister(this._unregisterToken);
+        this._unregisterToken = null;
     }
 
     arrayLength()
@@ -651,3 +667,9 @@ WI.RemoteObject.SourceCodeLocationPromise = {
     NoSourceFound: "remote-object-source-code-location-promise-no-source-found",
     MissingObjectId: "remote-object-source-code-location-promise-missing-object-id"
 };
+
+WI.RemoteObject._finalizationRegistry = new FinalizationRegistry(function(heldValue) {
+    let target = heldValue.targetWeakRef.deref();
+    if (target && !target.isDestroyed)
+        target.RuntimeAgent.releaseObject(heldValue.objectId);
+});


### PR DESCRIPTION
#### 4f82568153041877cb93e357b3ac771508ee963c
<pre>
Web Inspector: automatically `release` dangling `WI.RemoteObject`
<a href="https://bugs.webkit.org/show_bug.cgi?id=324048">https://bugs.webkit.org/show_bug.cgi?id=324048</a>

Reviewed by NOBODY (OOPS!).

This way, just in case, unreachable `WI.RemoteObject` do not keep objects alive via the `InjectedScript`.

* Source/WebInspectorUI/UserInterface/Protocol/RemoteObject.js:
(WI.RemoteObject):
(WI.RemoteObject.prototype.release):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f82568153041877cb93e357b3ac771508ee963c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196831 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/150999 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60142 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145737 "Build is in progress. Recent messages:Printed configuration; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 1 pre-existing failure(s); Uploaded test results; 1 failures; Compiled WebKit (warnings); 1 failures; Passed layout tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/100998 "1 flakes 15 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126121 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48161 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46090 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158506 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45846 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7906 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198823 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60080 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155335 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60791 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154970 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49385 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132965 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130276 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59203 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20827 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58618 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58833 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58725 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->