### PR TITLE
interpolateColors() takes its Color arguments by value, ref-churning out-of-line colors in gradient stop loops

### DIFF
--- a/Source/WebCore/platform/graphics/ColorInterpolation.cpp
+++ b/Source/WebCore/platform/graphics/ColorInterpolation.cpp
@@ -83,7 +83,7 @@ std::pair<float, float> fixupHueComponentsPriorToInterpolation(HueInterpolationM
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-Color interpolateColors(ColorInterpolationMethod colorInterpolationMethod, Color color1, double color1Multiplier, Color color2, double color2Multiplier)
+Color interpolateColors(ColorInterpolationMethod colorInterpolationMethod, const Color& color1, double color1Multiplier, const Color& color2, double color2Multiplier)
 {
     return WTF::switchOn(colorInterpolationMethod.colorSpace,
         [&]<typename MethodColorSpace> (const MethodColorSpace& colorSpace) -> Color {

--- a/Source/WebCore/platform/graphics/ColorInterpolation.h
+++ b/Source/WebCore/platform/graphics/ColorInterpolation.h
@@ -40,7 +40,7 @@ class Color;
 template<AlphaPremultiplication, typename InterpolationMethodColorSpace>
 typename InterpolationMethodColorSpace::ColorType interpolateColorComponents(InterpolationMethodColorSpace, typename InterpolationMethodColorSpace::ColorType color1, double color1Multiplier, typename InterpolationMethodColorSpace::ColorType color2, double color2Multiplier);
 
-Color interpolateColors(ColorInterpolationMethod, Color color1, double color1Multiplier, Color color2, double color2Multiplier);
+Color interpolateColors(ColorInterpolationMethod, const Color& color1, double color1Multiplier, const Color& color2, double color2Multiplier);
 
 template<AlphaPremultiplication, typename InterpolationMethodColorSpace>
 typename InterpolationMethodColorSpace::ColorType addColorComponents(InterpolationMethodColorSpace, typename InterpolationMethodColorSpace::ColorType color1, typename InterpolationMethodColorSpace::ColorType color2);


### PR DESCRIPTION
#### 24845f1b014dd496f6b285c4f2822d7c8d0a9833
<pre>
interpolateColors() takes its Color arguments by value, ref-churning out-of-line colors in gradient stop loops
<a href="https://bugs.webkit.org/show_bug.cgi?id=324106">https://bugs.webkit.org/show_bug.cgi?id=324106</a>
<a href="https://rdar.apple.com/187322060">rdar://187322060</a>

Reviewed by Sam Weinig.

interpolateColors() took both of its Color arguments by value. Color is
only 8 bytes, but its copy constructor is not trivial: for out-of-line
colors (extended color spaces such as oklch/lab/display-p3 and color-mix
results) it performs an atomic ref on the ThreadSafeRefCounted
OutOfLineComponents, with a matching deref when the parameter is
destroyed. These are exactly the colors that flow through this path.

The function is called once per gradient stop while building resolved
gradients (Style::interpolateColors callers in StyleGradient.cpp,
including the 9-iteration color-hint replacement loop), so each stop paid
two atomic ref/deref pairs for no reason. The body only reads the
arguments via const methods, so pass them by const reference instead.

* Source/WebCore/platform/graphics/ColorInterpolation.cpp:
(WebCore::interpolateColors):
* Source/WebCore/platform/graphics/ColorInterpolation.h:

Canonical link: <a href="https://commits.webkit.org/321012@main">https://commits.webkit.org/321012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/281b5739bc8dec21e4ea81a4271c75a853beb68a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/186697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/60569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/54314 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/196962 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/151277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7b070652-722f-42b5-9e51-246b76840427) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/188559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/61954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/60275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/145844 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/151277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/7a41b9e0-5eef-4563-b587-4268bb0f3410) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/189652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/49537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/166354 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/126255 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bcca27ba-2de7-4113-b386-1a8e37f239ca) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/48265 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/46199 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/158610 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/45952 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/8039 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/52993 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/50703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/198958 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/60213 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/155456 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/41631 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/60925 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/42502 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/155089 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/49490 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/133098 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/130473 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/59334 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/20933 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/58749 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/59002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/58858 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->