### PR TITLE
TransformationMatrix::map4ComponentPoint() ignores w in the identity/translation fast path

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMPoint-matrixTransform-translation-w-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMPoint-matrixTransform-translation-w-expected.txt
@@ -1,0 +1,6 @@
+
+PASS DOMPoint.matrixTransform by a translation matrix scales the translation by w
+PASS DOMMatrix.transformPoint by a translation matrix scales the translation by w
+PASS DOMMatrix.transformPoint by a translation matrix leaves a w=0 point untranslated
+PASS DOMMatrix.transformPoint by the identity matrix preserves the point
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMPoint-matrixTransform-translation-w.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMPoint-matrixTransform-translation-w.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html><head>
+    <title>Geometry Interfaces: transforming a point with w != 1 by a translation matrix</title>
+    <link href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-matrixtransform" rel="help">
+    <link href="https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-transformpoint" rel="help">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+    <div id="log"></div>
+    <script>
+        function checkDOMPoint(p, exp) {
+            assert_equals(p.x, exp.x, "x is not matched");
+            assert_equals(p.y, exp.y, "y is not matched");
+            assert_equals(p.z, exp.z, "z is not matched");
+            assert_equals(p.w, exp.w, "w is not matched");
+        }
+
+        test(function() {
+            var matrix = new DOMMatrix().translate(10, 20, 30);
+            var result = new DOMPoint(1, 2, 3, 2).matrixTransform(matrix);
+            checkDOMPoint(result, {x: 21, y: 42, z: 63, w: 2});
+        }, 'DOMPoint.matrixTransform by a translation matrix scales the translation by w');
+
+        test(function() {
+            var matrix = new DOMMatrix().translate(10, 20, 30);
+            var result = matrix.transformPoint({x: 1, y: 2, z: 3, w: 2});
+            checkDOMPoint(result, {x: 21, y: 42, z: 63, w: 2});
+        }, 'DOMMatrix.transformPoint by a translation matrix scales the translation by w');
+
+        test(function() {
+            var matrix = new DOMMatrix().translate(10, 20, 30);
+            var result = matrix.transformPoint({x: 1, y: 2, z: 3, w: 0});
+            checkDOMPoint(result, {x: 1, y: 2, z: 3, w: 0});
+        }, 'DOMMatrix.transformPoint by a translation matrix leaves a w=0 point untranslated');
+
+        test(function() {
+            var matrix = new DOMMatrix();
+            var result = matrix.transformPoint({x: 1, y: 2, z: 3, w: 5});
+            checkDOMPoint(result, {x: 1, y: 2, z: 3, w: 5});
+        }, 'DOMMatrix.transformPoint by the identity matrix preserves the point');
+    </script>
+</body></html>

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
@@ -853,9 +853,9 @@ LayoutRect TransformationMatrix::clampedBoundsOfProjectedQuad(const FloatQuad& q
 void TransformationMatrix::map4ComponentPoint(double& x, double& y, double& z, double& w) const
 {
     if (isIdentityOrTranslation()) {
-        x += m_matrix[3][0];
-        y += m_matrix[3][1];
-        z += m_matrix[3][2];
+        x += w * m_matrix[3][0];
+        y += w * m_matrix[3][1];
+        z += w * m_matrix[3][2];
         return;
     }
 


### PR DESCRIPTION
#### d1773079b63ba93655cb0eb892b549241c9b87be
<pre>
TransformationMatrix::map4ComponentPoint() ignores w in the identity/translation fast path
<a href="https://bugs.webkit.org/show_bug.cgi?id=324067">https://bugs.webkit.org/show_bug.cgi?id=324067</a>
<a href="https://rdar.apple.com/187297446">rdar://187297446</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

map4ComponentPoint() has a fast path for identity/translation matrices that
adds the translation directly to x, y, and z. This effectively assumes w == 1
and disagrees with the general v4MulPointByMatrix() path, which computes
x + w*tx, y + w*ty, z + w*tz for a translation matrix. As a result,
DOMMatrixReadOnly.transformPoint() and DOMPointReadOnly.matrixTransform()
produced incorrect coordinates whenever a translation (or identity+translation)
matrix was applied to a point whose w component was not 1.

Scale the translation by w in the fast path so it matches the general path.

Test: imported/w3c/web-platform-tests/css/geometry/DOMPoint-matrixTransform-translation-w.html

* LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMPoint-matrixTransform-translation-w-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/geometry/DOMPoint-matrixTransform-translation-w.html: Added.
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp:
(WebCore::TransformationMatrix::map4ComponentPoint const):

Canonical link: <a href="https://commits.webkit.org/321030@main">https://commits.webkit.org/321030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f811afbad3c5ac4f6bf11925d0730f06e1a1c2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196875 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/151047 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60187 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145771 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/101020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49464 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166279 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126164 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48192 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46125 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158537 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45877 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7950 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52905 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198867 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60125 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/165809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155376 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41651 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60836 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155009 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49418 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133010 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130350 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59248 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20858 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58663 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58878 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58770 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->