### PR TITLE
registerFontIfNeeded() leaks the CFErrorRef out-param from CTFontManagerRegisterFontsForURL()

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -676,9 +676,10 @@ static void registerFontIfNeeded(const String& family) WTF_REQUIRES_LOCK(userIns
 
         CFErrorRef error = nullptr;
         if (!CTFontManagerRegisterFontsForURL(cfURL.get(), kCTFontManagerScopeProcess, &error)) {
-            RetainPtr descriptionCF = adoptCF(CFErrorCopyDescription(error));
-            String error(descriptionCF.get());
-            RELEASE_LOG_FORWARDABLE(Fonts, FontCacheCoreTextRegisterError, family.utf8(), error.utf8());
+            SUPPRESS_RETAINPTR_CTOR_ADOPT RetainPtr adoptedError = adoptCF(error);
+            RetainPtr descriptionCF = adoptCF(CFErrorCopyDescription(adoptedError.get()));
+            String errorDescription(descriptionCF.get());
+            RELEASE_LOG_FORWARDABLE(Fonts, FontCacheCoreTextRegisterError, family.utf8(), errorDescription.utf8());
         }
 
         userInstalledFontMap().removeIf([&](auto& keyAndValue) {


### PR DESCRIPTION
#### 5a093c8e9a30a3953a0230073a8d61b00eece4f2
<pre>
registerFontIfNeeded() leaks the CFErrorRef out-param from CTFontManagerRegisterFontsForURL()
<a href="https://bugs.webkit.org/show_bug.cgi?id=324088">https://bugs.webkit.org/show_bug.cgi?id=324088</a>
<a href="https://rdar.apple.com/187312061">rdar://187312061</a>

Reviewed by Chris Dumez.

CTFontManagerRegisterFontsForURL()&apos;s error out-parameter follows the
Create rule: on failure it returns a +1-retained CFErrorRef whose
ownership transfers to the caller. registerFontIfNeeded() passed a raw
CFErrorRef, read its description via CFErrorCopyDescription(), but never
released the error itself, leaking one CFError on every failed
registration. Because registration is driven by the fonts the user has
installed, the leak is unbounded.

Adopt the error into a RetainPtr via adoptCF() so it is released when it
goes out of scope. CoreText&apos;s CFErrorRef out-parameter is not annotated
CF_RETURNS_RETAINED, so the adopt is annotated SUPPRESS_RETAINPTR_CTOR_ADOPT
to match every other in-tree adoption of an unannotated CFError out-param.
Also rename the shadowing local String from &quot;error&quot; to &quot;errorDescription&quot;.

* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::registerFontIfNeeded):

Canonical link: <a href="https://commits.webkit.org/321028@main">https://commits.webkit.org/321028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c518ef238f42da79aca7d888cae432f5abd890e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/151093 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/79953534-d243-4041-aa97-f2c20f96ccf7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188522 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145810 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/101049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/034579a7-e192-4e43-a068-ec9308c068b3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126214 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/97039b5e-3172-4ea5-a717-692ced8b3913) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48237 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46172 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158582 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45925 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/8002 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198920 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60177 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155419 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41649 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60889 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155052 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49464 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133062 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130416 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59299 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20906 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58714 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58929 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58822 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->