### PR TITLE
RFC7230::isValidValue() consumes a token's terminating octet without validating it, accepting control characters and DEL

### DIFF
--- a/Source/WebCore/platform/network/RFC7230.cpp
+++ b/Source/WebCore/platform/network/RFC7230.cpp
@@ -103,6 +103,7 @@ bool isValidName(StringView name)
     return true;
 }
 
+// See RFC 7230, Section 3.2 and Section 3.2.6.
 bool isValidValue(StringView value)
 {
     enum class State {
@@ -141,6 +142,8 @@ bool isValidValue(StringView value)
         case State::Token:
             if (isTokenCharacter(c))
                 continue;
+            if (!isTabOrSpace(c) && !isVisibleCharacter(c) && !isOBSText(c))
+                return false;
             state = State::OptionalWhitespace;
             continue;
         case State::QuotedString:

--- a/Tools/TestWebKitAPI/Tests/WebCore/HTTPHeaderField.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/HTTPHeaderField.cpp
@@ -64,6 +64,9 @@ TEST(HTTPHeaderField, Parser)
     static const char nonASCIIQuotedPairInComment[8] = {'a', ':', ' ', '(', '\\', static_cast<char>(0xFF), ')', '\0'};
     static const char nonASCIIQuotedPairInQuote[8] = {'a', ':', ' ', '"', '\\', static_cast<char>(0xFF), '"', '\0'};
     static const char delInQuote[7] = {'a', ':', ' ', '"', static_cast<char>(0x7F), '"', '\0'};
+    static const char obsTextAfterToken[7] = { 'a', ':', ' ', 'b', static_cast<char>(0xFF), 'c', '\0' };
+    static const char controlAfterToken[8] = { 'a', ':', ' ', 'a', 0x01, ' ', 'b', '\0' };
+    static const char delAfterToken[7] = { 'a', ':', ' ', 'b', static_cast<char>(0x7F), 'c', '\0' };
 
     shouldRemainUnchanged({
         "a: b"_s,
@@ -75,9 +78,13 @@ TEST(HTTPHeaderField, Parser)
         "a: \"\""_s,
         "a: \"aA?\t \""_s,
         "a: \"a\" (b) ((c))"_s,
+        "a: text/html"_s,
+        "a: text/html; charset=utf-8"_s,
+        "a: foo,bar"_s,
         String::fromLatin1(nonASCIIComment),
         String::fromLatin1(nonASCIIQuotedPairInComment),
         String::fromLatin1(nonASCIIQuotedPairInQuote),
+        String::fromLatin1(obsTextAfterToken),
     });
     
     shouldBeInvalid({
@@ -97,6 +104,8 @@ TEST(HTTPHeaderField, Parser)
         "a: \"\a\""_s,
         "a: \"a\" (b)}((c))"_s,
         String::fromLatin1(delInQuote),
+        String::fromLatin1(controlAfterToken),
+        String::fromLatin1(delAfterToken),
     });
     
     shouldBecome({


### PR DESCRIPTION
#### 0a265382662595a6e9f299b5aa61dd4a8f7f3b31
<pre>
RFC7230::isValidValue() consumes a token&apos;s terminating octet without validating it, accepting control characters and DEL
<a href="https://bugs.webkit.org/show_bug.cgi?id=324056">https://bugs.webkit.org/show_bug.cgi?id=324056</a>
<a href="https://rdar.apple.com/187288970">rdar://187288970</a>

Reviewed by Chris Dumez.

In RFC7230::isValidValue()&apos;s State::Token, hitting a non-token character
transitioned to State::OptionalWhitespace and continued to the next
character without validating the octet that ended the token. That octet
could be anything, so control characters and DEL slipped through: e.g.
&quot;a\x01 b&quot; and a DEL after a token were wrongly accepted as valid header
field values.

Per the RFC 7230 field-value grammar, field-content is built from
field-vchar = VCHAR (%x21-7E) / obs-text (%x80-FF), with SP / HTAB
permitted between vchars; a token is terminated legitimately by
whitespace, a delimiter, or the start of a quoted-string or comment.
Control characters and DEL are none of these. Validate the terminating
octet against that set instead of silently consuming it: it must be
whitespace, a visible character (token or delimiter), or obs-text,
otherwise the value is rejected. Re-feeding the octet to
State::OptionalWhitespace would instead reject legitimate values such as
&quot;text/html&quot; and &quot;foo,bar&quot;, since that state does not accept bare
delimiters, so the terminator is validated in place.

RFC 7230, Section 3.2:   <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-3.2">https://datatracker.ietf.org/doc/html/rfc7230#section-3.2</a>
RFC 7230, Section 3.2.6: <a href="https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6">https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6</a>

Test: Tools/TestWebKitAPI/Tests/WebCore/HTTPHeaderField.cpp

* Source/WebCore/platform/network/RFC7230.cpp:
(RFC7230::isValidValue): Reject a token terminator that is not
whitespace, a visible character, or obs-text.

* Tools/TestWebKitAPI/Tests/WebCore/HTTPHeaderField.cpp:
(TestWebKitAPI::TEST): Add coverage for a control character and DEL
after a token being invalid, and for delimiters and obs-text after a
token remaining valid.

Canonical link: <a href="https://commits.webkit.org/321019@main">https://commits.webkit.org/321019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b508e1ea2aef11ee332f6fe1e2d0a9da8b8b5b53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196844 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/151013 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6ff5eb0d-3c69-41a8-93dd-0c08141f4a3e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188436 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145749 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/101007 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/90cd9c50-8f02-45db-89c2-ecd257132546) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189529 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166260 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126134 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/3f14258f-65ad-4139-9833-a61922223318) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48173 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46102 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158518 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45858 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7919 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198836 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60093 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155348 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41637 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60804 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154983 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49397 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132978 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130302 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59216 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20839 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58631 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58846 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58738 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->