### PR TITLE
NetworkLoadMetrics constructor copies its String&& protocol argument instead of moving it

### DIFF
--- a/Source/WebCore/platform/network/NetworkLoadMetrics.cpp
+++ b/Source/WebCore/platform/network/NetworkLoadMetrics.cpp
@@ -46,7 +46,7 @@ NetworkLoadMetrics::NetworkLoadMetrics(MonotonicTime&& redirectStart, MonotonicT
     , responseEnd(WTF::move(responseEnd))
     , workerStart(WTF::move(workerStart))
     , firstInterimResponseStart(WTF::move(firstInterimResponseStart))
-    , protocol(protocol)
+    , protocol(WTF::move(protocol))
     , redirectCount(redirectCount)
     , complete(complete)
     , cellular(cellular)


### PR DESCRIPTION
#### 4b45526f09dc264a304ea00100b807c152205e35
<pre>
NetworkLoadMetrics constructor copies its String&amp;&amp; protocol argument instead of moving it
<a href="https://bugs.webkit.org/show_bug.cgi?id=324053">https://bugs.webkit.org/show_bug.cgi?id=324053</a>
<a href="https://rdar.apple.com/187288152">rdar://187288152</a>

Reviewed by Chris Dumez.

The NetworkLoadMetrics constructor takes protocol as a String&amp;&amp;, but the
member initializer list initialized protocol(protocol), which binds the
named rvalue reference as an lvalue and triggers a copy. Every other
by-value/by-rvalue member in the same initializer list is moved; protocol
was the lone exception.

Move the argument into the member so the caller&apos;s String is transferred
rather than atomically ref-counted and copied.

* Source/WebCore/platform/network/NetworkLoadMetrics.cpp:
(WebCore::NetworkLoadMetrics::NetworkLoadMetrics):

Canonical link: <a href="https://commits.webkit.org/321022@main">https://commits.webkit.org/321022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64dfdb74160524404ca7211c88de6bc831b641fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196840 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/151009 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d1a2b281-5d84-4b4e-9b3b-78bcb0e9bdca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188432 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145744 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/101005 "2 flakes 17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c27fa3bd-144d-4e34-a613-e1a9a38f46aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126128 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0cd32a6f-5f16-40fd-9c39-147eff0c88c0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48166 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46098 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45857 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7915 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52869 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50601 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198832 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60089 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155344 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41640 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60800 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154979 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49393 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132974 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130292 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59212 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20838 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58627 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58842 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58734 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->