### PR TITLE
convertFloatToHalfFloat() violates strict aliasing with a float*-to-unsigned* reinterpret_cast

### DIFF
--- a/Source/WebCore/platform/graphics/FormatConverter.cpp
+++ b/Source/WebCore/platform/graphics/FormatConverter.cpp
@@ -189,7 +189,7 @@ static constexpr std::array<uint8_t, 512> shiftTable {
 
 inline uint16_t NODELETE convertFloatToHalfFloat(float f)
 {
-    unsigned temp = *(reinterpret_cast<unsigned *>(&f));
+    uint32_t temp = std::bit_cast<uint32_t>(f);
     unsigned signexp = (temp >> 23) & 0x1ff;
     return baseTable[signexp] + ((temp & 0x007fffff) >> shiftTable[signexp]);
 }


### PR DESCRIPTION
#### e55a7c58d5721e23ace536f8187139cc31dd4b43
<pre>
convertFloatToHalfFloat() violates strict aliasing with a float*-to-unsigned* reinterpret_cast
<a href="https://bugs.webkit.org/show_bug.cgi?id=324095">https://bugs.webkit.org/show_bug.cgi?id=324095</a>
<a href="https://rdar.apple.com/187313552">rdar://187313552</a>

Reviewed by Chris Dumez.

convertFloatToHalfFloat() read a float&apos;s storage through an
`unsigned*` lvalue via `*(reinterpret_cast&lt;unsigned*&gt;(&amp;f))`. float
and unsigned are not similar types, so this is a strict-aliasing
violation: the compiler is free to assume the two lvalues do not
alias, making the result undefined. The function sits in the
per-pixel half-float conversion path, so the pattern is exercised
on every pixel of a HalfFloat texture pack.

Use std::bit_cast&lt;uint32_t&gt;(f), which reinterprets the bits by value
with no aliasing hazard and compiles to the same code. &lt;bit&gt; is
already available transitively through wtf/MathExtras.h.

No change in behavior.

* Source/WebCore/platform/graphics/FormatConverter.cpp:
(WebCore::convertFloatToHalfFloat):

Canonical link: <a href="https://commits.webkit.org/321017@main">https://commits.webkit.org/321017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/099018c2cb88ec3dd4f0b8cce0c05527ca16f585

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196932 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/151099 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e499b841-fde4-4016-a81f-a280cd06b3a2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60245 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145818 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/101055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126223 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/0ebae7e2-b3b7-4449-9632-5700d82caadd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48241 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46175 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45928 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/8008 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52963 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198926 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60183 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155427 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41635 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60895 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155061 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49467 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133068 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130422 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59305 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20909 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58720 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/58935 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58828 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->