### PR TITLE
[Text Extraction] Include more sibling context to interaction descriptions that only have a single word as rendered text

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -104,11 +104,13 @@
 #include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/RegularExpression.h>
 #include <ranges>
+#include <unicode/ubrk.h>
 #include <unicode/uchar.h>
 #include <wtf/Box.h>
 #include <wtf/Scope.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/text/TextBreakIterator.h>
 #include <wtf/unicode/CharacterNames.h>
 
 #if ENABLE(DATA_DETECTION)
@@ -2702,6 +2704,30 @@ static String adjacentRenderedTextLabelDescription(const Element& element, Vecto
     return { };
 }
 
+static bool hrefLacksEnoughContext(StringView href)
+{
+    return href.isEmpty() || href == "#"_s || startsWithLettersIgnoringASCIICase(href, "javascript:"_s);
+}
+
+static bool containsMultipleWords(StringView text)
+{
+    UBreakIterator* iterator = WTF::wordBreakIterator(text);
+    if (!iterator)
+        return false;
+
+    unsigned wordCount = 0;
+    ubrk_first(iterator);
+    for (int position = ubrk_next(iterator); position != UBRK_DONE; position = ubrk_next(iterator)) {
+        if (!isWordTextBreak(iterator))
+            continue;
+
+        if (++wordCount > 1)
+            return true;
+    }
+
+    return false;
+}
+
 static bool hasNoRenderedTextOrLabeledChild(Element& element)
 {
     if (containsLetterOrDigit(normalizeText(plainText(makeRangeSelectingNodeContents(element), behaviorsForTextExtraction))))
@@ -2730,14 +2756,16 @@ static String textDescription(Element& element, Vector<String>& stringsToValidat
 
     auto needsParentContext = true;
     auto hasAccessibleName = false;
+    auto hrefLacksEnoughContext = false;
 
     if (element.isLink()) {
         if (auto text = normalizeText(element.attributeWithoutSynchronization(HTMLNames::hrefAttr)); !text.isEmpty()) {
             auto shortenedHREF = shortenedHREFAttributeForDescription(text);
+            hrefLacksEnoughContext = TextExtraction::hrefLacksEnoughContext(shortenedHREF);
             description.append(makeString(" with href "_s, wrapWithDoubleQuotes(shortenedHREF)));
             stringsToValidate.append(WTF::move(shortenedHREF));
             needsParentContext = false;
-            hasAccessibleName = true;
+            hasAccessibleName = !hrefLacksEnoughContext;
         }
     }
 
@@ -2822,13 +2850,18 @@ static String textDescription(Element& element, Vector<String>& stringsToValidat
     }
 
     String neighborTextDescription;
-    if (isTargetElement && !hasAccessibleName && (is<HTMLImageElement>(element) || element.isSVGElement() || hasNoRenderedTextOrLabeledChild(element))) {
-        bool hasImageAltText = false;
-        if (RefPtr image = dynamicDowncast<HTMLImageElement>(element))
-            hasImageAltText = !normalizeText(image->altText()).isEmpty();
+    if (isTargetElement && !hasAccessibleName) {
+        bool isSingleWordLinkWithoutDestination = hrefLacksEnoughContext
+            && !containsMultipleWords(normalizeText(plainText(makeRangeSelectingNodeContents(element), behaviorsForTextExtraction)));
 
-        if (!hasImageAltText)
-            neighborTextDescription = adjacentRenderedTextLabelDescription(element, stringsToValidate);
+        if (is<HTMLImageElement>(element) || element.isSVGElement() || hasNoRenderedTextOrLabeledChild(element) || isSingleWordLinkWithoutDestination) {
+            bool hasImageAltText = false;
+            if (RefPtr image = dynamicDowncast<HTMLImageElement>(element))
+                hasImageAltText = !normalizeText(image->altText()).isEmpty();
+
+            if (!hasImageAltText)
+                neighborTextDescription = adjacentRenderedTextLabelDescription(element, stringsToValidate);
+        }
     }
 
     auto describedElement = [&] {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -235,8 +235,9 @@ SOFT_LINK_CLASS(SafariSafeBrowsing, SSBLookupContext);
 
 namespace TestWebKitAPI {
 
-static NSString *extractNodeIdentifier(NSString *debugText, NSString *searchText)
+static NSString *extractNodeIdentifier(NSString *debugText, NSString *searchText, NSUInteger occurrence)
 {
+    NSUInteger matchesSoFar = 0;
     for (NSString *line in [debugText componentsSeparatedByString:@"\n"]) {
         if (![line containsString:searchText])
             continue;
@@ -246,11 +247,19 @@ static NSString *extractNodeIdentifier(NSString *debugText, NSString *searchText
         if (!match)
             continue;
 
+        if (matchesSoFar++ < occurrence)
+            continue;
+
         NSRange identifierRange = [match rangeAtIndex:1];
         return [line substringWithRange:identifierRange];
     }
 
     return nil;
+}
+
+static NSString *extractNodeIdentifier(NSString *debugText, NSString *searchText)
+{
+    return extractNodeIdentifier(debugText, searchText, 0);
 }
 
 #if PLATFORM(MAC)
@@ -524,6 +533,44 @@ TEST(TextExtractionTests, InteractionDescriptionIncludesAssociatedLabelText)
     [interaction setNodeIdentifier:extractNodeIdentifier(debugText, @"Icon")];
     description = [interaction debugDescriptionInWebView:webView error:&error];
     EXPECT_WK_STREQ("Click on img labeled “Icon” under button labeled “Save changes” with id “save-button”", description);
+    EXPECT_NULL(error);
+}
+
+TEST(TextExtractionTests, InteractionDescriptionUsesAdjacentTextForSingleWordLinkWithoutDestination)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration preferences] _setTextExtractionEnabled:YES];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration]);
+    [webView synchronouslyLoadHTMLString:@"<div class='password-change-link'><label>Your password</label><span>••••••••••</span><a href='#'>Edit</a></div>"
+        "<div><label>Your name</label><span>Jane</span><a href='#'>Edit</a></div>"
+        "<div><label>Your handle</label><span>@jane</span><a href='#'>Edit profile</a></div>"
+        "<div><label>Your plan</label><span>Free</span><a href='/account/plan'>Edit</a></div>"];
+
+    RetainPtr debugText = [webView synchronouslyGetDebugText:nil];
+
+    NSError *error = nil;
+    NSString *description = nil;
+    RetainPtr interaction = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionClick]);
+
+    [interaction setNodeIdentifier:extractNodeIdentifier(debugText, @"'Edit'", 0)];
+    description = [interaction debugDescriptionInWebView:webView error:&error];
+    EXPECT_WK_STREQ("Click on link with href “#” after rendered text “Your password ••••••••••”, with rendered text “Edit”", description);
+    EXPECT_NULL(error);
+
+    [interaction setNodeIdentifier:extractNodeIdentifier(debugText, @"'Edit'", 1)];
+    description = [interaction debugDescriptionInWebView:webView error:&error];
+    EXPECT_WK_STREQ("Click on link with href “#” after rendered text “Jane”, with rendered text “Edit”", description);
+    EXPECT_NULL(error);
+
+    [interaction setNodeIdentifier:extractNodeIdentifier(debugText, @"'Edit profile'")];
+    description = [interaction debugDescriptionInWebView:webView error:&error];
+    EXPECT_WK_STREQ("Click on link with href “#”, with rendered text “Edit profile”", description);
+    EXPECT_NULL(error);
+
+    [interaction setNodeIdentifier:extractNodeIdentifier(debugText, @"'Edit'", 2)];
+    description = [interaction debugDescriptionInWebView:webView error:&error];
+    EXPECT_WK_STREQ("Click on link with href “/account/plan”, with rendered text “Edit”", description);
     EXPECT_NULL(error);
 }
 


### PR DESCRIPTION
#### ea2579d9114edeb63671b57fb5ef7db5f1db245e
<pre>
[Text Extraction] Include more sibling context to interaction descriptions that only have a single word as rendered text
<a href="https://bugs.webkit.org/show_bug.cgi?id=324023">https://bugs.webkit.org/show_bug.cgi?id=324023</a>
<a href="https://rdar.apple.com/187255119">rdar://187255119</a>

Reviewed by Abrar Rahman Protyasha.

For links that both:

1. Don&apos;t have any semantically interesting information in the `href`.
2. Have at most 1 single word in their rendered text.

…instead of surfacing them in interaction summaries as:

```
Click on link with href “#”, with rendered text “Edit”
```

…make sure that we include predecessor context, similar to how we handle `svg` image icons and other
text-less controls:

```
Click on link with href “#” after rendered text “Your password ••••••••••”, with rendered text “Edit”
```

This allows Automatically Fix Passwords&apos; supervision agent to (reliably) approve this interaction.

Test: TextExtractionTests.InteractionDescriptionUsesAdjacentTextForSingleWordLinkWithoutDestination

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::hrefLacksEnoughContext):
(WebCore::TextExtraction::containsMultipleWords):
(WebCore::TextExtraction::textDescription):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::extractNodeIdentifier):
(TestWebKitAPI::TEST(TextExtractionTests, InteractionDescriptionUsesAdjacentTextForSingleWordLinkWithoutDestination)):

Canonical link: <a href="https://commits.webkit.org/320995@main">https://commits.webkit.org/320995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82f309191efaae58e2b7f7561413e4c2f20e9f8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196868 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/151040 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b13a171a-e05a-4070-ab04-3abd501f2082) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188461 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60180 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145767 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/101017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/17725a41-2754-4ef7-9c91-744e66c8d07f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166274 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126159 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/2d6e2f3f-6ede-45b1-b5b7-a1ca10d4b737) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48186 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46120 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158531 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45872 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7943 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198859 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60118 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155369 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41617 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60829 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155003 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49412 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133003 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130342 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59241 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20853 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58656 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58871 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58763 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->