### PR TITLE
Share the canonical UUID string layout between WTF::UUID and FIDO AAGUID logging

### DIFF
--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -190,30 +190,35 @@ WTF_EXPORT_PRIVATE String createVersion4UUIDStringWeak();
 WTF_EXPORT_PRIVATE String bootSessionUUIDString();
 WTF_EXPORT_PRIVATE bool isVersion4UUID(StringView);
 
+// 128 bits rendered in the canonical UUID form, for bits that are UUID-shaped but cannot be held in a
+// UUID because they may be a reserved value, such as a FIDO AAGUID: 16 arbitrary vendor bytes, and
+// commonly all-zero. StringTypeAdapter<UUID> is this with the bits taken from a UUID.
+struct UUIDCanonicalForm {
+    uint64_t high { 0 };
+    uint64_t low { 0 };
+};
+
 template<>
-class StringTypeAdapter<UUID> {
+class StringTypeAdapter<UUIDCanonicalForm> {
 public:
-    StringTypeAdapter(UUID uuid)
-        : m_uuid { uuid }
+    StringTypeAdapter(UUIDCanonicalForm bits)
+        : m_bits { bits }
     {
     }
 
     template<typename Func>
     auto handle(Func&& func) const -> decltype(auto)
     {
-        UInt128 data = m_uuid.data();
-        auto high = static_cast<uint64_t>(data >> 64);
-        auto low = static_cast<uint64_t>(data);
         return handleWithAdapters(std::forward<Func>(func),
-            hex(high >> 32, 8, Lowercase),
+            hex(m_bits.high >> 32, 8, Lowercase),
             '-',
-            hex((high >> 16) & 0xffff, 4, Lowercase),
+            hex((m_bits.high >> 16) & 0xffff, 4, Lowercase),
             '-',
-            hex(high & 0xffff, 4, Lowercase),
+            hex(m_bits.high & 0xffff, 4, Lowercase),
             '-',
-            hex(low >> 48, 4, Lowercase),
+            hex(m_bits.low >> 48, 4, Lowercase),
             '-',
-            hex(low & 0xffffffffffff, 12, Lowercase));
+            hex(m_bits.low & 0xffffffffffff, 12, Lowercase));
     }
 
     unsigned length() const
@@ -237,7 +242,16 @@ public:
     }
 
 private:
-    UUID m_uuid;
+    UUIDCanonicalForm m_bits;
+};
+
+template<>
+class StringTypeAdapter<UUID> : public StringTypeAdapter<UUIDCanonicalForm> {
+public:
+    StringTypeAdapter(UUID uuid)
+        : StringTypeAdapter<UUIDCanonicalForm> { { uuid.high(), uuid.low() } }
+    {
+    }
 };
 
 }

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -46,8 +46,8 @@
 #include <array>
 #include <pal/crypto/CryptoDigest.h>
 #include <wtf/EnumTraits.h>
-#include <wtf/HexNumber.h>
 #include <wtf/RunLoop.h>
+#include <wtf/UUID.h>
 #include <wtf/text/Base64.h>
 #include <wtf/text/MakeString.h>
 
@@ -749,26 +749,17 @@ Vector<AuthenticatorTransport> CtapAuthenticator::transports() const
 }
 
 // An AAGUID is 16 arbitrary vendor bytes, commonly all-zero, so it is not a UUID and cannot be held
-// in one. It is only formatted like one.
+// in one. It is only formatted like one, by WTF::UUIDCanonicalForm.
 static String aaguidToString(std::span<const std::byte, aaguidLength> aaguid)
 {
-    auto group = [&](size_t offset, size_t length) {
+    auto readBigEndian = [](std::span<const std::byte, 8> bytes) {
         uint64_t value = 0;
-        for (auto byte : aaguid.subspan(offset, length))
+        for (auto byte : bytes)
             value = (value << 8) | std::to_integer<uint8_t>(byte);
         return value;
     };
 
-    return makeString(
-        hex(group(0, 4), 8, Lowercase),
-        '-',
-        hex(group(4, 2), 4, Lowercase),
-        '-',
-        hex(group(6, 2), 4, Lowercase),
-        '-',
-        hex(group(8, 2), 4, Lowercase),
-        '-',
-        hex(group(10, 6), 12, Lowercase));
+    return makeString(WTF::UUIDCanonicalForm { readBigEndian(aaguid.first<8>()), readBigEndian(aaguid.last<8>()) });
 }
 
 String CtapAuthenticator::aaguidForDebugging() const

--- a/Tools/TestWebKitAPI/Tests/WTF/UUID.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/UUID.cpp
@@ -154,3 +154,14 @@ TEST(WTF, UUIDTryCreateFromHighAndLow)
     EXPECT_EQ(uuid->low(), 0x89ab0123456789abULL);
     EXPECT_EQ(makeString(*uuid), "12345678-9abc-4de0-89ab-0123456789ab"_s);
 }
+
+// UUIDCanonicalForm renders bits a UUID cannot hold, and has to agree with a UUID on bits it can.
+TEST(WTF, UUIDCanonicalForm)
+{
+    EXPECT_EQ(makeString(WTF::UUIDCanonicalForm { }), "00000000-0000-0000-0000-000000000000"_s);
+    EXPECT_EQ(makeString(WTF::UUIDCanonicalForm { 0, 1 }), "00000000-0000-0000-0000-000000000001"_s);
+
+    auto uuid = WTF::UUID::tryCreate(0x123456789abc4de0ULL, 0x89ab0123456789abULL);
+    EXPECT_TRUE(!!uuid);
+    EXPECT_EQ(makeString(WTF::UUIDCanonicalForm { uuid->high(), uuid->low() }), makeString(*uuid));
+}


### PR DESCRIPTION
#### 2d4a4717af914f0abaaea207bee1aeac38c6383b
<pre>
Share the canonical UUID string layout between WTF::UUID and FIDO AAGUID logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=324075">https://bugs.webkit.org/show_bug.cgi?id=324075</a>

Reviewed by Darin Adler.

Follow-up to 320991@main, which gave CtapAuthenticator::aaguidForDebugging() its own
copy of the 8-4-4-4-12 lowercase-hex layout that StringTypeAdapter&lt;UUID&gt; already had,
rather than putting an AAGUID into a WTF::UUID it cannot legally hold.

The layout moves to StringTypeAdapter&lt;UUIDCanonicalForm&gt;, where UUIDCanonicalForm is
128 bits that are UUID-shaped but may be a reserved value and so cannot be held in a
UUID. StringTypeAdapter&lt;UUID&gt; derives from it and supplies the bits from the UUID, so
UUID formats exactly as before. aaguidToString() keeps its std::span&lt;const std::byte,
16&gt; and now only has to read the two halves big-endian, which is all its grouping loop
was really for.

* Source/WTF/wtf/UUID.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::aaguidToString):
* Tools/TestWebKitAPI/Tests/WTF/UUID.cpp:
(TEST(WTF, UUIDCanonicalForm)):

Canonical link: <a href="https://commits.webkit.org/321003@main">https://commits.webkit.org/321003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c16b1dbc1b594c69347137310c7f255a4a3238c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196898 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/151069 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/58261bff-a4f1-4b58-8cfc-b04a22b5a63f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188491 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60210 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145795 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/101030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c0bb9e46-d4d3-4c69-98e2-2670b88a6d4a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166301 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126194 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7dab97e9-473b-4172-acbc-73508f182ed2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48214 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46147 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/7978 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/14829 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158559 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45899 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/7973 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47852 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52928 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50651 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198890 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60148 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155399 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41623 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60859 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155032 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49440 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133034 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130378 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59271 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20880 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58686 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58901 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58793 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->