### PR TITLE
BlobResourceHandle::readSync() forwards uninitialized buffer tail when blob is shorter than the read buffer

### DIFF
--- a/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -194,7 +194,7 @@ int BlobResourceHandle::readSync(std::span<uint8_t> buffer)
         result = buffer.size() - remaining;
 
     if (result > 0)
-        didReceiveData(buffer);
+        didReceiveData(buffer.first(result));
 
     if (!result)
         didFinish();


### PR DESCRIPTION
#### dd06e977ecf0cd2a600d7eade4d50b1a0bfea58d
<pre>
BlobResourceHandle::readSync() forwards uninitialized buffer tail when blob is shorter than the read buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=324049">https://bugs.webkit.org/show_bug.cgi?id=324049</a>
<a href="https://rdar.apple.com/187287608">rdar://187287608</a>

Reviewed by Chris Dumez.

readSync() computes `result` as the number of bytes actually read
(buffer.size() - remaining), but then hands the entire buffer to
didReceiveData() rather than just the bytes it filled. When the blob
yields fewer bytes than the buffer holds (e.g. a file-backed blob whose
backing file shrank after its size was captured), the trailing
uninitialized Vector&lt;uint8_t&gt; bytes are forwarded to the client,
leading to uninitialized heap memory.

The asynchronous path already slices correctly
(BlobResourceHandleBase::readAsync passes m_buffer-&gt;subspan(0, bytesRead));
this brings the synchronous path in line by forwarding only the bytes read.

* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandle::readSync): Pass buffer.first(result) to
didReceiveData() instead of the whole buffer.

Canonical link: <a href="https://commits.webkit.org/321020@main">https://commits.webkit.org/321020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/525b3d352d43db1f906700f206f955f821b85e9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196837 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/151006 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2016885c-5907-4d9b-ad67-09aa6f17b0c8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188429 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145742 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/101002 "1 flakes 15 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/adc04c23-1d82-4f0e-9756-e46c6fc590ff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49437 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166254 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126126 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/1bd85826-3634-4b1c-920f-31e27961bac2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48165 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46095 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158510 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45852 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7912 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198829 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60086 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155340 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41642 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60797 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42402 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154975 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49390 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132971 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130289 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59209 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20833 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58624 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58839 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58731 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->