### PR TITLE
Cookie::operator== and Cookie::hash() build NSHTTPCookie objects on every hash-table operation

### DIFF
--- a/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/CookieCocoa.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "Cookie.h"
 #import <pal/spi/cf/CFNetworkSPI.h>
+#import <wtf/Hasher.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 // FIXME: Remove NS_ASSUME_NONNULL_BEGIN/END and all _Nullable annotations once we remove the NSHTTPCookie forward declaration below.
@@ -188,18 +189,28 @@ RetainPtr<NSHTTPCookie> Cookie::createNSHTTPCookie() const
 bool Cookie::operator==(const Cookie& other) const
 {
     ASSERT(!name.isHashTableDeletedValue());
-    bool thisNull = isNull();
-    bool otherNull = other.isNull();
-    if (thisNull || otherNull)
-        return thisNull == otherNull;
-    return [createNSHTTPCookie() isEqual:other.createNSHTTPCookie().get()];
+    return name == other.name
+        && value == other.value
+        && domain == other.domain
+        && path == other.path
+        && partitionKey == other.partitionKey
+        && created == other.created
+        && expires == other.expires
+        && httpOnly == other.httpOnly
+        && secure == other.secure
+        && session == other.session
+        && comment == other.comment
+        && commentURL == other.commentURL
+        && ports == other.ports
+        && sameSite == other.sameSite;
 }
-    
+
 unsigned Cookie::hash() const
 {
     ASSERT(!name.isHashTableDeletedValue());
     ASSERT(!isNull());
-    return createNSHTTPCookie().get().hash;
+    return computeHash(name, value, domain, path, partitionKey, created, expires,
+        httpOnly, secure, session, comment, commentURL, ports, sameSite);
 }
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### 8fd53d6aae4012312ec941204e18688faca3fcb3
<pre>
Cookie::operator== and Cookie::hash() build NSHTTPCookie objects on every hash-table operation
<a href="https://bugs.webkit.org/show_bug.cgi?id=324057">https://bugs.webkit.org/show_bug.cgi?id=324057</a>
<a href="https://rdar.apple.com/187289096">rdar://187289096</a>

Reviewed by Chris Dumez.

On Cocoa, Cookie::operator== constructed two NSHTTPCookie objects (via
createNSHTTPCookie()) and compared them with -isEqual:, and Cookie::hash()
constructed one NSHTTPCookie per call and returned its -hash. Each
createNSHTTPCookie() allocates an NSMutableDictionary of up to 14 entries,
bridges every WTF field into NSString/NSURL/NSDate objects, formats the port
list into a string, and constructs an NSHTTPCookie via +cookieWithProperties:.

Both functions are hot in hash-table operations -- Cookie is a hash-table key
(HashTraits&lt;WebCore::Cookie&gt; in Cookie.h) and is stored in ListHashSet&lt;Cookie&gt;
(e.g. InspectorPageAgent) -- so every insert and lookup paid for one or two
full NSHTTPCookie constructions.

Compare and hash the WTF data members directly instead, matching the
field-based implementation already used by the non-Cocoa platforms in
Cookie.cpp. This removes all NSHTTPCookie allocations from the equality and
hashing paths. Equality now uses strict member-wise comparison over all
fields rather than CFNetwork&apos;s normalized -isEqual:, which is the correct
definition for hash keying (equal fields imply an equal cookie) and keeps
hash() consistent with operator== so equal cookies still hash equal.

* Source/WebCore/platform/network/cocoa/CookieCocoa.mm:
(WebCore::Cookie::operator== const): Compare WTF fields directly.
(WebCore::Cookie::hash const): Hash WTF fields directly via computeHash().

Canonical link: <a href="https://commits.webkit.org/321018@main">https://commits.webkit.org/321018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a87f071696ea3eb8a6b01d272daf70cf6bc226b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196845 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/151014 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60156 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145750 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/101009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166262 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126135 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48172 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46103 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158517 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45860 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7920 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52874 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50606 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198837 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60094 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155349 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41636 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60805 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/154984 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49398 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/132979 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130303 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59217 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20841 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58632 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58847 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58739 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->