### PR TITLE
Use SAFE_WTFLOGALWAYS instead of WTFLogAlways at call sites that reach for a raw const char*

### DIFF
--- a/Source/JavaScriptCore/API/JSRemoteInspector.cpp
+++ b/Source/JavaScriptCore/API/JSRemoteInspector.cpp
@@ -96,7 +96,7 @@ static bool defaultStateForRemoteInspectionEnabledByDefault(void)
         auto developerProvisioningEntitlement = "get-task-allow"_s;
 #endif
         if (mainProcessHasEntitlement(developerProvisioningEntitlement, parentProcessAuditToken)) {
-            WTFLogAlways("Inspection is enabled by default for process or parent application with '%s' entitlement linked against old SDK. Use `inspectable` API to enable inspection on newer SDKs.", developerProvisioningEntitlement.characters());
+            SAFE_WTFLOGALWAYS("Inspection is enabled by default for process or parent application with '%s' entitlement linked against old SDK. Use `inspectable` API to enable inspection on newer SDKs.", developerProvisioningEntitlement);
             return true;
         }
     }
@@ -107,7 +107,7 @@ static bool defaultStateForRemoteInspectionEnabledByDefault(void)
     auto deprecatedWebInspectorAllowEntitlement = "com.apple.private.webinspector.allow-remote-inspection"_s;
 #endif
     if (mainProcessHasEntitlement(deprecatedWebInspectorAllowEntitlement, parentProcessAuditToken)) {
-        WTFLogAlways("Inspection is enabled by default for process or parent application with deprecated '%s' entitlement. Use `inspectable` API to enable inspection instead.", deprecatedWebInspectorAllowEntitlement.characters());
+        SAFE_WTFLOGALWAYS("Inspection is enabled by default for process or parent application with deprecated '%s' entitlement. Use `inspectable` API to enable inspection instead.", deprecatedWebInspectorAllowEntitlement);
         return true;
     }
 

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
@@ -189,7 +189,7 @@ InjectedScript InjectedScriptManager::injectedScriptFor(JSGlobalObject* globalOb
         auto& stack = error->stack();
         if (stack.size() > 0)
             lineColumn = stack[0].computeLineAndColumn();
-        WTFLogAlways("Error when creating injected script: %s (%d:%d)\n", error->value().toWTFString(globalObject).utf8().legacyCStringPointer(), lineColumn.line, lineColumn.column);
+        SAFE_WTFLOGALWAYS("Error when creating injected script: %s (%d:%d)\n", error->value().toWTFString(globalObject).utf8(), lineColumn.line, lineColumn.column);
         RELEASE_ASSERT_NOT_REACHED();
     }
     if (!createResult.value()) {

--- a/Source/JavaScriptCore/inspector/InjectedScriptModule.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptModule.cpp
@@ -72,11 +72,11 @@ void InjectedScriptModule::ensureInjected(InjectedScriptManager* injectedScriptM
         auto& stack = error->stack();
         if (stack.size() > 0)
             lineColumn = stack[0].computeLineAndColumn();
-        WTFLogAlways("Error when calling 'hasInjectedModule' for '%s': %s (%d:%d)\n", name().utf8().legacyCStringPointer(), error->value().toWTFString(injectedScript.globalObject()).utf8().legacyCStringPointer(), lineColumn.line, lineColumn.column);
+        SAFE_WTFLOGALWAYS("Error when calling 'hasInjectedModule' for '%s': %s (%d:%d)\n", name().utf8(), error->value().toWTFString(injectedScript.globalObject()).utf8(), lineColumn.line, lineColumn.column);
         RELEASE_ASSERT_NOT_REACHED();
     }
     if (!hasInjectedModuleResult.value()) {
-        WTFLogAlways("VM is terminated when calling 'injectModule' for '%s'\n", name().utf8().legacyCStringPointer());
+        SAFE_WTFLOGALWAYS("VM is terminated when calling 'injectModule' for '%s'\n", name().utf8());
         RELEASE_ASSERT_NOT_REACHED();
     }
     if (!hasInjectedModuleResult.value().isBoolean() || !hasInjectedModuleResult.value().asBoolean()) {
@@ -92,7 +92,7 @@ void InjectedScriptModule::ensureInjected(InjectedScriptManager* injectedScriptM
             auto& stack = error->stack();
             if (stack.size() > 0)
                 lineColumn = stack[0].computeLineAndColumn();
-            WTFLogAlways("Error when calling 'injectModule' for '%s': %s (%d:%d)\n", name().utf8().legacyCStringPointer(), error->value().toWTFString(injectedScript.globalObject()).utf8().legacyCStringPointer(), lineColumn.line, lineColumn.column);
+            SAFE_WTFLOGALWAYS("Error when calling 'injectModule' for '%s': %s (%d:%d)\n", name().utf8(), error->value().toWTFString(injectedScript.globalObject()).utf8(), lineColumn.line, lineColumn.column);
             RELEASE_ASSERT_NOT_REACHED();
         }
     }

--- a/Source/JavaScriptCore/runtime/ConsoleClient.cpp
+++ b/Source/JavaScriptCore/runtime/ConsoleClient.cpp
@@ -203,7 +203,7 @@ void ConsoleClient::printConsoleMessage(MessageSource source, MessageType type, 
     appendMessagePrefix(builder, source, type, level);
     builder.append(' ', message);
 
-    WTFLogAlways("%s", builder.toString().utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s", builder.toString().utf8());
 }
 
 void ConsoleClient::printConsoleMessageWithArguments(MessageSource source, MessageType type, MessageLevel level, JSC::JSGlobalObject* globalObject, Ref<ScriptArguments>&& arguments)
@@ -232,7 +232,7 @@ void ConsoleClient::printConsoleMessageWithArguments(MessageSource source, Messa
     if (builder.hasOverflowed())
         WTFLogAlways("Console message exceeded maximum length.");
     else
-        WTFLogAlways("%s", builder.toString().utf8().legacyCStringPointer());
+        SAFE_WTFLOGALWAYS("%s", builder.toString().utf8());
 
     if (isTraceMessage) {
         for (size_t i = 0; i < callStack->size(); ++i) {
@@ -246,7 +246,7 @@ void ConsoleClient::printConsoleMessageWithArguments(MessageSource source, Messa
             appendURLAndPosition(callFrameBuilder, callFrame.sourceURL(), callFrame.lineNumber(), callFrame.columnNumber());
             callFrameBuilder.append(')');
 
-            WTFLogAlways("%s", callFrameBuilder.toString().utf8().legacyCStringPointer());
+            SAFE_WTFLOGALWAYS("%s", callFrameBuilder.toString().utf8());
         }
     }
 }

--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -667,14 +667,14 @@ void WTFInitializeLogChannelStatesFromString(WTFLogChannel* channels[], size_t c
             else if (equalLettersIgnoringASCIICase(level, "debug"_s))
                 logChannelLevel = WTFLogLevel::Debug;
             else
-                WTFLogAlways("Unknown logging level: %s", level.utf8().legacyCStringPointer());
+                SAFE_WTFLOGALWAYS("Unknown logging level: %s", level.utf8());
         }
 
         if (WTFLogChannel* channel = WTFLogChannelByName(channels, count, component.utf8().legacyCStringPointer())) {
             channel->state = logChannelState;
             channel->level = logChannelLevel;
         } else
-            WTFLogAlways("Unknown logging channel: %s", component.utf8().legacyCStringPointer());
+            SAFE_WTFLOGALWAYS("Unknown logging channel: %s", component.utf8());
     }
 }
 

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -1260,7 +1260,7 @@ bool spansOverlap(std::span<T, TExtent> a, std::span<U, UExtent> b)
 // https://gist.github.com/sehe/3374327
 template<std::integral T> inline T safePrintfType(T arg) { return arg; }
 template<std::floating_point T> inline T safePrintfType(T arg) { return arg; }
-template<typename T> requires (std::is_pointer_v<T>) inline T safePrintfType(T arg)
+template<typename T> requires (std::is_pointer_v<T>) inline T NODELETE safePrintfType(T arg)
 {
     static_assert(!std::same_as<std::remove_cv_t<std::remove_pointer_t<T>>, char>, "char* is not bounds safe; please use a null terminated string type");
     return arg;
@@ -1306,14 +1306,14 @@ template<typename T> concept ObjectiveCObjectPointer = std::convertible_to<T, id
 template<typename T> concept ObjectiveCObjectPointer = false;
 #endif
 
-template<ObjectiveCObjectPointer T> inline T safeNSStringPrintfType(T argument) { return argument; }
+template<ObjectiveCObjectPointer T> inline T NODELETE safeNSStringPrintfType(T argument) { return argument; }
 template<typename T> requires (!ObjectiveCObjectPointer<std::decay_t<T>>)
-inline decltype(auto) safeNSStringPrintfType(T&& argument) { return safePrintfType(std::forward<T>(argument)); }
+inline decltype(auto) NODELETE safeNSStringPrintfType(T&& argument) { return safePrintfType(std::forward<T>(argument)); }
 
 #define SAFE_NSSTRING_PRINTF_TYPE(...) WTF_FOR_EACH(WTF::safeNSStringPrintfType, __VA_ARGS__)
 
 #define SAFE_WTFLOGALWAYS(format, ...) \
-    WTFLogAlways(format __VA_OPT__(, SAFE_NSSTRING_PRINTF_TYPE(__VA_ARGS__)))
+    SUPPRESS_UNCOUNTED_ARG WTFLogAlways(format __VA_OPT__(, SAFE_NSSTRING_PRINTF_TYPE(__VA_ARGS__)))
 
 template<typename T>
 concept NonConstByteType = CanBeConstByteType<T> && !std::is_const_v<T>;

--- a/Source/WTF/wtf/TimingScope.cpp
+++ b/Source/WTF/wtf/TimingScope.cpp
@@ -75,7 +75,7 @@ void TimingScope::scopeDidEnd()
 {
     const auto& data = state().addToTotal(m_name, MonotonicTime::now() - m_startTime);
     if (!(data.callCount % m_logIterationInterval))
-        WTFLogAlways("%s: %u calls, mean duration: %.6fms, total duration: %.6fms, max duration %.6fms", m_name.characters(), data.callCount, data.meanDuration().milliseconds(), data.totalDuration.milliseconds(), data.maxDuration.milliseconds());
+        SAFE_WTFLOGALWAYS("%s: %u calls, mean duration: %.6fms, total duration: %.6fms, max duration %.6fms", m_name, data.callCount, data.meanDuration().milliseconds(), data.totalDuration.milliseconds(), data.maxDuration.milliseconds());
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -281,7 +281,7 @@ bool makeSafeToUseMemoryMapForPath(const String& path)
     NSError *error = nil;
     BOOL success = [[NSFileManager defaultManager] setAttributes:@{ NSFileProtectionKey: NSFileProtectionCompleteUnlessOpen } ofItemAtPath:path.createNSString().get() error:&error];
     if (error || !success) {
-        WTFLogAlways("makeSafeToUseMemoryMapForPath(%s) failed with error %@", path.utf8().legacyCStringPointer(), error);
+        SAFE_WTFLOGALWAYS("makeSafeToUseMemoryMapForPath(%s) failed with error %@", path.utf8(), error);
         return false;
     }
     return true;

--- a/Source/WTF/wtf/cocoa/ResourceUsageCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/ResourceUsageCocoa.cpp
@@ -47,7 +47,7 @@ void logFootprintComparison(const std::array<TagInfo, 256>& before, const std::a
     const size_t pageSize = vmPageSize();
 
     WTFLogAlways("Per-tag breakdown of memory reclaimed by pressure handler:");
-    WTFLogAlways("  ## %16s %10s %10s %10s", "VM Tag", "Before", "After", "Diff");
+    SAFE_WTFLOGALWAYS("  ## %16s %10s %10s %10s", "VM Tag"_s, "Before"_s, "After"_s, "Diff"_s);
     for (unsigned i = 0; i < 256; ++i) {
         ssize_t dirtyBefore = before[i].dirty * pageSize;
         ssize_t dirtyAfter = after[i].dirty * pageSize;
@@ -57,9 +57,9 @@ void logFootprintComparison(const std::array<TagInfo, 256>& before, const std::a
         String tagName = displayNameForVMTag(i);
         if (!tagName)
             tagName = makeString("Tag "_s, i);
-        WTFLogAlways("  %02X %16s %10ld %10ld %10ld",
+        SAFE_WTFLOGALWAYS("  %02X %16s %10ld %10ld %10ld",
             i,
-            tagName.ascii().data(),
+            tagName.ascii(),
             dirtyBefore,
             dirtyAfter,
             dirtyDiff

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -243,7 +243,6 @@ page/ResizeObserver.cpp
 page/SettingsBase.cpp
 page/SpatialNavigation.cpp
 [ iOS ] page/cocoa/ContentChangeObserver.cpp
-page/cocoa/PageCocoa.mm
 [ iOS ] page/ios/FrameIOS.mm
 [ Mac ] page/mac/ServicesOverlayController.mm
 page/scrolling/AsyncScrollingCoordinator.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -238,7 +238,6 @@ page/PrintContext.cpp
 page/ResizeObserver.cpp
 page/WheelEventTestMonitor.h
 [ iOS ] page/cocoa/ContentChangeObserver.cpp
-page/cocoa/PageCocoa.mm
 page/cocoa/ResourceUsageOverlayCocoa.mm
 page/cocoa/WebTextIndicatorLayer.mm
 [ iOS ] page/ios/EventHandlerIOS.mm

--- a/Source/WebCore/bindings/js/GarbageCollectionController.cpp
+++ b/Source/WebCore/bindings/js/GarbageCollectionController.cpp
@@ -140,7 +140,7 @@ void GarbageCollectionController::dumpHeapForVM(VM& vm)
     auto utf8String = jsonData.utf8();
 
     fileHandle.write(byteCast<uint8_t>(utf8String.span()));
-    WTFLogAlways("Dumped GC heap to %s%s", tempFilePath.utf8().legacyCStringPointer(), isMainThread() ? "" : " for Worker");
+    SAFE_WTFLOGALWAYS("Dumped GC heap to %s%s", tempFilePath.utf8(), isMainThread() ? ""_s : " for Worker"_s);
 }
 
 void GarbageCollectionController::dumpHeap()

--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -374,7 +374,7 @@ void BackForwardCache::dump() const
     for (auto& item : m_cachedPageMap) {
         if (auto* cachedPage = std::get_if<UniqueRef<CachedPage>>(&item.value)) {
             RefPtr document = (*cachedPage)->document();
-            WTFLogAlways("  Page %p, document %p %s", protect((*cachedPage)->page()).ptr(), document.get(), document ? document->url().string().utf8().legacyCStringPointer() : "");
+            SAFE_WTFLOGALWAYS("  Page %p, document %p %s", protect((*cachedPage)->page()).ptr(), document.get(), document ? document->url().string().utf8() : ""_s);
         }
     }
 }

--- a/Source/WebCore/inspector/InspectorFrontendHost.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendHost.cpp
@@ -634,7 +634,7 @@ bool InspectorFrontendHost::isUnderTest()
 void InspectorFrontendHost::unbufferedLog(const String& message)
 {
     // This is used only for debugging inspector tests.
-    WTFLogAlways("%s", message.utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s", message.utf8());
 }
 
 void InspectorFrontendHost::beep()

--- a/Source/WebCore/layout/Verification.cpp
+++ b/Source/WebCore/layout/Verification.cpp
@@ -352,7 +352,7 @@ void LayoutContext::verifyAndOutputMismatchingLayoutTree(const LayoutState& layo
     showRenderTree(&rootRenderer);
     showLayoutTree(downcast<InitialContainingBlock>(layoutRoot), &layoutState);
 #endif
-    WTFLogAlways("%s", stream.release().utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s", stream.release().utf8());
     ASSERT_NOT_REACHED();
 }
 

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -906,7 +906,7 @@ static void printLegacyGridReasons()
         stream << "\n";
     }
     stream << "---------------------------------------------------\n";
-    WTFLogAlways("%s", stream.release().utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s", stream.release().utf8());
 }
 #endif
 

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
@@ -543,7 +543,7 @@ String layoutTreeAsText(const InitialContainingBlock& initialContainingBlock, co
 void showLayoutTree(const InitialContainingBlock& initialContainingBlock, const LayoutState* layoutState)
 {
     auto treeAsText = layoutTreeAsText(initialContainingBlock, layoutState);
-    WTFLogAlways("%s", treeAsText.utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s", treeAsText.utf8());
 }
 
 void showLayoutTree(const InitialContainingBlock& initialContainingBlock)

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -847,7 +847,7 @@ void MemoryCache::dumpLRULists(bool includeLive) const
         WTFLogAlways("\nList %d:\n", i);
         for (Ref resource : *m_allResources[i]) {
             if (includeLive || !resource->hasClients())
-                WTFLogAlways("  %p %.255s %.1fK, %.1fK, accesses: %u, clients: %d\n", resource.ptr(), resource->url().string().utf8().legacyCStringPointer(), resource->decodedSize() / 1024.0f, (resource->encodedSize() + resource->overheadSize()) / 1024.0f, resource->accessCount(), resource->numberOfClients());
+                SAFE_WTFLOGALWAYS("  %p %.255s %.1fK, %.1fK, accesses: %u, clients: %d\n", resource.ptr(), resource->url().string().utf8(), resource->decodedSize() / 1024.0f, (resource->encodedSize() + resource->overheadSize()) / 1024.0f, resource->accessCount(), resource->numberOfClients());
         }
     }
 }

--- a/Source/WebCore/page/ViewportConfiguration.cpp
+++ b/Source/WebCore/page/ViewportConfiguration.cpp
@@ -787,7 +787,7 @@ String ViewportConfiguration::description() const
 
 void ViewportConfiguration::dump() const
 {
-    WTFLogAlways("%s", description().utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s", description().utf8());
 }
 
 #endif

--- a/Source/WebCore/page/cocoa/PageCocoa.mm
+++ b/Source/WebCore/page/cocoa/PageCocoa.mm
@@ -79,13 +79,13 @@ void Page::platformInitialize()
                 RefPtr localTopDocument = page.localTopDocument();
                 if (!localTopDocument)
                     return;
-                WTFLogAlways("Page %p with main document %p %s", &page, localTopDocument.get(), localTopDocument ? localTopDocument->url().string().utf8().legacyCStringPointer() : "");
+                SAFE_WTFLOGALWAYS("Page %p with main document %p %s", &page, localTopDocument.get(), localTopDocument ? localTopDocument->url().string().utf8() : ""_s);
             });
 
             WTFLogAlways("%u live documents:", Document::allDocuments().size());
             for (auto& document : Document::allDocuments()) {
-                const char* documentType = is<SVGDocument>(document.get()) ? "SVGDocument" : "Document";
-                WTFLogAlways("%s %p %" PRIu64 "-%s (refCount %d, referencingNodeCount %d) %s", documentType, document.ptr(), document->identifier().processIdentifier().toUInt64(), document->identifier().toString().utf8().legacyCStringPointer(), document->refCount(), document->referencingNodeCount(), document->url().string().utf8().legacyCStringPointer());
+                auto documentType = is<SVGDocument>(document.get()) ? "SVGDocument"_s : "Document"_s;
+                SAFE_WTFLOGALWAYS("%s %p %" PRIu64 "-%s (refCount %d, referencingNodeCount %d) %s", documentType, document.ptr(), document->identifier().processIdentifier().toUInt64(), document->identifier().toString().utf8(), document->refCount(), document->referencingNodeCount(), document->url().string().utf8());
             }
         });
     });

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
@@ -526,7 +526,7 @@ void showScrollingStateTree(const WebCore::ScrollingStateTree& tree)
     }
 
     String output = rootNode->scrollingStateTreeAsText(WebCore::debugScrollingStateTreeAsTextBehaviors);
-    WTFLogAlways("%s\n", output.utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s\n", output.utf8());
 }
 
 void showScrollingStateTree(const WebCore::ScrollingStateNode& node)

--- a/Source/WebCore/platform/android/SharedMemoryAndroid.cpp
+++ b/Source/WebCore/platform/android/SharedMemoryAndroid.cpp
@@ -84,12 +84,12 @@ RefPtr<SharedMemory> SharedMemory::allocate(size_t size)
 {
     auto fileDescriptor = createSharedMemory(size);
     if (!fileDescriptor) {
-        WTFLogAlways("Failed to create shared memory: %s", safeStrerror(errno).data());
+        SAFE_WTFLOGALWAYS("Failed to create shared memory: %s", safeStrerror(errno));
         return nullptr;
     }
 
     if (ASharedMemory_setProt(fileDescriptor.value(), PROT_READ | PROT_WRITE) == -1) {
-        WTFLogAlways("Failed to set ASharedMemory protection: %s", safeStrerror(errno).data());
+        SAFE_WTFLOGALWAYS("Failed to set ASharedMemory protection: %s", safeStrerror(errno));
         return nullptr;
     }
 

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -415,7 +415,7 @@ void MediaSessionManagerCocoa::clearNowPlayingInfo()
 #endif
         });
     } @catch (NSException *exception) {
-        WTFLogAlways("MediaSessionManagerCocoa::clearNowPlayingInfo swallowed exception: %s", [[exception description] UTF8String]);
+        SAFE_WTFLOGALWAYS("MediaSessionManagerCocoa::clearNowPlayingInfo swallowed exception: %@", [exception description]);
     }
 
 #if USE(NOW_PLAYING_ACTIVITY_SUPPRESSION)
@@ -496,7 +496,7 @@ void MediaSessionManagerCocoa::setNowPlayingInfo(bool setAsNowPlayingApplication
         MRMediaRemoteSetNowPlayingVisibility(MRMediaRemoteGetLocalOrigin(), visibility);
     }
     } @catch (NSException *exception) {
-        WTFLogAlways("MediaSessionManagerCocoa::setNowPlayingInfo swallowed exception: %s", [[exception description] UTF8String]);
+        SAFE_WTFLOGALWAYS("MediaSessionManagerCocoa::setNowPlayingInfo swallowed exception: %@", [exception description]);
     }
 }
 

--- a/Source/WebCore/platform/glib/FileMonitorGLib.cpp
+++ b/Source/WebCore/platform/glib/FileMonitorGLib.cpp
@@ -28,6 +28,7 @@
 
 #include <wtf/FileSystem.h>
 #include <wtf/glib/GUniquePtr.h>
+#include <wtf/text/CStringView.h>
 
 namespace WebCore {
 
@@ -45,7 +46,7 @@ FileMonitor::FileMonitor(const String& path, Ref<WorkQueue>&& handlerQueue, Func
         if (m_platformMonitor)
             g_signal_connect(m_platformMonitor.get(), "changed", G_CALLBACK(fileChangedCallback), this);
         else
-            WTFLogAlways("Failed to create a monitor for path %s: %s", path.utf8().legacyCStringPointer(), error->message);
+            SAFE_WTFLOGALWAYS("Failed to create a monitor for path %s: %s", path.utf8(), CStringView::unsafeFromUTF8(error->message));
     };
 
     // The monitor can be created in the work queue thread.

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -1174,14 +1174,14 @@ void showGraphicsLayerTree(const WebCore::GraphicsLayer* layer)
         return;
 
     String output = layer->layerTreeAsText(WebCore::AllLayerTreeAsTextOptions);
-    WTFLogAlways("%s\n", output.utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s\n", output.utf8());
 
     // The tree is too large to print to the os log so save the tree output
     // to a file in case we don't have easy access to stderr.
     auto [tempFilePath, fileHandle] = FileSystem::openTemporaryFile("GraphicsLayerTree"_s);
     if (fileHandle) {
         fileHandle.write(byteCast<uint8_t>(output.utf8().span()));
-        WTFLogAlways("Saved GraphicsLayer Tree to %s", tempFilePath.utf8().legacyCStringPointer());
+        SAFE_WTFLOGALWAYS("Saved GraphicsLayer Tree to %s", tempFilePath.utf8());
     } else
         WTFLogAlways("Failed to open temporary file for saving the GraphicsLayer Tree.");
 }

--- a/Source/WebCore/platform/graphics/gbm/GBMDevice.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GBMDevice.cpp
@@ -41,12 +41,12 @@ RefPtr<GBMDevice> GBMDevice::create(const CString& filename)
     RELEASE_ASSERT(isMainThread());
     auto fd = UnixFileDescriptor { open(filename.data(), O_RDWR | O_CLOEXEC), UnixFileDescriptor::Adopt };
     if (!fd) {
-        WTFLogAlways("Failed to open DRM node %s: %s", filename.data(), safeStrerror(errno).data());
+        SAFE_WTFLOGALWAYS("Failed to open DRM node %s: %s", filename, safeStrerror(errno));
         return nullptr;
     }
     auto* device = gbm_create_device(fd.value());
     if (!device) {
-        WTFLogAlways("Failed to create GBM device for DRM node: %s: %s", filename.data(), safeStrerror(errno).data());
+        SAFE_WTFLOGALWAYS("Failed to create GBM device for DRM node: %s: %s", filename, safeStrerror(errno));
         return nullptr;
     }
     return adoptRef(*new GBMDevice(WTF::move(fd), device));

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1335,7 +1335,7 @@ GstElement* /* (transfer floating) */ makeGStreamerElement(CStringView factoryNa
         String factoryNameString(factoryName.span());
         if (!cache.contains(factoryNameString)) {
             cache.append(WTF::move(factoryNameString));
-            WTFLogAlways("GStreamer element %s not found. Please install it", factoryName.utf8());
+            SAFE_WTFLOGALWAYS("GStreamer element %s not found. Please install it", factoryName);
             ASSERT_NOT_REACHED_WITH_MESSAGE("GStreamer element %s not found. Please install it", factoryName.utf8());
         }
     }

--- a/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
@@ -112,7 +112,7 @@ static const Vector<String>* getLinkedFonts(String& family)
 
     DWORD linkedFontsBufferSize = 0;
     if (::RegQueryValueEx(fontLinkKey, family.wideCharacters().data(), 0, nullptr, nullptr, &linkedFontsBufferSize) == ERROR_FILE_NOT_FOUND) {
-        WTFLogAlways("The font link key %s does not exist in the registry.", family.utf8().legacyCStringPointer());
+        SAFE_WTFLOGALWAYS("The font link key %s does not exist in the registry.", family.utf8());
         return result;
     }
 

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -503,7 +503,7 @@ void VideoPresentationInterfaceIOS::doEnterFullscreen()
 void VideoPresentationInterfaceIOS::enterFullscreenHandler(BOOL success, NSError *error, NextActions nextActions)
 {
     if (!success) {
-        WTFLogAlways("-[AVPlayerViewController enterFullScreenAnimated:completionHandler:] failed with error %s", [[error localizedDescription] UTF8String]);
+        SAFE_WTFLOGALWAYS("-[AVPlayerViewController enterFullScreenAnimated:completionHandler:] failed with error %@", [error localizedDescription]);
         ASSERT_NOT_REACHED();
         return;
     }
@@ -595,7 +595,7 @@ void VideoPresentationInterfaceIOS::doExitFullscreen()
 void VideoPresentationInterfaceIOS::exitFullscreenHandler(BOOL success, NSError* error, NextActions nextActions)
 {
     if (!success)
-        WTFLogAlways("-[AVPlayerViewController exitFullScreenAnimated:completionHandler:] failed with error %s", [[error localizedDescription] UTF8String]);
+        SAFE_WTFLOGALWAYS("-[AVPlayerViewController exitFullScreenAnimated:completionHandler:] failed with error %@", [error localizedDescription]);
 
     LOG(Fullscreen, "VideoPresentationInterfaceIOS::didExitFullscreen(%p) - %d", this, success);
 
@@ -653,7 +653,7 @@ void VideoPresentationInterfaceIOS::cleanupFullscreen()
         [[playerViewController view] layoutIfNeeded];
         dismissFullscreen(false, [](BOOL success, NSError *error) {
             if (!success)
-                WTFLogAlways("-[AVPlayerViewController exitFullScreenAnimated:completionHandler:] failed with error %s", [[error localizedDescription] UTF8String]);
+                SAFE_WTFLOGALWAYS("-[AVPlayerViewController exitFullScreenAnimated:completionHandler:] failed with error %@", [error localizedDescription]);
         });
     }
 

--- a/Source/WebCore/platform/unix/SharedMemoryUnix.cpp
+++ b/Source/WebCore/platform/unix/SharedMemoryUnix.cpp
@@ -123,7 +123,7 @@ RefPtr<SharedMemory> SharedMemory::allocate(size_t size)
 {
     auto fileDescriptor = createSharedMemory();
     if (!fileDescriptor) {
-        WTFLogAlways("Failed to create shared memory: %s", safeStrerror(errno).data());
+        SAFE_WTFLOGALWAYS("Failed to create shared memory: %s", safeStrerror(errno));
         return nullptr;
     }
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -7000,7 +7000,7 @@ void showPaintOrderTree(const WebCore::RenderLayer* layer)
     if (layer)
         outputPaintOrderTreeRecursive(stream, *layer, ""_s);
     
-    WTFLogAlways("%s", stream.release().utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s", stream.release().utf8());
 }
 
 void showPaintOrderTree(const WebCore::RenderObject* renderer)
@@ -7090,7 +7090,7 @@ void showLayerPositionTree(const WebCore::RenderLayer* root, const WebCore::Rend
     if (root)
         outputLayerPositionTreeRecursive(stream, *root, 0, mark);
 
-    WTFLogAlways("%s", stream.release().utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s", stream.release().utf8());
 }
 
 #endif

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1208,7 +1208,7 @@ void RenderObject::showRenderTreeForThis() const
     TextStream stream(TextStream::LineMode::MultipleLine, TextStream::Formatting::SVGStyleRect);
     outputRenderTreeLegend(stream);
     root->outputRenderSubTreeAndMark(stream, this, 1);
-    WTFLogAlways("%s", stream.release().utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s", stream.release().utf8());
 }
 
 void RenderObject::showSubtreeForThis() const
@@ -1216,7 +1216,7 @@ void RenderObject::showSubtreeForThis() const
     TextStream stream(TextStream::LineMode::MultipleLine, TextStream::Formatting::SVGStyleRect);
     outputRenderTreeLegend(stream);
     outputRenderSubTreeAndMark(stream, this, 1);
-    WTFLogAlways("%s", stream.release().utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s", stream.release().utf8());
 }
 
 void RenderObject::showLineTreeForThis() const
@@ -1228,7 +1228,7 @@ void RenderObject::showLineTreeForThis() const
     outputRenderTreeLegend(stream);
     outputRenderObject(stream, false, 1);
     blockFlow->outputLineTreeAndMark(stream, nullptr, 2);
-    WTFLogAlways("%s", stream.release().utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s", stream.release().utf8());
 }
 
 static const RenderFragmentedFlow* enclosingFragmentedFlowFromRenderer(const RenderObject* renderer)
@@ -3164,7 +3164,7 @@ void printPaintOrderTreeForLiveDocuments()
             continue;
         if (document->frame() && document->frame()->isRootFrame())
             WTFLogAlways("----------------------root frame--------------------------\n");
-        WTFLogAlways("%s", document->url().string().utf8().legacyCStringPointer());
+        SAFE_WTFLOGALWAYS("%s", document->url().string().utf8());
         showPaintOrderTree(document->renderView());
     }
 }
@@ -3176,7 +3176,7 @@ void printRenderTreeForLiveDocuments()
             continue;
         if (document->frame() && document->frame()->isRootFrame())
             WTFLogAlways("----------------------root frame--------------------------\n");
-        WTFLogAlways("%s", document->url().string().utf8().legacyCStringPointer());
+        SAFE_WTFLOGALWAYS("%s", document->url().string().utf8());
         showRenderTree(document->renderView());
     }
 }
@@ -3188,7 +3188,7 @@ void printLayerTreeForLiveDocuments()
             continue;
         if (document->frame() && document->frame()->isRootFrame())
             WTFLogAlways("----------------------root frame--------------------------\n");
-        WTFLogAlways("%s", document->url().string().utf8().legacyCStringPointer());
+        SAFE_WTFLOGALWAYS("%s", document->url().string().utf8());
         showLayerTree(document->renderView());
     }
 }
@@ -3211,9 +3211,9 @@ void printAccessibilityTreeForLiveDocuments()
             continue;
         if (document->frame()) {
             if (document->frame()->isRootFrame())
-                WTFLogAlways("\nPID %d: Accessibility tree for root document %p %s", getpid(), document.ptr(), document->url().string().utf8().legacyCStringPointer());
+                SAFE_WTFLOGALWAYS("\nPID %d: Accessibility tree for root document %p %s", getpid(), document.ptr(), document->url().string().utf8());
             else
-                WTFLogAlways("\nPID %d: Accessibility tree for non-root document %p %s", getpid(), document.ptr(), document->url().string().utf8().legacyCStringPointer());
+                SAFE_WTFLOGALWAYS("\nPID %d: Accessibility tree for non-root document %p %s", getpid(), document.ptr(), document->url().string().utf8());
             dumpAccessibilityTreeToStderr(document.get());
         }
     }
@@ -3225,7 +3225,7 @@ void printGraphicsLayerTreeForLiveDocuments()
         if (!document->renderView())
             continue;
         if (document->frame() && document->frame()->isRootFrame()) {
-            WTFLogAlways("Graphics layer tree for root document %p %s", document.ptr(), document->url().string().utf8().legacyCStringPointer());
+            SAFE_WTFLOGALWAYS("Graphics layer tree for root document %p %s", document.ptr(), document->url().string().utf8());
             showGraphicsLayerTreeForCompositor(protect(document->renderView())->compositor());
         }
     }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -961,7 +961,7 @@ String Internals::description(JSC::JSValue value)
 
 void Internals::log(const String& value)
 {
-    WTFLogAlways("%s", value.utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s", value.utf8());
 }
 
 bool Internals::isPreloaded(const String& url)

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -283,7 +283,7 @@ static String psoPreamble()
 static void printPsoOnProgramExit(int sig)
 {
     if (psoReproStringBuilder().length())
-        /* NOLINT */ WTFLogAlways("// ------------------------------------------------------------------------\n// Dumping Metal repro case:\n// ------------------------------------------------------------------------\n%s\n// ------------------------------------------------------------------------\n// End of repro case\n// ------------------------------------------------------------------------", psoReproStringBuilder().toString().utf8().legacyCStringPointer());
+        /* NOLINT */ SAFE_WTFLOGALWAYS("// ------------------------------------------------------------------------\n// Dumping Metal repro case:\n// ------------------------------------------------------------------------\n%s\n// ------------------------------------------------------------------------\n// End of repro case\n// ------------------------------------------------------------------------", psoReproStringBuilder().toString().utf8());
 
     if (existingSigabortHandlers()[sig])
         existingSigabortHandlers()[sig](sig);

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -640,7 +640,7 @@ void NetworkSession::setPrivateClickMeasurementAppBundleIDForTesting(String&& ap
 #if PLATFORM(COCOA)
     auto appBundleID = applicationBundleIdentifier();
     if (!isRunningTest(appBundleID))
-        WTFLogAlways("isRunningTest() returned false. appBundleID is %s.", appBundleID.isEmpty() ? "empty" : appBundleID.utf8().legacyCStringPointer());
+        SAFE_WTFLOGALWAYS("isRunningTest() returned false. appBundleID is %s.", appBundleID.isEmpty() ? "empty"_s : appBundleID.utf8());
     RELEASE_ASSERT(isRunningTest(applicationBundleIdentifier()));
 #endif
     m_privateClickMeasurement->setPrivateClickMeasurementAppBundleIDForTesting(WTF::move(appBundleIDForTesting));

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp
@@ -162,7 +162,7 @@ BlobStorage::Blob BlobStorage::add(const String& path, const Data& data, bool ad
             auto existingData = mapFile(blobPath);
             if (bytesEqual(existingData, data)) {
                 if (!FileSystem::hardLink(blobPath, path))
-                    WTFLogAlways("Failed to create hard link from %s to %s", blobPath.utf8().legacyCStringPointer(), path.utf8().legacyCStringPointer());
+                    SAFE_WTFLOGALWAYS("Failed to create hard link from %s to %s", blobPath.utf8(), path.utf8());
                 BlobStorage::Blob result { existingData, hash };
 #if ENABLE(NETWORK_CACHE_BLOB_STORAGE_MEMORY_CACHE)
                 if (addToMemoryCache && m_memoryCache)
@@ -179,7 +179,7 @@ BlobStorage::Blob BlobStorage::add(const String& path, const Data& data, bool ad
         return { };
 
     if (!FileSystem::hardLink(blobPath, path))
-        WTFLogAlways("Failed to create hard link from %s to %s", blobPath.utf8().legacyCStringPointer(), path.utf8().legacyCStringPointer());
+        SAFE_WTFLOGALWAYS("Failed to create hard link from %s to %s", blobPath.utf8(), path.utf8());
 
     m_approximateSize += mappedData.size();
 

--- a/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
@@ -33,6 +33,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/RunLoop.h>
 #import <wtf/darwin/DispatchExtras.h>
+#import <wtf/text/CStringView.h>
 
 namespace WebKit {
 
@@ -84,9 +85,9 @@ void ConnectionToMachService<Traits>::initializeConnectionIfNeeded() const
         if (event == XPC_ERROR_CONNECTION_INVALID) {
 #if HAVE(XPC_CONNECTION_COPY_INVALIDATION_REASON)
             auto reason = std::unique_ptr<char[]>(xpc_connection_copy_invalidation_reason(protectedThis->m_connection.get()));
-            WTFLogAlways("Failed to connect to mach service %s, reason: %s", protectedThis->m_machServiceName.data(), reason.get());
+            SAFE_WTFLOGALWAYS("Failed to connect to mach service %s, reason: %s", protectedThis->m_machServiceName, CStringView::unsafeFromUTF8(reason.get()));
 #else
-            WTFLogAlways("Failed to connect to mach service %s, likely because it is not registered with launchd", protectedThis->m_machServiceName.data());
+            SAFE_WTFLOGALWAYS("Failed to connect to mach service %s, likely because it is not registered with launchd", protectedThis->m_machServiceName);
 #endif
         }
         if (event == XPC_ERROR_CONNECTION_INTERRUPTED) {

--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -303,7 +303,7 @@ void Connection::readyReadHandler()
             }
 
             if (m_isConnected) {
-                WTFLogAlways("Error receiving IPC message on socket %d in process %d: %s", socketDescriptor(), getpid(), safeStrerror(errno).data());
+                SAFE_WTFLOGALWAYS("Error receiving IPC message on socket %d in process %d: %s", socketDescriptor(), getpid(), safeStrerror(errno));
                 connectionDidClose();
             }
             return;
@@ -475,7 +475,7 @@ bool Connection::sendOutputMessage(UnixMessage&& outputMessage)
         }
 
         if (m_isConnected)
-            WTFLogAlways("Error sending IPC message: %s", safeStrerror(errno).data());
+            SAFE_WTFLOGALWAYS("Error sending IPC message: %s", safeStrerror(errno));
         return false;
     }
 

--- a/Source/WebKit/Platform/classifier/cocoa/ResourceLoadStatisticsClassifierCocoa.cpp
+++ b/Source/WebKit/Platform/classifier/cocoa/ResourceLoadStatisticsClassifierCocoa.cpp
@@ -113,7 +113,7 @@ const struct svm_model* ResourceLoadStatisticsClassifierCocoa::singletonPredicti
     if (corePredictionModel && corePredictionModel.value())
         return corePredictionModel.value();
 
-    WTFLogAlways("ResourceLoadStatisticsClassifierCocoa::singletonPredictionModel(): Couldn't load model file at path %s.", storagePath().utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("ResourceLoadStatisticsClassifierCocoa::singletonPredictionModel(): Couldn't load model file at path %s.", storagePath().utf8());
     m_useCorePrediction = false;
     return nullptr;
 }

--- a/Source/WebKit/Platform/glib/ModuleGlib.cpp
+++ b/Source/WebKit/Platform/glib/ModuleGlib.cpp
@@ -30,6 +30,7 @@
 
 #include <gmodule.h>
 #include <wtf/text/CString.h>
+#include <wtf/text/CStringView.h>
 
 namespace WebKit {
 
@@ -37,7 +38,7 @@ bool Module::load()
 {
     m_handle = g_module_open(m_path.utf8().legacyCStringPointer(), G_MODULE_BIND_LAZY);
     if (!m_handle)
-        WTFLogAlways("Error loading module '%s': %s", m_path.utf8().legacyCStringPointer(), g_module_error());
+        SAFE_WTFLOGALWAYS("Error loading module '%s': %s", m_path.utf8(), CStringView::unsafeFromUTF8(g_module_error()));
     return m_handle;
 }
 

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -292,7 +292,7 @@ void AuxiliaryProcess::initializeSandbox(const AuxiliaryProcessInitializationPar
 
 void AuxiliaryProcess::didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName messageName, const Vector<uint32_t>&)
 {
-    WTFLogAlways("Received invalid message: '%s'", description(messageName).characters());
+    SAFE_WTFLOGALWAYS("Received invalid message: '%s'", description(messageName));
     CRASH();
 }
 

--- a/Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm
+++ b/Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm
@@ -230,7 +230,7 @@ bool hasProhibitedUsageStrings()
     for (NSString *prohibitedString : prohibitedStrings) {
         if ([infoDictionary objectForKey:prohibitedString]) {
             String message = adoptNS([[NSString alloc] initWithFormat:@"[In-App Browser Privacy] %@ used prohibited usage string %@.", retainPtr([[NSBundle mainBundle] bundleIdentifier]).get(), prohibitedString]).get();
-            WTFLogAlways("%s", message.utf8().legacyCStringPointer());
+            SAFE_WTFLOGALWAYS("%s", message.utf8());
             hasProhibitedUsageStrings = true;
             break;
         }

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -217,7 +217,7 @@ auto SandboxExtension::createReadOnlyHandlesForFiles(ASCIILiteral logLabel, cons
         if (!handle) {
             // This can legitimately fail if a directory containing the file is deleted after the file was chosen.
             // We also have reports of cases where this likely fails for some unknown reason, <rdar://problem/10156710>.
-            WTFLogAlways("%s: could not create a sandbox extension for '%s'\n", logLabel.characters(), path.utf8().legacyCStringPointer());
+            SAFE_WTFLOGALWAYS("%s: could not create a sandbox extension for '%s'\n", logLabel, path.utf8());
             ASSERT_NOT_REACHED();
         }
         return handle;
@@ -256,7 +256,7 @@ auto SandboxExtension::createHandleForTemporaryFile(StringView prefix, Type type
     handle.m_sandboxExtension = SandboxExtensionImpl::create(FileSystem::fileSystemRepresentation(pathString), type);
 
     if (!handle.m_sandboxExtension) {
-        WTFLogAlways("Could not create a sandbox extension for temporary file '%s'", pathString.utf8().legacyCStringPointer());
+        SAFE_WTFLOGALWAYS("Could not create a sandbox extension for temporary file '%s'", pathString.utf8());
         return std::nullopt;
     }
     return { { WTF::move(handle), WTF::move(pathString) } };
@@ -269,7 +269,7 @@ auto SandboxExtension::createHandleForGenericExtension(ASCIILiteral extensionCla
 
     handle.m_sandboxExtension = SandboxExtensionImpl::create(extensionClass, Type::Generic);
     if (!handle.m_sandboxExtension) {
-        WTFLogAlways("Could not create a '%s' sandbox extension", extensionClass.characters());
+        SAFE_WTFLOGALWAYS("Could not create a '%s' sandbox extension", extensionClass);
         return std::nullopt;
     }
     
@@ -291,7 +291,7 @@ auto SandboxExtension::createHandleForMachLookup(ASCIILiteral service, std::opti
     
     handle.m_sandboxExtension = SandboxExtensionImpl::create(service, Type::Mach, auditToken, flags);
     if (!handle.m_sandboxExtension) {
-        WTFLogAlways("Could not create a '%s' sandbox extension", service.characters());
+        SAFE_WTFLOGALWAYS("Could not create a '%s' sandbox extension", service);
         return std::nullopt;
     }
     

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -254,7 +254,7 @@ static void dumpChangedLayers(TextStream& ts, const LayerPropertiesMap& changedL
 
 void RemoteLayerTreeTransaction::dump() const
 {
-    WTFLogAlways("%s", description().utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s", description().utf8());
 }
 
 String RemoteLayerTreeTransaction::description() const

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -320,7 +320,7 @@ String RemoteScrollingCoordinatorTransaction::description() const
 
 void RemoteScrollingCoordinatorTransaction::dump() const
 {
-    WTFLogAlways("%s", description().utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s", description().utf8());
 }
 #endif // !defined(NDEBUG) || !LOG_DISABLED
 

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -540,7 +540,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
         SAFE_WTFLOGALWAYS("%s: Could not initialize sandbox profile [%s], error '%s'\n", FileSystem::currentExecutableName(), temp, CStringView::unsafeFromUTF8(errorBuf));
         for (size_t i = 0, count = parameters.count(); i != count; ++i) {
-            WTFLogAlways("%s=%s\n", parameters.name(i).characters(), parameters.value(i));
+            SAFE_WTFLOGALWAYS("%s=%s\n", parameters.name(i), CStringView::unsafeFromUTF8(parameters.value(i)));
         }
         return false;
     }

--- a/Source/WebKit/Shared/unix/BreakpadExceptionHandler.cpp
+++ b/Source/WebKit/Shared/unix/BreakpadExceptionHandler.cpp
@@ -47,7 +47,7 @@ void installBreakpadExceptionHandler()
         return;
 
     if (FileSystem::fileType(breakpadMinidumpDir) != FileSystem::FileType::Directory) {
-        WTFLogAlways("Breakpad dir \"%s\" is not a directory, not installing handler", breakpadMinidumpDir.utf8().legacyCStringPointer());
+        SAFE_WTFLOGALWAYS("Breakpad dir \"%s\" is not a directory, not installing handler", breakpadMinidumpDir.utf8());
         return;
     }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -829,7 +829,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request, RenderPro
     webkit_uri_scheme_request_finish(request, stream.get(), streamLength, "text/html");
 
     if (requestURL.path() == "/stdout"_s)
-        WTFLogAlways("GPU information\n%s", prettyPrintJSON(infoAsString).utf8().legacyCStringPointer());
+        SAFE_WTFLOGALWAYS("GPU information\n%s", prettyPrintJSON(infoAsString).utf8());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
@@ -57,7 +57,7 @@ bool checkSandboxRequirementForType(MediaPermissionType type)
 
         int result = sandbox_check(getpid(), operation, static_cast<enum sandbox_filter_type>(SANDBOX_CHECK_NO_REPORT | SANDBOX_FILTER_NONE));
         if (result == -1)
-            WTFLogAlways("Error checking '%s' sandbox access, errno=%ld", operation.characters(), (long)errno);
+            SAFE_WTFLOGALWAYS("Error checking '%s' sandbox access, errno=%ld", operation, (long)errno);
         return !result;
     };
 

--- a/Source/WebKit/UIProcess/Cocoa/PreferenceObserver.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PreferenceObserver.mm
@@ -162,7 +162,7 @@
     for (RetainPtr domain : domains) {
         auto userDefaults = adoptNS([[WKUserDefaults alloc] initWithSuiteName:domain.get()]);
         if (!userDefaults) {
-            WTFLogAlways("Could not init user defaults instance for domain %s", String(domain.get()).utf8().legacyCStringPointer());
+            SAFE_WTFLOGALWAYS("Could not init user defaults instance for domain %s", String(domain.get()).utf8());
             continue;
         }
         userDefaults->m_observer = self;

--- a/Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp
+++ b/Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp
@@ -239,7 +239,7 @@ public:
                     [](const CString& path) {
                         if (!path.isNull()) {
                             if (unlink(path.data()) == -1)
-                                WTFLogAlways("Failed to remove cached notification icon %s: %s", path.data(), safeStrerror(errno).data());
+                                SAFE_WTFLOGALWAYS("Failed to remove cached notification icon %s: %s", path, safeStrerror(errno));
                         }
                     },
                     [](const GRefPtr<GBytes>&) {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -14001,7 +14001,7 @@ void WebPageProxy::logScrollingEvent(uint32_t eventType, MonotonicTime timestamp
         break;
     case PerformanceLoggingClient::ScrollingEvent::SwitchedScrollingMode:
         if (data)
-            WTFLogAlways("SCROLLING: Switching to main-thread scrolling mode. Time: %f Reason(s): %s\n", timestamp.secondsSinceEpoch().value(), PerformanceLoggingClient::synchronousScrollingReasonsAsString(OptionSet<SynchronousScrollingReason>::fromRaw(data)).utf8().legacyCStringPointer());
+            SAFE_WTFLOGALWAYS("SCROLLING: Switching to main-thread scrolling mode. Time: %f Reason(s): %s\n", timestamp.secondsSinceEpoch().value(), PerformanceLoggingClient::synchronousScrollingReasonsAsString(OptionSet<SynchronousScrollingReason>::fromRaw(data)).utf8());
         else
             WTFLogAlways("SCROLLING: Switching to threaded scrolling mode. Time: %f\n", timestamp.secondsSinceEpoch().value());
         break;

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -626,7 +626,7 @@ static RetainPtr<NSString> pathToPDFOnDisk(const String& suggestedFilename)
     if ([fileManager fileExistsAtPath:path.get()]) {
         auto [fileHandle, temporaryFilePath] = FileSystem::createTemporaryFileInDirectory(pdfDirectoryPath.get(), makeString('-', suggestedFilename));
         if (!fileHandle) {
-            WTFLogAlways("Cannot create PDF file in the temporary directory (%s).", suggestedFilename.utf8().legacyCStringPointer());
+            SAFE_WTFLOGALWAYS("Cannot create PDF file in the temporary directory (%s).", suggestedFilename.utf8());
             return nil;
         }
 
@@ -675,7 +675,7 @@ void WebPageProxy::savePDFToTemporaryFolderAndOpenWithNativeApplication(const St
     RetainPtr nsData = toNSDataNoCopy(data, FreeWhenDone::No);
 
     if (![[NSFileManager defaultManager] createFileAtPath:nsPath.get() contents:nsData.get() attributes:fileAttributes.get()]) {
-        WTFLogAlways("Cannot create PDF file in the temporary directory (%s).", sanitizedFilename.utf8().legacyCStringPointer());
+        SAFE_WTFLOGALWAYS("Cannot create PDF file in the temporary directory (%s).", sanitizedFilename.utf8());
         return;
     }
     auto originatingURLString = frameInfo.request.url().string();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -302,7 +302,7 @@ std::unique_ptr<AcceleratedSurface::RenderTarget> AcceleratedSurface::RenderTarg
     }
 
     if (!bo) {
-        WTFLogAlways("Failed to create GBM buffer of size %dx%d: %s", size.width(), size.height(), safeStrerror(errno).data());
+        SAFE_WTFLOGALWAYS("Failed to create GBM buffer of size %dx%d: %s", size.width(), size.height(), safeStrerror(errno));
         return nullptr;
     }
 

--- a/Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.cpp
+++ b/Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.cpp
@@ -53,7 +53,7 @@ static Color imageBufferPixelAt(const ImageBuffer& imageBuffer, FloatPoint point
     };
     if (differs(gotRed, expectedRed) || differs(gotGreen, expectedGreen) || differs(gotBlue, expectedBlue) || differs(gotAlpha, expectedAlpha)) {
         // Use this to debug the contents in the browser.
-        // WTFLogAlways("%s", imageBuffer.toDataURL("image/png"_s).utf8().legacyCStringPointer());
+        // SAFE_WTFLOGALWAYS("%s", imageBuffer.toDataURL("image/png"_s).utf8());
         return ::testing::AssertionFailure() << "color is not expected at " << point << ". Got: " << got << ", expected: " << expected << " with tolerance " << tolerance << ".";
     }
     return ::testing::AssertionSuccess();

--- a/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.cpp
@@ -37,7 +37,7 @@ void logCompilationError(WGSL::FailedCheck& failedCheck)
     message.print(String::number(failedCheck.errors.size()), " error", failedCheck.errors.size() != 1 ? "s" : "", " generated while compiling the shader:"_s);
     for (const auto& error : failedCheck.errors)
         message.print("\n"_s, error);
-    WTFLogAlways("%s", message.toString().utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s", message.toString().utf8());
     GTEST_FAIL();
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URL.cpp
@@ -551,10 +551,10 @@ TEST_F(WTF_URL, URLRemoveQueryParameters)
         WTFLogAlways("Test failed at %s:%d", __FILE__, lineNumber);
         WTFLogAlways("- Got %zu parameter(s)", removedParameters.size());
         for (auto& parameter : removedParameters)
-            WTFLogAlways("    %s", parameter.utf8().legacyCStringPointer());
+            SAFE_WTFLOGALWAYS("    %s", parameter.utf8());
         WTFLogAlways("- Expected %zu parameter(s)", expectedParameters.size());
         for (auto& parameter : expectedParameters)
-            WTFLogAlways("    %s", parameter.utf8().legacyCStringPointer());
+            SAFE_WTFLOGALWAYS("    %s", parameter.utf8());
     };
 
     auto removedParameters1 = removeQueryParameters(url1, keyRemovalSet2);

--- a/Tools/TestWebKitAPI/Tests/WebCore/FloatQuadTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FloatQuadTests.cpp
@@ -119,7 +119,7 @@ static void checkIsEmpty(bool expectation, FloatQuad&& quad)
 
     TextStream stream;
     stream << quad;
-    WTFLogAlways("Expected quad: %s to be %s", stream.release().utf8().legacyCStringPointer(), expectation ? "empty" : "non-empty");
+    SAFE_WTFLOGALWAYS("Expected quad: %s to be %s", stream.release().utf8(), expectation ? "empty"_s : "non-empty"_s);
 }
 
 TEST(FloatQuad, IsEmpty)

--- a/Tools/TestWebKitAPI/Tests/WebCore/Logging.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/Logging.cpp
@@ -267,7 +267,7 @@ TEST_F(LoggingTest, DISABLED_TestRELEASE_LOG_WITH_LEVEL_IF)
 {
     bool enabled = true;
     RELEASE_LOG_WITH_LEVEL_IF(enabled, Channel1, WTFLogLevel::Error, "Is there someone else up there that we can talk to?");
-    WTFLogAlways("%s", output().utf8().legacyCStringPointer());
+    SAFE_WTFLOGALWAYS("%s", output().utf8());
     EXPECT_TRUE(output().containsIgnoringASCIICase("someone else"_s));
 
     RELEASE_LOG_WITH_LEVEL_IF(enabled, Channel1, WTFLogLevel::Debug, "No, now go away");

--- a/Tools/TestWebKitAPI/Tests/WebCore/RegionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/RegionTests.cpp
@@ -239,8 +239,8 @@ TEST(RegionTests, FuzzOperationsIsValidShape)
                 ASSERT_TRUE(Shape::isValidShape(segments.span(), spans.span())) << commands.toString() << r.dataForTesting();
         }
         if (printPassed) {
-            WTFLogAlways("%s", commands.toString().utf8().legacyCStringPointer());
-            WTFLogAlways("Shape: %s", convertToString(r.dataForTesting()).utf8().legacyCStringPointer());
+            SAFE_WTFLOGALWAYS("%s", commands.toString().utf8());
+            SAFE_WTFLOGALWAYS("Shape: %s", convertToString(r.dataForTesting()).utf8());
         }
     }
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -612,21 +612,20 @@ static void checkProcessesTopDocumentURL(NSSet<_WKFrameTreeNode *> *trees, NSStr
     }
 }
 
-static Vector<char> indentation(size_t count)
+static ASCIICString indentation(size_t count)
 {
-    Vector<char> result;
-    for (size_t i = 0; i < count; i++)
-        result.append(' ');
-    result.append(0);
+    std::span<char> characters;
+    auto result = ASCIICString::newUninitialized(count, characters);
+    std::ranges::fill(characters, ' ');
     return result;
 }
 
 static void printTree(_WKFrameTreeNode *n, size_t indent = 0)
 {
     if (n.info._isLocalFrame)
-        WTFLogAlways("%s%@://%@ (pid %d)", indentation(indent).span().data(), n.info.securityOrigin.protocol, n.info.securityOrigin.host, n.info._processIdentifier);
+        SAFE_WTFLOGALWAYS("%s%@://%@ (pid %d)", indentation(indent), n.info.securityOrigin.protocol, n.info.securityOrigin.host, n.info._processIdentifier);
     else
-        WTFLogAlways("%s(remote) (pid %d)", indentation(indent).span().data(), n.info._processIdentifier);
+        SAFE_WTFLOGALWAYS("%s(remote) (pid %d)", indentation(indent), n.info._processIdentifier);
     for (_WKFrameTreeNode *c in n.childFrames)
         printTree(c, indent + 1);
 }
@@ -634,9 +633,9 @@ static void printTree(_WKFrameTreeNode *n, size_t indent = 0)
 static void printTree(const ExpectedFrameTree& n, size_t indent = 0)
 {
     if (auto* s = std::get_if<String>(&n.remoteOrOrigin))
-        WTFLogAlways("%s%s", indentation(indent).span().data(), s->utf8().legacyCStringPointer());
+        SAFE_WTFLOGALWAYS("%s%s", indentation(indent), s->utf8());
     else
-        WTFLogAlways("%s(remote)", indentation(indent).span().data());
+        SAFE_WTFLOGALWAYS("%s(remote)", indentation(indent));
     for (const auto& c : n.children)
         printTree(c, indent + 1);
 }

--- a/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp
@@ -276,7 +276,7 @@ void UIScriptControllerGtk::sendEventStream(JSStringRef eventsJSON, JSValueRef c
 
         auto eventTypeString = eventObject->getString("type"_s);
         if (!eventTypeString) {
-            WTFLogAlways("Failed to find type key in %s", eventTypeString.utf8().legacyCStringPointer());
+            SAFE_WTFLOGALWAYS("Failed to find type key in %s", eventTypeString.utf8());
             break;
         }
 
@@ -292,7 +292,7 @@ void UIScriptControllerGtk::sendEventStream(JSStringRef eventsJSON, JSValueRef c
             if (!momentumPhaseString.isNull()) {
                 momentumPhase = wheelEventPhaseFromString(momentumPhaseString);
                 if (momentumPhase == WheelEventPhase::Cancelled || momentumPhase == WheelEventPhase::MayBegin) {
-                    WTFLogAlways("Invalid value %s for momentumPhase", momentumPhaseString.utf8().legacyCStringPointer());
+                    SAFE_WTFLOGALWAYS("Invalid value %s for momentumPhase", momentumPhaseString.utf8());
                     break;
                 }
             }

--- a/Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.cpp
@@ -209,7 +209,7 @@ void UIScriptControllerWPE::sendEventStream(JSStringRef eventsJSON, JSValueRef c
 
         auto eventTypeString = eventObject->getString("type"_s);
         if (!eventTypeString) {
-            WTFLogAlways("Failed to find type key in %s", eventTypeString.utf8().legacyCStringPointer());
+            SAFE_WTFLOGALWAYS("Failed to find type key in %s", eventTypeString.utf8());
             break;
         }
 
@@ -225,7 +225,7 @@ void UIScriptControllerWPE::sendEventStream(JSStringRef eventsJSON, JSValueRef c
             if (!momentumPhaseString.isNull()) {
                 momentumPhase = wheelEventPhaseFromString(momentumPhaseString);
                 if (momentumPhase == EventSenderProxy::WheelEventPhase::Cancelled || momentumPhase == EventSenderProxy::WheelEventPhase::MayBegin) {
-                    WTFLogAlways("Invalid value %s for momentumPhase", momentumPhaseString.utf8().legacyCStringPointer());
+                    SAFE_WTFLOGALWAYS("Invalid value %s for momentumPhase", momentumPhaseString.utf8());
                     break;
                 }
             }


### PR DESCRIPTION
#### ce646f1f8523b64188d1fb68520a44e43c035906
<pre>
Use SAFE_WTFLOGALWAYS instead of WTFLogAlways at call sites that reach for a raw const char*
<a href="https://bugs.webkit.org/show_bug.cgi?id=324090">https://bugs.webkit.org/show_bug.cgi?id=324090</a>

Reviewed by Darin Adler and Mike Wyrzykowski.

SAFE_WTFLOGALWAYS routes every argument through WTF::safeNSStringPrintfType(),
which rejects char* while accepting the null-terminated string types that know
their own length (CString, CStringView, ASCIILiteral, GMallocString) and passing
Objective-C objects through untouched for %@. It was introduced with the sandbox
logging in AuxiliaryProcessMac.mm and had not been applied anywhere else, so the
rest of the tree kept calling WTFLogAlways() with an escape-hatch pointer.

Convert the call sites that were only reaching for const char* in order to
satisfy printf:

  - String::utf8().legacyCStringPointer() becomes String::utf8(). This is the
    bulk of the change and removes 60 uses of the accessor that CString.h
    documents as an escape hatch for printf-style formatting.
  - ASCIILiteral::characters() and CStringView::utf8() become the string itself.
  - safeStrerror(errno).data() and CString::data() become the CString.
  - char* string literals used as %s arguments become ASCIILiteral (&quot;empty&quot;_s).
  - [x UTF8String] with %s becomes the object with %@, which also stops a nil
    NSString from handing printf a null pointer.

Where the pointer genuinely comes from outside WTF -- GError::message,
g_module_error(), xpc_connection_copy_invalidation_reason() and the sandbox
parameter values -- wrap it in CStringView::unsafeFromUTF8() so the unchecked
conversion is named at the call site rather than implied, matching what
compileAndApplySandboxSlowCase() already does for sandbox_init&apos;s error buffer.

SiteIsolation.mm&apos;s indentation() helper built a manually null-terminated
Vector&lt;char&gt; purely to produce a %s argument; it returns an ASCIICString now.

ALWAYS_LOG_WITH_STREAM() and WTF_ALWAYS_LOG() in Assertions.h are left alone:
SAFE_WTFLOGALWAYS lives in StdLibExtras.h, which includes Assertions.h, so the
macro is not available there.

WTFLogAlways() call sites whose only arguments are Objective-C objects for %@
are unchanged -- there is no char* for the macro to reject, so converting them
would be churn.

No change in behavior.

* Source/JavaScriptCore/API/JSRemoteInspector.cpp:
(defaultStateForRemoteInspectionEnabledByDefault):
* Source/JavaScriptCore/inspector/InjectedScriptManager.cpp:
(Inspector::InjectedScriptManager::injectedScriptFor):
* Source/JavaScriptCore/inspector/InjectedScriptModule.cpp:
(Inspector::InjectedScriptModule::ensureInjected):
* Source/JavaScriptCore/runtime/ConsoleClient.cpp:
(JSC::ConsoleClient::printConsoleMessage):
(JSC::ConsoleClient::printConsoleMessageWithArguments):
* Source/WTF/wtf/Assertions.cpp:
* Source/WTF/wtf/TimingScope.cpp:
(WTF::TimingScope::scopeDidEnd):
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::makeSafeToUseMemoryMapForPath):
* Source/WTF/wtf/cocoa/ResourceUsageCocoa.cpp:
(WTF::logFootprintComparison):
* Source/WebCore/bindings/js/GarbageCollectionController.cpp:
(WebCore::GarbageCollectionController::dumpHeapForVM):
* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::BackForwardCache::dump const):
* Source/WebCore/inspector/InspectorFrontendHost.cpp:
(WebCore::InspectorFrontendHost::unbufferedLog):
* Source/WebCore/layout/Verification.cpp:
(WebCore::Layout::LayoutContext::verifyAndOutputMismatchingLayoutTree):
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
(WebCore::LayoutIntegration::printLegacyGridReasons):
* Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp:
(WebCore::Layout::showLayoutTree):
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::dumpLRULists const):
* Source/WebCore/page/ViewportConfiguration.cpp:
(WebCore::ViewportConfiguration::dump const):
* Source/WebCore/page/cocoa/PageCocoa.mm:
(WebCore::Page::platformInitialize):
* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
(showScrollingStateTree):
* Source/WebCore/platform/android/SharedMemoryAndroid.cpp:
(WebCore::SharedMemory::allocate):
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::clearNowPlayingInfo):
(WebCore::MediaSessionManagerCocoa::setNowPlayingInfo):
* Source/WebCore/platform/glib/FileMonitorGLib.cpp:
(WebCore::FileMonitor::FileMonitor):
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(showGraphicsLayerTree):
* Source/WebCore/platform/graphics/gbm/GBMDevice.cpp:
(WebCore::GBMDevice::create):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::makeGStreamerElement):
* Source/WebCore/platform/graphics/win/FontCacheWin.cpp:
(WebCore::getLinkedFonts):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::enterFullscreenHandler):
(WebCore::VideoPresentationInterfaceIOS::exitFullscreenHandler):
(WebCore::VideoPresentationInterfaceIOS::cleanupFullscreen):
* Source/WebCore/platform/unix/SharedMemoryUnix.cpp:
(WebCore::SharedMemory::allocate):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::showPaintOrderTree):
(WebCore::showLayerPositionTree):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::showRenderTreeForThis const):
(WebCore::RenderObject::showSubtreeForThis const):
(WebCore::RenderObject::showLineTreeForThis const):
(WebCore::printPaintOrderTreeForLiveDocuments):
(WebCore::printRenderTreeForLiveDocuments):
(WebCore::printLayerTreeForLiveDocuments):
(WebCore::printAccessibilityTreeForLiveDocuments):
(WebCore::printGraphicsLayerTreeForLiveDocuments):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::log):
* Source/WebGPU/WebGPU/Pipeline.mm:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::setPrivateClickMeasurementAppBundleIDForTesting):
* Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp:
(WebKit::NetworkCache::BlobStorage::add):
* Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm:
(WebKit::Daemon::ConnectionToMachService&lt;Traits&gt;::initializeConnectionIfNeeded const):
* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
(IPC::Connection::readyReadHandler):
(IPC::Connection::sendOutputMessage):
* Source/WebKit/Platform/classifier/cocoa/ResourceLoadStatisticsClassifierCocoa.cpp:
(WebKit::ResourceLoadStatisticsClassifierCocoa::singletonPredictionModel):
* Source/WebKit/Platform/glib/ModuleGlib.cpp:
(WebKit::Module::load):
* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::didReceiveInvalidMessage):
* Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm:
(WebKit::hasProhibitedUsageStrings):
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtension::createReadOnlyHandlesForFiles):
(WebKit::SandboxExtension::createHandleForTemporaryFile):
(WebKit::SandboxExtension::createHandleForGenericExtension):
(WebKit::SandboxExtension::createHandleForMachLookup):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::dump const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(WebKit::RemoteScrollingCoordinatorTransaction::dump const):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::compileAndApplySandboxSlowCase):
* Source/WebKit/Shared/unix/BreakpadExceptionHandler.cpp:
(WebKit::installBreakpadExceptionHandler):
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm:
(WebKit::checkSandboxRequirementForType):
* Source/WebKit/UIProcess/Cocoa/PreferenceObserver.mm:
(-[WKPreferenceObserver init]):
* Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp:
(WebKit::IconCache::removeUnusedIcons):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::logScrollingEvent):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::pathToPDFOnDisk):
(WebKit::WebPageProxy::savePDFToTemporaryFolderAndOpenWithNativeApplication):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::RenderTargetEGLImage::create):
* Tools/TestWebKitAPI/Helpers/GraphicsTestUtilities.cpp:
(TestWebKitAPI::imageBufferPixelIs):
* Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.cpp:
(TestWGSLAPI::logCompilationError):
* Tools/TestWebKitAPI/Tests/WTF/URL.cpp:
(TestWebKitAPI::TEST_F(WTF_URL, URLRemoveQueryParameters)):
* Tools/TestWebKitAPI/Tests/WebCore/FloatQuadTests.cpp:
(TestWebKitAPI::checkIsEmpty):
* Tools/TestWebKitAPI/Tests/WebCore/Logging.cpp:
(TestWebKitAPI::TEST_F(LoggingTest, DISABLED_TestRELEASE_LOG_WITH_LEVEL_IF)):
* Tools/TestWebKitAPI/Tests/WebCore/RegionTests.cpp:
(TestWebKitAPI::TEST(RegionTests, FuzzOperationsIsValidShape)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::indentation):
(TestWebKitAPI::printTree):
* Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp:
(WTR::UIScriptControllerGtk::sendEventStream):
* Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.cpp:
(WTR::UIScriptControllerWPE::sendEventStream):

Canonical link: <a href="https://commits.webkit.org/321031@main">https://commits.webkit.org/321031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66bb0d50bb999d91025e81977aef35bc1fb990dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186766 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60638 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/54383 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/197031 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/151760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a0782d86-9afd-4a42-b037-4d0b5f674b71) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/62023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60344 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/145905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/151760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b7d019a8-d6df-4e3e-ba4c-5bc699079c54) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49598 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/166412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/126332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/8eff415a-961c-4d95-a2b5-c8052f7ac419) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48326 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/46257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-wpe~~](https://ews-build.webkit.org/#/builders/251/builds/8090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/218/builds/14940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158671 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/46010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/8110 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/47988 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/53062 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/199029 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60281 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/165942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/155521 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41652 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60994 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/42559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155156 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49551 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/133162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130574 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59399 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/20994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58817 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/59027 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58926 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->